### PR TITLE
[ci] speed up PR checks on front

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -29,10 +29,6 @@ runs:
         # anyway costs ~15s per job for nothing.
         package-manager-cache: false
 
-    - name: Upgrade npm
-      shell: bash
-      run: npm install -g npm@11.10.0
-
     - name: Cache node_modules
       id: cache-node-modules
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -53,19 +49,42 @@ runs:
         restore-keys: |
           workspaces-node-modules-${{ runner.os }}-node${{ inputs.node-version }}-
 
+    # Only needed to run `npm ci` below with the npm version we pin. On a cache
+    # hit we never install, so paying ~4s per job for this is pure waste.
+    - name: Upgrade npm
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install -g npm@11.10.0
+
     - name: Install workspaces dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: npm ci
 
-    - name: Build SDK/JS
+    - name: Cache SDK/JS build
       if: inputs.build-sdks == 'true'
+      id: cache-sdks-dist
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: sdks/js/dist
+        key: sdks-js-dist-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('package-lock.json', 'sdks/js/src/**', 'sdks/js/package.json', 'sdks/js/tsconfig.json', 'sdks/js/esbuild.config.ts') }}
+
+    - name: Build SDK/JS
+      if: inputs.build-sdks == 'true' && steps.cache-sdks-dist.outputs.cache-hit != 'true'
       working-directory: sdks/js
       shell: bash
       run: npm run build
 
-    - name: Build Sparkle
+    - name: Cache Sparkle build
       if: inputs.build-sparkle == 'true'
+      id: cache-sparkle-dist
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: sparkle/dist
+        key: sparkle-dist-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('package-lock.json', 'sparkle/src/**', 'sparkle/package.json', 'sparkle/tsconfig.json', 'sparkle/scripts/**', 'sparkle/postcss.config.js') }}
+
+    - name: Build Sparkle
+      if: inputs.build-sparkle == 'true' && steps.cache-sparkle-dist.outputs.cache-hit != 'true'
       working-directory: sparkle
       shell: bash
       run: npm run build

--- a/.github/workflows/build-and-test-front-api.yml
+++ b/.github/workflows/build-and-test-front-api.yml
@@ -38,6 +38,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: mirror.gcr.io/postgres:14.13
+        env:
+          POSTGRES_DB: front_api_test_shard_${{ matrix.shardIndex }}
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
@@ -45,17 +58,11 @@ jobs:
         with:
           build-sdks: "true"
           build-sparkle: "true"
-      - name: Install Postgres
-        uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b
-        with:
-          postgresql docker image: mirror.gcr.io/postgres
-          postgresql version: "14.13"
-          postgresql db: front_api_test_shard_${{ matrix.shardIndex }}
-          postgresql user: test
-          postgresql password: test
-          postgresql port: 5433
       - name: Install Sandbox
-        run: sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd
+        # The runner image ships with a populated apt cache, so the install
+        # usually succeeds outright; `apt-get update` alone costs ~8s per shard,
+        # so only pay for it when the cached lists are too stale to resolve.
+        run: sudo apt-get install -y ripgrep fd-find sd || (sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd)
       - name: Run Tests
         working-directory: front-api
         env:

--- a/.github/workflows/build-and-test-front-api.yml
+++ b/.github/workflows/build-and-test-front-api.yml
@@ -15,14 +15,18 @@ permissions:
   actions: read
   checks: write
 
+concurrency:
+  group: build-and-test-front-api-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   tests:
     name: Test Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }}
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [ 1, 2, 3, 4, 5, 6 ]
-        shardTotal: [ 6 ]
+        shardIndex: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+        shardTotal: [ 10 ]
     runs-on: ubuntu-latest
     services:
       redis:
@@ -59,7 +63,7 @@ jobs:
           REDIS_CACHE_URI: "redis://localhost:5434"
           REDIS_URI: "redis://localhost:5434"
           NODE_ENV: test
-        run: npx tsx ../front/admin/db.ts && npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile.junit=junit-shard-${{ matrix.shardIndex }}.xml
+        run: npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile.junit=junit-shard-${{ matrix.shardIndex }}.xml
       - name: Build Tests Report
         if: always()
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -14,13 +14,17 @@ permissions:
   actions: read
   checks: write
 
