### PR TITLE
[front] fix: use Sparkle CheckboxWithText/RadioGroup for hand-rolled inputs

### DIFF
--- a/front/components/assistant/conversation/space/FirstSyncTaskLookbackForm.tsx
+++ b/front/components/assistant/conversation/space/FirstSyncTaskLookbackForm.tsx
@@ -1,4 +1,5 @@
 import type { InitialTasksSyncLookbackValue } from "@app/lib/project_task/analyze_document/types";
+import { Label, RadioGroup, RadioGroupCustomItem } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const OPTIONS: {
@@ -42,33 +43,41 @@ export function FirstSyncTaskLookbackForm({
         context is best-effort. Later runs cover everything new since the
         previous scan.
       </p>
-      <div className="flex flex-col gap-2">
+      <RadioGroup
+        value={value}
+        onValueChange={(newValue) => {
+          const opt = OPTIONS.find((o) => o.value === newValue);
+          if (opt) {
+            setValue(opt.value);
+            onValueChange(opt.value);
+          }
+        }}
+        className="flex flex-col gap-2"
+      >
         {OPTIONS.map((opt) => (
-          <label
+          <div
             key={opt.value}
-            className="border-border hover:bg-muted-background/50 flex cursor-pointer flex-col gap-0.5 rounded-lg border p-3"
+            className="border-border hover:bg-muted-background/50 flex flex-col gap-0.5 rounded-lg border p-3"
           >
-            <span className="flex items-center gap-2">
-              <input
-                type="radio"
-                className="mt-0.5"
-                name="initial-task-sync-lookback"
-                checked={value === opt.value}
-                onChange={() => {
-                  setValue(opt.value);
-                  onValueChange(opt.value);
-                }}
-              />
-              <span className="text-sm font-medium text-foreground">
-                {opt.title}
+            <RadioGroupCustomItem
+              value={opt.value}
+              id={opt.value}
+              customItem={
+                <Label
+                  htmlFor={opt.value}
+                  className="cursor-pointer text-sm font-medium text-foreground"
+                >
+                  {opt.title}
+                </Label>
+              }
+            >
+              <span className="pl-6 text-xs text-muted-foreground">
+                {opt.description}
               </span>
-            </span>
-            <span className="pl-6 text-xs text-muted-foreground">
-              {opt.description}
-            </span>
-          </label>
+            </RadioGroupCustomItem>
+          </div>
         ))}
-      </div>
+      </RadioGroup>
     </div>
   );
 }

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -3,7 +3,13 @@ import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { usePokeGlobalAgentFeedbacks } from "@app/hooks/usePokeGlobalAgentFeedbacks";
 import type { GlobalAgentFeedbackItem } from "@app/lib/api/poke/global_agent_feedbacks";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
-import { Button, Chip, LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import {
+  Button,
+  CheckboxWithText,
+  Chip,
+  LinkWrapper,
+  Spinner,
+} from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -157,15 +163,11 @@ export function GlobalAgentFeedbacksPage() {
         </div>
 
         <div className="mb-4 flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm text-primary-700">
-            <input
-              type="checkbox"
-              checked={includeEmpty}
-              onChange={handleIncludeEmptyChange}
-              className="rounded"
-            />
-            Include feedback without content
-          </label>
+          <CheckboxWithText
+            text="Include feedback without content"
+            checked={includeEmpty}
+            onCheckedChange={handleIncludeEmptyChange}
+          />
         </div>
 
         {isLoading ? (


### PR DESCRIPTION
## Description

Uniformize on existing Sparkle components instead of hand-rolled markup:

- `FirstSyncTaskLookbackForm`: raw radio inputs → `RadioGroup` / `RadioGroupCustomItem`.
- `GlobalAgentFeedbacksPage` (Poke): raw checkbox → `CheckboxWithText`.

**Before:**
<img width="712" height="383" alt="Capture d’écran 2026-08-27 à 11 54 31" src="https://github.com/user-attachments/assets/13b28c41-ee90-455a-a840-5790b7d3f8e4" />
<img width="536" height="500" alt="Capture d’écran 2026-08-27 à 11 54 46" src="https://github.com/user-attachments/assets/9c0c0623-e9fe-44d9-82c4-2f2f9279ed4f" />

**Now:**
<img width="715" height="402" alt="Capture d’écran 2026-08-27 à 11 54 24" src="https://github.com/user-attachments/assets/d92dca74-e07f-4e57-b1cb-6a67c04f6078" />
<img width="503" height="489" alt="Capture d’écran 2026-08-27 à 11 54 58" src="https://github.com/user-attachments/assets/9446250a-cc94-4dc6-a649-e203815d7917" />


## Tests

Manually verified each form locally: pod settings "Suggested tasks generation" first-sync dialog (radio group), Poke's `/global-agent-feedbacks` checkbox, and the workspace usage page's seat change modal.

## Risk

Low — presentational only, uses existing Sparkle primitives.

## Deploy Plan

Standard deploy, no special steps.
