### PR TITLE
Fix user message bubble colors in dark mode

### DIFF
--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -108,7 +108,7 @@ export const ConversationMessageContent = React.forwardRef<
               "flex min-w-0 flex-col gap-1",
               type === "user" &&
                 cn(
-                  "rounded-2xl border border-stone-100 bg-stone-50 px-3 py-2",
+                  "rounded-2xl border border-border bg-muted-background px-3 py-2",
                   CARD_SHADOW
                 ),
               className


### PR DESCRIPTION
## Summary
- Follow-up to #31239 (merged).
- `bg-stone-50` / `border-stone-100` are raw palette tokens pinned to their light values - the `.dark` theme only redefines semantic tokens (`--color-muted-background`, `--color-border`, etc.), not the raw scale. This made the user message bubble render as a near-white block in dark mode.
- Switched to `bg-muted-background` / `border-border`, which resolve to `stone-50`/`stone-100` in light mode and their dark-mode counterparts under `.dark`.

## Test plan
- [x] Verified in Storybook (`ConversationMessages` -> `User Agent Exchange`) in both light and dark theme toggles - bubble renders correctly with proper contrast in both.
- [ ] CI (lint/build/tests)

Generated with Claude Code