### PR TITLE
[front] use consumption ES index for usage_metrics export

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -4,13 +4,13 @@ import { honoApp } from "@front-api/app";
 import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/assistant/observability/messages_metrics", async () => ({
-  fetchMessageMetrics: vi.fn(
+vi.mock("@app/lib/api/analytics/usage_metrics_export", async () => ({
+  fetchUsageMetricsExportRows: vi.fn(
     async () =>
       new Ok([
         {
-          timestamp: 1717200000000,
-          count: 12,
+          date: "2024-06-01",
+          messages: 12,
           conversations: 3,
           activeUsers: 2,
         },

--- a/front-api/routes/w/[wId]/analytics/usage-metrics-export.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics-export.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import { formatUTCDateFromMillis } from "@app/lib/api/elasticsearch";
+import { buildDaysConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/period";
+import { fetchUsageMetricsExportRows } from "@app/lib/api/analytics/usage_metrics_export";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
@@ -21,16 +20,10 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
 
   const { days } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    days,
-  });
 
-  const result = await fetchMessageMetrics(baseQuery, "day", [
-    "conversations",
-    "activeUsers",
-  ] as const);
+  const baseQuery = await buildDaysConsumptionScopeQuery(auth, days);
+
+  const result = await fetchUsageMetricsExportRows(baseQuery, "UTC");
 
   if (result.isErr()) {
     return apiError(ctx, {
@@ -44,8 +37,8 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
 
   const headers = ["date", "messages", "conversations", "activeUsers"];
   const csvData = result.value.map((point) => [
-    formatUTCDateFromMillis(point.timestamp),
-    point.count,
+    point.date,
+    point.messages,
     point.conversations,
     point.activeUsers,
   ]);

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -283,6 +283,86 @@ describe("exportTable skills", () => {
   });
 });
 
+describe("exportTable usage_metrics", () => {
+  beforeEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("queries the consumption index with a half-open completed_at range and returns its aggregated metrics", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: {
+          by_date: {
+            buckets: [
+              {
+                key: Date.UTC(2024, 0, 15),
+                key_as_string: "2024-01-15",
+                doc_count: 10,
+                unique_messages: { value: 4 },
+                unique_conversations: { value: 3 },
+                unique_users: { value: 2 },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await exportTable({
+      auth: authenticator,
+      table: "usage_metrics",
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      timezone: "UTC",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    if (result.value.table !== "usage_metrics") {
+      throw new Error(
+        `Expected "usage_metrics" table, got "${result.value.table}"`
+      );
+    }
+
+    // Regression: exportUsageMetrics used to build its query with the legacy,
+    // timestamp-based buildAgentAnalyticsBaseQuery. It must now query the
+    // consumption index with a half-open [startDate, endDate) `completed_at`
+    // range, bumping the inclusive `endDate` calendar day up by one day, and
+    // dedupe messages by agent_message_id since the consumption index splits
+    // a message across several documents.
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.value.rows).toEqual([
+      { date: "2024-01-15", messages: 4, conversations: 3, activeUsers: 2 },
+    ]);
+  });
+});
+
 describe("exportTable source", () => {
   beforeEach(() => {
     vi.mocked(searchConsumptionAnalytics).mockReset();

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -99,7 +99,10 @@ describe("exportTable agents", () => {
                 { term: { workspace_id: workspace.sId } },
                 {
                   range: {
-                    completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+                    completed_at: {
+                      gte: "2024-01-01T00:00:00.000Z",
+                      lt: "2024-02-01T00:00:00.000Z",
+                    },
                   },
                 },
               ],
@@ -134,7 +137,15 @@ describe("exportTable users", () => {
     const today = moment.utc();
     const startDate = today.clone().subtract(30, "days").format("YYYY-MM-DD");
     const endDate = today.format("YYYY-MM-DD");
-    const exclusiveEndDate = today.clone().add(1, "day").format("YYYY-MM-DD");
+    const startInstant = moment
+      .tz(startDate, "UTC")
+      .startOf("day")
+      .toISOString();
+    const exclusiveEndInstant = moment
+      .tz(endDate, "UTC")
+      .add(1, "day")
+      .startOf("day")
+      .toISOString();
     const lastMessageAt = today.clone().subtract(1, "day");
 
     vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
@@ -195,7 +206,10 @@ describe("exportTable users", () => {
                 { term: { workspace_id: workspace.sId } },
                 {
                   range: {
-                    completed_at: { gte: startDate, lt: exclusiveEndDate },
+                    completed_at: {
+                      gte: startInstant,
+                      lt: exclusiveEndInstant,
+                    },
                   },
                 },
               ],
@@ -270,7 +284,10 @@ describe("exportTable skills", () => {
           { term: { workspace_id: workspace.sId } },
           {
             range: {
-              completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+              completed_at: {
+                gte: "2024-01-01T00:00:00.000Z",
+                lt: "2024-02-01T00:00:00.000Z",
+              },
             },
           },
         ],
@@ -350,7 +367,10 @@ describe("exportTable usage_metrics", () => {
           { term: { workspace_id: workspace.sId } },
           {
             range: {
-              completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+              completed_at: {
+                gte: "2024-01-01T00:00:00.000Z",
+                lt: "2024-02-01T00:00:00.000Z",
+              },
             },
           },
         ],
@@ -360,6 +380,55 @@ describe("exportTable usage_metrics", () => {
     expect(result.value.rows).toEqual([
       { date: "2024-01-15", messages: 4, conversations: 3, activeUsers: 2 },
     ]);
+  });
+
+  it("resolves the completed_at range from timezone-local day boundaries, not UTC", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: { by_date: { buckets: [] } },
+      })
+    );
+
+    await exportTable({
+      auth: authenticator,
+      table: "usage_metrics",
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      // UTC-8: local midnight on 2024-01-01 is 2024-01-01T08:00:00.000Z, not
+      // 2024-01-01T00:00:00.000Z. A bare-date range filter is parsed by
+      // Elasticsearch as UTC midnight, which would disagree with the
+      // date_histogram aggregation's timezone-local day buckets and cut off
+      // the first/last local day's early-morning activity.
+      timezone: "America/Los_Angeles",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              completed_at: {
+                gte: "2024-01-01T08:00:00.000Z",
+                lt: "2024-02-01T08:00:00.000Z",
+              },
+            },
+          },
+        ],
+      },
+    });
   });
 });
 
@@ -438,7 +507,10 @@ describe("exportTable source", () => {
           { term: { workspace_id: workspace.sId } },
           {
             range: {
-              completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+              completed_at: {
+                gte: "2024-01-01T00:00:00.000Z",
+                lt: "2024-02-01T00:00:00.000Z",
+              },
             },
           },
         ],

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -208,6 +208,7 @@ export async function exportTable({
         auth,
         startDate,
         endDate,
+        timezone,
         includeHiddenAgents,
       });
     case "users":
@@ -254,23 +255,35 @@ export function stringifyExportTableAsCsv(data: ExportTableData): string {
   }
 }
 
-// exportTable's startDate/endDate are inclusive calendar days ("YYYY-MM-DD"),
-// while the consumption index's completed_at range is half-open ([startDate,
-// endDate)); bump the upper bound to the start of the following day so the
-// whole endDate day is included.
+// exportTable's startDate/endDate are inclusive calendar days ("YYYY-MM-DD")
+// in the requested timezone, while the consumption index's completed_at
+// range is a half-open range of instants. Resolving bare date strings
+// directly (as UTC midnight) would disagree with the date_histogram
+// aggregations the export rows are built from, which bucket by calendar day
+// in that same timezone — so bounds are resolved to timezone-local instants
+// here too, mirroring exportUsers' membership-window resolution below.
 function buildExportConsumptionScopeQuery(
   auth: Authenticator,
-  { startDate, endDate }: { startDate: string; endDate: string }
+  {
+    startDate,
+    endDate,
+    timezone,
+  }: { startDate: string; endDate: string; timezone: string }
 ): estypes.QueryDslQueryContainer {
-  const exclusiveEndDate = moment
-    .utc(endDate)
+  const startInstant = moment
+    .tz(startDate, timezone)
+    .startOf("day")
+    .toISOString();
+  const exclusiveEndInstant = moment
+    .tz(endDate, timezone)
     .add(1, "day")
-    .format("YYYY-MM-DD");
+    .startOf("day")
+    .toISOString();
 
   return buildConsumptionScopeQuery({
     auth,
-    startDate,
-    endDate: exclusiveEndDate,
+    startDate: startInstant,
+    endDate: exclusiveEndInstant,
   });
 }
 
@@ -288,6 +301,7 @@ async function exportUsageMetrics({
   const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
+    timezone,
   });
 
   const result = await fetchUsageMetricsExportRows(baseQuery, timezone);
@@ -359,6 +373,7 @@ async function exportSource({
   const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
+    timezone,
   });
 
   const result = await fetchContextOriginDailyBreakdown(baseQuery, timezone);
@@ -390,16 +405,19 @@ async function exportAgents({
   auth,
   startDate,
   endDate,
+  timezone,
   includeHiddenAgents,
 }: {
   auth: Authenticator;
   startDate: string;
   endDate: string;
+  timezone: string;
   includeHiddenAgents: boolean;
 }): Promise<Result<ExportTableData, Error>> {
   const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
+    timezone,
   });
 
   const result = await fetchAgentExportRows(
@@ -437,6 +455,7 @@ async function exportUsers({
   const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
+    timezone,
   });
 
   // `startDate` / `endDate` are plain YYYY-MM-DD days. Elasticsearch rounds a
@@ -479,6 +498,7 @@ async function exportSkills({
   const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
+    timezone,
   });
 
   const result = await fetchSkillExportRows(auth, baseQuery, timezone);

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -21,6 +21,7 @@ import {
   fetchSkillExportRows,
   SKILL_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/skills_export";
+import { fetchUsageMetricsExportRows } from "@app/lib/api/analytics/usage_metrics_export";
 import type { UserExportRow } from "@app/lib/api/analytics/users_export";
 import {
   fetchUserExportRows,
@@ -28,7 +29,6 @@ import {
 } from "@app/lib/api/analytics/users_export";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
-import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   fetchAvailableSkills,
   fetchSkillUsageMetrics,
@@ -38,7 +38,6 @@ import {
   fetchToolUsageMetrics,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
@@ -199,7 +198,7 @@ export async function exportTable({
 }): Promise<Result<ExportTableData, Error>> {
   switch (table) {
     case "usage_metrics":
-      return exportUsageMetrics({ startDate, endDate, timezone, owner });
+      return exportUsageMetrics({ auth, startDate, endDate, timezone });
     case "active_users":
       return exportActiveUsers({ startDate, endDate, timezone, owner });
     case "source":
@@ -276,28 +275,22 @@ function buildExportConsumptionScopeQuery(
 }
 
 async function exportUsageMetrics({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
   });
 
-  const result = await fetchMessageMetrics(
-    baseQuery,
-    "day",
-    ["conversations", "activeUsers"] as const,
-    timezone
-  );
+  const result = await fetchUsageMetricsExportRows(baseQuery, timezone);
 
   if (result.isErr()) {
     return new Err(
@@ -305,17 +298,10 @@ async function exportUsageMetrics({
     );
   }
 
-  const rows: UsageMetricsRow[] = result.value.map((point) => ({
-    date: formatDateFromMillis(point.timestamp, timezone),
-    messages: point.count,
-    conversations: point.conversations,
-    activeUsers: point.activeUsers,
-  }));
-
   return new Ok({
     table: "usage_metrics",
     headers: USAGE_METRICS_HEADERS,
-    rows,
+    rows: result.value,
   });
 }
 

--- a/front/lib/api/analytics/usage_metrics_export.ts
+++ b/front/lib/api/analytics/usage_metrics_export.ts
@@ -11,7 +11,7 @@ import {
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
 type UsageMetricsExportBucket = {
@@ -71,7 +71,7 @@ export async function fetchUsageMetricsExportRows(
   });
 
   if (result.isErr()) {
-    return new Err(new Error(result.error.message));
+    return result;
   }
 
   const buckets = bucketsToArray<UsageMetricsExportBucket>(

--- a/front/lib/api/analytics/usage_metrics_export.ts
+++ b/front/lib/api/analytics/usage_metrics_export.ts
@@ -1,0 +1,89 @@
+import {
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CONVERSATION_ID_FIELD,
+  uniqueMessagesCardinalityAgg,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  formatDateFromMillis,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+type UsageMetricsExportBucket = {
+  key: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
+  unique_conversations?: estypes.AggregationsCardinalityAggregate;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type UsageMetricsExportAggs = {
+  by_date?: estypes.AggregationsMultiBucketAggregateBase<UsageMetricsExportBucket>;
+};
+
+export interface UsageMetricsExportRow {
+  date: string;
+  messages: number;
+  conversations: number;
+  activeUsers: number;
+}
+
+export async function fetchUsageMetricsExportRows(
+  baseQuery: estypes.QueryDslQueryContainer,
+  timezone: string
+): Promise<Result<UsageMetricsExportRow[], Error>> {
+  const result = await searchConsumptionAnalytics<
+    never,
+    UsageMetricsExportAggs
+  >(baseQuery, {
+    aggregations: {
+      by_date: {
+        date_histogram: {
+          field: COMPLETED_AT_FIELD,
+          calendar_interval: "day",
+          time_zone: timezone,
+        },
+        aggs: {
+          // Consumption documents are split per LLM step and per tool call, so
+          // a message contributes several documents to the same date bucket:
+          // dedupe by agent_message_id to count distinct messages.
+          unique_messages: uniqueMessagesCardinalityAgg(),
+          unique_conversations: {
+            cardinality: {
+              field: CONVERSATION_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          unique_users: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const buckets = bucketsToArray<UsageMetricsExportBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  return new Ok(
+    buckets.map((bucket) => ({
+      date: formatDateFromMillis(bucket.key, timezone),
+      messages: Math.round(bucket.unique_messages?.value ?? 0),
+      conversations: Math.round(bucket.unique_conversations?.value ?? 0),
+      activeUsers: Math.round(bucket.unique_users?.value ?? 0),
+    }))
+  );
+}


### PR DESCRIPTION
## Description

Same move as [#31087](https://github.com/dust-tt/dust/pull/31087) / [#31095](https://github.com/dust-tt/dust/pull/31095), applied to `usage_metrics`: reads from the consumption ES index now, for both the dedicated export endpoint and the combined export panel.

CSV output unchanged

## Tests

- New `usage_metrics` tests (data source + non-UTC bounds regression) in `export_tables.test.ts`.
- Updated agents/users/skills/source tests for the new instant-based bounds.

## Risk

Low. Panel temporarily sources tables from two different indices, same as prior PRs in this migration.

## Deploy Plan

Standard deploy. Base of a 4-PR stack: usage_metrics → active_users → skill_usage → tool_usage.
