### PR TITLE
Read committed Frames v2 publications

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -159,7 +159,7 @@ describe("storeFramePublication", () => {
   });
 });
 
-describe("loadFramePublication", () => {
+describe("Frame publication reads", () => {
   it("loads the manifest and source of a committed publication", async () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1,4 +1,8 @@
-import { storeFramePublication } from "@app/lib/api/frames/publication_storage";
+import {
+  loadFramePublicationManifest,
+  loadFramePublicationSourceFile,
+  storeFramePublication,
+} from "@app/lib/api/frames/publication_storage";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -10,6 +14,7 @@ import {
   getFramePublicationSourcePath,
 } from "@app/types/api/frame_storage";
 import { frameV2ContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it } from "vitest";
 
 async function setupFrame(): Promise<{
@@ -151,5 +156,112 @@ describe("storeFramePublication", () => {
         filePath.endsWith("/manifest.json")
       )
     ).toBe(false);
+  });
+});
+
+describe("loadFramePublication", () => {
+  it("loads the manifest and source of a committed publication", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+
+    const loadedManifest = await loadFramePublicationManifest(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+    });
+    expect(loadedManifest).toEqual(new Ok(manifest));
+
+    const loadedSource = await loadFramePublicationSourceFile(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+      relativePath: "index.tsx",
+    });
+    expect(loadedSource.isOk() && loadedSource.value.toString("utf8")).toBe(
+      "export default function App() {}"
+    );
+  });
+
+  it("does not expose source without the manifest commit marker", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+    const publicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    fileStorageMock.setObject(
+      getFramePublicationSourcePath({
+        workspaceId,
+        frameId: frame.sId,
+        publicationId,
+        relativePath: "index.tsx",
+      }),
+      "partial source"
+    );
+    fileStorageMock.setFetchFileContentNotFound(() => true);
+
+    const result = await loadFramePublicationSourceFile(auth, {
+      frame,
+      publicationId,
+      relativePath: "index.tsx",
+    });
+
+    expect(result.isErr() && result.error.code).toBe("publication_not_found");
+  });
+
+  it("rejects an invalid stored manifest", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+    const publicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    fileStorageMock.setObject(
+      getFramePublicationManifestPath({
+        workspaceId,
+        frameId: frame.sId,
+        publicationId,
+      }),
+      "not json"
+    );
+
+    const result = await loadFramePublicationManifest(auth, {
+      frame,
+      publicationId,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_manifest");
+  });
+
+  it("returns a typed error for a missing source file", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    fileStorageMock.setFetchFileContentNotFound(() => true);
+
+    const result = await loadFramePublicationSourceFile(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+      relativePath: "missing.ts",
+    });
+
+    expect(result.isErr() && result.error.code).toBe("source_not_found");
+  });
+
+  it("rejects unsafe source paths before reading", async () => {
+    const { auth, frame } = await setupFrame();
+
+    const result = await loadFramePublicationSourceFile(auth, {
+      frame,
+      publicationId: "b8c2b796-534a-4ad2-a5ad-071da692ca0b",
+      relativePath: "../index.tsx",
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_source");
   });
 });

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -53,7 +53,7 @@ function getFrameIdentity(
     return new Err(
       new FramePublicationError(
         "invalid_frame",
-        "Frame publication storage requires a Frames v2 FileResource from the current workspace."
+        "Frame publication access requires a Frames v2 FileResource from the current workspace."
       )
     );
   }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -4,10 +4,14 @@ import {
   GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
+import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
-import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
+import {
+  isSafeFrameRelativePath,
+  parseFrameManifest,
+} from "@app/types/api/frame_manifest";
 import {
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
@@ -27,12 +31,34 @@ export type FramePublicationSourceFile = {
 
 export class FramePublicationError extends Error {
   constructor(
-    readonly code: "invalid_frame" | "invalid_source",
+    readonly code:
+      | "invalid_frame"
+      | "invalid_manifest"
+      | "invalid_source"
+      | "publication_not_found"
+      | "source_not_found",
     message: string
   ) {
     super(message);
     this.name = "FramePublicationError";
   }
+}
+
+function getFrameIdentity(
+  auth: Authenticator,
+  frame: FileResource
+): Result<{ workspaceId: string; frameId: string }, FramePublicationError> {
+  const owner = auth.getNonNullableWorkspace();
+  if (!frame.isFrameV2 || frame.workspaceId !== owner.id) {
+    return new Err(
+      new FramePublicationError(
+        "invalid_frame",
+        "Frame publication storage requires a Frames v2 FileResource from the current workspace."
+      )
+    );
+  }
+
+  return new Ok({ workspaceId: owner.sId, frameId: frame.sId });
 }
 
 export async function storeFramePublication(
@@ -47,14 +73,9 @@ export async function storeFramePublication(
     sourceFiles: FramePublicationSourceFile[];
   }
 ): Promise<Result<{ publicationId: string }, FramePublicationError>> {
-  const owner = auth.getNonNullableWorkspace();
-  if (!frame.isFrameV2 || frame.workspaceId !== owner.id) {
-    return new Err(
-      new FramePublicationError(
-        "invalid_frame",
-        "Frame publication storage requires a Frames v2 FileResource from the current workspace."
-      )
-    );
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return frameIdentity;
   }
 
   const sourcePaths = new Set<string>();
@@ -87,8 +108,7 @@ export async function storeFramePublication(
   }
 
   const identity = {
-    workspaceId: owner.sId,
-    frameId: frame.sId,
+    ...frameIdentity.value,
     publicationId: randomUUID(),
   };
   const storage = getPrivateUploadBucket();
@@ -120,4 +140,102 @@ export async function storeFramePublication(
   });
 
   return new Ok({ publicationId: identity.publicationId });
+}
+
+export async function loadFramePublicationManifest(
+  auth: Authenticator,
+  {
+    frame,
+    publicationId,
+  }: {
+    frame: FileResource;
+    publicationId: string;
+  }
+): Promise<Result<FrameManifest, FramePublicationError>> {
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return frameIdentity;
+  }
+
+  const manifestPath = getFramePublicationManifestPath({
+    ...frameIdentity.value,
+    publicationId,
+  });
+  let manifestBuffer: Uint8Array<ArrayBuffer>;
+  try {
+    manifestBuffer =
+      await getPrivateUploadBucket().fetchFileBuffer(manifestPath);
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Err(
+        new FramePublicationError(
+          "publication_not_found",
+          `Frame publication not found: ${publicationId}`
+        )
+      );
+    }
+    throw error;
+  }
+
+  const manifest = parseFrameManifest(Buffer.from(manifestBuffer));
+  if (manifest.isErr()) {
+    return new Err(
+      new FramePublicationError("invalid_manifest", manifest.error)
+    );
+  }
+
+  return manifest;
+}
+
+export async function loadFramePublicationSourceFile(
+  auth: Authenticator,
+  {
+    frame,
+    publicationId,
+    relativePath,
+  }: {
+    frame: FileResource;
+    publicationId: string;
+    relativePath: string;
+  }
+): Promise<Result<Buffer, FramePublicationError>> {
+  if (!isSafeFrameRelativePath(relativePath)) {
+    return new Err(
+      new FramePublicationError(
+        "invalid_source",
+        `Invalid Frame source path: ${relativePath}`
+      )
+    );
+  }
+
+  const manifest = await loadFramePublicationManifest(auth, {
+    frame,
+    publicationId,
+  });
+  if (manifest.isErr()) {
+    return manifest;
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const sourcePath = getFramePublicationSourcePath({
+    workspaceId: owner.sId,
+    frameId: frame.sId,
+    publicationId,
+    relativePath,
+  });
+  try {
+    const sourceBuffer =
+      await getPrivateUploadBucket().fetchFileBuffer(sourcePath);
+    return new Ok(Buffer.from(sourceBuffer));
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Err(
+        new FramePublicationError(
+          "source_not_found",
+          `Frame publication source file not found: ${relativePath}`
+        )
+      );
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Description

Load and validate Frames v2 publication manifests from GCS. Source reads require the manifest commit marker and return typed errors for missing or invalid content.

## Tests

Added focused coverage for round-trip reads, partial publications, malformed manifests, missing source files, and unsafe paths.

## Risk

Low. The reader has no callers yet and storage failures remain internal errors.

## Deploy Plan

Standard deploy.