### PR TITLE
[sparkle] Add grow prop to DialogContent

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -65,13 +65,14 @@ const heightClasses: Record<DialogHeightType, string> = {
 };
 
 // With grow, the fixed height becomes a minimum: the h-* class is not
-// emitted, min-h keeps the height's size as the floor, and the base
-// max-h-[90vh] still caps the growth.
+// emitted and min-h keeps the height's size as the floor. min-height wins
+// over max-height in CSS, so the floor is itself capped at 90vh to never
+// exceed the base max-h-[90vh] on short viewports.
 const growHeightClasses: Record<DialogHeightType, string> = {
-  md: "sm:min-h-md",
-  lg: "sm:min-h-lg",
-  xl: "sm:min-h-xl",
-  "2xl": "sm:min-h-2xl",
+  md: "sm:min-h-[min(448px,90vh)]",
+  lg: "sm:min-h-[min(576px,90vh)]",
+  xl: "sm:min-h-[min(768px,90vh)]",
+  "2xl": "sm:min-h-[min(1024px,90vh)]",
 };
 
 const DIALOG_VARIANTS = ["default", "command"] as const;

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -64,10 +64,10 @@ const heightClasses: Record<DialogHeightType, string> = {
   "2xl": "sm:h-2xl",
 };
 
-const DIALOG_MIN_HEIGHTS = ["md", "lg", "xl", "2xl"] as const;
-type DialogMinHeightType = (typeof DIALOG_MIN_HEIGHTS)[number];
-
-const minHeightClasses: Record<DialogMinHeightType, string> = {
+// With grow, the fixed height becomes a minimum: the h-* class is not
+// emitted, min-h keeps the height's size as the floor, and the base
+// max-h-[90vh] still caps the growth.
+const growHeightClasses: Record<DialogHeightType, string> = {
   md: "sm:min-h-md",
   lg: "sm:min-h-lg",
   xl: "sm:min-h-xl",
@@ -105,7 +105,6 @@ const dialogVariants = cva(
     variants: {
       size: sizeClasses,
       height: heightClasses,
-      minHeight: minHeightClasses,
       variant: variantClasses,
     },
     defaultVariants: {
@@ -121,8 +120,8 @@ interface DialogContentProps
   size?: DialogSizeType;
   /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl"; unset grows with content up to 90vh. */
   height?: DialogHeightType;
-  /** Minimum height of the dialog: "md" | "lg" | "xl" | "2xl" (same scale as height); the dialog still grows with content up to 90vh. */
-  minHeight?: DialogMinHeightType;
+  /** Lets the dialog grow beyond its fixed `height` when the content needs it, up to the existing 90vh cap — the height becomes a minimum. No effect without `height`. */
+  grow?: boolean;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;
   /** Traps keyboard focus inside the dialog while open. */
@@ -146,7 +145,7 @@ const DialogContent = React.forwardRef<
       children,
       size,
       height,
-      minHeight,
+      grow,
       variant,
       trapFocusScope,
       isAlertDialog,
@@ -174,7 +173,12 @@ const DialogContent = React.forwardRef<
           <DialogPrimitive.Content
             ref={ref}
             className={cn(
-              dialogVariants({ size, height, minHeight, variant }),
+              dialogVariants({
+                size,
+                height: grow ? undefined : height,
+                variant,
+              }),
+              grow && height ? growHeightClasses[height] : undefined,
               className
             )}
             onInteractOutside={

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -120,7 +120,7 @@ interface DialogContentProps
   size?: DialogSizeType;
   /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl"; unset grows with content up to 90vh. */
   height?: DialogHeightType;
-  /** Lets the dialog grow beyond its fixed `height` when the content needs it, up to the existing 90vh cap — the height becomes a minimum. No effect without `height`. */
+  /** Lets the dialog grow beyond its fixed `height` when the content needs it, up to the existing 90vh cap: the height becomes a minimum. No effect without `height`. */
   grow?: boolean;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;
@@ -173,6 +173,7 @@ const DialogContent = React.forwardRef<
           <DialogPrimitive.Content
             ref={ref}
             className={cn(
+              // grow replaces the fixed height with a floor.
               dialogVariants({
                 size,
                 height: grow ? undefined : height,

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -64,6 +64,16 @@ const heightClasses: Record<DialogHeightType, string> = {
   "2xl": "sm:h-2xl",
 };
 
+const DIALOG_MIN_HEIGHTS = ["md", "lg", "xl", "2xl"] as const;
+type DialogMinHeightType = (typeof DIALOG_MIN_HEIGHTS)[number];
+
+const minHeightClasses: Record<DialogMinHeightType, string> = {
+  md: "sm:min-h-md",
+  lg: "sm:min-h-lg",
+  xl: "sm:min-h-xl",
+  "2xl": "sm:min-h-2xl",
+};
+
 const DIALOG_VARIANTS = ["default", "command"] as const;
 type DialogVariantType = (typeof DIALOG_VARIANTS)[number];
 
@@ -95,6 +105,7 @@ const dialogVariants = cva(
     variants: {
       size: sizeClasses,
       height: heightClasses,
+      minHeight: minHeightClasses,
       variant: variantClasses,
     },
     defaultVariants: {
@@ -110,6 +121,8 @@ interface DialogContentProps
   size?: DialogSizeType;
   /** Fixed height of the dialog: "md" | "lg" | "xl" | "2xl"; unset grows with content up to 90vh. */
   height?: DialogHeightType;
+  /** Minimum height of the dialog: "md" | "lg" | "xl" | "2xl" (same scale as height); the dialog still grows with content up to 90vh. */
+  minHeight?: DialogMinHeightType;
   /** "default" centers vertically; "command" pins near the top with a slide-in (command-palette style). */
   variant?: DialogVariantType;
   /** Traps keyboard focus inside the dialog while open. */
@@ -133,6 +146,7 @@ const DialogContent = React.forwardRef<
       children,
       size,
       height,
+      minHeight,
       variant,
       trapFocusScope,
       isAlertDialog,
@@ -159,7 +173,10 @@ const DialogContent = React.forwardRef<
         <FocusScope trapped={trapFocusScope} asChild>
           <DialogPrimitive.Content
             ref={ref}
-            className={cn(dialogVariants({ size, height, variant }), className)}
+            className={cn(
+              dialogVariants({ size, height, minHeight, variant }),
+              className
+            )}
             onInteractOutside={
               isAlertDialog
                 ? (e) => e.preventDefault()

--- a/sparkle/src/stories/Dialog.stories.tsx
+++ b/sparkle/src/stories/Dialog.stories.tsx
@@ -275,3 +275,46 @@ export const LargeContent: Story = {
     </Dialog>
   ),
 };
+
+/**
+ * `DialogContent height="md" grow` keeps the fixed height as a minimum: the
+ * dialog opens at least `md` tall, grows with its content, and only scrolls
+ * once it hits the 90vh cap. Toggle the content size to see all three states.
+ * @summary Dialog growing with content above a minimum height.
+ */
+export const GrowingDialog: Story = {
+  render: () => {
+    const [tall, setTall] = React.useState(false);
+    return (
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button label="Open growing dialog" />
+        </DialogTrigger>
+        <DialogContent size="lg" height="md" grow>
+          <DialogHeader>
+            <DialogTitle>Growing dialog</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <div className="flex flex-col gap-4">
+              <Button
+                label={tall ? "Shrink content" : "Make content tall"}
+                variant="outline"
+                onClick={() => setTall(!tall)}
+              />
+              <div
+                className="rounded-lg bg-highlight-100"
+                style={{ height: tall ? 1600 : 120 }}
+              />
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            rightButtonProps={{
+              label: "Close",
+              variant: "highlight",
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    );
+  },
+};

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -22,7 +22,8 @@
 }
 
 /* Fixed heights (was theme.extend.height). Defined as `@utility` because v4's
-   `h-*` utilities are otherwise driven by the dynamic spacing scale. */
+   `h-*` utilities are otherwise driven by the dynamic spacing scale, plus
+   matching min-height floors for Dialog `grow`. */
 @utility h-175 {
   height: 700px;
 }

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -22,8 +22,7 @@
 }
 
 /* Fixed heights (was theme.extend.height). Defined as `@utility` because v4's
-   `h-*` utilities are otherwise driven by the dynamic spacing scale, plus
-   matching min-height floors for Dialog `grow`. */
+   `h-*` utilities are otherwise driven by the dynamic spacing scale. */
 @utility h-175 {
   height: 700px;
 }
@@ -38,18 +37,6 @@
 }
 @utility h-2xl {
   height: 1024px;
-}
-@utility min-h-md {
-  min-height: 448px;
-}
-@utility min-h-lg {
-  min-height: 576px;
-}
-@utility min-h-xl {
-  min-height: 768px;
-}
-@utility min-h-2xl {
-  min-height: 1024px;
 }
 
 /* Rainbow gradient background (was theme.extend.backgroundImage). */

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -38,6 +38,18 @@
 @utility h-2xl {
   height: 1024px;
 }
+@utility min-h-md {
+  min-height: 448px;
+}
+@utility min-h-lg {
+  min-height: 576px;
+}
+@utility min-h-xl {
+  min-height: 768px;
+}
+@utility min-h-2xl {
+  min-height: 1024px;
+}
 
 /* Rainbow gradient background (was theme.extend.backgroundImage). */
 @utility bg-rainbow-gradient {


### PR DESCRIPTION
Fixed dialog heights force a trade-off: too small when the content is tall (inner scroll), wasted space when it is short. This adds a `grow` boolean to `DialogContent`: with a fixed `height`, the dialog can grow beyond it when the content needs it, up to the existing 90vh cap. The height becomes a minimum. Without `height` it is a no-op (growing is already the default behavior).

Implementation notes:
- When `grow` is set the `h-*` class is not emitted; a min-height floor is applied instead (rather than relying on tailwind-merge, which does not know the custom `h-md..h-2xl` utilities).
- `min-height` wins over `max-height` in CSS, so the floor is itself capped: `min-h-[min(768px,90vh)]`, otherwise the dialog would overflow short viewports.

Adds a `GrowingDialog` story (toggleable content size to see min / grown / capped states).

First consumers: the user menu Analytics/Tools/Automations dialogs (#31218), which currently inline `sm:min-h-[min(768px,90vh)]` and will become `height="xl" grow`.

## Risk
No class output changes unless `grow` is passed. Safe to rollback.