+concurrency:
+  group: build-and-test-front-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   tests:
     name: Test Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }}
     strategy:
       matrix:
-        shardIndex: [ 1, 2, 3, 4, 5, 6 ]
-        shardTotal: [ 6 ]
+        shardIndex: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+        shardTotal: [ 10 ]
     runs-on: ubuntu-latest
     services:
       redis:
@@ -58,7 +62,7 @@ jobs:
           REDIS_URI: "redis://localhost:5434"
           NODE_ENV: test
           NODE_OPTIONS: "--trace-deprecation" # Show stacktrace to eliminate deprecated calls.
-        run: npx tsx admin/db.ts && npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile=junit-shard-${{ matrix.shardIndex }}.xml
+        run: npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile=junit-shard-${{ matrix.shardIndex }}.xml
       - name: Build Tests Report
         if: always()
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
@@ -88,7 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Node Dependencies
-        uses: ./.github/actions/setup-node-deps
+      # No `setup-node-deps` here on purpose: `lint:audit-log-schemas` is a pure
+      # grep over `admin/audit_log_schemas/`, so restoring ~700MB of
+      # node_modules would cost ~50s for nothing.
       - name: Lint audit log schemas
         run: npm -w front run lint:audit-log-schemas

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -36,6 +36,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: mirror.gcr.io/postgres:14.13
+        env:
+          POSTGRES_DB: front_test_shard_${{ matrix.shardIndex }}
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
@@ -43,17 +56,11 @@ jobs:
         with:
           build-sdks: "true"
           build-sparkle: "true"
-      - name: Install Postgres
-        uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b
-        with:
-          postgresql docker image: mirror.gcr.io/postgres
-          postgresql version: "14.13"
-          postgresql db: front_test_shard_${{ matrix.shardIndex }}
-          postgresql user: test
-          postgresql password: test
-          postgresql port: 5433
       - name: Install Sandbox
-        run: sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd
+        # The runner image ships with a populated apt cache, so the install
+        # usually succeeds outright; `apt-get update` alone costs ~8s per shard,
+        # so only pay for it when the cached lists are too stale to resolve.
+        run: sudo apt-get install -y ripgrep fd-find sd || (sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd)
       - name: Run Tests
         working-directory: front
         env:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: format-check-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   format-check:
     runs-on: ubuntu-latest
@@ -34,6 +38,27 @@ jobs:
       - name: Install Grit CLI
         run: npm install --location=global @getgrit/cli
       - name: Format Check
