### PR TITLE
Store immutable Frames v2 publications

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -63,19 +63,22 @@ describe("storeFramePublication", () => {
     });
     const identity = { workspaceId, frameId: frame.sId, publicationId };
 
-    expect(
-      fileStorageMock.saveFileCalls.map(({ filePath }) => filePath)
-    ).toEqual([
-      getFramePublicationSourcePath({
-        ...identity,
-        relativePath: "index.tsx",
-      }),
-      getFramePublicationSourcePath({
-        ...identity,
-        relativePath: "data.json",
-      }),
-      getFramePublicationManifestPath(identity),
-    ]);
+    const savedPaths = fileStorageMock.saveFileCalls.map(
+      ({ filePath }) => filePath
+    );
+    expect(new Set(savedPaths.slice(0, -1))).toEqual(
+      new Set([
+        getFramePublicationSourcePath({
+          ...identity,
+          relativePath: "index.tsx",
+        }),
+        getFramePublicationSourcePath({
+          ...identity,
+          relativePath: "data.json",
+        }),
+      ])
+    );
+    expect(savedPaths.at(-1)).toBe(getFramePublicationManifestPath(identity));
     expect(fileStorageMock.saveFileCalls.at(-1)?.contentType).toBe(
       frameV2ContentType
     );

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -56,11 +56,16 @@ describe("storeFramePublication", () => {
   it("stores immutable source files before the manifest commit marker", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
 
-    const { publicationId } = await storeFramePublication(auth, {
+    const result = await storeFramePublication(auth, {
       frame,
       manifest,
       sourceFiles,
     });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    const { publicationId } = result.value;
     const identity = { workspaceId, frameId: frame.sId, publicationId };
 
     const savedPaths = fileStorageMock.saveFileCalls.map(
@@ -92,13 +97,43 @@ describe("storeFramePublication", () => {
   it("rejects a publication whose UI entry point is missing", async () => {
     const { auth, frame } = await setupFrame();
 
-    await expect(
-      storeFramePublication(auth, {
-        frame,
-        manifest,
-        sourceFiles: sourceFiles.slice(1),
-      })
-    ).rejects.toThrow("Frame UI entry point not found");
+    const result = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles: sourceFiles.slice(1),
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_source");
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["an invalid path", [{ ...sourceFiles[0], relativePath: "../index.tsx" }]],
+    ["a duplicate path", [sourceFiles[0], sourceFiles[0]]],
+  ])("rejects %s before writing", async (_name, invalidSourceFiles) => {
+    const { auth, frame } = await setupFrame();
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles: invalidSourceFiles,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_source");
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("rejects a Frame from another workspace before writing", async () => {
+    const { frame } = await setupFrame();
+    const { authenticator: otherAuth } = await createResourceTest({});
+
+    const result = await storeFramePublication(otherAuth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_frame");
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1,0 +1,117 @@
+import { storeFramePublication } from "@app/lib/api/frames/publication_storage";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FrameManifestSchema } from "@app/types/api/frame_manifest";
+import {
+  getFramePublicationManifestPath,
+  getFramePublicationSourcePath,
+} from "@app/types/api/frame_storage";
+import { frameV2ContentType } from "@app/types/files";
+import { beforeEach, describe, expect, it } from "vitest";
+
+async function setupFrame(): Promise<{
+  frame: FileResource;
+  workspaceId: string;
+  auth: Authenticator;
+}> {
+  const { authenticator, workspace } = await createResourceTest({});
+  const frame = await FileFactory.create(authenticator, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 0,
+    status: "created",
+    useCase: "project_context",
+  });
+
+  return { auth: authenticator, frame, workspaceId: workspace.sId };
+}
+
+const manifest = FrameManifestSchema.parse({
+  version: 1,
+  name: "Task List",
+  description: "Track tasks.",
+});
+
+const sourceFiles = [
+  {
+    relativePath: "index.tsx",
+    content: Buffer.from("export default function App() {}"),
+    contentType: "text/typescript" as const,
+  },
+  {
+    relativePath: "data.json",
+    content: Buffer.from("{}"),
+    contentType: "application/json" as const,
+  },
+];
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+describe("storeFramePublication", () => {
+  it("stores immutable source files before the manifest commit marker", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+
+    const { publicationId } = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    const identity = { workspaceId, frameId: frame.sId, publicationId };
+
+    expect(
+      fileStorageMock.saveFileCalls.map(({ filePath }) => filePath)
+    ).toEqual([
+      getFramePublicationSourcePath({
+        ...identity,
+        relativePath: "index.tsx",
+      }),
+      getFramePublicationSourcePath({
+        ...identity,
+        relativePath: "data.json",
+      }),
+      getFramePublicationManifestPath(identity),
+    ]);
+    expect(fileStorageMock.saveFileCalls.at(-1)?.contentType).toBe(
+      frameV2ContentType
+    );
+    expect(
+      fileStorageMock.saveFileCalls.some(({ filePath }) =>
+        filePath.startsWith("files/w/")
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a publication whose UI entry point is missing", async () => {
+    const { auth, frame } = await setupFrame();
+
+    await expect(
+      storeFramePublication(auth, {
+        frame,
+        manifest,
+        sourceFiles: sourceFiles.slice(1),
+      })
+    ).rejects.toThrow("Frame UI entry point not found");
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("does not write the manifest after a partial source failure", async () => {
+    const { auth, frame } = await setupFrame();
+    fileStorageMock.setFileSaveFails((filePath) =>
+      filePath.endsWith("/source/data.json")
+    );
+
+    await expect(
+      storeFramePublication(auth, { frame, manifest, sourceFiles })
+    ).rejects.toThrow("Simulated GCS write failure");
+    expect(
+      fileStorageMock.saveFileCalls.some(({ filePath }) =>
+        filePath.endsWith("/manifest.json")
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from "node:crypto";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { FrameManifest } from "@app/types/api/frame_manifest";
+import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
+import {
+  getFramePublicationManifestPath,
+  getFramePublicationSourcePath,
+} from "@app/types/api/frame_storage";
+import type { AllSupportedFileContentType } from "@app/types/files";
+import { frameV2ContentType } from "@app/types/files";
+
+export type FramePublicationSourceFile = {
+  relativePath: string;
+  content: Buffer;
+  contentType: AllSupportedFileContentType;
+};
+
+export async function storeFramePublication(
+  auth: Authenticator,
+  {
+    frame,
+    manifest,
+    sourceFiles,
+  }: {
+    frame: FileResource;
+    manifest: FrameManifest;
+    sourceFiles: FramePublicationSourceFile[];
+  }
+): Promise<{ publicationId: string }> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!frame.isFrameV2 || frame.workspaceId !== workspace.id) {
+    throw new Error(
+      "Frame publication storage requires a Frames v2 FileResource from the current workspace."
+    );
+  }
+
+  const sourcePaths = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    if (!isSafeFrameRelativePath(sourceFile.relativePath)) {
+      throw new Error(`Invalid Frame source path: ${sourceFile.relativePath}`);
+    }
+    if (sourcePaths.has(sourceFile.relativePath)) {
+      throw new Error(
+        `Duplicate Frame source path: ${sourceFile.relativePath}`
+      );
+    }
+    sourcePaths.add(sourceFile.relativePath);
+  }
+  if (!sourcePaths.has(manifest.uiEntryPoint)) {
+    throw new Error(`Frame UI entry point not found: ${manifest.uiEntryPoint}`);
+  }
+
+  const identity = {
+    workspaceId: workspace.sId,
+    frameId: frame.sId,
+    publicationId: randomUUID(),
+  };
+  const storage = getPrivateUploadBucket();
+
+  for (const sourceFile of sourceFiles) {
+    await storage.uploadBufferToBucketAsNewFile({
+      buffer: sourceFile.content,
+      contentType: sourceFile.contentType,
+      filePath: getFramePublicationSourcePath({
+        ...identity,
+        relativePath: sourceFile.relativePath,
+      }),
+    });
+  }
+
+  // The manifest is the publication commit marker. Readers never observe a partial source write.
+  await storage.uploadBufferToBucketAsNewFile({
+    buffer: Buffer.from(JSON.stringify(manifest), "utf8"),
+    contentType: frameV2ContentType,
+    filePath: getFramePublicationManifestPath(identity),
+  });
+
+  return { publicationId: identity.publicationId };
+}

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import {
@@ -10,6 +14,8 @@ import {
 } from "@app/types/api/frame_storage";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { frameV2ContentType } from "@app/types/files";
+
+const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 
 export type FramePublicationSourceFile = {
   relativePath: string;
@@ -59,22 +65,30 @@ export async function storeFramePublication(
   };
   const storage = getPrivateUploadBucket();
 
-  for (const sourceFile of sourceFiles) {
-    await storage.uploadBufferToBucketAsNewFile({
-      buffer: sourceFile.content,
-      contentType: sourceFile.contentType,
-      filePath: getFramePublicationSourcePath({
+  await concurrentExecutor(
+    sourceFiles,
+    (sourceFile) => {
+      const filePath = getFramePublicationSourcePath({
         ...identity,
         relativePath: sourceFile.relativePath,
-      }),
-    });
-  }
+      });
+      return storage.file(filePath).save(sourceFile.content, {
+        contentType: sourceFile.contentType,
+        preconditionOpts: {
+          ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+        },
+      });
+    },
+    { concurrency: FRAME_PUBLICATION_UPLOAD_CONCURRENCY }
+  );
 
   // The manifest is the publication commit marker. Readers never observe a partial source write.
-  await storage.uploadBufferToBucketAsNewFile({
-    buffer: Buffer.from(JSON.stringify(manifest), "utf8"),
+  const manifestPath = getFramePublicationManifestPath(identity);
+  await storage.file(manifestPath).save(Buffer.from(JSON.stringify(manifest)), {
     contentType: frameV2ContentType,
-    filePath: getFramePublicationManifestPath(identity),
+    preconditionOpts: {
+      ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+    },
   });
 
   return { publicationId: identity.publicationId };

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -14,6 +14,8 @@ import {
 } from "@app/types/api/frame_storage";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { frameV2ContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 
@@ -22,6 +24,16 @@ export type FramePublicationSourceFile = {
   content: Buffer;
   contentType: AllSupportedFileContentType;
 };
+
+export class FramePublicationError extends Error {
+  constructor(
+    readonly code: "invalid_frame" | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FramePublicationError";
+  }
+}
 
 export async function storeFramePublication(
   auth: Authenticator,
@@ -34,28 +46,44 @@ export async function storeFramePublication(
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
   }
-): Promise<{ publicationId: string }> {
+): Promise<Result<{ publicationId: string }, FramePublicationError>> {
   const owner = auth.getNonNullableWorkspace();
   if (!frame.isFrameV2 || frame.workspaceId !== owner.id) {
-    throw new Error(
-      "Frame publication storage requires a Frames v2 FileResource from the current workspace."
+    return new Err(
+      new FramePublicationError(
+        "invalid_frame",
+        "Frame publication storage requires a Frames v2 FileResource from the current workspace."
+      )
     );
   }
 
   const sourcePaths = new Set<string>();
   for (const sourceFile of sourceFiles) {
     if (!isSafeFrameRelativePath(sourceFile.relativePath)) {
-      throw new Error(`Invalid Frame source path: ${sourceFile.relativePath}`);
+      return new Err(
+        new FramePublicationError(
+          "invalid_source",
+          `Invalid Frame source path: ${sourceFile.relativePath}`
+        )
+      );
     }
     if (sourcePaths.has(sourceFile.relativePath)) {
-      throw new Error(
-        `Duplicate Frame source path: ${sourceFile.relativePath}`
+      return new Err(
+        new FramePublicationError(
+          "invalid_source",
+          `Duplicate Frame source path: ${sourceFile.relativePath}`
+        )
       );
     }
     sourcePaths.add(sourceFile.relativePath);
   }
   if (!sourcePaths.has(manifest.uiEntryPoint)) {
-    throw new Error(`Frame UI entry point not found: ${manifest.uiEntryPoint}`);
+    return new Err(
+      new FramePublicationError(
+        "invalid_source",
+        `Frame UI entry point not found: ${manifest.uiEntryPoint}`
+      )
+    );
   }
 
   const identity = {
@@ -91,5 +119,5 @@ export async function storeFramePublication(
     },
   });
 
-  return { publicationId: identity.publicationId };
+  return new Ok({ publicationId: identity.publicationId });
 }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -29,8 +29,8 @@ export async function storeFramePublication(
     sourceFiles: FramePublicationSourceFile[];
   }
 ): Promise<{ publicationId: string }> {
-  const workspace = auth.getNonNullableWorkspace();
-  if (!frame.isFrameV2 || frame.workspaceId !== workspace.id) {
+  const owner = auth.getNonNullableWorkspace();
+  if (!frame.isFrameV2 || frame.workspaceId !== owner.id) {
     throw new Error(
       "Frame publication storage requires a Frames v2 FileResource from the current workspace."
     );
@@ -53,7 +53,7 @@ export async function storeFramePublication(
   }
 
   const identity = {
-    workspaceId: workspace.sId,
+    workspaceId: owner.sId,
     frameId: frame.sId,
     publicationId: randomUUID(),
   };

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -178,6 +178,23 @@ export class FileStorage {
     );
   }
 
+  async uploadBufferToBucketAsNewFile({
+    buffer,
+    contentType,
+    filePath,
+  }: {
+    buffer: Buffer;
+    contentType: AllSupportedFileContentType;
+    filePath: string;
+  }) {
+    await this.file(filePath).save(buffer, {
+      contentType,
+      preconditionOpts: {
+        ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+      },
+    });
+  }
+
   async uploadRawContentToBucket({
     content,
     contentType,

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -26,7 +26,7 @@ const GCS_MAX_RETRIES = 3; // Same as the SDK default.
 const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
 // GCS generations are object versions. Matching generation 0 means "create only
 // if the object does not already exist", which makes the create safe to retry.
-const GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH = 0;
+export const GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH = 0;
 
 export const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
 
@@ -176,23 +176,6 @@ export class FileStorage {
         logContext: { filePath },
       }
     );
-  }
-
-  async uploadBufferToBucketAsNewFile({
-    buffer,
-    contentType,
-    filePath,
-  }: {
-    buffer: Buffer;
-    contentType: AllSupportedFileContentType;
-    filePath: string;
-  }) {
-    await this.file(filePath).save(buffer, {
-      contentType,
-      preconditionOpts: {
-        ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-      },
-    });
   }
 
   async uploadRawContentToBucket({

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -363,6 +363,30 @@ class FileStorageMock {
           return Promise.resolve(undefined);
         }
       ),
+      uploadBufferToBucketAsNewFile: vi.fn(
+        (args: { buffer: Buffer; contentType: string; filePath: string }) => {
+          if (this._objectStore.has(args.filePath)) {
+            return Promise.reject(
+              Object.assign(
+                new Error(`Object already exists: ${args.filePath}`),
+                { code: 412 }
+              )
+            );
+          }
+          if (this._saveShouldFail(args.filePath)) {
+            return Promise.reject(
+              new Error(`Simulated GCS write failure: ${args.filePath}`)
+            );
+          }
+          this._objectStore.set(args.filePath, args.buffer.toString());
+          this._saveFileCalls.push({
+            filePath: args.filePath,
+            content: args.buffer,
+            contentType: args.contentType,
+          });
+          return Promise.resolve(undefined);
+        }
+      ),
       uploadRawContentToBucket: vi.fn(
         (args: { content: string; contentType: string; filePath: string }) => {
           this._objectStore.set(args.filePath, args.content);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -363,30 +363,6 @@ class FileStorageMock {
           return Promise.resolve(undefined);
         }
       ),
-      uploadBufferToBucketAsNewFile: vi.fn(
-        (args: { buffer: Buffer; contentType: string; filePath: string }) => {
-          if (this._objectStore.has(args.filePath)) {
-            return Promise.reject(
-              Object.assign(
-                new Error(`Object already exists: ${args.filePath}`),
-                { code: 412 }
-              )
-            );
-          }
-          if (this._saveShouldFail(args.filePath)) {
-            return Promise.reject(
-              new Error(`Simulated GCS write failure: ${args.filePath}`)
-            );
-          }
-          this._objectStore.set(args.filePath, args.buffer.toString());
-          this._saveFileCalls.push({
-            filePath: args.filePath,
-            content: args.buffer,
-            contentType: args.contentType,
-          });
-          return Promise.resolve(undefined);
-        }
-      ),
       uploadRawContentToBucket: vi.fn(
         (args: { content: string; contentType: string; filePath: string }) => {
           this._objectStore.set(args.filePath, args.content);


### PR DESCRIPTION
## Description

- Store Frames v2 source files under a new immutable publication ID.
- Upload source files with bounded concurrency and write `manifest.json` last as the commit marker.
- Return typed validation failures before any GCS write.

Loading, activation, function registration, and runtime wiring remain deferred.

## Tests

Added focused coverage for canonical paths, manifest-last ordering, source validation, workspace isolation, and partial write failures.

## Risk

Low. There is no producer yet and the feature flag remains disabled. A failed write can leave source objects without a manifest; readers will not treat that prefix as a publication.

## Deploy Plan

Standard deploy.