### PR TITLE
[front] Make SpaceResource.isOpen async + check the global group's read grant

### DIFF
--- a/front-api/middlewares/with_space.ts
+++ b/front-api/middlewares/with_space.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import type { SpaceCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { createMiddleware } from "hono/factory";
@@ -89,23 +90,41 @@ export function withSpace(options: WithSpaceOptions) {
       });
     }
 
-    if (await space.isRestricted(auth)) {
-      void emitAuditLogEvent({
-        auth,
-        action: "space.accessed",
-        targets: [
-          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-          buildAuditLogTarget("space", space),
-        ],
-        context: getAuditLogContext(auth),
-        metadata: {
-          space_name: space.name,
-          space_kind: space.kind,
-          is_restricted: "true",
-          access_method: deriveAccessMethod(auth),
+    // The `space.accessed` audit log must not delay the request: resolving openness costs a query,
+    // and the emit is best-effort. Run the whole block off the critical path.
+    void (async () => {
+      // Only regular/project spaces are "restricted" (member-only); global and conversations spaces
+      // are workspace-wide and system is admin-only, so none of those is audited here. This is not
+      // simply `!isOpen`: a system space is not open, but is not restricted either.
+      const isRestricted =
+        (space.isRegular() || space.isProject()) && !(await space.isOpen(auth));
+      if (isRestricted) {
+        void emitAuditLogEvent({
+          auth,
+          action: "space.accessed",
+          targets: [
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("space", space),
+          ],
+          context: getAuditLogContext(auth),
+          metadata: {
+            space_name: space.name,
+            space_kind: space.kind,
+            is_restricted: "true",
+            access_method: deriveAccessMethod(auth),
+          },
+        });
+      }
+    })().catch((err) => {
+      logger.error(
+        {
+          err,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          spaceId: space.sId,
         },
-      });
-    }
+        "Failed to emit space.accessed audit log"
+      );
+    });
 
     ctx.set("space", space);
     await next();

--- a/front-api/middlewares/with_space.ts
+++ b/front-api/middlewares/with_space.ts
@@ -89,7 +89,7 @@ export function withSpace(options: WithSpaceOptions) {
       });
     }
 
-    if (space.isRestricted()) {
+    if (await space.isRestricted(auth)) {
       void emitAuditLogEvent({
         auth,
         action: "space.accessed",

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -41,7 +41,7 @@ app.delete(
       });
     }
 
-    if (space.managementMode === "group" || space.isOpen()) {
+    if (space.managementMode === "group" || (await space.isOpen(auth))) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -58,7 +58,7 @@ const withEditableSpace = createMiddleware<
     });
   }
 
-  if (space.managementMode === "group" || space.isOpen()) {
+  if (space.managementMode === "group" || (await space.isOpen(auth))) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
@@ -1,4 +1,5 @@
 import { listPodsWithEgressPolicy } from "@app/lib/api/sandbox/admin_pods";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { GetEgressPolicyPodsResponseBody } from "@app/types/api/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -27,11 +28,17 @@ app.get("/", async (ctx): HandlerResult<GetEgressPolicyPodsResponseBody> => {
     });
   }
 
+  // Resolve openness for every pod in one query rather than one per pod.
+  const openPodModelIds = await SpaceResource.listOpenSpaceModelIds(
+    auth,
+    pods.value
+  );
+
   return ctx.json({
     pods: pods.value.map((pod) => ({
       sId: pod.sId,
       name: pod.name,
-      isRestricted: pod.isProjectAndRestricted(),
+      isRestricted: pod.isProject() && !openPodModelIds.has(pod.id),
     })),
   });
 });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -29,7 +29,7 @@ app.post(
       });
     }
 
-    if (await space.isProjectAndRestricted(auth)) {
+    if (!(await space.isOpen(auth))) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -29,7 +29,7 @@ app.post(
       });
     }
 
