### PR TITLE
x(agentsearch): harden agent search permission coverage

### DIFF
--- a/x/adrsimon/agentsearch/.gitignore
+++ b/x/adrsimon/agentsearch/.gitignore
@@ -1,6 +1,7 @@
 # Workspace exports carry every agent's instructions and group-level usage.
 assets/agents_*.json
 !assets/agents_skeleton.json
+!assets/permissions/agents_mocked.json
 
 # Profile snapshots name a real person and their group/space memberships.
 assets/profile_*.json

--- a/x/adrsimon/agentsearch/NOTES.md
+++ b/x/adrsimon/agentsearch/NOTES.md
@@ -4,9 +4,9 @@ Status of the agent-search harness, what has been measured, and what has not bee
 
 ## Current state
 
-The harness indexes a workspace export into a local Elasticsearch 8.16.0 (same minor as prod, see `docker-compose.yml`), reproduces the `/manage/agents` permission model at query time, and scores retrieval against a generated query set.
+The harness indexes a workspace export into a local Elasticsearch 8.16.0 (same minor as prod, see `docker-compose.yml`), reproduces the agent-discovery `list` permission model at query time, and scores retrieval against a generated query set.
 
-Corpus: 2,566 agents from the Dust workspace, 30-day usage window. For `adrien@dust.tt` the manage view resolves to 389 agents, or 341 with `--exclude-global`.
+Corpus: 2,566 agents from the Dust workspace, 30-day usage window. For `adrien@dust.tt` the manage view resolves to 389 agents, or 341 with `--exclude-global`. Both figures come from a profile exported before `readablePodSpaces` was populated, so they exclude the 27 agents that request a pod; a fresh export moves them and every number derived from them.
 
 ### Defaults
 
@@ -20,22 +20,27 @@ Corpus: 2,566 agents from the Dust workspace, 30-day usage window. For `adrien@d
 
 Index: `name` and `description` carry named BM25 similarities (`name_bm25`, `text_bm25`) at Lucene defaults. `name` uses a `word_delimiter_graph` analyzer so `TitleClassifierAI` tokenizes; both text fields use an English stemmer and stopword list.
 
+### The space filter
+
+[PERMISSIONS.md](PERMISSIONS.md) is the canonical design and correctness record. The measured request sizes on a synthetic 5,252-pod corpus were 1.1, 15.9, then failure for the literal form, versus 1.2, 16.0, 33.7, 4.3, and 0.8 KB as access grew for the bounded filter. The real corpus references 88 spaces across 2,566 agents, including 35 pods. The eval was unchanged to three decimals.
+
 ### Query construction
 
 `scripts/query.ts` builds every query, and both `search.ts` and `eval.ts` call it, so the two cannot drift. Text clauses go in `must`; group adjacency goes in `should`. Keeping them separate matters: when they shared a `should` list under `minimum_should_match: 1`, any agent with group usage matched every query, and `--q invoice` and `--q datadog` returned the same results.
 
 ## Tests
 
-There are no unit tests. The eval harness is the regression suite.
+The permission harness checks named fixtures, every readable-space subset, query shapes, and the clause-budget branch. The eval harness covers ranking regressions.
 
 ```
