### PR TITLE
[front] Page the Poke agent conversations list

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
@@ -1,0 +1,105 @@
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function dateFromDaysAgo(daysAgo: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return date;
+}
+
+describe("GET /api/poke/workspaces/:wId/conversations", () => {
+  it("pages the agent conversations, newest first", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const otherAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Other Test Agent",
+    });
+
+    const oldestConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(10)],
+      conversationCreatedAt: dateFromDaysAgo(10),
+    });
+    const middleConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(5)],
+      conversationCreatedAt: dateFromDaysAgo(5),
+    });
+    const newestConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+      conversationCreatedAt: dateFromDaysAgo(1),
+    });
+    const otherAgentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: otherAgent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+      conversationCreatedAt: dateFromDaysAgo(1),
+    });
+
+    const url = `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}`;
+
+    const firstResponse = await honoApp.request(`${url}&limit=2`);
+    expect(firstResponse.status).toBe(200);
+    const firstPage = await firstResponse.json();
+    expect(firstPage.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+      newestConversation.sId,
+      middleConversation.sId,
+    ]);
+    expect(firstPage.hasMore).toBe(true);
+
+    const secondResponse = await honoApp.request(`${url}&limit=3`);
+    expect(secondResponse.status).toBe(200);
+    const secondPage = await secondResponse.json();
+    expect(secondPage.conversations.map((c: { sId: string }) => c.sId)).toEqual(
+      [newestConversation.sId, middleConversation.sId, oldestConversation.sId]
+    );
+    expect(secondPage.hasMore).toBe(false);
+    expect(
+      secondPage.conversations.map((c: { sId: string }) => c.sId)
+    ).not.toContain(otherAgentConversation.sId);
+  });
+
+  it("defaults the limit when none is provided", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+    });
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversations).toEqual([
+      expect.objectContaining({ sId: conversation.sId }),
+    ]);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("rejects a request with no agent, trigger or reinforced skill", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations`
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
@@ -66,6 +66,111 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
     ).not.toContain(otherAgentConversation.sId);
   });
 
+  it("restricts the agent conversations to the created-at window", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const januaryConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-15T12:00:00.000Z")],
+      conversationCreatedAt: new Date("2026-01-15T12:00:00.000Z"),
+    });
+    const februaryConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-02-20T12:00:00.000Z")],
+      conversationCreatedAt: new Date("2026-02-20T12:00:00.000Z"),
+    });
+    const marchConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-03-10T12:00:00.000Z")],
+      conversationCreatedAt: new Date("2026-03-10T12:00:00.000Z"),
+    });
+
+    const url = `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}`;
+
+    const rangeResponse = await honoApp.request(
+      `${url}&from=2026-02-01&to=2026-02-28`
+    );
+    expect(rangeResponse.status).toBe(200);
+    const range = await rangeResponse.json();
+    expect(range.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+      februaryConversation.sId,
+    ]);
+
+    const fromOnlyResponse = await honoApp.request(`${url}&from=2026-02-01`);
+    expect(fromOnlyResponse.status).toBe(200);
+    const fromOnly = await fromOnlyResponse.json();
+    expect(fromOnly.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+      marchConversation.sId,
+      februaryConversation.sId,
+    ]);
+
+    const toOnlyResponse = await honoApp.request(`${url}&to=2026-02-20`);
+    expect(toOnlyResponse.status).toBe(200);
+    const toOnly = await toOnlyResponse.json();
+    // `to` is inclusive, so the conversation created during that day is kept.
+    expect(toOnly.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+      februaryConversation.sId,
+      januaryConversation.sId,
+    ]);
+  });
+
+  it("pages within the created-at window", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-10T12:00:00.000Z")],
+      conversationCreatedAt: new Date("2026-01-10T12:00:00.000Z"),
+    });
+    const newerInWindow = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-20T12:00:00.000Z")],
+      conversationCreatedAt: new Date("2026-01-20T12:00:00.000Z"),
+    });
+    // Outside the window, and newer than everything in it.
+    await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-05-01T12:00:00.000Z")],
+      conversationCreatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}&from=2026-01-01&to=2026-01-31&limit=1`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+      newerInWindow.sId,
+    ]);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("rejects a malformed date bound", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}&from=not-a-date`
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   it("defaults the limit when none is provided", async () => {
     const { auth, workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
@@ -10,8 +10,12 @@ function dateFromDaysAgo(daysAgo: number): Date {
   return date;
 }
 
+function sIds(conversations: { sId: string }[]): string[] {
+  return conversations.map((conversation) => conversation.sId);
+}
+
 describe("GET /api/poke/workspaces/:wId/conversations", () => {
-  it("pages the agent conversations, newest first", async () => {
+  it("pages the agent conversations by offset, newest first", async () => {
     const { auth, workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
       role: "admin",
@@ -45,25 +49,102 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
 
     const url = `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}`;
 
-    const firstResponse = await honoApp.request(`${url}&limit=2`);
+    const firstResponse = await honoApp.request(`${url}&limit=2&offset=0`);
     expect(firstResponse.status).toBe(200);
     const firstPage = await firstResponse.json();
-    expect(firstPage.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+    expect(sIds(firstPage.conversations)).toEqual([
       newestConversation.sId,
       middleConversation.sId,
     ]);
-    expect(firstPage.hasMore).toBe(true);
+    // The count spans the whole matching set, not the page.
+    expect(firstPage.totalCount).toBe(3);
 
-    const secondResponse = await honoApp.request(`${url}&limit=3`);
+    const secondResponse = await honoApp.request(`${url}&limit=2&offset=2`);
     expect(secondResponse.status).toBe(200);
     const secondPage = await secondResponse.json();
-    expect(secondPage.conversations.map((c: { sId: string }) => c.sId)).toEqual(
-      [newestConversation.sId, middleConversation.sId, oldestConversation.sId]
+    expect(sIds(secondPage.conversations)).toEqual([oldestConversation.sId]);
+    expect(secondPage.totalCount).toBe(3);
+
+    expect([
+      ...sIds(firstPage.conversations),
+      ...sIds(secondPage.conversations),
+    ]).not.toContain(otherAgentConversation.sId);
+  });
+
+  it("returns an empty page past the end", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+    });
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}&limit=25&offset=100`
     );
