### PR TITLE
[front] fix: use DataTableLoadingSkeleton in MembersList, UpgradeRequestsTable, CreditsList, MembersUsageTable

### DIFF
--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -12,8 +12,8 @@ import type { RoleType, UserType } from "@app/types/user";
 import {
   Chip,
   DataTable,
+  DataTableLoadingSkeleton,
   IconButton,
-  LoadingBlock,
   XClose,
 } from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
@@ -225,11 +225,7 @@ export function MembersList({
   return (
     <>
       {isLoading ? (
-        <div className="flex w-full flex-col space-y-2">
-          <LoadingBlock className="h-8 w-full rounded-xl" />
-          <LoadingBlock className="h-8 w-full rounded-xl" />
-          <LoadingBlock className="h-8 w-full rounded-xl" />
-        </div>
+        <DataTableLoadingSkeleton showSelectionColumn={false} rows={3} />
       ) : (
         <DataTable
           data={rows}

--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -3,7 +3,12 @@ import type { CreditDisplayData, CreditType } from "@app/types/credits";
 import { CREDIT_TYPE_SORT_ORDER } from "@app/types/credits";
 import type { EditedByUser } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
-import { Chip, DataTable, LoadingBlock, Page } from "@dust-tt/sparkle";
+import {
+  Chip,
+  DataTable,
+  DataTableLoadingSkeleton,
+  Page,
+} from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import type React from "react";
 import { useMemo } from "react";
@@ -179,13 +184,7 @@ export function CreditsList({ credits, isLoading }: CreditsListProps) {
   }, [credits]);
 
   if (isLoading) {
-    return (
-      <div className="flex w-full flex-col space-y-2">
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-      </div>
-    );
+    return <DataTableLoadingSkeleton showSelectionColumn={false} rows={3} />;
   }
 
   if (credits.length === 0) {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -39,8 +39,8 @@ import {
   Clock,
   createSelectionColumn,
   DataTable,
+  DataTableLoadingSkeleton,
   Icon,
-  LoadingBlock,
   ProgressBar,
   Spinner,
   Tooltip,
@@ -820,11 +820,10 @@ export function MembersUsageTable({
 
   if (isLoading) {
     return (
-      <div className="flex w-full flex-col space-y-2">
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-      </div>
+      <DataTableLoadingSkeleton
+        showSelectionColumn={enableSelection}
+        rows={3}
+      />
     );
   }
 

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   Check,
   DataTable,
-  LoadingBlock,
+  DataTableLoadingSkeleton,
   Spinner,
   X,
 } from "@dust-tt/sparkle";
@@ -204,13 +204,7 @@ export function UpgradeRequestsTable({
   );
 
   if (isLoading) {
-    return (
-      <div className="flex w-full flex-col space-y-2">
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-        <LoadingBlock className="h-8 w-full rounded-xl" />
-      </div>
-    );
+    return <DataTableLoadingSkeleton showSelectionColumn={false} rows={3} />;
   }
 
   if (rows.length === 0) {


### PR DESCRIPTION
## Description

`MembersList`, `CreditsList`, `MembersUsageTable`, and `UpgradeRequestsTable` each hand-rolled their loading state as a stack of three `LoadingBlock`s instead of using Sparkle's `DataTableLoadingSkeleton`. This swaps them over. Same motivation as #30951, #31173, #31174, #31175: as more code gets AI-generated, uniform use of existing Sparkle primitives is what keeps patterns from silently drifting apart again.

## Tests

Manual: verified the loading skeleton renders correctly for each table (members list, credits list, members usage table, upgrade requests table), including with/without the selection column.

## Risk

Low. Purely a visual/markup swap to an existing Sparkle primitive, no behavior or data changes.

## Deploy Plan

- Deploy front
