### PR TITLE
Restyle user message

### DIFF
--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -108,7 +108,7 @@ export const ConversationMessageContent = React.forwardRef<
               "flex min-w-0 flex-col gap-1",
               type === "user" &&
                 cn(
-                  "rounded-3xl border border-gray-100 bg-gray-50 px-3 py-2",
+                  "rounded-2xl border border-gray-100 bg-gray-50 px-3 py-2",
                   CARD_SHADOW
                 ),
               className

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -106,14 +106,9 @@ export const ConversationMessageContent = React.forwardRef<
             ref={ref}
             className={cn(
               "flex min-w-0 flex-col gap-1",
-              // Fixed radius equal to half the single-line bubble height
-              // (py-2 + text-base leading-6 = 40px), so a one-line message
-              // still reads as a full pill while a wrapped, multi-line
-              // message degrades to a normal rounded rectangle instead of
-              // the corners ballooning with rounded-full.
               type === "user" &&
                 cn(
-                  "rounded-[20px] border border-gray-100 bg-gray-50 px-3 py-2",
+                  "rounded-3xl border border-gray-100 bg-gray-50 px-3 py-2",
                   CARD_SHADOW
                 ),
               className

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -106,16 +106,28 @@ export const ConversationMessageContent = React.forwardRef<
             ref={ref}
             className={cn(
               "flex min-w-0 flex-col gap-1",
+              // Fixed radius equal to half the single-line bubble height
+              // (py-2 + text-base leading-6 = 40px), so a one-line message
+              // still reads as a full pill while a wrapped, multi-line
+              // message degrades to a normal rounded rectangle instead of
+              // the corners ballooning with rounded-full.
               type === "user" &&
                 cn(
-                  "rounded-full border border-gray-100 bg-gray-50 px-3 py-2",
+                  "rounded-[20px] border border-gray-100 bg-gray-50 px-3 py-2",
                   CARD_SHADOW
                 ),
               className
             )}
             {...props}
           >
-            <div className="text-base text-foreground">{children}</div>
+            <div
+              className={cn(
+                "min-w-0 break-words text-base text-foreground",
+                type === "user" && "text-balance"
+              )}
+            >
+              {children}
+            </div>
             {type === "agent" && citations && citations.length > 0 && (
               <CitationGrid>{citations}</CitationGrid>
             )}

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -108,7 +108,7 @@ export const ConversationMessageContent = React.forwardRef<
               "flex min-w-0 flex-col gap-1",
               type === "user" &&
                 cn(
-                  "rounded-2xl border border-gray-100 bg-gray-50 px-3 py-2",
+                  "rounded-2xl border border-stone-100 bg-stone-50 px-3 py-2",
                   CARD_SHADOW
                 ),
               className

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -1,4 +1,5 @@
 import { Avatar } from "@sparkle/components/Avatar";
+import { CARD_SHADOW } from "@sparkle/components/Card";
 import { CitationGrid } from "@sparkle/components/Citation";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
@@ -105,7 +106,11 @@ export const ConversationMessageContent = React.forwardRef<
             ref={ref}
             className={cn(
               "flex min-w-0 flex-col gap-1",
-              type === "user" && "rounded-2xl bg-muted-background px-4 py-3",
+              type === "user" &&
+                cn(
+                  "rounded-full border border-gray-100 bg-gray-50 px-3 py-2",
+                  CARD_SHADOW
+                ),
               className
             )}
             {...props}

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -120,12 +120,7 @@ export const ConversationMessageContent = React.forwardRef<
             )}
             {...props}
           >
-            <div
-              className={cn(
-                "min-w-0 break-words text-base text-foreground",
-                type === "user" && "text-balance"
-              )}
-            >
+            <div className="min-w-0 break-words text-base text-foreground">
               {children}
             </div>
             {type === "agent" && citations && citations.length > 0 && (


### PR DESCRIPTION
## Summary

<img width="645" height="272" alt="image" src="https://github.com/user-attachments/assets/02417182-65da-44dd-adf6-a4a3272fe83a" />

<img width="203" height="95" alt="image" src="https://github.com/user-attachments/assets/2242f993-2aec-4808-9423-246a2beb7226" />




- Restyles the user message bubble in `ConversationMessageContent` (Sparkle) to match the updated Figma design: `rounded-full`, `bg-gray-50`, `border-gray-100`, and the existing `CARD_SHADOW` treatment.
- Scoped to `type === "user"` only — agent message bubbles are unchanged.

Figma: https://www.figma.com/design/R7vT7SUjyTSosoiTOABonk/Sparkle-Components?node-id=1759-9484

## Test plan
- [x] Verified visually in Storybook (`ConversationMessages` → `User Agent Exchange` story) that the user bubble renders as a pill matching the Figma spec, with agent messages unaffected.
- [x] CI (lint/build/tests)