### PR TITLE
Register Frames v2 FileResources

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -6,6 +6,7 @@ import {
   isContentFragmentInputWithInlinedContent,
 } from "@app/types/api/assistant";
 import {
+  isFrameV2ContentType,
   isInteractiveContentType,
   isSandboxFunctionContentType,
 } from "@app/types/files";
@@ -158,6 +159,7 @@ app.post(
 
     const publicContentFragment =
       !contentFragmentRes.value ||
+      isFrameV2ContentType(contentFragmentRes.value.contentType) ||
       isInteractiveContentType(contentFragmentRes.value.contentType) ||
       isSandboxFunctionContentType(contentFragmentRes.value.contentType)
         ? undefined

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -42,6 +42,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
+  isFrameV2ContentType,
   isInteractiveContentType,
   isSandboxFunctionContentType,
 } from "@app/types/files";
@@ -541,6 +542,7 @@ app.post(
       message: newMessage ?? undefined,
       contentFragment:
         !newContentFragment ||
+        isFrameV2ContentType(newContentFragment.contentType) ||
         isInteractiveContentType(newContentFragment.contentType) ||
         isSandboxFunctionContentType(newContentFragment.contentType)
           ? undefined

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -17,7 +17,11 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { sandboxFunctionContentType, TABLE_PREFIX } from "@app/types/files";
+import {
+  frameV2ContentType,
+  sandboxFunctionContentType,
+  TABLE_PREFIX,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
@@ -608,13 +612,18 @@ describe("isFileTypeUpsertableForUseCase", () => {
     }
   });
 
-  it("does not index sandbox function files", () => {
-    expect(
-      isFileTypeUpsertableForUseCase({
-        contentType: sandboxFunctionContentType,
-        useCase: "project_context",
-      })
-    ).toBe(false);
+  it("does not index internal executable files", () => {
+    for (const contentType of [
+      frameV2ContentType,
+      sandboxFunctionContentType,
+    ] as const) {
+      expect(
+        isFileTypeUpsertableForUseCase({
+          contentType,
+          useCase: "project_context",
+        })
+      ).toBe(false);
+    }
   });
 
   it("indexes plain-text files for non-conversation use cases", () => {

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -26,6 +26,7 @@ import type {
   FileUseCase,
 } from "@app/types/files";
 import {
+  isFrameV2ContentType,
   isInteractiveContentType,
   isSandboxFunctionContentType,
   isSupportedAudioContentType,
@@ -457,8 +458,9 @@ const getProcessingFunction = ({
     return undefined;
   }
 
-  // Interactive Content files should not be processed.
+  // Internal executable files should not be processed.
   if (
+    isFrameV2ContentType(contentType) ||
     isInteractiveContentType(contentType) ||
     isSandboxFunctionContentType(contentType)
   ) {

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -23,6 +23,7 @@ import {
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import {
+  isFrameV2ContentType,
   isInteractiveContentType,
   isSandboxFunctionContentType,
 } from "@app/types/files";
@@ -100,6 +101,7 @@ function filterOutInternalFileContentTypes(
   const result: ContentFragmentPublicType[] = [];
   for (const m of c) {
     if (
+      isFrameV2ContentType(m.contentType) ||
       isInteractiveContentType(m.contentType) ||
       isSandboxFunctionContentType(m.contentType)
     ) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -70,6 +70,7 @@ import {
   ALL_FILE_FORMATS,
   frameContentType,
   frameSlideshowContentType,
+  frameV2ContentType,
   isConversationFileUseCase,
   isInteractiveContentType,
   isSandboxFunctionContentType,
@@ -666,6 +667,10 @@ export class FileResource extends BaseResource<FileModel> {
 
   get isInteractiveContent(): boolean {
     return isInteractiveContentType(this.contentType);
+  }
+
+  get isFrameV2(): boolean {
+    return this.contentType === frameV2ContentType;
   }
 
   // Content access logic.

--- a/front/lib/resources/frame_file_resource.test.ts
+++ b/front/lib/resources/frame_file_resource.test.ts
@@ -1,0 +1,20 @@
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { frameV2ContentType } from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+describe("Frames v2 FileResource", () => {
+  it("identifies a manifest FileResource by its content type", async () => {
+    const { authenticator } = await createResourceTest({});
+    const frame = await FileFactory.create(authenticator, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+    });
+
+    expect(frame.isFrameV2).toBe(true);
+    expect(frame.isInteractiveContent).toBe(false);
+  });
+});

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -2,8 +2,11 @@ import {
   allowsSandboxRawUpload,
   authorizedFileAccessEntrySchema,
   ensureFileSize,
+  frameV2ContentType,
   getAuthorizedFileRefLabel,
   isAllSupportedFileContentType,
+  isFrameV2ContentType,
+  isInteractiveContentType,
   isSandboxFunctionContentType,
   isSupportedFileContentType,
   parseAuthorizedFileAccessEntry,
@@ -259,5 +262,14 @@ describe("sandboxFunctionContentType", () => {
       true
     );
     expect(isSupportedFileContentType(sandboxFunctionContentType)).toBe(false);
+  });
+});
+
+describe("frameV2ContentType", () => {
+  it("is an internal file type outside legacy Frame flows", () => {
+    expect(isFrameV2ContentType(frameV2ContentType)).toBe(true);
+    expect(isAllSupportedFileContentType(frameV2ContentType)).toBe(true);
+    expect(isInteractiveContentType(frameV2ContentType)).toBe(false);
+    expect(isSupportedFileContentType(frameV2ContentType)).toBe(false);
   });
 });

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -713,6 +713,7 @@ export const FILE_FORMATS = {
 export type SupportedFileContentType = keyof typeof FILE_FORMATS;
 
 export const frameContentType = "application/vnd.dust.frame";
+export const frameV2ContentType = "application/vnd.dust.frame.v2+json";
 export const frameSlideshowContentType = "application/vnd.dust.frame.slideshow";
 export const sandboxFunctionContentType =
   "application/vnd.dust.sandbox.function";
@@ -738,6 +739,16 @@ export const INTERACTIVE_CONTENT_FILE_FORMATS = {
 export type InteractiveContentFileContentType =
   keyof typeof INTERACTIVE_CONTENT_FILE_FORMATS;
 
+const FRAME_V2_FILE_FORMATS = {
+  [frameV2ContentType]: {
+    cat: "code",
+    exts: [".json"],
+    isSafeToDisplay: true,
+  },
+} as const satisfies Record<string, FileFormat>;
+
+type FrameV2FileContentType = keyof typeof FRAME_V2_FILE_FORMATS;
+
 const SANDBOX_FUNCTION_FILE_FORMATS = {
   [sandboxFunctionContentType]: {
     cat: "code",
@@ -751,12 +762,14 @@ export type SandboxFunctionFileContentType =
 
 export const ALL_FILE_FORMATS = {
   ...INTERACTIVE_CONTENT_FILE_FORMATS,
+  ...FRAME_V2_FILE_FORMATS,
   ...SANDBOX_FUNCTION_FILE_FORMATS,
   ...FILE_FORMATS,
 };
 // Union type for all supported content types.
 export type AllSupportedFileContentType =
   | InteractiveContentFileContentType
+  | FrameV2FileContentType
   | SandboxFunctionFileContentType
   | SupportedFileContentType;
 
@@ -826,11 +839,18 @@ export function isSandboxFunctionContentType(
   ];
 }
 
+export function isFrameV2ContentType(
+  contentType: string
+): contentType is FrameV2FileContentType {
+  return contentType === frameV2ContentType;
+}
+
 export function isAllSupportedFileContentType(
   contentType: string
 ): contentType is AllSupportedFileContentType {
   return (
     isInteractiveContentType(contentType) ||
+    isFrameV2ContentType(contentType) ||
     isSandboxFunctionContentType(contentType) ||
     isSupportedFileContentType(contentType)
   );

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -341,6 +341,9 @@ const FrameContentTypeSchema = z.literal("application/vnd.dust.frame");
 const FrameSlideshowContentTypeSchema = z.literal(
   "application/vnd.dust.frame.slideshow"
 );
+const FrameV2ContentTypeSchema = z.literal(
+  "application/vnd.dust.frame.v2+json"
+);
 const SandboxFunctionContentTypeSchema = z.literal(
   "application/vnd.dust.sandbox.function"
 );
@@ -349,6 +352,7 @@ const ActionGeneratedFileContentTypeSchema = z.union([
   SupportedFileContentFragmentTypeSchema,
   FrameContentTypeSchema,
   FrameSlideshowContentTypeSchema,
+  FrameV2ContentTypeSchema,
   SandboxFunctionContentTypeSchema,
 ]);
 


### PR DESCRIPTION
## Description

- Register `application/vnd.dust.frame.v2+json` as the internal manifest FileResource type.
- Add `FileResource.isFrameV2`.
- Keep Frames v2 out of legacy Interactive Content processing and public conversation serialization.
- Accept the type in generated-file SDK payloads.

Publication, activation, and GCS writes remain deferred. The existing `frames_v2` flag stays disabled.

## Tests

Added focused file-type, FileResource, and processing tests. Tested locally with the affected suites, front typechecking, and SDK type generation.

## Risk

Low. This registers an internal type without adding a producer or runtime entry point. Safe to roll back.

## Deploy Plan

Standard deploy.