-    expect(secondPage.hasMore).toBe(false);
-    expect(
-      secondPage.conversations.map((c: { sId: string }) => c.sId)
-    ).not.toContain(otherAgentConversation.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversations).toEqual([]);
+  });
+
+  it("orders the agent conversations by the requested column", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const oldest = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(10)],
+      conversationCreatedAt: dateFromDaysAgo(10),
+    });
+    const newest = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+      conversationCreatedAt: dateFromDaysAgo(1),
+    });
+
+    const url = `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}`;
+
+    const ascendingResponse = await honoApp.request(
+      `${url}&orderColumn=createdAt&orderDirection=asc`
+    );
+    expect(ascendingResponse.status).toBe(200);
+    expect(sIds((await ascendingResponse.json()).conversations)).toEqual([
+      oldest.sId,
+      newest.sId,
+    ]);
+
+    const descendingResponse = await honoApp.request(
+      `${url}&orderColumn=createdAt&orderDirection=desc`
+    );
+    expect(descendingResponse.status).toBe(200);
+    expect(sIds((await descendingResponse.json()).conversations)).toEqual([
+      newest.sId,
+      oldest.sId,
+    ]);
+  });
+
+  it("rejects an unknown order column", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}&orderColumn=hasError`
+    );
+
+    expect(response.status).toBe(400);
   });
 
   it("restricts the agent conversations to the created-at window", async () => {
@@ -97,23 +178,21 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
     );
     expect(rangeResponse.status).toBe(200);
     const range = await rangeResponse.json();
-    expect(range.conversations.map((c: { sId: string }) => c.sId)).toEqual([
-      februaryConversation.sId,
-    ]);
+    expect(sIds(range.conversations)).toEqual([februaryConversation.sId]);
+    // The count follows the window, so the page count does too.
+    expect(range.totalCount).toBe(1);
 
     const fromOnlyResponse = await honoApp.request(`${url}&from=2026-02-01`);
     expect(fromOnlyResponse.status).toBe(200);
-    const fromOnly = await fromOnlyResponse.json();
-    expect(fromOnly.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+    expect(sIds((await fromOnlyResponse.json()).conversations)).toEqual([
       marchConversation.sId,
       februaryConversation.sId,
     ]);
 
     const toOnlyResponse = await honoApp.request(`${url}&to=2026-02-20`);
     expect(toOnlyResponse.status).toBe(200);
-    const toOnly = await toOnlyResponse.json();
     // `to` is inclusive, so the conversation created during that day is kept.
-    expect(toOnly.conversations.map((c: { sId: string }) => c.sId)).toEqual([
+    expect(sIds((await toOnlyResponse.json()).conversations)).toEqual([
       februaryConversation.sId,
       januaryConversation.sId,
     ]);
@@ -127,7 +206,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
 
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
 
-    await ConversationFactory.create(auth, {
+    const olderInWindow = await ConversationFactory.create(auth, {
       agentConfigurationId: agent.sId,
       messagesCreatedAt: [new Date("2026-01-10T12:00:00.000Z")],
       conversationCreatedAt: new Date("2026-01-10T12:00:00.000Z"),
@@ -144,16 +223,19 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
       conversationCreatedAt: new Date("2026-05-01T12:00:00.000Z"),
     });
 
-    const response = await honoApp.request(
-      `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}&from=2026-01-01&to=2026-01-31&limit=1`
-    );
+    const url = `/api/poke/workspaces/${workspace.sId}/conversations?agentId=${agent.sId}&from=2026-01-01&to=2026-01-31&limit=1`;
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.conversations.map((c: { sId: string }) => c.sId)).toEqual([
-      newerInWindow.sId,
+    const firstResponse = await honoApp.request(`${url}&offset=0`);
+    expect(firstResponse.status).toBe(200);
+    const firstPage = await firstResponse.json();
+    expect(sIds(firstPage.conversations)).toEqual([newerInWindow.sId]);
+    expect(firstPage.totalCount).toBe(2);
+
+    const secondResponse = await honoApp.request(`${url}&offset=1`);
+    expect(secondResponse.status).toBe(200);
+    expect(sIds((await secondResponse.json()).conversations)).toEqual([
+      olderInWindow.sId,
     ]);
-    expect(body.hasMore).toBe(true);
   });
 
   it("rejects a malformed date bound", async () => {
@@ -171,7 +253,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
     expect(response.status).toBe(400);
   });
 
-  it("defaults the limit when none is provided", async () => {
+  it("defaults the paging and ordering when none is provided", async () => {
     const { auth, workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
       role: "admin",
@@ -189,10 +271,8 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.conversations).toEqual([
-      expect.objectContaining({ sId: conversation.sId }),
-    ]);
-    expect(body.hasMore).toBe(false);
+    expect(sIds(body.conversations)).toEqual([conversation.sId]);
+    expect(body.totalCount).toBe(1);
   });
 
   it("rejects a request with no agent, trigger or reinforced skill", async () => {

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
@@ -14,6 +14,9 @@ const ListConversationsQuerySchema = z.object({
   agentId: z.string().optional(),
   triggerId: z.string().optional(),
   reinforcedSkillId: z.string().optional(),
+  // Only honored on the agent branch: the trigger and reinforced-skill listings are
+  // already bounded by their own scope.
+  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
 });
 
 // Mounted at /api/poke/workspaces/:wId/conversations.
@@ -25,9 +28,11 @@ app.get(
   validate("query", ListConversationsQuerySchema),
   async (ctx): HandlerResult<PokeListConversations> => {
     const auth = ctx.get("auth");
-    const { agentId, triggerId, reinforcedSkillId } = ctx.req.valid("query");
+    const { agentId, triggerId, reinforcedSkillId, limit } =
+      ctx.req.valid("query");
 
     let conversations: PokeListConversationItem[];
+    let hasMore = false;
 
     if (triggerId) {
       conversations = await ConversationResource.listConversationsForTrigger(
@@ -45,16 +50,17 @@ app.get(
           { after: oneWeekAgo }
         );
     } else if (agentId) {
-      const conversationResources =
-        await ConversationResource.listConversationWithAgentCreatedBeforeDate(
+      const { conversations: conversationResources, hasMore: hasMoreForAgent } =
+        await ConversationResource.listConversationsWithAgentPaginated(
           auth,
           {
             agentConfigurationId: agentId,
-            cutoffDate: new Date(),
+            limit,
           },
           { includeDeleted: true }
         );
 
+      hasMore = hasMoreForAgent;
       conversations = conversationResources.map((c) => ({
         id: c.id,
         created: c.createdAt.getTime(),
@@ -74,8 +80,6 @@ app.get(
         metadata: c.metadata,
         isRunningAgentLoop: c.isRunningAgentLoop,
       }));
-
-      conversations.sort((a, b) => b.created - a.created);
     } else {
       return apiError(ctx, {
         status_code: 400,
@@ -87,7 +91,7 @@ app.get(
       });
     }
 
-    return ctx.json({ conversations });
+    return ctx.json({ conversations, hasMore });
   }
 );
 

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
@@ -17,7 +17,20 @@ const ListConversationsQuerySchema = z.object({
   // Only honored on the agent branch: the trigger and reinforced-skill listings are
   // already bounded by their own scope.
   limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+  // Inclusive `createdAt` day bounds, as YYYY-MM-DD interpreted in UTC.
+  from: z.string().date().optional(),
+  to: z.string().date().optional(),
 });
+
+function utcMidnight(day: string): Date {
+  return new Date(`${day}T00:00:00.000Z`);
+}
+
+function nextUtcMidnight(day: string): Date {
+  const date = utcMidnight(day);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date;
+}
 
 // Mounted at /api/poke/workspaces/:wId/conversations.
 const app = pokeApp();
@@ -28,7 +41,7 @@ app.get(
   validate("query", ListConversationsQuerySchema),
   async (ctx): HandlerResult<PokeListConversations> => {
     const auth = ctx.get("auth");
-    const { agentId, triggerId, reinforcedSkillId, limit } =
+    const { agentId, triggerId, reinforcedSkillId, limit, from, to } =
       ctx.req.valid("query");
 
     let conversations: PokeListConversationItem[];
@@ -56,6 +69,10 @@ app.get(
           {
             agentConfigurationId: agentId,
             limit,
+            createdAfter: from ? utcMidnight(from) : undefined,
+            // `to` names the last day to include, so the exclusive upper bound is the
+            // midnight that follows it.
+            createdBefore: to ? nextUtcMidnight(to) : undefined,
           },
           { includeDeleted: true }
         );

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
@@ -17,6 +17,12 @@ const ListConversationsQuerySchema = z.object({
   // Only honored on the agent branch: the trigger and reinforced-skill listings are
   // already bounded by their own scope.
   limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+  offset: z.coerce.number().int().nonnegative().optional().default(0),
+  orderColumn: z
+    .enum(["createdAt", "title", "sId"])
+    .optional()
+    .default("createdAt"),
+  orderDirection: z.enum(["asc", "desc"]).optional().default("desc"),
   // Inclusive `createdAt` day bounds, as YYYY-MM-DD interpreted in UTC.
   from: z.string().date().optional(),
   to: z.string().date().optional(),
@@ -41,17 +47,27 @@ app.get(
   validate("query", ListConversationsQuerySchema),
   async (ctx): HandlerResult<PokeListConversations> => {
     const auth = ctx.get("auth");
-    const { agentId, triggerId, reinforcedSkillId, limit, from, to } =
-      ctx.req.valid("query");
+    const {
+      agentId,
+      triggerId,
+      reinforcedSkillId,
+      limit,
+      offset,
+      orderColumn,
+      orderDirection,
+      from,
+      to,
+    } = ctx.req.valid("query");
 
     let conversations: PokeListConversationItem[];
-    let hasMore = false;
+    let totalCount: number;
 
     if (triggerId) {
       conversations = await ConversationResource.listConversationsForTrigger(
         auth,
         triggerId
       );
+      totalCount = conversations.length;
     } else if (reinforcedSkillId) {
       const oneWeekAgo = new Date();
       oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
@@ -62,22 +78,28 @@ app.get(
           reinforcedSkillId,
           { after: oneWeekAgo }
         );
+      totalCount = conversations.length;
     } else if (agentId) {
-      const { conversations: conversationResources, hasMore: hasMoreForAgent } =
-        await ConversationResource.listConversationsWithAgentPaginated(
-          auth,
-          {
-            agentConfigurationId: agentId,
-            limit,
-            createdAfter: from ? utcMidnight(from) : undefined,
-            // `to` names the last day to include, so the exclusive upper bound is the
-            // midnight that follows it.
-            createdBefore: to ? nextUtcMidnight(to) : undefined,
-          },
-          { includeDeleted: true }
-        );
+      const {
+        conversations: conversationResources,
+        totalCount: totalCountForAgent,
+      } = await ConversationResource.listConversationsWithAgentPaginated(
+        auth,
+        {
+          agentConfigurationId: agentId,
+          limit,
+          offset,
+          orderColumn,
+          orderDirection,
+          createdAfter: from ? utcMidnight(from) : undefined,
+          // `to` names the last day to include, so the exclusive upper bound is the
+          // midnight that follows it.
+          createdBefore: to ? nextUtcMidnight(to) : undefined,
+        },
+        { includeDeleted: true }
+      );
 
-      hasMore = hasMoreForAgent;
+      totalCount = totalCountForAgent;
       conversations = conversationResources.map((c) => ({
         id: c.id,
         created: c.createdAt.getTime(),
@@ -108,7 +130,7 @@ app.get(
       });
     }
 
-    return ctx.json({ conversations, hasMore });
+    return ctx.json({ conversations, totalCount });
   }
 );
 

--- a/front/components/poke/conversation/agent_table.tsx
+++ b/front/components/poke/conversation/agent_table.tsx
@@ -2,12 +2,15 @@ import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditio
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeListConversationItem } from "@app/lib/api/poke/conversations";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
-import { usePokeConversations } from "@app/poke/swr/conversation";
+import { usePokeAgentConversations } from "@app/poke/swr/conversation";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Chip, IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { Button, Chip, IconButton, LinkWrapper } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
+
+const PAGE_SIZE = 25;
 
 interface ConversationAgentDataTableProps {
   owner: LightWorkspaceType;
@@ -99,8 +102,9 @@ export function ConversationAgentDataTable({
   owner,
   agentId,
 }: ConversationAgentDataTableProps) {
-  const useConversationsWithAgent = (props: PokeConversationsFetchProps) =>
-    usePokeConversations({ ...props, agentId });
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const useConversationsWithAgent = (props: PokeConditionalFetchProps) =>
+    usePokeAgentConversations({ ...props, agentId, limit });
 
   return (
     <PokeDataTableConditionalFetch
@@ -109,16 +113,25 @@ export function ConversationAgentDataTable({
       showSensitiveDataWarning={true}
       useSWRHook={useConversationsWithAgent}
     >
-      {(conversations) => {
-        const columns = makeColumnsForConversations(owner);
-
-        return (
+      {({ conversations, hasMore, isLoadingMore }) => (
+        <div className="flex flex-col gap-3">
           <PokeDataTable<PokeListConversationItem, unknown>
-            columns={columns}
+            columns={makeColumnsForConversations(owner)}
             data={conversations}
+            pageSize={PAGE_SIZE}
           />
-        );
-      }}
+          {hasMore && (
+            <div className="flex justify-center">
+              <Button
+                variant="outline"
+                label="Load more"
+                isLoading={isLoadingMore}
+                onClick={() => setLimit((current) => current + PAGE_SIZE)}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </PokeDataTableConditionalFetch>
   );
 }

--- a/front/components/poke/conversation/agent_table.tsx
+++ b/front/components/poke/conversation/agent_table.tsx
@@ -110,7 +110,6 @@ export function ConversationAgentDataTable({
     <PokeDataTableConditionalFetch
       header="Conversations"
       owner={owner}
-      showSensitiveDataWarning={true}
       useSWRHook={useConversationsWithAgent}
     >
       {({ conversations, hasMore, isLoadingMore }) => (

--- a/front/components/poke/conversation/agent_table.tsx
+++ b/front/components/poke/conversation/agent_table.tsx
@@ -1,16 +1,31 @@
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeListConversationItem } from "@app/lib/api/poke/conversations";
+import type { AgentConversationsOrderColumn } from "@app/lib/resources/conversation_resource";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { usePokeAgentConversations } from "@app/poke/swr/conversation";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, Chip, IconButton, Input, LinkWrapper } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
-import type { ColumnDef } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
 import { useState } from "react";
 
 const PAGE_SIZE = 25;
+
+// The sortable columns, keyed by the `accessorKey` the table reports.
+const ORDER_COLUMN_BY_TABLE_COLUMN: Record<
+  string,
+  AgentConversationsOrderColumn
+> = {
+  sId: "sId",
+  created: "createdAt",
+  title: "title",
+};
 
 interface ConversationAgentDataTableProps {
   owner: LightWorkspaceType;
@@ -102,32 +117,52 @@ export function ConversationAgentDataTable({
   owner,
   agentId,
 }: ConversationAgentDataTableProps) {
-  const [limit, setLimit] = useState(PAGE_SIZE);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: PAGE_SIZE,
+  });
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "created", desc: true },
+  ]);
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
 
-  // A narrower window makes the rows already loaded meaningless, so start over.
+  const resetToFirstPage = () =>
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+
+  // A different window or order makes the current page number meaningless.
   const handleFromChange = (value: string) => {
     setFrom(value);
-    setLimit(PAGE_SIZE);
+    resetToFirstPage();
   };
 
   const handleToChange = (value: string) => {
     setTo(value);
-    setLimit(PAGE_SIZE);
+    resetToFirstPage();
   };
 
   const handleClearDates = () => {
     setFrom("");
     setTo("");
-    setLimit(PAGE_SIZE);
+    resetToFirstPage();
   };
 
+  const handleSortingChange = (nextSorting: SortingState) => {
+    setSorting(nextSorting);
+    resetToFirstPage();
+  };
+
+  const sortColumn = sorting[0];
   const useConversationsWithAgent = (props: PokeConditionalFetchProps) =>
     usePokeAgentConversations({
       ...props,
       agentId,
-      limit,
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      orderColumn:
+        (sortColumn && ORDER_COLUMN_BY_TABLE_COLUMN[sortColumn.id]) ??
+        "createdAt",
+      orderDirection: sortColumn?.desc === false ? "asc" : "desc",
       from: from || undefined,
       to: to || undefined,
     });
@@ -161,24 +196,17 @@ export function ConversationAgentDataTable({
       }
       useSWRHook={useConversationsWithAgent}
     >
-      {({ conversations, hasMore, isLoadingMore }) => (
-        <div className="flex flex-col gap-3">
-          <PokeDataTable<PokeListConversationItem, unknown>
-            columns={makeColumnsForConversations(owner)}
-            data={conversations}
-            pageSize={PAGE_SIZE}
-          />
-          {hasMore && (
-            <div className="flex justify-center">
-              <Button
-                variant="outline"
-                label="Load more"
-                isLoading={isLoadingMore}
-                onClick={() => setLimit((current) => current + PAGE_SIZE)}
-              />
-            </div>
-          )}
-        </div>
+      {({ conversations, totalCount, isValidating }) => (
+        <PokeDataTable<PokeListConversationItem, unknown>
+          columns={makeColumnsForConversations(owner)}
+          data={conversations}
+          isValidating={isValidating}
+          serverSideRowCount={totalCount}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          sorting={sorting}
+          onSortingChange={handleSortingChange}
+        />
       )}
     </PokeDataTableConditionalFetch>
   );

--- a/front/components/poke/conversation/agent_table.tsx
+++ b/front/components/poke/conversation/agent_table.tsx
@@ -5,7 +5,7 @@ import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { usePokeAgentConversations } from "@app/poke/swr/conversation";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Chip, IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { Button, Chip, IconButton, Input, LinkWrapper } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
@@ -103,13 +103,62 @@ export function ConversationAgentDataTable({
   agentId,
 }: ConversationAgentDataTableProps) {
   const [limit, setLimit] = useState(PAGE_SIZE);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  // A narrower window makes the rows already loaded meaningless, so start over.
+  const handleFromChange = (value: string) => {
+    setFrom(value);
+    setLimit(PAGE_SIZE);
+  };
+
+  const handleToChange = (value: string) => {
+    setTo(value);
+    setLimit(PAGE_SIZE);
+  };
+
+  const handleClearDates = () => {
+    setFrom("");
+    setTo("");
+    setLimit(PAGE_SIZE);
+  };
+
   const useConversationsWithAgent = (props: PokeConditionalFetchProps) =>
-    usePokeAgentConversations({ ...props, agentId, limit });
+    usePokeAgentConversations({
+      ...props,
+      agentId,
+      limit,
+      from: from || undefined,
+      to: to || undefined,
+    });
 
   return (
     <PokeDataTableConditionalFetch
       header="Conversations"
       owner={owner}
+      globalActions={
+        <div className="flex items-end gap-2">
+          <Input
+            label="Created from"
+            name="from"
+            type="date"
+            value={from}
+            max={to || undefined}
+            onChange={(e) => handleFromChange(e.target.value)}
+          />
+          <Input
+            label="to"
+            name="to"
+            type="date"
+            value={to}
+            min={from || undefined}
+            onChange={(e) => handleToChange(e.target.value)}
+          />
+          {(from || to) && (
+            <Button variant="ghost" label="Clear" onClick={handleClearDates} />
+          )}
+        </div>
+      }
       useSWRHook={useConversationsWithAgent}
     >
       {({ conversations, hasMore, isLoadingMore }) => (

--- a/front/components/poke/conversation/self_improving_skills_table.tsx
+++ b/front/components/poke/conversation/self_improving_skills_table.tsx
@@ -130,7 +130,6 @@ export function SelfImprovingSkillsConversationDataTable({
     <PokeDataTableConditionalFetch
       header="Self-improving skills conversations"
       owner={owner}
-      showSensitiveDataWarning={true}
       useSWRHook={useReinforcementSkillsConversations}
     >
       {(conversations) => {

--- a/front/components/poke/conversation/table.tsx
+++ b/front/components/poke/conversation/table.tsx
@@ -25,7 +25,6 @@ export function ConversationDataTable({
       header="Conversations"
       owner={owner}
       loadOnInit={loadOnInit}
-      showSensitiveDataWarning={true}
       useSWRHook={useConversationsWithTrigger}
     >
       {(conversations) => (

--- a/front/components/poke/projects/conversations/table.tsx
+++ b/front/components/poke/projects/conversations/table.tsx
@@ -26,7 +26,6 @@ export function ProjectConversationDataTable({
     <PokeDataTableConditionalFetch
       header="Conversations"
       owner={owner}
-      showSensitiveDataWarning={true}
       useSWRHook={useConversationsForProject}
     >
       {({ conversations, hasMore, isLoadingMore }) => (

--- a/front/lib/api/poke/conversations.ts
+++ b/front/lib/api/poke/conversations.ts
@@ -11,7 +11,10 @@ export type PokeListConversationItem = ConversationWithoutContentType & {
 
 export type PokeListConversations = {
   conversations: PokeListConversationItem[];
-  hasMore: boolean;
+  // Upper bound on the agent listing: counted before visibility and permission
+  // filtering. Equal to the returned length on the trigger and reinforced-skill
+  // listings, which are not paged.
+  totalCount: number;
 };
 
 export type PokeGetConversationConfig = {

--- a/front/lib/api/poke/conversations.ts
+++ b/front/lib/api/poke/conversations.ts
@@ -11,6 +11,7 @@ export type PokeListConversationItem = ConversationWithoutContentType & {
 
 export type PokeListConversations = {
   conversations: PokeListConversationItem[];
+  hasMore: boolean;
 };
 
 export type PokeGetConversationConfig = {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -90,6 +90,15 @@ type FetchConversationOptions = {
 
 type SpaceConversationsFilter = "all" | "group" | "with_me";
 
+export const AGENT_CONVERSATIONS_ORDER_COLUMNS = {
+  createdAt: `c."createdAt"`,
+  title: `c."title"`,
+  sId: `c."sId"`,
+} as const;
+
+export type AgentConversationsOrderColumn =
+  keyof typeof AGENT_CONVERSATIONS_ORDER_COLUMNS;
+
 interface UserParticipation {
   actionRequired: boolean;
   updated: number;
@@ -1707,29 +1716,36 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   /**
    * Page of the conversations in which `agentConfigurationId` produced at least one
-   * message, newest first, optionally restricted to a `createdAt` window
-   * (`createdAfter` inclusive, `createdBefore` exclusive). Paging happens in SQL: an
-   * active agent's conversation set is unbounded, so neither its conversation ids nor
-   * the hydrated conversations can be materialized in full.
+   * message, optionally restricted to a `createdAt` window (`createdAfter` inclusive,
+   * `createdBefore` exclusive). Paging and ordering happen in SQL: an active agent's
+   * conversation set is unbounded, so neither its conversation ids nor the hydrated
+   * conversations can be materialized in full.
    *
-   * `hasMore` is computed before visibility and permission filtering, so a page can hold
-   * fewer than `limit` conversations while still reporting that more can be loaded.
+   * `totalCount` is the size of the matching set before visibility and permission
+   * filtering, so it is an upper bound: a page can hold fewer than `limit`
+   * conversations when the caller cannot read some of them.
    */
   static async listConversationsWithAgentPaginated(
     auth: Authenticator,
     {
       agentConfigurationId,
       limit,
+      offset,
+      orderColumn = "createdAt",
+      orderDirection = "desc",
       createdAfter,
       createdBefore,
     }: {
       agentConfigurationId: string;
       limit: number;
+      offset: number;
+      orderColumn?: AgentConversationsOrderColumn;
+      orderDirection?: "asc" | "desc";
       createdAfter?: Date;
       createdBefore?: Date;
     },
     options?: FetchConversationOptions
-  ): Promise<{ conversations: ConversationResource[]; hasMore: boolean }> {
+  ): Promise<{ conversations: ConversationResource[]; totalCount: number }> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     // Static fragments, so the window stays out of the plan entirely when unbounded.
@@ -1738,8 +1754,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       createdBefore ? `AND c."createdAt" < :createdBefore` : "",
     ].join("\n       ");
 
+    // Never interpolated from caller input: both halves come from closed unions.
+    const direction = orderDirection === "asc" ? "ASC" : "DESC";
+    // `id` breaks ties so a row cannot drift between pages as the offset moves.
+    const orderBy = `${AGENT_CONVERSATIONS_ORDER_COLUMNS[orderColumn]} ${direction}, c."id" DESC`;
+
     // `agent_messages` carries `conversationId` since the side-table denormalization, so
-    // the agent's conversations resolve without joining `messages`.
+    // the agent's conversations resolve without joining `messages`. The window count is
+    // free: the full id set is already materialized to be sorted.
     const query = `
       WITH agent_conversations AS (
         SELECT DISTINCT am."conversationId"
@@ -1747,47 +1769,52 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         WHERE am."workspaceId" = :workspaceId
           AND am."agentConfigurationId" = :agentConfigurationId
       )
