### PR TITLE
Retire dust-chawi global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -1106,9 +1106,10 @@ export function _getDustNextHighGlobalAgent(
 // pistache, chalom). Their eval models were removed from the infra custom-models
 // config (GCS), so they no longer resolve to a custom model. They remain callable for past
 // conversations via a concrete fallback model and are listed in
-// RETIRED_GLOBAL_AGENTS_SID (see global_agents.ts). We may revive them as
-// custom-model agents in the future by moving them back into
-// CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS.
+// RETIRED_GLOBAL_AGENTS_SID (see global_agents.ts). Reviving one as a
+// custom-model agent requires moving it back into
+// CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS and restoring
+// _getCustomModelDustLikeGlobalAgent and its switch cases (removed in #31262).
 type RetiredDustGlobalAgentConfig = {
   name: string;
   preferredReasoningEffort: ReasoningEffort;

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -268,14 +268,12 @@ function _getDustLikeGlobalAgent(
     name,
     preferredModelConfiguration,
     preferredReasoningEffort,
-    requiredPreferredModelConfiguration,
     omittedThinking,
   }: {
     agentId: GLOBAL_AGENTS_SID;
     name: string;
     preferredModelConfiguration?: ModelConfigurationType | null;
     preferredReasoningEffort?: ReasoningEffort;
-    requiredPreferredModelConfiguration?: boolean;
     omittedThinking?: boolean;
   }
 ): (AgentConfigurationType & { omittedThinking?: boolean }) | null {
@@ -304,15 +302,6 @@ function _getDustLikeGlobalAgent(
         featureFlags,
         excludeProviders,
       }) != null;
-
-    if (requiredPreferredModelConfiguration) {
-      if (isPreferredModelConfigurationAvailable) {
-        isPreferredModel = true;
-        return preferredModelConfiguration;
-      }
-
-      return null;
-    }
 
     if (!auth.isUpgraded()) {
       return getSmallWhitelistedModel(auth, excludeProviders, {
@@ -1113,9 +1102,9 @@ export function _getDustNextHighGlobalAgent(
   });
 }
 
-// Formerly custom-model dust-* global agents (soupinou, sundae, pistache,
-// chalom). Their eval models were removed from the infra custom-models config
-// (GCS), so they no longer resolve to a custom model. They remain callable for past
+// Formerly custom-model dust-* global agents (chawi, soupinou, sundae,
+// pistache, chalom). Their eval models were removed from the infra custom-models
+// config (GCS), so they no longer resolve to a custom model. They remain callable for past
 // conversations via a concrete fallback model and are listed in
 // RETIRED_GLOBAL_AGENTS_SID (see global_agents.ts). We may revive them as
 // custom-model agents in the future by moving them back into
@@ -1168,6 +1157,18 @@ const RETIRED_DUST_GLOBAL_AGENT_CONFIGS = new Map<
   [
     GLOBAL_AGENTS_SID.DUST_SOUPINOU_NONE,
     { name: "dust-soupinou-none", preferredReasoningEffort: "none" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHAWI,
+    { name: "dust-chawi", preferredReasoningEffort: "light" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
+    { name: "dust-chawi-medium", preferredReasoningEffort: "medium" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
+    { name: "dust-chawi-high", preferredReasoningEffort: "high" },
   ],
 ]);
 
@@ -1231,30 +1232,6 @@ const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
       preferredReasoningEffort: "high",
     },
   ],
-  [
-    GLOBAL_AGENTS_SID.DUST_CHAWI,
-    {
-      name: "dust-chawi",
-      customModelIndex: 0,
-      preferredReasoningEffort: "light",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
-    {
-      name: "dust-chawi-medium",
-      customModelIndex: 0,
-      preferredReasoningEffort: "medium",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
-    {
-      name: "dust-chawi-high",
-      customModelIndex: 0,
-      preferredReasoningEffort: "high",
-    },
-  ],
 ]);
 
 export function getCustomModelDustGlobalAgentIndex(
@@ -1264,25 +1241,4 @@ export function getCustomModelDustGlobalAgentIndex(
     CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS.get(agentId)?.customModelIndex ??
     null
   );
-}
-
-export function _getCustomModelDustLikeGlobalAgent(
-  auth: Authenticator,
-  args: DustLikeGlobalAgentArgs,
-  agentId: GLOBAL_AGENTS_SID
-): AgentConfigurationType | null {
-  const config = CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS.get(agentId);
-
-  if (!config) {
-    return null;
-  }
-
-  return _getDustLikeGlobalAgent(auth, args, {
-    agentId,
-    name: config.name,
-    preferredModelConfiguration:
-      CUSTOM_MODEL_CONFIGS[config.customModelIndex] ?? null,
-    preferredReasoningEffort: config.preferredReasoningEffort,
-    requiredPreferredModelConfiguration: true,
-  });
 }

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -49,7 +49,7 @@ vi.mock("@app/types/assistant/models/custom_models.generated", async () => {
     },
   };
 
-  // Mirrors the infra config layout: index 0 is bound to the chawi agents,
+  // Mirrors the infra config layout: index 0 is bound to the dust-next agents,
   // index 1 is unbound.
   mockCustomModels.configs = [
     {
@@ -136,7 +136,7 @@ describe("getGlobalAgents custom model agents", () => {
 
     const agents = await getGlobalAgents(
       auth,
-      [GLOBAL_AGENTS_SID.DUST_CHAWI],
+      [GLOBAL_AGENTS_SID.DUST_NEXT],
       "light"
     );
 
@@ -152,9 +152,9 @@ describe("getGlobalAgents custom model agents", () => {
     const agents = await getGlobalAgents(
       auth,
       [
-        GLOBAL_AGENTS_SID.DUST_CHAWI,
-        GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
-        GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
+        GLOBAL_AGENTS_SID.DUST_NEXT,
+        GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM,
+        GLOBAL_AGENTS_SID.DUST_NEXT_HIGH,
       ],
       "light"
     );
@@ -168,21 +168,61 @@ describe("getGlobalAgents custom model agents", () => {
       }))
     ).toEqual([
       {
-        sId: GLOBAL_AGENTS_SID.DUST_CHAWI,
+        sId: GLOBAL_AGENTS_SID.DUST_NEXT,
         providerId: "openai",
         modelId: CUSTOM_MODEL_ID,
         reasoningEffort: "light",
       },
       {
-        sId: GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
+        sId: GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM,
         providerId: "openai",
         modelId: CUSTOM_MODEL_ID,
         reasoningEffort: "medium",
       },
       {
-        sId: GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
+        sId: GLOBAL_AGENTS_SID.DUST_NEXT_HIGH,
         providerId: "openai",
         modelId: CUSTOM_MODEL_ID,
+        reasoningEffort: "high",
+      },
+    ]);
+  });
+
+  it("resolves retired chawi agent variants to the GPT-5.5 fallback", async () => {
+    const auth = await createAuthenticatorWithFlags([
+      "dust_internal_global_agents",
+    ]);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [
+        GLOBAL_AGENTS_SID.DUST_CHAWI,
+        GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
+        GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
+      ],
+      "light"
+    );
+
+    expect(
+      agents.map((agent) => ({
+        sId: agent.sId,
+        modelId: agent.model.modelId,
+        reasoningEffort: agent.model.reasoningEffort,
+      }))
+    ).toEqual([
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_CHAWI,
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
+        modelId: GPT_5_5_MODEL_ID,
         reasoningEffort: "high",
       },
     ]);
@@ -245,9 +285,9 @@ describe("getGlobalAgents custom model agents", () => {
       const agents = await getGlobalAgents(
         auth,
         [
-          GLOBAL_AGENTS_SID.DUST_CHAWI,
-          GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
-          GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
+          GLOBAL_AGENTS_SID.DUST_NEXT,
+          GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM,
+          GLOBAL_AGENTS_SID.DUST_NEXT_HIGH,
         ],
         "light"
       );

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -280,6 +280,8 @@ describe("getGlobalAgents custom model agents", () => {
       "custom_model_feature",
     ]);
 
+    // The hiding comes from the sId filter in getGlobalAgents, not from the
+    // dust-next getter, which falls back to a concrete model on its own.
     const removed = mockCustomModels.configs.splice(0);
     try {
       const agents = await getGlobalAgents(

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -17,7 +17,6 @@ import {
   _getPlanningAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
 import {
-  _getCustomModelDustLikeGlobalAgent,
   _getDustAntGlobalAgent,
   _getDustAntHighGlobalAgent,
   _getDustAntHighOmittedGlobalAgent,
@@ -842,22 +841,6 @@ function getGlobalAgent({
         featureFlags,
       });
       break;
-    // Active custom-model dust-* agents.
-    case GLOBAL_AGENTS_SID.DUST_CHAWI:
-    case GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM:
-    case GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH:
-      agentConfiguration = _getCustomModelDustLikeGlobalAgent(
-        auth,
-        {
-          settings,
-          preFetchedDataSources,
-          mcpServerViews,
-          hasDeepDive,
-          featureFlags,
-        },
-        sId
-      );
-      break;
     // Retired custom-model dust-* agents: their eval models were removed from
     // the infra config, so they resolve to a fallback model for past
     // conversations only (see RETIRED_GLOBAL_AGENTS_SID).
@@ -871,6 +854,9 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM:
     case GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH:
     case GLOBAL_AGENTS_SID.DUST_SOUPINOU_NONE:
+    case GLOBAL_AGENTS_SID.DUST_CHAWI:
+    case GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM:
+    case GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH:
       agentConfiguration = _getRetiredDustLikeGlobalAgent(
         auth,
         {
@@ -988,6 +974,9 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM,
   GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH,
   GLOBAL_AGENTS_SID.DUST_SOUPINOU_NONE,
+  GLOBAL_AGENTS_SID.DUST_CHAWI,
+  GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH,
 ];
 
 // Retired global agents remain resolvable internally (to keep past conversations running) but


### PR DESCRIPTION
The eval model behind the dust-chawi agents is no longer supported. Move the three variants (light/medium/high) to the retired list: hidden from agent lists, still resolvable by sId for past conversations via the GPT-5.5 fallback.

Chawi was the last agent routed through `_getCustomModelDustLikeGlobalAgent`, so that helper and its `requiredPreferredModelConfiguration` option are removed. dust-next still binds to custom model index 0 through its own fallback path, so the custom-model tests now point at it.

Stacked on #31260 (soupinou retirement); the infra custom-models entry at index 0 ("Chawi") is still used by dust-next.