### PR TITLE
Add conversation window checkpoint storage

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.test.ts
@@ -1,0 +1,456 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+import type { ConversationWindowStateSnapshot } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import {
+  computeConversationWindowProfileHash,
+  loadConversationWindowCheckpoint,
+  makeConversationWindowCheckpoint,
+  publishConversationWindowCheckpoint,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_checkpoint";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import {
+  GPT_5_1_MODEL_CONFIG,
+  GPT_5_2_MODEL_CONFIG,
+} from "@app/types/assistant/models/openai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const identity = {
+  workspaceId: "w1",
+  conversationId: "c1",
+  agentMessageId: "a1",
+  agentMessageVersion: 0,
+  step: 2,
+};
+
+function emptyState(): ConversationWindowStateSnapshot {
+  return {
+    version: 1,
+    interactions: [],
+    retainedTokens: 0,
+    totalTokensBefore: 0,
+    prunedTokens: 0,
+  };
+}
+
+async function publishOrThrow(
+  checkpoint: ReturnType<typeof makeConversationWindowCheckpoint>
+) {
+  const result = await publishConversationWindowCheckpoint(checkpoint);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+describe("conversation window checkpoints", () => {
+  beforeEach(() => {
+    fileStorageMock.reset();
+  });
+
+  it("returns no checkpoint when the object does not exist", async () => {
+    fileStorageMock.setFetchFileContentNotFound(() => true);
+    const loaded = await loadConversationWindowCheckpoint(identity);
+
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isErr()) {
+      throw loaded.error;
+    }
+    expect(loaded.value).toBeNull();
+  });
+
+  it("returns storage failures as errors", async () => {
+    const storage = getPrivateUploadBucket();
+    vi.mocked(storage.fetchFileBuffer).mockRejectedValueOnce(
+      new Error("GCS unavailable")
+    );
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(storage);
+    const loaded = await loadConversationWindowCheckpoint(identity);
+
+    expect(loaded.isErr()).toBe(true);
+    if (loaded.isOk()) {
+      throw new Error("Expected the storage failure to be returned");
+    }
+    expect(loaded.error.message).toBe("GCS unavailable");
+  });
+
+  it("round-trips a compressed checkpoint", async () => {
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      missingActionCatcherFunctionCallIds: ["call_1"],
+      state: emptyState(),
+      nowMs: 1_000,
+    });
+
+    await publishOrThrow(checkpoint);
+    const loaded = await loadConversationWindowCheckpoint(identity, {
+      nowMs: 2_000,
+    });
+    if (loaded.isErr()) {
+      throw loaded.error;
+    }
+
+    expect(loaded.value).toEqual(checkpoint);
+    expect(loaded.value?.contextEpoch).toBe(0);
+    expect(loaded.value?.missingActionCatcherFunctionCallIds).toEqual([
+      "call_1",
+    ]);
+    const storedCheckpoint = fileStorageMock.saveFileCalls[0];
+    expect(storedCheckpoint.content.toString()).not.toContain("profileHash");
+    expect(storedCheckpoint.filePath).toBe(
+      "conversation-window-checkpoints/w/w1/conversations/c1/agent-messages/a1/versions/0/schemas/v1/steps/2.json"
+    );
+  });
+
+  it("ignores an expired checkpoint", async () => {
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state: emptyState(),
+      nowMs: 1_000,
+    });
+    await publishOrThrow(checkpoint);
+
+    const loaded = await loadConversationWindowCheckpoint(identity, {
+      nowMs: checkpoint.validUntilMs,
+    });
+
+    expect(loaded.isOk()).toBe(true);
+    if (loaded.isErr()) {
+      throw loaded.error;
+    }
+    expect(loaded.value).toBeNull();
+  });
+
+  it("rejects an invalid compressed payload", async () => {
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state: emptyState(),
+    });
+    await publishOrThrow(checkpoint);
+    const path = fileStorageMock.saveFileCalls[0].filePath;
+    fileStorageMock.setObject(
+      path,
+      JSON.stringify({ encoding: "gzip-base64", payload: "not-gzip" })
+    );
+
+    const loaded = await loadConversationWindowCheckpoint(identity);
+
+    expect(loaded.isErr()).toBe(true);
+  });
+
+  it("uses the earliest signed URL expiry with a safety margin", () => {
+    const state = emptyState();
+    state.interactions = [
+      {
+        messages: [
+          {
+            kind: "message",
+            message: {
+              role: "user",
+              name: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "Ignore https://storage.googleapis.com/bucket/not-an-image?X-Goog-Date=20260824T120000Z&X-Goog-Expires=600",
+                },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "https://storage.googleapis.com/bucket/file?X-Goog-Date=20260824T120000Z&X-Goog-Expires=3600",
+                  },
+                },
+              ],
+              tokenCount: 3_100,
+            },
+          },
+          {
+            kind: "tool_result",
+            message: {
+              role: "function",
+              name: "tool",
+              function_call_id: "call_1",
+              content: [
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "https://storage.googleapis.com/bucket/earlier?X-Goog-Date=20260824T120000Z&X-Goog-Expires=2400",
+                  },
+                },
+              ],
+              tokenCount: 3_100,
+            },
+            tokenSavings: 0,
+            pruned: false,
+            phase: "pending",
+          },
+        ],
+      },
+    ];
+    state.retainedTokens = 6_200;
+    state.totalTokensBefore = 6_200;
+
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state,
+      nowMs: Date.UTC(2026, 7, 24, 12, 0, 0),
+    });
+
+    expect(checkpoint.validUntilMs).toBe(Date.UTC(2026, 7, 24, 12, 35, 0));
+  });
+
+  it("loads the create-once winner", async () => {
+    const winner = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "winner",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state: emptyState(),
+    });
+    const loser = { ...winner, profileHash: "loser" };
+
+    await publishOrThrow(winner);
+    const published = await publishOrThrow(loser);
+
+    expect(published.profileHash).toBe("winner");
+  });
+
+  it("rejects malformed checkpointed model messages", async () => {
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state: emptyState(),
+    });
+    await publishOrThrow(checkpoint);
+
+    const path = fileStorageMock.saveFileCalls[0].filePath;
+    const raw = fileStorageMock.getObject(path);
+    if (!raw) {
+      throw new Error("Expected a stored checkpoint");
+    }
+    const envelope = JSON.parse(raw);
+    const payload = JSON.parse(
+      gunzipSync(Buffer.from(envelope.payload, "base64")).toString("utf8")
+    );
+    payload.state.interactions = [
+      {
+        messages: [
+          {
+            kind: "message",
+            message: {
+              role: "user",
+              name: "user",
+              content: [null],
+              tokenCount: 1,
+            },
+          },
+        ],
+      },
+    ];
+    envelope.payload = gzipSync(JSON.stringify(payload)).toString("base64");
+    fileStorageMock.setObject(path, JSON.stringify(envelope));
+
+    const loaded = await loadConversationWindowCheckpoint(identity);
+    expect(loaded.isErr()).toBe(true);
+    if (loaded.isOk()) {
+      throw new Error("Expected malformed checkpoint to fail");
+    }
+    expect(loaded.error.message).toContain(
+      "Invalid checkpointed model message"
+    );
+  });
+
+  it("rejects malformed assistant content", async () => {
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state: emptyState(),
+    });
+    await publishOrThrow(checkpoint);
+
+    const path = fileStorageMock.saveFileCalls[0].filePath;
+    const raw = fileStorageMock.getObject(path);
+    if (!raw) {
+      throw new Error("Expected a stored checkpoint");
+    }
+    const envelope = JSON.parse(raw);
+    const payload = JSON.parse(
+      gunzipSync(Buffer.from(envelope.payload, "base64")).toString("utf8")
+    );
+    payload.state = {
+      version: 1,
+      interactions: [
+        {
+          messages: [
+            {
+              kind: "message",
+              message: {
+                role: "assistant",
+                name: "assistant",
+                contents: [{ type: "reasoning" }],
+                tokenCount: 10,
+              },
+            },
+          ],
+        },
+      ],
+      retainedTokens: 10,
+      totalTokensBefore: 10,
+      prunedTokens: 0,
+    };
+    envelope.payload = gzipSync(JSON.stringify(payload)).toString("base64");
+    fileStorageMock.setObject(path, JSON.stringify(envelope));
+
+    const loaded = await loadConversationWindowCheckpoint(identity);
+    expect(loaded.isErr()).toBe(true);
+    if (loaded.isOk()) {
+      throw new Error("Expected malformed checkpoint to fail");
+    }
+    expect(loaded.error.message).toContain(
+      "Invalid checkpointed model message"
+    );
+  });
+
+  it.each([
+    ["workspace", { workspaceId: "w_2" }],
+    ["conversation", { conversationId: "conv_2" }],
+    ["agent message", { agentMessageId: "agent_2" }],
+    ["agent message version", { agentMessageVersion: 2 }],
+    ["step", { step: 3 }],
+  ])("uses a different object key when %s changes", async (_name, change) => {
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state: emptyState(),
+    });
+
+    await publishOrThrow(checkpoint);
+    await publishOrThrow({
+      ...checkpoint,
+      identity: { ...identity, ...change },
+    });
+
+    expect(fileStorageMock.saveFileCalls).toHaveLength(2);
+    expect(fileStorageMock.saveFileCalls[0].filePath).not.toBe(
+      fileStorageMock.saveFileCalls[1].filePath
+    );
+  });
+
+  type ProfileInput = Parameters<
+    typeof computeConversationWindowProfileHash
+  >[0];
+  const baseProfile: ProfileInput = {
+    model: GPT_5_1_MODEL_CONFIG,
+    prompt: "prompt",
+    tools: "tools",
+    allowedTokenCount: 100_000,
+    leadingMessages: [],
+    excludeActions: false,
+    excludeImages: false,
+    onMissingAction: "inject-placeholder",
+    agentConfigurationId: "agent_1",
+  };
+  const profileMutations: Array<
+    [string, (profile: ProfileInput) => ProfileInput]
+  > = [
+    [
+      "model provider",
+      (profile) => ({
+        ...profile,
+        model: { ...profile.model, providerId: "anthropic" },
+      }),
+    ],
+    ["model id", (profile) => ({ ...profile, model: GPT_5_2_MODEL_CONFIG })],
+    [
+      "model context size",
+      (profile) => ({
+        ...profile,
+        model: { ...profile.model, contextSize: 100_000 },
+      }),
+    ],
+    [
+      "model generation budget",
+      (profile) => ({
+        ...profile,
+        model: { ...profile.model, generationTokensCount: 8_192 },
+      }),
+    ],
+    [
+      "model token adjustment",
+      (profile) => ({
+        ...profile,
+        model: { ...profile.model, tokenCountAdjustment: 1.1 },
+      }),
+    ],
+    [
+      "model tokenizer",
+      (profile) => ({
+        ...profile,
+        model: {
+          ...profile.model,
+          tokenizer: { type: "tiktoken", base: "cl100k_base" },
+        },
+      }),
+    ],
+    [
+      "model vision support",
+      (profile) => ({
+        ...profile,
+        model: { ...profile.model, supportsVision: false },
+      }),
+    ],
+    ["prompt", (profile) => ({ ...profile, prompt: "changed prompt" })],
+    ["tools", (profile) => ({ ...profile, tools: "changed tools" })],
+    [
+      "allowed token count",
+      (profile) => ({ ...profile, allowedTokenCount: 90_000 }),
+    ],
+    [
+      "leading messages",
+      (profile) => ({
+        ...profile,
+        leadingMessages: [
+          {
+            role: "user",
+            name: "context",
+            content: [{ type: "text", text: "leading context" }],
+          },
+        ],
+      }),
+    ],
+    ["action exclusion", (profile) => ({ ...profile, excludeActions: true })],
+    ["image exclusion", (profile) => ({ ...profile, excludeImages: true })],
+    [
+      "missing-action behavior",
+      (profile) => ({ ...profile, onMissingAction: "skip" }),
+    ],
+    [
+      "agent configuration",
+      (profile) => ({ ...profile, agentConfigurationId: "agent_2" }),
+    ],
+  ];
+
+  it.each(
+    profileMutations
+  )("invalidates the profile when %s changes", (_name, mutate) => {
+    expect(computeConversationWindowProfileHash(mutate(baseProfile))).not.toBe(
+      computeConversationWindowProfileHash(baseProfile)
+    );
+  });
+});

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
@@ -26,28 +26,40 @@ const SIGNED_URL_EXPIRY_SAFETY_MARGIN_MS = 5 * 60 * 1000;
 const MAX_STORED_CHECKPOINT_SIZE_BYTES = 8 * 1024 * 1024;
 const MAX_EXPANDED_CHECKPOINT_SIZE_BYTES = 64 * 1024 * 1024;
 
