### PR TITLE
[front] Allow Dust-only feature flags on local envs

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
@@ -11,7 +11,7 @@ import {
   WHITELISTABLE_FEATURES,
   WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 function findFeatureFlagByDustOnlyStatus(dustOnly: boolean) {
   const feature = WHITELISTABLE_FEATURES.find(
@@ -145,6 +145,26 @@ describe("toggleFeatureFlagPlugin.execute", () => {
     await expect(
       FeatureFlagResource.isEnabledForWorkspace(workspace, dustOnlyFeature)
     ).resolves.toBe(true);
+  });
+
+  it("allows enabling Dust-only feature flags on any plan in development", async () => {
+    vi.stubEnv("IS_DEVELOPMENT", "true");
+    try {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const dustOnlyFeature = findFeatureFlagByDustOnlyStatus(true);
+
+      const result = await toggleFeatureFlagPlugin.execute(auth, null, {
+        features: [dustOnlyFeature],
+      });
+
+      expect(result.isOk()).toBe(true);
+      await expect(
+        FeatureFlagResource.isEnabledForWorkspace(workspace, dustOnlyFeature)
+      ).resolves.toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("allows enabling non-Dust-only feature flags on other plans", async () => {

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -7,6 +7,7 @@ import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import logger from "@app/logger/logger";
+import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
   FEATURE_FLAG_STAGE_LABELS,
@@ -90,7 +91,9 @@ export const toggleFeatureFlagPlugin = createPlugin({
     const dustOnlyFeatures = toAdd.filter(
       (feature) => WHITELISTABLE_FEATURES_CONFIG[feature].stage === "dust_only"
     );
+    // On local environments, Dust-only flags can be enabled freely.
     if (
+      !isDevelopment() &&
       dustOnlyFeatures.length > 0 &&
       (!planCode ||
         (!isDustCompanyPlan(planCode) && !isFriendsAndFamilyPlan(planCode)))


### PR DESCRIPTION
Skip the Dust/Friends & Family plan check in the toggle-feature-flag poke plugin when `isDevelopment()`, so `dust_only` flags can be enabled freely on local environments.

Adds a test covering the local bypass.