### PR TITLE
Add Shopify customer listing tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2142,6 +2142,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
     },
   },
   "shopify": {
+    "list_customers": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "list_products": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
@@ -3320,6 +3324,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "update_incident": "low",
   },
   "shopify": {
+    "list_customers": "never_ask",
     "list_products": "never_ask",
   },
   "skill_authoring": {

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1782,6 +1782,10 @@ const QUERIES: LabeledQuery[] = [
     query: "list the products in my shopify store",
     expected: "shopify.list_products",
   },
+  {
+    query: "list the customers in my shopify store",
+    expected: "shopify.list_customers",
+  },
 ];
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -7,6 +7,7 @@ import type {
   ShopifyProduct,
 } from "@app/lib/api/actions/servers/shopify/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 const mocks = vi.hoisted(() => ({
   untrustedFetch: vi.fn(),
@@ -15,6 +16,23 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@app/lib/egress/server", () => ({
   untrustedFetch: mocks.untrustedFetch,
 }));
+
+const ShopifyRequestBodySchema = z.object({
+  query: z.string(),
+  variables: z.object({
+    first: z.number(),
+    after: z.string().nullable(),
+    query: z.string().nullable(),
+  }),
+});
+
+function parseRequestBody(init: RequestInit) {
+  if (typeof init.body !== "string") {
+    throw new Error("Expected Shopify request body to be a string.");
+  }
+
+  return ShopifyRequestBodySchema.parse(JSON.parse(init.body));
+}
 
 function customer(id: number): ShopifyCustomer {
   return {
@@ -129,7 +147,7 @@ describe("ShopifyClient.listCustomers", () => {
     expect(firstUrl).toBe(
       "https://my-store.myshopify.com/admin/api/2026-07/graphql.json"
     );
-    const firstBody = JSON.parse(firstInit.body as string);
+    const firstBody = parseRequestBody(firstInit);
     expect(firstBody.query).toContain("query ListCustomers");
     expect(firstBody.variables).toEqual({
       first: 3,
@@ -138,9 +156,7 @@ describe("ShopifyClient.listCustomers", () => {
         "state:ENABLED email:'jane.o\\'reilly@example.com' tag:'VIP Customers' country:FR",
     });
 
-    const secondBody = JSON.parse(
-      mocks.untrustedFetch.mock.calls[1][1].body as string
-    );
+    const secondBody = parseRequestBody(mocks.untrustedFetch.mock.calls[1][1]);
     expect(secondBody.variables).toMatchObject({
       first: 1,
       after: "cursor-2",
@@ -201,16 +217,14 @@ describe("ShopifyClient.listProducts", () => {
     expect(firstUrl).toBe(
       "https://my-store.myshopify.com/admin/api/2026-07/graphql.json"
     );
-    const firstBody = JSON.parse(firstInit.body as string);
+    const firstBody = parseRequestBody(firstInit);
     expect(firstBody.variables).toEqual({
       first: 3,
       after: null,
       query: "status:active vendor:'O\\'Reilly' tag:sale",
     });
 
-    const secondBody = JSON.parse(
-      mocks.untrustedFetch.mock.calls[1][1].body as string
-    );
+    const secondBody = parseRequestBody(mocks.untrustedFetch.mock.calls[1][1]);
     expect(secondBody.variables).toMatchObject({
       first: 1,
       after: "cursor-2",

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -2,7 +2,10 @@ import {
   createShopifyClient,
   ShopifyClient,
 } from "@app/lib/api/actions/servers/shopify/client";
-import type { ShopifyProduct } from "@app/lib/api/actions/servers/shopify/types";
+import type {
+  ShopifyCustomer,
+  ShopifyProduct,
+} from "@app/lib/api/actions/servers/shopify/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -12,6 +15,33 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@app/lib/egress/server", () => ({
   untrustedFetch: mocks.untrustedFetch,
 }));
+
+function customer(id: number): ShopifyCustomer {
+  return {
+    id: `gid://shopify/Customer/${id}`,
+    displayName: `Customer ${id}`,
+    firstName: "Customer",
+    lastName: `${id}`,
+    defaultEmailAddress: { emailAddress: `customer-${id}@example.com` },
+    defaultPhoneNumber: { phoneNumber: "+33123456789" },
+    state: "ENABLED",
+    numberOfOrders: `${id}`,
+    amountSpent: { amount: `${id * 10}.00`, currencyCode: "EUR" },
+    tags: ["VIP"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    defaultAddress: {
+      address1: "1 Dust Avenue",
+      address2: null,
+      city: "Paris",
+      province: null,
+      provinceCode: null,
+      country: "France",
+      countryCodeV2: "FR",
+      zip: "75001",
+    },
+  };
+}
 
 function product(id: number): ShopifyProduct {
   return {
@@ -44,6 +74,93 @@ function pageResponse(
     { status: 200 }
   );
 }
+
+function customerPageResponse(
+  customers: ShopifyCustomer[],
+  { hasNextPage, endCursor }: { hasNextPage: boolean; endCursor: string | null }
+) {
+  return new Response(
+    JSON.stringify({
+      data: {
+        customers: { nodes: customers, pageInfo: { hasNextPage, endCursor } },
+      },
+    }),
+    { status: 200 }
+  );
+}
+
+describe("ShopifyClient.listCustomers", () => {
+  beforeEach(() => {
+    mocks.untrustedFetch.mockReset();
+  });
+
+  it("paginates customers up to the requested limit and sends filters as variables", async () => {
+    mocks.untrustedFetch
+      .mockResolvedValueOnce(
+        customerPageResponse([customer(1), customer(2)], {
+          hasNextPage: true,
+          endCursor: "cursor-2",
+        })
+      )
+      .mockResolvedValueOnce(
+        customerPageResponse([customer(3)], {
+          hasNextPage: false,
+          endCursor: null,
+        })
+      );
+    const client = new ShopifyClient("access-token", "my-store.myshopify.com");
+
+    const result = await client.listCustomers({
+      state: "ENABLED",
+      email: "jane.o'reilly@example.com",
+      tag: "VIP Customers",
+      searchQuery: "country:FR",
+      limit: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.customers).toHaveLength(3);
+    expect(mocks.untrustedFetch).toHaveBeenCalledTimes(2);
+
+    const [firstUrl, firstInit] = mocks.untrustedFetch.mock.calls[0];
+    expect(firstUrl).toBe(
+      "https://my-store.myshopify.com/admin/api/2026-07/graphql.json"
+    );
+    const firstBody = JSON.parse(firstInit.body as string);
+    expect(firstBody.query).toContain("query ListCustomers");
+    expect(firstBody.variables).toEqual({
+      first: 3,
+      after: null,
+      query:
+        "state:ENABLED email:'jane.o\\'reilly@example.com' tag:'VIP Customers' country:FR",
+    });
+
+    const secondBody = JSON.parse(
+      mocks.untrustedFetch.mock.calls[1][1].body as string
+    );
+    expect(secondBody.variables).toMatchObject({
+      first: 1,
+      after: "cursor-2",
+    });
+  });
+
+  it("identifies the required customer scope when authentication fails", async () => {
+    mocks.untrustedFetch.mockResolvedValueOnce(
+      new Response("Forbidden", { status: 403 })
+    );
+    const client = new ShopifyClient("access-token", "my-store.myshopify.com");
+
+    const result = await client.listCustomers({ limit: 10 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("read_customers scope");
+    }
+  });
+});
 
 describe("ShopifyClient.listProducts", () => {
   beforeEach(() => {
@@ -78,7 +195,6 @@ describe("ShopifyClient.listProducts", () => {
       return;
     }
     expect(result.value.products).toHaveLength(3);
-    expect(result.value.truncated).toBe(false);
     expect(mocks.untrustedFetch).toHaveBeenCalledTimes(2);
 
     const [firstUrl, firstInit] = mocks.untrustedFetch.mock.calls[0];

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -1,10 +1,15 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
 import type {
+  CustomerListResult,
   ProductListResult,
+  ShopifyCustomer,
+  ShopifyCustomerState,
   ShopifyProduct,
 } from "@app/lib/api/actions/servers/shopify/types";
-import { ProductNodeSchema } from "@app/lib/api/actions/servers/shopify/types";
+import {
+  CustomerNodeSchema,
+  ProductNodeSchema,
+} from "@app/lib/api/actions/servers/shopify/types";
 import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
 import { normalizeShopifyStoreDomain } from "@app/types/oauth/lib";
@@ -16,6 +21,38 @@ import { z } from "zod";
 
 const SHOPIFY_API_VERSION = "2026-07";
 const PAGE_SIZE = 250;
+
+const CUSTOMERS_QUERY = `
+  query ListCustomers($first: Int!, $after: String, $query: String) {
+    customers(first: $first, after: $after, query: $query) {
+      nodes {
+        id
+        displayName
+        firstName
+        lastName
+        defaultEmailAddress { emailAddress }
+        defaultPhoneNumber { phoneNumber }
+        state
+        numberOfOrders
+        amountSpent { amount currencyCode }
+        tags
+        createdAt
+        updatedAt
+        defaultAddress {
+          address1
+          address2
+          city
+          province
+          provinceCode
+          country
+          countryCodeV2
+          zip
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
 
 const PRODUCTS_QUERY = `
   query ListProducts($first: Int!, $after: String, $query: String) {
@@ -40,6 +77,16 @@ const PRODUCTS_QUERY = `
   }
 `;
 
+const CustomersDataSchema = z.object({
+  customers: z.object({
+    nodes: z.array(CustomerNodeSchema),
+    pageInfo: z.object({
+      hasNextPage: z.boolean(),
+      endCursor: z.string().nullable(),
+    }),
+  }),
+});
+
 const ProductsDataSchema = z.object({
   products: z.object({
     nodes: z.array(ProductNodeSchema),
@@ -50,10 +97,7 @@ const ProductsDataSchema = z.object({
   }),
 });
 
-const ProductsResponseSchema = z.object({
-  data: ProductsDataSchema.nullish(),
-  errors: z.array(z.object({ message: z.string() })).optional(),
-});
+const GraphQLErrorSchema = z.object({ message: z.string() });
 
 function quoteSearchValue(value: string): string {
   return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
@@ -65,24 +109,19 @@ export class ShopifyClient {
     private readonly storeDomain: string
   ) {}
 
-  private async fetchProductsPage({
-    first,
-    after,
+  private async fetchGraphQL<T>({
     query,
+    variables,
+    dataSchema,
+    resourceName,
+    requiredScope,
   }: {
-    first: number;
-    after: string | null;
-    query: string | null;
-  }): Promise<
-    Result<
-      {
-        products: ShopifyProduct[];
-        hasNextPage: boolean;
-        endCursor: string | null;
-      },
-      MCPError
-    >
-  > {
+    query: string;
+    variables: Record<string, unknown>;
+    dataSchema: z.ZodType<T>;
+    resourceName: "customer" | "product";
+    requiredScope: "read_customers" | "read_products";
+  }): Promise<Result<T, MCPError>> {
     const url = `https://${this.storeDomain}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
     let response: Awaited<ReturnType<typeof untrustedFetch>>;
     try {
@@ -92,10 +131,7 @@ export class ShopifyClient {
           "Content-Type": "application/json",
           "X-Shopify-Access-Token": this.accessToken,
         },
-        body: JSON.stringify({
-          query: PRODUCTS_QUERY,
-          variables: { first, after, query },
-        }),
+        body: JSON.stringify({ query, variables }),
       });
     } catch (error) {
       return new Err(
@@ -110,7 +146,7 @@ export class ShopifyClient {
       if (response.status === 401 || response.status === 403) {
         return new Err(
           new MCPError(
-            "Shopify authentication failed. Reconnect the Shopify tool and ensure the app has the read_products scope.",
+            `Shopify authentication failed. Reconnect the Shopify tool and ensure the app has the ${requiredScope} scope.`,
             { tracked: false }
           )
         );
@@ -135,11 +171,15 @@ export class ShopifyClient {
       );
     }
 
-    const parsed = ProductsResponseSchema.safeParse(payload);
+    const responseSchema = z.object({
+      data: dataSchema.nullish(),
+      errors: z.array(GraphQLErrorSchema).optional(),
+    });
+    const parsed = responseSchema.safeParse(payload);
     if (!parsed.success) {
       logger.error(
-        { error: parsed.error.message },
-        "[Shopify MCP Server] Product response validation failed"
+        { error: parsed.error.message, resourceName },
+        "[Shopify MCP Server] Response validation failed"
       );
       return new Err(
         new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
@@ -157,16 +197,133 @@ export class ShopifyClient {
     }
     if (errors?.length) {
       logger.warn(
-        { errors: errors.map((error) => error.message) },
-        "[Shopify MCP Server] Partial product response"
+        { errors: errors.map((error) => error.message), resourceName },
+        "[Shopify MCP Server] Partial response"
       );
     }
 
-    return new Ok({
-      products: data.products.nodes,
-      hasNextPage: data.products.pageInfo.hasNextPage,
-      endCursor: data.products.pageInfo.endCursor,
+    return new Ok(data);
+  }
+
+  private async fetchCustomersPage({
+    first,
+    after,
+    query,
+  }: {
+    first: number;
+    after: string | null;
+    query: string | null;
+  }): Promise<
+    Result<
+      {
+        customers: ShopifyCustomer[];
+        hasNextPage: boolean;
+        endCursor: string | null;
+      },
+      MCPError
+    >
+  > {
+    const data = await this.fetchGraphQL({
+      query: CUSTOMERS_QUERY,
+      variables: { first, after, query },
+      dataSchema: CustomersDataSchema,
+      resourceName: "customer",
+      requiredScope: "read_customers",
     });
+    if (data.isErr()) {
+      return data;
+    }
+
+    return new Ok({
+      customers: data.value.customers.nodes,
+      hasNextPage: data.value.customers.pageInfo.hasNextPage,
+      endCursor: data.value.customers.pageInfo.endCursor,
+    });
+  }
+
+  private async fetchProductsPage({
+    first,
+    after,
+    query,
+  }: {
+    first: number;
+    after: string | null;
+    query: string | null;
+  }): Promise<
+    Result<
+      {
+        products: ShopifyProduct[];
+        hasNextPage: boolean;
+        endCursor: string | null;
+      },
+      MCPError
+    >
+  > {
+    const data = await this.fetchGraphQL({
+      query: PRODUCTS_QUERY,
+      variables: { first, after, query },
+      dataSchema: ProductsDataSchema,
+      resourceName: "product",
+      requiredScope: "read_products",
+    });
+    if (data.isErr()) {
+      return data;
+    }
+
+    return new Ok({
+      products: data.value.products.nodes,
+      hasNextPage: data.value.products.pageInfo.hasNextPage,
+      endCursor: data.value.products.pageInfo.endCursor,
+    });
+  }
+
+  async listCustomers({
+    state,
+    email,
+    tag,
+    searchQuery,
+    limit,
+  }: {
+    state?: ShopifyCustomerState;
+    email?: string;
+    tag?: string;
+    searchQuery?: string;
+    limit: number;
+  }): Promise<Result<CustomerListResult, MCPError>> {
+    const filters: string[] = [];
+    if (state) {
+      filters.push(`state:${state}`);
+    }
+    if (email) {
+      filters.push(`email:${quoteSearchValue(email)}`);
+    }
+    if (tag) {
+      filters.push(`tag:${quoteSearchValue(tag)}`);
+    }
+    if (searchQuery) {
+      filters.push(searchQuery);
+    }
+
+    const customers: ShopifyCustomer[] = [];
+    let cursor: string | null = null;
+    while (customers.length < limit) {
+      const page = await this.fetchCustomersPage({
+        first: Math.min(PAGE_SIZE, limit - customers.length),
+        after: cursor,
+        query: filters.length > 0 ? filters.join(" ") : null,
+      });
+      if (page.isErr()) {
+        return page;
+      }
+
+      customers.push(...page.value.customers);
+      if (!page.value.hasNextPage || !page.value.endCursor) {
+        return new Ok({ customers });
+      }
+      cursor = page.value.endCursor;
+    }
+
+    return new Ok({ customers });
   }
 
   async listProducts({
@@ -180,7 +337,6 @@ export class ShopifyClient {
     searchQuery?: string;
     limit: number;
   }): Promise<Result<ProductListResult, MCPError>> {
-    const cap = Math.min(limit, MAX_EXPORT_ITEMS);
     const filters: string[] = [];
     if (status) {
       filters.push(`status:${status.toLowerCase()}`);
@@ -194,9 +350,9 @@ export class ShopifyClient {
 
     const products: ShopifyProduct[] = [];
     let cursor: string | null = null;
-    while (products.length < cap) {
+    while (products.length < limit) {
       const page = await this.fetchProductsPage({
-        first: Math.min(PAGE_SIZE, cap - products.length),
+        first: Math.min(PAGE_SIZE, limit - products.length),
         after: cursor,
         query: filters.length > 0 ? filters.join(" ") : null,
       });
@@ -206,15 +362,12 @@ export class ShopifyClient {
 
       products.push(...page.value.products);
       if (!page.value.hasNextPage || !page.value.endCursor) {
-        return new Ok({ products: products.slice(0, cap), truncated: false });
+        return new Ok({ products });
       }
       cursor = page.value.endCursor;
     }
 
-    return new Ok({
-      products: products.slice(0, cap),
-      truncated: cap === MAX_EXPORT_ITEMS,
-    });
+    return new Ok({ products });
   }
 }
 

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -1,2 +1,3 @@
-// Hard cap on exported records to keep responses and API usage bounded.
-export const MAX_EXPORT_ITEMS = 1_000;
+// The default matches Shopify's GraphQL page size, while the maximum bounds total results.
+export const DEFAULT_LIST_LIMIT = 250;
+export const MAX_LIST_LIMIT = 1_000;

--- a/front/lib/api/actions/servers/shopify/metadata.test.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.test.ts
@@ -1,0 +1,24 @@
+import {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+} from "@app/lib/api/actions/servers/shopify/helpers";
+import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
+import { describe, expect, it } from "vitest";
+
+describe("Shopify list tool metadata", () => {
+  it("applies the default and maximum to every list tool", () => {
+    for (const tool of SHOPIFY_TOOLS_METADATA) {
+      expect(tool.schema.limit.safeParse(undefined)).toEqual({
+        success: true,
+        data: DEFAULT_LIST_LIMIT,
+      });
+      expect(tool.schema.limit.safeParse(MAX_LIST_LIMIT).success).toBe(true);
+      expect(tool.schema.limit.safeParse(MAX_LIST_LIMIT + 1).success).toBe(
+        false
+      );
+      expect(tool.schema.limit.description).toContain(
+        `default: ${DEFAULT_LIST_LIMIT}, max: ${MAX_LIST_LIMIT}`
+      );
+    }
+  });
+});

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -1,4 +1,9 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+} from "@app/lib/api/actions/servers/shopify/helpers";
+import { ShopifyCustomerStateSchema } from "@app/lib/api/actions/servers/shopify/types";
 import { z } from "zod";
 
 export const SHOPIFY_SERVER_NAME = "shopify" as const;
@@ -8,11 +13,41 @@ const limitSchema = (noun: string) =>
     .number()
     .int()
     .positive()
-    .max(1000)
+    .max(MAX_LIST_LIMIT)
     .optional()
-    .describe(`Maximum number of ${noun} to return (max 1000).`);
+    .default(DEFAULT_LIST_LIMIT)
+    .describe(
+      `Maximum number of ${noun} to return (default: ${DEFAULT_LIST_LIMIT}, max: ${MAX_LIST_LIMIT}).`
+    );
 
 export const SHOPIFY_TOOLS_METADATA = [
+  {
+    name: "list_customers",
+    description:
+      "List Shopify customers with contact details, account state, order count, total spend, tags, and default address.",
+    schema: {
+      state: ShopifyCustomerStateSchema.optional().describe(
+        "Filter by customer account state."
+      ),
+      email: z
+        .string()
+        .optional()
+        .describe("Filter by exact customer email address."),
+      tag: z.string().optional().describe("Filter by exact customer tag."),
+      searchQuery: z
+        .string()
+        .optional()
+        .describe("Additional Shopify customer search query."),
+      limit: limitSchema("customers"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing Shopify customers",
+      done: "List Shopify customers",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
   {
     name: "list_products",
     description:

--- a/front/lib/api/actions/servers/shopify/rendering.ts
+++ b/front/lib/api/actions/servers/shopify/rendering.ts
@@ -1,16 +1,17 @@
-import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
-import type { ProductListResult } from "@app/lib/api/actions/servers/shopify/types";
+import type {
+  CustomerListResult,
+  ProductListResult,
+} from "@app/lib/api/actions/servers/shopify/types";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function renderCustomerList({
+  customers,
+}: CustomerListResult): CallToolResult["content"] {
+  return [{ type: "text", text: JSON.stringify(customers, null, 2) }];
+}
 
 export function renderProductList({
   products,
-  truncated,
 }: ProductListResult): CallToolResult["content"] {
-  const summary = truncated
-    ? `Listed ${products.length} products (truncated at the ${MAX_EXPORT_ITEMS}-product cap).`
-    : `Listed ${products.length} products.`;
-  return [
-    { type: "text", text: summary },
-    { type: "text", text: JSON.stringify(products, null, 2) },
-  ];
+  return [{ type: "text", text: JSON.stringify(products, null, 2) }];
 }

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,12 +1,34 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createShopifyClient } from "@app/lib/api/actions/servers/shopify/client";
-import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
-import { renderProductList } from "@app/lib/api/actions/servers/shopify/rendering";
+import {
+  renderCustomerList,
+  renderProductList,
+} from "@app/lib/api/actions/servers/shopify/rendering";
 import { Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
+  list_customers: async (
+    { state, email, tag, searchQuery, limit },
+    { authInfo }
+  ) => {
+    const client = createShopifyClient(authInfo);
+    if (client.isErr()) {
+      return client;
+    }
+    const customers = await client.value.listCustomers({
+      state,
+      email,
+      tag,
+      searchQuery,
+      limit,
+    });
+    if (customers.isErr()) {
+      return customers;
+    }
+    return new Ok(renderCustomerList(customers.value));
+  },
   list_products: async (
     { status, vendor, searchQuery, limit },
     { authInfo }
@@ -19,7 +41,7 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
       status,
       vendor,
       searchQuery,
-      limit: limit ?? MAX_EXPORT_ITEMS,
+      limit,
     });
     if (products.isErr()) {
       return products;

--- a/front/lib/api/actions/servers/shopify/types.ts
+++ b/front/lib/api/actions/servers/shopify/types.ts
@@ -5,6 +5,55 @@ const MoneySchema = z.object({
   currencyCode: z.string(),
 });
 
+export const ShopifyCustomerStateSchema = z.enum([
+  "DECLINED",
+  "DISABLED",
+  "ENABLED",
+  "INVITED",
+]);
+
+export const CustomerNodeSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  defaultEmailAddress: z
+    .object({
+      emailAddress: z.string(),
+    })
+    .nullable(),
+  defaultPhoneNumber: z
+    .object({
+      phoneNumber: z.string(),
+    })
+    .nullable(),
+  state: ShopifyCustomerStateSchema,
+  numberOfOrders: z.string(),
+  amountSpent: MoneySchema,
+  tags: z.array(z.string()),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  defaultAddress: z
+    .object({
+      address1: z.string().nullable(),
+      address2: z.string().nullable(),
+      city: z.string().nullable(),
+      province: z.string().nullable(),
+      provinceCode: z.string().nullable(),
+      country: z.string().nullable(),
+      countryCodeV2: z.string().nullable(),
+      zip: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+export type ShopifyCustomerState = z.infer<typeof ShopifyCustomerStateSchema>;
+export type ShopifyCustomer = z.infer<typeof CustomerNodeSchema>;
+
+export interface CustomerListResult {
+  customers: ShopifyCustomer[];
+}
+
 export const ProductNodeSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -25,5 +74,4 @@ export type ShopifyProduct = z.infer<typeof ProductNodeSchema>;
 
 export interface ProductListResult {
   products: ShopifyProduct[];
-  truncated: boolean;
 }


### PR DESCRIPTION
## Description

- Add a list_customers tool with filters for account state, email, tag, and Shopify search syntax.
- Return validated customer contact, order, spend, tag, timestamp, and default-address data.
- Default product and customer list limits to 250, reject limits above 1,000, and paginate Shopify GraphQL requests in batches of 250 (Shopify API accepts 250)
- Return list payloads directly without a redundant summary block.

## Tests

- NODE_ENV=test npm test -- lib/api/actions/servers/shopify/metadata.test.ts lib/api/actions/servers/shopify/client.test.ts
- NODE_ENV=test npm test -- --reporter verbose ./lib/api/actions/servers/bm25_tool_search.test.ts
- NODE_ENV=test npm test -- lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts

## Risk

Low. The new operation is read-only, external responses are validated with Zod, and list sizes are bounded.

## Deploy Plan

- deploy front