### PR TITLE
[front] fix: show full skill names in slash menu on hover

### DIFF
--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -344,8 +344,8 @@ describe("getSkillSlashCommandItem", () => {
       hasDetails: true,
       id: "skill_create_memo",
       label: "Create memo",
+      tooltip: { description: "Create memo" },
     });
-    expect(item.tooltip).toBeUndefined();
   });
 });
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -344,7 +344,7 @@ describe("getSkillSlashCommandItem", () => {
       hasDetails: true,
       id: "skill_create_memo",
       label: "Create memo",
-      tooltip: { description: "Create memo" },
+      tooltipLabel: "Create memo",
     });
   });
 });

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -246,6 +246,7 @@ export function getSkillSlashCommandItem(
     icon: () => React.createElement(getSkillAvatarIcon(skill)),
     id: skill.sId,
     label: skill.name,
+    tooltip: { description: skill.name },
   };
 }
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -246,7 +246,7 @@ export function getSkillSlashCommandItem(
     icon: () => React.createElement(getSkillAvatarIcon(skill)),
     id: skill.sId,
     label: skill.name,
-    tooltip: { description: skill.name },
+    tooltipLabel: skill.name,
   };
 }
 

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -45,12 +45,69 @@ const DEFAULT_EMPTY_MESSAGE = "No commands found";
 const DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME =
   SLASH_COMMAND_DROPDOWN_LIST_CLASS_NAME;
 
+const SKILL_NAME_TOOLTIP_DELAY_MS = 1000;
+
 function SlashCommandDropdownLoadingState({ message }: { message: string }) {
   return (
     <div className="flex h-14 items-center justify-center">
       <Spinner size="sm" />
       <span className="ml-2 text-sm text-muted-foreground">{message}</span>
     </div>
+  );
+}
+
+function SlashCommandNameTooltip({
+  label,
+  trigger,
+}: {
+  label: string;
+  trigger: React.ReactElement;
+}) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const labelElement =
+      triggerRef.current?.querySelector<HTMLElement>("span.truncate");
+
+    if (!labelElement || labelElement.textContent !== label) {
+      return;
+    }
+
+    const checkTruncation = () => {
+      const isOverflowing = labelElement.scrollWidth > labelElement.clientWidth;
+      setIsTruncated(isOverflowing);
+    };
+
+    checkTruncation();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(checkTruncation);
+    observer.observe(labelElement);
+
+    return () => observer.disconnect();
+  }, [label]);
+
+  const triggerElement = (
+    <span ref={triggerRef} className="block w-full">
+      {trigger}
+    </span>
+  );
+
+  if (!isTruncated) {
+    return triggerElement;
+  }
+
+  return (
+    <Tooltip
+      delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
+      label={label}
+      tooltipTriggerAsChild
+      trigger={triggerElement}
+    />
   );
 }
 
@@ -376,12 +433,9 @@ export const SlashCommandDropdown = forwardRef<
                     );
 
                     const itemContent = item.tooltipLabel ? (
-                      <Tooltip
+                      <SlashCommandNameTooltip
                         label={item.tooltipLabel}
-                        tooltipTriggerAsChild
-                        trigger={
-                          <span className="block w-full">{menuItem}</span>
-                        }
+                        trigger={menuItem}
                       />
                     ) : item.tooltip ? (
                       <DropdownTooltipTrigger
@@ -472,10 +526,9 @@ export const SlashCommandDropdown = forwardRef<
                   );
 
                   const itemContent = item.tooltipLabel ? (
-                    <Tooltip
+                    <SlashCommandNameTooltip
                       label={item.tooltipLabel}
-                      tooltipTriggerAsChild
-                      trigger={<span className="block w-full">{menuItem}</span>}
+                      trigger={menuItem}
                     />
                   ) : item.tooltip ? (
                     <DropdownTooltipTrigger

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -56,61 +56,6 @@ function SlashCommandDropdownLoadingState({ message }: { message: string }) {
   );
 }
 
