### PR TITLE
Activate committed Frames v2 publications

### DIFF
--- a/front/admin/audit_log_schemas/frame.publication_activated.json
+++ b/front/admin/audit_log_schemas/frame.publication_activated.json
@@ -1,0 +1,12 @@
+{
+  "action": "frame.publication_activated",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "frame_id": "string",
+    "publication_id": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -33,6 +33,7 @@
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,
+  "frame.publication_activated": 1,
   "frame.share_scope_updated": 2,
   "group.advanced_model_access_updated": 1,
   "group.member_added": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -179,6 +179,7 @@ export const AUDIT_ACTIONS = [
   "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",
+  "frame.publication_activated",
   "frame.share_scope_updated",
   // Audit Logs.
   "audit_log.viewed",

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1,10 +1,11 @@
 import {
+  activateFramePublication,
   loadFramePublicationManifest,
   loadFramePublicationSourceFile,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import type { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -263,5 +264,62 @@ describe("Frame publication reads", () => {
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_source");
+  });
+});
+
+describe("activateFramePublication", () => {
+  it("activates a committed publication", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+
+    const activated = await activateFramePublication(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+    });
+
+    expect(activated.isOk()).toBe(true);
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      stored.value.publicationId
+    );
+  });
+
+  it("keeps the active publication when validation fails", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    await activateFramePublication(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+    });
+    fileStorageMock.setFetchFileContentNotFound(() => true);
+
+    const activation = await activateFramePublication(auth, {
+      frame,
+      publicationId: "b8c2b796-534a-4ad2-a5ad-071da692ca0b",
+    });
+
+    expect(activation.isErr() && activation.error.code).toBe(
+      "publication_not_found"
+    );
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      stored.value.publicationId
+    );
   });
 });

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -187,6 +187,29 @@ export async function loadFramePublicationManifest(
   return manifest;
 }
 
+export async function activateFramePublication(
+  auth: Authenticator,
+  {
+    frame,
+    publicationId,
+  }: {
+    frame: FileResource;
+    publicationId: string;
+  }
+): Promise<Result<void, FramePublicationError>> {
+  const manifest = await loadFramePublicationManifest(auth, {
+    frame,
+    publicationId,
+  });
+  if (manifest.isErr()) {
+    return manifest;
+  }
+
+  await frame.setActiveFramePublication(publicationId);
+
+  return new Ok(undefined);
+}
+
 export async function loadFramePublicationSourceFile(
   auth: Authenticator,
   {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -1,4 +1,9 @@
 import { randomUUID } from "node:crypto";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
 import {
   GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
@@ -206,6 +211,23 @@ export async function activateFramePublication(
   }
 
   await frame.setActiveFramePublication(publicationId);
+
+  void emitAuditLogEvent({
+    auth,
+    action: "frame.publication_activated",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("frame", {
+        sId: frame.sId,
+        name: frame.fileName,
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      frame_id: frame.sId,
+      publication_id: publicationId,
+    },
+  });
 
   return new Ok(undefined);
 }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -671,6 +671,15 @@ export class FileResource extends BaseResource<FileModel> {
     return this.contentType === frameV2ContentType;
   }
 
+  async setActiveFramePublication(publicationId: string) {
+    return this.update({
+      useCaseMetadata: {
+        ...this.useCaseMetadata,
+        activePublicationId: publicationId,
+      },
+    });
+  }
+
   // Content access logic.
   //
   // Files may have a "processed" version (text extraction, image resize, audio transcription) or

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -61,6 +61,8 @@ export type FileUseCaseMetadata = {
   // record of what the entry actually is. Live edits (no model in the loop, triggered by a UI
   // click) reuse it to know what to rebuild from, rather than guessing from fileName.
   frameEntryRelPath?: string;
+  // Immutable Frames v2 publication currently served by the Frame.
+  activePublicationId?: string;
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

Validate the immutable manifest commit marker before activating a Frames v2 publication. Store the active publication ID in the Frame FileResource metadata only after validation succeeds. Emit a registered audit event after successful activation.

## Tests

- `NODE_ENV=test npm run test -- lib/api/frames/publication_storage.test.ts lib/api/audit/audit_log_schemas.test.ts`
- `npx biome check admin/audit_log_schemas/frame.publication_activated.json lib/api/audit/schema_versions.json lib/api/audit/workos_audit.ts lib/api/frames/publication_storage.ts lib/api/frames/publication_storage.test.ts lib/resources/file_resource.ts types/files.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`

## Risk

Low. The operation has no callers yet. Failed validation does not mutate the active publication pointer. Audit emission is non-blocking.

## Deploy Plan

Standard deploy. The `frame.publication_activated` WorkOS schema is already registered as v1.