### PR TITLE
[front] Replace rolling_out FF stage, clarify stage names

### DIFF
--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -4,6 +4,7 @@ import type {
   FeatureFlagStage,
   WhitelistableFeature,
 } from "@app/types/shared/feature_flags";
+import { getFeatureFlagOwner } from "@app/types/shared/feature_flags";
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -28,7 +29,12 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Stage" />
       ),
-      cell: ({ row }) => <FeatureFlagStageChip stage={row.original.stage} />,
+      cell: ({ row }) => (
+        <FeatureFlagStageChip
+          stage={row.original.stage}
+          owner={getFeatureFlagOwner(row.original.name)}
+        />
+      ),
     },
     {
       accessorKey: "description",

--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -4,7 +4,6 @@ import type {
   FeatureFlagStage,
   WhitelistableFeature,
 } from "@app/types/shared/feature_flags";
-import { getFeatureFlagOwner } from "@app/types/shared/feature_flags";
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -29,12 +28,7 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Stage" />
       ),
-      cell: ({ row }) => (
-        <FeatureFlagStageChip
-          stage={row.original.stage}
-          owner={getFeatureFlagOwner(row.original.name)}
-        />
-      ),
+      cell: ({ row }) => <FeatureFlagStageChip flagName={row.original.name} />,
     },
     {
       accessorKey: "description",

--- a/front/components/poke/features/stage_chip.tsx
+++ b/front/components/poke/features/stage_chip.tsx
@@ -16,7 +16,7 @@ export function FeatureFlagStageChip({ stage }: FeatureFlagStageChipProps) {
     );
   }
 
