### PR TITLE
Coordinate Frames v2 publication

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -2,6 +2,7 @@ import {
   activateFramePublication,
   loadFramePublicationManifest,
   loadFramePublicationSourceFile,
+  publishFramePublication,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import type { Authenticator } from "@app/lib/auth";
@@ -320,6 +321,44 @@ describe("activateFramePublication", () => {
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
+    );
+  });
+});
+
+describe("publishFramePublication", () => {
+  it("stores and activates a publication", async () => {
+    const { auth, frame } = await setupFrame();
+
+    const published = await publishFramePublication(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(published.isOk()).toBe(true);
+    if (published.isErr()) {
+      return;
+    }
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      published.value.publicationId
+    );
+  });
+
+  it("keeps the active publication when storage fails", async () => {
+    const { auth, frame } = await setupFrame();
+    const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    await frame.setActiveFramePublication(activePublicationId);
+    fileStorageMock.setFileSaveFails((filePath) =>
+      filePath.endsWith("/manifest.json")
+    );
+
+    await expect(
+      publishFramePublication(auth, { frame, manifest, sourceFiles })
+    ).rejects.toThrow("Simulated GCS write failure");
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      activePublicationId
     );
   });
 });

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -232,6 +232,38 @@ export async function activateFramePublication(
   return new Ok(undefined);
 }
 
+export async function publishFramePublication(
+  auth: Authenticator,
+  {
+    frame,
+    manifest,
+    sourceFiles,
+  }: {
+    frame: FileResource;
+    manifest: FrameManifest;
+    sourceFiles: FramePublicationSourceFile[];
+  }
+): Promise<Result<{ publicationId: string }, FramePublicationError>> {
+  const publication = await storeFramePublication(auth, {
+    frame,
+    manifest,
+    sourceFiles,
+  });
+  if (publication.isErr()) {
+    return publication;
+  }
+
+  const activation = await activateFramePublication(auth, {
+    frame,
+    publicationId: publication.value.publicationId,
+  });
+  if (activation.isErr()) {
+    return activation;
+  }
+
+  return publication;
+}
+
 export async function loadFramePublicationSourceFile(
   auth: Authenticator,
   {


### PR DESCRIPTION
## Description

Add one Frames v2 publish entry point that stores an immutable publication and activates it only after storage succeeds.

## Tests

Added coverage for successful store and activation, plus a failed manifest commit-marker write preserving the current active publication.

## Risk

Low. The coordinator has no callers yet. Failed writes can leave orphaned source objects but cannot change the active publication.

## Deploy Plan

Standard deploy.