### PR TITLE
[sparkle] Suppress focus outline on Dialog panel

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -100,7 +100,10 @@ const dialogVariants = cva(
     "rounded-2xl flex flex-col w-full max-w-[calc(100vw-2rem)] border border shadow-lg",
     "bg-modal-background",
     "border-border",
-    "max-h-[90vh]"
+    "max-h-[90vh]",
+    // Radix focuses the panel itself when nothing tabbable is inside or on
+    // background clicks; suppress the UA focus ring on the panel.
+    "focus:outline-none"
   ),
   {
     variants: {


### PR DESCRIPTION
Radix focuses the dialog panel itself when nothing tabbable is inside, or when clicking a non-interactive area of the panel (it has `tabindex="-1"`), and the UA focus ring then draws around the whole dialog. Consumers were suppressing it per call site (the analytics popover shipped with `className="focus:outline-none"`); move it into the Dialog base classes so no call site needs it.


You can easily see it on prod: 
- the Tools Dialog form User menu does not have this prop and you can see the weird blue border. 
- the Analytics Dialog from User menu does have this prop and you can see no weird blue border. 

## Risk
Removes a focus ring that only ever appeared on the panel itself, never on interactive elements. Safe to rollback.