-export type ConversationWindowCheckpointIdentity = {
-  workspaceId: string;
-  conversationId: string;
-  agentMessageId: string;
-  agentMessageVersion: number;
-  step: number;
-};
+const checkpointIdentitySchema = z
+  .object({
+    workspaceId: z.string(),
+    conversationId: z.string(),
+    agentMessageId: z.string(),
+    agentMessageVersion: z.number().int().nonnegative(),
+    step: z.number().int().nonnegative(),
+  })
+  .strict();
 
-export type ConversationWindowCheckpoint = {
-  version: typeof CONVERSATION_WINDOW_CHECKPOINT_VERSION;
-  // Reserved for invalidating cross-message checkpoints after earlier context changes.
-  // Same-agent-message schema v1 has no such mutation signal, so the epoch remains zero.
-  contextEpoch: 0;
-  identity: ConversationWindowCheckpointIdentity;
-  profileHash: string;
-  createdAtMs: number;
-  validUntilMs: number;
-  promptTokens: number;
-  toolDefinitionTokens: number;
-  missingActionCatcherFunctionCallIds: string[];
-  state: ConversationWindowStateSnapshot;
-};
+export type ConversationWindowCheckpointIdentity = z.infer<
+  typeof checkpointIdentitySchema
+>;
+
+const conversationWindowCheckpointSchema = z
+  .object({
+    version: z.literal(CONVERSATION_WINDOW_CHECKPOINT_VERSION),
+    // Reserved for invalidating cross-message checkpoints after earlier context changes.
+    // Same-agent-message schema v1 has no such mutation signal, so the epoch remains zero.
+    contextEpoch: z.literal(0),
+    identity: checkpointIdentitySchema,
+    profileHash: z.string(),
+    createdAtMs: z.number().int().nonnegative(),
+    validUntilMs: z.number().int().nonnegative(),
+    promptTokens: z.number().int().nonnegative(),
+    toolDefinitionTokens: z.number().int().nonnegative(),
+    missingActionCatcherFunctionCallIds: z.array(z.string()),
+    state: ConversationWindowStateSnapshotSchema,
+  })
+  .strict();
+
+export type ConversationWindowCheckpoint = z.infer<
+  typeof conversationWindowCheckpointSchema
+>;
 
 function checkpointPath(
   identity: ConversationWindowCheckpointIdentity
@@ -97,32 +109,6 @@ const checkpointEnvelopeSchema = z
     payload: z.string(),
   })
   .strict();
