### PR TITLE
[front] polish: explain agent insights access

### DIFF
--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -23,7 +23,6 @@ import type { TriggerType } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { isManager } from "@app/types/user";
 import {
   ArrowLeft,
   Avatar,
@@ -208,8 +207,7 @@ export function AgentDetailsSheet({
     isServerSideMCPServerConfigurationWithName(arg, AGENT_MEMORY_SERVER_NAME)
   );
 
-  const showInsightsTabs =
-    agentId != null && (agentConfiguration?.canEdit || isManager(owner));
+  const showInsightsTabs = agentId != null;
 
   const DescriptionSection = () => {
     const lastAuthor = agentConfiguration?.lastAuthors?.[0];

--- a/front/components/assistant/details/tabs/AgentInsightsTab.test.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.test.tsx
@@ -59,7 +59,7 @@ describe("AgentInsightsTab", () => {
     vi.clearAllMocks();
   });
 
-  it("explains why a non-editor cannot view agent insights", () => {
+  it("explains why a non-editor member cannot view agent insights", () => {
     render(
       <AgentInsightsTab owner={owner} agentConfiguration={agentConfiguration} />
     );
@@ -72,7 +72,7 @@ describe("AgentInsightsTab", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Only this agent’s editors can view its analytics and feedback."
+        "Only editors of this agent and workspace managers can view its analytics and feedback."
       )
     ).toBeInTheDocument();
     expect(consumptionOverviewMock).not.toHaveBeenCalled();

--- a/front/components/assistant/details/tabs/AgentInsightsTab.test.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.test.tsx
@@ -1,0 +1,80 @@
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { WorkspaceType } from "@app/types/user";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentInsightsTab } from "./AgentInsightsTab";
+
+const consumptionOverviewMock = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock(
+  "@app/components/workspace/analytics/consumption/ConsumptionOverview",
+  () => ({ ConsumptionOverview: consumptionOverviewMock })
+);
+
+const owner: WorkspaceType = {
+  id: 1,
+  sId: "w_1",
+  name: "Workspace",
+  role: "user",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  regionalModelsOnly: false,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+const agentConfiguration: AgentConfigurationType = {
+  id: 1,
+  sId: "agent_1",
+  versionCreatedAt: null,
+  version: 1,
+  versionAuthorId: null,
+  instructions: null,
+  instructionsHtml: null,
+  model: {
+    providerId: "openai",
+    modelId: "gpt-4o",
+    temperature: 0.7,
+  },
+  status: "active",
+  scope: "visible",
+  userFavorite: false,
+  name: "Agent",
+  description: "Agent description",
+  pictureUrl: "",
+  maxStepsPerRun: 8,
+  tags: [],
+  actions: [],
+  templateId: null,
+  requestedGroupIds: [],
+  requestedSpaceIds: [],
+  canRead: true,
+  canEdit: false,
+};
+
+describe("AgentInsightsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains why a non-editor cannot view agent insights", () => {
+    render(
+      <AgentInsightsTab owner={owner} agentConfiguration={agentConfiguration} />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Insights" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You’re not an editor of this agent")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Only this agent’s editors can view its analytics and feedback."
+      )
+    ).toBeInTheDocument();
+    expect(consumptionOverviewMock).not.toHaveBeenCalled();
+  });
+});

--- a/front/components/assistant/details/tabs/AgentInsightsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.tsx
@@ -24,7 +24,10 @@ import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_perio
 import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
+  ContentMessage,
+  Lock01,
   Page,
   Tabs,
   TabsContent,
@@ -60,6 +63,23 @@ export function AgentInsightsTab({
     agentId,
   };
   const isCustomAgent = agentConfiguration.scope !== "global";
+  const canViewInsights = agentConfiguration.canEdit || isAdmin(owner);
+
+  if (!canViewInsights) {
+    return (
+      <div className="flex flex-col gap-4">
+        <h2 className="text-lg font-semibold text-foreground">Insights</h2>
+        <ContentMessage
+          title="You’re not an editor of this agent"
+          icon={Lock01}
+          size="md"
+          variant="primary"
+        >
+          Only this agent’s editors can view its analytics and feedback.
+        </ContentMessage>
+      </div>
+    );
+  }
 
   return (
     <ObservabilityProvider>

--- a/front/components/assistant/details/tabs/AgentInsightsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.tsx
@@ -24,7 +24,7 @@ import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_perio
 import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WorkspaceType } from "@app/types/user";
-import { isAdmin } from "@app/types/user";
+import { isManager } from "@app/types/user";
 import {
   ContentMessage,
   Lock01,
@@ -63,7 +63,7 @@ export function AgentInsightsTab({
     agentId,
   };
   const isCustomAgent = agentConfiguration.scope !== "global";
-  const canViewInsights = agentConfiguration.canEdit || isAdmin(owner);
+  const canViewInsights = agentConfiguration.canEdit || isManager(owner);
 
   if (!canViewInsights) {
     return (
@@ -75,7 +75,8 @@ export function AgentInsightsTab({
           size="md"
           variant="primary"
         >
-          Only this agent’s editors can view its analytics and feedback.
+          Only editors of this agent and workspace managers can view its
+          analytics and feedback.
         </ContentMessage>
       </div>
     );


### PR DESCRIPTION
## Description

Keeps the Agent Details Insights tab discoverable for users who can open an agent.

For users who are neither an editor of that agent nor an admin, the tab now shows an explicit permission message and stops before any analytics content mounts. Editor and admin behavior is unchanged.

Stacked on #31222.

## Tests

- `NODE_ENV=test npm test -- --reporter verbose components/assistant/details/tabs/AgentInsightsTab.test.tsx` in `front` (1 test)
- `npm run tsgo` in `front`
- `npx biome check --error-on-warnings front/components/assistant/details/AgentDetailsSheet.tsx front/components/assistant/details/tabs/AgentInsightsTab.tsx front/components/assistant/details/tabs/AgentInsightsTab.test.tsx`
- Storybook MCP: `feedback-status-contentmessage--with-icon` passed with accessibility checks

## Risk

Low. The API authorization is unchanged, and the non-editor branch does not mount analytics components.

## Deploy Plan

- Deploy front.