### PR TITLE
[front] fix: keep the impersonated user's role on system-key auth exchange

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -9,6 +9,11 @@ import { CLAUDE_OPUS_4_8_MODEL_ID } from "@app/types/assistant/models/anthropic"
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
+}));
+
 vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
   isProgrammaticUsage: () => false,
   checkProgrammaticUsageLimits: vi.fn(),
@@ -278,5 +283,82 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.message.user).toBeNull();
+  });
+
+  it("gives the impersonated user their workspace role so role-gated agents stay mentionable", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [],
+    });
+
+    const response = await postMessage(
+      workspace,
+      conversation.sId,
+      key,
+      {
+        content: "Hello",
+        // `@analyst` is only visible to managers and admins.
+        mentions: [{ configurationId: GLOBAL_AGENTS_SID.ANALYST }],
+        context: {
+          username: "sub-agent",
+          timezone: "Europe/Paris",
+          origin: "api",
+        },
+      },
+      { "x-api-user-email": user.email }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.agentMessages).toHaveLength(1);
+  });
+
+  it("keeps role-gated agents out of reach of an impersonated regular user", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [],
+    });
+
+    const response = await postMessage(
+      workspace,
+      conversation.sId,
+      key,
+      {
+        content: "Hello",
+        mentions: [{ configurationId: GLOBAL_AGENTS_SID.ANALYST }],
+        context: {
+          username: "sub-agent",
+          timezone: "Europe/Paris",
+          origin: "api",
+        },
+      },
+      { "x-api-user-email": user.email }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.agentMessages).toHaveLength(0);
   });
 });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1198,8 +1198,11 @@ export class Authenticator {
     return new Authenticator({
       authMethod: auth.authMethod(),
       key: auth._key,
-      // We limit scope to a user role.
-      role: "user",
+      // Scope down to the impersonated user's own workspace role: the system key is admin by
+      // default, and the resulting authenticator must not grant more than the user has. The role
+      // comes from the verified active membership, never from the caller, and the groups below
+      // are already the user's own.
+      role: activeMembership.role,
       groupModelIds,
       user,
       subscription: auth._subscription,


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/10198

Issue: parent agent can't call child agent that requires admin user, even if user is admin.

### Root cause

`Authenticator.exchangeSystemKeyForUserAuthByEmail` hardcoded `role: "user"` when rebuilding the authenticator for the impersonated user, regardless of that user's real workspace role. Every conversation created through system-key + `x-api-user-email` impersonation therefore ran as a plain member.

### Fix

Use `activeMembership.role` — the role of the already-fetched, verified active membership.

The role comes from the database, never from a caller-supplied header, and a system key already defaults to `admin` in `Authenticator.fromKey`, so the exchanged authenticator can only ever end up *lower*-privileged than the key it was exchanged from.

### Tests

Two functional tests on `POST /api/v1/w/:wId/assistant/conversations/:cId/messages` with a system key and `x-api-user-email`.