-    if (space.isProjectAndRestricted()) {
+    if (await space.isProjectAndRestricted(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -52,7 +52,7 @@ app.patch(
     const owner = auth.getNonNullableWorkspace();
 
     if (
-      space.isProjectAndRestricted() &&
+      (await space.isProjectAndRestricted(auth)) &&
       !body.isRestricted &&
       !areOpenPodsAllowed(owner)
     ) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -52,9 +52,10 @@ app.patch(
     const owner = auth.getNonNullableWorkspace();
 
     if (
-      (await space.isProjectAndRestricted(auth)) &&
+      space.isProject() &&
       !body.isRestricted &&
-      !areOpenPodsAllowed(owner)
+      !areOpenPodsAllowed(owner) &&
+      !(await space.isOpen(auth))
     ) {
       return apiError(ctx, {
         status_code: 403,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -309,7 +309,7 @@ export function createProjectManagerTools(
           }
 
           const newIsRestricted = access !== "open";
-          const currentlyRestricted = !pod.isOpen();
+          const currentlyRestricted = !(await pod.isOpen(auth));
           if (newIsRestricted !== currentlyRestricted) {
             const { editorIds, memberIds } = await getPodMemberAndEditorSIds(
               auth,
@@ -703,7 +703,7 @@ export function createProjectManagerTools(
               id: pod.sId,
               name: pod.name,
               url: projectUrl,
-              access: pod.isOpen() ? "open" : "restricted",
+              access: (await pod.isOpen(auth)) ? "open" : "restricted",
               description: metadata?.description ?? null,
               pinnedFramePath: metadata?.pinnedFramePath ?? null,
               defaultAgent,
@@ -1107,7 +1107,7 @@ export function createProjectManagerTools(
             pod: {
               id: pod.sId,
               title: pod.name,
-              access: pod.isOpen() ? "open" : "restricted",
+              access: (await pod.isOpen(auth)) ? "open" : "restricted",
               dustPod: {
                 uri: makePodConfigurationURI(owner.sId, pod.sId),
                 mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2576,7 +2576,7 @@ describe("postUserMessage", () => {
     });
 
     it("should reject posting a message without an auth user to a restricted Pod even when user association is disabled", async () => {
-      expect(projectSpace.isOpen()).toBe(false);
+      expect(await projectSpace.isOpen(auth)).toBe(false);
 
       const apiKey = await KeyFactory.regular(globalGroup);
       const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
@@ -2590,7 +2590,7 @@ describe("postUserMessage", () => {
         projectSpace.sId
       );
       expect(restrictedPod).not.toBeNull();
-      expect(restrictedPod?.isOpen()).toBe(false);
+      expect(await restrictedPod?.isOpen(apiKeyAuth)).toBe(false);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource: projectConversationResource,
@@ -2637,7 +2637,7 @@ describe("postUserMessage", () => {
         projectSpace.sId
       );
       expect(openPod).not.toBeNull();
-      expect(openPod?.isOpen()).toBe(true);
+      expect(await openPod?.isOpen(apiKeyAuth)).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource: projectConversationResource,
@@ -2683,7 +2683,7 @@ describe("postUserMessage", () => {
         projectSpace.sId
       );
       expect(openPod).not.toBeNull();
-      expect(openPod?.isOpen()).toBe(true);
+      expect(await openPod?.isOpen(apiKeyAuth)).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource: projectConversationResource,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -590,7 +590,7 @@ export async function postUserMessage(
     // If the Pod is open and there is no user in the context (eg: slack bot message),
     // we allow the message to be posted.
     const skipMembershipCheck =
-      (await pod.isOpen(auth)) && !auth.user() && doNotAssociateUser === true;
+      !auth.user() && doNotAssociateUser === true && (await pod.isOpen(auth));
     if (!skipMembershipCheck && !pod.isMember(auth)) {
       return new Err({
         status_code: 403,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -590,7 +590,7 @@ export async function postUserMessage(
     // If the Pod is open and there is no user in the context (eg: slack bot message),
     // we allow the message to be posted.
     const skipMembershipCheck =
-      pod.isOpen() && !auth.user() && doNotAssociateUser === true;
+      (await pod.isOpen(auth)) && !auth.user() && doNotAssociateUser === true;
     if (!skipMembershipCheck && !pod.isMember(auth)) {
       return new Err({
         status_code: 403,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -834,7 +834,7 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
       // Regular spaces created by SpaceFactory.regular are restricted (no global group)
-      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
 
       // Create a user who is NOT a member of the restricted space
       const mentionedUser = await UserFactory.basic();
@@ -946,7 +946,7 @@ describe("createAgentMessages", () => {
         openSpace.sId
       );
       expect(refreshedOpenSpace).not.toBeNull();
-      expect(refreshedOpenSpace?.isOpen()).toBe(true);
+      expect(await refreshedOpenSpace?.isOpen(adminAuth)).toBe(true);
 
       // Create a user who can access the space (all users can access open spaces)
       const mentionedUser = await UserFactory.basic();
@@ -1042,7 +1042,7 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
       // Regular spaces created by SpaceFactory.regular are restricted (no global group)
-      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
 
       // Create a user who is NOT a member of the restricted space
       const mentionedUser = await UserFactory.basic();

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -908,7 +908,7 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
       // Regular spaces created by SpaceFactory.regular are restricted (no global group)
-      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
 
       // Refresh the conversation space to get updated permissions
       const refreshedConversationSpace = await SpaceResource.fetchById(
@@ -1052,7 +1052,7 @@ describe("createAgentMessages", () => {
         restrictedSpace.sId
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
-      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
 
       const refreshedConversationSpace = await SpaceResource.fetchById(
         userAuth,
@@ -1356,7 +1356,7 @@ describe("createAgentMessages", () => {
         openSpace.sId
       );
       expect(refreshedOpenSpace).not.toBeNull();
-      expect(refreshedOpenSpace?.isOpen()).toBe(true);
+      expect(await refreshedOpenSpace?.isOpen(adminAuth)).toBe(true);
       // Verify it's not global
       expect(refreshedOpenSpace?.isGlobal()).toBe(false);
 

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -239,7 +239,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
       }
 
       expect(openProjectHydrated.isProject()).toBe(true);
-      expect(openProjectHydrated.isOpen()).toBe(true);
+      expect(await openProjectHydrated.isOpen(auth)).toBe(true);
 
       const manualMembers =
         await openProjectHydrated.fetchDistinctActiveManualGroupMembers(auth);

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -112,12 +112,13 @@ export async function canAgentBeUsedInProjectConversation(
       uniq([conversation.spaceId, ...configuration.requestedSpaceIds]),
       { transaction }
     );
+    const openIds = await SpaceResource.listOpenSpaceModelIds(auth, spaces);
     if (
       spaces
         // Exclude the project's space from the check.
         .filter((space) => space.sId !== conversation.spaceId)
         // Check if any of the other spaces are restricted.
-        .some((space) => !space.isOpen())
+        .some((space) => !openIds.has(space.id))
     ) {
       const project = spaces.find(
         (space) => space.sId === conversation.spaceId
@@ -128,9 +129,10 @@ export async function canAgentBeUsedInProjectConversation(
 
       // Special case for restricted projects whose members all belong to every
       // restricted space required by the agent, we can use the agent directly.
-      if (!project.isOpen()) {
+      if (!openIds.has(project.id)) {
         const restrictedAgentSpaces = spaces.filter(
-          (space) => space.sId !== conversation.spaceId && !space.isOpen()
+          (space) =>
+            space.sId !== conversation.spaceId && !openIds.has(space.id)
         );
         const projectMembers =
           await project.fetchDistinctActiveManualGroupMembers(auth);

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -890,7 +890,7 @@ describe("DustFileSystem.forAgentLoop", () => {
         openProjectRes.value.sId
       );
       assert(openProject, "Open project not found after creation");
-      expect(openProject.isOpen()).toBe(true);
+      expect(await openProject.isOpen(adminAuth)).toBe(true);
 
       const podConversation = await ConversationFactory.create(
         refreshedAdminAuth,
@@ -945,7 +945,7 @@ describe("DustFileSystem.forAgentLoop", () => {
       const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
 
       const restrictedProject = await SpaceFactory.project(workspace, user.id);
-      expect(restrictedProject.isOpen()).toBe(false);
+      expect(await restrictedProject.isOpen(userSessionAuth)).toBe(false);
 
       const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
         user.sId,

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -144,9 +144,14 @@ export async function listPodsForScope(
     );
     const metadataMap = new Map(metadatas.map((m) => [m.spaceId, m]));
 
+    const openIds = await SpaceResource.listOpenSpaceModelIds(
+      auth,
+      page.spaces
+    );
+
     for (const space of page.spaces) {
       if (
-        space.isOpen() &&
+        openIds.has(space.id) &&
         metadataMap.get(space.id)?.archivedAt === null &&
         podNameMatches(q, space.name)
       ) {

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -20,6 +20,7 @@ import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import type { SearchWarningCode } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { APIError } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -38,14 +39,14 @@ type SearchError = {
   error: APIError;
 };
 
-function getSpaceAccessPriority(space: SpaceResource) {
+function getSpaceAccessPriority(space: SpaceResource, isOpen: boolean) {
   // Global spaces have highest priority.
   if (space.isGlobal()) {
     return 3;
   }
 
   // Open spaces have second highest priority.
-  if (space.isRegularAndOpen()) {
+  if (space.isRegular() && isOpen) {
     return 2;
   }
 
@@ -60,7 +61,8 @@ function getSpaceAccessPriority(space: SpaceResource) {
 }
 
 function selectHighestPriorityDataSourceView(
-  views: DataSourceViewResource[]
+  views: DataSourceViewResource[],
+  openSpaceIds: Set<ModelId>
 ): DataSourceViewResource {
   if (views.length <= 1) {
     return views[0];
@@ -68,7 +70,10 @@ function selectHighestPriorityDataSourceView(
 
   const viewsWithPriority = views.map((view) => ({
     view,
-    priority: getSpaceAccessPriority(view.space),
+    priority: getSpaceAccessPriority(
+      view.space,
+      openSpaceIds.has(view.space.id)
+    ),
     spaceName: view.space.name,
   }));
 
@@ -134,6 +139,11 @@ export async function handleSearch(
 
   const spacesToSearch = spaces.filter(
     (s) => !spaceIds || spaceIds.includes(s.sId)
+  );
+
+  const openSpaceIds = await SpaceResource.listOpenSpaceModelIds(
+    auth,
+    spacesToSearch
   );
 
   const allDatasourceViews = await DataSourceViewResource.listBySpaces(
@@ -242,7 +252,7 @@ export async function handleSearch(
       }
 
       const selectedViews = prioritizeSpaceAccess
-        ? [selectHighestPriorityDataSourceView(matchingViews)]
+        ? [selectHighestPriorityDataSourceView(matchingViews, openSpaceIds)]
         : matchingViews;
 
       return {

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -72,8 +72,13 @@ export async function findSkillEditorsWithoutSpaceAccess(
     return null;
   }
 
-  const restrictedSpaces = requestedSpaces.filter((space) =>
-    space.isRestricted()
+  const openIds = await SpaceResource.listOpenSpaceModelIds(
+    auth,
+    requestedSpaces
+  );
+  const restrictedSpaces = requestedSpaces.filter(
+    (space) =>
+      (space.isRegular() || space.isProject()) && !openIds.has(space.id)
   );
 
   const editorsWithoutAccess = await listUsersWithoutAccessToSpaceResources(

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -128,7 +128,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.name).toBe("Test Regular Space");
         expect(space.kind).toBe("regular");
         expect(space.managementMode).toBe("manual");
-        expect(await space.isRegularAndRestricted(adminAuth)).toBe(true);
+        expect(await space.isOpen(adminAuth)).toBe(false);
 
         // Verify the space has a group
         const groups = await space.fetchGroupResources(adminAuth);
@@ -189,7 +189,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.name).toBe("Test Group Space");
         expect(space.kind).toBe("regular");
         expect(space.managementMode).toBe("group");
-        expect(await space.isRegularAndRestricted(adminAuth)).toBe(true);
+        expect(await space.isOpen(adminAuth)).toBe(false);
 
         // Verify groups were associated (from the space's group_permissions grants).
         const reloadedSpace = await SpaceResource.fetchById(
@@ -419,9 +419,7 @@ describe("createSpaceAndGroup", () => {
           space.sId
         );
         expect(reloadedSpace).not.toBeNull();
-        expect(await reloadedSpace!.isRegularAndRestricted(adminAuth)).toBe(
-          false
-        );
+        expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
 
         // Verify global group was added (from the space's group_permissions grants).
         const associatedGroupIds = reloadedSpace!.groups.map(
@@ -486,7 +484,7 @@ describe("createSpaceAndGroup", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         const space = result.value;
-        expect(await space.isRegularAndRestricted(adminAuth)).toBe(true);
+        expect(await space.isOpen(adminAuth)).toBe(false);
 
         // Verify global group was NOT added (from the space's group_permissions grants).
         const associatedGroupIds = space.groups.map((group) => group.groupId);

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -128,7 +128,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.name).toBe("Test Regular Space");
         expect(space.kind).toBe("regular");
         expect(space.managementMode).toBe("manual");
-        expect(space.isRegularAndRestricted()).toBe(true);
+        expect(await space.isRegularAndRestricted(adminAuth)).toBe(true);
 
         // Verify the space has a group
         const groups = await space.fetchGroupResources(adminAuth);
@@ -189,7 +189,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.name).toBe("Test Group Space");
         expect(space.kind).toBe("regular");
         expect(space.managementMode).toBe("group");
-        expect(space.isRegularAndRestricted()).toBe(true);
+        expect(await space.isRegularAndRestricted(adminAuth)).toBe(true);
 
         // Verify groups were associated (from the space's group_permissions grants).
         const reloadedSpace = await SpaceResource.fetchById(
@@ -419,7 +419,9 @@ describe("createSpaceAndGroup", () => {
           space.sId
         );
         expect(reloadedSpace).not.toBeNull();
-        expect(reloadedSpace!.isRegularAndRestricted()).toBe(false);
+        expect(await reloadedSpace!.isRegularAndRestricted(adminAuth)).toBe(
+          false
+        );
 
         // Verify global group was added (from the space's group_permissions grants).
         const associatedGroupIds = reloadedSpace!.groups.map(
@@ -462,7 +464,7 @@ describe("createSpaceAndGroup", () => {
         result.value.sId
       );
 
-      expect(asMember!.isOpen()).toBe(true);
+      expect(await asMember!.isOpen(memberAuth)).toBe(true);
 
       // The member group confers write; the global group's `reader` grant only confers read.
       expect(asMember!.canRead(memberAuth)).toBe(true);
@@ -484,7 +486,7 @@ describe("createSpaceAndGroup", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         const space = result.value;
-        expect(space.isRegularAndRestricted()).toBe(true);
+        expect(await space.isRegularAndRestricted(adminAuth)).toBe(true);
 
         // Verify global group was NOT added (from the space's group_permissions grants).
         const associatedGroupIds = space.groups.map((group) => group.groupId);
@@ -930,7 +932,7 @@ describe("createSpaceAndGroup", () => {
           adminAuth,
           space.sId
         );
-        expect(reloadedSpace!.isOpen()).toBe(true);
+        expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
 
         // Verify the global group holds a reader grant on the space (open regular space).
         const grants = await GroupPermissionResource.listForResource(
@@ -965,7 +967,7 @@ describe("createSpaceAndGroup", () => {
           space.sId
         );
         expect(reloadedSpace!.kind).toBe("project");
-        expect(reloadedSpace!.isOpen()).toBe(true);
+        expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
 
         // Verify the global group holds a reader grant on the project (attached as viewer).
         const grants = await GroupPermissionResource.listForResource(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -129,6 +129,7 @@ export interface AuthenticatorType {
   attributionKey?: { id: ModelId; name: string };
   clientIp?: string;
   permissions?: GroupPermissionsJSON;
+  globalGroupModelId?: ModelId | null;
 }
 
 /**
@@ -154,6 +155,8 @@ export class Authenticator {
   _clientIp?: string;
   // Governance grants the caller holds, resolved by the factory (see `resolvePermissions`)
   _permissions: GroupPermissions;
+  // The workspace global group's model id. `undefined` = not resolved yet (resolved lazily on first use)
+  _globalGroupModelId: ModelId | null | undefined;
 
   // Should only be called from the static methods below.
   constructor({
@@ -168,6 +171,7 @@ export class Authenticator {
     providersHealth,
     clientIp,
     permissions,
+    globalGroupModelId,
   }: {
     workspace?: WorkspaceResource | null;
     user?: UserResource | null;
@@ -180,6 +184,7 @@ export class Authenticator {
     providersHealth?: ProvidersHealth | null;
     clientIp?: string;
     permissions: GroupPermissions;
+    globalGroupModelId?: ModelId | null;
   }) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
@@ -195,6 +200,7 @@ export class Authenticator {
     this._providersHealth = providersHealth ?? null;
     this._clientIp = clientIp;
     this._permissions = permissions;
+    this._globalGroupModelId = globalGroupModelId;
 
     if (user) {
       tracer.setUser({
@@ -271,11 +277,12 @@ export class Authenticator {
   }): Promise<{
     role: RoleType;
     groupModelIds: ModelId[];
+    globalGroupModelId: ModelId | null;
     subscription: SubscriptionResource | null;
   }> {
     const lightWorkspace = renderLightWorkspaceType({ workspace });
 
-    const [role, groupModelIds, subscription] = await Promise.all([
+    const [role, authGroups, subscription] = await Promise.all([
       MembershipResource.getActiveRoleForUserInWorkspace({
         user,
         workspace: lightWorkspace,
@@ -292,9 +299,11 @@ export class Authenticator {
       ),
     ]);
 
+    const isMember = Authenticator.isMember(role);
     return {
       role,
-      groupModelIds: Authenticator.isMember(role) ? groupModelIds : [],
+      groupModelIds: isMember ? authGroups.groupModelIds : [],
+      globalGroupModelId: isMember ? authGroups.globalGroupModelId : null,
       subscription,
     };
   }
@@ -319,6 +328,7 @@ export class Authenticator {
 
       let role = "none" as RoleType;
       let groupModelIds: ModelId[] = [];
+      let globalGroupModelId: ModelId | null = null;
       let subscription: SubscriptionResource | null = null;
 
       if (user && workspace) {
@@ -328,6 +338,7 @@ export class Authenticator {
         });
         role = authData.role;
         groupModelIds = authData.groupModelIds;
+        globalGroupModelId = authData.globalGroupModelId;
         subscription = authData.subscription;
       }
 
@@ -343,6 +354,7 @@ export class Authenticator {
         user,
         role,
         groupModelIds,
+        globalGroupModelId,
         subscription,
         providersHealth,
         permissions: await this.resolvePermissions({
@@ -382,13 +394,20 @@ export class Authenticator {
     // Reload group memberships for user-backed auths. Key auths carry a fixed group set derived
     // from the key (not from live membership), so their `_groupModelIds` are left as-is.
     if (this._user) {
-      this._groupModelIds = Authenticator.isMember(this._role)
-        ? await GroupResource.dangerouslyListUserGroupsForAuth({
+      if (Authenticator.isMember(this._role)) {
+        const authGroups = await GroupResource.dangerouslyListUserGroupsForAuth(
+          {
             user: this._user,
             workspace: renderLightWorkspaceType({ workspace: this._workspace }),
             transaction,
-          })
-        : [];
+          }
+        );
+        this._groupModelIds = authGroups.groupModelIds;
+        this._globalGroupModelId = authGroups.globalGroupModelId;
+      } else {
+        this._groupModelIds = [];
+        this._globalGroupModelId = null;
+      }
     }
 
     // Re-resolve grants from the current group set. Grants on those groups can change (backfill,
@@ -476,6 +495,7 @@ export class Authenticator {
 
     let role: RoleType = "none";
     let groupModelIds: ModelId[] = [];
+    let globalGroupModelId: ModelId | null = null;
     let subscription: SubscriptionResource | null = null;
 
     if (user && workspace) {
@@ -486,6 +506,7 @@ export class Authenticator {
       });
       role = authData.role;
       groupModelIds = authData.groupModelIds;
+      globalGroupModelId = authData.globalGroupModelId;
       subscription = authData.subscription;
     }
 
@@ -501,6 +522,7 @@ export class Authenticator {
       user,
       role,
       groupModelIds,
+      globalGroupModelId,
       subscription,
       providersHealth,
       permissions: await this.resolvePermissions({
@@ -1190,10 +1212,11 @@ export class Authenticator {
     }
 
     // Membership already verified above (activeMembership found).
-    const groupModelIds = await GroupResource.dangerouslyListUserGroupsForAuth({
-      user,
-      workspace: owner,
-    });
+    const { groupModelIds, globalGroupModelId } =
+      await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
+        workspace: owner,
+      });
 
     return new Authenticator({
       authMethod: auth.authMethod(),
@@ -1201,6 +1224,7 @@ export class Authenticator {
       // We limit scope to a user role.
       role: "user",
       groupModelIds,
+      globalGroupModelId,
       user,
       subscription: auth._subscription,
       workspace: auth._workspace,
@@ -1492,6 +1516,27 @@ export class Authenticator {
     return this._groupModelIds;
   }
 
+  // The workspace global group's model id, used by openness checks (see
+  // `SpaceResource.listOpenSpaceModelIds`). Resolved once by the factory from the caller's group
+  // fetch and cached on the instance; falls back to a lazy query for auths that did not provide it
+  // (e.g. system/internal auths). Returns null for a non-member or an auth with no workspace — a
+  // workspace always has a global group, so null is about this auth, not a missing group.
+  async getGlobalGroupModelId(): Promise<ModelId | null> {
+    if (this._globalGroupModelId !== undefined) {
+      return this._globalGroupModelId;
+    }
+    if (!this._workspace) {
+      this._globalGroupModelId = null;
+      return null;
+    }
+
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(this);
+    this._globalGroupModelId = globalGroupRes.isOk()
+      ? globalGroupRes.value.id
+      : null;
+    return this._globalGroupModelId;
+  }
+
   hasGroup(groupId: string): boolean {
     const workspaceId = this._workspace?.id;
     // Group are always tied to a workspace, so we can't have a group without a workspace.
@@ -1737,6 +1782,7 @@ export class Authenticator {
       attributionKey: this._attributionKey,
       clientIp: this._clientIp,
       permissions: this._permissions.toJSON(),
+      globalGroupModelId: this._globalGroupModelId,
     };
   }
 
@@ -1790,6 +1836,7 @@ export class Authenticator {
       attributionKey: authType.attributionKey,
       providersHealth,
       clientIp: authType.clientIp,
+      globalGroupModelId: authType.globalGroupModelId,
       permissions: authType.permissions
         ? GroupPermissions.fromJSON(authType.permissions)
         : // Payloads serialized before governance grants existed (in-flight Temporal workflows

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -90,7 +90,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 
 function getCacheKeyForUser(userId: number, workspaceId: number): string {
   // The function name is empty because an anonymous arrow function is passed to cacheWithRedis
-  return `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`;
+  return `cacheWithRedis--groups:v2:user:${userId}:workspace:${workspaceId}`;
 }
 
 function getCacheKeyForWorkspaceGroupsFromSystemKey(
@@ -147,26 +147,30 @@ describe("GroupResource", () => {
         users: [user.toJSON()],
       });
 
-      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
-        user,
-        workspace,
-      });
+      const { globalGroupModelId, groupModelIds } =
+        await GroupResource.dangerouslyListUserGroupsForAuth({
+          user,
+          workspace,
+        });
 
-      expect(groupIds.length).toBe(2);
-      expect(groupIds).toContain(globalGroup.id);
-      expect(groupIds).toContain(regularGroup.id);
+      expect(groupModelIds.length).toBe(2);
+      expect(groupModelIds).toContain(globalGroup.id);
+      expect(groupModelIds).toContain(regularGroup.id);
+      expect(globalGroupModelId).toBe(globalGroup.id);
     });
 
     it("returns global group for non-member (no membership check)", async () => {
       const nonMember = await UserFactory.basic();
 
-      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
-        user: nonMember,
-        workspace,
-      });
+      const { globalGroupModelId, groupModelIds } =
+        await GroupResource.dangerouslyListUserGroupsForAuth({
+          user: nonMember,
+          workspace,
+        });
 
-      expect(groupIds.length).toBe(1);
-      expect(groupIds).toContain(globalGroup.id);
+      expect(groupModelIds.length).toBe(1);
+      expect(groupModelIds).toContain(globalGroup.id);
+      expect(globalGroupModelId).toBe(globalGroup.id);
     });
 
     it("throws when global group is missing", async () => {
@@ -396,14 +400,15 @@ describe("GroupResource", () => {
         users: [user.toJSON()],
       });
 
-      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
-        user,
-        workspace,
-      });
+      const { groupModelIds } =
+        await GroupResource.dangerouslyListUserGroupsForAuth({
+          user,
+          workspace,
+        });
 
-      expect(groupIds.length).toBe(2);
-      expect(groupIds).toContain(globalGroup.id);
-      expect(groupIds).toContain(regularGroup.id);
+      expect(groupModelIds.length).toBe(2);
+      expect(groupModelIds).toContain(globalGroup.id);
+      expect(groupModelIds).toContain(regularGroup.id);
     });
 
     it("populates cache on first call", async () => {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -183,7 +183,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   }: {
     user: { id: ModelId };
     workspace: { id: ModelId };
-  }) => `groups:user:${user.id}:workspace:${workspace.id}`;
+  }) => `groups:v2:user:${user.id}:workspace:${workspace.id}`;
 
   private static async dangerouslyListUserGroupsForAuthUncached({
     user,
@@ -193,7 +193,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     user: UserResource;
     workspace: LightWorkspaceType;
     transaction?: Transaction;
-  }): Promise<ModelId[]> {
+  }): Promise<{
+    globalGroupModelId: ModelId | null;
+    groupModelIds: ModelId[];
+  }> {
     return GroupResource.listUserGroupModelIdsInWorkspace({
       user,
       workspace,
@@ -275,7 +278,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     user: UserResource;
     workspace: LightWorkspaceType;
     transaction?: Transaction;
-  }): Promise<ModelId[]> {
+  }): Promise<{
+    globalGroupModelId: ModelId | null;
+    groupModelIds: ModelId[];
+  }> {
     if (transaction) {
       logger.info(
         {
@@ -1171,7 +1177,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     transaction?: Transaction;
     dangerouslySkipMembershipCheck?: boolean;
     at?: Date;
-  }): Promise<ModelId[]> {
+  }): Promise<{
+    globalGroupModelId: ModelId | null;
+    groupModelIds: ModelId[];
+  }> {
     if (!dangerouslySkipMembershipCheck) {
       const workspaceMembership =
         await MembershipResource.getActiveMembershipOfUserInWorkspace({
@@ -1181,7 +1190,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           at,
         });
       if (!workspaceMembership) {
-        return [];
+        return { globalGroupModelId: null, groupModelIds: [] };
       }
     }
 
@@ -1221,11 +1230,16 @@ export class GroupResource extends BaseResource<GroupModel> {
       }
     );
 
-    if (includeGlobal && !groups.some((g) => g.kind === "global")) {
+    const globalGroupModelId =
+      groups.find((g) => g.kind === "global")?.id ?? null;
+    if (includeGlobal && globalGroupModelId === null) {
       throw new Error("Global group not found.");
     }
 
-    return groups.map((group) => group.id);
+    return {
+      globalGroupModelId,
+      groupModelIds: groups.map((group) => group.id),
+    };
   }
 
   // Warning, this function can be very memory hungry if there are a lot of groups (such as a workspace with a lot of agents and editors groups).
@@ -1243,7 +1257,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     transaction?: Transaction;
     at?: Date;
   }): Promise<GroupResource[]> {
-    const groupIds = await this.listUserGroupModelIdsInWorkspace({
+    const { groupModelIds } = await this.listUserGroupModelIdsInWorkspace({
       user,
       workspace,
       groupKinds,
@@ -1254,7 +1268,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const groups = await GroupModel.findAll({
       where: {
         id: {
-          [Op.in]: groupIds,
+          [Op.in]: groupModelIds,
         },
         workspaceId: workspace.id,
       },

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1609,7 +1609,7 @@ describe("SpaceResource", () => {
     const refetchIsOpen = async (space: SpaceResource): Promise<boolean> => {
       const refetched = await SpaceResource.fetchById(adminAuth, space.sId);
       expect(refetched).not.toBeNull();
-      return refetched!.isOpen();
+      return refetched!.isOpen(adminAuth);
     };
 
     it("is false for a restricted space and true once opened", async () => {
@@ -2637,7 +2637,7 @@ describe("SpaceResource group_permissions enforcement", () => {
     // Refetched, not reused: `space` holds the grant snapshot from before the update.
     const openSpace = await SpaceResource.fetchById(adminAuth, space.sId);
     expect(openSpace).not.toBeNull();
-    expect(openSpace!.isOpen()).toBe(true);
+    expect(await openSpace!.isOpen(adminAuth)).toBe(true);
 
     // The member group confers write; the global group's `reader` grant only confers read.
     expect(openSpace!.canRead(memberAuth)).toBe(true);
@@ -2792,7 +2792,7 @@ describe("SpaceResource group_permissions enforcement", () => {
     // Refetched, not reused: `space` holds the grant snapshot from before the update.
     const openSpace = await SpaceResource.fetchById(adminAuth, space.sId);
     expect(openSpace).not.toBeNull();
-    expect(openSpace!.isOpen()).toBe(true);
+    expect(await openSpace!.isOpen(adminAuth)).toBe(true);
 
     // In group management mode the provisioned group is the space's member group, so it is what
     // carries write.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -2104,7 +2104,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // Users can add themselves to open projects; otherwise managing a space's members requires
     // administration rights (held by workspace admins and a project's editors) — a project's plain
     // members hold `write` but must not be able to add others, so this gates on `canAdministrate`.
-    if (this.isProject() && this.isOpen()) {
+    if (this.isProject() && (await this.isOpen(auth))) {
       const currentUser = auth.getNonNullableUser();
       if (userId === currentUser.sId) {
         return true;
@@ -2156,31 +2156,68 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.kind === "project";
   }
 
-  isRegularAndRestricted() {
-    return this.isRegular() && !this.isOpen();
+  async isRegularAndRestricted(auth: Authenticator): Promise<boolean> {
+    return this.isRegular() && !(await this.isOpen(auth));
   }
 
-  isProjectAndRestricted() {
-    return this.isProject() && !this.isOpen();
+  async isProjectAndRestricted(auth: Authenticator): Promise<boolean> {
+    return this.isProject() && !(await this.isOpen(auth));
   }
 
-  isRegularAndOpen() {
-    return this.isRegular() && this.isOpen();
+  async isRegularAndOpen(auth: Authenticator): Promise<boolean> {
+    return this.isRegular() && (await this.isOpen(auth));
   }
 
   // Whether the space is restricted (its data is visible only to its members). Only regular and
   // project spaces can be restricted; the unique kinds (`global`/`conversations` are workspace-wide,
   // `system` is admin-only and not a membership space) are never "restricted" in this sense. Note
   // this is NOT `!isOpen()`: a `system` space is not open but is not restricted either.
-  isRestricted() {
-    return this.isRegularAndRestricted() || this.isProjectAndRestricted();
+  async isRestricted(auth: Authenticator): Promise<boolean> {
+    return (this.isRegular() || this.isProject()) && !(await this.isOpen(auth));
   }
 
-  isOpen() {
-    // A space is open when it has a reader (viewer) grant: the workspace global group is attached as
-    // a viewer on open spaces (restricted spaces have no reader grant). See
-    // `SpaceGroupReference.isReader`.
-    return this.groups.some((group) => group.isReader());
+  // A space is open when the workspace global group holds a `reader` grant on it (that grant is what
+  // makes the space visible to every workspace member). Resolved from `group_permissions` so it does
+  // not depend on the eagerly-loaded `this.groups`. Prefer `listOpenSpaceModelIds` when checking
+  // several spaces to avoid one query per space.
+  async isOpen(auth: Authenticator): Promise<boolean> {
+    return (await SpaceResource.listOpenSpaceModelIds(auth, [this])).has(
+      this.id
+    );
+  }
+
+  // The model ids of the `spaces` that are open (the workspace global group holds a `reader` grant).
+  // One `group_permissions` query (plus the global group lookup) for the whole batch.
+  static async listOpenSpaceModelIds(
+    auth: Authenticator,
+    spaces: SpaceResource[]
+  ): Promise<Set<ModelId>> {
+    const openSpaceModelIds = new Set<ModelId>();
+    if (spaces.length === 0) {
+      return openSpaceModelIds;
+    }
+
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (globalGroupRes.isErr()) {
+      return openSpaceModelIds;
+    }
+
+    const readerGrants = await GroupPermissionModel.findAll({
+      attributes: ["resourceId"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        resourceType: "space",
+        resourceId: spaces.map((space) => space.id),
+        groupId: globalGroupRes.value.id,
+        grantType: "reader",
+      },
+    });
+
+    for (const grant of readerGrants) {
+      openSpaceModelIds.add(grant.resourceId);
+    }
+
+    return openSpaceModelIds;
   }
 
   isDeletable() {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -2152,28 +2152,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   isRegular() {
     return this.kind === "regular";
   }
+
   isProject() {
     return this.kind === "project";
-  }
-
-  async isRegularAndRestricted(auth: Authenticator): Promise<boolean> {
-    return this.isRegular() && !(await this.isOpen(auth));
-  }
-
-  async isProjectAndRestricted(auth: Authenticator): Promise<boolean> {
-    return this.isProject() && !(await this.isOpen(auth));
-  }
-
-  async isRegularAndOpen(auth: Authenticator): Promise<boolean> {
-    return this.isRegular() && (await this.isOpen(auth));
-  }
-
-  // Whether the space is restricted (its data is visible only to its members). Only regular and
-  // project spaces can be restricted; the unique kinds (`global`/`conversations` are workspace-wide,
-  // `system` is admin-only and not a membership space) are never "restricted" in this sense. Note
-  // this is NOT `!isOpen()`: a `system` space is not open but is not restricted either.
-  async isRestricted(auth: Authenticator): Promise<boolean> {
-    return (this.isRegular() || this.isProject()) && !(await this.isOpen(auth));
   }
 
   // A space is open when the workspace global group holds a `reader` grant on it (that grant is what
@@ -2197,8 +2178,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return openSpaceModelIds;
     }
 
-    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
-    if (globalGroupRes.isErr()) {
+    const globalGroupModelId = await auth.getGlobalGroupModelId();
+    if (globalGroupModelId === null) {
       return openSpaceModelIds;
     }
 
@@ -2208,7 +2189,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         workspaceId: auth.getNonNullableWorkspace().id,
         resourceType: "space",
         resourceId: spaces.map((space) => space.id),
-        groupId: globalGroupRes.value.id,
+        groupId: globalGroupModelId,
         grantType: "reader",
       },
     });

--- a/front/migrations/20260825_backfill_open_space_admin_manager_members.ts
+++ b/front/migrations/20260825_backfill_open_space_admin_manager_members.ts
@@ -25,8 +25,12 @@ async function backfillWorkspaceOpenSpaceMembers(
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   const spaces = await SpaceResource.listWorkspaceSpaces(auth);
+  const openIds = await SpaceResource.listOpenSpaceModelIds(auth, spaces);
   const targets = spaces.filter(
-    (space) => space.isRegularAndOpen() && space.managementMode === "manual"
+    (space) =>
+      space.isRegular() &&
+      openIds.has(space.id) &&
+      space.managementMode === "manual"
   );
 
   // Counts for every stage, logged once: a run that adds nothing has to say which stage came up

--- a/front/migrations/20260825_reset_open_space_members.ts
+++ b/front/migrations/20260825_reset_open_space_members.ts
@@ -30,7 +30,10 @@ async function resetWorkspaceOpenSpaceMembers(
   // `isRegularAndOpen` is the predicate this targets: a regular space whose groups include the
   // workspace global group as a `reader` viewer. Soft-deleted spaces are left out (default scope).
   const spaces = await SpaceResource.listWorkspaceSpaces(auth);
-  const openRegularSpaces = spaces.filter((space) => space.isRegularAndOpen());
+  const openIds = await SpaceResource.listOpenSpaceModelIds(auth, spaces);
+  const openRegularSpaces = spaces.filter(
+    (space) => space.isRegular() && openIds.has(space.id)
+  );
   // Counts for every stage, logged once at the end: a run that removes nothing has to say which
   // stage came up empty, or a no-op is indistinguishable from a bug.
   const counts = {

--- a/front/migrations/20260825_reset_open_space_members.ts
+++ b/front/migrations/20260825_reset_open_space_members.ts
@@ -27,8 +27,8 @@ async function resetWorkspaceOpenSpaceMembers(
 ): Promise<void> {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  // `isRegularAndOpen` is the predicate this targets: a regular space whose groups include the
-  // workspace global group as a `reader` viewer. Soft-deleted spaces are left out (default scope).
+  // This targets regular spaces that are open: a regular space whose groups include the workspace
+  // global group as a `reader` viewer. Soft-deleted spaces are left out (default scope).
   const spaces = await SpaceResource.listWorkspaceSpaces(auth);
   const openIds = await SpaceResource.listOpenSpaceModelIds(auth, spaces);
   const openRegularSpaces = spaces.filter(

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -130,9 +130,7 @@ describe("governance seed script integration test", () => {
 
     // The restricted space holds the current user and Bob.
     expect(restrictedSpace).toBeDefined();
-    expect(await restrictedSpace!.isRegularAndRestricted(authenticator)).toBe(
-      true
-    );
+    expect(await restrictedSpace!.isOpen(authenticator)).toBe(false);
     const spaceMembers =
       await restrictedSpace!.fetchDistinctActiveManualGroupMembers(
         authenticator
@@ -179,9 +177,7 @@ describe("governance seed script integration test", () => {
 
     // The private space holds Alfred only: the current user is not a member.
     expect(privateSpace).toBeDefined();
-    expect(await privateSpace!.isRegularAndRestricted(authenticator)).toBe(
-      true
-    );
+    expect(await privateSpace!.isOpen(authenticator)).toBe(false);
     const privateSpaceMembers =
       await privateSpace!.fetchDistinctActiveManualGroupMembers(authenticator);
     expect(new Set(privateSpaceMembers.map((m) => m.sId))).toEqual(

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -130,7 +130,9 @@ describe("governance seed script integration test", () => {
 
     // The restricted space holds the current user and Bob.
     expect(restrictedSpace).toBeDefined();
-    expect(restrictedSpace!.isRegularAndRestricted()).toBe(true);
+    expect(await restrictedSpace!.isRegularAndRestricted(authenticator)).toBe(
+      true
+    );
     const spaceMembers =
       await restrictedSpace!.fetchDistinctActiveManualGroupMembers(
         authenticator
@@ -177,7 +179,9 @@ describe("governance seed script integration test", () => {
 
     // The private space holds Alfred only: the current user is not a member.
     expect(privateSpace).toBeDefined();
-    expect(privateSpace!.isRegularAndRestricted()).toBe(true);
+    expect(await privateSpace!.isRegularAndRestricted(authenticator)).toBe(
+      true
+    );
     const privateSpaceMembers =
       await privateSpace!.fetchDistinctActiveManualGroupMembers(authenticator);
     expect(new Set(privateSpaceMembers.map((m) => m.sId))).toEqual(

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -52,11 +52,7 @@ async function createConversationForAgentConfiguration({
   let spaceModelId: ModelId | null = null;
   if (trigger.spaceId) {
     const pod = await SpaceResource.fetchById(auth, trigger.spaceId);
-    if (
-      pod &&
-      pod.isProject() &&
-      ((await pod.isOpen(auth)) || pod.isMember(auth))
-    ) {
+    if (pod && pod.isProject() && pod.canRead(auth)) {
       spaceModelId = pod.id;
     } else {
       logger.warn(

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -52,7 +52,11 @@ async function createConversationForAgentConfiguration({
   let spaceModelId: ModelId | null = null;
   if (trigger.spaceId) {
     const pod = await SpaceResource.fetchById(auth, trigger.spaceId);
-    if (pod && pod.isProject() && (pod.isOpen() || pod.isMember(auth))) {
+    if (
+      pod &&
+      pod.isProject() &&
+      ((await pod.isOpen(auth)) || pod.isMember(auth))
+    ) {
       spaceModelId = pod.id;
     } else {
       logger.warn(


### PR DESCRIPTION
## Description

Makes `SpaceResource.isOpen()` **async** and resolves openness from `group_permissions` with the **correct predicate**: a space is open iff the workspace **global group** holds a `reader` grant on it (previously "any reader grant" — provably equivalent for current data, but no longer brittle). This removes the last serialization/permission reader of the eagerly-loaded `this.groups`, a step toward dropping the eager `spaceGrants` include (remaining readers handled in the follow-up PR).

- `isOpen(auth): Promise<boolean>` is async; new `SpaceResource.listOpenSpaceModelIds(auth, spaces)` resolves openness for a whole batch in **one** grant query so list/loop callers don't become N+1.
- Classifiers `isRegularAndRestricted` / `isProjectAndRestricted` / `isRegularAndOpen` / `isRestricted` are now `async(auth)`; single-space callers `await`, loop sites (conversation permissions, projects listing, skill space-requirements, search sort, the two open-space migrations) precompute the open-id set.
- **Global group id resolved on auth:** `dangerouslyListUserGroupsForAuth` now returns `{ globalGroupModelId, groupModelIds }` (the id was already selected by the query, just discarded), cached on the `Authenticator` and read by `auth.getGlobalGroupModelId()` — so openness checks drop the per-check global-group lookup. Tri-state: `undefined` = unresolved (lazy fetch for system/internal auths), `ModelId` = resolved, `null` = non-member / no-workspace auth. Serialized in `toJSON`/`fromJSON`; cache key bumped to `groups:v2:` since the cached value shape changed.
- **`space.accessed` audit off the critical path:** in `withSpace`, the `isRestricted` check + emit run in a detached async closure, so the request never blocks on them.
- Drive-by: `sandbox/egress-policy/pods.ts` still called the now-async `isProjectAndRestricted()` synchronously — fixed to batch via `listOpenSpaceModelIds`.

## Tests

- `tsgo --noEmit` clean in both `front` and `front-api`; no remaining sync `isOpen()`/classifier call sites.
- Updated existing tests (`group_resource` auth-groups shape + `groups:v2:` cache key). Passing: `group_resource` + `space_resource` (77) + `spaces` api (41) in front; front-api spaces list/detail, members, project_metadata, pods egress-policy, access-check.

## Risk

- **Low.** The openness predicate is provably equivalent to the prior behavior for current data, and covered by `space_resource`/`spaces` tests.
- **Cache key bump (`groups:` → `groups:v2:`):** one-time cold cache for user group lookups after deploy (each user re-fetches once). The cache has no TTL, so old `groups:` entries orphan until Redis LFU eviction — harmless. Rollback-safe: old code reads the old key, which still holds valid entries.
- **Serialization:** Temporal payloads in flight across the deploy lack `globalGroupModelId` — it's optional, so those auths resolve it lazily. No stale data (a workspace's global group id never changes).
- **Audit fire-and-forget:** `space.accessed` was already `void` (best-effort); it's now also non-blocking. A failure is logged, not thrown.

## Deploy Plan

- No migration, no ordering constraints — standard deploy of `front` + `front-api`.
- Safe to roll back at any point (cache keys diverge cleanly in both directions; no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)