+npm run test:permissions
 npx tsx scripts/generate_queries.ts --agents assets/agents_<id>.json --profile assets/profile_<id>.json
 npx tsx scripts/eval.ts --queries assets/eval_queries_dust.json --profile assets/profile_<id>.json \
   --exclude-global --compare assets/eval_baseline.json
 npx tsgo --noEmit -p .
 ```
 
-`--compare` prints a delta against the saved baseline, which is metrics only and safe to commit. Everything else in `assets/` is gitignored: exports carry agent instructions, group-level usage, and one person's memberships.
+`--compare` prints a delta against the saved baseline, which is metrics only and safe to commit. Real exports and generated query sets are gitignored because they carry agent instructions, group-level usage, and one person's memberships. Skeletons, permission fixtures, and the metric baseline are committed.
 
 ### The query set
 
@@ -72,6 +77,8 @@ Each query has exactly one labelled target, so precision has no ground truth. Th
 
 ### Correctness
 
+- Pods in the profile. `export_user_profile.ts` called `listWorkspaceSpaces` without `includeProjectSpaces`, so `readablePodSpaces` was always empty and the space filter dropped every pod-requesting agent — under-permissive, never a leak. Fixed, but `assets/profile_pQwo5uKyt6.json` predates it and needs regenerating from prod. The baseline is unaffected: the 27 pod agents it excludes are not eval targets.
+- `pod_space_count` was added to the mapping for the pod-side `terms_set`, so the index needs a re-ingest, not just a restart.
 - The manage-list gap. 341 hits against 350 observed in the UI. Attributed to export drift (the corpus is a 15:47 snapshot, the page was live), but never confirmed with a fresh export taken at the same time.
 - `description.subsequence`. Dead weight in the mapping since the clause was dropped. It matched almost anything (`*i*n*v*o*i*c*e*` hits "Incident investigation assistant for Dust using Datadog logs"). Remove it.
 - Programmatic traffic. 25 agents have usage and no group attribution, since API-key runs carry no `user.group_ids`. `CodingRules` has 1,568 messages and 0 users, so adjacency scores it zero however popular it is.

--- a/x/adrsimon/agentsearch/PERMISSIONS.md
+++ b/x/adrsimon/agentsearch/PERMISSIONS.md
@@ -1,0 +1,193 @@
+# Permissions
+
+What agent discovery shows a given user, and how the harness reproduces it in Elasticsearch.
+
+`README.md` covers running the harness and `NOTES.md` records what has been measured. This file is only about access.
+
+## Part 1: how front decides
+
+Every agent list in the app comes out of `getAgentConfigurationsForView` (`front/lib/api/assistant/configuration/views.ts`). The caller picks a view (`list`, `manage`, `all`, `favorites`, `analytics`, and a few more) and gets back the agents that view exposes to that `Authenticator`. The harness models `list`, the view used for agent discovery and the `@` mention picker. `manage` shares the two permission gates but handles inactive global agents differently.
+
+It fetches candidate rows from Postgres with a scope predicate in the `WHERE` clause, then drops the ones whose spaces the caller cannot read. Global agents come from a separate code path and rejoin the list at the end.
+
+### Gate 1: scope
+
+Scope lives on the agent row and says who the agent was published to.
+
+| scope | who sees it in `list` / `manage` |
+|---|---|
+| `visible` (formerly `workspace` / `published`) | everyone in the workspace |
+| `hidden` | the agent's editors |
+| `global` | everyone, and the row is synthetic |
+
+The SQL for `list` and `manage` is an `OR` over those cases (`views.ts:261`): scope in the visible family, or the caller authored it and it is `private` (a legacy scope), or its id appears in `agentIdsForUserAsEditor` and the scope is `hidden`.
+
+That editor list is resolved before the query by `GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())`. Each agent owns an editor group; being in the group makes you an editor. Editorship is therefore group membership, not a column on the agent.
+
+Global agents skip all of this. `getGlobalAgents` builds them in code rather than reading them from a table. `list` keeps only the active global agents (`views.ts:130`), while `manage` returns inactive ones too (`views.ts:117`).
+
+`status: "active"` and the workspace id are in the base `WHERE` for stored agents, so archived and cross-workspace rows never enter the candidate set. The separate global-agent path applies the view-specific status rule above.
+
+### Gate 2: requested spaces
+
+An agent's tools point at data. The spaces holding that data are denormalized onto the row as `requestedSpaceIds`, and the rule is unanimity (`agent.ts:1801`, `permission_utils.ts:14`):
+
+```ts
+return requestedSpaceIds.every(
+  (spaceId) => spaceById.get(spaceId)?.canRead(auth) ?? false
+);
+```
+
+Read one of an agent's spaces but not all of them and the agent disappears. A space that no longer resolves scores `false` through that `?? false`, so an agent pointing at a deleted space drops out with the same verdict as one pointing at a space you were never granted.
+
+`canRead` is `auth.hasPermission("read", space)` against the ACLs the space serves from `group_permissions`. A space is readable when some group you belong to holds a read grant on it. Open spaces attach the workspace global group as a viewer, which is what `isOpen()` tests, so every member reads them; restricted spaces have no such grant and only their members get in.
+
+Pods are project spaces. They carry no carve-out anywhere in this path: `filterAgentsByRequestedSpaces` treats a project space exactly like a regular one, and `canRead` resolves both through the same grant lookup. The only thing that distinguishes pods here is how many of them a workspace can have, which is the subject of part 2.
+
+Some views deliberately skip gate 2. `manage_unrestricted` lists everything for admins, `analytics` does the same for managers because credits are reported for agents built on spaces they cannot read, and `archived` is unrestricted for admins. Callers gate those on role.
+
+### Where the work happens
+
+Gate 1 is SQL. Gate 2 is a filter in application code over rows Postgres already returned, after one `SpaceResource.fetchByModelIds` for the spaces those rows mention. Nothing in the request path enumerates the caller's spaces, and nothing sends a space list to the database.
+
+That last point matters for part 2, because the obvious Elasticsearch translation does both.
+
+## Part 2: how the harness replicates it
+
+The index holds one document per agent with the fields the two gates need:
+
+```
+status, scope, editors[]
+non_pod_space_ids[],   non_pod_space_count
+pod_space_ids[],       pod_space_count
+```
+
+`editors` holds emails, resolved at export time by `getAgentsEditors`, which reads the agent's editor group. It is a denormalization of front's `agentIdsForUserAsEditor`, computed per agent instead of per caller.
+
+The caller is a profile: the output of `scripts/export_user_profile.ts`, holding `auth.groupIds()` and the spaces where `space.canRead(auth)` holds, split into pods and non-pods. It is a snapshot of an `Authenticator`, so it answers as the user was at `generatedAt`.
+
+`scripts/query.ts` turns the two into one `bool` query. Access clauses go in `filter`, so they are unscored and cacheable. Ranking goes in `must` and `should`.
+
+### Scope, in one clause
+
+```json
+{ "bool": { "should": [
+    { "terms": { "scope": ["visible", "global"] } },
+    { "bool": { "filter": [ { "term": { "scope": "hidden" } },
+                            { "term": { "editors": "adrien@dust.tt" } } ] } }
+  ], "minimum_should_match": 1 } }
+```
+
+Plus `{ "term": { "status": "active" } }`, which the export already guarantees but the filter states anyway.
+
+This is the whole of gate 1, and it is where the corpus concentrates: of 2,566 agents, 2,141 are `hidden`, 377 `visible`, 48 `global`. The `hidden` branch does most of the work, and 1,854 of those hidden agents carry a non-empty editor list.
+
+`--exclude-global` drops `global` from the terms, which is what the *All custom* tab shows.
+
+### Spaces
+
+Gate 2 says every requested space is readable. Written literally for one space class, that is a `terms_set` carrying the caller's readable spaces, with the required count stored on the document:
+
+```json
+{ "terms_set": { "non_pod_space_ids": {
+    "terms": ["<every space the caller can read>"],
+    "minimum_should_match_field": "non_pod_space_count" } } }
+```
+
+The same clause would be required for pods. It works, and it stops working as soon as pods scale. `terms_set` expands to one Lucene clause per term, so its ceiling is `maxClauseCount`: 1,024 at the floor, derived per node from heap and CPU above that. This laptop reports 2,978, verified by bisection, and 2,979 terms throws `query_shard_exception`. A caller who can read 3,000 spaces gets an error instead of an agent list, and the threshold moves between nodes.
+
+Two changes fix it, and the first is to send whichever side is shorter. The contrapositive of "every requested space is readable" is "no requested space is unreadable", which is a `must_not` over a `terms` clause. That clause stays a single `TermInSetQuery` however long its list, capped by `index.max_terms_count` at 65,536 rather than by the clause budget. Neither side is bounded on its own, since a workspace can reference thousands of spaces and a caller can read thousands, so `buildSpaceClassFilter` measures both and picks the smaller, taking the positive form only while it stays under the budget.
+
+The second is to filter pods apart from everything else. Non-pod spaces are bounded by the workspace, pod access by the caller's memberships, and pooling them lets whichever is larger size the whole list. Each class gets its own clause and the two are ANDed, which is what unanimity means anyway.
+
+Each class then takes whichever of four shapes is cheapest:
+
+| the caller reads | clause | terms sent |
+|---|---|---|
+| nothing in the class | `term` on the count field, zero | 0 |
+| few of the referenced spaces | `terms_set` over those | what they read |
+| most of them | `must_not` a `terms` list | what they cannot read |
+| all of them | no clause | 0 |
+
+Measured on a synthetic corpus of 2,566 agents over 5,252 referenced pods, growing only the caller's pod count:
+
+| caller's readable pods | `terms_set` over all readable | this filter |
+|---|---|---|
+| 20 | 1.1 KB | 1.2 KB, `terms_set`, 20 terms |
+| 1,000 | 15.9 KB | 16.0 KB, `terms_set`, 1,000 terms |
+| 3,000 | fails, `maxClauseCount` | 33.7 KB, `must_not`, 2,252 terms |
+| 5,000 | fails | 4.3 KB, `must_not`, 252 terms |
+| 5,252 | fails | 0.8 KB, no clause |
+
+Request size peaks near the halfway mark and shrinks as access grows past it.
+
+### What keeps the lists short
+
+Only a space some agent actually points at can change the answer, so both branches range over the referenced set rather than the space table. Across the real corpus that is 88 distinct spaces, 35 of them pods, and no agent requests more than five.
+
+`fetchReferencedSpaces` reads them from a `terms` aggregation over active agents. In front the same set is a `SELECT DISTINCT unnest("requestedSpaceIds")` over the workspace's active agents, cacheable per workspace and invalidated when an agent's spaces change. Readability then resolves through `SpaceResource.fetchByIds` over that bounded set, which preserves front's property that no request path enumerates the caller's spaces.
+
+The set is safe to over-list and unsafe to under-list. Naming a space no agent requests costs nothing, because the extra id is genuinely unreadable and excludes only agents that should already be excluded. Missing a space that some agent requests leaks that agent. A cache lagging on space deletions is therefore harmless, and one lagging on additions is not.
+
+A deleted space is absent from the readable set, lands on the denied side, and takes its agents with it, matching front's `?? false`. That only holds while every requested id survives into one class or the other, so `toAgentSearchDocument` refuses to build a document whose two class arrays do not add up to `requestedSpaceIds`. An id dropped from both is deniable by no clause, and the agent it belongs to outlives the filter.
+
+### Keeping ranking out of the filter
+
+Group adjacency (`usage.by_group`) scores agents used by the caller's groups. It sits in `should` alongside a `must` holding the text clauses, so it only contributes score. Collapsing the two into one `should` under `minimum_should_match: 1` makes any agent with group usage match every query, which is a permission-shaped bug even though the clause is about ranking. `README.md` covers the ranking side.
+
+## Verification dataset
+
+The committed fixtures under `assets/permissions/` exercise the permission model without production data. `agents_mocked.json` contains 21 agents over three non-pod spaces and two pods. It covers:
+
+- `visible`, `hidden`, and `global` scopes, plus inactive visible and global agents;
+- hidden agents with a matching editor and with another editor;
+- agents that request no spaces, one space, multiple spaces of one class, spaces from both classes, or all five spaces;
+- hidden agents whose editor can read all, some, or none of their requested spaces.
+
+Each `user_mocked_*.json` file describes one readable-space and identity scenario and carries the exact `expectedAgentIds` for that scenario. The named cases cover no spaces, company only, one or all restricted spaces with no pods, one or all pods, mixed pod and non-pod access, all spaces, three editor access levels, global exclusion, an extra readable space that no agent references, and a deleted requested space.
+
+### Test harness
+
+`npm run test:permissions` creates a temporary Elasticsearch index with the production mapping and indexes `agents_mocked.json` through the same document conversion as normal ingestion. It sends each permission check through `buildAgentSearchQuery`, the entry point used by search and eval, with an empty search term. For each named user it performs two comparisons:
+
+1. The fixture's `expectedAgentIds` must equal the direct permission predicate.
+2. The Elasticsearch result must equal that same predicate.
+
+The direct predicate keeps the expected side independent of the Elasticsearch query shape:
+
+```ts
+agent.status === "active" &&
+scopeAllows(agent, user) &&
+agent.requestedSpaceIds.every((id) => readableSpaceIds.has(id))
+```
+
+After the named cases, the harness generates all 32 subsets of the five mocked spaces and runs each one as an editor and a non-editor. These 64 combinations check every readable-space combination against the indexed filter. The named `exclude-global` case checks the optional global-agent branch separately.
+
+Five structural assertions pin the clause selection: no access, full access, `terms_set`, `must_not` because the denied side is shorter, and `must_not` because the readable side exceeds the 1,024-term budget. A final Elasticsearch query uses 5,000 readable and 5,001 denied spaces. The bounded query must return without a `query_shard_exception`; forcing the positive `terms_set` form crosses this node's clause limit.
+
+Run it against the local Elasticsearch container:
+
+```bash
+npm run es:up
+npm run test:permissions
+```
+
+A successful run currently reports:
+
+```text
+permissions: 14 named scenarios, 64 exhaustive combinations, 5 shape assertions, 1 clause-budget query, and 1 over-listing check passed
+```
+
+This proves equivalence between the direct predicate and the production query builder for the modeled scopes, identities, and space combinations. It also exercises the clause-budget branch against Elasticsearch. It does not test how `front` computes live ACLs or editor groups.
+
+### Additional checks
+
+The filter is also verified equal to the `terms_set` translation on full id sets, not just counts: at 0, 20, 1,000, 2,000 and 2,900 readable pods on the synthetic corpus, and on the real corpus for a caller reading none of the 35 pods (389 agents) and all of them (416). Past 2,978 the old form cannot run to be compared. The eval is unchanged to three decimals across 2,184 queries.
+
+### Known gaps
+
+- The profile is a snapshot. Memberships change, and a stale profile answers as the user was when it was taken.
+- Legacy scopes (`workspace`, `published`, `private`) do not appear in the export, so the author branch of front's `list` predicate has nothing to match and is not implemented.
+- `manage` includes inactive global agents. The harness models `list` and excludes them.
+- Views that skip gate 2 on purpose (`manage_unrestricted`, `analytics` for managers, `archived` for admins) are not modelled. The harness always applies the space filter.
+- `editors` is denormalized to emails at export time. Front resolves editorship live from group membership, so a membership change between export and query shows up here and not there.

--- a/x/adrsimon/agentsearch/README.md
+++ b/x/adrsimon/agentsearch/README.md
@@ -16,6 +16,7 @@ agentsearch/
 ├── assets/
 │   ├── agents_skeleton.json          shape of an agent export   (committed, no real data)
 │   ├── profile_skeleton.json         shape of a user profile    (committed, no real data)
+│   ├── permissions/                  mocked permission corpus and user scenarios
 │   ├── agents_<wId>.json             a real export   (gitignored, you produce it)
 │   ├── profile_<userSId>.json        a real profile  (gitignored, you produce it)
 │   ├── eval_queries_<name>.json      a generated eval set (gitignored)
@@ -26,6 +27,7 @@ agentsearch/
 │   ├── export_workspace_agents.ts    dumps a workspace's agents  — RUNS IN front/, not here
 │   ├── export_user_profile.ts        dumps a user's Authenticator — RUNS IN front/, not here
 │   ├── ingest.ts                     export JSON -> local ES
+│   ├── test_permissions.ts           exhaustive permission-model integration test
 │   ├── query.ts                      the query builder, shared by search and eval
 │   ├── search.ts                     query CLI
 │   ├── generate_queries.ts           builds a known-item eval set from the corpus
@@ -51,7 +53,7 @@ npm run search -- --q sales --spaces vlt_ZqMdUAzI0OTf --groups grp_gXHmJEbOCeCy
 
 ## Producing an export
 
-**Nothing real is committed.** An agent export carries every agent's full instructions and group-level usage; a profile names a real person and their memberships. Both are gitignored, and only the skeletons are tracked. Two scripts produce them.
+**Nothing real is committed.** An agent export carries every agent's full instructions and group-level usage; a profile names a real person and their memberships. Both are gitignored. The skeletons and mocked permission fixtures are safe to commit. Two scripts produce the real files.
 
 Neither runs from this directory — they import `@app/...`. On prodbox:
 
@@ -78,6 +80,10 @@ npm run search -- --profile assets/profile_<userSId>.json --q "pull request"
 
 `--profile` overrides `--spaces` and `--groups`. It does not make the search permission-correct — see below — it just stops you hand-assembling ids that drift.
 
+Profiles exported before pods were added to `readablePodSpaces` list zero of them, which silently hides every agent that requests a pod. Re-export rather than patch: `readablePodSpaces: []` on a workspace that has projects is the tell.
+
+The export enumerates every space the caller can read, pods included. That is fine for a snapshot of one user and is exactly what a request path must not do — see the space filter below.
+
 ### What the export contains
 
 Agent configuration comes from `getAgentConfigurationsForView` with `dangerouslySkipPermissionFiltering`, so unpublished agents and spaces the caller cannot read are included — this is an admin-side corpus.
@@ -88,23 +94,20 @@ See `assets/agents_skeleton.json` for the exact shape.
 
 ## The permission model
 
-The harness reproduces what `/manage/agents` (and the `@` mention picker) show, which is `getAgentConfigurationsForView` with the `manage` / `list` view. Two filters:
+The harness reproduces the `list` view used by agent discovery and the `@` mention picker. It applies the same two gates as front: every requested space must be readable, and the agent must be visible, global, or hidden with the caller as an editor. The `manage` view differs only by retaining inactive global agents.
 
-**Spaces** — `filterAgentsByRequestedSpaces` (`front/lib/api/assistant/configuration/agent.ts`) keeps an agent only when *every* space it requests is readable by the caller. Pods included; there is no carve-out. That is a `terms_set` with the required count stored on the document:
+The Elasticsearch space filter handles pods and non-pods independently. For each class it chooses between a positive `terms_set` and a negative `terms` clause, keeping the query within Lucene's clause budget without weakening the access rule. [PERMISSIONS.md](PERMISSIONS.md) contains the derivation, scale measurements, fixture contract, and known view differences.
 
-```json
-{ "terms_set": { "requested_space_ids": {
-    "terms": ["<every space the caller can read, pods included>"],
-    "minimum_should_match_field": "requested_space_count" } } }
+Profiles are snapshots. A stale profile answers with the memberships recorded at `generatedAt`, not the user's current access.
+
+### Permission model tests
+
+The committed dataset under `assets/permissions/` contains 21 mocked agents and 14 named user scenarios. The harness exercises the production query builder for every subset of the five mocked spaces, checks its clause shapes, runs a 10,001-space clause-budget query, and verifies that over-listing referenced spaces is safe. [PERMISSIONS.md](PERMISSIONS.md) documents the fixture contract, coverage, and limits.
+
+```bash
+npm run es:up
+npm run test:permissions
 ```
