### PR TITLE
Add Shopify order listing tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2146,6 +2146,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
+    "list_orders": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "list_products": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
@@ -3325,6 +3329,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "shopify": {
     "list_customers": "never_ask",
+    "list_orders": "never_ask",
     "list_products": "never_ask",
   },
   "skill_authoring": {

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1779,15 +1779,15 @@ const QUERIES: LabeledQuery[] = [
   },
   // --- shopify ---
   {
-    query: "list the products in my shopify store",
+    query: "list the products in the connected shopify store",
     expected: "shopify.list_products",
   },
   {
-    query: "list the customers in my shopify store",
+    query: "list the customers in the connected shopify store",
     expected: "shopify.list_customers",
   },
   {
-    query: "list the orders in my shopify store",
+    query: "list the orders in the connected shopify store",
     expected: "shopify.list_orders",
   },
 ];

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1779,15 +1779,15 @@ const QUERIES: LabeledQuery[] = [
   },
   // --- shopify ---
   {
-    query: "list the products in the connected shopify store",
+    query: "list products in Shopify store",
     expected: "shopify.list_products",
   },
   {
-    query: "list the customers in the connected shopify store",
+    query: "list customers in Shopify store",
     expected: "shopify.list_customers",
   },
   {
-    query: "list the orders in the connected shopify store",
+    query: "list orders in Shopify store",
     expected: "shopify.list_orders",
   },
 ];

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1786,6 +1786,10 @@ const QUERIES: LabeledQuery[] = [
     query: "list the customers in my shopify store",
     expected: "shopify.list_customers",
   },
+  {
+    query: "list the orders in my shopify store",
+    expected: "shopify.list_orders",
+  },
 ];
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/actions/servers/shopify/client";
 import type {
   ShopifyCustomer,
+  ShopifyOrder,
   ShopifyProduct,
 } from "@app/lib/api/actions/servers/shopify/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -79,6 +80,35 @@ function product(id: number): ShopifyProduct {
   };
 }
 