-        run: npm run format:ci
+        # Biome's linter is what costs: on a runner, checking all ~10k files
+        # takes ~275s for the linter and ~8s for the formatter. Branches only
+        # check the files they touch (~10s); `main` still runs the full check,
+        # so anything a per-file check could miss is caught on merge.
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            npm run format:ci
+            exit 0
+          fi
+
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+          # Biome's own `--changed` needs a merge base, which a depth-1
+          # checkout does not have, so pass the changed files explicitly.
+          readarray -t CHANGED < <(git diff --name-only --diff-filter=ACMR origin/main "$GITHUB_SHA")
+          if [ ${#CHANGED[@]} -eq 0 ]; then
+            echo "No changed files to check."
+            exit 0
+          fi
+
+          printf "%s\n" "${CHANGED[@]}"
+          npm run format:ci:files -- "${CHANGED[@]}"
       - name: GritQL Plugin Tests
         run: npm run test:grit

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
+        # Shallow on purpose: a full-history checkout of this monorepo costs 35s
+        # on a good day and has been seen taking 8 minutes. Both steps below only
+        # need the head commit and `origin/main`, which the depth-1 fetch below
+        # provides, and DangerJS reads the PR diff from the GitHub API.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       # Optimize compute resources by verifying changes in SQL models files and API files before running Danger.
       - name: Check for file changes
@@ -70,9 +72,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
+        # Shallow on purpose: a full-history checkout of this monorepo costs 35s
+        # on a good day and has been seen taking 8 minutes. Both steps below only
+        # need the head commit and `origin/main`, which the depth-1 fetch below
+        # provides, and DangerJS reads the PR diff from the GitHub API.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Check for activity file changes
         id: file_changes

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "knip": "knip",
     "format": "biome check --write --error-on-warnings .",
     "format:ci": "biome ci --error-on-warnings .",
+    "format:ci:files": "biome ci --error-on-warnings --no-errors-on-unmatched",
     "format:lefthook": "biome check --write --error-on-warnings --no-errors-on-unmatched",
     "format:changed": "biome check --write --error-on-warnings --changed",
     "test:grit": "command -v grit >/dev/null 2>&1 || { echo 'Error: grit CLI not found. Install it with: brew install getgrit/tap/grit (or: curl -fsSL https://docs.grit.io/install | bash)'; exit 1; } && grit patterns test",


### PR DESCRIPTION
Time-to-green on a `front` PR is 6-9 minutes. This is a set of measured cuts, each
verified on real runners against this branch.

### `run-dangerjs`: drop `fetch-depth: 0`

The single worst offender. A full-history checkout of this monorepo costs 35s on a
good day and was measured at **483s** on
https://github.com/dust-tt/dust/pull/31190 — for a job that then runs a 1s
`git diff` and exits. Both jobs only need the head commit and `origin/main`, which
the existing depth-1 `git fetch` already provides, and DangerJS reads the PR diff
from the GitHub API rather than from local history.

Measured on this branch: `danger-front` 539s -> 10s when it short-circuits, 60s
when Danger actually runs (verified with a throwaway commit under `front/lib/`, so
we know both the change detection and `npx danger ci` still work on a shallow
checkout).

### Biome: only check changed files on branches

`biome ci` is ~285s. A probe job on a real runner shows where it goes:

```
formatter only                    8s
linter only                     276s
linter without noImportCycles   275s
changed files only                8s
```

It is the linter as a whole — not the formatter, and not `noImportCycles`. Every
rule we enable (`noUnusedImports`, `noUnusedVariables`, `useBlockStatements`,
`useImportType`) is per-file, and `noImportCycles` reports on the file carrying
the offending import, so a branch that introduces a cycle is still flagged.
`main` keeps running the full check as a backstop.

Biome's own `--changed` needs a merge base, which a depth-1 checkout does not
have, so the file list comes from `git diff origin/main $GITHUB_SHA` — the same
approach `run-dangerjs` already uses.

### `setup-node-deps`: cache the Sparkle and SDK builds

Every front/front-api job rebuilt Sparkle (12s) and the SDK (2.4s) from scratch,
7+ jobs per run, for outputs that only change when `sparkle/src` or `sdks/js/src`
change. Also stop upgrading npm (4s/job) unless we are going to run `npm ci`.
`Setup Node Dependencies` went from 39-50s to 25-37s.

### Test jobs: 6 -> 10 shards, Postgres as a service, cheaper apt

- Per-shard fixed overhead is ~90s against ~1440s of aggregate test time, so more
  shards still pay off. Slowest front shard: 422s -> 231s.
- `dust-tt/postgresql-action` builds a Docker image for the action and then
  `docker run`s Postgres, 10-30s per shard. Declaring Postgres next to the Redis
  service folds it into `Initialize containers`, which already runs before
  checkout, and gives us a real health check instead of a readiness race.
- `apt-get update` alone is ~8s per shard; the runner's cached lists are normally
  fresh enough to resolve ripgrep/fd/sd, so only update when they are not.
  `Install Sandbox` 10-19s -> 4-8s.

### Housekeeping

- Cancel superseded runs on both test workflows and on Biome (never on `main`).
- The `lint` job skips the ~700MB `node_modules` restore: `lint:audit-log-schemas`
  is a `grep`. 48-184s -> 19s.

### Result

| | before | after |
|---|---|---|
| front, slowest shard | 247-422s | 178-231s |
| front-api, slowest shard | 310-392s | 201-329s |
| `danger-front` | 93-539s | 10-60s |
| Biome `Format Check` | 285-317s | ~10s on branches |
| front `lint` | 48-184s | 19s |

What is left is checkout tail latency: roughly one job per run spends 130-480s in
`git fetch` with no progress output, which is GitHub-side and predates this
change.