### PR TITLE
Skills: no longer suspend editors group membership on archive

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -40,6 +40,36 @@ function get(workspace: { sId: string }, sId: string) {
 }
 
 describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
+  it("refuses to change the editors of an archived skill", async () => {
+    const { workspace, auth } = await setup();
+
+    const skill = await SkillFactory.create(auth);
+    const builderUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, builderUser, {
+      role: "builder",
+    });
+
+    await skill.archive(auth);
+
+    const response = await patch(workspace, skill.sId, {
+      addEditorIds: [builderUser.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived skill cannot be updated. Restore it first.",
+      },
+    });
+
+    const editorsResponse = await get(workspace, skill.sId);
+    const editors = (await editorsResponse.json()).editors;
+    expect(editors.map((e: { sId: string }) => e.sId)).not.toContain(
+      builderUser.sId
+    );
+  });
+
   it("allows adding builder as editor", async () => {
     const { workspace, auth } = await setup();
 

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -12,6 +12,7 @@ import { toLightUser } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedSkill } from "@front-api/routes/w/[wId]/skills/guards";
 import type { Context } from "hono";
 import { z } from "zod";
 
@@ -90,6 +91,11 @@ app.patch(
           message: "User is not authorized to edit the skill editors list.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedSkill(ctx, skillRes);
+    if (archivedError) {
+      return archivedError;
     }
 
     const { addEditorIds = [], removeEditorIds = [] } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -1281,6 +1281,32 @@ describe("DELETE /api/w/:wId/skills/:sId", () => {
     });
   });
 
+  it("refuses to re-archive an already archived skill", async () => {
+    const { workspace, requestUserAuth, skill, skillOwnerAuth } =
+      await setupTest({
+        requestUserRole: "admin",
+        skillOwnerRole: "admin",
+      });
+
+    await skill.archive(skillOwnerAuth);
+
+    const response = await deleteSkill(workspace, skill.sId);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived skill cannot be updated. Restore it first.",
+      },
+    });
+
+    // Archiving twice used to rename the skill after itself: `archive` timestamps the same-named
+    // archived skill it finds, which is this one.
+    const untouched = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(untouched?.name).toBe(skill.name);
+    expect(untouched?.status).toBe("archived");
+  });
+
   it("allows a workspace admin to archive a skill they do not edit", async () => {
     const { workspace, requestUserAuth, skill } = await setupTest({
       skillOwnerRole: "builder",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -279,6 +279,57 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     });
   });
 
