### PR TITLE
[front] Analytics modal fills the viewport height

### DIFF
--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -68,7 +68,10 @@ export function UserAnalyticsPopover({
   }, [open, owner.sId]);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    // min-h-0 + content-sized children (grow, not flex-1) let the dialog size
+    // itself on the content: it grows past its min height and only scrolls
+    // inside once the dialog hits its 90vh cap.
+    <div className="flex min-h-0 flex-col overflow-hidden">
       <DialogHeader hideButton className="p-5 sm:p-6">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
           <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
@@ -98,7 +101,7 @@ export function UserAnalyticsPopover({
         </div>
       </DialogHeader>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
+      <div className="min-h-0 grow overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
           <PersonalUsageCard
             owner={owner}

--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -68,10 +68,7 @@ export function UserAnalyticsPopover({
   }, [open, owner.sId]);
 
   return (
-    // min-h-0 + content-sized children (grow, not flex-1) let the dialog size
-    // itself on the content: it grows past its min height and only scrolls
-    // inside once the dialog hits its 90vh cap.
-    <div className="flex min-h-0 flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       <DialogHeader hideButton className="p-5 sm:p-6">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
           <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
@@ -101,7 +98,7 @@ export function UserAnalyticsPopover({
         </div>
       </DialogHeader>
 
-      <div className="min-h-0 grow overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
           <PersonalUsageCard
             owner={owner}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -291,12 +291,7 @@ export function UserMenu({
         owner={owner}
       />
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
-        <DialogContent
-          size="2xl"
-          height="xl"
-          grow
-          className="focus:outline-none"
-        >
+        <DialogContent size="2xl" height="xl" grow>
           <UserAnalyticsPopover
             key={owner.sId}
             open={analyticsOpen}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -293,7 +293,7 @@ export function UserMenu({
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
         <DialogContent
           size="full"
-          className="h-dvh max-h-none max-w-none rounded-none border-none focus:outline-none"
+          className="flex h-full max-h-full overflow-hidden rounded-none p-0"
         >
           <UserAnalyticsPopover
             key={owner.sId}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -291,10 +291,7 @@ export function UserMenu({
         owner={owner}
       />
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
-        <DialogContent
-          size="full"
-          className="flex h-full max-h-full overflow-hidden rounded-none border-none p-0 focus:outline-none"
-        >
+        <DialogContent size="2xl" className="h-full focus:outline-none">
           <UserAnalyticsPopover
             key={owner.sId}
             open={analyticsOpen}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -293,7 +293,9 @@ export function UserMenu({
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
         <DialogContent
           size="2xl"
-          className="focus:outline-none sm:min-h-[min(768px,90vh)]"
+          height="xl"
+          grow
+          className="focus:outline-none"
         >
           <UserAnalyticsPopover
             key={owner.sId}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -291,7 +291,7 @@ export function UserMenu({
         owner={owner}
       />
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
-        <DialogContent size="2xl" height="xl" className="focus:outline-none">
+        <DialogContent size="full" className="focus:outline-none">
           <UserAnalyticsPopover
             key={owner.sId}
             open={analyticsOpen}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -293,7 +293,7 @@ export function UserMenu({
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
         <DialogContent
           size="full"
-          className="flex h-full max-h-full overflow-hidden rounded-none p-0"
+          className="flex h-full max-h-full overflow-hidden rounded-none border-none p-0 focus:outline-none"
         >
           <UserAnalyticsPopover
             key={owner.sId}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -293,7 +293,7 @@ export function UserMenu({
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
         <DialogContent
           size="2xl"
-          className="focus:outline-none sm:min-h-[768px]"
+          className="focus:outline-none sm:min-h-[min(768px,90vh)]"
         >
           <UserAnalyticsPopover
             key={owner.sId}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -291,7 +291,10 @@ export function UserMenu({
         owner={owner}
       />
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
-        <DialogContent size="full" className="focus:outline-none">
+        <DialogContent
+          size="full"
+          className="h-dvh max-h-none max-w-none rounded-none border-none focus:outline-none"
+        >
           <UserAnalyticsPopover
             key={owner.sId}
             open={analyticsOpen}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -291,7 +291,10 @@ export function UserMenu({
         owner={owner}
       />
       <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
-        <DialogContent size="2xl" className="h-full focus:outline-none">
+        <DialogContent
+          size="2xl"
+          className="focus:outline-none sm:min-h-[768px]"
+        >
           <UserAnalyticsPopover
             key={owner.sId}
             open={analyticsOpen}

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -23,7 +23,7 @@ export function UserAutomationsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" className="sm:min-h-[768px]">
+      <DialogContent size="2xl" className="sm:min-h-[min(768px,90vh)]">
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -23,7 +23,7 @@ export function UserAutomationsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl">
+      <DialogContent size="2xl" className="sm:min-h-[768px]">
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -23,7 +23,7 @@ export function UserAutomationsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" className="sm:min-h-[min(768px,90vh)]">
+      <DialogContent size="2xl" height="xl" grow>
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -23,7 +23,7 @@ export function UserAutomationsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" height="xl">
+      <DialogContent size="2xl">
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserToolsDialog.tsx
+++ b/front/components/me/UserToolsDialog.tsx
@@ -23,7 +23,7 @@ export function UserToolsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" className="sm:min-h-[768px]">
+      <DialogContent size="2xl" className="sm:min-h-[min(768px,90vh)]">
         <DialogHeader>
           <DialogTitle>Tools</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserToolsDialog.tsx
+++ b/front/components/me/UserToolsDialog.tsx
@@ -23,7 +23,7 @@ export function UserToolsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl">
+      <DialogContent size="2xl" className="sm:min-h-[768px]">
         <DialogHeader>
           <DialogTitle>Tools</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserToolsDialog.tsx
+++ b/front/components/me/UserToolsDialog.tsx
@@ -23,7 +23,7 @@ export function UserToolsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" className="sm:min-h-[min(768px,90vh)]">
+      <DialogContent size="2xl" height="xl" grow>
         <DialogHeader>
           <DialogTitle>Tools</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserToolsDialog.tsx
+++ b/front/components/me/UserToolsDialog.tsx
@@ -23,7 +23,7 @@ export function UserToolsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" height="xl">
+      <DialogContent size="2xl">
         <DialogHeader>
           <DialogTitle>Tools</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
The user menu dialogs (Analytics, Tools, Automations) had a fixed `height="xl"` (768px): small on tall screens, with unnecessary inner scrolling.

They now use `height="xl" grow` (#31240): 768px stays the minimum, and the dialog grows with its content up to the dialog's built-in 90vh cap, so they keep their usual size when content is short and use the available screen when it is not.