-
-A second `should` branch matches `requested_space_count: 0` for agents that require nothing.
-
-**Visibility** — `scope` in `visible` / `global`, plus `hidden` agents where the caller is an editor (`editors` holds emails, and the profile carries the caller's). `--exclude-global` drops the globals, which is what the default *All custom* tab of `/manage/agents` displays. Passing `--scope` explicitly bypasses the visibility filter entirely.
-
-The index also carries `non_pod_space_ids` / `non_pod_space_count`, the projection skill search uses (PRs #30452 / #30450). Skill search excludes pods from the query because a user's project memberships are potentially unbounded: it over-fetches a bounded candidate window and authorizes pods afterwards against Postgres. Those fields are indexed here for comparison but are not what the default filter uses.
-
-A profile is also a **snapshot**. Memberships change; a stale profile answers as the user was on `generatedAt`, not as they are now.
 
 ## Ranking
 
@@ -154,7 +157,6 @@ BM25 sums over the terms a document *matches* and never penalizes the ones it mi
 | `--match-mode` | `hybrid` (default), `best_fields`, or `bool_prefix` |
 | `--name-fallback` | typo tolerance on `name`: `fuzzy` (default), `subsequence`, `both`, `off` |
 | `--exclude-global` | drop global agents, matching the *All custom* tab |
-| `--scope` | restrict to `visible`, `hidden`, `global`; bypasses the visibility filter |
 | `--limit` | number of hits (default 10) |
 | `--explain` | dump the ES explanation for the top hit |
 | `--es`, `--index` | point elsewhere |
@@ -250,7 +252,7 @@ Against the Dust workspace (2,566 agents, 30-day window):
 - **Two precision bugs the eval could not see.** Group adjacency shared a `should` list with the text clauses under `minimum_should_match: 1`, so it satisfied the match by itself and every agent with group usage matched every query. And the `description.subsequence` wildcard matched nearly anything. Together they made `--q invoice` and `--q datadog` return the same agents. Fixing both moved the eval by +0.003 — it measures whether the target ranks, not whether junk ranks with it. `--q invoice` now returns 0 hits.
 - **Subsequence wildcards blow up past ~24 characters.** Lucene refuses to determinize the automaton (`would require more than 10000 effort`), and the whole query errors — not just that clause. The clause is also pointless for multi-word input, since the field holds the full name and a space in the pattern demands a literal space in the name. Now gated on both length and token count.
 - **Global agents swamp anything usage-weighted.** `dust` alone accounts for 42k of the workspace's messages. `--exclude-global` filters them out.
-- **The manage list reproduces.** With no query, `adrien@dust.tt` gets 389 hits, or 341 with `--exclude-global` — against 350 observed in `/manage/agents`. The residual is export drift: the corpus is a snapshot, the page is live.
+- **The historical list comparison was close.** With no query, the old profile returned 389 hits, or 341 with `--exclude-global`, against 350 observed in `/manage/agents`. The profile predates pod export support, so those numbers are not a current correctness check.
 - **82% of the corpus is dead.** 2,108 of 2,566 agents saw zero messages in the window, and 2,141 are `hidden`. BM25 will happily surface a well-written agent nobody has ever used.
 - **Programmatic traffic has no groups.** 25 agents have usage but no group attribution at all (`CodingRules`: 1,568 messages, 0 users) — API-key runs carry no `user.group_ids`, so adjacency scores them zero no matter how popular.
 - **Group sums exceed agent totals** by 2-4x, since `user.group_ids` is multi-valued. Good as a per-group signal, wrong as a denominator.

--- a/x/adrsimon/agentsearch/assets/agents_skeleton.json
+++ b/x/adrsimon/agentsearch/assets/agents_skeleton.json
@@ -35,7 +35,6 @@
         }
       ],
       "nonPodSpaceIds": ["vlt_AAAAAAAAAAAA"],
