### PR TITLE
[front] Show FF owner in workspace poke table and toggle plugin labels

### DIFF
--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -11,6 +11,7 @@ type FeatureFlagsDisplayType = {
   name: WhitelistableFeature;
   description: string;
   stage: FeatureFlagStage;
+  owner: string;
   enabled: boolean;
   enabledAt: string | null;
 };
@@ -29,6 +30,13 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
         <PokeColumnSortableHeader column={column} label="Stage" />
       ),
       cell: ({ row }) => <FeatureFlagStageChip flagName={row.original.name} />,
+    },
+    {
+      accessorKey: "owner",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Owner" />
+      ),
+      cell: ({ row }) => <span className="text-sm">@{row.original.owner}</span>,
     },
     {
       accessorKey: "description",

--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -36,7 +36,16 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Owner" />
       ),
-      cell: ({ row }) => <span className="text-sm">@{row.original.owner}</span>,
+      cell: ({ row }) => (
+        <a
+          href={`https://github.com/${row.original.owner}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-highlight-600 hover:underline"
+        >
+          @{row.original.owner}
+        </a>
+      ),
     },
     {
       accessorKey: "description",

--- a/front/components/poke/features/table.tsx
+++ b/front/components/poke/features/table.tsx
@@ -30,6 +30,7 @@ function prepareFeatureFlagsForDisplay(
         name: ff,
         description: WHITELISTABLE_FEATURES_CONFIG[ff].description,
         stage: WHITELISTABLE_FEATURES_CONFIG[ff].stage,
+        owner: WHITELISTABLE_FEATURES_CONFIG[ff].owner,
         enabled: !!enabledFlag,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         enabledAt: enabledFlag?.createdAt || null,

--- a/front/components/poke/pages/FeatureFlagsPage.tsx
+++ b/front/components/poke/pages/FeatureFlagsPage.tsx
@@ -78,7 +78,16 @@ function makeColumns({
         if (!owner) {
           return <span className="text-muted-foreground">—</span>;
         }
-        return <span className="text-sm">@{owner}</span>;
+        return (
+          <a
+            href={`https://github.com/${owner}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-highlight-600 hover:underline"
+          >
+            @{owner}
+          </a>
+        );
       },
     },
     {

--- a/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
+++ b/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
@@ -62,7 +62,7 @@ export const toggleGlobalFeatureFlagPlugin = createPlugin({
         const globalLabel =
           globalPct !== undefined ? ` [Global: ${globalPct}%]` : "";
         return {
-          label: `[${FEATURE_FLAG_STAGE_LABELS[config.stage]}] ${feature}${globalLabel}`,
+          label: `[${FEATURE_FLAG_STAGE_LABELS[config.stage]}] ${feature} (@${config.owner})${globalLabel}`,
           value: feature,
         };
       }),

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -65,7 +65,7 @@ export const toggleFeatureFlagPlugin = createPlugin({
         const globalLabel =
           globalPct !== undefined ? ` [Global: ${globalPct}%]` : "";
         return {
-          label: `[${FEATURE_FLAG_STAGE_LABELS[config.stage]}] ${feature}${globalLabel}`,
+          label: `[${FEATURE_FLAG_STAGE_LABELS[config.stage]}] ${feature} (@${config.owner})${globalLabel}`,
           value: feature,
           checked: enabledFlagNames.has(feature),
         };


### PR DESCRIPTION
Adds an Owner column to the feature flags table on the workspace poke page, and appends the owner handle to the flag labels in the toggle-feature-flag plugins (workspace and global), e.g. `[Ask owner] google_sheets_tool (@frankaloia)`.

Owner handles (here and on the /feature-flags page) link to the GitHub profile.