-  const warningStages: FeatureFlagStage[] = ["dust_only", "rolling_out"];
+  const warningStages: FeatureFlagStage[] = ["dust_only", "ask_eng"];
 
   return (
     <Chip

--- a/front/components/poke/features/stage_chip.tsx
+++ b/front/components/poke/features/stage_chip.tsx
@@ -1,22 +1,18 @@
-import type { FeatureFlagStage } from "@app/types/shared/feature_flags";
 import {
   FEATURE_FLAG_STAGE_DESCRIPTIONS,
   FEATURE_FLAG_STAGE_LABELS,
+  isWhitelistableFeature,
+  WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
 import { Chip, Tooltip } from "@dust-tt/sparkle";
 
 interface FeatureFlagStageChipProps {
-  // `null` for flag rows whose name is no longer in WHITELISTABLE_FEATURES_CONFIG.
-  stage: FeatureFlagStage | null;
-  // GitHub handle of the eng owner; `null` for legacy flag rows.
-  owner?: string | null;
+  // A name no longer in WHITELISTABLE_FEATURES_CONFIG renders as a legacy chip.
+  flagName: string;
 }
 
-export function FeatureFlagStageChip({
-  stage,
-  owner,
-}: FeatureFlagStageChipProps) {
-  if (!stage) {
+export function FeatureFlagStageChip({ flagName }: FeatureFlagStageChipProps) {
+  if (!isWhitelistableFeature(flagName)) {
     return (
       <Chip color="info" size="xs">
         Legacy
@@ -24,23 +20,17 @@ export function FeatureFlagStageChip({
     );
   }
 
-  const warningStages: FeatureFlagStage[] = ["dust_only", "ask_owner"];
-
-  const tooltipLabel = owner
-    ? `${FEATURE_FLAG_STAGE_DESCRIPTIONS[stage]}\nOwner: @${owner}`
-    : FEATURE_FLAG_STAGE_DESCRIPTIONS[stage];
+  const { stage, owner } = WHITELISTABLE_FEATURES_CONFIG[flagName];
+  const isWarningStage = stage === "dust_only" || stage === "ask_owner";
 
   return (
     <Tooltip
       trigger={
-        <Chip
-          color={warningStages.includes(stage) ? "warning" : "highlight"}
-          size="xs"
-        >
+        <Chip color={isWarningStage ? "warning" : "highlight"} size="xs">
           {FEATURE_FLAG_STAGE_LABELS[stage]}
         </Chip>
       }
-      label={tooltipLabel}
+      label={`${FEATURE_FLAG_STAGE_DESCRIPTIONS[stage]}\nOwner: @${owner}`}
     />
   );
 }

--- a/front/components/poke/features/stage_chip.tsx
+++ b/front/components/poke/features/stage_chip.tsx
@@ -8,7 +8,7 @@ import { Chip, Tooltip } from "@dust-tt/sparkle";
 interface FeatureFlagStageChipProps {
   // `null` for flag rows whose name is no longer in WHITELISTABLE_FEATURES_CONFIG.
   stage: FeatureFlagStage | null;
-  // GitHub handle of the eng owner, for `ask_owner` flags.
+  // GitHub handle of the eng owner; `null` for legacy flag rows.
   owner?: string | null;
 }
 

--- a/front/components/poke/features/stage_chip.tsx
+++ b/front/components/poke/features/stage_chip.tsx
@@ -1,13 +1,21 @@
 import type { FeatureFlagStage } from "@app/types/shared/feature_flags";
-import { FEATURE_FLAG_STAGE_LABELS } from "@app/types/shared/feature_flags";
-import { Chip } from "@dust-tt/sparkle";
+import {
+  FEATURE_FLAG_STAGE_DESCRIPTIONS,
+  FEATURE_FLAG_STAGE_LABELS,
+} from "@app/types/shared/feature_flags";
+import { Chip, Tooltip } from "@dust-tt/sparkle";
 
 interface FeatureFlagStageChipProps {
   // `null` for flag rows whose name is no longer in WHITELISTABLE_FEATURES_CONFIG.
   stage: FeatureFlagStage | null;
+  // GitHub handle of the eng owner, for `ask_owner` flags.
+  owner?: string | null;
 }
 
-export function FeatureFlagStageChip({ stage }: FeatureFlagStageChipProps) {
+export function FeatureFlagStageChip({
+  stage,
+  owner,
+}: FeatureFlagStageChipProps) {
   if (!stage) {
     return (
       <Chip color="info" size="xs">
@@ -16,14 +24,23 @@ export function FeatureFlagStageChip({ stage }: FeatureFlagStageChipProps) {
     );
   }
 
-  const warningStages: FeatureFlagStage[] = ["dust_only", "ask_eng"];
+  const warningStages: FeatureFlagStage[] = ["dust_only", "ask_owner"];
+
+  const tooltipLabel = owner
+    ? `${FEATURE_FLAG_STAGE_DESCRIPTIONS[stage]}\nOwner: @${owner}`
+    : FEATURE_FLAG_STAGE_DESCRIPTIONS[stage];
 
   return (
-    <Chip
-      color={warningStages.includes(stage) ? "warning" : "highlight"}
-      size="xs"
-    >
-      {FEATURE_FLAG_STAGE_LABELS[stage]}
-    </Chip>
+    <Tooltip
+      trigger={
+        <Chip
+          color={warningStages.includes(stage) ? "warning" : "highlight"}
+          size="xs"
+        >
+          {FEATURE_FLAG_STAGE_LABELS[stage]}
+        </Chip>
+      }
+      label={tooltipLabel}
+    />
   );
 }

--- a/front/components/poke/pages/FeatureFlagDetailPage.tsx
+++ b/front/components/poke/pages/FeatureFlagDetailPage.tsx
@@ -9,7 +9,6 @@ import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeListPluginForResourceType } from "@app/poke/swr/plugins";
 import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
-  getFeatureFlagOwner,
   isWhitelistableFeature,
   WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
@@ -214,10 +213,7 @@ export function FeatureFlagDetailPage() {
         </LinkWrapper>
         <div className="mt-2 flex items-center gap-3">
           <h1 className="font-mono text-2xl font-bold">{flagName}</h1>
-          <FeatureFlagStageChip
-            stage={flagConfig?.stage ?? null}
-            owner={getFeatureFlagOwner(flagName)}
-          />
+          <FeatureFlagStageChip flagName={flagName} />
           {globalRolloutPercentage !== null && (
             <span className="text-sm text-muted-foreground">
               global rollout: {globalRolloutPercentage}%

--- a/front/components/poke/pages/FeatureFlagDetailPage.tsx
+++ b/front/components/poke/pages/FeatureFlagDetailPage.tsx
@@ -9,6 +9,7 @@ import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeListPluginForResourceType } from "@app/poke/swr/plugins";
 import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
+  getFeatureFlagOwner,
   isWhitelistableFeature,
   WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
@@ -213,7 +214,10 @@ export function FeatureFlagDetailPage() {
         </LinkWrapper>
         <div className="mt-2 flex items-center gap-3">
           <h1 className="font-mono text-2xl font-bold">{flagName}</h1>
-          <FeatureFlagStageChip stage={flagConfig?.stage ?? null} />
+          <FeatureFlagStageChip
+            stage={flagConfig?.stage ?? null}
+            owner={getFeatureFlagOwner(flagName)}
+          />
           {globalRolloutPercentage !== null && (
             <span className="text-sm text-muted-foreground">
               global rollout: {globalRolloutPercentage}%

--- a/front/components/poke/pages/FeatureFlagsPage.tsx
+++ b/front/components/poke/pages/FeatureFlagsPage.tsx
@@ -10,7 +10,6 @@ import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
   FEATURE_FLAG_STAGE_LABELS,
   FEATURE_FLAG_STAGES,
-  getFeatureFlagOwner,
 } from "@app/types/shared/feature_flags";
 import { Button, LinkWrapper, Pencil01, Trash01 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -61,12 +60,7 @@ function makeColumns({
         <PokeColumnSortableHeader column={column} label="Stage" />
       ),
       filterFn: (row, id, value) => value.includes(row.getValue(id)),
-      cell: ({ row }) => (
-        <FeatureFlagStageChip
-          stage={row.original.stage}
-          owner={getFeatureFlagOwner(row.original.name)}
-        />
-      ),
+      cell: ({ row }) => <FeatureFlagStageChip flagName={row.original.name} />,
     },
     {
       accessorKey: "workspaceCount",

--- a/front/components/poke/pages/FeatureFlagsPage.tsx
+++ b/front/components/poke/pages/FeatureFlagsPage.tsx
@@ -10,6 +10,7 @@ import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
   FEATURE_FLAG_STAGE_LABELS,
   FEATURE_FLAG_STAGES,
+  getFeatureFlagOwner,
 } from "@app/types/shared/feature_flags";
 import { Button, LinkWrapper, Pencil01, Trash01 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -60,7 +61,12 @@ function makeColumns({
         <PokeColumnSortableHeader column={column} label="Stage" />
       ),
       filterFn: (row, id, value) => value.includes(row.getValue(id)),
-      cell: ({ row }) => <FeatureFlagStageChip stage={row.original.stage} />,
+      cell: ({ row }) => (
+        <FeatureFlagStageChip
+          stage={row.original.stage}
+          owner={getFeatureFlagOwner(row.original.name)}
+        />
+      ),
     },
     {
       accessorKey: "workspaceCount",

--- a/front/components/poke/pages/FeatureFlagsPage.tsx
+++ b/front/components/poke/pages/FeatureFlagsPage.tsx
@@ -10,6 +10,8 @@ import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
   FEATURE_FLAG_STAGE_LABELS,
   FEATURE_FLAG_STAGES,
+  isWhitelistableFeature,
+  WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
 import { Button, LinkWrapper, Pencil01, Trash01 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -61,6 +63,23 @@ function makeColumns({
       ),
       filterFn: (row, id, value) => value.includes(row.getValue(id)),
       cell: ({ row }) => <FeatureFlagStageChip flagName={row.original.name} />,
+    },
+    {
+      id: "owner",
+      accessorFn: (flag) =>
+        isWhitelistableFeature(flag.name)
+          ? WHITELISTABLE_FEATURES_CONFIG[flag.name].owner
+          : null,
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Owner" />
+      ),
+      cell: ({ row }) => {
+        const owner = row.getValue<string | null>("owner");
+        if (!owner) {
+          return <span className="text-muted-foreground">—</span>;
+        }
+        return <span className="text-sm">@{owner}</span>;
+      },
     },
     {
       accessorKey: "workspaceCount",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -503,11 +503,3 @@ export function isWhitelistableFeature(
 ): feature is WhitelistableFeature {
   return WHITELISTABLE_FEATURES.includes(feature as WhitelistableFeature);
 }
-
-// Returns `null` only for legacy flag names no longer in WHITELISTABLE_FEATURES_CONFIG.
-export function getFeatureFlagOwner(feature: string): string | null {
-  if (!isWhitelistableFeature(feature)) {
-    return null;
-  }
-  return WHITELISTABLE_FEATURES_CONFIG[feature].owner;
-}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -8,6 +8,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   frames_v2: {
     description: "Enable Frames v2",
     stage: "dust_only",
+    owner: "fontanierh",
   },
   allow_sso: {
     description:

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -103,7 +103,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
-    stage: "rolling_out",
+    stage: "ask_eng",
   },
   http_client_tool: {
     description: "HTTP Client MCP tool for making external API requests",
@@ -137,7 +137,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   self_created_slack_app_connector_rollout: {
     description:
       "Slack Connection: rollout for self-created Slack app connector",
-    stage: "rolling_out",
+    stage: "ask_eng",
   },
   salesforce_tool: {
     description:
@@ -373,17 +373,20 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
 } as const satisfies Record<string, FeatureFlag>;
 
-export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";
+// dust_only: cannot be activated outside Dust workspaces, the feature is not ready.
+// ask_eng: ask the eng owner before activating.
+// on_demand: safe to activate if you understand the feature and its impact on the workspace.
+export type FeatureFlagStage = "dust_only" | "ask_eng" | "on_demand";
 
 export const FEATURE_FLAG_STAGE_LABELS: Record<FeatureFlagStage, string> = {
   dust_only: "Dust-only",
-  rolling_out: "Rolling out",
+  ask_eng: "Ask eng",
   on_demand: "On demand",
 };
 
 export const FEATURE_FLAG_STAGES = [
   "dust_only",
-  "rolling_out",
+  "ask_eng",
   "on_demand",
 ] as const satisfies readonly FeatureFlagStage[];
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -161,7 +161,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
-    stage: "self_serve",
+    stage: "ask_owner",
     owner: "PopDaph",
   },
   self_created_slack_app_connector_rollout: {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -3,6 +3,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Allow fresh Pods and standalone conversations to use the database-backed filesystem",
     stage: "dust_only",
+    owner: "flvndvd",
   },
   frames_v2: {
     description: "Enable Frames v2",
@@ -12,94 +13,115 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Allow this workspace to configure SSO, independently of the plan's isSSOAllowed flag. Enable on demand for Business plan workspaces.",
     stage: "self_serve",
+    owner: "tdraier",
   },
   allow_scim: {
     description:
       "Allow this workspace to configure SCIM user provisioning, independently of the plan's isSCIMAllowed flag. Enable on demand.",
     stage: "self_serve",
+    owner: "tdraier",
   },
   live_speech_to_text: {
     description:
       "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",
     stage: "dust_only",
+    owner: "adrsimon",
   },
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   anthropic_vertex_fallback: {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
+    owner: "flvndvd",
   },
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",
     stage: "self_serve",
+    owner: "pmilliotte",
   },
   audit_logs: {
     description: "Enable audit log emission via WorkOS",
     stage: "self_serve",
+    owner: "smb2268",
   },
   custom_model_feature: {
     description: "Access to custom models loaded from external config",
     stage: "dust_only",
+    owner: "flvndvd",
   },
   dust_internal_global_agents: {
     description:
       "Access to internal global agents (dust-edge, dust-quick, dust-oai, dust-goog, custom model agents and their variants)",
     stage: "dust_only",
+    owner: "fontanierh",
   },
   gpt_5_6_terra_long_context: {
     description: "Access to GPT 5.6 Terra with its full context window",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   dust_agent_sonnet_5_default: {
     description: "Use Claude Sonnet 5 as the default model for the @dust agent",
     stage: "dust_only",
+    owner: "pmilliotte",
   },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   claude_4_opus_feature: {
     description: "Access to Claude 4 Opus model in the agent builder",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   claude_4_5_opus_feature: {
     description:
       "Access to Claude Opus and GPT 5.6 Sol models in the agent builder",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   claude_fable_5_feature: {
     description:
       "Access to Claude Fable 5 model (served through the EAP Anthropic key)",
     stage: "dust_only",
+    owner: "fontanierh",
   },
   deepseek_feature: {
     description:
       "Access to DeepSeek models (they cannot use tool so can't be selected in the agent builder)",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   fireworks_new_model_feature: {
     description: "Access to Fireworks new model",
     stage: "self_serve",
+    owner: "pmilliotte",
   },
   dev_mcp_actions: {
     description: "MCP tools currently in development",
     stage: "dust_only",
+    owner: "adrsimon",
   },
   exa_people_and_company: {
     description: "Access to Exa MCP server (search_people, search_companies)",
     stage: "dust_only",
+    owner: "spolu",
   },
   disable_run_logs: {
     description: "Disable logging of agent runs",
     stage: "dust_only",
+    owner: "spolu",
   },
   disable_computer_feature: {
     description: "Disable all Computer sandbox features for this workspace",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
@@ -109,31 +131,38 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   http_client_tool: {
     description: "HTTP Client MCP tool for making external API requests",
     stage: "self_serve",
+    owner: "frankaloia",
   },
   index_private_slack_channel: {
     description: "Allow indexing of private Slack channels",
     stage: "self_serve",
+    owner: "spolu",
   },
   labs_transcripts: {
     description: "Transcript feature (Labs)",
     stage: "self_serve",
+    owner: "frankaloia",
   },
   openai_o1_feature: {
     description: "Access to OpenAI o1 model",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   openai_usage_mcp: {
     description: "OpenAI tool for tracking API consumption and costs",
     stage: "self_serve",
+    owner: "frankaloia",
   },
   openai_concise_reasoning_summaries: {
     description:
       "Use concise reasoning summaries for supported OpenAI models in the new LLM router",
     stage: "dust_only",
+    owner: "fontanierh",
   },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "self_serve",
+    owner: "PopDaph",
   },
   self_created_slack_app_connector_rollout: {
     description:
@@ -145,233 +174,282 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Salesforce MCP tool (activated by default on most plans, FF to override the plan config)",
     stage: "self_serve",
+    owner: "PopDaph",
   },
   show_debug_tools: {
     description: "Display debug tools in the interface",
     stage: "dust_only",
+    owner: "spolu",
   },
   usage_data_api: {
     description:
       "API for accessing usage data (Means that any builder with an API key can access usage data of the workspace from API)",
     stage: "self_serve",
+    owner: "flvndvd",
   },
   usage_page_read_only: {
     description:
       "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",
     stage: "self_serve",
+    owner: "tdraier",
   },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "self_serve",
+    owner: "fontanierh",
   },
   noop_model_feature: {
     description: "Access to noop model in the agent builder",
     stage: "dust_only",
+    owner: "davidebbo",
   },
   slack_message_splitting: {
     description:
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
     stage: "self_serve",
+    owner: "frankaloia",
   },
   legacy_dust_apps: {
     description: "Access to legacy Dust Apps (editor and associated tools)",
     stage: "self_serve",
+    owner: "spolu",
   },
   power_bi_mcp: {
     description: "Power BI MCP tool for querying semantic models and DAX",
     stage: "self_serve",
+    owner: "LeandreLeBizec",
   },
   netsuite_mcp: {
     description:
       "NetSuite MCP tool for querying records and interacting with your NetSuite account",
     stage: "self_serve",
+    owner: "LeandreLeBizec",
   },
   dust_internal_dangerous_in_cluster_mcp_servers: {
     description:
       "EXPERIMENTAL FEATURE. DUST INTERNAL ONLY. Allow remote MCP servers pointing at hosts on the MCP_IN_CLUSTER_HOSTS allowlist, reached in-cluster instead of through the untrusted egress proxy.",
     stage: "dust_only",
+    owner: "id13",
   },
   discord_bot: {
     description:
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
+    owner: "frankaloia",
   },
   databricks_tool: {
     description: "Databricks MCP tool",
     stage: "self_serve",
+    owner: "FlagBenett",
   },
   servicenow_tool: {
     description: "ServiceNow MCP tool",
     stage: "self_serve",
+    owner: "thomasvicaire",
   },
   shopify_tool: {
     description: "Shopify MCP tool",
     stage: "self_serve",
+    owner: "spolu",
   },
   sandbox_functions: {
     description: "Enable Pod Function invocation endpoints",
     stage: "dust_only",
+    owner: "spolu",
   },
   run_tools_from_prompt: {
     description: "Enable /run command to directly call tools without LLM",
     stage: "dust_only",
+    owner: "davidebbo",
   },
   conversations_slack_notifications: {
     description: "Enable slack notifications",
     stage: "dust_only",
+    owner: "matteotrab",
   },
   reinforced_agents: {
     description:
       "Enable self-improvement (background analysis of conversations to suggest improvements to skills).",
     stage: "self_serve",
+    owner: "davidebbo",
   },
   self_improvement_beta_tester: {
     description:
       "Self-improvement runs for free: consumption is not reported to billing (Metronome or programmatic usage).",
     stage: "self_serve",
+    owner: "fabiencelier",
   },
   collapsible_messages: {
     description: "Enable collapsible messages in conversations",
     stage: "dust_only",
+    owner: "ykmsd",
   },
   conversation_consumption_details: {
     description:
       "Show the detailed credit attribution for agent messages in conversations",
     stage: "dust_only",
+    owner: "flvndvd",
   },
   poke_mcp: {
     description: "Enable the Poke MCP server for cross-workspace data access.",
     stage: "dust_only",
+    owner: "aubin-tchoi",
   },
   legacy_billing: {
     description:
       "Force this workspace to use legacy Stripe billing, bypassing Metronome credit-priced plans regardless of the global kill switch.",
     stage: "self_serve",
+    owner: "tdraier",
   },
   plan_mode: {
     description:
       "Enable the Plan Mode skill: agents maintain a live plan.md for genuinely multi-step tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",
+    owner: "PopDaph",
   },
   skill_favorites: {
     description:
       "Enable user favorites for skills, including favorite controls and runtime skill availability.",
     stage: "dust_only",
+    owner: "aubin-tchoi",
   },
   allow_old_notion_mcp: {
     description:
       "Allow individual workspaces to keep using the old internal Notion MCP server alongside the official one",
-    stage: "on_demand",
+    stage: "self_serve",
+    owner: "davidebbo",
   },
   use_dust_keys: {
     description:
       "Force BYOK workspaces to use Dust-managed keys instead of customer-provided keys",
     // Not really self-serve but we want to be able to enable it for customers
     stage: "self_serve",
+    owner: "pmilliotte",
   },
   dummy_feature_for_flag_testing: {
     description: "Dummy feature flag used for testing feature flag behavior",
     stage: "dust_only",
+    owner: "davidebbo",
   },
   sensitivity_labels: {
     description:
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",
     stage: "self_serve",
+    owner: "tdraier",
   },
   restricted_spaces_in_input_bar: {
     description:
       "Allow users to explicitly select Spaces from the conversation input bar.",
     stage: "dust_only",
+    owner: "fontanierh",
   },
   disable_formatting_prompt: {
     description:
       "Skip injecting the OpenAI formatting meta prompt entirely (no markdown/paragraph style guidance)",
     stage: "dust_only",
+    owner: "fontanierh",
   },
   workspace_default_agent: {
     description:
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",
     stage: "self_serve",
+    owner: "davidebbo",
   },
   whitelabel_frames: {
     description:
       "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",
     stage: "self_serve",
+    owner: "flvndvd",
   },
   models_picker: {
     description:
       "Model picker in the conversation input bar: keep Auto (the agent's configured model) or pick a specific model and reasoning effort.",
     stage: "self_serve",
+    owner: "Nils-Fedrigo",
   },
   activation_force_nudge: {
     description:
       "Bypass the activated-user check in the activation orchestrator so already-activated users are still nudged",
     stage: "dust_only",
+    owner: "frankaloia",
   },
   dust_pod_goal: {
     description:
       "Enable the Dust Pod Goal skill for persistent job loops in Pods",
     stage: "dust_only",
+    owner: "frankaloia",
   },
   admin_controlled_pods: {
     description:
       "Enable admin-controlled Pods: admins manage membership and attach connected data (Space DataSourceViews) to the Pod itself.",
     stage: "dust_only",
+    owner: "Fraggle",
   },
   pod_frame_tabs: {
     description:
       "Allow adding frames from the pod file system as custom tabs (title, icon, order) on the pod.",
     stage: "dust_only",
+    owner: "Fraggle",
   },
   pod_applications: {
     description:
       "Enable the Pod Apps UI: browse, import, clone, export and delete the apps published on a Pod.",
     stage: "dust_only",
+    owner: "davidebbo",
   },
   group_permissions_shadow: {
     description:
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",
     stage: "dust_only",
+    owner: "philipperolet",
   },
   user_memory: {
     description:
       "Enable the user_memory internal MCP server: agents can store and retrieve per-user memory in a user-scoped filesystem.",
     stage: "dust_only",
+    owner: "PopDaph",
   },
   similar_agents_check: {
     description:
       "Warn users about similar existing agents before they create a duplicate in the agent builder.",
     stage: "self_serve",
+    owner: "avervaet",
   },
   enforce_user_spend_limit_rate_cap: {
     description:
       "Enable the Redis fixed-window spend-cap backups (per-user, per-API-key, programmatic, and workspace usage cap): record AWU usage into the counters and enforce them at message send. When off, usage is neither recorded nor enforced.",
     stage: "dust_only",
+    owner: "tdraier",
   },
   enforce_premium_model_message_limit: {
     description:
       "Enforce the premium-model cap: once the user has spent 25 premium-tier messages in the rolling week, run the message on the Standard stream instead, on workspaces with a non-credit-priced (legacy) plan. Usage is counted regardless, so the flag only controls enforcement.",
     stage: "dust_only",
+    owner: "id13",
   },
   editable_tool_inputs: {
     description:
       "Allow editing tool inputs before approving a tool call in the tool validation UI.",
     stage: "dust_only",
+    owner: "matteotrab",
   },
   skip_free_usage_rate_limit: {
     description:
       "Skip the per-user daily free-usage cost cap enforced at the LLM call site. Escape hatch to unstick legitimate workspaces that legitimately exceed the free-usage limit.",
     stage: "self_serve",
+    owner: "fabiencelier",
   },
   disable_fair_use_awu_limit: {
     description:
       "Disable the per-user fair-use AWU credit limit on this workspace: skip both the pre-message enforcement (read) and the usage recording (write). Escape hatch for workspaces that should not be subject to the fair-use cap.",
     stage: "self_serve",
+    owner: "tdraier",
   },
   archive_inactive_agents: {
     description:
       "Allow this workspace to preview and archive agents that have not been mentioned for a configurable number of days.",
     stage: "self_serve",
+    owner: "achilleburah",
   },
 } as const satisfies Record<string, FeatureFlag>;
 
@@ -398,17 +476,12 @@ export const FEATURE_FLAG_STAGES = [
   "self_serve",
 ] as const satisfies readonly FeatureFlagStage[];
 
-export type FeatureFlag =
-  | {
-      description: string;
-      stage: "dust_only" | "self_serve";
-    }
-  | {
-      description: string;
-      stage: "ask_owner";
-      // GitHub handle of the eng owner to ask before activating.
-      owner: string;
-    };
+export type FeatureFlag = {
+  description: string;
+  stage: FeatureFlagStage;
+  // GitHub handle of the eng owner of the feature.
+  owner: string;
+};
 
 export type WhitelistableFeature = keyof typeof WHITELISTABLE_FEATURES_CONFIG;
 
@@ -431,10 +504,10 @@ export function isWhitelistableFeature(
   return WHITELISTABLE_FEATURES.includes(feature as WhitelistableFeature);
 }
 
+// Returns `null` only for legacy flag names no longer in WHITELISTABLE_FEATURES_CONFIG.
 export function getFeatureFlagOwner(feature: string): string | null {
   if (!isWhitelistableFeature(feature)) {
     return null;
   }
-  const config: FeatureFlag = WHITELISTABLE_FEATURES_CONFIG[feature];
-  return config.stage === "ask_owner" ? config.owner : null;
+  return WHITELISTABLE_FEATURES_CONFIG[feature].owner;
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -11,12 +11,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   allow_sso: {
     description:
       "Allow this workspace to configure SSO, independently of the plan's isSSOAllowed flag. Enable on demand for Business plan workspaces.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   allow_scim: {
     description:
       "Allow this workspace to configure SCIM user provisioning, independently of the plan's isSCIMAllowed flag. Enable on demand.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   live_speech_to_text: {
     description:
@@ -26,7 +26,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   anthropic_vertex_fallback: {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
@@ -35,11 +35,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   audit_logs: {
     description: "Enable audit log emission via WorkOS",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   custom_model_feature: {
     description: "Access to custom models loaded from external config",
@@ -52,7 +52,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   gpt_5_6_terra_long_context: {
     description: "Access to GPT 5.6 Terra with its full context window",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   dust_agent_sonnet_5_default: {
     description: "Use Claude Sonnet 5 as the default model for the @dust agent",
@@ -60,16 +60,16 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   claude_4_opus_feature: {
     description: "Access to Claude 4 Opus model in the agent builder",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   claude_4_5_opus_feature: {
     description:
       "Access to Claude Opus and GPT 5.6 Sol models in the agent builder",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   claude_fable_5_feature: {
     description:
@@ -79,11 +79,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   deepseek_feature: {
     description:
       "Access to DeepSeek models (they cannot use tool so can't be selected in the agent builder)",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   fireworks_new_model_feature: {
     description: "Access to Fireworks new model",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   dev_mcp_actions: {
     description: "MCP tools currently in development",
@@ -99,31 +99,32 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   disable_computer_feature: {
     description: "Disable all Computer sandbox features for this workspace",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
-    stage: "ask_eng",
+    stage: "ask_owner",
+    owner: "frankaloia",
   },
   http_client_tool: {
     description: "HTTP Client MCP tool for making external API requests",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   index_private_slack_channel: {
     description: "Allow indexing of private Slack channels",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   labs_transcripts: {
     description: "Transcript feature (Labs)",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   openai_o1_feature: {
     description: "Access to OpenAI o1 model",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   openai_usage_mcp: {
     description: "OpenAI tool for tracking API consumption and costs",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   openai_concise_reasoning_summaries: {
     description:
@@ -132,17 +133,18 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   self_created_slack_app_connector_rollout: {
     description:
       "Slack Connection: rollout for self-created Slack app connector",
-    stage: "ask_eng",
+    stage: "ask_owner",
+    owner: "fabiencelier",
   },
   salesforce_tool: {
     description:
       "Salesforce MCP tool (activated by default on most plans, FF to override the plan config)",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   show_debug_tools: {
     description: "Display debug tools in the interface",
@@ -151,16 +153,16 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   usage_data_api: {
     description:
       "API for accessing usage data (Means that any builder with an API key can access usage data of the workspace from API)",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   usage_page_read_only: {
     description:
       "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   noop_model_feature: {
     description: "Access to noop model in the agent builder",
@@ -169,20 +171,20 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   slack_message_splitting: {
     description:
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   legacy_dust_apps: {
     description: "Access to legacy Dust Apps (editor and associated tools)",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   power_bi_mcp: {
     description: "Power BI MCP tool for querying semantic models and DAX",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   netsuite_mcp: {
     description:
       "NetSuite MCP tool for querying records and interacting with your NetSuite account",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   dust_internal_dangerous_in_cluster_mcp_servers: {
     description:
@@ -196,15 +198,15 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   databricks_tool: {
     description: "Databricks MCP tool",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   servicenow_tool: {
     description: "ServiceNow MCP tool",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   shopify_tool: {
     description: "Shopify MCP tool",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   sandbox_functions: {
     description: "Enable Pod Function invocation endpoints",
@@ -221,12 +223,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   reinforced_agents: {
     description:
       "Enable self-improvement (background analysis of conversations to suggest improvements to skills).",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   self_improvement_beta_tester: {
     description:
       "Self-improvement runs for free: consumption is not reported to billing (Metronome or programmatic usage).",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   collapsible_messages: {
     description: "Enable collapsible messages in conversations",
@@ -244,7 +246,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   legacy_billing: {
     description:
       "Force this workspace to use legacy Stripe billing, bypassing Metronome credit-priced plans regardless of the global kill switch.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   plan_mode: {
     description:
@@ -264,8 +266,8 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   use_dust_keys: {
     description:
       "Force BYOK workspaces to use Dust-managed keys instead of customer-provided keys",
-    // Not really on_demand but we want to be able to enable it for customers
-    stage: "on_demand",
+    // Not really self-serve but we want to be able to enable it for customers
+    stage: "self_serve",
   },
   dummy_feature_for_flag_testing: {
     description: "Dummy feature flag used for testing feature flag behavior",
@@ -274,7 +276,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   sensitivity_labels: {
     description:
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   restricted_spaces_in_input_bar: {
     description:
@@ -289,17 +291,17 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   workspace_default_agent: {
     description:
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   whitelabel_frames: {
     description:
       "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   models_picker: {
     description:
       "Model picker in the conversation input bar: keep Auto (the agent's configured model) or pick a specific model and reasoning effort.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   activation_force_nudge: {
     description:
@@ -339,7 +341,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   similar_agents_check: {
     description:
       "Warn users about similar existing agents before they create a duplicate in the agent builder.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   enforce_user_spend_limit_rate_cap: {
     description:
@@ -359,41 +361,54 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   skip_free_usage_rate_limit: {
     description:
       "Skip the per-user daily free-usage cost cap enforced at the LLM call site. Escape hatch to unstick legitimate workspaces that legitimately exceed the free-usage limit.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   disable_fair_use_awu_limit: {
     description:
       "Disable the per-user fair-use AWU credit limit on this workspace: skip both the pre-message enforcement (read) and the usage recording (write). Escape hatch for workspaces that should not be subject to the fair-use cap.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
   archive_inactive_agents: {
     description:
       "Allow this workspace to preview and archive agents that have not been mentioned for a configurable number of days.",
-    stage: "on_demand",
+    stage: "self_serve",
   },
 } as const satisfies Record<string, FeatureFlag>;
 
-// dust_only: cannot be activated outside Dust workspaces, the feature is not ready.
-// ask_eng: ask the eng owner before activating.
-// on_demand: safe to activate if you understand the feature and its impact on the workspace.
-export type FeatureFlagStage = "dust_only" | "ask_eng" | "on_demand";
+export type FeatureFlagStage = "dust_only" | "ask_owner" | "self_serve";
 
 export const FEATURE_FLAG_STAGE_LABELS: Record<FeatureFlagStage, string> = {
   dust_only: "Dust-only",
-  ask_eng: "Ask eng",
-  on_demand: "On demand",
+  ask_owner: "Ask owner",
+  self_serve: "Self-serve",
 };
+
+export const FEATURE_FLAG_STAGE_DESCRIPTIONS: Record<FeatureFlagStage, string> =
+  {
+    dust_only:
+      "Cannot be activated outside Dust workspaces, the feature is not ready.",
+    ask_owner: "Ask the eng owner before activating.",
+    self_serve:
+      "Safe to activate if you understand the feature and its impact on the workspace.",
+  };
 
 export const FEATURE_FLAG_STAGES = [
   "dust_only",
-  "ask_eng",
-  "on_demand",
+  "ask_owner",
+  "self_serve",
 ] as const satisfies readonly FeatureFlagStage[];
 
-export type FeatureFlag = {
-  description: string;
-  stage: FeatureFlagStage;
-};
+export type FeatureFlag =
+  | {
+      description: string;
+      stage: "dust_only" | "self_serve";
+    }
+  | {
+      description: string;
+      stage: "ask_owner";
+      // GitHub handle of the eng owner to ask before activating.
+      owner: string;
+    };
 
 export type WhitelistableFeature = keyof typeof WHITELISTABLE_FEATURES_CONFIG;
 
@@ -414,4 +429,12 @@ export function isWhitelistableFeature(
   feature: unknown
 ): feature is WhitelistableFeature {
   return WHITELISTABLE_FEATURES.includes(feature as WhitelistableFeature);
+}
+
+export function getFeatureFlagOwner(feature: string): string | null {
+  if (!isWhitelistableFeature(feature)) {
+    return null;
+  }
+  const config: FeatureFlag = WHITELISTABLE_FEATURES_CONFIG[feature];
+  return config.stage === "ask_owner" ? config.owner : null;
 }


### PR DESCRIPTION
Deprecates the `rolling_out` feature flag stage and renames the others by activation policy.

Stages are now:
- `dust_only`: cannot be activated outside Dust workspaces, the feature is not ready.
- `ask_owner`: ask the eng owner before activating.
- `self_serve`: safe to activate if you understand the feature and its impact on the workspace.

The two `rolling_out` flags (`google_sheets_tool`, `self_created_slack_app_connector_rollout`) move to `ask_owner`.

Every flag now carries a required `owner` field (GitHub handle), from the ownership sheet. The poke stage chip shows the stage description and owner in a tooltip.

Stage and owner are static config only, no migration.