-      SELECT c."id"
+      SELECT c."id", COUNT(*) OVER () AS total_count
       FROM agent_conversations ac
       JOIN conversations c
         ON c."id" = ac."conversationId"
        AND c."workspaceId" = :workspaceId
        ${windowConditions}
-      ORDER BY c."createdAt" DESC, c."id" DESC
-      LIMIT :limit
+      ORDER BY ${orderBy}
+      LIMIT :limit OFFSET :offset
     `;
 
     // biome-ignore lint/plugin/noRawSql: no association from conversations to agent_messages.
-    const rows = await frontSequelize.query<{ id: ModelId }>(query, {
+    const rows = await frontSequelize.query<{
+      id: ModelId;
+      total_count: number;
+    }>(query, {
       type: QueryTypes.SELECT,
       replacements: {
         workspaceId,
         agentConfigurationId,
-        // One extra row tells us whether another page exists.
-        limit: limit + 1,
+        limit,
+        offset,
         ...(createdAfter && { createdAfter }),
         ...(createdBefore && { createdBefore }),
       },
     });
 
-    const conversationIds = rows.slice(0, limit).map((r) => r.id);
-    if (conversationIds.length === 0) {
-      return { conversations: [], hasMore: false };
+    if (rows.length === 0) {
+      return { conversations: [], totalCount: 0 };
     }
 
     const conversations = await this.baseFetchWithAuthorization(auth, options, {
       where: {
         id: {
-          [Op.in]: conversationIds,
+          [Op.in]: rows.map((r) => r.id),
         },
       },
-      order: [
-        ["createdAt", "DESC"],
-        ["id", "DESC"],
-      ],
     });
 
-    return { conversations, hasMore: rows.length > limit };
+    // Walk the SQL order, which the hydrating fetch does not preserve. Ids the fetch
+    // dropped on visibility or permissions simply fall out here.
+    const conversationById = new Map(conversations.map((c) => [c.id, c]));
+    const ordered = removeNulls(
+      rows.map((r) => conversationById.get(r.id) ?? null)
+    );
+
+    return { conversations: ordered, totalCount: rows[0].total_count };
   }
 
   /**

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1706,6 +1706,77 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
+   * Page of the conversations in which `agentConfigurationId` produced at least one
+   * message, newest first. Paging happens in SQL: an active agent's conversation set is
+   * unbounded, so neither its conversation ids nor the hydrated conversations can be
+   * materialized in full.
+   *
+   * `hasMore` is computed before visibility and permission filtering, so a page can hold
+   * fewer than `limit` conversations while still reporting that more can be loaded.
+   */
+  static async listConversationsWithAgentPaginated(
+    auth: Authenticator,
+    {
+      agentConfigurationId,
+      limit,
+    }: {
+      agentConfigurationId: string;
+      limit: number;
+    },
+    options?: FetchConversationOptions
+  ): Promise<{ conversations: ConversationResource[]; hasMore: boolean }> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    // `agent_messages` carries `conversationId` since the side-table denormalization, so
+    // the agent's conversations resolve without joining `messages`.
+    const query = `
+      WITH agent_conversations AS (
+        SELECT DISTINCT am."conversationId"
+        FROM agent_messages am
+        WHERE am."workspaceId" = :workspaceId
+          AND am."agentConfigurationId" = :agentConfigurationId
+      )
+      SELECT c."id"
+      FROM agent_conversations ac
+      JOIN conversations c
+        ON c."id" = ac."conversationId"
+       AND c."workspaceId" = :workspaceId
+      ORDER BY c."createdAt" DESC, c."id" DESC
+      LIMIT :limit
+    `;
+
+    // biome-ignore lint/plugin/noRawSql: no association from conversations to agent_messages.
+    const rows = await frontSequelize.query<{ id: ModelId }>(query, {
+      type: QueryTypes.SELECT,
+      replacements: {
+        workspaceId,
+        agentConfigurationId,
+        // One extra row tells us whether another page exists.
+        limit: limit + 1,
+      },
+    });
+
+    const conversationIds = rows.slice(0, limit).map((r) => r.id);
+    if (conversationIds.length === 0) {
+      return { conversations: [], hasMore: false };
+    }
+
+    const conversations = await this.baseFetchWithAuthorization(auth, options, {
+      where: {
+        id: {
+          [Op.in]: conversationIds,
+        },
+      },
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
+    });
+
+    return { conversations, hasMore: rows.length > limit };
+  }
+
+  /**
    * For each agent, returns the sIds of qualifying conversations in the window
    * createdAt >= cutoffDate. With excludeHumanOutOfTheLoop, removes conversations where
    * triggerId IS NOT NULL and no user messages are present.

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1707,9 +1707,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   /**
    * Page of the conversations in which `agentConfigurationId` produced at least one
-   * message, newest first. Paging happens in SQL: an active agent's conversation set is
-   * unbounded, so neither its conversation ids nor the hydrated conversations can be
-   * materialized in full.
+   * message, newest first, optionally restricted to a `createdAt` window
+   * (`createdAfter` inclusive, `createdBefore` exclusive). Paging happens in SQL: an
+   * active agent's conversation set is unbounded, so neither its conversation ids nor
+   * the hydrated conversations can be materialized in full.
    *
    * `hasMore` is computed before visibility and permission filtering, so a page can hold
    * fewer than `limit` conversations while still reporting that more can be loaded.
@@ -1719,13 +1720,23 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     {
       agentConfigurationId,
       limit,
+      createdAfter,
+      createdBefore,
     }: {
       agentConfigurationId: string;
       limit: number;
+      createdAfter?: Date;
+      createdBefore?: Date;
     },
     options?: FetchConversationOptions
   ): Promise<{ conversations: ConversationResource[]; hasMore: boolean }> {
     const workspaceId = auth.getNonNullableWorkspace().id;
+
+    // Static fragments, so the window stays out of the plan entirely when unbounded.
+    const windowConditions = [
+      createdAfter ? `AND c."createdAt" >= :createdAfter` : "",
+      createdBefore ? `AND c."createdAt" < :createdBefore` : "",
+    ].join("\n       ");
 
     // `agent_messages` carries `conversationId` since the side-table denormalization, so
     // the agent's conversations resolve without joining `messages`.
@@ -1741,6 +1752,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       JOIN conversations c
         ON c."id" = ac."conversationId"
        AND c."workspaceId" = :workspaceId
+       ${windowConditions}
       ORDER BY c."createdAt" DESC, c."id" DESC
       LIMIT :limit
     `;