-      "nonPodSpaceCount": 1,
       "podSpaceIds": ["vlt_BBBBBBBBBBBB"],
       "usage": {
         "periodDays": 30,

--- a/x/adrsimon/agentsearch/assets/permissions/agents_mocked.json
+++ b/x/adrsimon/agentsearch/assets/permissions/agents_mocked.json
@@ -1,0 +1,869 @@
+{
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "usagePeriodDays": 30,
+  "agentCount": 21,
+  "permissionTest": {
+    "nonPodSpaces": [
+      {
+        "sId": "vlt_company",
+        "name": "Company",
+        "kind": "global"
+      },
+      {
+        "sId": "vlt_restricted_alpha",
+        "name": "Restricted Alpha",
+        "kind": "regular"
+      },
+      {
+        "sId": "vlt_restricted_beta",
+        "name": "Restricted Beta",
+        "kind": "regular"
+      }
+    ],
+    "podSpaces": [
+      {
+        "sId": "vlt_pod_alpha",
+        "name": "Pod Alpha",
+        "kind": "project"
+      },
+      {
+        "sId": "vlt_pod_beta",
+        "name": "Pod Beta",
+        "kind": "project"
+      }
+    ],
+    "editorEmail": "editor@example.com",
+    "nonEditorEmail": "member@example.com"
+  },
+  "agents": [
+    {
+      "sId": "agt_visible_none",
+      "name": "Visible without spaces",
+      "description": "Visible to every workspace member.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [],
+      "spaces": [],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_global_none",
+      "name": "Global without spaces",
+      "description": "Global and active.",
+      "instructions": null,
+      "scope": "global",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [],
+      "spaces": [],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_inactive_global_none",
+      "name": "Inactive global without spaces",
+      "description": "Excluded by the list view.",
+      "instructions": null,
+      "scope": "global",
+      "status": "inactive",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [],
+      "spaces": [],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_inactive_visible_none",
+      "name": "Inactive visible without spaces",
+      "description": "Excluded by status.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "inactive",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [],
+      "spaces": [],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_hidden_editor_none",
+      "name": "Hidden editor without spaces",
+      "description": "Visible only to editor@example.com.",
+      "instructions": null,
+      "scope": "hidden",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [
+        "editor@example.com"
+      ],
+      "requestedSpaceIds": [],
+      "spaces": [],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_hidden_other_none",
+      "name": "Hidden other editor without spaces",
+      "description": "Not visible to the tested identities.",
+      "instructions": null,
+      "scope": "hidden",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [
+        "other@example.com"
+      ],
+      "requestedSpaceIds": [],
+      "spaces": [],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_company",
+      "name": "Visible company",
+      "description": "Requires the company space.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_company"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_company",
+          "name": "Company",
+          "kind": "global"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_company"
+      ],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_restricted_alpha",
+      "name": "Visible restricted alpha",
+      "description": "Requires restricted alpha.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_restricted_alpha"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_restricted_alpha"
+      ],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_restricted_beta",
+      "name": "Visible restricted beta",
+      "description": "Requires restricted beta.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_restricted_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_restricted_beta",
+          "name": "Restricted Beta",
+          "kind": "regular"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_restricted_beta"
+      ],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_restricted_both",
+      "name": "Visible both restricted",
+      "description": "Requires both restricted spaces.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_restricted_beta",
+          "name": "Restricted Beta",
+          "kind": "regular"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta"
+      ],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_pod_alpha",
+      "name": "Visible pod alpha",
+      "description": "Requires pod alpha.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_pod_alpha"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [
+        "vlt_pod_alpha"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_pod_beta",
+      "name": "Visible pod beta",
+      "description": "Requires pod beta.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_pod_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_pod_beta",
+          "name": "Pod Beta",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [
+        "vlt_pod_beta"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_pods_all",
+      "name": "Visible both pods",
+      "description": "Requires both pods.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        },
+        {
+          "sId": "vlt_pod_beta",
+          "name": "Pod Beta",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_company_pod_alpha",
+      "name": "Visible company and pod alpha",
+      "description": "Requires a non-pod and a pod.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_company",
+        "vlt_pod_alpha"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_company",
+          "name": "Company",
+          "kind": "global"
+        },
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_company"
+      ],
+      "podSpaceIds": [
+        "vlt_pod_alpha"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_restricted_alpha_pod_beta",
+      "name": "Visible restricted alpha and pod beta",
+      "description": "Requires a restricted space and a pod.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_restricted_alpha",
+        "vlt_pod_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_pod_beta",
+          "name": "Pod Beta",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_restricted_alpha"
+      ],
+      "podSpaceIds": [
+        "vlt_pod_beta"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_all",
+      "name": "Visible all spaces",
+      "description": "Requires every mocked space.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_company",
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta",
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_company",
+          "name": "Company",
+          "kind": "global"
+        },
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_restricted_beta",
+          "name": "Restricted Beta",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        },
+        {
+          "sId": "vlt_pod_beta",
+          "name": "Pod Beta",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_company",
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta"
+      ],
+      "podSpaceIds": [
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_hidden_editor_restricted_alpha",
+      "name": "Hidden editor restricted alpha",
+      "description": "Requires editorship and restricted alpha.",
+      "instructions": null,
+      "scope": "hidden",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [
+        "editor@example.com"
+      ],
+      "requestedSpaceIds": [
+        "vlt_restricted_alpha"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_restricted_alpha"
+      ],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_hidden_editor_pod_alpha",
+      "name": "Hidden editor pod alpha",
+      "description": "Requires editorship and pod alpha.",
+      "instructions": null,
+      "scope": "hidden",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [
+        "editor@example.com"
+      ],
+      "requestedSpaceIds": [
+        "vlt_pod_alpha"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [],
+      "podSpaceIds": [
+        "vlt_pod_alpha"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_hidden_editor_all",
+      "name": "Hidden editor all spaces",
+      "description": "Requires editorship and every mocked space.",
+      "instructions": null,
+      "scope": "hidden",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [
+        "editor@example.com"
+      ],
+      "requestedSpaceIds": [
+        "vlt_company",
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta",
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_company",
+          "name": "Company",
+          "kind": "global"
+        },
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_restricted_beta",
+          "name": "Restricted Beta",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        },
+        {
+          "sId": "vlt_pod_beta",
+          "name": "Pod Beta",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_company",
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta"
+      ],
+      "podSpaceIds": [
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_hidden_other_all",
+      "name": "Hidden other editor all spaces",
+      "description": "Never visible to the tested identities.",
+      "instructions": null,
+      "scope": "hidden",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [
+        "other@example.com"
+      ],
+      "requestedSpaceIds": [
+        "vlt_company",
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta",
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_company",
+          "name": "Company",
+          "kind": "global"
+        },
+        {
+          "sId": "vlt_restricted_alpha",
+          "name": "Restricted Alpha",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_restricted_beta",
+          "name": "Restricted Beta",
+          "kind": "regular"
+        },
+        {
+          "sId": "vlt_pod_alpha",
+          "name": "Pod Alpha",
+          "kind": "project"
+        },
+        {
+          "sId": "vlt_pod_beta",
+          "name": "Pod Beta",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_company",
+        "vlt_restricted_alpha",
+        "vlt_restricted_beta"
+      ],
+      "podSpaceIds": [
+        "vlt_pod_alpha",
+        "vlt_pod_beta"
+      ],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    },
+    {
+      "sId": "agt_visible_company_and_deleted",
+      "name": "Visible, company space and a deleted one",
+      "description": "Requests a space no profile can hold, standing in for a deleted space.",
+      "instructions": null,
+      "scope": "visible",
+      "status": "active",
+      "tags": [],
+      "templateId": null,
+      "author": null,
+      "editors": [],
+      "requestedSpaceIds": [
+        "vlt_company",
+        "vlt_deleted"
+      ],
+      "spaces": [
+        {
+          "sId": "vlt_company",
+          "name": "Company",
+          "kind": "global"
+        }
+      ],
+      "nonPodSpaceIds": [
+        "vlt_company",
+        "vlt_deleted"
+      ],
+      "podSpaceIds": [],
+      "usage": {
+        "periodDays": 30,
+        "messages": 0,
+        "conversations": 0,
+        "users": 0,
+        "credits": 0,
+        "feedbacksUp": 0,
+        "feedbacksDown": 0,
+        "byGroup": []
+      }
+    }
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_all_pods.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_all_pods.json
@@ -1,0 +1,26 @@
+{
+  "scenario": "all pods and no restricted spaces",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_all_pods", "email": "member@example.com", "fullName": "All pods" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_pod_alpha", "name": "Pod Alpha", "kind": "project" },
+    { "sId": "vlt_pod_beta", "name": "Pod Beta", "kind": "project" }
+  ],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_company",
+    "agt_visible_company_pod_alpha",
+    "agt_visible_none",
+    "agt_visible_pod_alpha",
+    "agt_visible_pod_beta",
+    "agt_visible_pods_all"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_all_restricted_no_pods.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_all_restricted_no_pods.json
@@ -1,0 +1,24 @@
+{
+  "scenario": "all non-pod spaces and no pods",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_all_non_pod", "email": "member@example.com", "fullName": "All non-pod" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" },
+    { "sId": "vlt_restricted_beta", "name": "Restricted Beta", "kind": "regular" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_company",
+    "agt_visible_none",
+    "agt_visible_restricted_alpha",
+    "agt_visible_restricted_beta",
+    "agt_visible_restricted_both"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_all_spaces.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_all_spaces.json
@@ -1,0 +1,33 @@
+{
+  "scenario": "all spaces without editorship",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_all_spaces", "email": "member@example.com", "fullName": "All spaces" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" },
+    { "sId": "vlt_restricted_beta", "name": "Restricted Beta", "kind": "regular" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_pod_alpha", "name": "Pod Alpha", "kind": "project" },
+    { "sId": "vlt_pod_beta", "name": "Pod Beta", "kind": "project" }
+  ],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_all",
+    "agt_visible_company",
+    "agt_visible_company_pod_alpha",
+    "agt_visible_none",
+    "agt_visible_pod_alpha",
+    "agt_visible_pod_beta",
+    "agt_visible_pods_all",
+    "agt_visible_restricted_alpha",
+    "agt_visible_restricted_alpha_pod_beta",
+    "agt_visible_restricted_beta",
+    "agt_visible_restricted_both"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_company_space_only.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_company_space_only.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "company space only",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_company", "email": "member@example.com", "fullName": "Company only" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": ["agt_global_none", "agt_visible_company", "agt_visible_none"]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_deleted_space.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_deleted_space.json
@@ -1,0 +1,33 @@
+{
+  "scenario": "every catalog space readable, so only the deleted space can hide an agent",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_deleted_space", "email": "member@example.com", "fullName": "Deleted space" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" },
+    { "sId": "vlt_restricted_beta", "name": "Restricted Beta", "kind": "regular" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_pod_alpha", "name": "Pod Alpha", "kind": "project" },
+    { "sId": "vlt_pod_beta", "name": "Pod Beta", "kind": "project" }
+  ],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_all",
+    "agt_visible_company",
+    "agt_visible_company_pod_alpha",
+    "agt_visible_none",
+    "agt_visible_pod_alpha",
+    "agt_visible_pod_beta",
+    "agt_visible_pods_all",
+    "agt_visible_restricted_alpha",
+    "agt_visible_restricted_alpha_pod_beta",
+    "agt_visible_restricted_beta",
+    "agt_visible_restricted_both"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_editor_all_spaces.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_editor_all_spaces.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "editor with all spaces",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_editor_all", "email": "editor@example.com", "fullName": "Editor all spaces" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" },
+    { "sId": "vlt_restricted_beta", "name": "Restricted Beta", "kind": "regular" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_pod_alpha", "name": "Pod Alpha", "kind": "project" },
+    { "sId": "vlt_pod_beta", "name": "Pod Beta", "kind": "project" }
+  ],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_hidden_editor_all",
+    "agt_hidden_editor_none",
+    "agt_hidden_editor_pod_alpha",
+    "agt_hidden_editor_restricted_alpha",
+    "agt_visible_all",
+    "agt_visible_company",
+    "agt_visible_company_pod_alpha",
+    "agt_visible_none",
+    "agt_visible_pod_alpha",
+    "agt_visible_pod_beta",
+    "agt_visible_pods_all",
+    "agt_visible_restricted_alpha",
+    "agt_visible_restricted_alpha_pod_beta",
+    "agt_visible_restricted_beta",
+    "agt_visible_restricted_both"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_editor_company_only.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_editor_company_only.json
@@ -1,0 +1,20 @@
+{
+  "scenario": "editor with company space only",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_editor_company", "email": "editor@example.com", "fullName": "Editor company" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_hidden_editor_none",
+    "agt_visible_company",
+    "agt_visible_none"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_editor_restricted.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_editor_restricted.json
@@ -1,0 +1,23 @@
+{
+  "scenario": "editor with restricted alpha",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_editor_restricted", "email": "editor@example.com", "fullName": "Editor restricted" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_hidden_editor_none",
+    "agt_hidden_editor_restricted_alpha",
+    "agt_visible_company",
+    "agt_visible_none",
+    "agt_visible_restricted_alpha"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_exclude_global.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_exclude_global.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "company space with global agents excluded",
+  "excludeGlobal": true,
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_exclude_global", "email": "member@example.com", "fullName": "Exclude global" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": ["agt_visible_company", "agt_visible_none"]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_mixed_restricted_and_pod.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_mixed_restricted_and_pod.json
@@ -1,0 +1,25 @@
+{
+  "scenario": "restricted alpha and pod beta",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_mixed", "email": "member@example.com", "fullName": "Mixed access" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_pod_beta", "name": "Pod Beta", "kind": "project" }
+  ],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_company",
+    "agt_visible_none",
+    "agt_visible_pod_beta",
+    "agt_visible_restricted_alpha",
+    "agt_visible_restricted_alpha_pod_beta"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_no_spaces.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_no_spaces.json
@@ -1,0 +1,13 @@
+{
+  "scenario": "no readable spaces",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_no_spaces", "email": "member@example.com", "fullName": "No spaces" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [],
+  "readablePodSpaces": [],
+  "expectedAgentIds": ["agt_global_none", "agt_visible_none"]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_pod_alpha.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_pod_alpha.json
@@ -1,0 +1,23 @@
+{
+  "scenario": "one pod and no restricted spaces",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_pod_alpha", "email": "member@example.com", "fullName": "Pod alpha" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_pod_alpha", "name": "Pod Alpha", "kind": "project" }
+  ],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_company",
+    "agt_visible_company_pod_alpha",
+    "agt_visible_none",
+    "agt_visible_pod_alpha"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_restricted_alpha.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_restricted_alpha.json
@@ -1,0 +1,21 @@
+{
+  "scenario": "one restricted space and no pods",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_restricted_alpha", "email": "member@example.com", "fullName": "Restricted alpha" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_restricted_alpha", "name": "Restricted Alpha", "kind": "regular" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": [
+    "agt_global_none",
+    "agt_visible_company",
+    "agt_visible_none",
+    "agt_visible_restricted_alpha"
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/permissions/user_mocked_unreferenced_space.json
+++ b/x/adrsimon/agentsearch/assets/permissions/user_mocked_unreferenced_space.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "company space plus an unreferenced readable space",
+  "workspaceId": "w_mocked",
+  "workspaceName": "Permission model",
+  "generatedAt": "2026-08-27T00:00:00.000Z",
+  "user": { "sId": "usr_unreferenced", "email": "member@example.com", "fullName": "Unreferenced space" },
+  "role": "user",
+  "groupIds": [],
+  "groups": [],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_company", "name": "Company", "kind": "global" },
+    { "sId": "vlt_unreferenced", "name": "Unreferenced", "kind": "regular" }
+  ],
+  "readablePodSpaces": [],
+  "expectedAgentIds": ["agt_global_none", "agt_visible_company", "agt_visible_none"]
+}

--- a/x/adrsimon/agentsearch/assets/profile_skeleton.json
+++ b/x/adrsimon/agentsearch/assets/profile_skeleton.json
@@ -10,9 +10,8 @@
     "(see README.md, 'Producing an export'). It writes profile_<userSId>.json; drop it",
     "in this directory and pass it to search with --profile.",
     "",
-    "readableNonPodSpaces feeds the terms_set space filter. readablePodSpaces is",
-    "recorded but not filtered on, mirroring skill search, which authorizes pods",
-    "against Postgres after the query rather than inside it."
+    "readableNonPodSpaces and readablePodSpaces feed independent Elasticsearch",
+    "filters. An agent must pass both filters."
   ],
   "workspaceId": "0000000000",
   "workspaceName": "Example Workspace",

