### PR TITLE
Update GPT-5.6 Sol pricing

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -21,6 +21,7 @@ export type PricingEntry = TokenPricingRates & {
 // This record contains all static model IDs. Custom models use default pricing.
 const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
   // Verified 2026-08-26: https://developers.openai.com/api/docs/pricing
+  // Promotional pricing is available at least through 2026-11-21; re-verify after that date.
   "gpt-5.6-sol": {
     input: 4.0,
     output: 20.0,

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -20,12 +20,12 @@ export type PricingEntry = TokenPricingRates & {
 // Pricing for current models (USD per million tokens - equivalent to micro-USD per token)
 // This record contains all static model IDs. Custom models use default pricing.
 const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
-  // https://openai.com/api/pricing
+  // Verified 2026-08-26: https://developers.openai.com/api/docs/pricing
   "gpt-5.6-sol": {
-    input: 5.0,
-    output: 30.0,
-    cache_creation_input_tokens: 6.25,
-    cache_read_input_tokens: 0.5,
+    input: 4.0,
+    output: 20.0,
+    cache_creation_input_tokens: 5.0,
+    cache_read_input_tokens: 0.4,
   },
   // https://openai.com/api/pricing
   "gpt-5.6-terra": {

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
@@ -1,3 +1,4 @@
+import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { DustOpenAIGptFiveDotSixTerraLongContextGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_terra_long_context_global_openai_responses";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
@@ -14,6 +15,7 @@ import { GPT_5_6_TERRA_LONG_CONTEXT } from "@app/lib/model_constructors/types/mo
 import {
   GPT_5_6_LUNA_MODEL_CONFIG,
   GPT_5_6_SOL_MODEL_CONFIG,
+  GPT_5_6_SOL_MODEL_ID,
   GPT_5_6_TERRA_LONG_CONTEXT_MODEL_CONFIG,
   GPT_5_6_TERRA_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
@@ -51,6 +53,29 @@ const GPT_5_6_CONFIGURATIONS = [
 ] as const;
 
 describe("GPT 5.6 model configurations", () => {
+  it("keeps Sol pricing synchronized across billing and endpoints", () => {
+    expect(MODEL_PRICING[GPT_5_6_SOL_MODEL_ID]).toEqual({
+      input: 4.0,
+      output: 20.0,
+      cache_creation_input_tokens: 5.0,
+      cache_read_input_tokens: 0.4,
+    });
+    expect(
+      OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream.tokenPricing
+    ).toEqual({
+      cacheHit: 0.4,
+      standardInput: 4.0,
+      standardOutput: 20.0,
+    });
+    expect(
+      OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream.tokenPricing
+    ).toEqual({
+      cacheHit: 0.44,
+      standardInput: 4.4,
+      standardOutput: 22.0,
+    });
+  });
+
   it.each(
     GPT_5_6_CONFIGURATIONS
   )("caps $name context consistently without changing output limits", ({

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses.ts
@@ -8,6 +8,7 @@ export class OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream extends WithOpenA
   OpenAIResponsesStream
 ) {
   // Verified 2026-08-26: https://developers.openai.com/api/docs/pricing
+  // Promotional pricing is available at least through 2026-11-21; re-verify after that date.
   // Regional (data residency) endpoints are charged a 10% uplift for models
   // released on or after March 5, 2026.
   static readonly tokenPricing = {

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses.ts
@@ -7,13 +7,13 @@ import { EUROPE } from "@app/lib/model_constructors/types/regions";
 export class OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream extends WithOpenAIGptFiveDotSixSolConfig(
   OpenAIResponsesStream
 ) {
-  // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+  // Verified 2026-08-26: https://developers.openai.com/api/docs/pricing
   // Regional (data residency) endpoints are charged a 10% uplift for models
   // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.55,
-    standardInput: 5.5,
-    standardOutput: 33.0,
+    cacheHit: 0.44,
+    standardInput: 4.4,
+    standardOutput: 22.0,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses.ts
@@ -7,11 +7,11 @@ import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 export class OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream extends WithOpenAIGptFiveDotSixSolConfig(
   OpenAIResponsesStream
 ) {
-  // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+  // Verified 2026-08-26: https://developers.openai.com/api/docs/pricing
   static readonly tokenPricing = {
-    cacheHit: 0.5,
-    standardInput: 5.0,
-    standardOutput: 30.0,
+    cacheHit: 0.4,
+    standardInput: 4.0,
+    standardOutput: 20.0,
   };
 
   static readonly region = GLOBAL;

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses.ts
@@ -8,6 +8,7 @@ export class OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream extends WithOpenA
   OpenAIResponsesStream
 ) {
   // Verified 2026-08-26: https://developers.openai.com/api/docs/pricing
+  // Promotional pricing is available at least through 2026-11-21; re-verify after that date.
   static readonly tokenPricing = {
     cacheHit: 0.4,
     standardInput: 4.0,


### PR DESCRIPTION
## Description

Update GPT-5.6 Sol to OpenAI's current $4 input, $0.40 cached input, $5 cache write, and $20 output rates per million tokens. Keep global and EU endpoint metadata in sync.

## Tests

Added focused coverage for the billing table and global and EU endpoint pricing.

## Risk

Low. This only lowers Sol cost attribution and is safe to revert.

## Deploy Plan

Standard deploy.