-function SlashCommandNameTooltip({
-  label,
-  trigger,
-}: {
-  label: string;
-  trigger: React.ReactElement;
-}) {
-  const triggerRef = useRef<HTMLSpanElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useEffect(() => {
-    const labelElement =
-      triggerRef.current?.querySelector<HTMLElement>("span.truncate");
-
-    if (!labelElement || labelElement.textContent !== label) {
-      return;
-    }
-
-    const checkTruncation = () => {
-      const isOverflowing = labelElement.scrollWidth > labelElement.clientWidth;
-      setIsTruncated(isOverflowing);
-    };
-
-    checkTruncation();
-
-    if (typeof ResizeObserver === "undefined") {
-      return;
-    }
-
-    const observer = new ResizeObserver(checkTruncation);
-    observer.observe(labelElement);
-
-    return () => observer.disconnect();
-  }, [label]);
-
-  const triggerElement = (
-    <span ref={triggerRef} className="block w-full">
-      {trigger}
-    </span>
-  );
-
-  if (!isTruncated) {
-    return triggerElement;
-  }
-
-  return (
-    <Tooltip
-      delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
-      label={label}
-      tooltipTriggerAsChild
-      trigger={triggerElement}
-    />
-  );
-}
-
 export interface SlashCommand {
   action: string;
   // Command-specific payload, opaque to the dropdown. Consumers narrow it back with type guards
@@ -433,9 +378,13 @@ export const SlashCommandDropdown = forwardRef<
                     );
 
                     const itemContent = item.tooltipLabel ? (
-                      <SlashCommandNameTooltip
+                      <Tooltip
+                        delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
                         label={item.tooltipLabel}
-                        trigger={menuItem}
+                        tooltipTriggerAsChild
+                        trigger={
+                          <span className="block w-full">{menuItem}</span>
+                        }
                       />
                     ) : item.tooltip ? (
                       <DropdownTooltipTrigger
@@ -526,9 +475,11 @@ export const SlashCommandDropdown = forwardRef<
                   );
 
                   const itemContent = item.tooltipLabel ? (
-                    <SlashCommandNameTooltip
+                    <Tooltip
+                      delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
                       label={item.tooltipLabel}
-                      trigger={menuItem}
+                      tooltipTriggerAsChild
+                      trigger={<span className="block w-full">{menuItem}</span>}
                     />
                   ) : item.tooltip ? (
                     <DropdownTooltipTrigger

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
   Spinner,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import type React from "react";
@@ -65,6 +66,7 @@ export interface SlashCommand {
   id: string;
   label: string;
   tooltip?: SlashCommandTooltip;
+  tooltipLabel?: string;
 }
 
 interface SlashCommandSubMenuNavigation {
@@ -373,7 +375,15 @@ export const SlashCommandDropdown = forwardRef<
                       />
                     );
 
-                    const itemContent = item.tooltip ? (
+                    const itemContent = item.tooltipLabel ? (
+                      <Tooltip
+                        label={item.tooltipLabel}
+                        tooltipTriggerAsChild
+                        trigger={
+                          <span className="block w-full">{menuItem}</span>
+                        }
+                      />
+                    ) : item.tooltip ? (
                       <DropdownTooltipTrigger
                         description={item.tooltip.description}
                         media={item.tooltip.media}
@@ -461,7 +471,13 @@ export const SlashCommandDropdown = forwardRef<
                     />
                   );
 
-                  const itemContent = item.tooltip ? (
+                  const itemContent = item.tooltipLabel ? (
+                    <Tooltip
+                      label={item.tooltipLabel}
+                      tooltipTriggerAsChild
+                      trigger={<span className="block w-full">{menuItem}</span>}
+                    />
+                  ) : item.tooltip ? (
                     <DropdownTooltipTrigger
                       description={item.tooltip.description}
                       media={item.tooltip.media}

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -45,7 +45,7 @@ const DEFAULT_EMPTY_MESSAGE = "No commands found";
 const DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME =
   SLASH_COMMAND_DROPDOWN_LIST_CLASS_NAME;
 
-const SKILL_NAME_TOOLTIP_DELAY_MS = 1500;
+const SKILL_NAME_TOOLTIP_DELAY_MS = 1000;
 
 function SlashCommandDropdownLoadingState({ message }: { message: string }) {
   return (

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -152,6 +152,7 @@ export const SlashCommandDropdown = forwardRef<
     const [selectedIndex, setSelectedIndex] = useState(() =>
       getDefaultSelectedIndex(!!subMenuNavigation, items.length)
     );
+    const [showSkillNameTooltips, setShowSkillNameTooltips] = useState(true);
     const listRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
       useState<React.CSSProperties>({});
@@ -319,7 +320,12 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div ref={listRef} className={listMaxHeightClassName}>
+            <div
+              ref={listRef}
+              className={listMaxHeightClassName}
+              onPointerMove={() => setShowSkillNameTooltips(true)}
+              onWheel={() => setShowSkillNameTooltips(false)}
+            >
               {subMenuNavigation ? (
                 <DropdownMenuItem
                   icon={ArrowLeft}
@@ -386,27 +392,28 @@ export const SlashCommandDropdown = forwardRef<
                       />
                     );
 
-                    const itemContent = item.tooltipLabel ? (
-                      <Tooltip
-                        delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
-                        label={item.tooltipLabel}
-                        tooltipTriggerAsChild
-                        trigger={
-                          <span className="block w-full">{menuItem}</span>
-                        }
-                      />
-                    ) : item.tooltip ? (
-                      <DropdownTooltipTrigger
-                        description={item.tooltip.description}
-                        media={item.tooltip.media}
-                        side="right"
-                        sideOffset={8}
-                      >
-                        {menuItem}
-                      </DropdownTooltipTrigger>
-                    ) : (
-                      menuItem
-                    );
+                    const itemContent =
+                      item.tooltipLabel && showSkillNameTooltips ? (
+                        <Tooltip
+                          delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
+                          label={item.tooltipLabel}
+                          tooltipTriggerAsChild
+                          trigger={
+                            <span className="block w-full">{menuItem}</span>
+                          }
+                        />
+                      ) : item.tooltip ? (
+                        <DropdownTooltipTrigger
+                          description={item.tooltip.description}
+                          media={item.tooltip.media}
+                          side="right"
+                          sideOffset={8}
+                        >
+                          {menuItem}
+                        </DropdownTooltipTrigger>
+                      ) : (
+                        menuItem
+                      );
 
                     return <Fragment key={item.id}>{itemContent}</Fragment>;
                   };
@@ -492,25 +499,28 @@ export const SlashCommandDropdown = forwardRef<
                     />
                   );
 
-                  const itemContent = item.tooltipLabel ? (
-                    <Tooltip
-                      delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
-                      label={item.tooltipLabel}
-                      tooltipTriggerAsChild
-                      trigger={<span className="block w-full">{menuItem}</span>}
-                    />
-                  ) : item.tooltip ? (
-                    <DropdownTooltipTrigger
-                      description={item.tooltip.description}
-                      media={item.tooltip.media}
-                      side="right"
-                      sideOffset={8}
-                    >
-                      {menuItem}
-                    </DropdownTooltipTrigger>
-                  ) : (
-                    menuItem
-                  );
+                  const itemContent =
+                    item.tooltipLabel && showSkillNameTooltips ? (
+                      <Tooltip
+                        delayDuration={SKILL_NAME_TOOLTIP_DELAY_MS}
+                        label={item.tooltipLabel}
+                        tooltipTriggerAsChild
+                        trigger={
+                          <span className="block w-full">{menuItem}</span>
+                        }
+                      />
+                    ) : item.tooltip ? (
+                      <DropdownTooltipTrigger
+                        description={item.tooltip.description}
+                        media={item.tooltip.media}
+                        side="right"
+                        sideOffset={8}
+                      >
+                        {menuItem}
+                      </DropdownTooltipTrigger>
+                    ) : (
+                      menuItem
+                    );
 
                   return <Fragment key={item.id}>{itemContent}</Fragment>;
                 })

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -45,7 +45,7 @@ const DEFAULT_EMPTY_MESSAGE = "No commands found";
 const DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME =
   SLASH_COMMAND_DROPDOWN_LIST_CLASS_NAME;
 
-const SKILL_NAME_TOOLTIP_DELAY_MS = 1000;
+const SKILL_NAME_TOOLTIP_DELAY_MS = 1500;
 
 function SlashCommandDropdownLoadingState({ message }: { message: string }) {
   return (
@@ -368,7 +368,16 @@ export const SlashCommandDropdown = forwardRef<
                           ) : undefined
                         }
                         onClick={() => selectEntry(index)}
-                        onFocus={() => setSelectedIndex(index)}
+                        onFocus={(event) => {
+                          if (
+                            item.tooltipLabel &&
+                            event.currentTarget.matches(":hover")
+                          ) {
+                            // Menu items focus on pointer move, which would bypass the tooltip delay.
+                            event.stopPropagation();
+                          }
+                          setSelectedIndex(index);
+                        }}
                         className={cn(
                           "group",
                           index === selectedIndex &&
@@ -465,7 +474,16 @@ export const SlashCommandDropdown = forwardRef<
                         ) : undefined
                       }
                       onClick={() => selectEntry(entryIndex)}
-                      onFocus={() => setSelectedIndex(entryIndex)}
+                      onFocus={(event) => {
+                        if (
+                          item.tooltipLabel &&
+                          event.currentTarget.matches(":hover")
+                        ) {
+                          // Menu items focus on pointer move, which would bypass the tooltip delay.
+                          event.stopPropagation();
+                        }
+                        setSelectedIndex(entryIndex);
+                      }}
                       className={cn(
                         "group",
                         entryIndex === selectedIndex &&


### PR DESCRIPTION
## Description

Long skill names are truncated in the slash dropdown, which makes them impossible to read in full.
This PR adds a very slow tooltip on hover. Having the tooltip only if the name is truncated ended would be better, but also ends up being quite complex

## Tests

- Updated existing tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.