### PR TITLE
[front] Gate aggregated Metronome usage event behind a feature flag

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -5,7 +5,7 @@ import {
   trackProgrammaticCost,
 } from "@app/lib/api/programmatic_usage/tracking";
 import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
   billedCostAwuFromEvents,
@@ -389,7 +389,9 @@ export async function emitMetronomeUsageEventsActivity(
   // ceils per the exact same execution partition that is billed here.
   const runKey = computeRunKey(effectiveRunIds);
 
-  // Build and ingest events.
+  // Build the legacy (per-model llm_usage_v3 + per-tool tool_use_v3) events and
+  // the single aggregated event. Which set is ingested depends on the feature
+  // flag below; the cost parity of both is logged in all cases.
   const llmEvents = buildLlmUsageEvents({
     workspaceId: workspace.sId,
     isByok,
@@ -431,11 +433,6 @@ export async function emitMetronomeUsageEventsActivity(
     timestamp,
   });
 
-  await ingestMetronomeEvents([...llmEvents, ...toolEvents]);
-
-  // Shadow the upcoming single aggregated event and log its cost against the
-  // legacy events' cost, so we can confirm parity on real traffic before
-  // switching over. The aggregated event is NOT ingested yet.
   const aggregatedUsageEvents = buildUsageEvents({
     workspaceId: workspace.sId,
     isByok,
@@ -457,6 +454,14 @@ export async function emitMetronomeUsageEventsActivity(
     isSubAgentMessage,
     timestamp,
   });
+
+  // When the flag is on, ingest the single aggregated event; otherwise keep
+  // ingesting the legacy events. Log the cost of both paths in all cases so we
+  // can confirm parity on real traffic.
+  const useAggregatedEvent = await hasFeatureFlag(
+    auth,
+    "metronome_aggregated_usage_event"
+  );
   const newCostAwu = aggregatedUsageEvents.reduce((total, event) => {
     const costAwu = event.properties["cost_awu"];
     return total + (typeof costAwu === "number" ? costAwu : 0);
@@ -471,8 +476,13 @@ export async function emitMetronomeUsageEventsActivity(
       newCostAwu,
       oldCostAwu,
       costMatches: newCostAwu === oldCostAwu,
+      useAggregatedEvent,
     },
     "[UsageQueue] Metronome usage event cost parity check."
+  );
+
+  await ingestMetronomeEvents(
+    useAggregatedEvent ? aggregatedUsageEvents : [...llmEvents, ...toolEvents]
   );
 
   // Per-key cap enforcement is pull-based: Metronome spend alerts can't

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -447,6 +447,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "achilleburah",
   },
+  metronome_aggregated_usage_event: {
+    description:
+      "Ingest a single aggregated Metronome usage event (LLM + tools) instead of the legacy per-model llm_usage_v3 and per-tool tool_use_v3 events.",
+    stage: "dust_only",
+    owner: "tdraier",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "ask_owner" | "self_serve";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -822,6 +822,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"
   | "disable_fair_use_awu_limit"
+  | "metronome_aggregated_usage_event"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Follow-up to #31130. Adds a feature flag that switches the Metronome usage activity from the legacy events to the single aggregated event, per workspace.

- New flag `metronome_aggregated_usage_event` (stage `dust_only`).
- In `emitMetronomeUsageEventsActivity`, both the legacy events (per-model `llm_usage_v3` + per-tool `tool_use_v3`) and the aggregated event (`buildUsageEvents`) are built. When the flag is **on**, only the aggregated event is ingested; when **off**, the legacy events are ingested as before.
- The cost parity log is kept in **all** cases and now also carries `useAggregatedEvent`, so we keep observing new-vs-old cost regardless of which path ingests.

## Tests

- `npm run test -- lib/metronome/events.test.ts` — 9 tests (event builders + legacy/aggregated parity), unchanged and green.
- `activities.ts` type-checks with the flag name (a bad flag name would fail `hasFeatureFlag`'s `WhitelistableFeature` arg).

## Risk

Low. Default behavior is unchanged: with the flag off (the default for all workspaces) the legacy events are ingested exactly as today. The aggregated path is only taken for workspaces explicitly opted in, and `buildUsageEvents` was already merged and shadow-validated against the legacy cost in #31130. Rollback = disable the flag (or revert the commit). No schema/migration.

## Deploy Plan

1. Deploy. No workspace has the flag, so nothing changes.
2. Enable `metronome_aggregated_usage_event` on a Dust test workspace; confirm via the parity log (`useAggregatedEvent: true`, `costMatches: true`) and Metronome that the aggregated event bills the same.
3. Roll out gradually. Once broadly enabled and stable, follow up to drop the legacy builders + `tool_use_v3` and prune the dead Metronome metric/product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)