-
-const checkpointIdentitySchema = z
-  .object({
-    workspaceId: z.string(),
-    conversationId: z.string(),
-    agentMessageId: z.string(),
-    agentMessageVersion: z.number().int().nonnegative(),
-    step: z.number().int().nonnegative(),
-  })
-  .strict();
-
-const conversationWindowCheckpointSchema: z.ZodType<ConversationWindowCheckpoint> =
-  z
-    .object({
-      version: z.literal(CONVERSATION_WINDOW_CHECKPOINT_VERSION),
-      contextEpoch: z.literal(0),
-      identity: checkpointIdentitySchema,
-      profileHash: z.string(),
-      createdAtMs: z.number().int().nonnegative(),
-      validUntilMs: z.number().int().nonnegative(),
-      promptTokens: z.number().int().nonnegative(),
-      toolDefinitionTokens: z.number().int().nonnegative(),
-      missingActionCatcherFunctionCallIds: z.array(z.string()),
-      state: ConversationWindowStateSnapshotSchema,
-    })
-    .strict();
 
 function decodeCheckpoint(
   content: string

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
@@ -1,0 +1,410 @@
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+import type { ConversationWindowStateSnapshot } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import { ConversationWindowStateSnapshotSchema } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  isGCSNotFoundError,
+  isGCSPreconditionFailedError,
+} from "@app/lib/file_storage/types";
+import type {
+  Content,
+  ModelMessageTypeMultiActionsWithoutContentFragment,
+} from "@app/types/assistant/generation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export const CONVERSATION_WINDOW_CHECKPOINT_VERSION = 1 as const;
+const CHECKPOINT_MAX_AGE_MS = 55 * 60 * 1000;
+const SIGNED_URL_EXPIRY_SAFETY_MARGIN_MS = 5 * 60 * 1000;
+const MAX_STORED_CHECKPOINT_SIZE_BYTES = 8 * 1024 * 1024;
+const MAX_EXPANDED_CHECKPOINT_SIZE_BYTES = 64 * 1024 * 1024;
+
+export type ConversationWindowCheckpointIdentity = {
+  workspaceId: string;
+  conversationId: string;
+  agentMessageId: string;
+  agentMessageVersion: number;
+  step: number;
+};
+
+export type ConversationWindowCheckpoint = {
+  version: typeof CONVERSATION_WINDOW_CHECKPOINT_VERSION;
+  // Reserved for invalidating cross-message checkpoints after earlier context changes.
+  // Same-agent-message schema v1 has no such mutation signal, so the epoch remains zero.
+  contextEpoch: 0;
+  identity: ConversationWindowCheckpointIdentity;
+  profileHash: string;
+  createdAtMs: number;
+  validUntilMs: number;
+  promptTokens: number;
+  toolDefinitionTokens: number;
+  missingActionCatcherFunctionCallIds: string[];
+  state: ConversationWindowStateSnapshot;
+};
+
+function checkpointPath(
+  identity: ConversationWindowCheckpointIdentity
+): string {
+  const component = (value: string | number) =>
+    encodeURIComponent(String(value));
+
+  return [
+    "conversation-window-checkpoints",
+    "w",
+    component(identity.workspaceId),
+    "conversations",
+    component(identity.conversationId),
+    "agent-messages",
+    component(identity.agentMessageId),
+    "versions",
+    component(identity.agentMessageVersion),
+    "schemas",
+    `v${CONVERSATION_WINDOW_CHECKPOINT_VERSION}`,
+    "steps",
+    `${component(identity.step)}.json`,
+  ].join("/");
+}
+
+function encodeCheckpoint(checkpoint: ConversationWindowCheckpoint): string {
+  const checkpointContent = JSON.stringify(checkpoint);
+  if (
+    Buffer.byteLength(checkpointContent) > MAX_EXPANDED_CHECKPOINT_SIZE_BYTES
+  ) {
+    throw new Error("Conversation window checkpoint is too large");
+  }
+
+  const content = JSON.stringify({
+    encoding: "gzip-base64",
+    payload: gzipSync(checkpointContent).toString("base64"),
+  });
+  if (Buffer.byteLength(content) > MAX_STORED_CHECKPOINT_SIZE_BYTES) {
+    throw new Error("Compressed conversation window checkpoint is too large");
+  }
+
+  return content;
+}
+
+const checkpointEnvelopeSchema = z
+  .object({
+    encoding: z.literal("gzip-base64"),
+    payload: z.string(),
+  })
+  .strict();
+
+const checkpointIdentitySchema = z
+  .object({
+    workspaceId: z.string(),
+    conversationId: z.string(),
+    agentMessageId: z.string(),
+    agentMessageVersion: z.number().int().nonnegative(),
+    step: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const conversationWindowCheckpointSchema: z.ZodType<ConversationWindowCheckpoint> =
+  z
+    .object({
+      version: z.literal(CONVERSATION_WINDOW_CHECKPOINT_VERSION),
+      contextEpoch: z.literal(0),
+      identity: checkpointIdentitySchema,
+      profileHash: z.string(),
+      createdAtMs: z.number().int().nonnegative(),
+      validUntilMs: z.number().int().nonnegative(),
+      promptTokens: z.number().int().nonnegative(),
+      toolDefinitionTokens: z.number().int().nonnegative(),
+      missingActionCatcherFunctionCallIds: z.array(z.string()),
+      state: ConversationWindowStateSnapshotSchema,
+    })
+    .strict();
+
+function decodeCheckpoint(
+  content: string
+): Result<ConversationWindowCheckpoint, Error> {
+  if (Buffer.byteLength(content) > MAX_STORED_CHECKPOINT_SIZE_BYTES) {
+    return new Err(
+      new Error("Compressed conversation window checkpoint is too large")
+    );
+  }
+
+  const rawEnvelopeResult = safeParseJSON(content);
+  if (rawEnvelopeResult.isErr()) {
+    return rawEnvelopeResult;
+  }
+
+  const envelopeResult = checkpointEnvelopeSchema.safeParse(
+    rawEnvelopeResult.value
+  );
+  if (!envelopeResult.success) {
+    return new Err(new Error(fromError(envelopeResult.error).toString()));
+  }
+
+  let checkpointContent: string;
+  try {
+    checkpointContent = gunzipSync(
+      Buffer.from(envelopeResult.data.payload, "base64"),
+      { maxOutputLength: MAX_EXPANDED_CHECKPOINT_SIZE_BYTES }
+    ).toString("utf8");
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+
+  const rawCheckpointResult = safeParseJSON(checkpointContent);
+  if (rawCheckpointResult.isErr()) {
+    return rawCheckpointResult;
+  }
+
+  const checkpointResult = conversationWindowCheckpointSchema.safeParse(
+    rawCheckpointResult.value
+  );
+  if (!checkpointResult.success) {
+    return new Err(new Error(fromError(checkpointResult.error).toString()));
+  }
+
+  return new Ok(checkpointResult.data);
+}
+
+function identitiesEqual(
+  left: ConversationWindowCheckpointIdentity,
+  right: ConversationWindowCheckpointIdentity
+): boolean {
+  return (
+    left.workspaceId === right.workspaceId &&
+    left.conversationId === right.conversationId &&
+    left.agentMessageId === right.agentMessageId &&
+    left.agentMessageVersion === right.agentMessageVersion &&
+    left.step === right.step
+  );
+}
+
+function parseGcsV4SignedUrlExpiryMs(value: string): number | null {
+  if (!value.includes("X-Goog-Date=") || !value.includes("X-Goog-Expires=")) {
+    return null;
+  }
+
+  if (!URL.canParse(value)) {
+    return null;
+  }
+  const url = new URL(value);
+
+  const signedAt = url.searchParams.get("X-Goog-Date");
+  const expiresInSeconds = Number(url.searchParams.get("X-Goog-Expires"));
+  if (!signedAt || !Number.isFinite(expiresInSeconds)) {
+    return null;
+  }
+
+  const match = signedAt.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/
+  );
+  if (!match) {
+    return null;
+  }
+
+  const [, year, month, day, hour, minute, second] = match;
+  return (
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second)
+    ) +
+    expiresInSeconds * 1000
+  );
+}
+
+function earliestImageSignedUrlExpiryMs(
+  state: ConversationWindowStateSnapshot
+): number | null {
+  let earliestMs: number | null = null;
+  const visitContent = (content: Content[]): void => {
+    for (const item of content) {
+      if (item.type !== "image_url") {
+        continue;
+      }
+
+      const expiryMs = parseGcsV4SignedUrlExpiryMs(item.image_url.url);
+      if (expiryMs !== null && (earliestMs === null || expiryMs < earliestMs)) {
+        earliestMs = expiryMs;
+      }
+    }
+  };
+
+  for (const interaction of state.interactions) {
+    for (const { message } of interaction.messages) {
+      switch (message.role) {
+        case "user":
+        case "content_fragment":
+          visitContent(message.content);
+          break;
+        case "function":
+          if (Array.isArray(message.content)) {
+            visitContent(message.content);
+          }
+          break;
+        case "assistant":
+        case "compaction":
+          break;
+        default:
+          assertNever(message);
+      }
+    }
+  }
+
+  return earliestMs;
+}
+
+// Skill activation is intentionally excluded. Its tool call, result, and instructions are
+// model-visible messages in the completed-step delta rather than request-level rendering inputs.
+export function computeConversationWindowProfileHash({
+  model,
+  prompt,
+  tools,
+  allowedTokenCount,
+  leadingMessages,
+  excludeActions = false,
+  excludeImages = false,
+  onMissingAction = "inject-placeholder",
+  agentConfigurationId,
+}: {
+  model: ModelConfigurationType;
+  prompt: string;
+  tools: string;
+  allowedTokenCount: number;
+  leadingMessages: ModelMessageTypeMultiActionsWithoutContentFragment[];
+  excludeActions?: boolean;
+  excludeImages?: boolean;
+  onMissingAction?: "inject-placeholder" | "skip";
+  agentConfigurationId?: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: CONVERSATION_WINDOW_CHECKPOINT_VERSION,
+        model,
+        prompt,
+        tools,
+        allowedTokenCount,
+        leadingMessages,
+        excludeActions,
+        excludeImages,
+        onMissingAction,
+        agentConfigurationId,
+      })
+    )
+    .digest("hex");
+}
+
+export function makeConversationWindowCheckpoint({
+  identity,
+  profileHash,
+  promptTokens,
+  toolDefinitionTokens,
+  missingActionCatcherFunctionCallIds = [],
+  state,
+  nowMs = Date.now(),
+}: {
+  identity: ConversationWindowCheckpointIdentity;
+  profileHash: string;
+  promptTokens: number;
+  toolDefinitionTokens: number;
+  missingActionCatcherFunctionCallIds?: string[];
+  state: ConversationWindowStateSnapshot;
+  nowMs?: number;
+}): ConversationWindowCheckpoint {
+  const signedUrlExpiryMs = earliestImageSignedUrlExpiryMs(state);
+  const maxValidUntilMs = nowMs + CHECKPOINT_MAX_AGE_MS;
+  const validUntilMs = signedUrlExpiryMs
+    ? Math.min(
+        maxValidUntilMs,
+        signedUrlExpiryMs - SIGNED_URL_EXPIRY_SAFETY_MARGIN_MS
+      )
+    : maxValidUntilMs;
+
+  return {
+    version: CONVERSATION_WINDOW_CHECKPOINT_VERSION,
+    contextEpoch: 0,
+    identity,
+    profileHash,
+    createdAtMs: nowMs,
+    validUntilMs,
+    promptTokens,
+    toolDefinitionTokens,
+    missingActionCatcherFunctionCallIds: [
+      ...missingActionCatcherFunctionCallIds,
+    ].sort(),
+    state,
+  };
+}
+
+export async function loadConversationWindowCheckpoint(
+  identity: ConversationWindowCheckpointIdentity,
+  { nowMs = Date.now() }: { nowMs?: number } = {}
+): Promise<Result<ConversationWindowCheckpoint | null, Error>> {
+  const storage = getPrivateUploadBucket();
+  let contentBuffer: Uint8Array<ArrayBuffer>;
+  try {
+    contentBuffer = await storage.fetchFileBuffer(checkpointPath(identity));
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Ok(null);
+    }
+    return new Err(normalizeError(error));
+  }
+
+  const checkpointResult = decodeCheckpoint(
+    Buffer.from(contentBuffer).toString("utf8")
+  );
+  if (checkpointResult.isErr()) {
+    return checkpointResult;
+  }
+  const checkpoint = checkpointResult.value;
+
+  if (
+    !identitiesEqual(checkpoint.identity, identity) ||
+    checkpoint.validUntilMs <= nowMs
+  ) {
+    return new Ok(null);
+  }
+  return new Ok(checkpoint);
+}
+
+export async function publishConversationWindowCheckpoint(
+  checkpoint: ConversationWindowCheckpoint
+): Promise<Result<ConversationWindowCheckpoint, Error>> {
+  const storage = getPrivateUploadBucket();
+  const filePath = checkpointPath(checkpoint.identity);
+  try {
+    await storage.uploadSmallRawContentToBucketAsNewFile({
+      content: encodeCheckpoint(checkpoint),
+      contentType: "application/json",
+      filePath,
+    });
+    return new Ok(checkpoint);
+  } catch (error) {
+    if (!isGCSPreconditionFailedError(error)) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  const winnerResult = await loadConversationWindowCheckpoint(
+    checkpoint.identity
+  );
+  if (winnerResult.isErr()) {
+    return winnerResult;
+  }
+  const winner = winnerResult.value;
+  if (!winner) {
+    return new Err(
+      new Error("Conversation window checkpoint winner is unavailable")
+    );
+  }
+  return new Ok(winner);
+}

--- a/front/lib/file_storage/signed_url_cache.ts
+++ b/front/lib/file_storage/signed_url_cache.ts
@@ -5,7 +5,7 @@ import {
 import { cacheWithRedis } from "@app/lib/utils/cache";
 
 // LLM providers may fetch a cached image URL several minutes after it was signed.
-export const MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS = 15 * 60 * 1000;
+export const MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS = 60 * 60 * 1000;
 
 // Cache TTL as a fraction of the signed URL's own expiration, so a served URL still has
 // real validity left instead of sitting right at its expiry.

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -25,6 +25,15 @@ interface MockFileMetadata {
   contentDisposition?: string;
 }
 
+class MockGcsError extends Error {
+  constructor(
+    readonly code: number,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
 // Minimal duck-typed stand-in for the GCS `File` objects `getSortedFileVersions` resolves to.
 // Callers (e.g. FileResource.revert()) only ever call `.copy(dest)` and `.delete()` on them.
 export interface MockFileVersion {
@@ -374,9 +383,27 @@ class FileStorageMock {
           return Promise.resolve(undefined);
         }
       ),
-      uploadSmallRawContentToBucketAsNewFile: vi
-        .fn()
-        .mockResolvedValue(undefined),
+      uploadSmallRawContentToBucketAsNewFile: vi.fn(
+        (args: { content: string; contentType: string; filePath: string }) => {
+          if (this._objectStore.has(args.filePath)) {
+            return Promise.reject(
+              new MockGcsError(412, `Object already exists: ${args.filePath}`)
+            );
+          }
+          if (this._saveShouldFail(args.filePath)) {
+            return Promise.reject(
+              new Error(`Simulated GCS write failure: ${args.filePath}`)
+            );
+          }
+          this._objectStore.set(args.filePath, args.content);
+          this._saveFileCalls.push({
+            filePath: args.filePath,
+            content: args.content,
+            contentType: args.contentType,
+          });
+          return Promise.resolve(undefined);
+        }
+      ),
       fetchFileContent: vi.fn((filePath: string) => {
         const stored = this._objectStore.get(filePath);
         if (stored !== undefined) {
@@ -389,14 +416,23 @@ class FileStorageMock {
         if (this._fetchNotFoundPredicate(filePath)) {
           // Same shape isGCSNotFoundError matches on real GCS ApiErrors.
           return Promise.reject(
-            Object.assign(new Error(`No such object: ${filePath}`), {
-              code: 404,
-            })
+            new MockGcsError(404, `No such object: ${filePath}`)
           );
         }
         return Promise.resolve("mock content");
       }),
-      fetchFileBuffer: vi.fn().mockResolvedValue(new Uint8Array()),
+      fetchFileBuffer: vi.fn((filePath: string) => {
+        const stored = this._objectStore.get(filePath);
+        if (stored !== undefined) {
+          return Promise.resolve(Uint8Array.from(Buffer.from(stored)));
+        }
+        if (this._fetchNotFoundPredicate(filePath)) {
+          return Promise.reject(
+            new MockGcsError(404, `No such object: ${filePath}`)
+          );
+        }
+        return Promise.resolve(new Uint8Array());
+      }),
       copyFile: vi.fn((src: string, dest: string) => {
         if (this._copyFileShouldFail(src, dest)) {
           return Promise.reject(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the durable storage layer required for stateful conversation windows across agent-loop steps.

Today, every model step rebuilds its context from authoritative conversation data and tokenizes the full rendered window again. The broader project will allow step N to start from the validated checkpoint produced by step N-1, then hydrate and tokenize only the new interaction data.

This PR focuses exclusively on persistence. It stores versioned conversation-window snapshots in GCS using an explicit path scoped by workspace, conversation, agent message, agent version, schema version, and step.
Checkpoints are compressed, validated when loaded, and written with create-once semantics so retries cannot silently overwrite an existing step. As content repeats heavily gzip compression is pretty impressive here!

The storage layer also distinguishes a missing checkpoint from an invalid or unavailable one, validates signed URL expiration before reuse, and keeps failures compatible with a later full-rendering fallback.

Nothing is wired into the agent loop yet, so this PR does not change conversation rendering behavior.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
