### PR TITLE
Redesign/Refactor the formatting toolbar and fix its placement

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -11,6 +11,7 @@ import {
 import { UserHandle } from "@app/components/assistant/conversation/UserHandle";
 import { UserMessageMarkdown } from "@app/components/assistant/UserMessageMarkdown";
 import { ConfirmContext } from "@app/components/Confirm";
+import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import { useDeleteMessage } from "@app/hooks/useDeleteMessage";
@@ -55,7 +56,6 @@ import {
 } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
-import { BubbleMenu } from "@tiptap/react/menus";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import { cva } from "class-variance-authority";
 import type React from "react";
@@ -98,13 +98,13 @@ function UserMessageEditor({
         className="inline-block max-h-[40vh] min-h-14 w-full overflow-y-auto whitespace-pre-wrap scrollbar-hide"
       />
 
-      <BubbleMenu editor={editor} className={cn("flex", isMobile && "hidden")}>
+      <EditorSelectionToolbar editor={editor} disabled={isMobile}>
         {editor && (
-          <Toolbar className={cn("inline-flex", isMobile && "hidden")}>
+          <Toolbar className="inline-flex">
             <ToolBarContent editor={editor} />
           </Toolbar>
         )}
-      </BubbleMenu>
+      </EditorSelectionToolbar>
 
       <div className="flex justify-end gap-2">
         <Button

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -14,6 +14,7 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { useInputBarOverlayTracker } from "@app/components/assistant/conversation/input_bar/useInputBarOverlayTracker";
+import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
 import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { getAvailableInputBarSlashCommands } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { SKILL_NODE_TYPE } from "@app/components/editor/extensions/input_bar/SkillNode";
@@ -107,7 +108,6 @@ import {
 } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
-import { BubbleMenu } from "@tiptap/react/menus";
 import React, {
   useCallback,
   useContext,
@@ -1742,16 +1742,13 @@ const InputBarContainer = ({
               )}
             />
           </div>
-          <BubbleMenu
-            editor={editor ?? undefined}
-            className={cn("flex", isMobile && "hidden")}
-          >
+          <EditorSelectionToolbar editor={editor} disabled={isMobile}>
             {editor && (
-              <Toolbar className={cn("inline-flex", isMobile && "hidden")}>
+              <Toolbar className="inline-flex">
                 <ToolBarContent editor={editor} />
               </Toolbar>
             )}
-          </BubbleMenu>
+          </EditorSelectionToolbar>
           <div
             className={cn("mt-auto flex w-full flex-col", "pt-2 pb-3")}
             style={{

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarContent.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarContent.tsx
@@ -28,7 +28,7 @@ interface LinkPosition {
 
 export function ToolBarContent({ editor }: ToolBarContentProps) {
   const isMobile = useIsMobile();
-  const buttonSize = isMobile ? "xs" : "mini";
+  const buttonSize = isMobile ? "xs" : "sm";
   const headingShortcutLabel = useKeyboardShortcutLabel("Mod+Alt+1");
   const boldShortcutLabel = useKeyboardShortcutLabel("Mod+B");
   const italicShortcutLabel = useKeyboardShortcutLabel("Mod+I");

--- a/front/components/editor/EditorSelectionToolbar.tsx
+++ b/front/components/editor/EditorSelectionToolbar.tsx
@@ -1,0 +1,118 @@
+import { cn } from "@dust-tt/sparkle";
+import type { Editor } from "@tiptap/react";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+const TOOLBAR_Z_INDEX = 60;
+const SELECTION_GAP_PX = 8;
+
+interface Position {
+  top: number;
+  left: number;
+}
+
+function readSelectionPosition(editor: Editor): Position | null {
+  const { state, view } = editor;
+  if (!view.hasFocus() || state.selection.empty) {
+    return null;
+  }
+
+  const { from, to } = state.selection;
+  const start = view.coordsAtPos(from);
+  const end = view.coordsAtPos(to, -1);
+
+  return {
+    top: Math.min(start.top, end.top) - SELECTION_GAP_PX,
+    left:
+      (Math.min(start.left, end.left) + Math.max(start.right, end.right)) / 2,
+  };
+}
+
+interface EditorSelectionToolbarProps {
+  editor: Editor | null;
+  children: ReactNode;
+  disabled?: boolean;
+}
+
+export function EditorSelectionToolbar({
+  editor,
+  children,
+  disabled = false,
+}: EditorSelectionToolbarProps) {
+  const [position, setPosition] = useState<Position | null>(null);
+  const [hasEntered, setHasEntered] = useState(false);
+
+  const syncPosition = useCallback(() => {
+    if (!editor || editor.isDestroyed) {
+      setPosition(null);
+      return;
+    }
+    setPosition(readSelectionPosition(editor));
+  }, [editor]);
+
+  useEffect(() => {
+    if (!editor || disabled) {
+      setPosition(null);
+      return;
+    }
+
+    editor.on("transaction", syncPosition);
+    editor.on("focus", syncPosition);
+    editor.on("blur", syncPosition);
+
+    return () => {
+      editor.off("transaction", syncPosition);
+      editor.off("focus", syncPosition);
+      editor.off("blur", syncPosition);
+    };
+  }, [editor, disabled, syncPosition]);
+
+  useEffect(() => {
+    if (!position) {
+      return;
+    }
+
+    window.addEventListener("scroll", syncPosition, true);
+    window.addEventListener("resize", syncPosition);
+
+    return () => {
+      window.removeEventListener("scroll", syncPosition, true);
+      window.removeEventListener("resize", syncPosition);
+    };
+  }, [position, syncPosition]);
+
+  useLayoutEffect(() => {
+    if (!position) {
+      setHasEntered(false);
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => setHasEntered(true));
+    return () => cancelAnimationFrame(frame);
+  }, [position]);
+
+  if (!position) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className={cn(
+        "fixed -translate-x-1/2 -translate-y-full",
+        "origin-bottom transition-[opacity,scale] duration-100 ease-out-quart",
+        "motion-reduce:transition-none",
+        hasEntered ? "scale-100 opacity-100" : "scale-[0.98] opacity-0"
+      )}
+      style={{
+        top: position.top,
+        left: position.left,
+        zIndex: TOOLBAR_Z_INDEX,
+      }}
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      {children}
+    </div>,
+    document.body
+  );
+}

--- a/front/components/editor/EditorSelectionToolbar.tsx
+++ b/front/components/editor/EditorSelectionToolbar.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 const TOOLBAR_Z_INDEX = 60;
@@ -57,6 +57,8 @@ export function EditorSelectionToolbar({
       return;
     }
 
+    syncPosition();
+
     editor.on("transaction", syncPosition);
     editor.on("focus", syncPosition);
     editor.on("blur", syncPosition);
@@ -82,7 +84,7 @@ export function EditorSelectionToolbar({
     };
   }, [position, syncPosition]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!position) {
       setHasEntered(false);
       return;

--- a/front/components/editor/MarkdownEditor.tsx
+++ b/front/components/editor/MarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
+import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { buildMarkdownEditorExtensions } from "@app/lib/editor/build_markdown_editor_extensions";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -6,7 +7,6 @@ import { cn, Toolbar } from "@dust-tt/sparkle";
 import type { Editor as CoreEditor, Extensions } from "@tiptap/core";
 import type { Editor, EditorOptions } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { BubbleMenu } from "@tiptap/react/menus";
 import { cva } from "class-variance-authority";
 import debounce from "lodash/debounce";
 import type { ReactNode } from "react";
@@ -302,15 +302,12 @@ export function MarkdownEditor({
       <div className="relative">
         <EditorContent editor={editor} />
         {shouldShowFormattingMenu && editor ? (
-          <BubbleMenu
-            editor={editor}
-            className={cn("flex", isMobile && "hidden")}
-          >
-            <Toolbar className={cn("inline-flex", isMobile && "hidden")}>
+          <EditorSelectionToolbar editor={editor} disabled={isMobile}>
+            <Toolbar className="inline-flex">
               <ToolBarContent editor={editor} />
               {toolbarExtra}
             </Toolbar>
-          </BubbleMenu>
+          </EditorSelectionToolbar>
         ) : null}
       </div>
       {shouldShowCharacterCount && editor ? (

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -26,7 +26,7 @@ const toolbarRootVariants = cva("inline-flex items-center", {
       overlay:
         "absolute left-0 top-0 z-10 justify-start gap-3 overflow-hidden rounded-xl bg-primary-50 py-1 pl-3 duration-700 ease-in-out",
       inline:
-        "gap-1 border-b border-t border-border bg-background p-1 sm:rounded-2xl sm:border sm:border-border/50 sm:shadow-md",
+        "gap-1 rounded-full bg-linear-to-b from-white to-muted-background px-1.5 py-1 shadow-[0px_1px_4px_0px_rgba(0,0,0,0.12),0px_1px_0px_0px_rgba(0,0,0,0.08)] dark:from-stone-800 dark:to-stone-850 dark:shadow-[inset_0px_1px_0px_0px_rgba(255,255,255,0.06),0px_0px_0px_1px_rgba(0,0,0,0.4),0px_4px_8px_0px_rgba(0,0,0,0.3)]",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary

Redesigns the rich-text formatting toolbar to match the [Figma spec](https://www.figma.com/design/R7vT7SUjyTSosoiTOABonk/Sparkle-Components?node-id=1759-8994), and fixes it appearing at the wrong place and behind the input bar.


https://github.com/user-attachments/assets/f93a782a-3293-4178-9e08-9fd900410e3d



## The positioning bug

The toolbar used tiptap's `BubbleMenu`, a plugin that creates its element **outside React**, moves it between DOM parents, and overwrites `position`, `left/top` and `visibility` from an async callback. Fighting it from the outside is why the pill kept landing unpredictably and why raising the z-index changed nothing.

Replaced it with `EditorSelectionToolbar`, which we own:

- portals into `document.body`, so no ancestor can clip it or paint over it;
- positions itself `fixed` from ProseMirror's `coordsAtPos`, which is already viewport-relative — immune to ancestor `overflow`, `transform` and `filter`. The home page composer animates a blur filter, which is why the old placement was page-dependent;
- re-syncs on scroll and resize.

Verified in the Sparkle playground: toolbar bottom at 270px against a selection top of 278px — an exact 8px gap, horizontally centred, parented to `body`.

## Design

- `Toolbar` `inline` variant: rounded pill, white→grey gradient, layered shadow, per Figma.
- Dark mode: the gradient previously ended on `primary-900`, but that scale is **inverted** in dark mode and resolved to a near-white, washing the pill out. Now uses the dark surface scale (`stone-800` → `stone-850`) with an inset highlight.
- Desktop buttons `mini` → `sm` (32px); 40px read as too bulky in context.
- Enter animation: 100ms `ease-out-quart`, `scale(0.98) → 1`, `origin-bottom`, with `motion-reduce` handling. Transform/opacity only.

Applied across all three editors that use this toolbar: the input bar, user-message editing, and `MarkdownEditor`.

## Test plan

- [x] `npx tsgo --noEmit` — no new errors (pre-existing unrelated failures also present on `main`)
- [x] Pill styling verified in Storybook, light and dark
- [x] Positioning math verified in the Sparkle playground
- [x] Confirmed working on the app preview, including the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)