### PR TITLE
[sparkle][front] migrate hand-rolled filter buttons to FilterChips

### DIFF
--- a/front/components/assistant/conversation/agent_browser/shared.tsx
+++ b/front/components/assistant/conversation/agent_browser/shared.tsx
@@ -19,6 +19,7 @@ import {
   DotsHorizontal,
   DropdownMenuItem,
   DropdownMenuLabel,
+  FilterChips,
   SearchDropdownMenu,
   Spinner,
 } from "@dust-tt/sparkle";
@@ -405,21 +406,18 @@ export function AllTabContent({
   trackAgentBrowserEvents,
   canGetMore = true,
 }: AllTabContentProps) {
+  const tagLabelById = new Map(uniqueTags.map((tag) => [tag.sId, tag.name]));
+
   return (
     <>
       <div className="mb-2 flex flex-wrap items-center gap-2">
         {!noTagsDefined && (
-          <>
-            {uniqueTags.map((tag) => (
-              <Button
-                size="xs"
-                variant={selectedTag === tag.sId ? "primary" : "outline"}
-                key={tag.sId}
-                label={tag.name}
-                onClick={() => setSelectedTag(tag.sId)}
-              />
-            ))}
-          </>
+          <FilterChips
+            filters={uniqueTags.map((tag) => tag.sId)}
+            selectedFilter={selectedTag}
+            onFilterClick={setSelectedTag}
+            getLabel={(sId) => tagLabelById.get(sId) ?? sId}
+          />
         )}
       </div>
       <div className="flex flex-col gap-4">

--- a/front/components/file_explorer/FileExplorerFilters.tsx
+++ b/front/components/file_explorer/FileExplorerFilters.tsx
@@ -1,19 +1,27 @@
 import type { FileExplorerFilter } from "@app/components/file_explorer/types";
-import { Button } from "@dust-tt/sparkle";
+import { FilterChips } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
-const FILTER_CHIPS: {
-  value: FileExplorerFilter;
-  label: string;
-}[] = [
-  { value: "all", label: "All" },
-  { value: "nodes", label: "Knowledge" },
-  { value: "tables", label: "Tables" },
-  { value: "frames", label: "Frames" },
-  { value: "texts", label: "Texts" },
-  { value: "folders", label: "Folders" },
-  { value: "images", label: "Images" },
-  { value: "code", label: "Code" },
+const FILTER_LABELS: Record<FileExplorerFilter, string> = {
+  all: "All",
+  nodes: "Knowledge",
+  tables: "Tables",
+  frames: "Frames",
+  texts: "Texts",
+  folders: "Folders",
+  images: "Images",
+  code: "Code",
+};
+
+const FILTER_ORDER: FileExplorerFilter[] = [
+  "all",
+  "nodes",
+  "tables",
+  "frames",
+  "texts",
+  "folders",
+  "images",
+  "code",
 ];
 
 interface FileExplorerFiltersProps {
@@ -28,36 +36,35 @@ export function FileExplorerFilters({
   counts,
 }: FileExplorerFiltersProps) {
   // "All" stays pinned first. Remaining chips are sorted by count desc, ties broken by the
-  // canonical order defined in FILTER_CHIPS.
-  const orderedChips = useMemo(() => {
-    const [allChip, ...rest] = FILTER_CHIPS;
-    const visible = rest.filter((chip) => (counts[chip.value] ?? 0) > 0);
-    visible.sort((a, b) => (counts[b.value] ?? 0) - (counts[a.value] ?? 0));
+  // canonical order defined in FILTER_ORDER.
+  const orderedFilters = useMemo(() => {
+    const [allFilter, ...rest] = FILTER_ORDER;
+    const visible = rest.filter((filter) => (counts[filter] ?? 0) > 0);
+    visible.sort((a, b) => (counts[b] ?? 0) - (counts[a] ?? 0));
 
-    return [allChip, ...visible];
+    return [allFilter, ...visible];
+  }, [counts]);
+
+  // "All" never shows a count, even if one is provided for it.
+  const countsWithoutAll = useMemo(() => {
+    const { all: _all, ...rest } = counts;
+    return rest;
   }, [counts]);
 
   // If only one it's "All" so there's nothing to filter against.
-  if (orderedChips.length <= 1) {
+  if (orderedFilters.length <= 1) {
     return null;
   }
 
   return (
-    <div className="flex shrink-0 flex-wrap items-center gap-1.5">
-      {orderedChips.map(({ value, label }) => {
-        const count = value === "all" ? undefined : counts[value];
-        return (
-          <Button
-            key={value}
-            size="xs"
-            variant={active === value ? "primary" : "outline"}
-            label={label}
-            isCounter={count !== undefined}
-            counterValue={count !== undefined ? String(count) : undefined}
-            onClick={() => onActiveChange(value)}
-          />
-        );
-      })}
+    <div className="shrink-0">
+      <FilterChips
+        filters={orderedFilters}
+        selectedFilter={active}
+        onFilterClick={onActiveChange}
+        getLabel={(filter) => FILTER_LABELS[filter]}
+        counts={countsWithoutAll}
+      />
     </div>
   );
 }

--- a/front/components/shared/tools_picker/CapabilityFilterButtons.tsx
+++ b/front/components/shared/tools_picker/CapabilityFilterButtons.tsx
@@ -1,5 +1,13 @@
 import type { CapabilityFilterType } from "@app/components/shared/tools_picker/types";
-import { Button } from "@dust-tt/sparkle";
+import { FilterChips } from "@dust-tt/sparkle";
+
+const CAPABILITY_FILTERS: CapabilityFilterType[] = ["all", "skills", "tools"];
+
+const CAPABILITY_FILTER_LABELS: Record<CapabilityFilterType, string> = {
+  all: "All",
+  skills: "Skills",
+  tools: "Tools",
+};
 
 interface CapabilityFilterButtonsProps {
   filter: CapabilityFilterType;
@@ -13,25 +21,12 @@ export function CapabilityFilterButtons({
   size = "sm",
 }: CapabilityFilterButtonsProps) {
   return (
-    <div className="flex gap-2">
-      <Button
-        label="All"
-        variant={filter === "all" ? "primary" : "outline"}
-        size={size}
-        onClick={() => setFilter("all")}
-      />
-      <Button
-        label="Skills"
-        variant={filter === "skills" ? "primary" : "outline"}
-        size={size}
-        onClick={() => setFilter("skills")}
-      />
-      <Button
-        label="Tools"
-        variant={filter === "tools" ? "primary" : "outline"}
-        size={size}
-        onClick={() => setFilter("tools")}
-      />
-    </div>
+    <FilterChips
+      filters={CAPABILITY_FILTERS}
+      selectedFilter={filter}
+      onFilterClick={setFilter}
+      getLabel={(f) => CAPABILITY_FILTER_LABELS[f]}
+      size={size}
+    />
   );
 }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
@@ -1,7 +1,7 @@
 import type { UsageFilterAgentScope } from "@app/components/workspace/analytics/usageFilter";
 import { USAGE_FILTER_SCOPE_LABEL } from "@app/components/workspace/analytics/usageFilter";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
-import { Button } from "@dust-tt/sparkle";
+import { FilterChips } from "@dust-tt/sparkle";
 
 interface UsageFilterAgentScopeControlsProps {
   scopes: readonly UsageFilterAgentScope[];
@@ -16,18 +16,12 @@ export function UsageFilterAgentScopeControls({
 }: UsageFilterAgentScopeControlsProps) {
   return (
     <UsageFilterSection title="Scopes">
-      <div className="flex items-center gap-1">
-        {scopes.map((scope) => (
-          <Button
-            key={scope}
-            label={USAGE_FILTER_SCOPE_LABEL[scope]}
-            size="xs"
-            variant={activeScope === scope ? "primary" : "outline"}
-            aria-pressed={activeScope === scope}
-            onClick={() => onScopeChange(scope)}
-          />
-        ))}
-      </div>
+      <FilterChips
+        filters={[...scopes]}
+        selectedFilter={activeScope}
+        onFilterClick={onScopeChange}
+        getLabel={(scope) => USAGE_FILTER_SCOPE_LABEL[scope]}
+      />
     </UsageFilterSection>
   );
 }

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -7,8 +7,15 @@ interface FilterChipsProps<T extends string> {
   filters: T[];
   /** Called with the clicked filter's name; only fires when the selection changes. */
   onFilterClick: (filterName: T) => void;
-  /** Filter preselected on mount (must be one of filters). */
+  /** Filter preselected on mount (must be one of filters). Ignored if selectedFilter is set. */
   defaultFilter?: T;
+  /** Drives the selection from outside instead of the component's own state. */
+  selectedFilter?: T | null;
+  /** Custom chip label; defaults to the filter name itself. */
+  getLabel?: (filterName: T) => string;
+  /** Optional per-filter count, rendered as a counter badge on the chip. */
+  counts?: Partial<Record<T, number>>;
+  size?: "xs" | "sm";
 }
 
 /**
@@ -22,33 +29,52 @@ export function FilterChips<T extends string>({
   filters,
   onFilterClick,
   defaultFilter,
+  selectedFilter: controlledSelectedFilter,
+  getLabel,
+  counts,
+  size = "xs",
 }: FilterChipsProps<T>) {
-  const [selectedFilter, setSelectedFilter] = useState<T | null>(
-    defaultFilter && filters.includes(defaultFilter) ? defaultFilter : null
-  );
+  const isControlled = controlledSelectedFilter !== undefined;
+
+  const [uncontrolledSelectedFilter, setUncontrolledSelectedFilter] =
+    useState<T | null>(
+      defaultFilter && filters.includes(defaultFilter) ? defaultFilter : null
+    );
+
+  const selectedFilter = isControlled
+    ? controlledSelectedFilter
+    : uncontrolledSelectedFilter;
 
   const handleFilterClick = useCallback(
     (filterName: T) => {
       // Avoid unnecessary re-renders by only triggering event if filter has changed.
       if (filterName !== selectedFilter) {
-        setSelectedFilter(filterName);
+        if (!isControlled) {
+          setUncontrolledSelectedFilter(filterName);
+        }
         onFilterClick(filterName);
       }
     },
-    [onFilterClick, selectedFilter]
+    [isControlled, onFilterClick, selectedFilter]
   );
 
   return (
     <div className="flex flex-row flex-wrap gap-2">
-      {filters.map((filterName) => (
-        <Button
-          label={filterName}
-          variant={selectedFilter === filterName ? "primary" : "ghost"}
-          key={filterName}
-          size="xs"
-          onClick={() => handleFilterClick(filterName)}
-        />
-      ))}
+      {filters.map((filterName) => {
+        const count = counts?.[filterName];
+        return (
+          <Button
+            label={getLabel ? getLabel(filterName) : filterName}
+            variant={selectedFilter === filterName ? "primary" : "ghost"}
+            key={filterName}
+            size={size}
+            isCounter={count !== undefined}
+            counterValue={count !== undefined ? String(count) : undefined}
+            aria-pressed={selectedFilter === filterName}
+            onClick={() => handleFilterClick(filterName)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
 import { fn } from "storybook/test";
 
 import { FilterChips } from "../index_with_tw_base";
@@ -16,7 +17,10 @@ const meta = {
 
 **Guidelines**
 - Selection is single-choice: only one chip is active at a time, so use it for filtering rather than multi-tagging.
-- Pass a **defaultFilter** that matches an entry in **filters** to highlight the initial category.
+- Pass a **defaultFilter** that matches an entry in **filters** to highlight the initial category (uncontrolled usage).
+- Pass **selectedFilter** to drive the selection from external state instead (controlled usage) — the component no longer tracks its own selection in this case.
+- Use **getLabel** when the chip's display text should differ from its filter value (e.g. an id or slug backing a human-readable label).
+- Pass **counts** to show a counter badge per chip.
 - For a standalone status or metadata label that is not interactive, use **Chip** instead.`,
       },
     },
@@ -52,4 +56,35 @@ export const NoDefaultSelection: Story = {
   args: {
     filters: ["Featured", "Writing", "Productivity", "Research", "Knowledge"],
   },
+};
+
+const ControlledDemo = () => {
+  const [selectedFilter, setSelectedFilter] = useState<string | null>(
+    "featured"
+  );
+
+  return (
+    <FilterChips
+      filters={["featured", "writing", "productivity", "research"]}
+      selectedFilter={selectedFilter}
+      getLabel={(filter) => filter.charAt(0).toUpperCase() + filter.slice(1)}
+      onFilterClick={setSelectedFilter}
+    />
+  );
+};
+
+/**
+ * Passing **selectedFilter** drives the selection from external state instead
+ * of the component's own — useful when the filter value is stored on a
+ * parent (a router param, a form field) rather than owned by the chip row
+ * itself. **getLabel** lets the chip's display text differ from its filter
+ * value, here capitalizing an id-shaped value into a label.
+ * @summary Controlled filter row with a custom label per chip.
+ */
+export const Controlled: Story = {
+  args: {
+    filters: ["featured", "writing", "productivity", "research"],
+    onFilterClick: fn(),
+  },
+  render: () => <ControlledDemo />,
 };


### PR DESCRIPTION
## Summary
- Extends Sparkle's `FilterChips` with controlled selection (`selectedFilter`), custom per-chip labels (`getLabel`), and a per-chip counter badge (`counts`), while staying backward-compatible with its existing uncontrolled usage.
- Migrates four hand-rolled Button-loop filter rows to `FilterChips`:
  - `front/components/file_explorer/FileExplorerFilters.tsx`
  - `front/components/shared/tools_picker/CapabilityFilterButtons.tsx`
  - `front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx`
  - `front/components/assistant/conversation/agent_browser/shared.tsx` (`AllTabContent` tag filter)
- Adds a `Controlled` story demonstrating the new `selectedFilter`/`getLabel` props.

## Test plan
- [ ] `npm -w sparkle run build` (builds clean, no type errors)
- [ ] `npx tsgo --noEmit` on the four touched `front` files (clean; pre-existing unrelated repo-wide type errors are untouched by this change)
- [ ] Manual check in Storybook of `FilterChips` `Default`, `NoDefaultSelection`, and `Controlled` stories
- [ ] Manual smoke test of File Explorer filters, tools picker capability filter, usage analytics scope filter, and agent browser tag filter in the app