### PR TITLE
[front] chore: read API key usage from consumption index

### DIFF
--- a/front/lib/api/credits/members_usage.test.ts
+++ b/front/lib/api/credits/members_usage.test.ts
@@ -1,9 +1,20 @@
-import { fetchSeatDataForMembersTable } from "@app/lib/api/credits/members_usage";
+import {
+  fetchConsumedAwuCreditsByApiKeyName,
+  fetchSeatDataForMembersTable,
+} from "@app/lib/api/credits/members_usage";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import {
   buildSeatDataByUserId,
   getCachedSeatDataByUserId,
 } from "@app/lib/metronome/seats";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
 
 vi.mock("@app/lib/metronome/seats", async () => {
   const actual = await vi.importActual<
@@ -14,6 +25,76 @@ vi.mock("@app/lib/metronome/seats", async () => {
     getCachedSeatDataByUserId: vi.fn(),
     buildSeatDataByUserId: vi.fn(),
   };
+});
+
+function esResponse(aggregations: unknown) {
+  return new Ok({ aggregations }) as Awaited<
+    ReturnType<typeof searchConsumptionAnalytics>
+  >;
+}
+
+describe("fetchConsumedAwuCreditsByApiKeyName", () => {
+  afterEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("sums consumption-index microcredits by API key name for the billing cycle", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const cycle = {
+      cycleStart: new Date("2026-08-01T00:00:00.000Z"),
+      cycleEnd: new Date("2026-09-01T00:00:00.000Z"),
+    };
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({
+        by_api_key_name: {
+          buckets: [
+            { key: "Production", credits: { value: 2_000_000 } },
+            { key: "Automation", credits: { value: 3_000_000 } },
+          ],
+        },
+      })
+    );
+
+    const result = await fetchConsumedAwuCreditsByApiKeyName({
+      workspace,
+      apiKeyNames: ["Production", "Automation"],
+      cycle,
+    });
+
+    expect(result).toEqual(
+      new Map([
+        ["Production", 2],
+        ["Automation", 3],
+      ])
+    );
+    expect(searchConsumptionAnalytics).toHaveBeenCalledWith(
+      {
+        bool: {
+          filter: [
+            { term: { workspace_id: workspace.sId } },
+            { terms: { api_key_name: ["Production", "Automation"] } },
+            {
+              range: {
+                completed_at: {
+                  gte: cycle.cycleStart.toISOString(),
+                  lte: cycle.cycleEnd.toISOString(),
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        aggregations: {
+          by_api_key_name: {
+            terms: { field: "api_key_name", size: 2 },
+            aggs: { credits: { sum: { field: "credit_micro" } } },
+          },
+        },
+        size: 0,
+      }
+    );
+  });
 });
 
 // Regression tests for the Metronome 429 storm of 2026-08: a failing cached

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -7,7 +7,11 @@ import {
   makeSpendLimitCycleWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
@@ -463,7 +467,10 @@ export async function fetchConsumedAwuCreditsByApiKeyName({
   }
   const { cycleStart, cycleEnd } = resolvedCycle;
 
-  const result = await searchAnalytics<never, ApiKeyConsumedCreditsAggs>(
+  const result = await searchConsumptionAnalytics<
+    never,
+    ApiKeyConsumedCreditsAggs
+  >(
     {
       bool: {
         filter: [
@@ -471,7 +478,7 @@ export async function fetchConsumedAwuCreditsByApiKeyName({
           { terms: { api_key_name: apiKeyNames } },
           {
             range: {
-              timestamp: {
+              completed_at: {
                 gte: cycleStart.toISOString(),
                 lte: cycleEnd.toISOString(),
               },
@@ -487,7 +494,7 @@ export async function fetchConsumedAwuCreditsByApiKeyName({
             field: "api_key_name",
             size: Math.max(1, apiKeyNames.length),
           },
-          aggs: { credits: { sum: { field: "cost.billable_awu" } } },
+          aggs: { credits: { sum: { field: "credit_micro" } } },
         },
       },
       size: 0,
@@ -507,7 +514,7 @@ export async function fetchConsumedAwuCreditsByApiKeyName({
   )) {
     consumedByApiKeyName.set(
       String(bucket.key),
-      Math.round(bucket.credits?.value ?? 0)
+      Math.round(microCreditsToCredits(bucket.credits?.value ?? 0))
     );
   }
   return consumedByApiKeyName;

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -1,0 +1,258 @@
+/**
+ * Compare per-API-key credit usage between the legacy agent-message analytics index and the
+ * consumption analytics index over an explicit time window.
+ *
+ * This script is read-only. `--execute` only suppresses the standard migration-script dry-run
+ * warning.
+ *
+ *   npx tsx migrations/20260827_compare_api_key_usage_indices.ts \
+ *     --workspaceId <wId> \
+ *     --fromDate 2026-08-01T00:00:00.000Z \
+ *     --toDate 2026-08-27T00:00:00.000Z \
+ *     --execute
+ *
+ * The legacy index is bounded by message creation time (`timestamp`), while the consumption index
+ * is bounded by message completion time (`completed_at`). Messages that cross either boundary can
+ * therefore produce legitimate differences.
+ */
+import {
+  ANALYTICS_ALIAS_NAME,
+  bucketsToArray,
+  CONSUMPTION_ANALYTICS_ALIAS_NAME,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+import type { estypes } from "@elastic/elasticsearch";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const MAX_API_KEY_NAMES = 10_000;
+const TimestampSchema = z.string().datetime({ offset: true });
+
+type ApiKeyCreditsBucket = {
+  key: string;
+  credits?: estypes.AggregationsSumAggregate;
+};
+
+type ApiKeyCreditsTermsAggregate =
+  estypes.AggregationsTermsAggregateBase<ApiKeyCreditsBucket>;
+
+type ApiKeyCreditsAggs = {
+  by_api_key_name?: ApiKeyCreditsTermsAggregate;
+};
+
+function parseTimestamp(value: string, argumentName: string): Date {
+  const result = TimestampSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(
+      `Invalid --${argumentName}: ${fromError(result.error).toString()}`
+    );
+  }
+
+  return new Date(result.data);
+}
+
+function assertCompleteAggregation(
+  aggregation: ApiKeyCreditsTermsAggregate | undefined,
+  indexName: string
+): void {
+  if ((aggregation?.sum_other_doc_count ?? 0) > 0) {
+    throw new Error(
+      `${indexName} contains more than ${MAX_API_KEY_NAMES} API key names for this window; ` +
+        "the comparison would be incomplete."
+    );
+  }
+  if ((aggregation?.doc_count_error_upper_bound ?? 0) > 0) {
+    throw new Error(
+      `${indexName} returned approximate API key buckets; the comparison would be incomplete.`
+    );
+  }
+}
+
+async function fetchCreditsMicroByApiKeyName({
+  creditsField,
+  creditsToMicro,
+  fromDate,
+  indexName,
+  search,
+  timestampField,
+  toDate,
+  workspaceId,
+}: {
+  creditsField: string;
+  creditsToMicro: (credits: number) => number;
+  fromDate: Date;
+  indexName: string;
+  search: typeof searchAnalytics;
+  timestampField: string;
+  toDate: Date;
+  workspaceId: string;
+}): Promise<Map<string, number>> {
+  const result = await search<never, ApiKeyCreditsAggs>(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspaceId } },
+          {
+            range: {
+              [timestampField]: {
+                gte: fromDate.toISOString(),
+                lte: toDate.toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    },
+    {
+      aggregations: {
+        by_api_key_name: {
+          terms: { field: "api_key_name", size: MAX_API_KEY_NAMES },
+          aggs: { credits: { sum: { field: creditsField } } },
+        },
+      },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    throw new Error(`Failed to query ${indexName}: ${result.error.message}`);
+  }
+
+  const aggregation = result.value.aggregations?.by_api_key_name;
+  assertCompleteAggregation(aggregation, indexName);
+  return new Map(
+    bucketsToArray<ApiKeyCreditsBucket>(aggregation?.buckets).map((bucket) => [
+      String(bucket.key),
+      creditsToMicro(bucket.credits?.value ?? 0),
+    ])
+  );
+}
+
+function totalMicroCredits(creditsByApiKeyName: Map<string, number>): number {
+  return [...creditsByApiKeyName.values()].reduce(
+    (total, creditsMicro) => total + creditsMicro,
+    0
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      type: "string",
+      demandOption: true,
+      description: "Workspace sId to compare.",
+    },
+    fromDate: {
+      type: "string",
+      demandOption: true,
+      description: "Inclusive ISO-8601 start timestamp.",
+    },
+    toDate: {
+      type: "string",
+      demandOption: true,
+      description: "Inclusive ISO-8601 end timestamp.",
+    },
+  },
+  async ({ fromDate, toDate, workspaceId }, logger) => {
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+
+    const parsedFromDate = parseTimestamp(fromDate, "fromDate");
+    const parsedToDate = parseTimestamp(toDate, "toDate");
+    if (parsedFromDate >= parsedToDate) {
+      throw new Error("--fromDate must precede --toDate");
+    }
+
+    const [legacyByApiKeyName, consumptionByApiKeyName] = await Promise.all([
+      fetchCreditsMicroByApiKeyName({
+        creditsField: "cost.billable_awu",
+        creditsToMicro: roundCreditsToMicroCredits,
+        fromDate: parsedFromDate,
+        indexName: ANALYTICS_ALIAS_NAME,
+        search: searchAnalytics,
+        timestampField: "timestamp",
+        toDate: parsedToDate,
+        workspaceId: workspace.sId,
+      }),
+      fetchCreditsMicroByApiKeyName({
+        creditsField: "credit_micro",
+        creditsToMicro: Math.round,
+        fromDate: parsedFromDate,
+        indexName: CONSUMPTION_ANALYTICS_ALIAS_NAME,
+        search: searchConsumptionAnalytics,
+        timestampField: "completed_at",
+        toDate: parsedToDate,
+        workspaceId: workspace.sId,
+      }),
+    ]);
+    const apiKeyNames = [
+      ...new Set([
+        ...legacyByApiKeyName.keys(),
+        ...consumptionByApiKeyName.keys(),
+      ]),
+    ].sort();
+
+    const mismatches = apiKeyNames.flatMap((apiKeyName) => {
+      const legacyCreditsMicro = legacyByApiKeyName.get(apiKeyName) ?? 0;
+      const consumptionCreditsMicro =
+        consumptionByApiKeyName.get(apiKeyName) ?? 0;
+
+      return legacyCreditsMicro === consumptionCreditsMicro
+        ? []
+        : [
+            {
+              apiKeyName,
+              legacyCredits: microCreditsToCredits(legacyCreditsMicro),
+              consumptionCredits: microCreditsToCredits(
+                consumptionCreditsMicro
+              ),
+              deltaCredits: microCreditsToCredits(
+                consumptionCreditsMicro - legacyCreditsMicro
+              ),
+            },
+          ];
+    });
+
+    for (const mismatch of mismatches) {
+      logger.warn(mismatch, "API key usage differs between analytics indices");
+    }
+
+    const legacyTotalMicroCredits = totalMicroCredits(legacyByApiKeyName);
+    const consumptionTotalMicroCredits = totalMicroCredits(
+      consumptionByApiKeyName
+    );
+    const summary = {
+      workspaceId: workspace.sId,
+      fromDate: parsedFromDate.toISOString(),
+      toDate: parsedToDate.toISOString(),
+      comparedApiKeyNames: apiKeyNames.length,
+      mismatchedApiKeyNames: mismatches.length,
+      legacyCredits: microCreditsToCredits(legacyTotalMicroCredits),
+      consumptionCredits: microCreditsToCredits(consumptionTotalMicroCredits),
+      deltaCredits: microCreditsToCredits(
+        consumptionTotalMicroCredits - legacyTotalMicroCredits
+      ),
+    };
+
+    if (apiKeyNames.length === 0) {
+      logger.warn(summary, "No API key usage found in either analytics index");
+      return;
+    }
+
+    if (mismatches.length > 0) {
+      logger.error(summary, "API key usage comparison failed");
+      throw new Error(`Found ${mismatches.length} API key usage mismatch(es)`);
+    }
+
+    logger.info(summary, "API key usage matches across analytics indices");
+  }
+);

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -269,7 +269,7 @@ makeScript(
 
     if (mismatches.length > 0) {
       logger.error(summary, "API key usage comparison failed");
-      throw new Error(`Found ${mismatches.length} API key usage mismatch(es)`);
+      return;
     }
 
     logger.info(summary, "API key usage matches across analytics indices");

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -1,20 +1,3 @@
-/**
- * Compare per-API-key credit usage between the legacy agent-message analytics index and the
- * consumption analytics index over an explicit time window.
- *
- * This script is read-only. `--execute` only suppresses the standard migration-script dry-run
- * warning.
- *
- *   npx tsx migrations/20260827_compare_api_key_usage_indices.ts \
- *     --workspaceId <wId> \
- *     --fromDate 2026-08-01T00:00:00.000Z \
- *     --toDate 2026-08-27T00:00:00.000Z \
- *     --execute
- *
- * The legacy index is bounded by message creation time (`timestamp`), while the consumption index
- * is bounded by message completion time (`completed_at`). Messages that cross either boundary can
- * therefore produce legitimate differences.
- */
 import {
   ANALYTICS_ALIAS_NAME,
   bucketsToArray,

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -1,3 +1,4 @@
+import { TOOL_EXECUTION_BLOCKED_STATUSES } from "@app/lib/actions/statuses";
 import {
   ANALYTICS_ALIAS_NAME,
   bucketsToArray,
@@ -9,13 +10,22 @@ import {
   microCreditsToCredits,
   roundCreditsToMicroCredits,
 } from "@app/lib/credits/units";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
+import type { AgentMessageAnalyticsData } from "@app/types/assistant/analytics";
 import type { estypes } from "@elastic/elasticsearch";
+import { Op } from "sequelize";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 const MAX_API_KEY_NAMES = 10_000;
+const MAX_DIAGNOSTIC_SAMPLES = 20;
+const ES_PAGE_SIZE = 1_000;
 const DEFAULT_DAYS = 90;
 const DAY_DURATION_MS = 24 * 60 * 60 * 1000;
 const DaysSchema = z.number().int().positive();
@@ -40,6 +50,14 @@ type ApiKeyCreditsTermsAggregate =
 type ApiKeyCreditsAggs = {
   by_api_key_name?: ApiKeyCreditsTermsAggregate;
 };
+
+type LegacyCreatedDocument = AgentMessageAnalyticsData & {
+  api_key_name?: string;
+};
+
+const BLOCKED_ACTION_STATUSES = new Set<string>(
+  TOOL_EXECUTION_BLOCKED_STATUSES
+);
 
 function parseDays(value: number): number {
   const result = DaysSchema.safeParse(value);
@@ -72,6 +90,65 @@ function totalMicroCredits(creditsByApiKeyName: Map<string, number>): number {
     (total, creditsMicro) => total + creditsMicro,
     0
   );
+}
+
+async function fetchLegacyCreatedDocuments({
+  apiKeyNames,
+  workspaceId,
+  windowEnd,
+  windowStart,
+}: {
+  apiKeyNames: string[];
+  workspaceId: string;
+  windowEnd: Date;
+  windowStart: Date;
+}): Promise<LegacyCreatedDocument[]> {
+  const documents: LegacyCreatedDocument[] = [];
+  let searchAfter: estypes.SortResults | undefined;
+
+  while (true) {
+    const result = await searchAnalytics<LegacyCreatedDocument>(
+      {
+        bool: {
+          filter: [
+            { term: { workspace_id: workspaceId } },
+            { term: { status: "created" } },
+            { terms: { api_key_name: apiKeyNames } },
+            {
+              range: {
+                timestamp: {
+                  gte: windowStart.toISOString(),
+                  lte: windowEnd.toISOString(),
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        size: ES_PAGE_SIZE,
+        sort: [{ timestamp: "asc" }, { message_id: "asc" }],
+        search_after: searchAfter,
+      }
+    );
+    if (result.isErr()) {
+      throw new Error(
+        `Failed to query created documents in ${ANALYTICS_ALIAS_NAME}: ${result.error.message}`
+      );
+    }
+
+    const { hits } = result.value.hits;
+    for (const hit of hits) {
+      if (hit._source) {
+        documents.push(hit._source);
+      }
+    }
+
+    if (hits.length < ES_PAGE_SIZE) {
+      return documents;
+    }
+    searchAfter = hits[hits.length - 1]?.sort;
+  }
 }
 
 makeScript(
@@ -242,6 +319,203 @@ makeScript(
 
     for (const mismatch of mismatches) {
       logger.warn(mismatch, "API key usage differs between analytics indices");
+    }
+
+    const apiKeyNamesWithLegacyCreatedCredits = mismatches.flatMap(
+      ({ apiKeyName, legacyCreditsByStatus }) =>
+        (legacyCreditsByStatus.created ?? 0) > 0 ? [apiKeyName] : []
+    );
+    if (apiKeyNamesWithLegacyCreatedCredits.length > 0) {
+      const legacyCreatedDocuments = await fetchLegacyCreatedDocuments({
+        apiKeyNames: apiKeyNamesWithLegacyCreatedCredits,
+        workspaceId: workspace.sId,
+        windowEnd,
+        windowStart,
+      });
+      const legacyCreatedMessageIds = [
+        ...new Set(legacyCreatedDocuments.map(({ message_id }) => message_id)),
+      ];
+
+      const currentMessageRows = await MessageModel.findAll({
+        attributes: ["sId", "version", "agentMessageId"],
+        where: {
+          sId: { [Op.in]: legacyCreatedMessageIds },
+          workspaceId: workspace.id,
+        },
+        include: [
+          {
+            model: AgentMessageModel,
+            as: "agentMessage",
+            attributes: [
+              "id",
+              "status",
+              "completedAt",
+              "costCredits",
+              "updatedAt",
+            ],
+            required: true,
+          },
+        ],
+      });
+
+      const currentMessageByMessageId = new Map<
+        string,
+        {
+          agentMessageModelId: number;
+          completedAt: Date | null;
+          costCredits: number | null;
+          status: AgentMessageModel["status"];
+          updatedAt: Date;
+          version: number;
+        }
+      >();
+      for (const messageRow of currentMessageRows) {
+        if (messageRow.agentMessage) {
+          currentMessageByMessageId.set(messageRow.sId, {
+            agentMessageModelId: messageRow.agentMessage.id,
+            completedAt: messageRow.agentMessage.completedAt,
+            costCredits: messageRow.agentMessage.costCredits,
+            status: messageRow.agentMessage.status,
+            updatedAt: messageRow.agentMessage.updatedAt,
+            version: messageRow.version,
+          });
+        }
+      }
+
+      const agentMessageModelIds = currentMessageRows.flatMap(
+        ({ agentMessage }) => (agentMessage ? [agentMessage.id] : [])
+      );
+      const actionRows = await AgentMCPActionModel.findAll({
+        attributes: [
+          "agentMessageId",
+          "status",
+          "toolConfiguration",
+          "updatedAt",
+        ],
+        where: {
+          agentMessageId: { [Op.in]: agentMessageModelIds },
+          workspaceId: workspace.id,
+        },
+      });
+      const blockedActionsByAgentMessageModelId = new Map<
+        number,
+        Array<{ status: string; toolName: string; updatedAt: Date }>
+      >();
+      for (const actionRow of actionRows) {
+        if (!BLOCKED_ACTION_STATUSES.has(actionRow.status)) {
+          continue;
+        }
+        const blockedActions =
+          blockedActionsByAgentMessageModelId.get(actionRow.agentMessageId) ??
+          [];
+        blockedActions.push({
+          status: actionRow.status,
+          toolName: actionRow.toolConfiguration.name,
+          updatedAt: actionRow.updatedAt,
+        });
+        blockedActionsByAgentMessageModelId.set(
+          actionRow.agentMessageId,
+          blockedActions
+        );
+      }
+
+      const legacyCreatedDocumentsByApiKeyName = new Map<
+        string,
+        LegacyCreatedDocument[]
+      >();
+      for (const document of legacyCreatedDocuments) {
+        if (!document.api_key_name) {
+          continue;
+        }
+        const documents =
+          legacyCreatedDocumentsByApiKeyName.get(document.api_key_name) ?? [];
+        documents.push(document);
+        legacyCreatedDocumentsByApiKeyName.set(
+          document.api_key_name,
+          documents
+        );
+      }
+
+      for (const apiKeyName of apiKeyNamesWithLegacyCreatedCredits) {
+        const documents =
+          legacyCreatedDocumentsByApiKeyName.get(apiKeyName) ?? [];
+        const legacyMicroCreditsByCurrentState = new Map<string, number>();
+        let legacyCreatedMicroCredits = 0;
+
+        const samples = documents
+          .map((document) => {
+            const legacyMicroCredits = roundCreditsToMicroCredits(
+              document.cost.billable_awu
+            );
+            legacyCreatedMicroCredits += legacyMicroCredits;
+
+            const currentMessage = currentMessageByMessageId.get(
+              document.message_id
+            );
+            const blockedActions = currentMessage
+              ? (blockedActionsByAgentMessageModelId.get(
+                  currentMessage.agentMessageModelId
+                ) ?? [])
+              : [];
+            const blockingState =
+              [...new Set(blockedActions.map(({ status }) => status))]
+                .sort()
+                .join("+") || "no_blocked_action";
+            let currentState = "missing";
+            if (currentMessage) {
+              currentState =
+                currentMessage.status === "created"
+                  ? `created:${blockingState}`
+                  : `terminal:${currentMessage.status}`;
+            }
+            legacyMicroCreditsByCurrentState.set(
+              currentState,
+              (legacyMicroCreditsByCurrentState.get(currentState) ?? 0) +
+                legacyMicroCredits
+            );
+
+            return {
+              messageId: document.message_id,
+              legacyTimestamp: document.timestamp,
+              legacyVersion: document.version,
+              legacyCredits: microCreditsToCredits(legacyMicroCredits),
+              currentState,
+              currentVersion: currentMessage?.version ?? null,
+              currentUpdatedAt: currentMessage?.updatedAt.toISOString() ?? null,
+              currentCompletedAt:
+                currentMessage?.completedAt?.toISOString() ?? null,
+              currentCostCredits: currentMessage?.costCredits ?? null,
+              blockedActions: blockedActions.map(
+                ({ status, toolName, updatedAt }) => ({
+                  status,
+                  toolName,
+                  updatedAt: updatedAt.toISOString(),
+                })
+              ),
+            };
+          })
+          .slice(0, MAX_DIAGNOSTIC_SAMPLES);
+
+        logger.warn(
+          {
+            apiKeyName,
+            legacyCreatedMessageCount: documents.length,
+            legacyCreatedCredits: microCreditsToCredits(
+              legacyCreatedMicroCredits
+            ),
+            legacyCreatedCreditsByCurrentState: Object.fromEntries(
+              [...legacyMicroCreditsByCurrentState.entries()]
+                .sort(([left], [right]) => left.localeCompare(right))
+                .map(([currentState, creditsMicro]) => [
+                  currentState,
+                  microCreditsToCredits(creditsMicro),
+                ])
+            ),
+            samples,
+          },
+          "Diagnosed legacy created API key usage"
+        );
+      }
     }
 
     const legacyTotalMicroCredits = totalMicroCredits(legacyByApiKeyName);

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -16,7 +16,9 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 const MAX_API_KEY_NAMES = 10_000;
-const TimestampSchema = z.string().datetime({ offset: true });
+const DEFAULT_DAYS = 90;
+const DAY_DURATION_MS = 24 * 60 * 60 * 1000;
+const DaysSchema = z.number().int().positive();
 
 type ApiKeyCreditsBucket = {
   key: string;
@@ -30,15 +32,13 @@ type ApiKeyCreditsAggs = {
   by_api_key_name?: ApiKeyCreditsTermsAggregate;
 };
 
-function parseTimestamp(value: string, argumentName: string): Date {
-  const result = TimestampSchema.safeParse(value);
+function parseDays(value: number): number {
+  const result = DaysSchema.safeParse(value);
   if (!result.success) {
-    throw new Error(
-      `Invalid --${argumentName}: ${fromError(result.error).toString()}`
-    );
+    throw new Error(`Invalid --days: ${fromError(result.error).toString()}`);
   }
 
-  return new Date(result.data);
+  return result.data;
 }
 
 function assertCompleteAggregation(
@@ -73,28 +73,23 @@ makeScript(
       demandOption: true,
       description: "Workspace sId to compare.",
     },
-    fromDate: {
-      type: "string",
-      demandOption: true,
-      description: "Inclusive ISO-8601 start timestamp.",
-    },
-    toDate: {
-      type: "string",
-      demandOption: true,
-      description: "Inclusive ISO-8601 end timestamp.",
+    days: {
+      type: "number",
+      default: DEFAULT_DAYS,
+      description: "Number of past days to compare.",
     },
   },
-  async ({ fromDate, toDate, workspaceId }, logger) => {
+  async ({ days, workspaceId }, logger) => {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
     if (!workspace) {
       throw new Error(`Workspace not found: ${workspaceId}`);
     }
 
-    const parsedFromDate = parseTimestamp(fromDate, "fromDate");
-    const parsedToDate = parseTimestamp(toDate, "toDate");
-    if (parsedFromDate >= parsedToDate) {
-      throw new Error("--fromDate must precede --toDate");
-    }
+    const parsedDays = parseDays(days);
+    const windowEnd = new Date();
+    const windowStart = new Date(
+      windowEnd.getTime() - parsedDays * DAY_DURATION_MS
+    );
 
     const [legacyResult, consumptionResult] = await Promise.all([
       searchAnalytics<never, ApiKeyCreditsAggs>(
@@ -105,8 +100,8 @@ makeScript(
               {
                 range: {
                   timestamp: {
-                    gte: parsedFromDate.toISOString(),
-                    lte: parsedToDate.toISOString(),
+                    gte: windowStart.toISOString(),
+                    lte: windowEnd.toISOString(),
                   },
                 },
               },
@@ -131,8 +126,8 @@ makeScript(
               {
                 range: {
                   completed_at: {
-                    gte: parsedFromDate.toISOString(),
-                    lte: parsedToDate.toISOString(),
+                    gte: windowStart.toISOString(),
+                    lte: windowEnd.toISOString(),
                   },
                 },
               },
@@ -222,8 +217,9 @@ makeScript(
     );
     const summary = {
       workspaceId: workspace.sId,
-      fromDate: parsedFromDate.toISOString(),
-      toDate: parsedToDate.toISOString(),
+      days: parsedDays,
+      fromDate: windowStart.toISOString(),
+      toDate: windowEnd.toISOString(),
       comparedApiKeyNames: apiKeyNames.length,
       mismatchedApiKeyNames: mismatches.length,
       legacyCredits: microCreditsToCredits(legacyTotalMicroCredits),

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -75,65 +75,6 @@ function assertCompleteAggregation(
   }
 }
 
-async function fetchCreditsMicroByApiKeyName({
-  creditsField,
-  creditsToMicro,
-  fromDate,
-  indexName,
-  search,
-  timestampField,
-  toDate,
-  workspaceId,
-}: {
-  creditsField: string;
-  creditsToMicro: (credits: number) => number;
-  fromDate: Date;
-  indexName: string;
-  search: typeof searchAnalytics;
-  timestampField: string;
-  toDate: Date;
-  workspaceId: string;
-}): Promise<Map<string, number>> {
-  const result = await search<never, ApiKeyCreditsAggs>(
-    {
-      bool: {
-        filter: [
-          { term: { workspace_id: workspaceId } },
-          {
-            range: {
-              [timestampField]: {
-                gte: fromDate.toISOString(),
-                lte: toDate.toISOString(),
-              },
-            },
-          },
-        ],
-      },
-    },
-    {
-      aggregations: {
-        by_api_key_name: {
-          terms: { field: "api_key_name", size: MAX_API_KEY_NAMES },
-          aggs: { credits: { sum: { field: creditsField } } },
-        },
-      },
-      size: 0,
-    }
-  );
-  if (result.isErr()) {
-    throw new Error(`Failed to query ${indexName}: ${result.error.message}`);
-  }
-
-  const aggregation = result.value.aggregations?.by_api_key_name;
-  assertCompleteAggregation(aggregation, indexName);
-  return new Map(
-    bucketsToArray<ApiKeyCreditsBucket>(aggregation?.buckets).map((bucket) => [
-      String(bucket.key),
-      creditsToMicro(bucket.credits?.value ?? 0),
-    ])
-  );
-}
-
 function totalMicroCredits(creditsByApiKeyName: Map<string, number>): number {
   return [...creditsByApiKeyName.values()].reduce(
     (total, creditsMicro) => total + creditsMicro,
@@ -172,28 +113,94 @@ makeScript(
       throw new Error("--fromDate must precede --toDate");
     }
 
-    const [legacyByApiKeyName, consumptionByApiKeyName] = await Promise.all([
-      fetchCreditsMicroByApiKeyName({
-        creditsField: "cost.billable_awu",
-        creditsToMicro: roundCreditsToMicroCredits,
-        fromDate: parsedFromDate,
-        indexName: ANALYTICS_ALIAS_NAME,
-        search: searchAnalytics,
-        timestampField: "timestamp",
-        toDate: parsedToDate,
-        workspaceId: workspace.sId,
-      }),
-      fetchCreditsMicroByApiKeyName({
-        creditsField: "credit_micro",
-        creditsToMicro: Math.round,
-        fromDate: parsedFromDate,
-        indexName: CONSUMPTION_ANALYTICS_ALIAS_NAME,
-        search: searchConsumptionAnalytics,
-        timestampField: "completed_at",
-        toDate: parsedToDate,
-        workspaceId: workspace.sId,
-      }),
+    const [legacyResult, consumptionResult] = await Promise.all([
+      searchAnalytics<never, ApiKeyCreditsAggs>(
+        {
+          bool: {
+            filter: [
+              { term: { workspace_id: workspace.sId } },
+              {
+                range: {
+                  timestamp: {
+                    gte: parsedFromDate.toISOString(),
+                    lte: parsedToDate.toISOString(),
+                  },
+                },
+              },
+            ],
+          },
+        },
+        {
+          aggregations: {
+            by_api_key_name: {
+              terms: { field: "api_key_name", size: MAX_API_KEY_NAMES },
+              aggs: { credits: { sum: { field: "cost.billable_awu" } } },
+            },
+          },
+          size: 0,
+        }
+      ),
+      searchConsumptionAnalytics<never, ApiKeyCreditsAggs>(
+        {
+          bool: {
+            filter: [
+              { term: { workspace_id: workspace.sId } },
+              {
+                range: {
+                  completed_at: {
+                    gte: parsedFromDate.toISOString(),
+                    lte: parsedToDate.toISOString(),
+                  },
+                },
+              },
+            ],
+          },
+        },
+        {
+          aggregations: {
+            by_api_key_name: {
+              terms: { field: "api_key_name", size: MAX_API_KEY_NAMES },
+              aggs: { credits: { sum: { field: "credit_micro" } } },
+            },
+          },
+          size: 0,
+        }
+      ),
     ]);
+
+    if (legacyResult.isErr()) {
+      throw new Error(
+        `Failed to query ${ANALYTICS_ALIAS_NAME}: ${legacyResult.error.message}`
+      );
+    }
+    if (consumptionResult.isErr()) {
+      throw new Error(
+        `Failed to query ${CONSUMPTION_ANALYTICS_ALIAS_NAME}: ${consumptionResult.error.message}`
+      );
+    }
+
+    const legacyAggregation = legacyResult.value.aggregations?.by_api_key_name;
+    const consumptionAggregation =
+      consumptionResult.value.aggregations?.by_api_key_name;
+    assertCompleteAggregation(legacyAggregation, ANALYTICS_ALIAS_NAME);
+    assertCompleteAggregation(
+      consumptionAggregation,
+      CONSUMPTION_ANALYTICS_ALIAS_NAME
+    );
+
+    const legacyByApiKeyName = new Map(
+      bucketsToArray<ApiKeyCreditsBucket>(legacyAggregation?.buckets).map(
+        (bucket) => [
+          String(bucket.key),
+          roundCreditsToMicroCredits(bucket.credits?.value ?? 0),
+        ]
+      )
+    );
+    const consumptionByApiKeyName = new Map(
+      bucketsToArray<ApiKeyCreditsBucket>(consumptionAggregation?.buckets).map(
+        (bucket) => [String(bucket.key), Math.round(bucket.credits?.value ?? 0)]
+      )
+    );
     const apiKeyNames = [
       ...new Set([
         ...legacyByApiKeyName.keys(),

--- a/front/migrations/20260827_compare_api_key_usage_indices.ts
+++ b/front/migrations/20260827_compare_api_key_usage_indices.ts
@@ -23,7 +23,16 @@ const DaysSchema = z.number().int().positive();
 type ApiKeyCreditsBucket = {
   key: string;
   credits?: estypes.AggregationsSumAggregate;
+  by_status?: StatusCreditsTermsAggregate;
 };
+
+type StatusCreditsBucket = {
+  key: string;
+  credits?: estypes.AggregationsSumAggregate;
+};
+
+type StatusCreditsTermsAggregate =
+  estypes.AggregationsTermsAggregateBase<StatusCreditsBucket>;
 
 type ApiKeyCreditsTermsAggregate =
   estypes.AggregationsTermsAggregateBase<ApiKeyCreditsBucket>;
@@ -112,7 +121,15 @@ makeScript(
           aggregations: {
             by_api_key_name: {
               terms: { field: "api_key_name", size: MAX_API_KEY_NAMES },
-              aggs: { credits: { sum: { field: "cost.billable_awu" } } },
+              aggs: {
+                credits: { sum: { field: "cost.billable_awu" } },
+                by_status: {
+                  terms: { field: "status", size: 10 },
+                  aggs: {
+                    credits: { sum: { field: "cost.billable_awu" } },
+                  },
+                },
+              },
             },
           },
           size: 0,
@@ -166,13 +183,27 @@ makeScript(
       CONSUMPTION_ANALYTICS_ALIAS_NAME
     );
 
+    const legacyBuckets = bucketsToArray<ApiKeyCreditsBucket>(
+      legacyAggregation?.buckets
+    );
     const legacyByApiKeyName = new Map(
-      bucketsToArray<ApiKeyCreditsBucket>(legacyAggregation?.buckets).map(
-        (bucket) => [
-          String(bucket.key),
-          roundCreditsToMicroCredits(bucket.credits?.value ?? 0),
-        ]
-      )
+      legacyBuckets.map((bucket) => [
+        String(bucket.key),
+        roundCreditsToMicroCredits(bucket.credits?.value ?? 0),
+      ])
+    );
+    const legacyCreditsByStatusByApiKeyName = new Map(
+      legacyBuckets.map((bucket) => [
+        String(bucket.key),
+        Object.fromEntries(
+          bucketsToArray<StatusCreditsBucket>(bucket.by_status?.buckets).map(
+            (statusBucket) => [
+              String(statusBucket.key),
+              statusBucket.credits?.value ?? 0,
+            ]
+          )
+        ),
+      ])
     );
     const consumptionByApiKeyName = new Map(
       bucketsToArray<ApiKeyCreditsBucket>(consumptionAggregation?.buckets).map(
@@ -197,6 +228,8 @@ makeScript(
             {
               apiKeyName,
               legacyCredits: microCreditsToCredits(legacyCreditsMicro),
+              legacyCreditsByStatus:
+                legacyCreditsByStatusByApiKeyName.get(apiKeyName) ?? {},
               consumptionCredits: microCreditsToCredits(
                 consumptionCreditsMicro
               ),


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/10185.

API key spend-cap usage still reads from the `front.agent_message_analytics` ES index.

This moves the per-key billing-cycle aggregation to `front.agent_message_consumption_analytics` instead, which will become the source of truth for billing at some point (planned to deprecate the other index).

This PR also adds a script to check out the differences before merging.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Run script.
- Deploy front.
