### PR TITLE
[front] fix: use Sparkle Chip for hand-rolled status/tag badges

### DIFF
--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -38,6 +38,7 @@ import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Avatar,
+  Chip,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -243,11 +244,7 @@ export function ChangeSeatModal({
     info: SeatTypeInfo
   ): React.ReactNode {
     if (seatType === currentSeatType) {
-      return (
-        <span className="rounded-full border border-blue-400 px-2 py-0.5 text-xs font-medium text-highlight-600">
-          Current
-        </span>
-      );
+      return <Chip size="xs" color="highlight" label="Current" />;
     }
     const price =
       info.billingFrequency === "annual" ? (


### PR DESCRIPTION
## Description

Replace the hand-rolled seat badge in `ChangeSeatModal` with Sparkle's `Chip`.

## Tests

Manual check that the "Current" seat badge still renders correctly.

## Risk

Low — purely visual, swapping a hand-rolled span for the equivalent Sparkle component.

## Deploy Plan

- Deploy front
