### PR TITLE
[front] use consumption ES index for active_users export

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -18,24 +18,19 @@ vi.mock("@app/lib/api/analytics/usage_metrics_export", async () => ({
   ),
 }));
 
-vi.mock(
-  "@app/lib/api/assistant/observability/active_users_metrics",
-  async () => ({
-    fetchActiveUsersMetrics: vi.fn(
-      async () =>
-        new Ok([
-          {
-            timestamp: 1717200000000,
-            date: "2024-06-01",
-            dau: 5,
-            wau: 10,
-            mau: 20,
-            memberCount: 50,
-          },
-        ])
-    ),
-  })
-);
+vi.mock("@app/lib/api/analytics/active_users_export", async () => ({
+  fetchActiveUsersExportRows: vi.fn(
+    async () =>
+      new Ok([
+        {
+          date: "2024-06-01",
+          dau: 5,
+          wau: 10,
+          mau: 20,
+        },
+      ])
+  ),
+}));
 
 vi.mock(
   "@app/lib/api/assistant/observability/context_origin",

--- a/front-api/routes/w/[wId]/analytics/active-users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users-export.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { fetchActiveUsersExportRows } from "@app/lib/api/analytics/active_users_export";
 import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -20,10 +20,13 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
 
   const { days } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
 
   const { startDate, endDate } = daysToDateRange(days);
-  const result = await fetchActiveUsersMetrics(owner, startDate, endDate);
+  const result = await fetchActiveUsersExportRows(auth, {
+    startDate,
+    endDate,
+    timezone: "UTC",
+  });
 
   if (result.isErr()) {
     return apiError(ctx, {

--- a/front/lib/api/analytics/active_users_export.ts
+++ b/front/lib/api/analytics/active_users_export.ts
@@ -46,14 +46,14 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
  */
 function computeRollingActiveUsers(
   usersByDay: Map<number, Set<string>>,
-  endTimestamp: number,
+  endTimestampMs: number,
   windowDays: number
 ): number {
-  const startMs = endTimestamp - (windowDays - 1) * MS_PER_DAY;
+  const startMs = endTimestampMs - (windowDays - 1) * MS_PER_DAY;
   const uniqueUsers = new Set<string>();
 
   for (const [ts, users] of usersByDay) {
-    if (ts >= startMs && ts <= endTimestamp) {
+    if (ts >= startMs && ts <= endTimestampMs) {
       for (const user of users) {
         uniqueUsers.add(user);
       }
@@ -100,7 +100,7 @@ export async function fetchActiveUsersExportRows(
     .add(1, "day")
     .startOf("day")
     .toISOString();
-  const cutoffTimestamp = moment
+  const cutoffTimestampMs = moment
     .tz(startDate, timezone)
     .startOf("day")
     .valueOf();
@@ -171,16 +171,18 @@ export async function fetchActiveUsersExportRows(
     afterKey = aggregation?.after_key;
   } while (afterKey !== undefined && buckets.length > 0);
 
-  const requestedTimestamps = [...usersByDay.keys()]
-    .filter((ts) => ts >= cutoffTimestamp)
+  const requestedTimestampsMs = [...usersByDay.keys()]
+    .filter((ts) => ts >= cutoffTimestampMs)
     .sort((a, b) => a - b);
 
-  const rows: ActiveUsersExportRow[] = requestedTimestamps.map((timestamp) => ({
-    date: formatDateFromMillis(timestamp, timezone),
-    dau: usersByDay.get(timestamp)?.size ?? 0,
-    wau: computeRollingActiveUsers(usersByDay, timestamp, WAU_WINDOW_DAYS),
-    mau: computeRollingActiveUsers(usersByDay, timestamp, MAU_WINDOW_DAYS),
-  }));
+  const rows: ActiveUsersExportRow[] = requestedTimestampsMs.map(
+    (timestampMs) => ({
+      date: formatDateFromMillis(timestampMs, timezone),
+      dau: usersByDay.get(timestampMs)?.size ?? 0,
+      wau: computeRollingActiveUsers(usersByDay, timestampMs, WAU_WINDOW_DAYS),
+      mau: computeRollingActiveUsers(usersByDay, timestampMs, MAU_WINDOW_DAYS),
+    })
+  );
 
   return new Ok(rows);
 }

--- a/front/lib/api/analytics/active_users_export.ts
+++ b/front/lib/api/analytics/active_users_export.ts
@@ -87,14 +87,19 @@ export async function fetchActiveUsersExportRows(
 ): Promise<Result<ActiveUsersExportRow[], Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
 
-  const extendedStart = moment
+  // Resolved to timezone-local instants, not bare "YYYY-MM-DD" strings:
+  // Elasticsearch parses a bare date as UTC midnight, which would disagree
+  // with the composite aggregation's timezone-local day buckets below.
+  const extendedStartInstant = moment
     .tz(startDate, timezone)
     .subtract(MAU_WINDOW_DAYS - 1, "days")
-    .format("YYYY-MM-DD");
-  const exclusiveEndDate = moment
-    .utc(endDate)
+    .startOf("day")
+    .toISOString();
+  const exclusiveEndInstant = moment
+    .tz(endDate, timezone)
     .add(1, "day")
-    .format("YYYY-MM-DD");
+    .startOf("day")
+    .toISOString();
   const cutoffTimestamp = moment
     .tz(startDate, timezone)
     .startOf("day")
@@ -107,8 +112,8 @@ export async function fetchActiveUsersExportRows(
         {
           range: {
             [COMPLETED_AT_FIELD]: {
-              gte: extendedStart,
-              lt: exclusiveEndDate,
+              gte: extendedStartInstant,
+              lt: exclusiveEndInstant,
             },
           },
         },

--- a/front/lib/api/analytics/active_users_export.ts
+++ b/front/lib/api/analytics/active_users_export.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -154,7 +154,7 @@ export async function fetchActiveUsersExportRows(
     });
 
     if (result.isErr()) {
-      return new Err(new Error(result.error.message));
+      return result;
     }
 
     const aggregation = result.value.aggregations?.by_user_day;

--- a/front/lib/api/analytics/active_users_export.ts
+++ b/front/lib/api/analytics/active_users_export.ts
@@ -1,0 +1,181 @@
+import {
+  COMPLETED_AT_FIELD,
+  CONSUMPTION_DIMENSION_FIELDS,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  formatDateFromMillis,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+import moment from "moment-timezone";
+
+export interface ActiveUsersExportRow {
+  date: string;
+  dau: number;
+  wau: number;
+  mau: number;
+}
+
+interface CompositeKey {
+  day: number;
+  user: string;
+}
+
+interface UserDayBucket {
+  key: CompositeKey;
+  doc_count: number;
+}
+
+interface ActiveUsersExportAggs {
+  by_user_day?: {
+    after_key?: CompositeKey;
+    buckets: UserDayBucket[];
+  };
+}
+
+const WAU_WINDOW_DAYS = 7;
+const MAU_WINDOW_DAYS = 28;
+const COMPOSITE_AGG_SIZE = 10_000;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Computes the count of unique users over a rolling window ending at the given timestamp.
+ */
+function computeRollingActiveUsers(
+  usersByDay: Map<number, Set<string>>,
+  endTimestamp: number,
+  windowDays: number
+): number {
+  const startMs = endTimestamp - (windowDays - 1) * MS_PER_DAY;
+  const uniqueUsers = new Set<string>();
+
+  for (const [ts, users] of usersByDay) {
+    if (ts >= startMs && ts <= endTimestamp) {
+      for (const user of users) {
+        uniqueUsers.add(user);
+      }
+    }
+  }
+
+  return uniqueUsers.size;
+}
+
+/**
+ * Fetches DAU/WAU/MAU metrics for the export's [startDate, endDate] inclusive
+ * calendar-day window from the consumption index.
+ *
+ * Strategy:
+ * 1. Fetch all (day, user id) pairs with a paginated composite aggregation,
+ *    extending the queried range back by the MAU window so the rolling
+ *    windows for the first requested days are complete.
+ * 2. Compute the rolling WAU (7-day) and MAU (28-day) windows in memory.
+ *
+ * Programmatic consumption (triggers, API runs without an attributable
+ * member) carries no `user.id`, so it is naturally excluded from the
+ * composite aggregation's per-day user sets.
+ */
+export async function fetchActiveUsersExportRows(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    timezone,
+  }: { startDate: string; endDate: string; timezone: string }
+): Promise<Result<ActiveUsersExportRow[], Error>> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+
+  const extendedStart = moment
+    .tz(startDate, timezone)
+    .subtract(MAU_WINDOW_DAYS - 1, "days")
+    .format("YYYY-MM-DD");
+  const exclusiveEndDate = moment
+    .utc(endDate)
+    .add(1, "day")
+    .format("YYYY-MM-DD");
+  const cutoffTimestamp = moment
+    .tz(startDate, timezone)
+    .startOf("day")
+    .valueOf();
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        {
+          range: {
+            [COMPLETED_AT_FIELD]: {
+              gte: extendedStart,
+              lt: exclusiveEndDate,
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const usersByDay = new Map<number, Set<string>>();
+  let afterKey: CompositeKey | undefined;
+  let buckets: UserDayBucket[];
+
+  do {
+    const result = await searchConsumptionAnalytics<
+      never,
+      ActiveUsersExportAggs
+    >(query, {
+      aggregations: {
+        by_user_day: {
+          composite: {
+            size: COMPOSITE_AGG_SIZE,
+            sources: [
+              {
+                day: {
+                  date_histogram: {
+                    field: COMPLETED_AT_FIELD,
+                    calendar_interval: "day",
+                    time_zone: timezone,
+                  },
+                },
+              },
+              { user: { terms: { field: CONSUMPTION_DIMENSION_FIELDS.user } } },
+            ],
+            ...(afterKey ? { after: afterKey } : {}),
+          },
+        },
+      },
+      size: 0,
+    });
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const aggregation = result.value.aggregations?.by_user_day;
+    buckets = aggregation?.buckets ?? [];
+    for (const bucket of buckets) {
+      const users = usersByDay.get(bucket.key.day);
+      if (users) {
+        users.add(bucket.key.user);
+      } else {
+        usersByDay.set(bucket.key.day, new Set([bucket.key.user]));
+      }
+    }
+
+    afterKey = aggregation?.after_key;
+  } while (afterKey !== undefined && buckets.length > 0);
+
+  const requestedTimestamps = [...usersByDay.keys()]
+    .filter((ts) => ts >= cutoffTimestamp)
+    .sort((a, b) => a - b);
+
+  const rows: ActiveUsersExportRow[] = requestedTimestamps.map((timestamp) => ({
+    date: formatDateFromMillis(timestamp, timezone),
+    dau: usersByDay.get(timestamp)?.size ?? 0,
+    wau: computeRollingActiveUsers(usersByDay, timestamp, WAU_WINDOW_DAYS),
+    mau: computeRollingActiveUsers(usersByDay, timestamp, MAU_WINDOW_DAYS),
+  }));
+
+  return new Ok(rows);
+}

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -432,6 +432,84 @@ describe("exportTable usage_metrics", () => {
   });
 });
 
+describe("exportTable active_users", () => {
+  beforeEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("queries the consumption index over an MAU-extended half-open completed_at range and computes rolling DAU/WAU/MAU", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const day1 = Date.UTC(2024, 0, 1);
+    const day2 = Date.UTC(2024, 0, 2);
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: {
+          by_user_day: {
+            buckets: [
+              { key: { day: day1, user: "user_1" }, doc_count: 3 },
+              { key: { day: day2, user: "user_1" }, doc_count: 2 },
+              { key: { day: day2, user: "user_2" }, doc_count: 1 },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await exportTable({
+      auth: authenticator,
+      table: "active_users",
+      startDate: "2024-01-01",
+      endDate: "2024-01-02",
+      timezone: "UTC",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    if (result.value.table !== "active_users") {
+      throw new Error(
+        `Expected "active_users" table, got "${result.value.table}"`
+      );
+    }
+
+    // Regression: exportActiveUsers used to build its query against the
+    // legacy timestamp/user_id index. It must now query the consumption
+    // index's completed_at/user.id fields, extending the queried range back
+    // by the MAU window so the rolling windows on the first requested days
+    // are complete, with a half-open upper bound on the inclusive endDate.
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              completed_at: { gte: "2023-12-05", lt: "2024-01-03" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.value.rows).toEqual([
+      { date: "2024-01-01", dau: 1, wau: 1, mau: 1 },
+      { date: "2024-01-02", dau: 2, wau: 2, mau: 2 },
+    ]);
+  });
+});
+
 describe("exportTable source", () => {
   beforeEach(() => {
     vi.mocked(searchConsumptionAnalytics).mockReset();

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -496,7 +496,10 @@ describe("exportTable active_users", () => {
           { term: { workspace_id: workspace.sId } },
           {
             range: {
-              completed_at: { gte: "2023-12-05", lt: "2024-01-03" },
+              completed_at: {
+                gte: "2023-12-05T00:00:00.000Z",
+                lt: "2024-01-03T00:00:00.000Z",
+              },
             },
           },
         ],
@@ -507,6 +510,55 @@ describe("exportTable active_users", () => {
       { date: "2024-01-01", dau: 1, wau: 1, mau: 1 },
       { date: "2024-01-02", dau: 2, wau: 2, mau: 2 },
     ]);
+  });
+
+  it("resolves the completed_at range from timezone-local day boundaries, not UTC", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: { by_user_day: { buckets: [] } },
+      })
+    );
+
+    await exportTable({
+      auth: authenticator,
+      table: "active_users",
+      startDate: "2024-01-01",
+      endDate: "2024-01-02",
+      // UTC-8: local midnight on 2024-01-01 is 2024-01-01T08:00:00.000Z, not
+      // 2024-01-01T00:00:00.000Z. A bare-date range filter is parsed by
+      // Elasticsearch as UTC midnight, which would disagree with the
+      // composite aggregation's timezone-local day buckets and cut off the
+      // first/last local day's early-morning activity.
+      timezone: "America/Los_Angeles",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              completed_at: {
+                gte: "2023-12-05T08:00:00.000Z",
+                lt: "2024-01-03T08:00:00.000Z",
+              },
+            },
+          },
+        ],
+      },
+    });
   });
 });
 

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -1,3 +1,4 @@
+import { fetchActiveUsersExportRows } from "@app/lib/api/analytics/active_users_export";
 import type { AgentExportRow } from "@app/lib/api/analytics/agents_export";
 import {
   AGENT_EXPORT_HEADERS,
@@ -27,7 +28,6 @@ import {
   fetchUserExportRows,
   USER_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/users_export";
-import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import {
   fetchAvailableSkills,
@@ -200,7 +200,7 @@ export async function exportTable({
     case "usage_metrics":
       return exportUsageMetrics({ auth, startDate, endDate, timezone });
     case "active_users":
-      return exportActiveUsers({ startDate, endDate, timezone, owner });
+      return exportActiveUsers({ auth, startDate, endDate, timezone });
     case "source":
       return exportSource({ auth, startDate, endDate, timezone });
     case "agents":
@@ -320,22 +320,21 @@ async function exportUsageMetrics({
 }
 
 async function exportActiveUsers({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const result = await fetchActiveUsersMetrics(
-    owner,
+  const result = await fetchActiveUsersExportRows(auth, {
     startDate,
     endDate,
-    timezone
-  );
+    timezone,
+  });
 
   if (result.isErr()) {
     return new Err(
@@ -345,17 +344,10 @@ async function exportActiveUsers({
     );
   }
 
-  const rows: ActiveUsersRow[] = result.value.map((point) => ({
-    date: point.date,
-    dau: point.dau,
-    wau: point.wau,
-    mau: point.mau,
-  }));
-
   return new Ok({
     table: "active_users",
     headers: ACTIVE_USERS_HEADERS,
-    rows,
+    rows: result.value,
   });
 }
 


### PR DESCRIPTION
## Description

Continues [#31264](https://github.com/dust-tt/dust/pull/31264): `active_users` now reads from the consumption index (`completed_at`/`user.id`) instead of the legacy `timestamp`/`user_id` index.

## Tests

- New `active_users` tests (data source + non-UTC bounds regression).

## Risk

Low, same profile as #31264.

## Deploy Plan

Standard deploy. Stacked on #31264.
