### PR TITLE
Wire checkpointed conversation windows into agent loop

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,3 +1,4 @@
+import { deleteConversationWindowCheckpoints } from "@app/lib/api/assistant/conversation_rendering/conversation_window_checkpoint";
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
@@ -254,6 +255,10 @@ export async function destroyConversation(
     await getPrivateUploadBucket().deleteByPrefix(
       `${getContentFragmentBaseCloudStorageForWorkspace(owner.sId)}${conversation.sId}/`
     );
+    await deleteConversationWindowCheckpoints({
+      workspaceId: owner.sId,
+      conversationId: conversation.sId,
+    });
 
     const messages = await MessageModel.findAll({
       attributes: [

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -80,7 +80,7 @@ const assistantContentSchema = z.discriminatedUnion("type", [
       value: z.string(),
       metadata: z
         .object({ phase: z.enum(["commentary", "final_answer"]).optional() })
-        .strict()
+        .passthrough()
         .optional(),
     })
     .strict(),

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.test.ts
@@ -2,6 +2,7 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import type { ConversationWindowStateSnapshot } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
 import {
   computeConversationWindowProfileHash,
+  deleteConversationWindowCheckpoints,
   loadConversationWindowCheckpoint,
   makeConversationWindowCheckpoint,
   publishConversationWindowCheckpoint,
@@ -56,6 +57,19 @@ describe("conversation window checkpoints", () => {
       throw loaded.error;
     }
     expect(loaded.value).toBeNull();
+  });
+
+  it("deletes every checkpoint for a conversation", async () => {
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) => {
+      deletedPrefixes.push(prefix);
+    });
+
+    await deleteConversationWindowCheckpoints(identity);
+
+    expect(deletedPrefixes).toEqual([
+      "conversation-window-checkpoints/w/w1/conversations/c1/",
+    ]);
   });
 
   it("returns storage failures as errors", async () => {
@@ -222,7 +236,8 @@ describe("conversation window checkpoints", () => {
     await publishOrThrow(winner);
     const published = await publishOrThrow(loser);
 
-    expect(published.profileHash).toBe("winner");
+    expect(published.created).toBe(false);
+    expect(published.checkpoint.profileHash).toBe("winner");
   });
 
   it("rejects malformed checkpointed model messages", async () => {

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.test.ts
@@ -118,6 +118,59 @@ describe("conversation window checkpoints", () => {
     );
   });
 
+  it("round-trips text content with LLM provenance metadata", async () => {
+    const metadata = {
+      phase: "final_answer" as const,
+      region: "us",
+      modelId: "gpt-5.1",
+      clientId: "openai",
+      inferenceRegion: "global",
+      inferenceProvider: "openai-responses",
+    };
+    const state: ConversationWindowStateSnapshot = {
+      version: 1,
+      interactions: [
+        {
+          messages: [
+            {
+              kind: "message",
+              message: {
+                role: "assistant",
+                name: "assistant",
+                contents: [
+                  {
+                    type: "text_content",
+                    value: "Hello",
+                    metadata,
+                  },
+                ],
+                tokenCount: 10,
+              },
+            },
+          ],
+        },
+      ],
+      retainedTokens: 10,
+      totalTokensBefore: 10,
+      prunedTokens: 0,
+    };
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "profile",
+      promptTokens: 20,
+      toolDefinitionTokens: 30,
+      state,
+    });
+
+    await publishOrThrow(checkpoint);
+    const loaded = await loadConversationWindowCheckpoint(identity);
+    if (loaded.isErr()) {
+      throw loaded.error;
+    }
+
+    expect(loaded.value).toEqual(checkpoint);
+  });
+
   it("ignores an expired checkpoint", async () => {
     const checkpoint = makeConversationWindowCheckpoint({
       identity,

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
@@ -244,14 +244,17 @@ function earliestImageSignedUrlExpiryMs(
         case "content_fragment":
           visitContent(message.content);
           break;
+
         case "function":
           if (Array.isArray(message.content)) {
             visitContent(message.content);
           }
           break;
+
         case "assistant":
         case "compaction":
           break;
+
         default:
           assertNever(message);
       }
@@ -350,12 +353,14 @@ export async function loadConversationWindowCheckpoint(
 ): Promise<Result<ConversationWindowCheckpoint | null, Error>> {
   const storage = getPrivateUploadBucket();
   let contentBuffer: Uint8Array<ArrayBuffer>;
+
   try {
     contentBuffer = await storage.fetchFileBuffer(checkpointPath(identity));
   } catch (error) {
     if (isGCSNotFoundError(error)) {
       return new Ok(null);
     }
+
     return new Err(normalizeError(error));
   }
 
@@ -365,6 +370,7 @@ export async function loadConversationWindowCheckpoint(
   if (checkpointResult.isErr()) {
     return checkpointResult;
   }
+
   const checkpoint = checkpointResult.value;
 
   if (
@@ -373,6 +379,7 @@ export async function loadConversationWindowCheckpoint(
   ) {
     return new Ok(null);
   }
+
   return new Ok(checkpoint);
 }
 
@@ -389,6 +396,7 @@ export async function publishConversationWindowCheckpoint(
       contentType: "application/json",
       filePath,
     });
+
     return new Ok({ checkpoint, created: true });
   } catch (error) {
     if (!isGCSPreconditionFailedError(error)) {
@@ -402,12 +410,14 @@ export async function publishConversationWindowCheckpoint(
   if (winnerResult.isErr()) {
     return winnerResult;
   }
+
   const winner = winnerResult.value;
   if (!winner) {
     return new Err(
       new Error("Conversation window checkpoint winner is unavailable")
     );
   }
+
   return new Ok({ checkpoint: winner, created: false });
 }
 

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_checkpoint.ts
@@ -68,11 +68,7 @@ function checkpointPath(
     encodeURIComponent(String(value));
 
   return [
-    "conversation-window-checkpoints",
-    "w",
-    component(identity.workspaceId),
-    "conversations",
-    component(identity.conversationId),
+    checkpointConversationPrefix(identity),
     "agent-messages",
     component(identity.agentMessageId),
     "versions",
@@ -81,6 +77,24 @@ function checkpointPath(
     `v${CONVERSATION_WINDOW_CHECKPOINT_VERSION}`,
     "steps",
     `${component(identity.step)}.json`,
+  ].join("/");
+}
+
+function checkpointConversationPrefix({
+  workspaceId,
+  conversationId,
+}: Pick<
+  ConversationWindowCheckpointIdentity,
+  "workspaceId" | "conversationId"
+>): string {
+  const component = (value: string) => encodeURIComponent(value);
+
+  return [
+    "conversation-window-checkpoints",
+    "w",
+    component(workspaceId),
+    "conversations",
+    component(conversationId),
   ].join("/");
 }
 
@@ -364,7 +378,9 @@ export async function loadConversationWindowCheckpoint(
 
 export async function publishConversationWindowCheckpoint(
   checkpoint: ConversationWindowCheckpoint
-): Promise<Result<ConversationWindowCheckpoint, Error>> {
+): Promise<
+  Result<{ checkpoint: ConversationWindowCheckpoint; created: boolean }, Error>
+> {
   const storage = getPrivateUploadBucket();
   const filePath = checkpointPath(checkpoint.identity);
   try {
@@ -373,7 +389,7 @@ export async function publishConversationWindowCheckpoint(
       contentType: "application/json",
       filePath,
     });
-    return new Ok(checkpoint);
+    return new Ok({ checkpoint, created: true });
   } catch (error) {
     if (!isGCSPreconditionFailedError(error)) {
       return new Err(normalizeError(error));
@@ -392,5 +408,17 @@ export async function publishConversationWindowCheckpoint(
       new Error("Conversation window checkpoint winner is unavailable")
     );
   }
-  return new Ok(winner);
+  return new Ok({ checkpoint: winner, created: false });
+}
+
+export async function deleteConversationWindowCheckpoints({
+  workspaceId,
+  conversationId,
+}: Pick<
+  ConversationWindowCheckpointIdentity,
+  "workspaceId" | "conversationId"
+>): Promise<void> {
+  await getPrivateUploadBucket().deleteByPrefix(
+    `${checkpointConversationPrefix({ workspaceId, conversationId })}/`
+  );
 }

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_core.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_core.ts
@@ -549,7 +549,7 @@ function finalizeConversationWindow(
       tokensUsed,
       messageSelected: finalMessages.length,
       prunedContext,
-      elapsed: Date.now() - built.startedAtMs,
+      elapsedMs: Date.now() - built.startedAtMs,
       ...built.timings,
       pruneSelectAndFinalizeMs: Date.now() - built.windowProcessingStartedAtMs,
     },

--- a/front/lib/api/files/processing/index.ts
+++ b/front/lib/api/files/processing/index.ts
@@ -448,14 +448,14 @@ const maybeApplyProcessing = async (
     return new Ok(undefined);
   }
 
-  const start = performance.now();
+  const startedAtMs = performance.now();
   const res = await entry.process(auth, file);
 
-  const elapsed = performance.now() - start;
+  const elapsedMs = performance.now() - startedAtMs;
   logger.info(
     {
       file: file.toPublicJSON(auth),
-      elapsed,
+      elapsedMs,
       error: res.isErr() ? res.error : undefined,
     },
     "Processed file"

--- a/front/logger/datadogLogger.test.ts
+++ b/front/logger/datadogLogger.test.ts
@@ -1,7 +1,7 @@
 import datadogLogger from "@app/logger/datadogLogger";
 import { describe, expectTypeOf, it } from "vitest";
 
-describe("datadog logger status typing", () => {
+describe("datadog logger context typing", () => {
   it("accepts a real Datadog severity as status", () => {
     expectTypeOf(datadogLogger.info).toBeCallableWith(
       { status: "critical" },
@@ -26,6 +26,22 @@ describe("datadog logger status typing", () => {
     expectTypeOf(datadogLogger.child).toBeCallableWith({
       // @ts-expect-error - child bindings are logged as a top-level status too.
       status: "completed",
+    });
+  });
+
+  it("rejects elapsed and accepts elapsedMs", () => {
+    expectTypeOf(datadogLogger.info).toBeCallableWith(
+      { elapsedMs: 12 },
+      "message"
+    );
+    expectTypeOf(datadogLogger.info).toBeCallableWith(
+      // @ts-expect-error - Datadog reserves elapsed and may replace its value.
+      { elapsed: 12 },
+      "message"
+    );
+    expectTypeOf(datadogLogger.child).toBeCallableWith({
+      // @ts-expect-error - child bindings are logged as top-level fields too.
+      elapsed: 12,
     });
   });
 });

--- a/front/logger/datadogLogger.ts
+++ b/front/logger/datadogLogger.ts
@@ -1,10 +1,9 @@
+import type { DatadogLogContext } from "@app/logger/logger";
 import { datadogLogs } from "@datadog/browser-logs";
-
-import type { DatadogLogStatus } from "./logger";
 
 // Keep the exported Logger type for compatibility with existing imports. Type-only, so the
 // pino-backed module is erased from the browser bundle.
-export type { Logger } from "./logger";
+export type { Logger } from "@app/logger/logger";
 
 // Benign error messages that should not be forwarded to Datadog.
 // - ResizeObserver: https://github.com/DataDog/browser-sdk/issues/1616
@@ -90,10 +89,7 @@ function toMessageAndContext(
 
 type LogContext = Record<string, unknown>;
 type LogMessage = string;
-// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
-// `status: "completed"` reads as critical. Same check as the server-side logger.
-type CheckedLogContext = { status?: DatadogLogStatus } & LogContext;
-type LogArg = CheckedLogContext | LogMessage;
+type LogArg = DatadogLogContext | LogMessage;
 
 function makeLogger(baseBindings?: LogContext) {
   const call = (level: Level, arg1?: LogArg, arg2?: LogArg) => {
@@ -141,7 +137,7 @@ function makeLogger(baseBindings?: LogContext) {
     error: (a?: LogArg, b?: LogArg) => call("error", a, b),
 
     // Pino-like child logger to bind persistent context
-    child: (bindings?: CheckedLogContext) =>
+    child: (bindings?: DatadogLogContext) =>
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       makeLogger({ ...(baseBindings || {}), ...(bindings || {}) }),
   };

--- a/front/logger/logger.test.ts
+++ b/front/logger/logger.test.ts
@@ -1,7 +1,7 @@
 import logger from "@app/logger/logger";
 import { describe, expectTypeOf, it } from "vitest";
 
-describe("logger status typing", () => {
+describe("logger Datadog context typing", () => {
   it("accepts a real Datadog severity as status", () => {
     expectTypeOf(logger.info).toBeCallableWith(
       { status: "critical" },
@@ -18,5 +18,11 @@ describe("logger status typing", () => {
   it("rejects a status Datadog would misread as a severity", () => {
     // @ts-expect-error - "completed" is prefix-matched to critical by Datadog.
     expectTypeOf(logger.info).toBeCallableWith({ status: "completed" }, "msg");
+  });
+
+  it("rejects elapsed and accepts elapsedMs", () => {
+    expectTypeOf(logger.info).toBeCallableWith({ elapsedMs: 12 }, "message");
+    // @ts-expect-error - Datadog reserves elapsed and may replace its value.
+    expectTypeOf(logger.info).toBeCallableWith({ elapsed: 12 }, "message");
   });
 });

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -22,17 +22,20 @@ export const DATADOG_LOG_STATUSES = [
 
 export type DatadogLogStatus = (typeof DATADOG_LOG_STATUSES)[number];
 
+// Datadog reserves `elapsed` and may replace its value. Use an explicit unit such as
+// `elapsedMs` instead.
+export type DatadogLogContext = {
+  status?: DatadogLogStatus;
+  elapsed?: never;
+} & Record<string, unknown>;
+
 interface CheckedLogFn {
   (msg: string, ...args: unknown[]): void;
   (obj: Error, msg?: string, ...args: unknown[]): void;
-  (
-    obj: { status?: DatadogLogStatus } & Record<string, unknown>,
-    msg?: string,
-    ...args: unknown[]
-  ): void;
+  (obj: DatadogLogContext, msg?: string, ...args: unknown[]): void;
 }
 
-// pino's own log methods accept any `status`; ours reject the values Datadog would misread.
+// Pino's own log methods accept Datadog-reserved fields with any value. Ours constrain them.
 export type Logger = Omit<
   pino.Logger,
   "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "child"

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -20,7 +20,7 @@ import {
   MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
   RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS,
 } from "@app/temporal/agent_loop/config";
-import { prepareFullContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/full";
+import { prepareAgentLoopContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/checkpointed";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { handlePromptCommand } from "@app/temporal/agent_loop/lib/prompt_commands";
@@ -124,9 +124,15 @@ async function _runModelAndCreateActionsActivity({
   const durationRecorder = DurationRecorder.create([]);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  const featureFlags = await getFeatureFlags(auth);
   const contextProviderRes = await startActiveObservation(
     "get-agent-loop-data",
-    () => prepareFullContextProvider(auth, runAgentArgs, step)
+    () =>
+      prepareAgentLoopContextProvider(auth, runAgentArgs, {
+        featureFlags,
+        isActivityRetry: Context.current().info.attempt > 1,
+        step,
+      })
   );
   if (contextProviderRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(contextProviderRes.error)) {
@@ -235,7 +241,6 @@ async function _runModelAndCreateActionsActivity({
   }
 
   // Tool test run: bypass LLM and directly execute tool commands.
-  const featureFlags = await getFeatureFlags(auth);
   if (featureFlags.includes("run_tools_from_prompt")) {
     const result = await handlePromptCommand(auth, runAgentData, step, runIds);
     if (result !== "not_a_command") {

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider.test.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider.test.ts
@@ -1,0 +1,554 @@
+import type { ConversationWindowStateSnapshot } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import { CheckpointedConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import {
+  computeConversationWindowProfileHash,
+  makeConversationWindowCheckpoint,
+  publishConversationWindowCheckpoint,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_checkpoint";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { tokenCountForTexts } from "@app/lib/tokenization";
+import { prepareAgentLoopContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/checkpointed";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { GPT_4O_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/provider_credentials", () => ({
+  getLlmCredentials: vi.fn(),
+}));
+
+vi.mock("@app/lib/tokenization", () => ({
+  tokenCountForTexts: vi.fn(),
+}));
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
+    distribution: vi.fn(),
+    increment: vi.fn(),
+  }),
+}));
+
+function emptyState(): ConversationWindowStateSnapshot {
+  return {
+    version: 1,
+    interactions: [],
+    retainedTokens: 0,
+    totalTokensBefore: 0,
+    prunedTokens: 0,
+  };
+}
+
+async function publishCheckpoint(
+  checkpoint: ReturnType<typeof makeConversationWindowCheckpoint>
+): Promise<void> {
+  const result = await publishConversationWindowCheckpoint(checkpoint);
+  if (result.isErr()) {
+    throw result.error;
+  }
+}
+
+function renderingInput() {
+  return {
+    model: GPT_4O_MODEL_CONFIG,
+    prompt: "PROMPT",
+    tools: "TOOLS",
+    allowedTokenCount: 100_000,
+    enabledSkills: [],
+  };
+}
+
+function profileHash() {
+  return computeConversationWindowProfileHash({
+    ...renderingInput(),
+    leadingMessages: [],
+  });
+}
+
+function checkpointState(label: string): ConversationWindowStateSnapshot {
+  const state = CheckpointedConversationWindowState.empty({
+    pruningBudget: 100_000,
+    budgetForInteractions: 100_000,
+    logDetails: {},
+  });
+  state.append({
+    messages: [
+      {
+        role: "user",
+        name: "user",
+        content: [{ type: "text", text: label }],
+        tokenCount: 10,
+      },
+    ],
+  });
+  return state.snapshot();
+}
+
+async function createAgentLoopFixture() {
+  const { authenticator: auth, workspace } = await createResourceTest({});
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfig.sId,
+    messagesCreatedAt: [],
+  });
+  const { messageRow: userMessageRow, userMessage } =
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Hello",
+    });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig,
+    parentMessageModelId: userMessageRow.id,
+    rank: 1,
+  });
+
+  return {
+    auth,
+    agentMessage,
+    args: {
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+      userMessageOrigin: userMessage.context.origin,
+    },
+  };
+}
+
+describe("prepareAgentLoopContextProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+    fileStorageMock.setFetchFileContentNotFound(() => true);
+    vi.mocked(getLlmCredentials).mockResolvedValue({});
+    vi.mocked(tokenCountForTexts).mockImplementation(
+      async (texts) => new Ok(texts.map(() => 10))
+    );
+  });
+
+  it("hydrates only the selected step's action outputs", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow, userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+      });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      auth,
+      {
+        workspace,
+        conversation,
+        agentConfig,
+        parentMessageModelId: userMessageRow.id,
+        rank: 1,
+      }
+    );
+
+    for (const step of [0, 1]) {
+      await AgentMCPActionFactory.create(auth, {
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: agentMessage.agentMessageId,
+        status: "succeeded",
+        step,
+        output: [{ type: "text", text: `step ${step} output` }],
+      });
+    }
+
+    const args = {
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+      userMessageOrigin: userMessage.context.origin,
+    };
+
+    const full = await prepareAgentLoopContextProvider(auth, args, {
+      step: 2,
+      featureFlags: [],
+      isActivityRetry: false,
+    });
+    if (full.isErr()) {
+      throw full.error;
+    }
+    expect("content" in full.value.runtimeData.conversation).toBe(false);
+
+    await publishCheckpoint(
+      makeConversationWindowCheckpoint({
+        identity: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+          agentMessageId: agentMessage.sId,
+          agentMessageVersion: agentMessage.version,
+          step: 1,
+        },
+        profileHash: "profile",
+        promptTokens: 0,
+        toolDefinitionTokens: 0,
+        state: emptyState(),
+      })
+    );
+    const previousCheckpoint = await prepareAgentLoopContextProvider(
+      auth,
+      args,
+      {
+        step: 2,
+        featureFlags: ["stateful_conversation_window"],
+        isActivityRetry: false,
+      }
+    );
+    if (previousCheckpoint.isErr()) {
+      throw previousCheckpoint.error;
+    }
+    expect(
+      previousCheckpoint.value.runtimeData.agentMessage.actions
+    ).toHaveLength(2);
+    expect(
+      previousCheckpoint.value.runtimeData.agentMessage.actions.find(
+        (action) => action.step === 0
+      )?.output
+    ).toEqual([]);
+    expect(
+      previousCheckpoint.value.runtimeData.agentMessage.actions.find(
+        (action) => action.step === 1
+      )?.output
+    ).toEqual([{ type: "text", text: "step 1 output" }]);
+
+    const exactCheckpoint = await prepareAgentLoopContextProvider(auth, args, {
+      step: 1,
+      featureFlags: ["stateful_conversation_window"],
+      isActivityRetry: true,
+    });
+    if (exactCheckpoint.isErr()) {
+      throw exactCheckpoint.error;
+    }
+    expect(exactCheckpoint.value.runtimeData.agentMessage.actions).toHaveLength(
+      1
+    );
+    expect(
+      exactCheckpoint.value.runtimeData.agentMessage.actions.map(
+        (action) => action.output
+      )
+    ).toEqual([[{ type: "text", text: "step 0 output" }]]);
+    expect("content" in exactCheckpoint.value.runtimeData.conversation).toBe(
+      false
+    );
+  });
+
+  it("resolves an auto stream while keeping the bounded content shape", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      model: { providerId: AUTO_MODEL_ID, modelId: AUTO_MODEL_ID },
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow, userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+      });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      auth,
+      {
+        workspace,
+        conversation,
+        agentConfig,
+        parentMessageModelId: userMessageRow.id,
+        rank: 1,
+      }
+    );
+    await AgentStepContentResource.createNewVersion({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: { type: "text_content", value: "step zero" },
+    });
+    await AgentStepContentResource.createNewVersion({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: 1,
+      index: 0,
+      type: "text_content",
+      value: { type: "text_content", value: "step one" },
+    });
+    await AgentStepContentResource.createNewVersion({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: 0,
+      index: 1,
+      type: "reasoning",
+      value: {
+        type: "reasoning",
+        value: {
+          reasoning: "old reasoning",
+          metadata: "",
+          tokens: 1,
+          provider: "openai",
+        },
+      },
+    });
+
+    const args = {
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+      userMessageOrigin: userMessage.context.origin,
+    };
+    await publishCheckpoint(
+      makeConversationWindowCheckpoint({
+        identity: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+          agentMessageId: agentMessage.sId,
+          agentMessageVersion: agentMessage.version,
+          step: 1,
+        },
+        profileHash: "profile",
+        promptTokens: 0,
+        toolDefinitionTokens: 0,
+        state: emptyState(),
+      })
+    );
+    const previousCheckpoint = await prepareAgentLoopContextProvider(
+      auth,
+      args,
+      {
+        step: 2,
+        featureFlags: ["stateful_conversation_window"],
+        isActivityRetry: false,
+      }
+    );
+    if (previousCheckpoint.isErr()) {
+      throw previousCheckpoint.error;
+    }
+    expect(
+      previousCheckpoint.value.runtimeData.modelInfo.endpoint.modelConfig
+        .modelId
+    ).not.toBe(AUTO_MODEL_ID);
+    expect(
+      previousCheckpoint.value.runtimeData.agentMessage.contents.map(
+        (content) => content.step
+      )
+    ).toEqual([0, 1]);
+    expect(
+      previousCheckpoint.value.runtimeData.agentMessage.contents.map(
+        ({ content }) => content.type
+      )
+    ).toEqual(["text_content", "text_content"]);
+
+    const exactCheckpoint = await prepareAgentLoopContextProvider(auth, args, {
+      step: 1,
+      featureFlags: ["stateful_conversation_window"],
+      isActivityRetry: true,
+    });
+    if (exactCheckpoint.isErr()) {
+      throw exactCheckpoint.error;
+    }
+    expect(
+      exactCheckpoint.value.runtimeData.agentMessage.contents.map(
+        ({ content }) => content.type
+      )
+    ).toEqual(["text_content", "reasoning"]);
+  });
+
+  it("adopts the canonical checkpoint after a publication race", async () => {
+    const { auth, agentMessage, args } = await createAgentLoopFixture();
+    const sourceIdentity = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      conversationId: args.conversationId,
+      agentMessageId: args.agentMessageId,
+      agentMessageVersion: args.agentMessageVersion,
+      step: 0,
+    };
+    const targetIdentity = { ...sourceIdentity, step: 1 };
+    const sourceCheckpoint = makeConversationWindowCheckpoint({
+      identity: sourceIdentity,
+      profileHash: profileHash(),
+      promptTokens: 1,
+      toolDefinitionTokens: 2,
+      state: checkpointState("source"),
+    });
+    const winner = makeConversationWindowCheckpoint({
+      identity: targetIdentity,
+      profileHash: profileHash(),
+      promptTokens: 1,
+      toolDefinitionTokens: 2,
+      missingActionCatcherFunctionCallIds: ["winner_call"],
+      state: checkpointState("winner"),
+    });
+    await AgentStepContentResource.createNewVersion({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: { type: "text_content", value: "local" },
+    });
+    await publishCheckpoint(sourceCheckpoint);
+    await publishCheckpoint(winner);
+
+    const provider = await prepareAgentLoopContextProvider(auth, args, {
+      featureFlags: ["stateful_conversation_window"],
+      isActivityRetry: false,
+      step: targetIdentity.step,
+    });
+    if (provider.isErr()) {
+      throw provider.error;
+    }
+    const result = await provider.value.render(renderingInput());
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.modelConversation.messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: [{ type: "text", text: "winner" }],
+      }),
+    ]);
+    expect(result.value.missingActionCatcherFunctionCallIds).toEqual([
+      "winner_call",
+    ]);
+  });
+
+  it("uses an exact checkpoint without publishing it again", async () => {
+    const { auth, args } = await createAgentLoopFixture();
+    const identity = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      conversationId: args.conversationId,
+      agentMessageId: args.agentMessageId,
+      agentMessageVersion: args.agentMessageVersion,
+      step: 0,
+    };
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: profileHash(),
+      promptTokens: 1,
+      toolDefinitionTokens: 2,
+      state: checkpointState("exact"),
+    });
+    await publishCheckpoint(checkpoint);
+
+    const provider = await prepareAgentLoopContextProvider(auth, args, {
+      featureFlags: ["stateful_conversation_window"],
+      isActivityRetry: true,
+      step: identity.step,
+    });
+    if (provider.isErr()) {
+      throw provider.error;
+    }
+    const result = await provider.value.render(renderingInput());
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.modelConversation.messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: [{ type: "text", text: "exact" }],
+      }),
+    ]);
+  });
+
+  it("rebuilds from the full conversation when the profile changes", async () => {
+    const { auth, args } = await createAgentLoopFixture();
+    const identity = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      conversationId: args.conversationId,
+      agentMessageId: args.agentMessageId,
+      agentMessageVersion: args.agentMessageVersion,
+      step: 0,
+    };
+    const checkpoint = makeConversationWindowCheckpoint({
+      identity,
+      profileHash: "different-profile",
+      promptTokens: 1,
+      toolDefinitionTokens: 2,
+      state: checkpointState("stale"),
+    });
+    await publishCheckpoint(checkpoint);
+
+    const provider = await prepareAgentLoopContextProvider(auth, args, {
+      featureFlags: ["stateful_conversation_window"],
+      isActivityRetry: true,
+      step: identity.step,
+    });
+    if (provider.isErr()) {
+      throw provider.error;
+    }
+    const result = await provider.value.render(renderingInput());
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.modelConversation.messages).toContainEqual(
+      expect.objectContaining({
+        role: "user",
+        content: [
+          expect.objectContaining({ text: expect.stringContaining("Hello") }),
+        ],
+      })
+    );
+  });
+
+  it("keeps the locally rendered context when checkpoint publication fails", async () => {
+    const { auth, args } = await createAgentLoopFixture();
+    const storage = getPrivateUploadBucket();
+    vi.mocked(storage.uploadSmallRawContentToBucketAsNewFile).mockRejectedValue(
+      new Error("GCS unavailable")
+    );
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(storage);
+
+    const provider = await prepareAgentLoopContextProvider(auth, args, {
+      featureFlags: ["stateful_conversation_window"],
+      isActivityRetry: false,
+      step: 0,
+    });
+    if (provider.isErr()) {
+      throw provider.error;
+    }
+    const result = await provider.value.render(renderingInput());
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.modelConversation.messages).toContainEqual(
+      expect.objectContaining({
+        role: "user",
+        content: [
+          expect.objectContaining({ text: expect.stringContaining("Hello") }),
+        ],
+      })
+    );
+  });
+});

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider/checkpointed.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider/checkpointed.ts
@@ -1,0 +1,476 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getConversationForCheckpoint } from "@app/lib/api/assistant/conversation_rendering/checkpoint_conversation";
+import type {
+  ConversationWindowCheckpoint,
+  ConversationWindowCheckpointIdentity,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_checkpoint";
+import {
+  computeConversationWindowProfileHash,
+  loadConversationWindowCheckpoint,
+  makeConversationWindowCheckpoint,
+  publishConversationWindowCheckpoint,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_checkpoint";
+import type {
+  ConversationRenderingInput,
+  ConversationWindowSource,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_core";
+import {
+  PREVIOUS_INTERACTIONS_TO_PRESERVE,
+  renderConversationWindow,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_core";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { prepareFullContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/full";
+import {
+  getMissingActionCatcherFunctionCallIds,
+  prepareRuntimeData,
+} from "@app/temporal/agent_loop/lib/agent_loop_context_provider/shared";
+import type { AgentLoopContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/types";
+import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
+import type {
+  AgentLoopArgs,
+  FullAgentLoopDataWithAuth,
+} from "@app/types/assistant/agent_run";
+import {
+  buildAgentLoopDataFromConversation,
+  getFullAgentLoopDataWithAuth,
+} from "@app/types/assistant/agent_run";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { isAgentMessageType } from "@app/types/assistant/conversation";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+type CheckpointStatus = "missing" | "exact" | "previous" | "rejected";
+
+type ResolvedConversationWindowSource = {
+  checkpointStatus: CheckpointStatus;
+  source: ConversationWindowSource;
+  missingActionCatcherFunctionCallIds: string[];
+};
+
+type CheckpointedContext = {
+  agentLoopArgs: AgentLoopArgs;
+  conversation: ConversationType;
+  localMissingActionCatcherFunctionCallIds: string[];
+  sourceCheckpoint: ConversationWindowCheckpoint | null;
+  targetIdentity: ConversationWindowCheckpointIdentity;
+};
+
+function identitiesMatchExceptStep(
+  source: ConversationWindowCheckpointIdentity,
+  target: ConversationWindowCheckpointIdentity
+): boolean {
+  return (
+    source.workspaceId === target.workspaceId &&
+    source.conversationId === target.conversationId &&
+    source.agentMessageId === target.agentMessageId &&
+    source.agentMessageVersion === target.agentMessageVersion
+  );
+}
+
+function checkpointCanSeedTarget(
+  checkpoint: ConversationWindowCheckpoint,
+  target: ConversationWindowCheckpointIdentity,
+  profileHash: string
+): boolean {
+  return (
+    checkpoint.validUntilMs > Date.now() &&
+    checkpoint.profileHash === profileHash &&
+    identitiesMatchExceptStep(checkpoint.identity, target) &&
+    (checkpoint.identity.step === target.step ||
+      checkpoint.identity.step === target.step - 1)
+  );
+}
+
+function conversationForCheckpointContinuation(
+  conversation: ConversationType,
+  checkpoint: ConversationWindowCheckpoint
+): Result<ConversationType, Error> {
+  for (const versions of conversation.content) {
+    const message = versions.find(
+      (candidate) =>
+        isAgentMessageType(candidate) &&
+        candidate.sId === checkpoint.identity.agentMessageId &&
+        candidate.version === checkpoint.identity.agentMessageVersion
+    );
+    if (message && isAgentMessageType(message)) {
+      return new Ok({
+        ...conversation,
+        content: [
+          [
+            {
+              ...message,
+              contents: message.contents.filter(
+                (content) => content.step === checkpoint.identity.step
+              ),
+              actions: message.actions.filter(
+                (action) => action.step === checkpoint.identity.step
+              ),
+            },
+          ],
+        ],
+      });
+    }
+  }
+
+  return new Err(
+    new Error("Agent message not found while rendering checkpoint continuation")
+  );
+}
+
+async function loadSourceCheckpoint(
+  identity: ConversationWindowCheckpointIdentity,
+  { preferExactCheckpoint }: { preferExactCheckpoint: boolean }
+): Promise<Result<ConversationWindowCheckpoint | null, Error>> {
+  const previousStep = identity.step > 0 ? [identity.step - 1] : [];
+  let candidateSteps = [...previousStep, identity.step];
+  if (preferExactCheckpoint) {
+    candidateSteps = [identity.step, ...previousStep];
+  }
+
+  for (const candidateStep of candidateSteps) {
+    const checkpointResult = await loadConversationWindowCheckpoint({
+      ...identity,
+      step: candidateStep,
+    });
+    if (checkpointResult.isErr()) {
+      return checkpointResult;
+    }
+    if (checkpointResult.value) {
+      return checkpointResult;
+    }
+  }
+
+  return new Ok(null);
+}
+
+async function loadFullConversationForStep(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs,
+  step: number
+): Promise<Result<ConversationType, Error>> {
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: checkpoint rejection requires the authoritative context
+  const result = await getConversation(
+    auth,
+    agentLoopArgs.conversationId,
+    false,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE + 1
+  );
+  if (result.isErr()) {
+    return result;
+  }
+
+  return new Ok(
+    sliceConversationForAgentMessage(result.value, {
+      agentMessageId: agentLoopArgs.agentMessageId,
+      agentMessageVersion: agentLoopArgs.agentMessageVersion,
+      step,
+    }).slicedConversation
+  );
+}
+
+async function resolveConversationWindowSource(
+  auth: Authenticator,
+  {
+    context,
+    profileHash,
+  }: {
+    context: CheckpointedContext;
+    profileHash: string;
+  }
+): Promise<Result<ResolvedConversationWindowSource, Error>> {
+  const {
+    agentLoopArgs,
+    conversation,
+    localMissingActionCatcherFunctionCallIds,
+    sourceCheckpoint,
+    targetIdentity,
+  } = context;
+
+  if (!sourceCheckpoint) {
+    return new Ok({
+      checkpointStatus: "missing",
+      source: { kind: "full", conversation },
+      missingActionCatcherFunctionCallIds:
+        localMissingActionCatcherFunctionCallIds,
+    });
+  }
+
+  if (!checkpointCanSeedTarget(sourceCheckpoint, targetIdentity, profileHash)) {
+    const fullConversation = await loadFullConversationForStep(
+      auth,
+      agentLoopArgs,
+      targetIdentity.step
+    );
+    if (fullConversation.isErr()) {
+      return fullConversation;
+    }
+
+    return new Ok({
+      checkpointStatus: "rejected",
+      source: { kind: "full", conversation: fullConversation.value },
+      missingActionCatcherFunctionCallIds:
+        getMissingActionCatcherFunctionCallIds(fullConversation.value),
+    });
+  }
+
+  if (sourceCheckpoint.identity.step === targetIdentity.step) {
+    return new Ok({
+      checkpointStatus: "exact",
+      source: {
+        kind: "checkpoint_exact",
+        conversation,
+        checkpoint: sourceCheckpoint,
+      },
+      missingActionCatcherFunctionCallIds:
+        sourceCheckpoint.missingActionCatcherFunctionCallIds,
+    });
+  }
+
+  const continuation = conversationForCheckpointContinuation(
+    conversation,
+    sourceCheckpoint
+  );
+  if (continuation.isErr()) {
+    return continuation;
+  }
+
+  return new Ok({
+    checkpointStatus: "previous",
+    source: {
+      kind: "checkpoint_continuation",
+      conversation,
+      continuation: continuation.value,
+      checkpoint: sourceCheckpoint,
+    },
+    missingActionCatcherFunctionCallIds:
+      localMissingActionCatcherFunctionCallIds,
+  });
+}
+
+function shouldPublishCheckpoint(status: CheckpointStatus): boolean {
+  switch (status) {
+    case "exact":
+      return false;
+    case "missing":
+    case "previous":
+    case "rejected":
+      return true;
+    default:
+      return assertNever(status);
+  }
+}
+
+async function renderCheckpointedConversation(
+  auth: Authenticator,
+  input: ConversationRenderingInput,
+  context: CheckpointedContext
+): ReturnType<AgentLoopContextProvider["render"]> {
+  const startedAtMs = Date.now();
+  const { sourceCheckpoint, targetIdentity } = context;
+  const profileHash = computeConversationWindowProfileHash({
+    model: input.model,
+    prompt: input.prompt,
+    tools: input.tools,
+    allowedTokenCount: input.allowedTokenCount,
+    leadingMessages: input.leadingMessages ?? [],
+    excludeActions: input.excludeActions,
+    excludeImages: input.excludeImages,
+    onMissingAction: input.onMissingAction,
+    agentConfigurationId: input.agentConfiguration?.sId,
+  });
+
+  const sourceResult = await resolveConversationWindowSource(auth, {
+    context,
+    profileHash,
+  });
+  if (sourceResult.isErr()) {
+    return sourceResult;
+  }
+  const resolvedSource = sourceResult.value;
+
+  const renderedResult = await renderConversationWindow(
+    auth,
+    input,
+    resolvedSource.source
+  );
+  if (renderedResult.isErr()) {
+    return renderedResult;
+  }
+
+  let rendered = renderedResult.value;
+  let missingActionCatcherFunctionCallIds =
+    resolvedSource.missingActionCatcherFunctionCallIds;
+
+  if (shouldPublishCheckpoint(resolvedSource.checkpointStatus)) {
+    const localCheckpoint = makeConversationWindowCheckpoint({
+      identity: targetIdentity,
+      profileHash,
+      promptTokens: rendered.checkpointData.promptTokens,
+      toolDefinitionTokens: rendered.checkpointData.toolDefinitionTokens,
+      missingActionCatcherFunctionCallIds,
+      state: rendered.checkpointData.state,
+    });
+    const winnerResult =
+      await publishConversationWindowCheckpoint(localCheckpoint);
+
+    if (winnerResult.isErr()) {
+      logger.warn(
+        { ...targetIdentity, error: winnerResult.error },
+        "Failed to publish conversation window checkpoint, continuing without it"
+      );
+    } else if (
+      !winnerResult.value.created &&
+      winnerResult.value.checkpoint.profileHash === profileHash
+    ) {
+      const winner = winnerResult.value.checkpoint;
+      const winnerResultForModel = await renderConversationWindow(
+        auth,
+        { ...input, metricsCaller: undefined },
+        {
+          kind: "checkpoint_exact",
+          conversation: resolvedSource.source.conversation,
+          checkpoint: winner,
+        }
+      );
+      if (winnerResultForModel.isErr()) {
+        return winnerResultForModel;
+      }
+
+      rendered = winnerResultForModel.value;
+      missingActionCatcherFunctionCallIds =
+        winner.missingActionCatcherFunctionCallIds;
+    }
+  }
+
+  logger.info(
+    {
+      ...targetIdentity,
+      checkpointStep: sourceCheckpoint?.identity.step,
+      checkpointStatus: resolvedSource.checkpointStatus,
+      elapsedMs: Date.now() - startedAtMs,
+    },
+    "[ASSISTANT_TRACE] render agent loop conversation window"
+  );
+
+  const { checkpointData: _checkpointData, ...modelContext } = rendered;
+  return new Ok({
+    ...modelContext,
+    missingActionCatcherFunctionCallIds,
+  });
+}
+
+export async function prepareAgentLoopContextProvider(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs,
+  {
+    featureFlags,
+    isActivityRetry,
+    step,
+  }: {
+    featureFlags: WhitelistableFeature[];
+    isActivityRetry: boolean;
+    step: number;
+  }
+): Promise<Result<AgentLoopContextProvider, Error>> {
+  if (!featureFlags.includes("stateful_conversation_window")) {
+    return prepareFullContextProvider(auth, agentLoopArgs, step);
+  }
+
+  const targetIdentity: ConversationWindowCheckpointIdentity = {
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    conversationId: agentLoopArgs.conversationId,
+    agentMessageId: agentLoopArgs.agentMessageId,
+    agentMessageVersion: agentLoopArgs.agentMessageVersion,
+    step,
+  };
+
+  const checkpointStartedAtMs = Date.now();
+  const sourceCheckpointResult = await loadSourceCheckpoint(targetIdentity, {
+    preferExactCheckpoint: isActivityRetry,
+  });
+  if (sourceCheckpointResult.isErr()) {
+    logger.warn(
+      { ...targetIdentity, error: sourceCheckpointResult.error },
+      "Failed to load conversation window checkpoint, using full rendering"
+    );
+    return prepareFullContextProvider(auth, agentLoopArgs, step);
+  }
+  const sourceCheckpoint = sourceCheckpointResult.value;
+  const checkpointLoadMs = Date.now() - checkpointStartedAtMs;
+
+  const dataStartedAtMs = Date.now();
+  let dataResult: Result<FullAgentLoopDataWithAuth, Error>;
+  if (sourceCheckpoint) {
+    const conversationResult = await getConversationForCheckpoint(
+      auth,
+      agentLoopArgs.conversationId,
+      {
+        agentMessageId: agentLoopArgs.agentMessageId,
+        targetStep: step,
+        userMessageId: agentLoopArgs.userMessageId,
+      }
+    );
+    if (conversationResult.isErr()) {
+      logger.warn(
+        { ...targetIdentity, error: conversationResult.error },
+        "Failed to load bounded model context, using full conversation"
+      );
+      return prepareFullContextProvider(auth, agentLoopArgs, step);
+    }
+
+    dataResult = await buildAgentLoopDataFromConversation(
+      auth,
+      agentLoopArgs,
+      conversationResult.value
+    );
+  } else {
+    dataResult = await getFullAgentLoopDataWithAuth(auth, agentLoopArgs);
+  }
+
+  if (dataResult.isErr()) {
+    if (sourceCheckpoint) {
+      logger.warn(
+        { ...targetIdentity, error: dataResult.error },
+        "Failed to load bounded model context, using full conversation"
+      );
+      return prepareFullContextProvider(auth, agentLoopArgs, step);
+    }
+    return dataResult;
+  }
+
+  const { conversation, runtimeData } = prepareRuntimeData(
+    dataResult.value,
+    step
+  );
+  const localMissingActionCatcherFunctionCallIds = [
+    ...new Set([
+      ...(sourceCheckpoint?.missingActionCatcherFunctionCallIds ?? []),
+      ...getMissingActionCatcherFunctionCallIds(conversation),
+    ]),
+  ];
+
+  logger.info(
+    {
+      ...targetIdentity,
+      checkpointStep: sourceCheckpoint?.identity.step,
+      checkpointLoadMs,
+      getAgentLoopDataMs: Date.now() - dataStartedAtMs,
+    },
+    "[ASSISTANT_TRACE] prepare checkpointed conversation window"
+  );
+
+  return new Ok({
+    runtimeData,
+    render: (input) =>
+      renderCheckpointedConversation(auth, input, {
+        agentLoopArgs,
+        conversation,
+        localMissingActionCatcherFunctionCallIds,
+        sourceCheckpoint,
+        targetIdentity,
+      }),
+  });
+}

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider/checkpointed.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider/checkpointed.ts
@@ -254,10 +254,12 @@ function shouldPublishCheckpoint(status: CheckpointStatus): boolean {
   switch (status) {
     case "exact":
       return false;
+
     case "missing":
     case "previous":
     case "rejected":
       return true;
+
     default:
       return assertNever(status);
   }
@@ -289,6 +291,7 @@ async function renderCheckpointedConversation(
   if (sourceResult.isErr()) {
     return sourceResult;
   }
+
   const resolvedSource = sourceResult.value;
 
   const renderedResult = await renderConversationWindow(
@@ -418,6 +421,7 @@ export async function prepareAgentLoopContextProvider(
         { ...targetIdentity, error: conversationResult.error },
         "Failed to load bounded model context, using full conversation"
       );
+
       return prepareFullContextProvider(auth, agentLoopArgs, step);
     }
 
@@ -436,8 +440,10 @@ export async function prepareAgentLoopContextProvider(
         { ...targetIdentity, error: dataResult.error },
         "Failed to load bounded model context, using full conversation"
       );
+
       return prepareFullContextProvider(auth, agentLoopArgs, step);
     }
+
     return dataResult;
   }
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1155,7 +1155,7 @@ export async function runModel(
   // We have actions.
   localLogger.info(
     {
-      elapsed: Date.now() - now,
+      elapsedMs: Date.now() - now,
     },
     "[ASSISTANT_TRACE] Action inputs generation"
   );

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -280,14 +280,7 @@ export async function getFullAgentLoopDataWithAuth(
   auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<Result<FullAgentLoopDataWithAuth, AgentLoopDataError | Error>> {
-  const {
-    agentMessageId,
-    agentMessageVersion,
-    caching,
-    conversationId,
-    userMessageId,
-    userMessageVersion,
-  } = agentLoopArgs;
+  const { caching, conversationId } = agentLoopArgs;
 
   let conversation: ConversationType;
   if (caching?.useCachedGetConversation) {
@@ -344,6 +337,21 @@ export async function getFullAgentLoopDataWithAuth(
     }
     conversation = conversationRes.value;
   }
+
+  return buildAgentLoopDataFromConversation(auth, agentLoopArgs, conversation);
+}
+
+export async function buildAgentLoopDataFromConversation(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs,
+  conversation: ConversationType
+): Promise<Result<FullAgentLoopDataWithAuth, AgentLoopDataError | Error>> {
+  const {
+    agentMessageId,
+    agentMessageVersion,
+    userMessageId,
+    userMessageVersion,
+  } = agentLoopArgs;
 
   // Find the agent message by searching all groups in reverse order. Retried messages do not have
   // the same sId as the original message, so we need to search all groups.

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -1,4 +1,10 @@
 export const WHITELISTABLE_FEATURES_CONFIG = {
+  stateful_conversation_window: {
+    description:
+      "Restore agent-loop context windows from the previous model step checkpoint",
+    stage: "dust_only",
+    owner: "flvndvd",
+  },
   dust_filesystem: {
     description:
       "Allow fresh Pods and standalone conversations to use the database-backed filesystem",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -800,6 +800,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "shopify_tool"
   | "show_debug_tools"
   | "slack_message_splitting"
+  | "stateful_conversation_window"
   | "run_tools_from_prompt"
   | "usage_data_api"
   | "usage_page_read_only"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR completes the feature-flagged integration of checkpointed conversation windows into the agent loop.

Today, each model step reloads and renders the bounded conversation context, then tokenizes the model-visible messages again. With this change, a step can restore the context window produced for the preceding step from GCS, hydrate only the newly completed step, and tokenize only that continuation.

The checkpointed context provider owns checkpoint selection, profile validation, bounded hydration, rendering, and create-once publication. Exact checkpoints are reused on activity retries. Missing, expired, incompatible, or unreadable checkpoints degrade directly to the existing full-rendering provider.

The profile includes model and rendering inputs that affect the resulting context. Checkpoints also account for signed image URL expiry, publication races, conversation deletion, and missing-action catcher state.

The feature is disabled by default behind `stateful_conversation_window`. It does not change Temporal activity parameters or workflow history.

This initially supports statefulness across steps of the same agent message. Cross-agent-message reuse and in-turn compaction remain follow-up extensions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