+function order(id: number): ShopifyOrder {
+  return {
+    id: `gid://shopify/Order/${id}`,
+    name: `#${id}`,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    cancelledAt: null,
+    displayFinancialStatus: "PAID",
+    displayFulfillmentStatus: "FULFILLED",
+    currentSubtotalPriceSet: {
+      shopMoney: { amount: "90.00", currencyCode: "EUR" },
+    },
+    currentTotalPriceSet: {
+      shopMoney: { amount: "100.00", currencyCode: "EUR" },
+    },
+    currentTotalTaxSet: {
+      shopMoney: { amount: "10.00", currencyCode: "EUR" },
+    },
+    currentSubtotalLineItemsQuantity: 2,
+    email: `customer-${id}@example.com`,
+    tags: ["online"],
+    customer: {
+      id: `gid://shopify/Customer/${id}`,
+      displayName: `Customer ${id}`,
+      defaultEmailAddress: { emailAddress: `customer-${id}@example.com` },
+    },
+  };
+}
+
 function pageResponse(
   products: ShopifyProduct[],
   { hasNextPage, endCursor }: { hasNextPage: boolean; endCursor: string | null }
@@ -101,6 +131,20 @@ function customerPageResponse(
     JSON.stringify({
       data: {
         customers: { nodes: customers, pageInfo: { hasNextPage, endCursor } },
+      },
+    }),
+    { status: 200 }
+  );
+}
+
+function orderPageResponse(
+  orders: ShopifyOrder[],
+  { hasNextPage, endCursor }: { hasNextPage: boolean; endCursor: string | null }
+) {
+  return new Response(
+    JSON.stringify({
+      data: {
+        orders: { nodes: orders, pageInfo: { hasNextPage, endCursor } },
       },
     }),
     { status: 200 }
@@ -250,6 +294,74 @@ describe("ShopifyClient.listProducts", () => {
       expect(result.error.message).toContain(
         "Access denied for products field"
       );
+    }
+  });
+});
+
+describe("ShopifyClient.listOrders", () => {
+  beforeEach(() => {
+    mocks.untrustedFetch.mockReset();
+  });
+
+  it("paginates orders and filters by the customer GID returned by listCustomers", async () => {
+    mocks.untrustedFetch
+      .mockResolvedValueOnce(
+        orderPageResponse([order(1), order(2)], {
+          hasNextPage: true,
+          endCursor: "cursor-2",
+        })
+      )
+      .mockResolvedValueOnce(
+        orderPageResponse([order(3)], {
+          hasNextPage: false,
+          endCursor: null,
+        })
+      );
+    const client = new ShopifyClient("access-token", "my-store.myshopify.com");
+
+    const result = await client.listOrders({
+      customerId: "gid://shopify/Customer/123",
+      searchQuery: "financial_status:paid",
+      limit: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.orders).toHaveLength(3);
+    expect(mocks.untrustedFetch).toHaveBeenCalledTimes(2);
+
+    const [firstUrl, firstInit] = mocks.untrustedFetch.mock.calls[0];
+    expect(firstUrl).toBe(
+      "https://my-store.myshopify.com/admin/api/2026-07/graphql.json"
+    );
+    const firstBody = parseRequestBody(firstInit);
+    expect(firstBody.query).toContain("query ListOrders");
+    expect(firstBody.variables).toEqual({
+      first: 3,
+      after: null,
+      query: "customer_id:123 financial_status:paid",
+    });
+
+    const secondBody = parseRequestBody(mocks.untrustedFetch.mock.calls[1][1]);
+    expect(secondBody.variables).toMatchObject({
+      first: 1,
+      after: "cursor-2",
+    });
+  });
+
+  it("identifies the required order scope when authentication fails", async () => {
+    mocks.untrustedFetch.mockResolvedValueOnce(
+      new Response("Forbidden", { status: 403 })
+    );
+    const client = new ShopifyClient("access-token", "my-store.myshopify.com");
+
+    const result = await client.listOrders({ limit: 10 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("read_orders scope");
     }
   });
 });

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -1,13 +1,16 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   CustomerListResult,
+  OrderListResult,
   ProductListResult,
   ShopifyCustomer,
   ShopifyCustomerState,
+  ShopifyOrder,
   ShopifyProduct,
 } from "@app/lib/api/actions/servers/shopify/types";
 import {
   CustomerNodeSchema,
+  OrderNodeSchema,
   ProductNodeSchema,
 } from "@app/lib/api/actions/servers/shopify/types";
 import { untrustedFetch } from "@app/lib/egress/server";
@@ -77,6 +80,34 @@ const PRODUCTS_QUERY = `
   }
 `;
 
+const ORDERS_QUERY = `
+  query ListOrders($first: Int!, $after: String, $query: String) {
+    orders(first: $first, after: $after, query: $query) {
+      nodes {
+        id
+        name
+        createdAt
+        updatedAt
+        cancelledAt
+        displayFinancialStatus
+        displayFulfillmentStatus
+        currentSubtotalPriceSet { shopMoney { amount currencyCode } }
+        currentTotalPriceSet { shopMoney { amount currencyCode } }
+        currentTotalTaxSet { shopMoney { amount currencyCode } }
+        currentSubtotalLineItemsQuantity
+        email
+        tags
+        customer {
+          id
+          displayName
+          defaultEmailAddress { emailAddress }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
 const CustomersDataSchema = z.object({
   customers: z.object({
     nodes: z.array(CustomerNodeSchema),
@@ -90,6 +121,16 @@ const CustomersDataSchema = z.object({
 const ProductsDataSchema = z.object({
   products: z.object({
     nodes: z.array(ProductNodeSchema),
+    pageInfo: z.object({
+      hasNextPage: z.boolean(),
+      endCursor: z.string().nullable(),
+    }),
+  }),
+});
+
+const OrdersDataSchema = z.object({
+  orders: z.object({
+    nodes: z.array(OrderNodeSchema),
     pageInfo: z.object({
       hasNextPage: z.boolean(),
       endCursor: z.string().nullable(),
@@ -119,8 +160,8 @@ export class ShopifyClient {
     query: string;
     variables: Record<string, unknown>;
     dataSchema: z.ZodType<T>;
-    resourceName: "customer" | "product";
-    requiredScope: "read_customers" | "read_products";
+    resourceName: "customer" | "order" | "product";
+    requiredScope: "read_customers" | "read_orders" | "read_products";
   }): Promise<Result<T, MCPError>> {
     const url = `https://${this.storeDomain}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
     let response: Awaited<ReturnType<typeof untrustedFetch>>;
@@ -277,6 +318,42 @@ export class ShopifyClient {
     });
   }
 
