### PR TITLE
[front] fix: prevent answer card stretching on exit

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -662,6 +662,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         <AnimatePresence initial={false} mode="popLayout" anchorY="bottom">
           <motion.div
             key={inputBarContentKey}
+            layout={shouldReduceMotion ? undefined : "position"}
             layoutId={
               shouldReduceMotion
                 ? undefined


### PR DESCRIPTION
## Description

The UserAnswerRequired card visibly stretches as it exits (can be repro-ed by asking a question and hitting Esc).

My best shot at explaining it is the following: the layout wrapper is shared between the question card and the composer, and it interpolates size between the tall question card and the shorter composer during the animation.

A slow motion video could help pinpointing exactly what the stretch matches with in height.

This PR fixes that.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
