### PR TITLE
Shrink agent-details button in agent picker

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -158,7 +158,7 @@ export function AgentPicker({
                       <Button
                         icon={DotsHorizontal}
                         variant="outline"
-                        size="mini"
+                        size="xmini"
                         className="opacity-0 group-hover:opacity-100"
                         onClick={(e) => {
                           e.stopPropagation();


### PR DESCRIPTION
## Summary
- Reduce the "..." (agent details) button in the agent picker dropdown from `sm` to `xs`.

## Test plan
- [ ] Visual check: open the agent picker, hover a row, confirm the "..." button is smaller and still clickable.