+  private async fetchOrdersPage({
+    first,
+    after,
+    query,
+  }: {
+    first: number;
+    after: string | null;
+    query: string | null;
+  }): Promise<
+    Result<
+      {
+        orders: ShopifyOrder[];
+        hasNextPage: boolean;
+        endCursor: string | null;
+      },
+      MCPError
+    >
+  > {
+    const data = await this.fetchGraphQL({
+      query: ORDERS_QUERY,
+      variables: { first, after, query },
+      dataSchema: OrdersDataSchema,
+      resourceName: "order",
+      requiredScope: "read_orders",
+    });
+    if (data.isErr()) {
+      return data;
+    }
+
+    return new Ok({
+      orders: data.value.orders.nodes,
+      hasNextPage: data.value.orders.pageInfo.hasNextPage,
+      endCursor: data.value.orders.pageInfo.endCursor,
+    });
+  }
+
   async listCustomers({
     state,
     email,
@@ -368,6 +445,48 @@ export class ShopifyClient {
     }
 
     return new Ok({ products });
+  }
+
+  async listOrders({
+    customerId,
+    searchQuery,
+    limit,
+  }: {
+    customerId?: string;
+    searchQuery?: string;
+    limit: number;
+  }): Promise<Result<OrderListResult, MCPError>> {
+    const filters: string[] = [];
+    if (customerId) {
+      const customerGidMatch = /^gid:\/\/shopify\/Customer\/(\d+)$/.exec(
+        customerId
+      );
+      filters.push(`customer_id:${customerGidMatch?.[1] ?? customerId}`);
+    }
+    if (searchQuery) {
+      filters.push(searchQuery);
+    }
+
+    const orders: ShopifyOrder[] = [];
+    let cursor: string | null = null;
+    while (orders.length < limit) {
+      const page = await this.fetchOrdersPage({
+        first: Math.min(PAGE_SIZE, limit - orders.length),
+        after: cursor,
+        query: filters.length > 0 ? filters.join(" ") : null,
+      });
+      if (page.isErr()) {
+        return page;
+      }
+
+      orders.push(...page.value.orders);
+      if (!page.value.hasNextPage || !page.value.endCursor) {
+        return new Ok({ orders });
+      }
+      cursor = page.value.endCursor;
+    }
+
+    return new Ok({ orders });
   }
 }
 

--- a/front/lib/api/actions/servers/shopify/metadata.test.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.test.ts
@@ -21,4 +21,19 @@ describe("Shopify list tool metadata", () => {
       );
     }
   });
+
+  it("accepts Shopify customer IDs for the order filter", () => {
+    const listOrders = SHOPIFY_TOOLS_METADATA.find(
+      (tool) => tool.name === "list_orders"
+    );
+    expect(listOrders?.schema.customerId.safeParse("123").success).toBe(true);
+    expect(
+      listOrders?.schema.customerId.safeParse("gid://shopify/Customer/123")
+        .success
+    ).toBe(true);
+    expect(
+      listOrders?.schema.customerId.safeParse("gid://shopify/Product/123")
+        .success
+    ).toBe(false);
+  });
 });

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -3,7 +3,10 @@ import {
   DEFAULT_LIST_LIMIT,
   MAX_LIST_LIMIT,
 } from "@app/lib/api/actions/servers/shopify/helpers";
-import { ShopifyCustomerStateSchema } from "@app/lib/api/actions/servers/shopify/types";
+import {
+  ShopifyCustomerIdSchema,
+  ShopifyCustomerStateSchema,
+} from "@app/lib/api/actions/servers/shopify/types";
 import { z } from "zod";
 
 export const SHOPIFY_SERVER_NAME = "shopify" as const;