@@ -1753,6 +1765,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         agentConfigurationId,
         // One extra row tells us whether another page exists.
         limit: limit + 1,
+        ...(createdAfter && { createdAfter }),
+        ...(createdBefore && { createdBefore }),
       },
     });
 

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -44,19 +44,32 @@ export function usePokeConversations({
 interface UsePokeAgentConversationsProps extends PokeConditionalFetchProps {
   agentId: string;
   limit: number;
+  // Inclusive `createdAt` day bounds, as YYYY-MM-DD.
+  from?: string;
+  to?: string;
 }
 
 export function usePokeAgentConversations({
   agentId,
   disabled,
+  from,
   limit,
   owner,
+  to,
 }: UsePokeAgentConversationsProps) {
   const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
 
+  const params = new URLSearchParams({ agentId, limit: limit.toString() });
+  if (from) {
+    params.set("from", from);
+  }
+  if (to) {
+    params.set("to", to);
+  }
+
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}&limit=${limit}`,
+    `/api/poke/workspaces/${owner.sId}/conversations?${params.toString()}`,
     conversationsFetcher,
     { disabled, keepPreviousData: true }
   );

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -2,6 +2,7 @@ import type {
   PokeListConversationItem,
   PokeListConversations,
 } from "@app/lib/api/poke/conversations";
+import type { AgentConversationsOrderColumn } from "@app/lib/resources/conversation_resource";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -44,6 +45,9 @@ export function usePokeConversations({
 interface UsePokeAgentConversationsProps extends PokeConditionalFetchProps {
   agentId: string;
   limit: number;
+  offset: number;
+  orderColumn: AgentConversationsOrderColumn;
+  orderDirection: "asc" | "desc";
   // Inclusive `createdAt` day bounds, as YYYY-MM-DD.
   from?: string;
   to?: string;
@@ -54,13 +58,22 @@ export function usePokeAgentConversations({
   disabled,
   from,
   limit,
+  offset,
+  orderColumn,
+  orderDirection,
   owner,
   to,
 }: UsePokeAgentConversationsProps) {
   const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
 
-  const params = new URLSearchParams({ agentId, limit: limit.toString() });
+  const params = new URLSearchParams({
+    agentId,
+    limit: limit.toString(),
+    offset: offset.toString(),
+    orderColumn,
+    orderDirection,
+  });
   if (from) {
     params.set("from", from);
   }
@@ -78,8 +91,8 @@ export function usePokeAgentConversations({
     data: {
       conversations:
         data?.conversations ?? emptyArray<PokeListConversationItem>(),
-      hasMore: data?.hasMore ?? false,
-      isLoadingMore: isValidating && !!data,
+      totalCount: data?.totalCount ?? 0,
+      isValidating: isValidating && !!data,
     },
     isLoading: !error && !data && !disabled,
     isError: error,

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -1,10 +1,12 @@
-import type { PokeListConversations } from "@app/lib/api/poke/conversations";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  PokeListConversationItem,
+  PokeListConversations,
+} from "@app/lib/api/poke/conversations";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 
 export interface PokeConversationsFetchProps extends PokeConditionalFetchProps {
-  agentId?: string;
   triggerId?: string;
   reinforcedSkillId?: string;
 }
@@ -12,7 +14,6 @@ export interface PokeConversationsFetchProps extends PokeConditionalFetchProps {
 export function usePokeConversations({
   disabled,
   owner,
-  agentId,
   triggerId,
   reinforcedSkillId,
 }: PokeConversationsFetchProps) {
@@ -22,8 +23,6 @@ export function usePokeConversations({
   let url: string | null = null;
   if (reinforcedSkillId) {
     url = `/api/poke/workspaces/${owner.sId}/conversations?reinforcedSkillId=${reinforcedSkillId}`;
-  } else if (agentId) {
-    url = `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}`;
   } else if (triggerId) {
     url = `/api/poke/workspaces/${owner.sId}/conversations?triggerId=${triggerId}`;
   }
@@ -35,8 +34,41 @@ export function usePokeConversations({
   );
 
   return {
-    data: data?.conversations ?? [],
-    isLoading: !error && !data,
+    data: data?.conversations ?? emptyArray<PokeListConversationItem>(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}
+
+interface UsePokeAgentConversationsProps extends PokeConditionalFetchProps {
+  agentId: string;
+  limit: number;
+}
+
+export function usePokeAgentConversations({
+  agentId,
+  disabled,
+  limit,
+  owner,
+}: UsePokeAgentConversationsProps) {
+  const { fetcher } = useFetcher();
+  const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}&limit=${limit}`,
+    conversationsFetcher,
+    { disabled, keepPreviousData: true }
+  );
+
+  return {
+    data: {
+      conversations:
+        data?.conversations ?? emptyArray<PokeListConversationItem>(),
+      hasMore: data?.hasMore ?? false,
+      isLoadingMore: isValidating && !!data,
+    },
+    isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
   };


### PR DESCRIPTION
## Problem

In Poke, we have UI that lists conversations for a given agent. Today, it's insanely inefficient, listing all conversations at the DB level (can be super high for Dust agent in large orgs).

This adds proper paging to make it fast.

Also:
- Add a date filter so you can more easily find old convos
- Remove some warning messages that are no longer needed now that we have handling when you open an actual message.

<img width="924" height="268" alt="Screenshot 2026-08-27 at 11 10 29" src="https://github.com/user-attachments/assets/243bf408-82d9-4d56-b01d-184aaf0e3382" />

