### PR TITLE
[sparkle] Add height="full" Dialog variant

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -45,7 +45,7 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DIALOG_SIZES = ["md", "lg", "xl", "2xl", "full", "fit"] as const;
 type DialogSizeType = (typeof DIALOG_SIZES)[number];
 
-const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl"] as const;
+const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "full"] as const;
 type DialogHeightType = (typeof DIALOG_HEIGHTS)[number];
 
 const sizeClasses: Record<DialogSizeType, string> = {
@@ -62,6 +62,7 @@ const heightClasses: Record<DialogHeightType, string> = {
   lg: "sm:h-lg",
   xl: "sm:h-xl",
   "2xl": "sm:h-2xl",
+  full: "h-dvh max-h-none",
 };
 
 const DIALOG_VARIANTS = ["default", "command"] as const;
@@ -97,6 +98,14 @@ const dialogVariants = cva(
       height: heightClasses,
       variant: variantClasses,
     },
+    compoundVariants: [
+      // Fully full screen: edge to edge, no rounded corners, border or focus outline.
+      {
+        size: "full",
+        height: "full",
+        class: "max-w-none rounded-none border-none focus:outline-none",
+      },
+    ],
     defaultVariants: {
       size: "md",
       variant: "default",
@@ -108,7 +117,7 @@ interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   /** Max width of the dialog: "md" | "lg" | "xl" | "2xl" | "full" (full screen) | "fit" (content width). */
   size?: DialogSizeType;
-  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl"; unset grows with content up to 90vh. */
+  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "full" (viewport height; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh. */
   height?: DialogHeightType;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -64,7 +64,7 @@ const heightClasses: Record<DialogHeightType, string> = {
   xl: "sm:h-xl",
   "2xl": "sm:h-2xl",
   "3xl": "sm:h-3xl",
-  full: "h-dvh max-h-none",
+  full: "h-full",
 };
 
 const DIALOG_VARIANTS = ["default", "command"] as const;
@@ -92,7 +92,8 @@ const dialogVariants = cva(
     "rounded-2xl flex flex-col w-full max-w-[calc(100vw-2rem)] border border shadow-lg",
     "bg-modal-background",
     "border-border",
-    "max-h-[90vh]"
+    "max-h-[90vh]",
+    "focus:outline-none"
   ),
   {
     variants: {
@@ -105,7 +106,7 @@ const dialogVariants = cva(
       {
         size: "full",
         height: "full",
-        class: "max-w-none rounded-none border-none focus:outline-none",
+        class: "h-dvh max-h-none max-w-none rounded-none border-none",
       },
     ],
     defaultVariants: {
@@ -119,7 +120,7 @@ interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   /** Max width of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "full" (full screen) | "fit" (content width). */
   size?: DialogSizeType;
-  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "full" (viewport height; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh (which also caps the fixed heights). */
+  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "full" (fills the available height, capped at 90vh; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh (which also caps the fixed heights). */
   height?: DialogHeightType;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -42,19 +42,10 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DIALOG_SIZES = [
-  "md",
-  "lg",
-  "xl",
-  "2xl",
-  "3xl",
-  "4xl",
-  "full",
-  "fit",
-] as const;
+const DIALOG_SIZES = ["md", "lg", "xl", "2xl", "3xl", "full", "fit"] as const;
 type DialogSizeType = (typeof DIALOG_SIZES)[number];
 
-const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "3xl", "4xl", "full"] as const;
+const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "3xl", "full"] as const;
 type DialogHeightType = (typeof DIALOG_HEIGHTS)[number];
 
 const sizeClasses: Record<DialogSizeType, string> = {
@@ -63,7 +54,6 @@ const sizeClasses: Record<DialogSizeType, string> = {
   xl: "sm:max-w-3xl",
   "2xl": "sm:max-w-5xl",
   "3xl": "sm:max-w-6xl",
-  "4xl": "sm:max-w-7xl",
   full: "sm:max-w-full sm:h-full",
   fit: "sm:max-w-[90vw] w-fit",
 };
@@ -74,7 +64,6 @@ const heightClasses: Record<DialogHeightType, string> = {
   xl: "sm:h-xl",
   "2xl": "sm:h-2xl",
   "3xl": "sm:h-3xl",
-  "4xl": "sm:h-4xl",
   full: "h-dvh max-h-none",
 };
 
@@ -128,9 +117,9 @@ const dialogVariants = cva(
 
 interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
-  /** Max width of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "full" (full screen) | "fit" (content width). */
+  /** Max width of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "full" (full screen) | "fit" (content width). */
   size?: DialogSizeType;
-  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "full" (viewport height; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh (which also caps the fixed heights). */
+  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "full" (viewport height; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh (which also caps the fixed heights). */
   height?: DialogHeightType;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -42,10 +42,19 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DIALOG_SIZES = ["md", "lg", "xl", "2xl", "full", "fit"] as const;
+const DIALOG_SIZES = [
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "full",
+  "fit",
+] as const;
 type DialogSizeType = (typeof DIALOG_SIZES)[number];
 
-const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "full"] as const;
+const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "3xl", "4xl", "full"] as const;
 type DialogHeightType = (typeof DIALOG_HEIGHTS)[number];
 
 const sizeClasses: Record<DialogSizeType, string> = {
@@ -53,6 +62,8 @@ const sizeClasses: Record<DialogSizeType, string> = {
   lg: "sm:max-w-xl",
   xl: "sm:max-w-3xl",
   "2xl": "sm:max-w-5xl",
+  "3xl": "sm:max-w-6xl",
+  "4xl": "sm:max-w-7xl",
   full: "sm:max-w-full sm:h-full",
   fit: "sm:max-w-[90vw] w-fit",
 };
@@ -62,6 +73,8 @@ const heightClasses: Record<DialogHeightType, string> = {
   lg: "sm:h-lg",
   xl: "sm:h-xl",
   "2xl": "sm:h-2xl",
+  "3xl": "sm:h-3xl",
+  "4xl": "sm:h-4xl",
   full: "h-dvh max-h-none",
 };
 
@@ -115,9 +128,9 @@ const dialogVariants = cva(
 
 interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
-  /** Max width of the dialog: "md" | "lg" | "xl" | "2xl" | "full" (full screen) | "fit" (content width). */
+  /** Max width of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "full" (full screen) | "fit" (content width). */
   size?: DialogSizeType;
-  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "full" (viewport height; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh. */
+  /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "full" (viewport height; combined with size="full" the dialog covers the whole screen); unset grows with content up to 90vh (which also caps the fixed heights). */
   height?: DialogHeightType;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;

--- a/sparkle/src/stories/Dialog.stories.tsx
+++ b/sparkle/src/stories/Dialog.stories.tsx
@@ -275,3 +275,34 @@ export const LargeContent: Story = {
     </Dialog>
   ),
 };
+
+/**
+ * True full screen: `DialogContent size="full" height="full"` covers the whole
+ * viewport, edge to edge, with no rounded corners or border.
+ * @summary Full screen dialog covering the viewport.
+ */
+export const FullScreen: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button label="Open full screen" />
+      </DialogTrigger>
+      <DialogContent size="full" height="full">
+        <DialogHeader>
+          <DialogTitle>Full screen dialog</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <p className="text-sm text-muted-foreground">
+            This dialog covers the entire viewport, like a full page.
+          </p>
+        </DialogContainer>
+        <DialogFooter
+          rightButtonProps={{
+            label: "Close",
+            variant: "highlight",
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -38,6 +38,12 @@
 @utility h-2xl {
   height: 1024px;
 }
+@utility h-3xl {
+  height: 1280px;
+}
+@utility h-4xl {
+  height: 1536px;
+}
 
 /* Rainbow gradient background (was theme.extend.backgroundImage). */
 @utility bg-rainbow-gradient {

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -39,10 +39,7 @@
   height: 1024px;
 }
 @utility h-3xl {
-  height: 1280px;
-}
-@utility h-4xl {
-  height: 1536px;
+  height: 1152px;
 }
 
 /* Rainbow gradient background (was theme.extend.backgroundImage). */


### PR DESCRIPTION
Extends `DialogContent` sizing:

- `height="full"`: fills the available height (still capped by the dialog's 90vh). Combined with `size="full"`, a cva compound variant uncaps it into a true full screen dialog: edge to edge, no rounded corners or border.
- New `3xl` step for `size` (max-w-6xl) and `height` (1152px), following the existing convention where each height matches its size's width (md 448, lg 576, xl 768, 2xl 1024).
- `focus:outline-none` moved into the Dialog base classes: Radix focuses the panel on open and consumers were suppressing the outline per call site.

No `4xl`: the 90vh cap makes heights beyond ~1024px dead on laptop viewports, and a 1280px width is near-indistinguishable from `full` there — `3xl` + `full` cover the space.

Adds a FullScreen story. First consumer: the user analytics modal in front (#31218).