--- a/x/adrsimon/agentsearch/index/agent_search.mappings.json
+++ b/x/adrsimon/agentsearch/index/agent_search.mappings.json
@@ -50,12 +50,6 @@
       "editors": {
         "type": "keyword"
       },
-      "requested_space_ids": {
-        "type": "keyword"
-      },
-      "requested_space_count": {
-        "type": "integer"
-      },
       "non_pod_space_ids": {
         "type": "keyword"
       },
@@ -64,6 +58,9 @@
       },
       "pod_space_ids": {
         "type": "keyword"
+      },
+      "pod_space_count": {
+        "type": "integer"
       },
       "usage": {
         "properties": {

--- a/x/adrsimon/agentsearch/package.json
+++ b/x/adrsimon/agentsearch/package.json
@@ -9,6 +9,7 @@
     "es:reset": "docker compose down -v && docker compose up -d",
     "ingest": "tsx scripts/ingest.ts",
     "search": "tsx scripts/search.ts",
+    "test:permissions": "tsx scripts/test_permissions.ts",
     "typecheck": "tsgo --noEmit -p .",
     "gen:queries": "tsx scripts/generate_queries.ts",
     "eval": "tsx scripts/eval.ts"

--- a/x/adrsimon/agentsearch/scripts/documents.ts
+++ b/x/adrsimon/agentsearch/scripts/documents.ts
@@ -1,0 +1,52 @@
+import type { AgentSearchDocument, ExportedAgent } from "./types.ts";
+
+export function toAgentSearchDocument(
+  agent: ExportedAgent
+): AgentSearchDocument {
+  // A requested space missing from both classes is deniable by no clause, so the agent would
+  // outlive `canReadRequestedSpaces` and reach users who cannot read it.
+  const requestedSpaceIds = [...agent.requestedSpaceIds].sort();
+  const classifiedSpaceIds = [
+    ...agent.nonPodSpaceIds,
+    ...agent.podSpaceIds,
+  ].sort();
+  if (
+    requestedSpaceIds.length !== classifiedSpaceIds.length ||
+    requestedSpaceIds.some(
+      (spaceId, index) => spaceId !== classifiedSpaceIds[index]
+    )
+  ) {
+    throw new Error(
+      `${agent.sId}: requested spaces ${agent.requestedSpaceIds.join(",")} do not split into ${agent.nonPodSpaceIds.join(",")} and ${agent.podSpaceIds.join(",")}`
+    );
+  }
+  return {
+    agent_id: agent.sId,
+    name: agent.name,
+    description: agent.description,
+    instructions: agent.instructions,
+    tags: agent.tags,
+    scope: agent.scope,
+    status: agent.status,
+    author: agent.author,
+    editors: agent.editors,
+    non_pod_space_ids: agent.nonPodSpaceIds,
+    non_pod_space_count: agent.nonPodSpaceIds.length,
+    pod_space_ids: agent.podSpaceIds,
+    pod_space_count: agent.podSpaceIds.length,
+    usage: {
+      messages: agent.usage.messages,
+      conversations: agent.usage.conversations,
+      users: agent.usage.users,
+      credits: agent.usage.credits,
+      feedbacks_up: agent.usage.feedbacksUp,
+      feedbacks_down: agent.usage.feedbacksDown,
+      by_group: agent.usage.byGroup.map((group) => ({
+        group_id: group.groupId,
+        group_name: group.groupName,
+        messages: group.messages,
+        users: group.users,
+      })),
+    },
+  };
+}

--- a/x/adrsimon/agentsearch/scripts/eval.ts
+++ b/x/adrsimon/agentsearch/scripts/eval.ts
@@ -4,7 +4,11 @@ import { parseArgs } from "node:util";
 
 import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
 import type { MatchMode, NameFallback } from "./query.ts";
-import { buildAgentSearchQuery, contextFromProfile } from "./query.ts";
+import {
+  buildAgentSearchQuery,
+  contextFromProfile,
+  fetchReferencedSpaces,
+} from "./query.ts";
 import { contentTerms, documentTerms } from "./text.ts";
 import type {
   EvalMetrics,
@@ -56,6 +60,7 @@ const includeInstructions = values["with-instructions"];
 const minShouldMatch = values["min-should-match"];
 const matchMode = values["match-mode"] as MatchMode;
 const nameFallback = values["name-fallback"] as NameFallback;
+const referencedSpaces = await fetchReferencedSpaces(values.es, values.index);
 const maxQueries = Number(values["max-queries"]);
 const queries =
   maxQueries > 0 ? querySet.queries.slice(0, maxQueries) : querySet.queries;
@@ -118,13 +123,13 @@ async function runBatch(
         query: buildAgentSearchQuery({
           ...context,
           searchTerm: query.query,
-          scopes: [],
           excludeGlobal,
           includeInstructions,
           minShouldMatch,
           matchMode,
           nameFallback,
           groupBoost,
+          referencedSpaces,
         }),
         size: CUTOFF,
         _source: ["name", "description"],

--- a/x/adrsimon/agentsearch/scripts/export_user_profile.ts
+++ b/x/adrsimon/agentsearch/scripts/export_user_profile.ts
@@ -46,6 +46,7 @@ makeScript(
 
     const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
       includeConversationsSpace: true,
+      includeProjectSpaces: true,
     });
     const readableSpaces = spaces.filter((space) => space.canRead(auth));
 
@@ -91,6 +92,7 @@ makeScript(
         path,
         groupCount: profile.groups.length,
         readableSpaceCount: readableSpaces.length,
+        readablePodSpaceCount: profile.readablePodSpaces.length,
       },
       "Profile exported"
     );

--- a/x/adrsimon/agentsearch/scripts/export_workspace_agents.ts
+++ b/x/adrsimon/agentsearch/scripts/export_workspace_agents.ts
@@ -252,8 +252,11 @@ makeScript(
     const spaceById = new Map(spaces.map((s) => [s.sId, s]));
 
     const isPod = (sId: string) => spaceById.get(sId)?.isProject() ?? false;
+    // An unresolvable space still has to land in a class: dropped from both, no clause can
+    // deny it and the agent becomes visible to anyone reading its remaining spaces, where
+    // `canReadRequestedSpaces` hides it from everyone.
     const nonPodSpaceIdsFor = (spaceIds: string[]) =>
-      spaceIds.filter((sId) => spaceById.has(sId) && !isPod(sId));
+      spaceIds.filter((sId) => !isPod(sId));
     const podSpaceIdsFor = (spaceIds: string[]) => spaceIds.filter(isPod);
 
     const unresolvedSpaceAgents = agentConfigurations.filter((agent) =>
@@ -293,7 +296,6 @@ makeScript(
           kind: spaceById.get(sId)?.kind ?? null,
         })),
         nonPodSpaceIds: nonPodSpaceIdsFor(agent.requestedSpaceIds),
-        nonPodSpaceCount: nonPodSpaceIdsFor(agent.requestedSpaceIds).length,
         podSpaceIds: podSpaceIdsFor(agent.requestedSpaceIds),
         usage: {
           periodDays: days,

--- a/x/adrsimon/agentsearch/scripts/generate_queries.ts
+++ b/x/adrsimon/agentsearch/scripts/generate_queries.ts
@@ -3,7 +3,11 @@ import { basename, resolve } from "node:path";
 import { parseArgs } from "node:util";
 
 import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
-import { buildFilters, contextFromProfile } from "./query.ts";
+import {
+  buildFilters,
+  contextFromProfile,
+  fetchReferencedSpaces,
+} from "./query.ts";
 import { splitName, tokenize } from "./text.ts";
 import type {
   EvalNegative,
@@ -67,19 +71,21 @@ interface PageResponse {
   };
 }
 
+const referencedSpaces = await fetchReferencedSpaces(values.es, values.index);
+
 async function fetchCandidates(): Promise<Candidate[]> {
   const query = {
     bool: {
       filter: buildFilters({
         ...context,
         searchTerm: "",
-        scopes: [],
         excludeGlobal: values["exclude-global"],
         includeInstructions: false,
         minShouldMatch: "",
         matchMode: "bool_prefix",
         nameFallback: "off",
         groupBoost: 0,
+        referencedSpaces,
       }),
     },
   };

--- a/x/adrsimon/agentsearch/scripts/ingest.ts
+++ b/x/adrsimon/agentsearch/scripts/ingest.ts
@@ -3,9 +3,8 @@ import { dirname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 
 import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
+import { toAgentSearchDocument } from "./documents.ts";
 import type {
-  AgentSearchDocument,
-  ExportedAgent,
   WorkspaceAgentExport,
 } from "./types.ts";
 
@@ -23,39 +22,6 @@ const { values } = parseArgs({
 interface BulkResponse {
   errors: boolean;
   items: { index: { error?: unknown } }[];
-}
-
-function toDocument(agent: ExportedAgent): AgentSearchDocument {
-  return {
-    agent_id: agent.sId,
-    name: agent.name,
-    description: agent.description,
-    instructions: agent.instructions,
-    tags: agent.tags,
-    scope: agent.scope,
-    status: agent.status,
-    author: agent.author,
-    editors: agent.editors,
-    requested_space_ids: agent.requestedSpaceIds,
-    requested_space_count: agent.requestedSpaceIds.length,
-    non_pod_space_ids: agent.nonPodSpaceIds,
-    non_pod_space_count: agent.nonPodSpaceCount,
-    pod_space_ids: agent.podSpaceIds,
-    usage: {
-      messages: agent.usage.messages,
-      conversations: agent.usage.conversations,
-      users: agent.usage.users,
-      credits: agent.usage.credits,
-      feedbacks_up: agent.usage.feedbacksUp,
-      feedbacks_down: agent.usage.feedbacksDown,
-      by_group: agent.usage.byGroup.map((group) => ({
-        group_id: group.groupId,
-        group_name: group.groupName,
-        messages: group.messages,
-        users: group.users,
-      })),
-    },
-  };
 }
 
 const exportPath = values.file
@@ -88,7 +54,7 @@ for (let i = 0; i < workspaceExport.agents.length; i += BATCH_SIZE) {
   const batch = workspaceExport.agents.slice(i, i + BATCH_SIZE);
   const lines = batch.flatMap((agent) => [
     JSON.stringify({ index: { _index: values.index, _id: agent.sId } }),
-    JSON.stringify(toDocument(agent)),
+    JSON.stringify(toAgentSearchDocument(agent)),
   ]);
   const result = await esRequest<BulkResponse>(
     values.es,

--- a/x/adrsimon/agentsearch/scripts/query.ts
+++ b/x/adrsimon/agentsearch/scripts/query.ts
@@ -1,3 +1,4 @@
+import { esRequest } from "./es.ts";
 import type { UserProfile } from "./types.ts";
 
 export type EsQuery = Record<string, unknown>;
@@ -17,20 +18,26 @@ const PREFIX_CLAUSE_BOOST = 0.5;
 const MAX_SUBSEQUENCE_LENGTH = 24;
 
 export interface SearchContext {
-  readableSpaceIds: string[];
+  readableNonPodSpaceIds: string[];
+  readablePodSpaceIds: string[];
   userGroupIds: string[];
   userEmail: string | null;
 }
 
+export interface ReferencedSpaces {
+  nonPodSpaceIds: string[];
+  podSpaceIds: string[];
+}
+
 export interface SearchParams extends SearchContext {
   searchTerm: string;
-  scopes: string[];
   includeInstructions: boolean;
   minShouldMatch: string;
   matchMode: MatchMode;
   nameFallback: NameFallback;
   excludeGlobal: boolean;
   groupBoost: number;
+  referencedSpaces: ReferencedSpaces;
 }
 
 export function contextFromProfile(
@@ -39,40 +46,143 @@ export function contextFromProfile(
 ): SearchContext {
   if (profile) {
     return {
-      readableSpaceIds: [
-        ...profile.readableNonPodSpaces,
-        ...profile.readablePodSpaces,
-      ].map((space) => space.sId),
+      readableNonPodSpaceIds: profile.readableNonPodSpaces.map(
+        (space) => space.sId
+      ),
+      readablePodSpaceIds: profile.readablePodSpaces.map((space) => space.sId),
       userGroupIds: profile.groupIds,
       userEmail: profile.user.email,
     };
   }
   return {
-    readableSpaceIds: fallback.spaces.split(",").filter(Boolean),
+    readableNonPodSpaceIds: fallback.spaces.split(",").filter(Boolean),
+    readablePodSpaceIds: [],
     userGroupIds: fallback.groups.split(",").filter(Boolean),
     userEmail: null,
   };
 }
 
-function buildSpaceAccessFilter(readableSpaceIds: string[]): EsQuery {
-  if (readableSpaceIds.length === 0) {
-    return { term: { requested_space_count: 0 } };
+// `terms_set` is the literal translation of `filterAgentsByRequestedSpaces` — every requested
+// space readable — but it expands to one Lucene clause per term, so its ceiling is
+// `maxClauseCount`: 1024 at the floor, derived per node from heap and CPU above it. Its
+// contrapositive, `must_not` a `terms` list of the spaces the caller cannot read, is the same
+// predicate in a single `TermInSetQuery` and runs to `index.max_terms_count`.
+//
+// Neither side is bounded on its own. A workspace can reference thousands of pods, and a user can
+// belong to thousands. What is small is one of the two, per space class: send whichever side is
+// shorter, and only take the positive form while it fits the clause budget.
+const MAX_TERMS_SET_TERMS = 1024;
+
+export function buildSpaceClassFilter(
+  spaceIdsField: string,
+  spaceCountField: string,
+  readableSpaceIds: string[],
+  referencedSpaceIds: string[]
+): EsQuery {
+  const readableSpaceIdSet = new Set(readableSpaceIds);
+  const deniedSpaceIds = referencedSpaceIds.filter(
+    (spaceId) => !readableSpaceIdSet.has(spaceId)
+  );
+  if (deniedSpaceIds.length === 0) {
+    return { match_all: {} };
+  }
+
+  const grantingSpaceIds = referencedSpaceIds.filter((spaceId) =>
+    readableSpaceIdSet.has(spaceId)
+  );
+  if (grantingSpaceIds.length === 0) {
+    return { term: { [spaceCountField]: 0 } };
+  }
+  if (
+    grantingSpaceIds.length >
+    Math.min(deniedSpaceIds.length, MAX_TERMS_SET_TERMS)
+  ) {
+    return {
+      bool: { must_not: [{ terms: { [spaceIdsField]: deniedSpaceIds } }] },
+    };
   }
   return {
     bool: {
       should: [
-        { term: { requested_space_count: 0 } },
+        { term: { [spaceCountField]: 0 } },
         {
           terms_set: {
-            requested_space_ids: {
-              terms: readableSpaceIds,
-              minimum_should_match_field: "requested_space_count",
+            [spaceIdsField]: {
+              terms: grantingSpaceIds,
+              minimum_should_match_field: spaceCountField,
             },
           },
         },
       ],
       minimum_should_match: 1,
     },
+  };
+}
+
+// Pods and non-pods are filtered apart because their bounds are unrelated: non-pod spaces are
+// bounded by the workspace, pod membership by the caller. An agent is visible when both hold, so
+// the two clauses are ANDed, which is what `canReadRequestedSpaces` does term by term.
+function buildSpaceAccessFilter(params: SearchParams): EsQuery[] {
+  return [
+    buildSpaceClassFilter(
+      "non_pod_space_ids",
+      "non_pod_space_count",
+      params.readableNonPodSpaceIds,
+      params.referencedSpaces.nonPodSpaceIds
+    ),
+    buildSpaceClassFilter(
+      "pod_space_ids",
+      "pod_space_count",
+      params.readablePodSpaceIds,
+      params.referencedSpaces.podSpaceIds
+    ),
+  ];
+}
+
+interface ReferencedSpacesResponse {
+  aggregations: Record<
+    string,
+    { sum_other_doc_count: number; buckets: { key: string }[] }
+  >;
+}
+
+const MAX_REFERENCED_SPACES = 20000;
+
+// The spaces agents actually point at, the only ones that can change the answer. In front, a
+// cached `SELECT DISTINCT unnest("requestedSpaceIds")` over the workspace's active agents.
+// Over-listing this set is harmless; under-listing it leaks.
+export async function fetchReferencedSpaces(
+  esUrl: string,
+  index: string
+): Promise<ReferencedSpaces> {
+  const aggFor = (field: string) => ({
+    terms: { field, size: MAX_REFERENCED_SPACES },
+  });
+  const result = await esRequest<ReferencedSpacesResponse>(
+    esUrl,
+    "POST",
+    `/${index}/_search`,
+    JSON.stringify({
+      size: 0,
+      query: { term: { status: "active" } },
+      aggs: {
+        non_pod_space_ids: aggFor("non_pod_space_ids"),
+        pod_space_ids: aggFor("pod_space_ids"),
+      },
+    })
+  );
+  const spaceIdsOf = (field: string) => {
+    const agg = result.aggregations[field];
+    if (agg.sum_other_doc_count > 0) {
+      throw new Error(
+        `agents reference more than ${MAX_REFERENCED_SPACES} ${field}; the filter would be incomplete`
+      );
+    }
+    return agg.buckets.map((bucket) => bucket.key);
+  };
+  return {
+    nonPodSpaceIds: spaceIdsOf("non_pod_space_ids"),
+    podSpaceIds: spaceIdsOf("pod_space_ids"),
   };
 }
 
@@ -216,10 +326,8 @@ function buildGroupAdjacencyClause(
 export function buildFilters(params: SearchParams): EsQuery[] {
   return [
     { term: { status: "active" } },
-    buildSpaceAccessFilter(params.readableSpaceIds),
-    ...(params.scopes.length > 0
-      ? [{ terms: { scope: params.scopes } }]
-      : [buildVisibilityFilter(params.userEmail, params.excludeGlobal)]),
+    ...buildSpaceAccessFilter(params),
+    buildVisibilityFilter(params.userEmail, params.excludeGlobal),
   ];
 }
 

--- a/x/adrsimon/agentsearch/scripts/search.ts
+++ b/x/adrsimon/agentsearch/scripts/search.ts
@@ -4,7 +4,11 @@ import { parseArgs } from "node:util";
 
 import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
 import type { MatchMode, NameFallback } from "./query.ts";
-import { buildAgentSearchQuery, contextFromProfile } from "./query.ts";
+import {
+  buildAgentSearchQuery,
+  contextFromProfile,
+  fetchReferencedSpaces,
+} from "./query.ts";
 import type { AgentSearchDocument, UserProfile } from "./types.ts";
 
 const { values } = parseArgs({
@@ -13,7 +17,6 @@ const { values } = parseArgs({
     profile: { type: "string" },
     spaces: { type: "string", default: "" },
     groups: { type: "string", default: "" },
-    scope: { type: "string", default: "" },
     "exclude-global": { type: "boolean", default: false },
     "with-instructions": { type: "boolean", default: false },
     "min-should-match": { type: "string", default: "" },
@@ -37,6 +40,7 @@ const context = contextFromProfile(profile, {
 });
 const searchTerm = values.q.trim();
 const limit = Number(values.limit);
+const referencedSpaces = await fetchReferencedSpaces(values.es, values.index);
 
 interface SearchResponse {
   hits: {
@@ -55,13 +59,13 @@ interface SearchResponse {
 const query = buildAgentSearchQuery({
   ...context,
   searchTerm,
-  scopes: values.scope.split(",").filter(Boolean),
   excludeGlobal: values["exclude-global"],
   includeInstructions: values["with-instructions"],
   minShouldMatch: values["min-should-match"],
   matchMode: values["match-mode"] as MatchMode,
   nameFallback: values["name-fallback"] as NameFallback,
   groupBoost: Number(values["group-boost"]),
+  referencedSpaces,
 });
 
 const result = await esRequest<SearchResponse>(
@@ -80,7 +84,9 @@ const asWhom = profile
   ? `as ${profile.user.email} (${profile.role})`
   : "as an anonymous caller";
 console.log(
-  `q="${searchTerm}" ${asWhom} spaces=${context.readableSpaceIds.length} groups=${context.userGroupIds.length} -> ${result.hits.total.value} hits\n`
+  `q="${searchTerm}" ${asWhom}`
+    + ` spaces=${context.readableNonPodSpaceIds.length}+${context.readablePodSpaceIds.length} pods`
+    + ` groups=${context.userGroupIds.length} -> ${result.hits.total.value} hits\n`
 );
 for (const [rank, hit] of result.hits.hits.entries()) {
   const source = hit._source;

--- a/x/adrsimon/agentsearch/scripts/test_permissions.ts
+++ b/x/adrsimon/agentsearch/scripts/test_permissions.ts
@@ -1,0 +1,450 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { toAgentSearchDocument } from "./documents.ts";
+import { DEFAULT_ES_URL, esRequest } from "./es.ts";
+import {
+  buildAgentSearchQuery,
+  buildSpaceClassFilter,
+  fetchReferencedSpaces,
+} from "./query.ts";
+import type { ReferencedSpaces, SearchParams } from "./query.ts";
+import type {
+  ExportedAgent,
+  ProfileSpace,
+  UserProfile,
+  WorkspaceAgentExport,
+} from "./types.ts";
+
+const PROJECT_ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const FIXTURES_ROOT = join(PROJECT_ROOT, "assets", "permissions");
+const INDEX = `agent_search_permissions_test_${process.pid}`;
+const { values } = parseArgs({
+  options: {
+    es: { type: "string", default: DEFAULT_ES_URL },
+  },
+});
+
+interface PermissionFixture extends WorkspaceAgentExport {
+  permissionTest: {
+    nonPodSpaces: ProfileSpace[];
+    podSpaces: ProfileSpace[];
+    editorEmail: string;
+    nonEditorEmail: string;
+  };
+}
+
+interface PermissionScenario extends UserProfile {
+  scenario: string;
+  excludeGlobal?: boolean;
+  expectedAgentIds: string[];
+}
+
+interface BulkResponse {
+  errors: boolean;
+  items: { index: { error?: unknown } }[];
+}
+
+interface SearchResponse {
+  hits: { hits: { _id: string }[] };
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf-8"));
+}
+
+function readableSpaceIds(profile: UserProfile): Set<string> {
+  return new Set(
+    [...profile.readableNonPodSpaces, ...profile.readablePodSpaces].map(
+      (space) => space.sId
+    )
+  );
+}
+
+function expectedAgentIds(
+  agents: ExportedAgent[],
+  profile: UserProfile,
+  excludeGlobal: boolean
+): string[] {
+  const readableSpaceIdSet = readableSpaceIds(profile);
+  return agents
+    .filter((agent) => {
+      if (agent.status !== "active") {
+        return false;
+      }
+      const hasVisibleScope =
+        agent.scope === "visible" ||
+        (agent.scope === "global" && !excludeGlobal) ||
+        (agent.scope === "hidden" && agent.editors.includes(profile.user.email));
+      return (
+        hasVisibleScope &&
+        agent.requestedSpaceIds.every((spaceId) =>
+          readableSpaceIdSet.has(spaceId)
+        )
+      );
+    })
+    .map((agent) => agent.sId)
+    .sort();
+}
+
+async function actualAgentIds(
+  esUrl: string,
+  profile: UserProfile,
+  excludeGlobal: boolean,
+  referencedSpaces: Awaited<ReturnType<typeof fetchReferencedSpaces>>,
+  agentCount: number
+): Promise<string[]> {
+  const result = await esRequest<SearchResponse>(
+    esUrl,
+    "POST",
+    `/${INDEX}/_search`,
+    JSON.stringify({
+      size: agentCount,
+      _source: false,
+      query: buildAgentSearchQuery(
+        searchParamsFor(profile, excludeGlobal, referencedSpaces)
+      ),
+    })
+  );
+  return result.hits.hits.map((hit) => hit._id).sort();
+}
+
+function searchParamsFor(
+  profile: UserProfile,
+  excludeGlobal: boolean,
+  referencedSpaces: ReferencedSpaces
+): SearchParams {
+  return {
+    readableNonPodSpaceIds: profile.readableNonPodSpaces.map(
+      (space) => space.sId
+    ),
+    readablePodSpaceIds: profile.readablePodSpaces.map((space) => space.sId),
+    userGroupIds: profile.groupIds,
+    userEmail: profile.user.email,
+    searchTerm: "",
+    includeInstructions: false,
+    minShouldMatch: "",
+    matchMode: "best_fields",
+    nameFallback: "off",
+    excludeGlobal,
+    groupBoost: 0,
+    referencedSpaces,
+  };
+}
+
+function numberedSpaceIds(prefix: string, count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `${prefix}${index}`);
+}
+
+function assertSpaceFilterShapes(): void {
+  assert.deepEqual(
+    buildSpaceClassFilter("space_ids", "space_count", [], ["a"]),
+    { term: { space_count: 0 } },
+    "no readable spaces"
+  );
+  assert.deepEqual(
+    buildSpaceClassFilter("space_ids", "space_count", ["a"], ["a"]),
+    { match_all: {} },
+    "all referenced spaces readable"
+  );
+  assert.deepEqual(
+    buildSpaceClassFilter("space_ids", "space_count", ["a"], [
+      "a",
+      "b",
+      "c",
+    ]),
+    {
+      bool: {
+        should: [
+          { term: { space_count: 0 } },
+          {
+            terms_set: {
+              space_ids: {
+                terms: ["a"],
+                minimum_should_match_field: "space_count",
+              },
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      },
+    },
+    "readable side selected"
+  );
+  assert.deepEqual(
+    buildSpaceClassFilter("space_ids", "space_count", ["a", "b"], [
+      "a",
+      "b",
+      "c",
+    ]),
+    { bool: { must_not: [{ terms: { space_ids: ["c"] } }] } },
+    "denied side selected"
+  );
+
+  const readableSpaceIds = numberedSpaceIds("readable_", 1200);
+  const deniedSpaceIds = numberedSpaceIds("denied_", 1300);
+  const budgetFilter = buildSpaceClassFilter(
+    "space_ids",
+    "space_count",
+    readableSpaceIds,
+    [...readableSpaceIds, ...deniedSpaceIds]
+  );
+  assert.equal(
+    JSON.stringify(budgetFilter).includes('"must_not"'),
+    true,
+    "clause budget selects denied side"
+  );
+}
+
+// Naming a space no agent requests must not change the answer; missing one leaks the agents
+// that request it. Front's cached referenced set can lag on deletions, never on additions.
+async function assertOverListingIsSafe(
+  esUrl: string,
+  fixture: PermissionFixture,
+  referencedSpaces: ReferencedSpaces
+): Promise<void> {
+  const profile = profileFor(
+    fixture,
+    fixture.permissionTest.editorEmail,
+    fixture.permissionTest.nonPodSpaces,
+    fixture.permissionTest.podSpaces
+  );
+  const exact = await actualAgentIds(
+    esUrl,
+    profile,
+    false,
+    referencedSpaces,
+    fixture.agents.length
+  );
+  const overListed = await actualAgentIds(
+    esUrl,
+    profile,
+    false,
+    {
+      nonPodSpaceIds: [...referencedSpaces.nonPodSpaceIds, "vlt_never_requested"],
+      podSpaceIds: [...referencedSpaces.podSpaceIds, "vlt_never_requested_pod"],
+    },
+    fixture.agents.length
+  );
+  assert.deepEqual(overListed, exact, "over-listed referenced spaces");
+}
+
+async function assertClauseBudgetQuery(esUrl: string): Promise<void> {
+  const readableNonPodSpaceIds = numberedSpaceIds("budget_readable_", 5000);
+  const deniedNonPodSpaceIds = numberedSpaceIds("budget_denied_", 5001);
+  const query = buildAgentSearchQuery({
+    readableNonPodSpaceIds,
+    readablePodSpaceIds: [],
+    userGroupIds: [],
+    userEmail: "member@example.com",
+    searchTerm: "",
+    includeInstructions: false,
+    minShouldMatch: "",
+    matchMode: "best_fields",
+    nameFallback: "off",
+    excludeGlobal: false,
+    groupBoost: 0,
+    referencedSpaces: {
+      nonPodSpaceIds: [
+        ...readableNonPodSpaceIds,
+        ...deniedNonPodSpaceIds,
+      ],
+      podSpaceIds: [],
+    },
+  });
+  await esRequest(
+    esUrl,
+    "POST",
+    `/${INDEX}/_search`,
+    JSON.stringify({ size: 0, query })
+  );
+}
+
+function profileFor(
+  fixture: PermissionFixture,
+  email: string,
+  nonPodSpaces: ProfileSpace[],
+  podSpaces: ProfileSpace[]
+): UserProfile {
+  return {
+    workspaceId: fixture.workspaceId,
+    workspaceName: fixture.workspaceName,
+    generatedAt: fixture.generatedAt,
+    user: { sId: email, email, fullName: email },
+    role: "user",
+    groupIds: [],
+    groups: [],
+    readableNonPodSpaces: nonPodSpaces,
+    readablePodSpaces: podSpaces,
+  };
+}
+
+function subsets<T>(values: T[]): T[][] {
+  return Array.from({ length: 2 ** values.length }, (_, mask) =>
+    values.filter((_, index) => (mask & (1 << index)) !== 0)
+  );
+}
+
+async function ingestFixture(
+  esUrl: string,
+  fixture: PermissionFixture
+): Promise<void> {
+  await esRequest(
+    esUrl,
+    "PUT",
+    `/${INDEX}`,
+    await readFile(
+      join(PROJECT_ROOT, "index", "agent_search.mappings.json"),
+      "utf-8"
+    )
+  );
+  const lines = fixture.agents.flatMap((agent) => [
+    JSON.stringify({ index: { _index: INDEX, _id: agent.sId } }),
+    JSON.stringify(toAgentSearchDocument(agent)),
+  ]);
+  const result = await esRequest<BulkResponse>(
+    esUrl,
+    "POST",
+    "/_bulk",
+    `${lines.join("\n")}\n`,
+    "application/x-ndjson"
+  );
+  assert.equal(result.errors, false, JSON.stringify(result.items));
+  await esRequest(esUrl, "POST", `/${INDEX}/_refresh`);
+}
+
+async function run(): Promise<void> {
+  const esUrl = values.es;
+  assertSpaceFilterShapes();
+  const fixture = await readJson<PermissionFixture>(
+    join(FIXTURES_ROOT, "agents_mocked.json")
+  );
+  assert.equal(fixture.agentCount, fixture.agents.length);
+  const multiSpaceAgent = fixture.agents.find(
+    (agent) => agent.requestedSpaceIds.length > 1
+  );
+  assert.ok(multiSpaceAgent, "fixture has no multi-space agent");
+  assert.throws(
+    () =>
+      toAgentSearchDocument({
+        ...multiSpaceAgent,
+        nonPodSpaceIds: multiSpaceAgent.requestedSpaceIds.map(
+          () => multiSpaceAgent.requestedSpaceIds[0]
+        ),
+        podSpaceIds: [],
+      }),
+    /do not split/,
+    "document conversion accepts a same-length invalid space partition"
+  );
+  const catalogSpaceIds = [
+    ...fixture.permissionTest.nonPodSpaces,
+    ...fixture.permissionTest.podSpaces,
+  ]
+    .map((space) => space.sId)
+    .sort();
+  const requestedSpaceIds = new Set(
+    fixture.agents.flatMap((agent) => agent.requestedSpaceIds)
+  );
+  assert.equal(
+    new Set(catalogSpaceIds).size,
+    catalogSpaceIds.length,
+    "permission space catalog holds no duplicates"
+  );
+  // Requested ids may sit outside the catalog on purpose: a space no profile can ever hold
+  // stands in for one deleted under front's `canRead(...) ?? false`.
+  for (const spaceId of catalogSpaceIds) {
+    assert.equal(
+      requestedSpaceIds.has(spaceId),
+      true,
+      `catalog space ${spaceId} is requested by no agent`
+    );
+  }
+  const scenarioFiles = (await readdir(FIXTURES_ROOT))
+    .filter((file) => file.startsWith("user_mocked_") && file.endsWith(".json"))
+    .sort();
+  const scenarios = await Promise.all(
+    scenarioFiles.map((file) =>
+      readJson<PermissionScenario>(join(FIXTURES_ROOT, file))
+    )
+  );
+  assert.ok(scenarios.length > 0, "no user_mocked_*.json scenarios found");
+
+  try {
+    await ingestFixture(esUrl, fixture);
+    const referencedSpaces = await fetchReferencedSpaces(esUrl, INDEX);
+
+    for (const scenario of scenarios) {
+      const expectedFromModel = expectedAgentIds(
+        fixture.agents,
+        scenario,
+        scenario.excludeGlobal ?? false
+      );
+      assert.deepEqual(
+        [...scenario.expectedAgentIds].sort(),
+        expectedFromModel,
+        `${scenario.scenario}: fixture expectation`
+      );
+      const actual = await actualAgentIds(
+        esUrl,
+        scenario,
+        scenario.excludeGlobal ?? false,
+        referencedSpaces,
+        fixture.agents.length
+      );
+      assert.deepEqual(actual, expectedFromModel, scenario.scenario);
+    }
+
+    const allSpaces = [
+      ...fixture.permissionTest.nonPodSpaces,
+      ...fixture.permissionTest.podSpaces,
+    ];
+    // One ES roundtrip per subset per identity, so the sweep is 2^n and worth a ceiling.
+    assert.ok(allSpaces.length <= 8, "space catalog too large for a 2^n sweep");
+    const allSubsets = subsets(allSpaces);
+    const identities = [
+      fixture.permissionTest.nonEditorEmail,
+      fixture.permissionTest.editorEmail,
+    ];
+    let exhaustiveCases = 0;
+
+    for (const spaces of allSubsets) {
+      const nonPodSpaces = spaces.filter((space) => space.kind !== "project");
+      const podSpaces = spaces.filter((space) => space.kind === "project");
+      for (const email of identities) {
+        const profile = profileFor(
+          fixture,
+          email,
+          nonPodSpaces,
+          podSpaces
+        );
+        const expected = expectedAgentIds(fixture.agents, profile, false);
+        const actual = await actualAgentIds(
+          esUrl,
+          profile,
+          false,
+          referencedSpaces,
+          fixture.agents.length
+        );
+        assert.deepEqual(
+          actual,
+          expected,
+          `exhaustive spaces=${spaces.map((space) => space.sId).join(",")} email=${email}`
+        );
+        exhaustiveCases += 1;
+      }
+    }
+
+    await assertClauseBudgetQuery(esUrl);
+    await assertOverListingIsSafe(esUrl, fixture, referencedSpaces);
+
+    process.stdout.write(
+      `permissions: ${scenarios.length} named scenarios, ${exhaustiveCases} exhaustive combinations, 5 shape assertions, 1 clause-budget query, and 1 over-listing check passed\n`
+    );
+  } finally {
+    await esRequest(esUrl, "DELETE", `/${INDEX}`);
+  }
+}
+
+await run();

--- a/x/adrsimon/agentsearch/scripts/types.ts
+++ b/x/adrsimon/agentsearch/scripts/types.ts
@@ -37,7 +37,6 @@ export interface ExportedAgent {
   requestedSpaceIds: string[];
   spaces: { sId: string; name: string | null; kind: SpaceKind | null }[];
   nonPodSpaceIds: string[];
-  nonPodSpaceCount: number;
   podSpaceIds: string[];
   usage: AgentUsage;
 }
@@ -61,11 +60,10 @@ export interface AgentSearchDocument {
   status: string;
   author: string | null;
   editors: string[];
-  requested_space_ids: string[];
-  requested_space_count: number;
   non_pod_space_ids: string[];
   non_pod_space_count: number;
   pod_space_ids: string[];
+  pod_space_count: number;
   usage: {
     messages: number;
     conversations: number;

--- a/x/adrsimon/agentsearch/tsconfig.json
+++ b/x/adrsimon/agentsearch/tsconfig.json
@@ -11,5 +11,12 @@
     "allowImportingTsExtensions": true,
     "skipLibCheck": true
   },
-  "include": ["scripts/ingest.ts", "scripts/search.ts"]
+  "include": [
+    "scripts/eval.ts",
+    "scripts/generate_queries.ts",
+    "scripts/ingest.ts",
+    "scripts/search.ts",
+    "scripts/test_permissions.ts",
+    "scripts/sweep_bm25.ts"
+  ]
 }


### PR DESCRIPTION
## Description

Hardens the agent-search permission exploration. This adds mocked agents and user profiles for the main access combinations. The test harness runs the same query builder used by search and eval.
It covers visibility, editorship, pods, deleted spaces, and every mocked space subset.

## Tests

- `npm run typecheck`
- `npm run test:permissions`

## Risk

Limited to the agent-search exploration harness and local index mapping.

## Deploy Plan

None