### PR TITLE
[front] enh: add Agent/Skill info pages from analytics page

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,4 +1,6 @@
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { CHART_HEIGHT } from "@app/components/charts/constants";
+import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
 import { AnalyticsExportPanel } from "@app/components/workspace/analytics/AnalyticsExportPanel";
 import type { ConsumptionAttributionTableProps } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
@@ -28,7 +30,7 @@ import {
   consumptionPeriodKey,
   DEFAULT_CONSUMPTION_PERIOD,
 } from "@app/lib/analytics/consumption_period";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import type { TrackingExtra } from "@app/lib/tracking";
 import {
@@ -144,6 +146,9 @@ function ChartFallback({ controlsInCard = false }: ChartFallbackProps) {
 
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
+  const { user } = useAuth();
+  const [agentDetailsId, setAgentDetailsId] = useState<string | null>(null);
+  const [skillDetailsId, setSkillDetailsId] = useState<string | null>(null);
   const state = useAnalyticsConsumptionState(useAnalyticsViewState());
   const filter = useResolvedUsageFilter({
     workspaceId: owner.sId,
@@ -161,7 +166,26 @@ export function AnalyticsConsumptionPage() {
   }, [owner.sId]);
 
   return (
-    <AnalyticsConsumptionContent owner={owner} state={{ ...state, filter }} />
+    <>
+      <AgentDetailsSheet
+        owner={owner}
+        user={user}
+        agentId={agentDetailsId}
+        onClose={() => setAgentDetailsId(null)}
+      />
+      <SkillDetailsSheetById
+        owner={owner}
+        user={user}
+        skillId={skillDetailsId}
+        onClose={() => setSkillDetailsId(null)}
+      />
+      <AnalyticsConsumptionContent
+        owner={owner}
+        state={{ ...state, filter }}
+        onAgentClick={setAgentDetailsId}
+        onSkillClick={setSkillDetailsId}
+      />
+    </>
   );
 }
 
@@ -169,6 +193,8 @@ interface AnalyticsConsumptionContentProps {
   components?: AnalyticsConsumptionComponents;
   embedded?: boolean;
   owner: LightWorkspaceType;
+  onAgentClick?: (agentId: string) => void;
+  onSkillClick?: (skillId: string) => void;
   showExport?: boolean;
   showMemberGroupFilter?: boolean;
   showOverviewError?: boolean;
@@ -182,6 +208,8 @@ export function AnalyticsConsumptionContent({
   components = WORKSPACE_CONSUMPTION_COMPONENTS,
   embedded = false,
   owner,
+  onAgentClick,
+  onSkillClick,
   showExport = true,
   showMemberGroupFilter = true,
   showOverviewError = false,
@@ -330,6 +358,7 @@ export function AnalyticsConsumptionContent({
             addUsageFilterFromAttributionRow(current, dimension, selectedRow)
           );
         }}
+        onAgentClick={onAgentClick}
         onRemoveFilter={(selectedRow) => {
           trackAnalyticsClick(trackingWorkspaceId, "attribution_filter", {
             dimension,
@@ -339,6 +368,7 @@ export function AnalyticsConsumptionContent({
             removeUsageFilterFromAttributionRow(current, dimension, selectedRow)
           );
         }}
+        onSkillClick={onSkillClick}
         dimension={dimension}
         onDimensionChange={(nextDimension) => {
           trackAnalyticsClick(trackingWorkspaceId, "attribution_tab", {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -33,6 +33,7 @@ import type { ConsumptionDimension } from "./consumptionDimensions";
 export type AttributionRowData = ConsumptionTopRow & {
   onClick: () => void;
   onAddFilter: () => void;
+  onNameClick?: () => void;
   onRemoveFilter: () => void;
 };
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -739,6 +739,74 @@ describe("ConsumptionAttributionTable", () => {
     expect(onAddFilter).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    {
+      dimension: "agent" as const,
+      row: {
+        id: "agent-id",
+        name: "Research agent",
+        pictureUrl: null,
+        description: null,
+        icon: null,
+        modelId: "model-id",
+        modelDisplayName: "Model",
+        credits: 100,
+        avgCredits: 10,
+        previousCredits: null,
+      },
+    },
+    {
+      dimension: "skill" as const,
+      row: {
+        id: "skill-id",
+        name: "Research skill",
+        pictureUrl: null,
+        description: null,
+        icon: null,
+        modelId: null,
+        modelDisplayName: null,
+        credits: 100,
+        avgCredits: 10,
+        previousCredits: null,
+      },
+    },
+  ])("opens the $dimension info page from its name", ({ dimension, row }) => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [row],
+      totalCredits: 100,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+    const onAgentClick = vi.fn();
+    const onSkillClick = vi.fn();
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension={dimension}
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onAgentClick={onAgentClick}
+        onRemoveFilter={vi.fn()}
+        onSkillClick={onSkillClick}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText(row.name));
+
+    expect(
+      dimension === "agent" ? onAgentClick : onSkillClick
+    ).toHaveBeenCalledWith(row.id);
+    expect(
+      dimension === "agent" ? onSkillClick : onAgentClick
+    ).not.toHaveBeenCalled();
+  });
+
   it("renders the skill identity and description without a model", () => {
     mockUseConsumptionTop.mockReturnValue({
       rows: [

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -294,14 +294,17 @@ function buildColumns({
           );
         const interactiveClassName = cn(
           "inline-flex min-h-11 min-w-11 max-w-full items-center rounded-sm text-left",
-          "text-highlight-500 outline-hidden ring-offset-background",
-          "pointer-fine:hover:text-highlight-600 pointer-fine:hover:underline",
+          "outline-hidden ring-offset-background",
+          "pointer-fine:hover:underline",
           "focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1"
         );
         const interactiveContent = row.detailsHref ? (
           <LinkWrapper
             href={row.detailsHref}
-            className={interactiveClassName}
+            className={cn(
+              interactiveClassName,
+              "text-highlight-500 pointer-fine:hover:text-highlight-600"
+            )}
             onClick={(event) => event.stopPropagation()}
           >
             {content}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -292,19 +292,31 @@ function buildColumns({
           ) : (
             <span className="truncate text-sm">{name}</span>
           );
+        const interactiveClassName = cn(
+          "inline-flex min-h-11 min-w-11 max-w-full items-center rounded-sm text-left",
+          "text-highlight-500 outline-hidden ring-offset-background",
+          "pointer-fine:hover:text-highlight-600 pointer-fine:hover:underline",
+          "focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1"
+        );
         const interactiveContent = row.detailsHref ? (
           <LinkWrapper
             href={row.detailsHref}
-            className={cn(
-              "inline-flex min-h-11 min-w-11 max-w-full items-center rounded-sm",
-              "text-highlight-500 outline-hidden ring-offset-background",
-              "pointer-fine:hover:text-highlight-600 pointer-fine:hover:underline",
-              "focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1"
-            )}
+            className={interactiveClassName}
             onClick={(event) => event.stopPropagation()}
           >
             {content}
           </LinkWrapper>
+        ) : row.onNameClick ? (
+          <button
+            type="button"
+            className={cn(interactiveClassName, "cursor-pointer")}
+            onClick={(event) => {
+              event.stopPropagation();
+              row.onNameClick?.();
+            }}
+          >
+            {content}
+          </button>
         ) : (
           content
         );
@@ -452,7 +464,9 @@ export interface ConsumptionAttributionRowsProps {
   analyticsScope?: ConsumptionAnalyticsScope;
   disabled?: boolean;
   onAddFilter: (row: ConsumptionTopRow) => void;
+  onAgentClick?: (agentId: string) => void;
   onRemoveFilter: (row: ConsumptionTopRow) => void;
+  onSkillClick?: (skillId: string) => void;
   search: string;
   onViewAll: (
     dimension: ConsumptionDimension,
@@ -530,7 +544,9 @@ export function ConsumptionAttributionRowsView({
   analyticsScope,
   disabled,
   onAddFilter,
+  onAgentClick,
   onRemoveFilter,
+  onSkillClick,
   search,
   onViewAll,
   emptyMessage,
@@ -580,14 +596,29 @@ export function ConsumptionAttributionRowsView({
 
   const data = useMemo<AttributionRowData[]>(
     () =>
-      rows.map((row) => ({
-        ...row,
-        onClick: () =>
-          setExpandedRowId((current) => (current === row.id ? null : row.id)),
-        onAddFilter: () => onAddFilter(row),
-        onRemoveFilter: () => onRemoveFilter(row),
-      })),
-    [rows, onAddFilter, onRemoveFilter]
+      rows.map((row) => {
+        let onNameClick: (() => void) | undefined;
+
+        if (dimension === "agent" && row.modelId && onAgentClick) {
+          onNameClick = () => onAgentClick(row.id);
+        } else if (
+          dimension === "skill" &&
+          row.name !== row.id &&
+          onSkillClick
+        ) {
+          onNameClick = () => onSkillClick(row.id);
+        }
+
+        return {
+          ...row,
+          onClick: () =>
+            setExpandedRowId((current) => (current === row.id ? null : row.id)),
+          onAddFilter: () => onAddFilter(row),
+          onNameClick,
+          onRemoveFilter: () => onRemoveFilter(row),
+        };
+      }),
+    [dimension, rows, onAddFilter, onAgentClick, onRemoveFilter, onSkillClick]
   );
   const isLoading = isTopLoading;
   const skeletonRowCount =
@@ -743,7 +774,9 @@ export interface ConsumptionAttributionTableProps {
   analyticsScope?: ConsumptionAnalyticsScope;
   disabled?: boolean;
   onAddFilter: (row: ConsumptionTopRow) => void;
+  onAgentClick?: (agentId: string) => void;
   onRemoveFilter: (row: ConsumptionTopRow) => void;
+  onSkillClick?: (skillId: string) => void;
   // Owned by the page: the selected tab also drives the chart's breakdown.
   dimension: ConsumptionDimension;
   onDimensionChange: (dimension: ConsumptionDimension) => void;
@@ -767,7 +800,9 @@ export function ConsumptionAttributionTableView({
   analyticsScope = WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE,
   disabled,
   onAddFilter,
+  onAgentClick,
   onRemoveFilter,
+  onSkillClick,
   dimension,
   onDimensionChange,
   onViewAll,
@@ -912,7 +947,9 @@ export function ConsumptionAttributionTableView({
                       analyticsScope={analyticsScope}
                       disabled={disabled}
                       onAddFilter={onAddFilter}
+                      onAgentClick={onAgentClick}
                       onRemoveFilter={onRemoveFilter}
+                      onSkillClick={onSkillClick}
                       search={debouncedValue}
                       onViewAll={onViewAll}
                     />


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10218

When browsing the analytics, it can be useful to quickly inspect an agent or a skill to see what tools, what instructions it has.

This PR adds a way to do this by making the agent and skill names clickable from there, which opens the existing agent/skill info sheets.

This sheet comes on top of the right split we'll add for the analyst convo on the side.

## Tests

- Updated tests.
- Tested locally + preview/

## Risk

- Low.

## Deploy Plan

- Deploy front.
