### PR TITLE
feat: remove unused listForSpaceById in group resource

### DIFF
--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -22,7 +22,6 @@ export type GetGroupsResponseBody = {
 
 const GetGroupsQuerySchema = z.object({
   kind: z.union([GroupKindCodec, z.array(GroupKindCodec)]).optional(),
-  spaceId: z.string().optional(),
   // When "true", each group also carries its member sIds (one extra batched
   // query) instead of just memberCount.
   withMembers: z.enum(["true", "false"]).optional(),
@@ -37,7 +36,7 @@ app.get(
   validate("query", GetGroupsQuerySchema),
   async (ctx): HandlerResult<GetGroupsResponseBody> => {
     const auth = ctx.get("auth");
-    const { kind, spaceId, withMembers } = ctx.req.valid("query");
+    const { kind, withMembers } = ctx.req.valid("query");
 
     const groupKinds: GroupKind[] = kind
       ? Array.isArray(kind)
@@ -45,9 +44,9 @@ app.get(
         : [kind]
       : ["global", "regular_auto"];
 
-    const groups: GroupResource[] = spaceId
-      ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })
-      : await GroupResource.listAllWorkspaceGroups(auth, { groupKinds });
+    const groups = await GroupResource.listAllWorkspaceGroups(auth, {
+      groupKinds,
+    });
 
     return ctx.json({
       groups:

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1106,55 +1106,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.filter((group) => group.canRead(auth));
   }
 
-  static async listForSpaceById(
-    auth: Authenticator,
-    spaceId: string,
-    options: { groupKinds?: GroupKind[] } = {}
-  ): Promise<GroupResource[]> {
-    const workspace = auth.getNonNullableWorkspace();
-    const spaceModelId = getResourceIdFromSId(spaceId);
-
-    if (!spaceModelId) {
-      return [];
-    }
-
-    // Find groups associated with the space through its group_permissions grants.
-    const spaceGrants = await GroupPermissionModel.findAll({
-      where: {
-        resourceType: "space",
-        resourceId: spaceModelId,
-        workspaceId: workspace.id,
-      },
-      attributes: ["groupId"],
-    });
-
-    if (spaceGrants.length === 0) {
-      return [];
-    }
-
-    const groupIds = [...new Set(spaceGrants.map((grant) => grant.groupId))];
-    const { groupKinds } = options;
-
-    const whereClause: WhereOptions<GroupModel> = {
-      id: {
-        [Op.in]: groupIds,
-      },
-    };
-
-    // Apply groupKinds filter if provided
-    if (groupKinds && groupKinds.length > 0) {
-      whereClause.kind = {
-        [Op.in]: groupKinds,
-      };
-    }
-
-    const groups = await this.baseFetch(auth, {
-      where: whereClause,
-    });
-
-    return groups.filter((group) => group.canRead(auth));
-  }
-
   /**
    * Group model ids the user was a member of at `at`, defaulting to now.
    *

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -23,13 +23,11 @@ import { z } from "zod";
 export function useGroups({
   owner,
   kinds,
-  spaceId,
   withMembers,
   disabled,
 }: {
   owner: LightWorkspaceType;
   kinds?: readonly GroupKind[];
-  spaceId?: string;
   // Also resolves each group's member sIds (one extra batched query
   // server-side) instead of just its memberCount.
   withMembers?: boolean;
@@ -41,15 +39,12 @@ export function useGroups({
     if (kinds && kinds.length > 0) {
       kinds.forEach((k) => params.append("kind", k));
     }
-    if (spaceId) {
-      params.append("spaceId", spaceId);
-    }
     if (withMembers) {
       params.append("withMembers", "true");
     }
     const queryString = params.toString();
     return `/api/w/${owner.sId}/groups${queryString ? `?${queryString}` : ""}`;
-  }, [owner.sId, kinds, spaceId, withMembers]);
+  }, [owner.sId, kinds, withMembers]);
 
   const groupsFetcher: Fetcher<GetGroupsResponseBody> = fetcher;
 


### PR DESCRIPTION
## Description

This PR removes the unused space-specific group listing path.

## Tests

Manually.

## Risks

Low. Unused method.

## Deploy Plan

Standard deployment.