### PR TITLE
[front] use consumption ES index for tool_usage export

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -89,9 +89,8 @@ vi.mock("@app/lib/api/analytics/skill_usage_export", async () => ({
   fetchSkillUsageExportRows: vi.fn(async () => new Ok([])),
 }));
 
-vi.mock("@app/lib/api/assistant/observability/tool_usage", async () => ({
-  fetchAvailableTools: vi.fn(async () => new Ok([])),
-  fetchToolUsageMetrics: vi.fn(async () => new Ok([])),
+vi.mock("@app/lib/api/analytics/tool_usage_export", async () => ({
+  fetchToolUsageExportRows: vi.fn(async () => new Ok([])),
 }));
 
 vi.mock("@app/lib/api/analytics/messages_export", async () => ({

--- a/front-api/routes/w/[wId]/analytics/tool-usage-export.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage-export.ts
@@ -1,10 +1,7 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import {
-  fetchAvailableTools,
-  fetchToolUsageMetrics,
-  resolveToolDisplayNames,
-} from "@app/lib/api/assistant/observability/tool_usage";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { buildDaysConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/period";
+import { fetchToolUsageExportRows } from "@app/lib/api/analytics/tool_usage_export";
+import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
@@ -16,13 +13,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
 
-interface ToolUsageExportRow {
-  date: string;
-  toolName: string;
-  executions: number;
-  uniqueUsers: number;
-}
-
 // Mounted at /api/w/:wId/analytics/tool-usage-export.
 const app = workspaceApp();
 
@@ -31,62 +21,30 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
 
   const { days } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    days,
-  });
 
-  const toolsResult = await fetchAvailableTools(baseQuery);
-  if (toolsResult.isErr()) {
+  const baseQuery = await buildDaysConsumptionScopeQuery(auth, days);
+
+  const result = await fetchToolUsageExportRows(baseQuery, "UTC");
+  if (result.isErr()) {
     return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
-        message: `Failed to retrieve available tools: ${toolsResult.error.message}`,
+        message: `Failed to retrieve tool usage: ${result.error.message}`,
       },
     });
   }
 
-  const tools = await resolveToolDisplayNames(auth, toolsResult.value);
-  const rows: ToolUsageExportRow[] = [];
+  const displayNameByServerName = await resolveServerDisplayNames(
+    auth,
+    result.value.map((row) => row.toolName)
+  );
+  const rows = result.value.map((row) => ({
+    ...row,
+    toolName: displayNameByServerName.get(row.toolName) ?? row.toolName,
+  }));
 
-  for (const tool of tools) {
-    const usageResult = await fetchToolUsageMetrics(baseQuery, tool.serverName);
-    if (usageResult.isErr()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve tool usage for ${tool.serverName}: ${usageResult.error.message}`,
-        },
-      });
-    }
-
-    for (const point of usageResult.value) {
-      rows.push({
-        date: point.date,
-        toolName: tool.displayName,
-        executions: point.executionCount,
-        uniqueUsers: point.uniqueUsers,
-      });
-    }
-  }
-
-  rows.sort((a, b) => {
-    const dateCompare = a.date.localeCompare(b.date);
-    if (dateCompare !== 0) {
-      return dateCompare;
-    }
-    return a.toolName.localeCompare(b.toolName);
-  });
-
-  const headers: (keyof ToolUsageExportRow)[] = [
-    "date",
-    "toolName",
-    "executions",
-    "uniqueUsers",
-  ];
+  const headers = ["date", "toolName", "executions", "uniqueUsers"] as const;
   const csvData = rows.map((row) => headers.map((h) => row[h]));
   const csv = stringify([headers, ...csvData], { header: false });
 

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -708,6 +708,92 @@ describe("exportTable skill_usage", () => {
   });
 });
 
+describe("exportTable tool_usage", () => {
+  beforeEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("queries the consumption index with a half-open completed_at range and returns raw server names", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: {
+          by_tool: {
+            buckets: [
+              {
+                key: "search",
+                doc_count: 5,
+                by_date: {
+                  buckets: [
+                    {
+                      key: Date.UTC(2024, 0, 15),
+                      doc_count: 5,
+                      unique_users: { value: 3 },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await exportTable({
+      auth: authenticator,
+      table: "tool_usage",
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      timezone: "UTC",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    if (result.value.table !== "tool_usage") {
+      throw new Error(
+        `Expected "tool_usage" table, got "${result.value.table}"`
+      );
+    }
+
+    // Regression: exportToolUsage used to build its query with the legacy,
+    // timestamp-based buildAgentAnalyticsBaseQuery, looping once per tool.
+    // It must now query the consumption index with a single
+    // terms+date_histogram aggregation over a half-open [startDate, endDate)
+    // `completed_at` range; doc_count within a (tool, date) bucket is
+    // already the execution count since the consumption index has one
+    // document per tool call invocation.
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.value.rows).toEqual([
+      { date: "2024-01-15", toolName: "search", executions: 5, uniqueUsers: 3 },
+    ]);
+  });
+});
+
 describe("exportTable source", () => {
   beforeEach(() => {
     vi.mocked(searchConsumptionAnalytics).mockReset();

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -781,7 +781,10 @@ describe("exportTable tool_usage", () => {
           { term: { workspace_id: workspace.sId } },
           {
             range: {
-              completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+              completed_at: {
+                gte: "2024-01-01T00:00:00.000Z",
+                lt: "2024-02-01T00:00:00.000Z",
+              },
             },
           },
         ],
@@ -791,6 +794,55 @@ describe("exportTable tool_usage", () => {
     expect(result.value.rows).toEqual([
       { date: "2024-01-15", toolName: "search", executions: 5, uniqueUsers: 3 },
     ]);
+  });
+
+  it("resolves the completed_at range from timezone-local day boundaries, not UTC", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: { by_tool: { buckets: [] } },
+      })
+    );
+
+    await exportTable({
+      auth: authenticator,
+      table: "tool_usage",
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      // UTC-8: local midnight on 2024-01-01 is 2024-01-01T08:00:00.000Z, not
+      // 2024-01-01T00:00:00.000Z. A bare-date range filter is parsed by
+      // Elasticsearch as UTC midnight, which would disagree with the
+      // date_histogram aggregation's timezone-local day buckets and cut off
+      // the first/last local day's early-morning activity.
+      timezone: "America/Los_Angeles",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              completed_at: {
+                gte: "2024-01-01T08:00:00.000Z",
+                lt: "2024-02-01T08:00:00.000Z",
+              },
+            },
+          },
+        ],
+      },
+    });
   });
 });
 

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -23,6 +23,7 @@ import {
   fetchSkillExportRows,
   SKILL_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/skills_export";
+import { fetchToolUsageExportRows } from "@app/lib/api/analytics/tool_usage_export";
 import { fetchUsageMetricsExportRows } from "@app/lib/api/analytics/usage_metrics_export";
 import type { UserExportRow } from "@app/lib/api/analytics/users_export";
 import {
@@ -30,13 +31,7 @@ import {
   USER_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/users_export";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
-import {
-  fetchAvailableTools,
-  fetchToolUsageMetrics,
-} from "@app/lib/api/assistant/observability/tool_usage";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -215,7 +210,7 @@ export async function exportTable({
     case "skill_usage":
       return exportSkillUsage({ auth, startDate, endDate, timezone });
     case "tool_usage":
-      return exportToolUsage({ startDate, endDate, timezone, owner });
+      return exportToolUsage({ auth, startDate, endDate, timezone });
     case "messages":
       return exportMessages({ auth, startDate, endDate, timezone, owner });
     case "feedback":
@@ -538,66 +533,33 @@ async function exportSkillUsage({
 }
 
 async function exportToolUsage({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
   });
 
-  const toolsResult = await fetchAvailableTools(baseQuery);
-  if (toolsResult.isErr()) {
+  const result = await fetchToolUsageExportRows(baseQuery, timezone);
+
+  if (result.isErr()) {
     return new Err(
-      new Error(
-        `Failed to retrieve available tools: ${toolsResult.error.message}`
-      )
+      new Error(`Failed to retrieve tool usage: ${result.error.message}`)
     );
   }
-
-  const nestedRows = await concurrentExecutor(
-    toolsResult.value,
-    async (item) => {
-      const usageResult = await fetchToolUsageMetrics(
-        baseQuery,
-        item.serverName,
-        timezone
-      );
-      if (usageResult.isErr()) {
-        throw new Error(
-          `Failed to retrieve tool usage for ${item.serverName}: ${usageResult.error.message}`
-        );
-      }
-      return usageResult.value.map<ToolUsageRow>((point) => ({
-        date: point.date,
-        toolName: item.serverName,
-        executions: point.executionCount,
-        uniqueUsers: point.uniqueUsers,
-      }));
-    },
-    { concurrency: 8 }
-  );
-
-  const rows = nestedRows.flat().sort((a, b) => {
-    const dateCompare = a.date.localeCompare(b.date);
-    if (dateCompare !== 0) {
-      return dateCompare;
-    }
-    return a.toolName.localeCompare(b.toolName);
-  });
 
   return new Ok({
     table: "tool_usage",
     headers: TOOL_USAGE_HEADERS,
-    rows,
+    rows: result.value,
   });
 }
 

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -546,6 +546,7 @@ async function exportToolUsage({
   const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
+    timezone,
   });
 
   const result = await fetchToolUsageExportRows(baseQuery, timezone);

--- a/front/lib/api/analytics/tool_usage_export.ts
+++ b/front/lib/api/analytics/tool_usage_export.ts
@@ -10,7 +10,7 @@ import {
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
 type ToolDateBucket = {
@@ -82,7 +82,7 @@ export async function fetchToolUsageExportRows(
   );
 
   if (result.isErr()) {
-    return new Err(new Error(result.error.message));
+    return result;
   }
 
   const toolBuckets = bucketsToArray<ToolBucket>(

--- a/front/lib/api/analytics/tool_usage_export.ts
+++ b/front/lib/api/analytics/tool_usage_export.ts
@@ -1,0 +1,114 @@
+import {
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  MAX_EXPORT_TERMS_SIZE,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  formatDateFromMillis,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+type ToolDateBucket = {
+  key: number;
+  doc_count: number;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type ToolBucket = {
+  key: string;
+  doc_count: number;
+  by_date?: estypes.AggregationsMultiBucketAggregateBase<ToolDateBucket>;
+};
+
+type ToolUsageExportAggs = {
+  by_tool?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
+};
+
+export interface ToolUsageExportRow {
+  date: string;
+  // Raw MCP server name; callers that want a display name resolve it
+  // themselves (e.g. via resolveServerDisplayNames).
+  toolName: string;
+  executions: number;
+  uniqueUsers: number;
+}
+
+/**
+ * Tool attribution is a flat field on the consumption index, and each
+ * document is already a single tool call invocation (unlike the old index's
+ * nested `tools_used` array), so a plain terms+date_histogram aggregation is
+ * enough: doc_count within a (tool, date) bucket is the execution count
+ * directly, no unwrap needed.
+ */
+export async function fetchToolUsageExportRows(
+  baseQuery: estypes.QueryDslQueryContainer,
+  timezone: string
+): Promise<Result<ToolUsageExportRow[], Error>> {
+  const result = await searchConsumptionAnalytics<never, ToolUsageExportAggs>(
+    baseQuery,
+    {
+      aggregations: {
+        by_tool: {
+          terms: {
+            field: CONSUMPTION_DIMENSION_FIELDS.tool,
+            size: MAX_EXPORT_TERMS_SIZE,
+          },
+          aggs: {
+            by_date: {
+              date_histogram: {
+                field: COMPLETED_AT_FIELD,
+                calendar_interval: "day",
+                time_zone: timezone,
+              },
+              aggs: {
+                unique_users: {
+                  cardinality: {
+                    field: CONSUMPTION_DIMENSION_FIELDS.user,
+                    precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const toolBuckets = bucketsToArray<ToolBucket>(
+    result.value.aggregations?.by_tool?.buckets
+  );
+
+  const rows: ToolUsageExportRow[] = toolBuckets.flatMap((toolBucket) => {
+    const toolName = String(toolBucket.key);
+    const dateBuckets = bucketsToArray<ToolDateBucket>(
+      toolBucket.by_date?.buckets
+    );
+    return dateBuckets.map((dateBucket) => ({
+      date: formatDateFromMillis(dateBucket.key, timezone),
+      toolName,
+      executions: dateBucket.doc_count,
+      uniqueUsers: Math.round(dateBucket.unique_users?.value ?? 0),
+    }));
+  });
+
+  rows.sort((a, b) => {
+    const dateCompare = a.date.localeCompare(b.date);
+    if (dateCompare !== 0) {
+      return dateCompare;
+    }
+    return a.toolName.localeCompare(b.toolName);
+  });
+
+  return new Ok(rows);
+}


### PR DESCRIPTION
## Description

Completes [#31266](https://github.com/dust-tt/dust/pull/31266): `tool_usage` now reads from the consumption index.

Retires `buildAgentAnalyticsBaseQuery` from `export_tables.ts`, every export table now reads from the consumption index.

## Tests

- New `tool_usage` tests (data source + non-UTC bounds regression).

## Risk

Low, same profile as the earlier PRs. Last table on the old index — panel is fully on the consumption index after this merges.

## Deploy Plan

Standard deploy. Stacked on #31266.
