### PR TITLE
feat(sandbox): pod egress-policy hooks + isRestricted for the Computer admin

### DIFF
--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.test.ts
@@ -73,7 +73,7 @@ describe("GET /api/w/:wId/sandbox/egress-policy/pods", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      pods: [{ sId: podA.sId, name: podA.name }],
+      pods: [{ sId: podA.sId, name: podA.name, isRestricted: true }],
     });
   });
 

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
@@ -28,7 +28,11 @@ app.get("/", async (ctx): HandlerResult<GetEgressPolicyPodsResponseBody> => {
   }
 
   return ctx.json({
-    pods: pods.value.map((pod) => ({ sId: pod.sId, name: pod.name })),
+    pods: pods.value.map((pod) => ({
+      sId: pod.sId,
+      name: pod.name,
+      isRestricted: pod.isProjectAndRestricted(),
+    })),
   });
 });
 

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -8,9 +8,14 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
+  GetEgressPolicyPodsResponseBody,
+  GetPodEgressPoliciesBulkResponseBody,
   GetWorkspaceEgressPolicyResponseBody,
+  PostBulkEgressPolicyResponseBody,
   PutWorkspaceEgressPolicyResponseBody,
+  SandboxAdminPod,
 } from "@app/types/api/sandbox/egress_policy";