+  it("should return 400 for an archived skill, which only restore can change", async () => {
+    const { workspace, skill, skillOwnerAuth } = await setupTest({
+      requestUserRole: "admin",
+      skillOwnerRole: "admin",
+    });
+
+    await skill.archive(skillOwnerAuth);
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: "Renamed While Archived",
+      agentFacingDescription: "Agent description",
+      userFacingDescription: "User description",
+      instructions: "Updated instructions",
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived skill cannot be updated. Restore it first.",
+      },
+    });
+
+    const untouched = await SkillResource.fetchById(skillOwnerAuth, skill.sId);
+    expect(untouched?.name).toBe(skill.name);
+    expect(untouched?.instructions).not.toBe("Updated instructions");
+
+    // Restoring is the one change it accepts, and editing works again afterwards.
+    const restoreResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/${skill.sId}/restore`,
+      { method: "POST" }
+    );
+    expect(restoreResponse.status).toBe(200);
+
+    const patchAfterRestore = await patchSkill(workspace, skill.sId, {
+      name: "Renamed After Restore",
+      agentFacingDescription: "Agent description",
+      userFacingDescription: "User description",
+      instructions: "Updated instructions",
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+    expect(patchAfterRestore.status).toBe(200);
+  });
+
   it("should return 400 for duplicate skill name", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -30,6 +30,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedSkill } from "@front-api/routes/w/[wId]/skills/guards";
 import type { Context, TypedResponse } from "hono";
 import uniq from "lodash/uniq";
 import uniqBy from "lodash/uniqBy";
@@ -252,15 +253,9 @@ app.patch(
       });
     }
 
-    // An archived skill is frozen: POST /skills/:sId/restore is the only change it accepts.
-    if (skill.status === "archived") {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "An archived skill cannot be updated. Restore it first.",
-        },
-      });
+    const archivedError = rejectArchivedSkill(ctx, skill);
+    if (archivedError) {
+      return archivedError;
     }
 
     // Editing a skill remains editor-only; non-editors holding the publish permission use
@@ -527,6 +522,11 @@ app.delete(
           message: "Only admins and editors can archive this skill.",
         },
       });
+    }
+
+    const archivedDeleteError = rejectArchivedSkill(ctx, skill);
+    if (archivedDeleteError) {
+      return archivedDeleteError;
     }
 
     if (skill.status === "suggested") {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -252,6 +252,17 @@ app.patch(
       });
     }
 
+    // An archived skill is frozen: POST /skills/:sId/restore is the only change it accepts.
+    if (skill.status === "archived") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "An archived skill cannot be updated. Restore it first.",
+        },
+      });
+    }
+
     // Editing a skill remains editor-only; non-editors holding the publish permission use
     // PATCH /skills/:sId/availability to publish or unpublish without editing.
     if (!skill.canWrite(auth)) {

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -90,6 +90,29 @@ function patch(workspace: { sId: string }, sId: string, body: unknown) {
 }
 
 describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
+  it("refuses to change the reinforcement of an archived skill", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    await skill.archive(requestUserAuth);
+
+    const response = await patch(workspace, skill.sId, {
+      reinforcement: "off",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived skill cannot be updated. Restore it first.",
+      },
+    });
+
+    const untouched = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(untouched?.reinforcement).toBe("on");
+  });
+
   it("updates the reinforcement field", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
@@ -10,6 +10,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedSkill } from "@front-api/routes/w/[wId]/skills/guards";
 import { z } from "zod";
 
 const PatchSkillReinforcementBodySchema = z
@@ -67,6 +68,11 @@ app.patch(
           message: "The skill you're trying to access was not found.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedSkill(ctx, skill);
+    if (archivedError) {
+      return archivedError;
     }
 
     const {

--- a/front-api/routes/w/[wId]/skills/availability.test.ts
+++ b/front-api/routes/w/[wId]/skills/availability.test.ts
@@ -98,6 +98,41 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
     expect(untouchedSkill?.editedBy).toBe(skillOwner.id);
   });
 
+  it("refuses the batch when one of the skills is archived", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } = await setupTest();
+
+    const activeSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Active Batch Skill",
+      availability: "editors",
+    });
+    const archivedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Archived Batch Skill",
+      availability: "editors",
+    });
+    await archivedSkill.archive(skillOwnerAuth);
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [activeSkill.sId, archivedSkill.sId],
+      availability: "workspace_users",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Archived skills cannot be updated: Archived Batch Skill. Restore them first.",
+      },
+    });
+
+    // The whole batch is rejected: the active skill keeps its availability too.
+    const untouchedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      activeSkill.sId
+    );
+    expect(untouchedSkill?.availability).toBe("editors");
+  });
+
   it("snapshots a version of each updated skill", async () => {
     const { workspace, requestUserAuth, skillOwnerAuth } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/availability.ts
+++ b/front-api/routes/w/[wId]/skills/availability.ts
@@ -6,6 +6,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedSkills } from "@front-api/routes/w/[wId]/skills/guards";
 import uniq from "lodash/uniq";
 import { z } from "zod";
 
@@ -87,6 +88,11 @@ app.patch(
           message: `Skills not found: ${missingSkillIds.join(", ")}.`,
         },
       });
+    }
+
+    const archivedError = rejectArchivedSkills(ctx, skills);
+    if (archivedError) {
+      return archivedError;
     }
 
     // Changing an already auto-discoverable skill's availability also requires the

--- a/front-api/routes/w/[wId]/skills/guards.ts
+++ b/front-api/routes/w/[wId]/skills/guards.ts
@@ -1,0 +1,52 @@
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+// `apiError` returns a typed JSON response the route handlers' `HandlerResult` expects; keep that
+// type rather than widening it to `Response`.
+type ApiErrorResponse = ReturnType<typeof apiError>;
+
+// An archived skill is frozen: POST /skills/:sId/restore is the only change it accepts. Every
+// mutation route runs this check, so archiving cannot be worked around one endpoint at a time —
+// and re-archiving cannot rename a skill after itself (`archive` renames the same-named archived
+// skill it finds, which would be this very one).
+//
+// Returns the error response to hand back, or null when the skill can be mutated.
+export function rejectArchivedSkill(
+  ctx: Context,
+  skill: SkillResource
+): ApiErrorResponse | null {
+  if (skill.status !== "archived") {
+    return null;
+  }
+
+  return apiError(ctx, {
+    status_code: 400,
+    api_error: {
+      type: "invalid_request_error",
+      message: "An archived skill cannot be updated. Restore it first.",
+    },
+  });
+}
+
+// The batch counterpart of `rejectArchivedSkill`: nothing is applied unless every skill is
+// mutable, so a batch never lands half-way.
+export function rejectArchivedSkills(
+  ctx: Context,
+  skills: SkillResource[]
+): ApiErrorResponse | null {
+  const archivedSkillNames = skills
+    .filter((skill) => skill.status === "archived")
+    .map((skill) => skill.name);
+  if (archivedSkillNames.length === 0) {
+    return null;
+  }
+
+  return apiError(ctx, {
+    status_code: 400,
+    api_error: {
+      type: "invalid_request_error",
+      message: `Archived skills cannot be updated: ${archivedSkillNames.join(", ")}. Restore them first.`,
+    },
+  });
+}

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -164,6 +164,51 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).not.toContain("Someone Else's Unpublished Skill");
   });
 
+  // Archiving no longer suspends the editor memberships, so an archived editors-only skill
+  // stays visible to its editors — otherwise it would vanish from the archived tab for
+  // everyone, leaving nobody able to restore it.
+  it("lists archived editors-only skills to members of their editor group", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const mySkill = await SkillFactory.create(auth, {
+      name: "My Archived Unpublished Skill",
+      availability: "editors",
+    });
+    await mySkill.archive(auth);
+
+    // Archived by another user: the requester is not one of its editors.
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, {
+      role: "manager",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    const otherSkill = await SkillFactory.create(otherAuth, {
+      name: "Someone Else's Archived Unpublished Skill",
+      availability: "editors",
+    });
+    await otherSkill.archive(otherAuth);
+
+    const response = await getSkills(workspace, { status: "archived" });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("My Archived Unpublished Skill");
+    expect(skillNames).not.toContain(
+      "Someone Else's Archived Unpublished Skill"
+    );
+  });
+
   // Suggestions are created with an empty editor group (SkillResource.makeSuggestion), and
   // they get editors-only availability. Without the status exemption the editor-visibility
   // rule would hide them from everyone.
@@ -740,6 +785,34 @@ describe("GET /api/w/:wId/skills", () => {
 });
 
 describe("GET /api/w/:wId/skills?withRelations=true", () => {
+  it("returns the editors of archived skills", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const skill = await SkillFactory.create(auth, {
+      name: "Archived Skill With Editors",
+    });
+    await skill.archive(auth);
+
+    const response = await getSkills(workspace, {
+      withRelations: "true",
+      status: "archived",
+    });
+    expect(response.status).toBe(200);
+
+    const responseBody: GetSkillsWithRelationsResponseBody =
+      await response.json();
+    const archivedSkill = responseBody.skills.find((s) => s.sId === skill.sId);
+    // Archiving keeps the editor memberships: the skill stays visible to its editors (it is
+    // unpublished, so that visibility comes from editorship) and still lists them.
+    expect(archivedSkill?.relations.editors?.map((e) => e.sId)).toEqual([
+      user.sId,
+    ]);
+  });
+
   it("should return the number of messages using each skill", async () => {
     const { workspace, user } = await setupTest();
 

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -540,6 +540,13 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       );
     }
 
+    // An archived skill is frozen: restoring it is the only change it accepts.
+    if (skill.status === "archived") {
+      return new Err(
+        new MCPError("This skill is archived and cannot be updated.")
+      );
+    }
+
     // Resolve the new instructions: undefined keeps the existing ones, a full
     // string replaces them, and a targeted edit applies a str-replace on the
     // current instructions (mirroring the Files MCP edit pattern).

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1430,7 +1430,7 @@ describe("SkillResource", () => {
   });
 
   describe("archive and restore", () => {
-    it("suspends editor grants when archiving and restores them when restoring", async () => {
+    it("keeps the editor grants active when archiving, so editors are still listed", async () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Skill To Archive",
       });
@@ -1459,17 +1459,47 @@ describe("SkillResource", () => {
         testContext.authenticator
       );
       expect(archiveCount).toBe(1);
-      expect((await memberships()).every((m) => m.status === "suspended")).toBe(
+
+      // Archiving leaves the memberships alone: an archived skill keeps its editors, both on the
+      // in-memory resource and on a freshly fetched one.
+      expect((await memberships()).every((m) => m.status === "active")).toBe(
         true
       );
+      expect(
+        (await skill.listEditors(testContext.authenticator))?.map((e) => e.id)
+      ).toEqual([testContext.user.id]);
 
-      const { affectedCount: restoreCount } = await skill.restore(
+      const archivedSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        skill.sId
+      );
+      assert(archivedSkill);
+      expect(
+        (await archivedSkill.listEditors(testContext.authenticator))?.map(
+          (e) => e.id
+        )
+      ).toEqual([testContext.user.id]);
+
+      const editorsMap = await SkillResource.batchListEditors(
+        testContext.authenticator,
+        [archivedSkill]
+      );
+      expect(editorsMap.get(skill.sId)?.map((e) => e.id)).toEqual([
+        testContext.user.id,
+      ]);
+
+      const { affectedCount: restoreCount } = await archivedSkill.restore(
         testContext.authenticator
       );
       expect(restoreCount).toBe(1);
       expect((await memberships()).every((m) => m.status === "active")).toBe(
         true
       );
+      expect(
+        (await archivedSkill.listEditors(testContext.authenticator))?.map(
+          (e) => e.id
+        )
+      ).toEqual([testContext.user.id]);
     });
 
     it("archives multiple skills sharing the same name without a unique constraint violation", async () => {
@@ -2799,6 +2829,30 @@ describe("SkillResource", () => {
 
       expect(editorsMap.get(skillA.sId)).not.toBeNull();
       expect(editorsMap.get(skillB.sId)).not.toBeNull();
+    });
+
+    it("returns editors for a mix of active and archived skills", async () => {
+      const activeSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Active Skill Editors",
+      });
+      const skillToArchive = await SkillFactory.create(
+        testContext.authenticator,
+        { name: "Archived Skill Editors" }
+      );
+      await skillToArchive.archive(testContext.authenticator);
+
+      const editorsMap = await SkillResource.batchListEditors(
+        testContext.authenticator,
+        [activeSkill, skillToArchive]
+      );
+
+      // Archiving keeps the editor memberships, so the archived skill still lists its editors.
+      expect(editorsMap.get(activeSkill.sId)?.map((e) => e.id)).toEqual([
+        testContext.user.id,
+      ]);
+      expect(editorsMap.get(skillToArchive.sId)?.map((e) => e.id)).toEqual([
+        testContext.user.id,
+      ]);
     });
 
     it("returns empty map for empty input", async () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2608,31 +2608,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return new Ok(undefined);
   }
 
-  // Archive/restore suspend and restore the editor memberships; the per-user grant group holds the
-  // same people, so it has to follow (see `writeEditorUserGrants`).
-  private async suspendOrRestoreEditorGrantGroup(
-    auth: Authenticator,
-    operation: "suspend" | "restore",
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<void> {
-    const grantGroup =
-      await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
-        grantType: SKILL_EDITOR_GRANT_TYPE,
-        resourceType: "skill",
-        resourceId: this.id,
-        transaction,
-      });
-    if (!grantGroup) {
-      return;
-    }
-
-    if (operation === "suspend") {
-      await grantGroup.suspendMembers(auth, { transaction });
-    } else {
-      await grantGroup.restoreMembers(auth, { transaction });
-    }
-  }
-
   private async upsertCurrentUserAsEditor(auth: Authenticator): Promise<void> {
     const user = auth.user();
     if (!user) {
@@ -3077,12 +3052,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           },
           { transaction }
         );
-
-        // Suspend the memberships of the per-user grant group: editors lose their permissions on
-        // the skill, and only admins keep the "admin" permission to unarchive it.
-        await this.suspendOrRestoreEditorGrantGroup(auth, "suspend", {
-          transaction,
-        });
       }
 
       return count;
@@ -3122,11 +3091,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           },
           { transaction }
         );
-
-        // Restore the editors (suspended → active).
-        await this.suspendOrRestoreEditorGrantGroup(auth, "restore", {
-          transaction,
-        });
       }
 
       return count;

--- a/front/migrations/20260828_restore_skill_editor_memberships.ts
+++ b/front/migrations/20260828_restore_skill_editor_memberships.ts
@@ -26,13 +26,23 @@ import { Op } from "sequelize";
 
 const WORKSPACE_CONCURRENCY = 8;
 
-// The regular_auto groups holding a skill `editor` grant. Read straight from the model: the skills
-// involved may reference restricted or deleted spaces, which makes them unfetchable through
-// `SkillResource`, and their editors need the backfill too.
-async function listSkillEditorGrantGroups(
+// The regular_auto groups holding a skill `editor` grant, restricted to those that still have a
+// suspended membership to bring back. Two queries for the whole workspace, no per-group count.
+//
+// Read straight from the models: the skills involved may reference restricted or deleted spaces,
+// which makes them unfetchable through `SkillResource`, and their editors need the backfill too.
+async function listGroupsToRestore(
   auth: Authenticator,
   workspaceModelId: ModelId
-): Promise<GroupResource[]> {
+): Promise<{
+  groups: GroupResource[];
+  suspendedCountByGroupId: Map<ModelId, number>;
+}> {
+  const empty = {
+    groups: [],
+    suspendedCountByGroupId: new Map<ModelId, number>(),
+  };
+
   const grants = await GroupPermissionModel.findAll({
     attributes: ["groupId"],
     where: {
@@ -42,31 +52,39 @@ async function listSkillEditorGrantGroups(
     },
   });
   if (grants.length === 0) {
-    return [];
+    return empty;
   }
 
-  return GroupResource.fetchByModelIds(
-    auth,
-    [...new Set(grants.map((grant) => grant.groupId))],
-    { groupKinds: ["regular_auto"] }
-  );
-}
-
-async function countSuspendedMembers(
-  group: GroupResource,
-  workspaceModelId: ModelId
-): Promise<number> {
   const now = new Date();
-
-  return GroupMembershipModel.count({
+  const suspendedMemberships = await GroupMembershipModel.findAll({
+    attributes: ["groupId", "userId"],
     where: {
-      groupId: group.id,
       workspaceId: workspaceModelId,
+      groupId: [...new Set(grants.map((grant) => grant.groupId))],
       status: "suspended",
       startAt: { [Op.lte]: now },
       [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
     },
   });
+  if (suspendedMemberships.length === 0) {
+    return empty;
+  }
+
+  const suspendedCountByGroupId = new Map<ModelId, number>();
+  for (const membership of suspendedMemberships) {
+    suspendedCountByGroupId.set(
+      membership.groupId,
+      (suspendedCountByGroupId.get(membership.groupId) ?? 0) + 1
+    );
+  }
+
+  const groups = await GroupResource.fetchByModelIds(
+    auth,
+    [...suspendedCountByGroupId.keys()],
+    { groupKinds: ["regular_auto"] }
+  );
+
+  return { groups, suspendedCountByGroupId };
 }
 
 async function restoreWorkspaceSkillEditors(
@@ -81,42 +99,33 @@ async function restoreWorkspaceSkillEditors(
   });
   const workspaceModelId = auth.getNonNullableWorkspace().id;
 
-  const groups = await listSkillEditorGrantGroups(auth, workspaceModelId);
+  const { groups, suspendedCountByGroupId } = await listGroupsToRestore(
+    auth,
+    workspaceModelId
+  );
   if (groups.length === 0) {
     return;
   }
 
-  let groupsWritten = 0;
   let membershipsRestored = 0;
 
   for (const group of groups) {
-    if (!execute) {
-      const suspendedCount = await countSuspendedMembers(
-        group,
-        workspaceModelId
-      );
-      if (suspendedCount > 0) {
-        groupsWritten += 1;
-        membershipsRestored += suspendedCount;
+    const suspendedCount = suspendedCountByGroupId.get(group.id) ?? 0;
 
-        logger.info(
-          {
-            workspaceId: workspace.sId,
-            groupId: group.id,
-            editorCount: suspendedCount,
-          },
-          "Dry run: would restore the skill's suspended editor memberships"
-        );
-      }
+    if (!execute) {
+      membershipsRestored += suspendedCount;
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          groupId: group.id,
+          editorCount: suspendedCount,
+        },
+        "Dry run: would restore the skill's suspended editor memberships"
+      );
       continue;
     }
 
     const restoredUserIds = await group.restoreMembers(auth);
-    if (restoredUserIds.length === 0) {
-      continue;
-    }
-
-    groupsWritten += 1;
     membershipsRestored += restoredUserIds.length;
 
     logger.info(
@@ -133,7 +142,6 @@ async function restoreWorkspaceSkillEditors(
     {
       workspaceId: workspace.sId,
       groups: groups.length,
-      groupsWritten,
       membershipsRestored,
     },
     "Completed skill editor membership restoration for workspace"

--- a/front/migrations/20260828_restore_skill_editor_memberships.ts
+++ b/front/migrations/20260828_restore_skill_editor_memberships.ts
@@ -1,0 +1,159 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+// Backfill: re-activate the suspended memberships of the regular_auto groups holding a skill's
+// `editor` grant.
+//
+// Archiving a skill used to suspend its editor memberships, which made archived skills look
+// editor-less everywhere editors are read (`listEditors` / `batchListEditors` are active-only) and
+// hid unpublished ones from their own editors. `archive` no longer suspends anything and `restore`
+// no longer un-suspends anything, so those memberships have to be brought back.
+//
+// Scope is every skill `editor` grant group, not just the archived skills': nothing suspends these
+// groups anymore, so any suspended membership left in one is stale. That also makes this script
+// order-independent with the deploy — a skill restored between the two would otherwise keep
+// suspended editors forever, since it is no longer archived for a status-scoped backfill to find.
+//
+// Idempotent: `restoreMembers` only touches memberships whose status is "suspended".
+
+const WORKSPACE_CONCURRENCY = 8;
+
+// The regular_auto groups holding a skill `editor` grant. Read straight from the model: the skills
+// involved may reference restricted or deleted spaces, which makes them unfetchable through
+// `SkillResource`, and their editors need the backfill too.
+async function listSkillEditorGrantGroups(
+  auth: Authenticator,
+  workspaceModelId: ModelId
+): Promise<GroupResource[]> {
+  const grants = await GroupPermissionModel.findAll({
+    attributes: ["groupId"],
+    where: {
+      workspaceId: workspaceModelId,
+      grantType: "editor",
+      resourceType: "skill",
+    },
+  });
+  if (grants.length === 0) {
+    return [];
+  }
+
+  return GroupResource.fetchByModelIds(
+    auth,
+    [...new Set(grants.map((grant) => grant.groupId))],
+    { groupKinds: ["regular_auto"] }
+  );
+}
+
+async function countSuspendedMembers(
+  group: GroupResource,
+  workspaceModelId: ModelId
+): Promise<number> {
+  const now = new Date();
+
+  return GroupMembershipModel.count({
+    where: {
+      groupId: group.id,
+      workspaceId: workspaceModelId,
+      status: "suspended",
+      startAt: { [Op.lte]: now },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+    },
+  });
+}
+
+async function restoreWorkspaceSkillEditors(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  // All groups: the skills involved may reference restricted spaces, which the default auth cannot
+  // read.
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
+  const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+  const groups = await listSkillEditorGrantGroups(auth, workspaceModelId);
+  if (groups.length === 0) {
+    return;
+  }
+
+  let groupsWritten = 0;
+  let membershipsRestored = 0;
+
+  for (const group of groups) {
+    if (!execute) {
+      const suspendedCount = await countSuspendedMembers(
+        group,
+        workspaceModelId
+      );
+      if (suspendedCount > 0) {
+        groupsWritten += 1;
+        membershipsRestored += suspendedCount;
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            groupId: group.id,
+            editorCount: suspendedCount,
+          },
+          "Dry run: would restore the skill's suspended editor memberships"
+        );
+      }
+      continue;
+    }
+
+    const restoredUserIds = await group.restoreMembers(auth);
+    if (restoredUserIds.length === 0) {
+      continue;
+    }
+
+    groupsWritten += 1;
+    membershipsRestored += restoredUserIds.length;
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        groupId: group.id,
+        editorCount: restoredUserIds.length,
+      },
+      "Restored the skill's suspended editor memberships"
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      groups: groups.length,
+      groupsWritten,
+      membershipsRestored,
+    },
+    "Completed skill editor membership restoration for workspace"
+  );
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting skill editor membership restoration");
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await restoreWorkspaceSkillEditors(execute, logger, workspace);
+      },
+      { concurrency: WORKSPACE_CONCURRENCY, wId }
+    );
+
+    logger.info("Skill editor membership restoration completed");
+  }
+);


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/10211

Membership was suspended so the group no longer appears in the auth of the user.
However, this is an issue because:
 - the editors of archived can no longer be listed
 - A user can no longer see their "editor-only" archived skills 

This stop suspending the membership when archiving the skills.
We consider it OK because groups will be removed from auth soon.
A follow up would be to stop listing the editors of old archived skills (maybe 6 months+)

This PR also add a migration to restore all the memberships of all the skills editors groups 

## Tests

 - added unit tests

## Risk

low

## Deploy Plan

deploy front
run migration:
```
npx tsx migrations/20260828_restore_skill_editor_memberships.ts
```
