### PR TITLE
[front] Drop SpaceResource.groups field + eager spaceGrants include

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -932,7 +932,9 @@ describe("createAgentMessages", () => {
       const globalGroup = globalGroupRes.value;
 
       // Add global group directly to make it open (if not already there)
-      const existingGroupIds = openSpace.groups.map((g) => g.groupSId);
+      const existingGroupIds = (await openSpace.fetchGrantReferences()).map(
+        (g) => g.groupSId
+      );
       const hasGlobalGroup = existingGroupIds.includes(globalGroup.sId);
 
       // If global group is not already there, associate it directly

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1342,7 +1342,9 @@ describe("createAgentMessages", () => {
       const globalGroup = globalGroupRes.value;
 
       // Add global group directly to make it open (if not already there)
-      const existingGroupIds = openSpace.groups.map((g) => g.groupSId);
+      const existingGroupIds = (await openSpace.fetchGrantReferences()).map(
+        (g) => g.groupSId
+      );
       const hasGlobalGroup = existingGroupIds.includes(globalGroup.sId);
 
       // If global group is not already there, associate it directly

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -196,9 +196,9 @@ describe("createSpaceAndGroup", () => {
           adminAuth,
           space.sId
         );
-        const associatedGroupIds = reloadedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await reloadedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).toContain(provisionedGroup.id);
       }
     });
@@ -422,9 +422,9 @@ describe("createSpaceAndGroup", () => {
         expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
 
         // Verify global group was added (from the space's group_permissions grants).
-        const associatedGroupIds = reloadedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await reloadedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).toContain(globalGroup.id);
       }
     });
@@ -487,7 +487,9 @@ describe("createSpaceAndGroup", () => {
         expect(await space.isOpen(adminAuth)).toBe(false);
 
         // Verify global group was NOT added (from the space's group_permissions grants).
-        const associatedGroupIds = space.groups.map((group) => group.groupId);
+        const associatedGroupIds = (await space.fetchGrantReferences()).map(
+          (group) => group.groupId
+        );
         expect(associatedGroupIds).not.toContain(globalGroup.id);
       }
     });
@@ -906,9 +908,9 @@ describe("createSpaceAndGroup", () => {
           adminAuth,
           space.sId
         );
-        const associatedGroupIds = reloadedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await reloadedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).toContain(provisionedGroup1.id);
         expect(associatedGroupIds).toContain(provisionedGroup2.id);
       }
@@ -1245,7 +1247,11 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
           space.sId
         );
         // Verify the space has the global group
-        expect(reloadedSpace!.groups.some((g) => g.isReader())).toBe(true);
+        expect(
+          (await reloadedSpace!.fetchGrantReferences()).some((g) =>
+            g.isReader()
+          )
+        ).toBe(true);
 
         // Create an active API key for the global group
         await KeyFactory.regular(globalGroup);
@@ -1282,7 +1288,11 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
           space.sId
         );
         // Verify the space has the global group
-        expect(reloadedSpace!.groups.some((g) => g.isReader())).toBe(true);
+        expect(
+          (await reloadedSpace!.fetchGrantReferences()).some((g) =>
+            g.isReader()
+          )
+        ).toBe(true);
 
         // Create an active API key for the global group
         await KeyFactory.regular(globalGroup);

