### PR TITLE
Declare Frames v2 manifest functions

### DIFF
--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -5,6 +5,10 @@ import {
   MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
+import {
+  DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+  DEFAULT_SANDBOX_FUNCTION_STAKE,
+} from "@app/types/api/sandbox_functions";
 import { describe, expect, it } from "vitest";
 
 const MANIFEST = {
@@ -17,16 +21,6 @@ const FUNCTION = {
   name: "add-task",
   description: "Add a task.",
   entryPoint: "functions/add_task.ts",
-  inputSchema: {
-    type: "object",
-    properties: { title: { type: "string" } },
-    required: ["title"],
-  },
-  outputSchema: {
-    type: "object",
-    properties: { id: { type: "string" } },
-    required: ["id"],
-  },
 };
 
 describe("FrameManifestSchema", () => {
@@ -56,7 +50,28 @@ describe("FrameManifestSchema", () => {
 
     expect(parsed.success).toBe(true);
     if (parsed.success) {
-      expect(parsed.data.functions).toEqual([FUNCTION]);
+      expect(parsed.data.functions).toEqual([
+        {
+          ...FUNCTION,
+          executionMode: DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+          defaultStake: DEFAULT_SANDBOX_FUNCTION_STAKE,
+        },
+      ]);
+    }
+  });
+
+  it("parses explicit function execution settings", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [{ ...FUNCTION, executionMode: "fast", defaultStake: "high" }],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.functions[0]).toMatchObject({
+        executionMode: "fast",
+        defaultStake: "high",
+      });
     }
   });
 
@@ -102,20 +117,6 @@ describe("FrameManifestSchema", () => {
         {
           ...FUNCTION,
           description: "a".repeat(MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH + 1),
-        },
-      ],
-    });
-
-    expect(parsed.success).toBe(false);
-  });
-
-  it("rejects invalid function contracts", () => {
-    const parsed = FrameManifestSchema.safeParse({
-      ...MANIFEST,
-      functions: [
-        {
-          ...FUNCTION,
-          inputSchema: { type: "unsupported" },
         },
       ],
     });

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -12,6 +12,22 @@ const MANIFEST = {
   description: "Track tasks.",
 };
 
+const FUNCTION = {
+  name: "add-task",
+  description: "Add a task.",
+  entryPoint: "functions/add_task.ts",
+  inputSchema: {
+    type: "object",
+    properties: { title: { type: "string" } },
+    required: ["title"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: { id: { type: "string" } },
+    required: ["id"],
+  },
+};
+
 describe("FrameManifestSchema", () => {
   it("defaults the single UI entry point to index.tsx", () => {
     const parsed = FrameManifestSchema.safeParse(MANIFEST);
@@ -19,6 +35,7 @@ describe("FrameManifestSchema", () => {
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect(parsed.data.uiEntryPoint).toBe(FRAME_DEFAULT_UI_ENTRY_POINT);
+      expect(parsed.data.functions).toEqual([]);
     }
   });
 
@@ -28,6 +45,67 @@ describe("FrameManifestSchema", () => {
       uiEntryPoint: "ui/App.tsx",
     });
     expect(explicit.success).toBe(true);
+  });
+
+  it("parses function declarations", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [FUNCTION],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.functions).toEqual([FUNCTION]);
+    }
+  });
+
+  it("rejects unsafe function entry points", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [
+        {
+          ...FUNCTION,
+          entryPoint: "../add_task.ts",
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects duplicate function names", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [
+        FUNCTION,
+        { ...FUNCTION, entryPoint: "functions/add_another_task.ts" },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects function names that cannot become slugs", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [{ ...FUNCTION, name: "Add Task" }],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects invalid function contracts", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [
+        {
+          ...FUNCTION,
+          inputSchema: { type: "unsupported" },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
   });
 
   it("returns a useful error for invalid JSON", () => {

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -2,6 +2,7 @@ import {
   FRAME_DEFAULT_UI_ENTRY_POINT,
   FrameManifestSchema,
   isSafeFrameRelativePath,
+  MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
 import { describe, expect, it } from "vitest";
@@ -89,6 +90,20 @@ describe("FrameManifestSchema", () => {
     const parsed = FrameManifestSchema.safeParse({
       ...MANIFEST,
       functions: [{ ...FUNCTION, name: "Add Task" }],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects function descriptions that cannot be persisted", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      functions: [
+        {
+          ...FUNCTION,
+          description: "a".repeat(MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH + 1),
+        },
+      ],
     });
 
     expect(parsed.success).toBe(false);

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -1,12 +1,13 @@
 import {
-  isJSONSchemaObject,
-  validateJsonSchema,
-} from "@app/lib/utils/json_schemas";
-import { SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX } from "@app/types/api/sandbox_functions";
+  DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+  DEFAULT_SANDBOX_FUNCTION_STAKE,
+  SANDBOX_FUNCTION_EXECUTION_MODES,
+  SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
+  SANDBOX_FUNCTION_STAKES,
+} from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
@@ -37,11 +38,6 @@ const FrameRelativePathSchema = z
       "Path must be relative to the Frame folder, using forward slashes and no '.', '..' or empty segments.",
   });
 
-const JsonSchemaSchema = z.custom<JSONSchema>(
-  (value) => isJSONSchemaObject(value) && validateJsonSchema(value).isValid,
-  { message: "Invalid JSON schema" }
-);
-
 export const FrameFunctionManifestSchema = z.object({
   name: z
     .string()
@@ -52,8 +48,12 @@ export const FrameFunctionManifestSchema = z.object({
     }),
   description: z.string().max(MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH),
   entryPoint: FrameRelativePathSchema,
-  inputSchema: JsonSchemaSchema,
-  outputSchema: JsonSchemaSchema,
+  executionMode: z
+    .enum(SANDBOX_FUNCTION_EXECUTION_MODES)
+    .default(DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE),
+  defaultStake: z
+    .enum(SANDBOX_FUNCTION_STAKES)
+    .default(DEFAULT_SANDBOX_FUNCTION_STAKE),
 });
 
 export const FrameSourceManifestSchema = z

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -1,6 +1,9 @@
+import { validateJsonSchema } from "@app/lib/utils/json_schemas";
+import { SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
@@ -8,6 +11,7 @@ export const FRAME_MANIFEST_FILE = "manifest.json";
 export const FRAME_MANIFEST_VERSION = 1;
 export const FRAME_DEFAULT_UI_ENTRY_POINT = "index.tsx";
 export const MAX_FRAME_NAME_LENGTH = 128;
+export const MAX_FRAME_FUNCTION_NAME_LENGTH = 128;
 
 /** Manifest paths are always relative to the Frame source folder. */
 export function isSafeFrameRelativePath(path: string): boolean {
@@ -29,12 +33,50 @@ const FrameRelativePathSchema = z
       "Path must be relative to the Frame folder, using forward slashes and no '.', '..' or empty segments.",
   });
 
-export const FrameSourceManifestSchema = z.object({
-  version: z.literal(FRAME_MANIFEST_VERSION),
-  name: z.string().min(1).max(MAX_FRAME_NAME_LENGTH),
+const JsonSchemaSchema = z.custom<JSONSchema>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    validateJsonSchema(value).isValid,
+  { message: "Invalid JSON schema" }
+);
+
+export const FrameFunctionManifestSchema = z.object({
+  name: z
+    .string()
+    .max(MAX_FRAME_FUNCTION_NAME_LENGTH)
+    .regex(SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX, {
+      message:
+        "Function name must be lowercase alphanumeric with single hyphen separators.",
+    }),
   description: z.string(),
-  uiEntryPoint: FrameRelativePathSchema.optional(),
+  entryPoint: FrameRelativePathSchema,
+  inputSchema: JsonSchemaSchema,
+  outputSchema: JsonSchemaSchema,
 });
+
+export const FrameSourceManifestSchema = z
+  .object({
+    version: z.literal(FRAME_MANIFEST_VERSION),
+    name: z.string().min(1).max(MAX_FRAME_NAME_LENGTH),
+    description: z.string(),
+    uiEntryPoint: FrameRelativePathSchema.optional(),
+    functions: z.array(FrameFunctionManifestSchema).default([]),
+  })
+  .superRefine((manifest, context) => {
+    const names = new Set<string>();
+
+    manifest.functions.forEach((fn, index) => {
+      if (names.has(fn.name)) {
+        context.addIssue({
+          code: "custom",
+          message: `Function name '${fn.name}' must be unique.`,
+          path: ["functions", index, "name"],
+        });
+      }
+      names.add(fn.name);
+    });
+  });
 
 export const FrameManifestSchema = FrameSourceManifestSchema.transform(
   (manifest) => ({

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -1,4 +1,7 @@
-import { validateJsonSchema } from "@app/lib/utils/json_schemas";
+import {
+  isJSONSchemaObject,
+  validateJsonSchema,
+} from "@app/lib/utils/json_schemas";
 import { SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -12,6 +15,7 @@ export const FRAME_MANIFEST_VERSION = 1;
 export const FRAME_DEFAULT_UI_ENTRY_POINT = "index.tsx";
 export const MAX_FRAME_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_NAME_LENGTH = 128;
+export const MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH = 255;
 
 /** Manifest paths are always relative to the Frame source folder. */
 export function isSafeFrameRelativePath(path: string): boolean {
@@ -34,10 +38,7 @@ const FrameRelativePathSchema = z
   });
 
 const JsonSchemaSchema = z.custom<JSONSchema>(
-  (value) =>
-    typeof value === "object" &&
-    value !== null &&
-    validateJsonSchema(value).isValid,
+  (value) => isJSONSchemaObject(value) && validateJsonSchema(value).isValid,
   { message: "Invalid JSON schema" }
 );
 
@@ -49,7 +50,7 @@ export const FrameFunctionManifestSchema = z.object({
       message:
         "Function name must be lowercase alphanumeric with single hyphen separators.",
     }),
-  description: z.string(),
+  description: z.string().max(MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH),
   entryPoint: FrameRelativePathSchema,
   inputSchema: JsonSchemaSchema,
   outputSchema: JsonSchemaSchema,


### PR DESCRIPTION
## Description

Add function declarations to the Frames v2 manifest contract. Each declaration carries a stable name, description, source entry point, execution mode, and default stake. Missing functions normalize to an empty list; missing execution settings normalize to the existing platform defaults.

Input and output contracts remain defined by the function's Zod schemas. Publication will extract and persist their derived JSON Schemas rather than duplicating them in the manifest.

## Tests

Added parser coverage for valid declarations, defaults, explicit execution settings, unsafe paths, duplicate and invalid names, and persistence bounds.

## Risk

Low. The contract change is additive and backward compatible. Function materialization and execution remain out of scope.

## Deploy Plan

Standard deploy.