@@ -44,6 +47,28 @@ export const SHOPIFY_TOOLS_METADATA = [
     displayLabels: {
       running: "Listing Shopify customers",
       done: "List Shopify customers",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "list_orders",
+    description:
+      "List Shopify orders with buyer details, status, quantity, and current financial totals.",
+    schema: {
+      customerId: ShopifyCustomerIdSchema.optional().describe(
+        "Filter by buyer ID. Accepts a numeric ID or the full Shopify GID."
+      ),
+      searchQuery: z
+        .string()
+        .optional()
+        .describe("Additional Shopify order search query."),
+      limit: limitSchema("orders"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing Shopify orders",
+      done: "List Shopify orders",
     },
     toolCostCategory: "advanced",
     freeUsage: false,

--- a/front/lib/api/actions/servers/shopify/rendering.ts
+++ b/front/lib/api/actions/servers/shopify/rendering.ts
@@ -1,5 +1,6 @@
 import type {
   CustomerListResult,
+  OrderListResult,
   ProductListResult,
 } from "@app/lib/api/actions/servers/shopify/types";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -14,4 +15,10 @@ export function renderProductList({
   products,
 }: ProductListResult): CallToolResult["content"] {
   return [{ type: "text", text: JSON.stringify(products, null, 2) }];
+}
+
+export function renderOrderList({
+  orders,
+}: OrderListResult): CallToolResult["content"] {
+  return [{ type: "text", text: JSON.stringify(orders, null, 2) }];
 }

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -4,6 +4,7 @@ import { createShopifyClient } from "@app/lib/api/actions/servers/shopify/client
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
 import {
   renderCustomerList,
+  renderOrderList,
   renderProductList,
 } from "@app/lib/api/actions/servers/shopify/rendering";
 import { Ok } from "@app/types/shared/result";
@@ -28,6 +29,21 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
       return customers;
     }
     return new Ok(renderCustomerList(customers.value));
+  },
+  list_orders: async ({ customerId, searchQuery, limit }, { authInfo }) => {
+    const client = createShopifyClient(authInfo);
+    if (client.isErr()) {
+      return client;
+    }
+    const orders = await client.value.listOrders({
+      customerId,
+      searchQuery,
+      limit,
+    });
+    if (orders.isErr()) {
+      return orders;
+    }
+    return new Ok(renderOrderList(orders.value));
   },
   list_products: async (
     { status, vendor, searchQuery, limit },

--- a/front/lib/api/actions/servers/shopify/types.ts
+++ b/front/lib/api/actions/servers/shopify/types.ts
@@ -5,6 +5,17 @@ const MoneySchema = z.object({
   currencyCode: z.string(),
 });
 
+const MoneyBagSchema = z.object({
+  shopMoney: MoneySchema,
+});
+
+export const ShopifyCustomerIdSchema = z
+  .string()
+  .regex(
+    /^(?:\d+|gid:\/\/shopify\/Customer\/\d+)$/,
+    "Customer ID must be a numeric ID or a Shopify Customer GID."
+  );
+
 export const ShopifyCustomerStateSchema = z.enum([
   "DECLINED",
   "DISABLED",
@@ -52,6 +63,39 @@ export type ShopifyCustomer = z.infer<typeof CustomerNodeSchema>;
 
 export interface CustomerListResult {
   customers: ShopifyCustomer[];
+}
+
+export const OrderNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  cancelledAt: z.string().nullable(),
+  displayFinancialStatus: z.string().nullable(),
+  displayFulfillmentStatus: z.string(),
+  currentSubtotalPriceSet: MoneyBagSchema,
+  currentTotalPriceSet: MoneyBagSchema,
+  currentTotalTaxSet: MoneyBagSchema,
+  currentSubtotalLineItemsQuantity: z.number(),
+  email: z.string().nullable(),
+  tags: z.array(z.string()),
+  customer: z
+    .object({
+      id: z.string(),
+      displayName: z.string(),
+      defaultEmailAddress: z
+        .object({
+          emailAddress: z.string(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+});
+
+export type ShopifyOrder = z.infer<typeof OrderNodeSchema>;
+
+export interface OrderListResult {
+  orders: ShopifyOrder[];
 }
 
 export const ProductNodeSchema = z.object({


### PR DESCRIPTION
## Description

- add a paginated Shopify list_orders MCP tool
- support filtering orders by numeric customer ID or Shopify Customer GID
- return validated order status, buyer, quantity, and financial totals
- add client, metadata, snapshot, and tool-retrieval coverage

## Tests

- NODE_ENV=test npm test -- Shopify client, metadata, MCP metadata, availability, and BM25 suites
- npm run tsgo -- --noEmit

## Risks

None

## Deploy

- deploy `front`
- Wait for first users to test.
- Iterate as needed and remove the feature flag.