--- a/front/lib/resources/data_source_resource.test.ts
+++ b/front/lib/resources/data_source_resource.test.ts
@@ -282,7 +282,9 @@ describe("DataSourceResource cross-workspace fetch", () => {
 
     expect(dataSource).not.toBeNull();
     expect(dataSource?.space.id).toBe(spaceA.id);
-    expect(dataSource?.space.groups.length).toBeGreaterThan(0);
+    expect(
+      (await dataSource?.space.fetchGrantReferences())?.length
+    ).toBeGreaterThan(0);
   });
 
   it("unsafeFetchByDustAPIProjectId filters out other-workspace resources for non super users", async () => {
@@ -338,10 +340,12 @@ describe("DataSourceResource cross-workspace fetch", () => {
 
     expect(dataSource).not.toBeNull();
     expect(dataSource?.space.workspaceId).toBe(dataSource?.workspaceId);
-    expect(dataSource?.space.groups.length).toBeGreaterThan(0);
     expect(
-      dataSource?.space.groups.every(
-        (group) => group.workspaceId === dataSource.workspaceId
+      (await dataSource?.space.fetchGrantReferences())?.length
+    ).toBeGreaterThan(0);
+    expect(
+      (await dataSource?.space.fetchGrantReferences())?.every(
+        (group) => group.workspaceId === dataSource!.workspaceId
       )
     ).toBe(true);
   });

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -2,7 +2,6 @@ import type { Authenticator } from "@app/lib/auth";
 import type { ResourceWithId } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type {
@@ -97,19 +96,6 @@ export abstract class ResourceWithSpace<
         id: blobs.map((b) => b.vaultId),
         workspaceId: blobWorkspaceIds,
       },
-      include: [
-        {
-          as: "spaceGrants",
-          model: GroupPermissionModel,
-          // A where on an include implies required: true;
-          // pass this required: false to keep the original behavior intact
-          required: false,
-          where: {
-            workspaceId: blobWorkspaceIds,
-            resourceType: "space",
-          },
-        },
-      ],
       includeDeleted,
       transaction,
       // WORKSPACE_ISOLATION_BYPASS: The where clause is scoped to the blobs' workspaces, which

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -9,7 +9,6 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
-import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { SandboxEnvVarModel } from "@app/lib/resources/storage/models/sandbox_env_var";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -26,7 +25,7 @@ import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("SpaceResource", () => {
   describe("updatePermissions", () => {
@@ -523,9 +522,9 @@ describe("SpaceResource", () => {
           regularSpace.sId
         );
         expect(updatedSpace).not.toBeNull();
-        const associatedGroupIds = updatedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await updatedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).toContain(provisionedGroup1.id);
         expect(associatedGroupIds).toContain(provisionedGroup2.id);
       });
@@ -578,9 +577,9 @@ describe("SpaceResource", () => {
           adminAuth,
           regularSpace.sId
         );
-        const associatedGroupIds = refetchedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await refetchedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).not.toContain(provisionedGroup1.id);
         expect(associatedGroupIds).toContain(provisionedGroup2.id);
         expect(associatedGroupIds).toContain(regularGroup.id); // Regular group should still be there
@@ -791,9 +790,9 @@ describe("SpaceResource", () => {
           adminAuth,
           regularSpace.sId
         );
-        const associatedGroupIds = updatedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await updatedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).toContain(globalGroup.id);
       });
 
@@ -834,9 +833,9 @@ describe("SpaceResource", () => {
           adminAuth,
           regularSpace.sId
         );
-        const associatedGroupIds = refetchedSpace!.groups.map(
-          (group) => group.groupId
-        );
+        const associatedGroupIds = (
+          await refetchedSpace!.fetchGrantReferences()
+        ).map((group) => group.groupId);
         expect(associatedGroupIds).not.toContain(globalGroup.id);
       });
 
@@ -854,9 +853,9 @@ describe("SpaceResource", () => {
           adminAuth,
           regularSpace.sId
         );
-        const globalGroupPresentBefore = spaceBefore!.groups.some(
-          (group) => group.groupId === globalGroup.id
-        );
+        const globalGroupPresentBefore = (
+          await spaceBefore!.fetchGrantReferences()
+        ).some((group) => group.groupId === globalGroup.id);
 
         // Update but keep restricted
         await regularSpace.updatePermissions(adminAuth, {
@@ -871,9 +870,9 @@ describe("SpaceResource", () => {
           adminAuth,
           regularSpace.sId
         );
-        const globalGroupPresentAfter = spaceAfter!.groups.some(
-          (group) => group.groupId === globalGroup.id
-        );
+        const globalGroupPresentAfter = (
+          await spaceAfter!.fetchGrantReferences()
+        ).some((group) => group.groupId === globalGroup.id);
 
         expect(globalGroupPresentBefore).toBe(globalGroupPresentAfter);
       });
@@ -1567,9 +1566,9 @@ describe("SpaceResource", () => {
             adminAuth,
             projectSpace.sId
           );
-          const associatedGroupIds = refetchedSpace!.groups.map(
-            (group) => group.groupId
-          );
+          const associatedGroupIds = (
+            await refetchedSpace!.fetchGrantReferences()
+          ).map((group) => group.groupId);
           // The new provisioned member group is associated.
           expect(associatedGroupIds).toContain(newProvisionedMemberGroup.id);
           // The editor group is still associated.
@@ -1701,10 +1700,9 @@ describe("SpaceResource", () => {
       expect(spaces.some((s) => s.id === regularSpace.id)).toBe(true);
     });
 
-    it("hydrates group references from the space's group_permissions grants", async () => {
+    it("loads group references from the space's group_permissions grants on demand", async () => {
       const regularSpace = await SpaceFactory.regular(workspace);
-      const [groupReference] = regularSpace.groups;
-      const findAllSpy = vi.spyOn(SpaceModel, "findAll");
+      const [groupReference] = await regularSpace.fetchGrantReferences();
 
       const fetchedSpace = await SpaceResource.fetchById(
         adminAuth,
@@ -1712,33 +1710,21 @@ describe("SpaceResource", () => {
       );
 
       expect(fetchedSpace).not.toBeNull();
-      expect(findAllSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          include: expect.arrayContaining([
-            expect.objectContaining({
-              as: "spaceGrants",
-              model: GroupPermissionModel,
-            }),
-          ]),
-        })
-      );
-      expect(fetchedSpace?.groups).toEqual([
+      // Grants are no longer eagerly included on the space fetch; they are loaded on demand.
+      expect(await fetchedSpace?.fetchGrantReferences()).toEqual([
         expect.objectContaining({
           groupId: groupReference.groupId,
           grantType: "member",
           workspaceId: workspace.id,
         }),
       ]);
-      // groupIds/isRestricted are no longer on `toJSON`; they are loaded on demand from
-      // group_permissions via `batchToJSONEnriched`.
+      // groupIds/isRestricted are likewise loaded on demand (via `batchToJSONEnriched`).
       const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(
         adminAuth,
         [regularSpace]
       );
       expect(enrichedSpace.groupIds).toEqual([groupReference.groupSId]);
       expect(enrichedSpace.isRestricted).toBe(true);
-
-      findAllSpy.mockRestore();
     });
 
     it("should include conversations space when includeConversationsSpace is true", async () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -63,7 +63,7 @@ export interface SpaceResource extends ReadonlyAttributesType<SpaceModel> {}
  * holds — the group id and the grant type it confers — so it can be built straight from a
  * `group_permissions` row.
  */
-class SpaceGroupReference {
+export class SpaceGroupReference {
   constructor(
     readonly groupId: ModelId,
     readonly grantType: GrantType,
@@ -143,20 +143,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   constructor(
     model: ModelStaticSoftDeletable<SpaceModel>,
-    blob: Attributes<SpaceModel>,
-    readonly groups: SpaceGroupReference[]
+    blob: Attributes<SpaceModel>
   ) {
     super(SpaceModel, blob);
   }
 
   static fromModel(space: SpaceModel) {
-    // Groups come from the space's `group_permissions` grants (the `spaceGrants` include), not
-    // `group_vaults`. Each grant is eager-loaded with its `group` so the reference carries the kind.
-    return new SpaceResource(
-      SpaceModel,
-      space.get(),
-      (space.spaceGrants ?? []).map(SpaceGroupReference.fromGrant)
-    );
+    return new SpaceResource(SpaceModel, space.get());
   }
 
   /**
@@ -199,7 +192,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         );
       }
 
-      const spaceResource = new this(SpaceModel, space.get(), []);
+      const spaceResource = new this(SpaceModel, space.get());
 
       // Write group_permissions directly from the in-hand groups, so a space is never
       // persisted without its grants. `auth` only needs to be in the space's workspace: the write
@@ -211,22 +204,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         transaction: t,
       });
 
-      // Re-read the grants just written so `this.groups` reflects the space's actual grant set
-      // (its source of truth). No `group` join needed: the reference only carries the grant type.
-      const spaceGrants = await GroupPermissionModel.findAll({
-        where: {
-          workspaceId: space.workspaceId,
-          resourceType: "space",
-          resourceId: space.id,
-        },
-        transaction: t,
-      });
-
-      return new this(
-        SpaceModel,
-        space.get(),
-        spaceGrants.map(SpaceGroupReference.fromGrant)
-      );
+      return spaceResource;
     }, transaction);
   }
 
@@ -315,28 +293,79 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
+  // This space's grant references, loaded from `group_permissions` on demand. The space's grants
+  // are their own source of truth; loading here (rather than an eager include on every space fetch)
+  // keeps space loads cheap. Use `listGrantReferencesBySpaceModelId` when resolving several spaces.
+  async fetchGrantReferences(
+    transaction?: Transaction
+  ): Promise<SpaceGroupReference[]> {
+    const grants = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId: this.workspaceId,
+        resourceType: "space",
+        resourceId: this.id,
+      },
+      transaction,
+    });
+
+    return grants.map(SpaceGroupReference.fromGrant);
+  }
+
+  // The grant references for each of `spaces`, keyed by space model id — one `group_permissions`
+  // query for the whole batch (avoids the N+1 of `fetchGrantReferences` per space).
+  static async listGrantReferencesBySpaceModelId(
+    spaces: SpaceResource[]
+  ): Promise<Map<ModelId, SpaceGroupReference[]>> {
+    const referencesBySpaceModelId = new Map<ModelId, SpaceGroupReference[]>();
+    if (spaces.length === 0) {
+      return referencesBySpaceModelId;
+    }
+
+    const grants = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId: [...new Set(spaces.map((space) => space.workspaceId))],
+        resourceType: "space",
+        resourceId: spaces.map((space) => space.id),
+      },
+    });
+
+    for (const grant of grants) {
+      const reference = SpaceGroupReference.fromGrant(grant);
+      const existing = referencesBySpaceModelId.get(grant.resourceId);
+      if (existing) {
+        existing.push(reference);
+      } else {
+        referencesBySpaceModelId.set(grant.resourceId, [reference]);
+      }
+    }
+
+    return referencesBySpaceModelId;
+  }
+
   async fetchGroupResources(
     auth: Authenticator,
     {
-      groupReferences = this.groups,
+      groupReferences,
       transaction,
     }: {
       groupReferences?: SpaceGroupReference[];
       transaction?: Transaction;
     } = {}
   ): Promise<GroupResource[]> {
-    if (groupReferences.length === 0) {
+    const references =
+      groupReferences ?? (await this.fetchGrantReferences(transaction));
+    if (references.length === 0) {
       return [];
     }
 
     const groups = await GroupResource.fetchByModelIds(
       auth,
-      groupReferences.map((group) => group.groupId),
+      references.map((group) => group.groupId),
       { transaction }
     );
     const groupsById = new Map(groups.map((group) => [group.id, group]));
 
-    return groupReferences.map((group) => {
+    return references.map((group) => {
       const resource = groupsById.get(group.groupId);
       assert(resource, `Group ${group.groupSId} not found.`);
       return resource;
@@ -355,20 +384,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     t?: Transaction
   ) {
     const includeClauses: Includeable[] = [
-      {
-        as: "spaceGrants",
-        model: GroupPermissionModel,
-        // A where on an include implies required: true;
-        // pass this required: false to keep the original behavior intact.
-        required: false,
-        // workspaceId + resourceType make the (workspaceId, resourceType, resourceId) index usable
-        // for the join on resourceId; resourceType is also required for correctness since resourceId
-        // is polymorphic.
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          resourceType: "space",
-        },
-      },
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ...(includes || []),
     ];
@@ -728,16 +743,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           [Op.in]: spaceModelIds,
         },
       },
-      include: [
-        {
-          as: "spaceGrants",
-          model: GroupPermissionModel,
-          required: false,
-          // No workspaceId here (cross-workspace bypass); resourceType is still required since
-          // resourceId is polymorphic. Space ids are globally unique, so the join stays correct.
-          where: { resourceType: "space" },
-        },
-      ],
       includeDeleted: true,
     });
 
@@ -1678,8 +1683,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   // The space's auto-created (regular_auto) groups: its manual member group and, for projects, its
-  // editor group. Resolved from `group_permissions` (not `this.groups`, whose grant references
-  // cannot tell a regular_auto group from the global group by grant type). Empty in group management
+  // editor group. Resolved from `group_permissions`, filtered to regular_auto groups (a grant's
+  // type alone cannot tell a regular_auto group from the global group). Empty in group management
   // mode, where the space's groups are provisioned (IdP-owned) rather than auto-created.
   async fetchRegularAutoGroups(
     auth: Authenticator,
@@ -1701,7 +1706,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<GroupResource[]> {
-    const groupReferences = this.groups.filter((group) => !group.isReader());
+    const groupReferences = (
+      await this.fetchGrantReferences(transaction)
+    ).filter((group) => !group.isReader());
     return this.fetchGroupResources(auth, { groupReferences, transaction });
   }
 
@@ -1775,7 +1782,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const workspace = auth.getNonNullableWorkspace();
 
     // group_permissions is the source of truth for space access: read every space's grants in one
-    // query rather than through the per-instance `this.groups`.
+    // query rather than per space.
     const grants = await GroupPermissionModel.findAll({
       attributes: ["resourceId", "workspaceId", "groupId", "grantType"],
       where: {
@@ -1836,7 +1843,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // space's grant references and a precomputed set of the user's group model ids, the user is a
   // member iff they belong to a group whose grant confers that verb (resolved through the registry,
   // like `isMember`). Kept private and fed by `listMemberSpaceModelIdsByUser` so it needs neither an
-  // `Authenticator` nor `this.groups`.
+  // `Authenticator` nor a per-space grant fetch.
   private isMemberFromGrants(
     grants: SpaceGroupReference[],
     userGroupModelIds: ReadonlySet<ModelId>
@@ -1936,10 +1943,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // they are `ROLE_REGISTRY.space`'s to expand when the table is read back.
   //
   // `associatedGroups` is the full set of groups attached to this space, and `editorGroupIds`
-  // classifies which of a project's groups are editors. Both are passed in rather than read from
-  // `this.groups`: callers mutate the group set in-transaction (so `this.groups` would be stale),
-  // and a provisioned group can be an editor or a member so the group kind alone cannot tell them
-  // apart. Callers pass the `{ members, editors }` set they just computed.
+  // classifies which of a project's groups are editors. Both are passed in rather than loaded here:
+  // callers mutate the group set in-transaction (so a fetch would be stale), and a provisioned group
+  // can be an editor or a member so the group kind alone cannot tell them apart. Callers pass the
+  // `{ members, editors }` set they just computed.
   private spaceGroupRoles(
     associatedGroups: GroupResource[],
     editorGroupIds: ModelId[]
@@ -2017,9 +2024,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // transaction.
   //
   // The caller passes the space's groups split into `members` and `editors` (the workspace global
-  // group, attached to unrestricted spaces, goes in `members`) rather than this method reading
-  // `this.groups`: callers mutate the group set in-transaction so `this.groups` would be stale
-  // anyway. `editors` only applies to projects.
+  // group, attached to unrestricted spaces, goes in `members`) rather than this method loading them:
+  // callers mutate the group set in-transaction so a fetch would be stale anyway. `editors` only
+  // applies to projects.
   async writeGroupPermissions(
     auth: Authenticator,
     {
@@ -2158,9 +2165,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   // A space is open when the workspace global group holds a `reader` grant on it (that grant is what
-  // makes the space visible to every workspace member). Resolved from `group_permissions` so it does
-  // not depend on the eagerly-loaded `this.groups`. Prefer `listOpenSpaceModelIds` when checking
-  // several spaces to avoid one query per space.
+  // makes the space visible to every workspace member). Resolved from `group_permissions`. Prefer
+  // `listOpenSpaceModelIds` when checking several spaces to avoid one query per space.
   async isOpen(auth: Authenticator): Promise<boolean> {
     return (await SpaceResource.listOpenSpaceModelIds(auth, [this])).has(
       this.id
@@ -2336,13 +2342,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return result;
     }
 
-    // Fetch every space grant's group once, then keep the regular_auto ones (a space's manual
+    // Load every space's grant references once, then keep the regular_auto ones (a space's manual
     // member + editor groups). Grant type cannot identify them (an open regular space's member group
     // holds a `reader` grant like the global group), so kind is resolved from the fetched groups.
+    const referencesBySpaceModelId =
+      await SpaceResource.listGrantReferencesBySpaceModelId(spaces);
+
     const allGroupModelIds = new Set<ModelId>();
-    for (const space of spaces) {
-      for (const group of space.groups) {
-        allGroupModelIds.add(group.groupId);
+    for (const references of referencesBySpaceModelId.values()) {
+      for (const reference of references) {
+        allGroupModelIds.add(reference.groupId);
       }
     }
     const allGroups = await GroupResource.fetchByModelIds(auth, [
@@ -2360,8 +2369,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     for (const space of spaces) {
       manualGroupModelIdsBySpaceModelId.set(
         space.id,
-        space.groups
-          .map((group) => group.groupId)
+        (referencesBySpaceModelId.get(space.id) ?? [])
+          .map((reference) => reference.groupId)
           .filter((groupId) => regularAutoGroupModelIds.has(groupId))
       );
     }
@@ -2448,10 +2457,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   // The grant-derived enrichment (`groupIds` + `isRestricted`) for each of `spaces`, keyed by space
-  // model id. One query against `group_permissions` (the source of truth), so `batchToJSONEnriched`
-  // can serialize without relying on the eagerly-loaded `this.groups`. `groupIds` mirrors `toJSON`'s
-  // former output (every grant group: members, editors, provisioned, and the open-space global
-  // reader); `isRestricted` mirrors `isRestricted()` (grant-based, without `this.groups`).
+  // model id. One query against `group_permissions` (the source of truth) so `batchToJSONEnriched`
+  // can serialize each space. `groupIds` is every grant group (members, editors, provisioned, and
+  // the open-space global reader); `isRestricted` mirrors `isRestricted()`.
   private static async listSpaceEnrichmentBySpaceModelId(
     auth: Authenticator,
     spaces: SpaceResource[]

--- a/front/migrations/20260402_backfill_project_content_fragments.ts
+++ b/front/migrations/20260402_backfill_project_content_fragments.ts
@@ -60,8 +60,7 @@ async function backfillProjectContentFragmentsForWorkspace(
   const perSpaceStats = await concurrentExecutor(
     projectSpaces,
     async (spaceModel) => {
-      // fromModel expects `groups` included on the Sequelize instance; plain findAll does not load it.
-      const space = new SpaceResource(SpaceModel, spaceModel.get(), []);
+      const space = SpaceResource.fromModel(spaceModel);
       const files = await FileResource.listByProject(baseAuth, {
         projectId: space.sId,
       });

--- a/front/migrations/20260825_reset_open_space_members.ts
+++ b/front/migrations/20260825_reset_open_space_members.ts
@@ -54,11 +54,14 @@ async function resetWorkspaceOpenSpaceMembers(
     return;
   }
 
-  // Resolved in bulk rather than per space: one query for the groups, one for their memberships.
+  // Resolved in bulk rather than per space: one query for the grants, one for the groups, one for
+  // their memberships.
+  const referencesBySpaceModelId =
+    await SpaceResource.listGrantReferencesBySpaceModelId(openRegularSpaces);
   const groupModelIds = [
     ...new Set(
-      openRegularSpaces.flatMap((space) =>
-        space.groups.map((ref) => ref.groupId)
+      [...referencesBySpaceModelId.values()].flatMap((references) =>
+        references.map((ref) => ref.groupId)
       )
     ),
   ];
@@ -77,7 +80,9 @@ async function resetWorkspaceOpenSpaceMembers(
 
   const spaceByGroupModelId = new Map(
     openRegularSpaces.flatMap((space) =>
-      space.groups.map((ref) => [ref.groupId, space] as const)
+      (referencesBySpaceModelId.get(space.id) ?? []).map(
+        (ref) => [ref.groupId, space] as const
+      )
     )
   );
 


### PR DESCRIPTION
## What

Now that `isOpen()` no longer reads `this.groups` (#31220), the only remaining readers were the group-management helpers. This loads their grants on demand and **drops the eagerly-loaded `groups` field and the `spaceGrants` include entirely** — so space loads (and every space-scoped resource load via `resource_with_space`) no longer join `group_permissions`.

- New public `SpaceResource.fetchGrantReferences()` (per space) and static `listGrantReferencesBySpaceModelId(spaces)` (batched, one query); `SpaceGroupReference` is now exported.
- `fetchGroupResources`' default, `fetchMembershipGroups`, and the batched `fetchDistinctActiveManualGroupMembersBySpaces` load references on demand (the batched method uses the batched loader — no N+1).
- Removed the `groups` constructor field, the `fromModel`/`makeNew` grant re-read, and the eager `spaceGrants` include from all three fetch paths: `baseFetch`, the cross-workspace `fetchByModelIds`, and `resource_with_space`'s `baseFetchWithAuthorization`.
- Updated the two migrations that read `space.groups`.

## Why

Completes the series (`#31053` batched membership → `#31157` groupIds/isRestricted off `toJSON` → `#31220` async `isOpen`): `this.groups` has no readers left, so the field and the per-fetch grant join are gone. Space loads are cheaper across the board.

## Test plan

- `tsgo --noEmit` clean in both `front` and `front-api`; no `this.groups` code readers remain (comments only).
- Passing: `space_resource` (77), `spaces` api (41), `data_source_resource`, conversation `mentions`/`messages` (181 front total); front-api spaces list/detail, members, project_metadata, pods apps, access-check (30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)