### PR TITLE
[front] enh: rewrite the unsaved-changes modal copy

### DIFF
--- a/front/hooks/useNavigationLock.tsx
+++ b/front/hooks/useNavigationLock.tsx
@@ -9,10 +9,10 @@ import React, { useCallback, useContext, useEffect } from "react";
 export function useNavigationLock(
   isEnabled = true,
   warningData = {
-    title: "Double checking",
-    message:
-      "You have unsaved changes - are you sure you wish to leave this page?",
-    validation: "primaryWarning",
+    title: "Discard your unsaved changes?",
+    message: "If you leave now, your latest edits won't be kept.",
+    validateLabel: "Discard",
+    cancelLabel: "Keep editing",
   }
 ) {
   const router = useAppRouter();


### PR DESCRIPTION
## Description

**WHAT**
Rewrites the copy of the confirm dialog that appears when you navigate away with unsaved changes.

**WHY**
Current copy and button create surprise and warning without clearly stating what is happening.
-> When closing a builder pager, the blocker is unexpected - "double checking" title does not give any clue on the type of risk - "OK" warning button does not help. Users tend to skip subtitle on first scan.
-> UX writing improvement : provide the key information directly in the title ("Discard your unsaved changes?") and make the action of the button straightforward ("Discard"). Keeps the warning but avoid unnecessary stress.

-------------------------------

Before:
- Title: `Double checking`
- Message: `You have unsaved changes - are you sure you wish to leave this page?`
- Buttons: `Cancel` / `OK`
<img width="1485" height="839" alt="image" src="https://github.com/user-attachments/assets/5bd9384f-ac61-4921-9a4e-c46ad90477b4" />



After:
- Title: `Discard your unsaved changes?`
- Message: `If you leave now, your latest edits won't be kept.`
- Buttons: `Keep editing` / `Discard`
<img width="1484" height="833" alt="image" src="https://github.com/user-attachments/assets/059fef76-3521-47c0-9544-d39949f7e59c" />


The copy lives in a default parameter on `useNavigationLock`, so this one change covers all four surfaces that use it, none of which override it:

- `AgentBuilder.tsx:711` — agent builder
- `SkillBuilder.tsx:144` — skill builder
- `DatasetPage.tsx:51` and `NewDatasetPage.tsx:43` — dataset editors

Two notes beyond the strings:

- The button labels were never set. They fell through to `Confirm.tsx`'s `"OK"` / `"Cancel"` defaults, which named no action. This sets `validateLabel` / `cancelLabel` explicitly.
- Drops the dead `validation: "primaryWarning"` key. It is not a field on `ConfirmDataType` and nothing reads it — it only survived because `warningData` is passed as a variable rather than an object literal, which skips TypeScript's excess-property check.

`validateVariant` is deliberately untouched, so the `Discard` button keeps rendering with `Confirm`'s `warning` default — unchanged from before, and the right signal for a destructive action.

## Tests

Typecheck (`npx tsgo` in `front`) and `biome check` both pass; the lefthook pre-commit hooks ran clean.

Not verified in a running app — this is a strings-only change to a default parameter, with no logic, no conditional rendering and no new props. There is no existing test coverage of `Confirm` or `useNavigationLock` to extend, and the dialog is not a Sparkle component, so it does not appear in Storybook.

Screenshot pending — flagging that I have not seen the rendered dialog, so a reviewer with a local stack should eyeball the two-line message wrapping in the `md` dialog width.

## Risk

Very low. Strings only, plus the removal of an already-inert object key. No API, schema or behaviour change; the dialog's trigger conditions, resolution logic and button variants are all untouched.

Worth a reviewer's attention: this changes copy on four surfaces at once. That is the intent, but if any of the four should keep distinct wording, the hook's `warningData` parameter already accepts a per-caller override.

Rollback is a straight revert of a single commit touching one file.

## Deploy Plan

Standard deploy, no ordering constraints, no migration, no feature flag.