### PR TITLE
[front] enh: use the highlight variant for the enable-notifications CTA

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -13,7 +13,7 @@ export type ConfirmDataType = {
   title: string | ReactNode;
   message: string | ReactNode;
   validateLabel?: string;
-  validateVariant?: "primary" | "warning";
+  validateVariant?: "primary" | "warning" | "highlight";
   validateDisabled?: boolean;
   cancelLabel?: string;
 };

--- a/front/hooks/useEnableBrowserNotification.tsx
+++ b/front/hooks/useEnableBrowserNotification.tsx
@@ -77,6 +77,7 @@ export const useEnableBrowserNotification = () => {
       ),
       message: "Get notified in your browser when messages arrive.",
       validateLabel: "Enable",
+      validateVariant: "highlight",
       cancelLabel: "Later",
     });
 


### PR DESCRIPTION
## Description

**WHAT & WHY**
The dialog to enable notifications has a warning button "enable". The action is not a warning not destructive and should be presented as positive to the user. Moving it the button default highlight variant.

**Before**
<img width="2048" height="1151" alt="image" src="https://github.com/user-attachments/assets/b198a2f2-4241-47ac-a609-c64dd6dfd51e" />



**After**
<img width="1565" height="834" alt="image" src="https://github.com/user-attachments/assets/54d54e01-9b5d-4206-b810-fd8d5fe97602" />


-------

**Claude details :**

The Dust dialog titled **"Enable notifications"** ("Get notified in your browser when messages arrive.", with **Enable** / **Later** buttons) never passed a `validateVariant`, so its **Enable** button fell through to `Confirm`'s `warning` default and rendered red.

It is defined in `front/hooks/useEnableBrowserNotification.tsx:74`.

Enabling notifications is neither a warning nor a destructive action, so it should not carry the destructive treatment. This passes `"highlight"` explicitly.

Two files, two lines:

- `useEnableBrowserNotification.tsx` — adds `validateVariant: "highlight"`
- `Confirm.tsx` — widens `ConfirmDataType.validateVariant` from `"primary" | "warning"` to include `"highlight"`, which is required for the above to typecheck

**No component changes.** Sparkle's `Button` is untouched: `highlight` is an existing variant, already used 72× across `front`. The `Confirm.tsx` edit is a type annotation — erased at compile time, zero runtime difference. The component body, the JSX and the `?? "warning"` fallback are all unchanged.

**Scope is one button.** `validateVariant` is per-call, so the other 60 confirm dialogs are unaffected — the 45 destructive ones keep `warning`, the 12 on `primary` keep it, and the 3 that pass nothing still hit the `warning` fallback (including the `Discard` dialog from #31187, where red is correct).

## This matches the documented Sparkle convention

`sparkle/src/stories/Dialog.stories.tsx` already establishes highlight-for-confirm / warning-for-destructive by example:

| story | confirm button |
|---|---|
| `Default` | `highlight` |
| `ToolValidation` | `highlight` |
| `WithForm` | `highlight` |
| `LargeContent` | `highlight` |
| `DestructiveConfirmation` | `warning` |

The one `warning` story documents itself as *"a Dialog used as a destructive confirmation: `warning`-variant trigger and confirm buttons, an irreversibility note in the body."*

Notably, the canonical `Default` story **is this dialog** — same title ("Enable notifications for new messages"), same body copy ("Get notified in your browser when messages arrive."), with `rightButtonProps: { variant: "highlight" }`. The design system documented this exact prompt as blue; the implementation renders it red.

So this is not a new style, it is the implementation catching up with documented guidance.

Follow-up worth doing separately: the convention is demonstrated in the stories but never stated in prose. A guideline bullet on the Dialog page ("use `highlight` for the confirming action; reserve `warning` for destructive or irreversible ones") would make it citable.

## Tests

`npx tsgo --noEmit` in `front` exits 0; `biome` and the lefthook pre-commit hooks pass.

No behavioural test to add — there is no existing coverage of `Confirm` or `useEnableBrowserNotification`, and this changes no logic: the `subscriberHash` gate, the 7-day `localStorage` throttle, `Notification.requestPermission()` and the Chrome-extension branch are all untouched.


## Risk

Very low, and reversible with a one-line revert.

One thing to weigh honestly: **contrast gets slightly worse.** White text on the `highlight` gradient measures 2.45:1 → 3.21:1, versus 2.85:1 → 4.18:1 on `warning`. 14px medium text wants 4.5:1 for WCAG AA, so neither variant passes today — a pre-existing Sparkle-wide condition shared by all 72 existing `highlight` buttons, not a regression introduced here. Worth naming rather than discovering later.

Also worth knowing: neither `useEnableBrowserNotification` nor `Confirm` has any instrumentation — no shown/accepted/dismissed events — so we cannot measure whether this affects opt-in rates. Adding tracking would need its own change.

## Deploy Plan

Standard deploy. No migration, no feature flag, no ordering constraints.