+import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
 import type {
   GetSandboxEnvVarsResponseBody,
   PostSandboxEnvVarsResponseBody,
@@ -28,6 +33,40 @@ import type { Fetcher } from "swr";
 
 function workspaceEgressPolicyUrl(workspaceId: string) {
   return `/api/w/${workspaceId}/sandbox/egress-policy`;
+}
+
+// The Pods a central-admin bulk egress read/write targets: every configured
+// Pod ("all-pods") or an explicit set.
+export type SandboxPodSelection =
+  | { kind: "all-pods" }
+  | { kind: "pods"; podIds: string[] };
+
+// Sorted so the same selection always produces the same SWR key.
+function podSelectionQuery(selection: SandboxPodSelection): string {
+  return selection.kind === "all-pods"
+    ? "scope=all-pods"
+    : `podIds=${[...selection.podIds].sort().map(encodeURIComponent).join(",")}`;
+}
+
+function scopeNameById(pods: { sId: string; name: string }[]) {
+  return new Map<string, string>([
+    [SANDBOX_WORKSPACE_SCOPE_ID, "Workspace"],
+    ...pods.map((pod) => [pod.sId, pod.name] as const),
+  ]);
+}
+
+function describeScopeFailures(
+  failures: { scopeId: string; errorMessage?: string }[],
+  nameByScopeId: Map<string, string>
+): string {
+  return failures
+    .map(
+      (failure) =>
+        `${nameByScopeId.get(failure.scopeId) ?? failure.scopeId}: ${
+          failure.errorMessage ?? "unknown error"
+        }`
+    )
+    .join(" — ");
 }
 
 // Workspace-scoped env vars live under /sandbox/env-vars; pod-scoped ones
@@ -66,6 +105,218 @@ export function useWorkspaceEgressPolicy({
     isWorkspaceEgressPolicyLoading: disabled ? false : isLoading,
     isWorkspaceEgressPolicyError: !!error,
     mutateWorkspaceEgressPolicy: mutate,
+  };
+}
+
+// The Pods that have their own egress policy — the options for the central
+// Computer admin scope selector.
+export function useEgressPolicyPods({
+  owner,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const podsFetcher: Fetcher<GetEgressPolicyPodsResponseBody> = fetcher;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    `${workspaceEgressPolicyUrl(owner.sId)}/pods`,
+    podsFetcher,
+    { disabled }
+  );
+
+  return {
+    pods: data?.pods ?? emptyArray<SandboxAdminPod>(),
+    isEgressPolicyPodsLoading: disabled ? false : isLoading,
+    isEgressPolicyPodsError: !!error,
+    mutateEgressPolicyPods: mutate,
+  };
+}
+
+// Reads the egress policies of the selected Pods in one request. null selection
+// (workspace-only) skips the read; only the workspace baseline is then shown.
+export function useBulkPodEgressPolicies({
+  owner,
+  selection,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  selection: SandboxPodSelection | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const policiesFetcher: Fetcher<GetPodEgressPoliciesBulkResponseBody> =
+    fetcher;
+  const url = selection
+    ? `${workspaceEgressPolicyUrl(owner.sId)}/bulk?${podSelectionQuery(selection)}`
+    : null;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    url,
+    policiesFetcher,
+    { disabled }
+  );
+
+  return {
+    podPolicies: data?.policies ?? emptyArray(),
+    isPodPoliciesLoading: disabled || !selection ? false : isLoading,
+    isPodPoliciesError: !!error,
+    mutatePodPolicies: mutate,
+  };
+}
+
+// Adds or removes one egress domain across the selected scopes (optionally the
+// workspace baseline, plus each Pod) in a single request. Reports partial
+// failures per scope; the caller revalidates the affected reads afterward,
+// since a partial success still changes some scopes.
+export function useBulkUpdateEgressDomain({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const bulkUpdateEgressDomain = async ({
+    includeWorkspace,
+    pods,
+    operation,
+    domain,
+  }: {
+    includeWorkspace: boolean;
+    pods: { sId: string; name: string }[];
+    operation: "add" | "remove";
+    domain: string;
+  }): Promise<boolean> => {
+    setIsUpdating(true);
+    const failureTitle =
+      operation === "add" ? "Failed to add domain" : "Failed to remove domain";
+    try {
+      const response = await clientFetch(
+        `${workspaceEgressPolicyUrl(owner.sId)}/bulk`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            includeWorkspace,
+            podIds: pods.map((pod) => pod.sId),
+            operation: { operation, domain },
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: failureTitle,
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PostBulkEgressPolicyResponseBody = await response.json();
+      const scopeLabel = (count: number) =>
+        count === 1 ? "1 scope" : `${count} scopes`;
+      const verb = operation === "add" ? "added to" : "removed from";
+
+      const failures = data.results.filter((result) => !result.success);
+      if (failures.length > 0) {
+        const okCount = data.results.length - failures.length;
+        sendNotification({
+          type: "error",
+          title:
+            operation === "add"
+              ? "Domain partially added"
+              : "Domain partially removed",
+          description: `${domain} was ${verb} ${okCount} of ${scopeLabel(
+            data.results.length
+          )}. Failed: ${describeScopeFailures(failures, scopeNameById(pods))}`,
+        });
+        return false;
+      }
+
+      // A workspace add applies to every Pod, so spell that out rather than
+      // reporting the single workspace scope.
+      const workspaceAddCoversPods = operation === "add" && includeWorkspace;
+      sendNotification({
+        type: "success",
+        title: operation === "add" ? "Domain added" : "Domain removed",
+        description: workspaceAddCoversPods
+          ? `${domain} was added to the workspace, which applies to all Pods. Computer egress policy changes will be applied by the proxy cache shortly.`
+          : `${domain} was ${verb} ${scopeLabel(
+              data.results.length
+            )}. Computer egress policy changes will be applied by the proxy cache shortly.`,
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: failureTitle,
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return {
+    bulkUpdateEgressDomain,
+    isBulkUpdatingEgressDomain: isUpdating,
+  };
+}
+
+// Rejects one agent-requested domain on a specific Pod (its originating scope).
+// Parameterized by podId so the multi-scope view can reject across Pods without
+// a hook bound per Pod; the caller revalidates the bulk read afterward.
+export function useDismissPodEgressRequestByPod({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isDismissing, setIsDismissing] = useState(false);
+
+  const dismissPodEgressRequest = async (
+    podId: string,
+    domain: string
+  ): Promise<boolean> => {
+    setIsDismissing(true);
+    try {
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${podId}/sandbox/egress-policy/requests/dismiss`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to reject domain request",
+          description: error.message,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to reject domain request",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsDismissing(false);
+    }
+  };
+
+  return {
+    dismissPodEgressRequest,
+    isDismissingPodEgressRequest: isDismissing,
   };
 }
 

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -42,9 +42,17 @@ export type PostPodEgressPolicyRequestResponseBody = {
   outcome: SandboxEgressRequestOutcome;
 };
 
+// A Pod offered by the central Computer admin scope selector: identity, display
+// name, and whether it is restricted (drives the open/restricted Pod icon).
+export type SandboxAdminPod = {
+  sId: string;
+  name: string;
+  isRestricted: boolean;
+};
+
 // The Pods that have their own egress policy, for the admin scope selector.
 export type GetEgressPolicyPodsResponseBody = {
-  pods: { sId: string; name: string }[];
+  pods: SandboxAdminPod[];
 };
 
 export type GetPodEgressPoliciesBulkResponseBody = {


### PR DESCRIPTION
## Description

Data layer for the scope-aware multi-Pod network admin UI (follow-up `30996`, which stacks on this). Split out so the data contract lands and reviews on its own; the UI PR stays pure-presentation.

- **SWR hooks** (`useEgressPolicyPods`, `useBulkPodEgressPolicies`, `useBulkUpdateEgressDomain`, `useDismissPodEgressRequestByPod`) over the already-merged bulk read/write endpoints (`30986` / `30995`) and the existing per-scope dismiss routes, plus the scope-selection helpers.
- **`SandboxAdminPod`** type for the scope selector.
- **`isRestricted`** on `GET /egress-policy/pods` (via `pod.isProjectAndRestricted()`) so the selector can show the correct open/restricted Pod icon.

> [!NOTE]
> The hooks have no consumer in this PR — they're used by `30996` (stacked on top). Landing the data contract first keeps that UI PR pure-presentation. The `/egress-policy/pods` and `/bulk` routes stay gated on `sandbox_functions`.

## Tests

`tsc` clean (front + front-api). The `/egress-policy/pods` test covers the new `isRestricted` field.

## Risk

Very low. Additive hooks + one response field, no behavior change (the hooks aren't called yet). Safe to roll back.

## Deploy Plan

Standard front / front-api deploy. No migration. Merge before `30996`.
