### PR TITLE
feat(models): flag degraded models in the model picker

### DIFF
--- a/front/components/model_picker/DegradedModelIcon.tsx
+++ b/front/components/model_picker/DegradedModelIcon.tsx
@@ -1,0 +1,18 @@
+import { DoubleIcon, InfoCircle } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+interface DegradedModelIconProps {
+  icon: ComponentType;
+}
+
+export function DegradedModelIcon({ icon }: DegradedModelIconProps) {
+  return (
+    <DoubleIcon
+      size="xs"
+      mainIcon={icon}
+      secondaryIcon={InfoCircle}
+      position="top-right"
+      secondaryColor="info"
+    />
+  );
+}

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -1,3 +1,4 @@
+import { DegradedModelIcon } from "@app/components/model_picker/DegradedModelIcon";
 import { ModelPickerContent } from "@app/components/model_picker/ModelPickerContent";
 import { MODEL_TIER_ICON } from "@app/components/model_picker/modelPickerIcons";
 import type {
@@ -16,6 +17,7 @@ import type {
 import {
   buildModelSelection,
   buildTierSelection,
+  DEGRADED_MODEL_TOOLTIP,
   getInitialEffort,
   getModelTier,
   getModelWithReasoningEffortLabel,
@@ -110,8 +112,13 @@ export function ModelPicker({
 
   const [userOverride, setUserOverride] = useState<Selection | null>(null);
 
-  const { modelProps, models, streamModels, lockPremiumEfforts } =
-    useModelPickerModels({ owner });
+  const {
+    modelProps,
+    models,
+    streamModels,
+    lockPremiumEfforts,
+    degradedModelIds,
+  } = useModelPickerModels({ owner });
   const { menuStateProps, resetMenu } = useModelPickerMenuState();
 
   const { shown: baseSelection, agentDefault } = useMemo(
@@ -270,6 +277,10 @@ export function ModelPicker({
       ? MODEL_TIER_ICON[shown.display.tierId]
       : getModelMakerLogo(getModelMaker(shown.display.model), isDark);
 
+  const isShownModelDegraded =
+    shown.display.kind === "model" &&
+    degradedModelIds.has(shown.display.model.modelId);
+
   // Model name and reasoning effort read as one string for the tooltip and the
   // accessible name, but the visible trigger splits the effort into its own
   // chip so it reads as a modifier rather than part of the model's name.
@@ -301,7 +312,13 @@ export function ModelPicker({
           className="px-2"
           variant={buttonVariant}
           size={buttonSize}
-          icon={buttonIcon}
+          icon={
+            isShownModelDegraded ? (
+              <DegradedModelIcon icon={buttonIcon} />
+            ) : (
+              buttonIcon
+            )
+          }
           label={showLabel ? triggerLabel : undefined}
           iconRight={
             showLabel && effortLabel ? (
@@ -313,7 +330,13 @@ export function ModelPicker({
             ) : undefined
           }
           isSelect={showLabel && showDropdownArrow}
-          tooltip={showLabel ? undefined : `Model picker: ${label}`}
+          tooltip={
+            isShownModelDegraded
+              ? DEGRADED_MODEL_TOOLTIP
+              : showLabel
+                ? undefined
+                : `Model picker: ${label}`
+          }
           aria-label={`Model picker: ${label}`}
           disabled={disabled}
         />

--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -39,6 +39,7 @@ interface ModelPickerContentProps {
   lockPremiumEfforts: boolean;
   ignoreTierRestrictions: boolean;
   tiers: ModelTierDefinition[];
+  degradedModelIds: ReadonlySet<string>;
   makerGroups: MakerGroup[];
   streamModels: EnabledModelConfigurationType[];
   streams: ModelStreamResolutionsType | null;
@@ -65,6 +66,7 @@ export function ModelPickerContent({
   lockPremiumEfforts,
   ignoreTierRestrictions,
   tiers,
+  degradedModelIds,
   makerGroups,
   streamModels,
   streams,
@@ -155,6 +157,7 @@ export function ModelPickerContent({
           selection={selection}
           ignoreTierRestrictions={ignoreTierRestrictions}
           lockPremiumEfforts={lockPremiumEfforts}
+          degradedModelIds={degradedModelIds}
           onSelectModel={onSelectModel}
           onChangeEffort={onChangeEffort}
         />

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -31,6 +31,7 @@ interface ModelPickerMakersViewProps {
   // When true, premium (model, effort) picks are locked (workspace not on a
   // credit-based plan).
   lockPremiumEfforts: boolean;
+  degradedModelIds: ReadonlySet<string>;
   onSelectModel: (model: ModelConfigurationType) => void;
   onChangeEffort?: (
     model: ModelConfigurationType,
@@ -43,6 +44,7 @@ export function ModelPickerMakersView({
   selection,
   ignoreTierRestrictions,
   lockPremiumEfforts,
+  degradedModelIds,
   onSelectModel,
   onChangeEffort,
 }: ModelPickerMakersViewProps) {
@@ -76,6 +78,7 @@ export function ModelPickerMakersView({
                   isSelected={isSelected}
                   isDefault={isDefault}
                   lockReason={lockReason}
+                  isDegraded={degradedModelIds.has(model.modelId)}
                   effort={effort}
                   effortStops={getEffortStops(model, { lockPremiumEfforts })}
                   onSelectModel={onSelectModel}

--- a/front/components/model_picker/ModelPickerModelRow.test.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.test.tsx
@@ -35,6 +35,7 @@ function TestMenu({ onSelectModel, onOpenChange }: TestMenuProps) {
           isSelected={false}
           isDefault={false}
           lockReason={null}
+          isDegraded={false}
           effort={MODEL.defaultReasoningEffort}
           effortStops={getEffortStops(MODEL, { lockPremiumEfforts: false })}
           onSelectModel={onSelectModel}

--- a/front/components/model_picker/ModelPickerModelRow.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.tsx
@@ -4,13 +4,16 @@ import type {
   EffortStop,
   ModelLockReason,
 } from "@app/components/model_picker/modelPickerUtils";
-import { getModelLockTooltip } from "@app/components/model_picker/modelPickerUtils";
+import {
+  DEGRADED_MODEL_TOOLTIP,
+  getModelLockTooltip,
+} from "@app/components/model_picker/modelPickerUtils";
 import { ReasoningEffortSlider } from "@app/components/model_picker/ReasoningEffortSlider";
 import type {
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
-import { DropdownMenuItem, Icon, Lock01 } from "@dust-tt/sparkle";
+import { DropdownMenuItem, Icon, InfoCircle, Lock01 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 
@@ -19,6 +22,7 @@ interface ModelPickerModelRowProps {
   isSelected: boolean;
   isDefault: boolean;
   lockReason: ModelLockReason | null;
+  isDegraded: boolean;
   effort: ReasoningEffort | null;
   effortStops: EffortStop[];
   icon?: ComponentType;
@@ -32,6 +36,7 @@ export function ModelPickerModelRow({
   isSelected,
   isDefault,
   lockReason,
+  isDegraded,
   effort,
   effortStops,
   icon,
@@ -57,6 +62,26 @@ export function ModelPickerModelRow({
     );
   }
 
+  // A degraded model stays pickable, so it takes the lock's slot with an info
+  // icon rather than being disabled.
+  const endComponent =
+    isSelected || isDegraded ? (
+      <div className="flex items-center gap-2">
+        {isDegraded && (
+          <Icon visual={InfoCircle} size="sm" className="text-info-500" />
+        )}
+        {isSelected && (
+          <>
+            <ModelTierChip
+              model={model}
+              reasoningEffort={effort ?? undefined}
+            />
+            <ModelPickerSelectionIndicator onRevert={onRevert} />
+          </>
+        )}
+      </div>
+    ) : undefined;
+
   return (
     <>
       <DropdownMenuItem
@@ -64,17 +89,8 @@ export function ModelPickerModelRow({
         label={`${model.displayName}${isDefault ? " (Default)" : ""}`}
         icon={icon}
         truncateText
-        endComponent={
-          isSelected ? (
-            <div className="flex items-center gap-2">
-              <ModelTierChip
-                model={model}
-                reasoningEffort={effort ?? undefined}
-              />
-              <ModelPickerSelectionIndicator onRevert={onRevert} />
-            </div>
-          ) : undefined
-        }
+        tooltip={isDegraded ? DEGRADED_MODEL_TOOLTIP : undefined}
+        endComponent={endComponent}
         onClick={() => {
           onSelectModel(model);
         }}

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -40,6 +40,10 @@ const MODEL_TIER_LOCKED_TOOLTIP =
   "Your current model access doesn't include this option. " +
   "Contact your administrator to get access.";
 
+export const DEGRADED_MODEL_TOOLTIP =
+  "This model is currently degraded following an incident on the provider side. " +
+  "Answers may be slower or fail — consider picking another model.";
+
 // The three primary picks of the model picker. Each tier is backed by a
 // meta-model that is resolved to a concrete model at message-send time. Tier ids
 // keep the meta-model wording; `name` is what users see:

--- a/front/components/model_picker/useModelPickerModels.ts
+++ b/front/components/model_picker/useModelPickerModels.ts
@@ -42,7 +42,10 @@ export function useModelPickerModels({
   const isFilterMode = mode === "filter";
   const lockPremiumEfforts = !canSelectPremiumModels;
 
-  const { models, streams, isModelsLoading } = useModels({ owner, disabled });
+  const { models, streams, degradedModelIds, isModelsLoading } = useModels({
+    owner,
+    disabled,
+  });
 
   // Concrete models (meta-models are surfaced as tiers instead).
   const allModels = useMemo<ModelConfigurationType[]>(() => {
@@ -110,6 +113,7 @@ export function useModelPickerModels({
       lockPremiumEfforts,
       ignoreTierRestrictions: isFilterMode,
       tiers,
+      degradedModelIds,
       makerGroups,
       allModels,
       streamModels,
@@ -118,6 +122,7 @@ export function useModelPickerModels({
     models,
     allModels,
     streamModels,
+    degradedModelIds,
     isModelsLoading,
     lockPremiumEfforts,
   };

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { resolveAllowedTierNames } from "@app/lib/model_tiers/allowed_tiers";
 import type {
   EnabledModelConfigurationType,
+  GetEnabledModelsResponseType,
   ModelStreamResolutionsType,
   ModelStreamResolutionType,
 } from "@app/types/api/assistant/models";
@@ -237,15 +238,18 @@ export function getStreamResolutions(
   };
 }
 
-export async function getModelsForAuth(auth: Authenticator): Promise<{
-  models: EnabledModelConfigurationType[];
-  defaultModel: EnabledModelConfigurationType;
-  streams: ModelStreamResolutionsType;
-}> {
+export async function getModelsForAuth(
+  auth: Authenticator
+): Promise<GetEnabledModelsResponseType> {
   const models = await getEnabledModelsForAuth(auth);
+  const degradedModelIds = getDegradedModelIds();
+
   return {
     models,
     defaultModel: getDefaultModelFromEnabledModels(models),
-    streams: getStreamResolutions(models, getDegradedModelIds()),
+    streams: getStreamResolutions(models, degradedModelIds),
+    degradedModelIds: models
+      .filter((m) => degradedModelIds.has(m.modelId))
+      .map((m) => m.modelId),
   };
 }

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -10,6 +10,12 @@ import type { Fetcher } from "swr";
 
 const EMPTY_DEGRADED_MODEL_IDS: ReadonlySet<string> = new Set();
 
+// The catalog itself barely moves, but the degraded models it reports do: an
+// operator flagging a model mid-incident must reach tabs that stay open for
+// hours without a reload. Polling pauses while the tab is hidden, and focus
+// revalidation (throttled to the same cadence) covers coming back to it.
+const MODELS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 export function useModels({
   owner,
   disabled,
@@ -23,7 +29,11 @@ export function useModels({
   const { data, error } = useSWRWithDefaults(
     `/api/w/${owner.sId}/models`,
     modelsFetcher,
-    { disabled, revalidateOnFocus: false }
+    {
+      disabled,
+      refreshInterval: MODELS_REFRESH_INTERVAL_MS,
+      focusThrottleInterval: MODELS_REFRESH_INTERVAL_MS,
+    }
   );
 
   const degradedModelIds = useMemo(

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -5,7 +5,10 @@ import type {
 } from "@app/types/api/assistant/models";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import type { LightWorkspaceType } from "@app/types/user";
+import { useMemo } from "react";
 import type { Fetcher } from "swr";
+
+const EMPTY_DEGRADED_MODEL_IDS: ReadonlySet<string> = new Set();
 
 export function useModels({
   owner,
@@ -23,12 +26,18 @@ export function useModels({
     { disabled, revalidateOnFocus: false }
   );
 
+  const degradedModelIds = useMemo(
+    () => (data ? new Set(data.degradedModelIds) : EMPTY_DEGRADED_MODEL_IDS),
+    [data]
+  );
+
   return {
     models:
       data?.models.filter((model) => isStaticModelId(model.modelId)) ??
       emptyArray<EnabledModelConfigurationType>(),
     defaultModel: data?.defaultModel ?? null,
     streams: data?.streams ?? null,
+    degradedModelIds,
     isModelsLoading: !error && !data && !disabled,
     isModelsError: !!error,
   };

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -25,4 +25,5 @@ export type GetEnabledModelsResponseType = {
   models: EnabledModelConfigurationType[];
   defaultModel: EnabledModelConfigurationType;
   streams: ModelStreamResolutionsType;
+  degradedModelIds: string[];
 };

--- a/sparkle/src/components/Icon.tsx
+++ b/sparkle/src/components/Icon.tsx
@@ -5,12 +5,14 @@ import React, { type ComponentType } from "react";
 export interface IconProps {
   /** The SVG icon component to render; nothing is rendered when omitted. */
   visual?: ComponentType<{ className?: string }>;
-  size?: "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+  size?: "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
   /** Color is inherited from text color, so set it with a `text-*` class here. */
   className?: string;
 }
 
 const IconSizes = {
+  // Badge scale: too small for a standalone glyph, use it inside DoubleIcon.
+  "2xs": "h-3 w-3",
   xs: "h-4 w-4",
   sm: "h-5 w-5",
   md: "h-6 w-6",
@@ -41,6 +43,7 @@ export function Icon({
 const sizeVariants = cva("relative", {
   variants: {
     size: {
+      xs: "h-4 w-4",
       sm: "h-5 w-5",
       md: "h-6 w-6",
       lg: "h-8 w-8 p-0.5",
@@ -52,33 +55,69 @@ const sizeVariants = cva("relative", {
   },
 });
 
-const iconSizeVariants = cva("absolute", {
+const positionVariants = cva("absolute", {
   variants: {
-    size: {
-      sm: "bottom-0 right-0",
-      md: "bottom-0 right-0",
-      lg: "bottom-0 right-0",
-      xl: "bottom-0 right-0",
+    position: {
+      "bottom-right": "bottom-0 right-0",
+      "top-right": "right-0 top-0 -translate-y-1/4 translate-x-1/4",
     },
   },
   defaultVariants: {
-    size: "lg",
+    position: "bottom-right",
   },
 });
 
-export interface DoubleIconProps extends VariantProps<typeof sizeVariants> {
+// Inset by a hair because the status glyphs (InfoCircle, AlertCircle,
+// CheckCircle...) draw their own ring just inside the icon box.
+const fillVariants = cva("absolute inset-px rounded-full", {
+  variants: {
+    color: {
+      info: "bg-info-500",
+      warning: "bg-warning-500",
+      success: "bg-success-500",
+      highlight: "bg-highlight-500",
+    },
+  },
+});
+
+type DoubleIconSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+const MAIN_ICON_SIZE: Record<DoubleIconSize, IconProps["size"]> = {
+  xs: "xs",
+  sm: "xs",
+  md: "sm",
+  lg: "md",
+  xl: "lg",
+};
+
+const SECONDARY_ICON_SIZE: Record<DoubleIconSize, IconProps["size"]> = {
+  xs: "2xs",
+  sm: "xs",
+  md: "xs",
+  lg: "xs",
+  xl: "sm",
+};
+
+export interface DoubleIconProps
+  extends VariantProps<typeof sizeVariants>,
+    VariantProps<typeof positionVariants> {
   /** The primary icon, rendered at the full size. */
   mainIcon: React.ComponentType;
-  /** The smaller badge icon, overlaid on the bottom-right corner. */
+  /** The smaller badge icon, overlaid on a corner of the main icon. */
   secondaryIcon: React.ComponentType;
-  size?: "sm" | "md" | "lg" | "xl";
+  size?: DoubleIconSize;
+  /** Corner the badge sits in; defaults to the bottom-right. */
+  position?: "bottom-right" | "top-right";
+  /** Fills the badge with a semantic color and knocks the glyph out in white. */
+  secondaryColor?: "info" | "warning" | "success" | "highlight";
   className?: string;
 }
 
 /**
- * Renders a main icon with a smaller secondary icon overlaid on its
- * bottom-right corner, e.g. a tool icon badged with its provider logo. Use it
- * when a glyph needs a provider or status badge; for a plain glyph use Icon.
+ * Renders a main icon with a smaller secondary icon overlaid on one of its
+ * corners, e.g. a tool icon badged with its provider logo, or a model icon
+ * badged with an `info` status. Pass `secondaryColor` to turn the badge into a
+ * filled status disc. For a plain glyph use Icon.
  *
  * @summary Icon with an overlaid badge icon.
  */
@@ -87,35 +126,32 @@ export const DoubleIcon = ({
   secondaryIcon,
   className,
   size = "lg",
+  position = "bottom-right",
+  secondaryColor,
 }: DoubleIconProps) => {
   return (
     <div className={cn(sizeVariants({ size }), className)}>
       <Icon
         className="text-foreground"
-        size={
-          size === "sm"
-            ? "xs"
-            : size === "md"
-              ? "sm"
-              : size === "lg"
-                ? "md"
-                : "lg"
-        }
+        size={MAIN_ICON_SIZE[size]}
         visual={mainIcon}
       />
-      <Icon
-        size={
-          size === "sm"
-            ? "xs"
-            : size === "md"
-              ? "xs"
-              : size === "lg"
-                ? "xs"
-                : "md"
-        }
-        visual={secondaryIcon}
-        className={cn("absolute", iconSizeVariants({ size }))}
-      />
+      {secondaryColor ? (
+        <span className={cn(positionVariants({ position }), "flex")}>
+          <span className={fillVariants({ color: secondaryColor })} />
+          <Icon
+            size={SECONDARY_ICON_SIZE[size]}
+            visual={secondaryIcon}
+            className="relative text-white"
+          />
+        </span>
+      ) : (
+        <Icon
+          size={SECONDARY_ICON_SIZE[size]}
+          visual={secondaryIcon}
+          className={positionVariants({ position })}
+        />
+      )}
     </div>
   );
 };

--- a/sparkle/src/stories/DoubleIcon.stories.tsx
+++ b/sparkle/src/stories/DoubleIcon.stories.tsx
@@ -4,7 +4,14 @@ import React from "react";
 import { DoubleIcon } from "@sparkle/components";
 
 import { DriveLogo, NotionLogo, SlackLogo } from "@sparkle/logo";
-import { File02, Folder, MessageDotsCircle } from "@sparkle/icons/v2-stroke";
+import {
+  AlertCircle,
+  CheckCircle,
+  File02,
+  Folder,
+  InfoCircle,
+  MessageDotsCircle,
+} from "@sparkle/icons/v2-stroke";
 
 const MAIN_ICONS = {
   Folder: Folder,
@@ -24,13 +31,16 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `Overlays a small **secondaryIcon** badge on the corner of a **mainIcon**, supporting a range of **sizes** (\`sm\`, \`md\`, \`lg\`, \`xl\`). Typically used to combine a content-type glyph with a source/provider logo.
+        component: `Overlays a small **secondaryIcon** badge on a corner of a **mainIcon**, supporting a range of **sizes** (\`xs\`, \`sm\`, \`md\`, \`lg\`, \`xl\`) and either corner via **position**. Typically used to combine a content-type glyph with a source/provider logo, or to flag a glyph with a status.
 
 **When to use**
 - To show a piece of content alongside its origin (e.g. a document with its connector logo).
+- To flag an icon with a status: pass **secondaryColor** to fill the badge and knock the glyph out in white.
 
 **Guidelines**
-- Keep the **mainIcon** as the subject and the **secondaryIcon** as a small qualifier such as a provider logo.
+- Keep the **mainIcon** as the subject and the **secondaryIcon** as a small qualifier such as a provider logo or a status glyph.
+- Use **secondaryColor** only with the semantic intent it names (\`info\`, \`warning\`, \`success\`, \`highlight\`); leave it unset for provider logos, which carry their own colors.
+- \`xs\` badges a 16px glyph — the scale of an icon inside a button; reach for a larger size wherever there is room.
 - For a single glyph use **Icon**; for an entity image use **Avatar**.`,
       },
     },
@@ -43,7 +53,18 @@ const meta = {
   argTypes: {
     size: {
       description: "Overall size of the composed icon",
-      options: ["sm", "md", "lg", "xl"],
+      options: ["xs", "sm", "md", "lg", "xl"],
+      control: { type: "select" },
+    },
+    position: {
+      description: "Corner the badge sits in",
+      options: ["bottom-right", "top-right"],
+      control: { type: "inline-radio" },
+    },
+    secondaryColor: {
+      description:
+        "Fills the badge with a semantic color and knocks the glyph out in white",
+      options: [undefined, "info", "warning", "success", "highlight"],
       control: { type: "select" },
     },
     mainIcon: {
@@ -89,7 +110,7 @@ export const Sizes: Story = {
   tags: ["!manifest"],
   render: () => (
     <div className="flex flex-col gap-8">
-      {(["xl", "lg", "md", "sm"] as const).map((size) => (
+      {(["xl", "lg", "md", "sm", "xs"] as const).map((size) => (
         <div key={size} className="flex items-center gap-8">
           <DoubleIcon size={size} mainIcon={Folder} secondaryIcon={DriveLogo} />
           <DoubleIcon
@@ -101,6 +122,69 @@ export const Sizes: Story = {
             size={size}
             mainIcon={MessageDotsCircle}
             secondaryIcon={SlackLogo}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * A status badge: `secondaryColor` fills the corner disc and knocks the glyph
+ * out in white, so the flag reads at a glance over a busy main icon. Used for
+ * flagging a model as degraded in the model picker, where the whole control is
+ * a 16px button icon (`size="xs"`, badged top-right).
+ * @summary Glyph flagged with a filled status badge.
+ */
+export const StatusBadge: Story = {
+  args: {
+    size: "md",
+    mainIcon: MessageDotsCircle,
+    secondaryIcon: InfoCircle,
+    position: "top-right",
+    secondaryColor: "info",
+  },
+};
+
+/**
+ * Visual reference: each semantic `secondaryColor` in both corners, at the
+ * `xs` scale used inside buttons and at `lg` for a closer look at the disc.
+ * Kept for design review.
+ * @summary Status badge colors and corners.
+ */
+export const StatusBadges: Story = {
+  tags: ["!manifest"],
+  render: () => (
+    <div className="flex flex-col gap-8">
+      {(["lg", "xs"] as const).map((size) => (
+        <div key={size} className="flex items-center gap-8">
+          <DoubleIcon
+            size={size}
+            mainIcon={Folder}
+            secondaryIcon={InfoCircle}
+            position="top-right"
+            secondaryColor="info"
+          />
+          <DoubleIcon
+            size={size}
+            mainIcon={Folder}
+            secondaryIcon={AlertCircle}
+            position="top-right"
+            secondaryColor="warning"
+          />
+          <DoubleIcon
+            size={size}
+            mainIcon={Folder}
+            secondaryIcon={CheckCircle}
+            position="bottom-right"
+            secondaryColor="success"
+          />
+          <DoubleIcon
+            size={size}
+            mainIcon={Folder}
+            secondaryIcon={InfoCircle}
+            position="bottom-right"
+            secondaryColor="highlight"
           />
         </div>
       ))}

--- a/sparkle/src/stories/Icon.stories.tsx
+++ b/sparkle/src/stories/Icon.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { MessageCircle01, Icon } from "../index_with_tw_base";
 
-const ICON_SIZES = ["xs", "sm", "md", "lg", "xl", "2xl"] as const;
+const ICON_SIZES = ["2xs", "xs", "sm", "md", "lg", "xl", "2xl"] as const;
 
 const meta = {
   title: "Data Display/Icon",
@@ -12,7 +12,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `Renders an SVG icon component passed via **visual** at a consistent **size** (\`xs\`, \`sm\`, \`md\`, \`lg\`). Color is inherited from text color, so apply a \`text-*\` class via \`className\`.
+        component: `Renders an SVG icon component passed via **visual** at a consistent **size** (\`2xs\` through \`2xl\`). Color is inherited from text color, so apply a \`text-*\` class via \`className\`.
 
 **When to use**
 - To display a standalone glyph inside labels, buttons, list items, or status indicators.


### PR DESCRIPTION
## Description
<img width="1009" height="480" alt="Screenshot 2026-08-26 at 18 50 33" src="https://github.com/user-attachments/assets/7615216c-6b42-40c9-8aa9-43292bd4eee7" />

Surfaces degraded models (the ones an operator marks from the Poke Kill page) in the model picker, so a user who picks one knows what they are opting into. Degraded models stay selectable: only `auto` streams route around them, a definitive pick is never rerouted.

Two indicators, both explained by the same tooltip ("This model is currently degraded following an incident on the provider side. Answers may be slower or fail — consider picking another model."):

- the picker's trigger button badges its icon in the top-right corner when the selected model is degraded (tiers never badge: streams already skip degraded candidates);
- a degraded model row shows the badge glyph where a locked row shows its lock, and stays clickable.

`GET /api/w/:wId/models` now returns `degradedModelIds`, scoped to the models the workspace can see so we don't leak ids it has no access to.

The badge comes from `DoubleIcon`, extended for it rather than hand-rolled in `front`:

- `position` (`bottom-right` default, `top-right`), which hangs the badge a quarter of its width off the corner so it doesn't bury a small main icon;
- `secondaryColor` (`info` / `warning` / `success` / `highlight`), filling the badge and knocking the glyph out in white — the fill sits inset under the glyph's own ring, which would otherwise leave a sliver of fill showing around it;
- a `xs` size for badging a 16px button icon, which needed a `2xs` (12px) step on the `Icon` scale.

`sm` / `md` / `lg` / `xl` and `bottom-right` map exactly as before, so the attachment chips and dropdowns already using `DoubleIcon` are unchanged.

## Tests

New Storybook stories cover the badge (`DoubleIcon` → Status Badge, Status Badges); the existing `DoubleIcon`, `Icon`, `AttachmentChip` and `Dropdown` story tests pass, confirming existing consumers are unaffected.

To check by hand: mark a model degraded from Poke → Kill page, then in the input bar pick that model from the picker — the row and the trigger button should both carry the badge, and the model should still send. A tier pick ("Basic" / "Standard" / "Premium") should never badge.

Note the picker's view of the degraded set can lag an operator's change by up to a minute: the server refreshes its cache every 60s and the models response is cached by SWR.
