### PR TITLE
feat(workspace-analytics): add a billed-credits ranking tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2610,6 +2610,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "get_top_entities_by_credits": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "get_top_models": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -3456,6 +3460,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_source_breakdown": "never_ask",
     "get_top_agent_tags": "never_ask",
     "get_top_agents": "never_ask",
+    "get_top_entities_by_credits": "never_ask",
     "get_top_models": "never_ask",
     "get_top_skills": "never_ask",
     "get_top_tools": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1128,6 +1128,21 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "break down credit spending by agent",
     expected: "workspace_analytics.get_credit_usage",
+    // get_top_entities_by_credits is the tool that replaces this one, so it
+    // legitimately competes. Drop back to rank 1 once this one is gone.
+    maxRank: 2,
+  },
+  {
+    query: "which agents cost the most credits this month",
+    expected: "workspace_analytics.get_top_entities_by_credits",
+  },
+  {
+    query: "which conversations were the most expensive",
+    expected: "workspace_analytics.get_top_entities_by_credits",
+  },
+  {
+    query: "attribute credit spend to our API keys",
+    expected: "workspace_analytics.get_top_entities_by_credits",
   },
   {
     query: "show the credit spending trend over the last 30 days",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1128,9 +1128,6 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "break down credit spending by agent",
     expected: "workspace_analytics.get_credit_usage",
-    // get_top_entities_by_credits is the tool that replaces this one, so it
-    // legitimately competes. Drop back to rank 1 once this one is gone.
-    maxRank: 2,
   },
   {
     query: "which agents cost the most credits this month",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -11,6 +11,9 @@ import {
 import { CONSUMPTION_TOP_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
+export const GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME =
+  "get_top_entities_by_credits" as const;
+
 const topListSchema = (entityPlural: string) => ({
   ...timeWindowSchemaShape,
   ...usageFilterSchema,
@@ -122,14 +125,7 @@ const getUsageTimeseriesSchema = {
 const getTopEntitiesByCreditsSchema = {
   dimension: z
     .enum(CONSUMPTION_TOP_DIMENSIONS)
-    .describe(
-      "What to rank: 'agent', 'user', 'model', 'source' (where the traffic " +
-        "came in from), 'api_key', 'group' (a member group), 'tag' (an agent " +
-        "tag), 'tool', 'skill' or 'conversation'. Rows overlap and do not add " +
-        "up to the workspace total for 'model', 'skill', 'tag' and 'group', " +
-        "nor for 'tool' (tool credits exclude the surrounding model work); " +
-        "'user' and 'api_key' have no row for consumption with nobody behind it."
-    ),
+    .describe("What to group results by."),
   ...timeWindowSchemaShape,
   ...consumptionFilterSchema,
   limit: z
@@ -354,19 +350,13 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     freeUsage: true,
   },
   {
-    name: "get_top_entities_by_credits",
+    name: GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME,
     description:
-      "Rank what costs the most credits over a time window (defaults to the " +
-      "current calendar month): the most expensive agents, members, models, " +
-      "skills, tools, sources, API keys, member groups, agent tags or " +
-      "conversations. Each row carries its credits, its average credits per " +
-      "message, and how many messages or tool calls it covers. These are the " +
-      "rankings the workspace Analytics page shows, over billed credits, so " +
-      "the figures match the Usage page exactly. Use this to break credit " +
-      "spending down by agent, user or model, and for any spend, cost or " +
-      "expense question — where the budget goes, which agent is most " +
-      "expensive, which integration burns credits. Prefer it over " +
-      "get_credit_usage, whose figures are estimates. Admin-only.",
+      "Rank the workspace's credit consumption by entity " +
+      "over a time window (defaults to the current calendar month). Use " +
+      "this to answer 'which agent is most expensive', or to attribute " +
+      "credit spend by API key, tag, or model. Figures are billed " +
+      "credits. Rows may overlap, so don't sum them for a workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -374,7 +364,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       done: "Retrieved top consumers",
     },
     toolCostCategory: "basic",
-    freeUsage: false,
+    freeUsage: true,
   },
 ] as const;
 

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -1,5 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  consumptionFilterSchema,
   DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
   MAX_CREDIT_GROUPS,
@@ -7,6 +8,7 @@ import {
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { CONSUMPTION_TOP_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
 const topListSchema = (entityPlural: string) => ({
@@ -117,6 +119,31 @@ const getUsageTimeseriesSchema = {
     ),
 };
 
+const getTopEntitiesByCreditsSchema = {
+  dimension: z
+    .enum(CONSUMPTION_TOP_DIMENSIONS)
+    .describe(
+      "What to rank: 'agent', 'user', 'model', 'source' (where the traffic " +
+        "came in from), 'api_key', 'group' (a member group), 'tag' (an agent " +
+        "tag), 'tool', 'skill' or 'conversation'. Rows overlap and do not add " +
+        "up to the workspace total for 'model', 'skill', 'tag' and 'group', " +
+        "nor for 'tool' (tool credits exclude the surrounding model work); " +
+        "'user' and 'api_key' have no row for consumption with nobody behind it."
+    ),
+  ...timeWindowSchemaShape,
+  ...consumptionFilterSchema,
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_RESULTS)
+    .optional()
+    .describe(
+      `Maximum number of rows to return ` +
+        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
+    ),
+};
+
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_top_agents",
@@ -214,7 +241,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "Return the workspace's most-used skills over a time window (defaults " +
       "to the current calendar month), ranked by execution count. Optionally " +
       "filter by source (context_origin), agent, user, tag, or model. Use this " +
-      "to answer which skills are used most. Admin-only.",
+      "to answer which skills are executed or used most. Admin-only.",
     schema: getTopSkillsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -325,6 +352,29 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     },
     toolCostCategory: "basic",
     freeUsage: true,
+  },
+  {
+    name: "get_top_entities_by_credits",
+    description:
+      "Rank what costs the most credits over a time window (defaults to the " +
+      "current calendar month): the most expensive agents, members, models, " +
+      "skills, tools, sources, API keys, member groups, agent tags or " +
+      "conversations. Each row carries its credits, its average credits per " +
+      "message, and how many messages or tool calls it covers. These are the " +
+      "rankings the workspace Analytics page shows, over billed credits, so " +
+      "the figures match the Usage page exactly. Use this to break credit " +
+      "spending down by agent, user or model, and for any spend, cost or " +
+      "expense question — where the budget goes, which agent is most " +
+      "expensive, which integration burns credits. Prefer it over " +
+      "get_credit_usage, whose figures are estimates. Admin-only.",
+    schema: getTopEntitiesByCreditsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top consumers",
+      done: "Retrieved top consumers",
+    },
+    toolCostCategory: "basic",
+    freeUsage: false,
   },
 ] as const;
 

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -1,11 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import { AGENT_TAG_IDS_FIELD } from "@app/lib/api/analytics/consumption/scope";
 import { isValidTimezone, timezoneSchema } from "@app/lib/api/timezone";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 import { z } from "zod";
 
@@ -100,17 +98,14 @@ export const usageFilterSchema = {
 };
 
 // Filters for the consumption-index tools. Every key narrows the same scope the
-// workspace Analytics page filters on, so any value a ranking returns can be fed
-// straight back in. The legacy `usageFilterSchema` above stays until the tools
-// still reading the old index are gone.
+// workspace Analytics page filters on. The legacy `usageFilterSchema` above stays
+// until the tools still reading the old index are gone.
 export const consumptionFilterSchema = {
   sources: z
     .array(z.string())
     .optional()
     .describe(
-      "Restrict to these message origins — where a message came in from. Many " +
-        "origins exist (channels, integrations, triggers, and more); do not " +
-        "assume a fixed short list, take the values from a 'source' ranking."
+      "Restrict to these message origins (e.g. 'web', 'slack', 'api')."
     ),
   agentIds: z
     .array(z.string())
@@ -123,41 +118,30 @@ export const consumptionFilterSchema = {
   agentTagIds: z
     .array(z.string())
     .optional()
-    .describe(
-      "Restrict to agents carrying any of these agent tag sIds, as returned " +
-        "by a 'tag' ranking."
-    ),
+    .describe("Restrict to agents carrying any of these agent tag sIds."),
   modelIds: z
     .array(z.string())
     .optional()
     .describe(
       "Restrict to these models, identified by their model id (e.g. " +
-        "'claude-sonnet-4-5'), as returned by a 'model' ranking."
+        "'claude-sonnet-4-5')."
     ),
   apiKeyNames: z
     .array(z.string())
     .optional()
-    .describe(
-      "Restrict to these API key names, as returned by an 'api_key' ranking."
-    ),
+    .describe("Restrict to these API key names."),
   groupIds: z
     .array(z.string())
     .optional()
-    .describe(
-      "Restrict to members of these group sIds, as returned by a 'group' ranking."
-    ),
+    .describe("Restrict to members of these group sIds."),
   toolNames: z
     .array(z.string())
     .optional()
-    .describe(
-      "Restrict to these MCP server names, as returned by a 'tool' ranking."
-    ),
+    .describe("Restrict to these MCP server names."),
   skillIds: z
     .array(z.string())
     .optional()
-    .describe(
-      "Restrict to these skill sIds, as returned by a 'skill' ranking."
-    ),
+    .describe("Restrict to these skill sIds."),
 };
 
 const consumptionFilterInputSchema = z.object(consumptionFilterSchema);
@@ -168,17 +152,12 @@ export type ConsumptionFilterInput = z.input<
 
 export type ConsumptionScope = {
   filter: ConsumptionScopeFilter;
-  extraFilters: estypes.QueryDslQueryContainer[];
+  agentTagIds: string[];
 };
 
-// Agent tags are the one input with no filter key: a document carries its
-// agent's tags but no dimension is defined over them, so they go through as a
-// raw clause.
 export function toConsumptionScope(
   input: ConsumptionFilterInput
 ): ConsumptionScope {
-  const agentTagIds = input.agentTagIds?.filter((id) => id.length > 0) ?? [];
-
   return {
     filter: {
       sources: input.sources,
@@ -190,10 +169,7 @@ export function toConsumptionScope(
       tools: input.toolNames,
       skills: input.skillIds,
     },
-    extraFilters:
-      agentTagIds.length > 0
-        ? [{ terms: { [AGENT_TAG_IDS_FIELD]: agentTagIds } }]
-        : [],
+    agentTagIds: input.agentTagIds ?? [],
   };
 }
 

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -1,7 +1,11 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { AGENT_TAG_IDS_FIELD } from "@app/lib/api/analytics/consumption/scope";
 import { isValidTimezone, timezoneSchema } from "@app/lib/api/timezone";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 import { z } from "zod";
 
@@ -94,6 +98,116 @@ export const usageFilterSchema = {
         "model id (e.g. 'claude-sonnet-4-5'), as returned by get_top_models."
     ),
 };
+
+// Filters for the consumption-index tools. Every key narrows the same scope the
+// workspace Analytics page filters on, so any value a ranking returns can be fed
+// straight back in. The legacy `usageFilterSchema` above stays until the tools
+// still reading the old index are gone.
+export const consumptionFilterSchema = {
+  sources: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to these message origins — where a message came in from. Many " +
+        "origins exist (channels, integrations, triggers, and more); do not " +
+        "assume a fixed short list, take the values from a 'source' ranking."
+    ),
+  agentIds: z
+    .array(z.string())
+    .optional()
+    .describe("Restrict to these agent sIds."),
+  userIds: z
+    .array(z.string())
+    .optional()
+    .describe("Restrict to these user sIds."),
+  agentTagIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to agents carrying any of these agent tag sIds, as returned " +
+        "by a 'tag' ranking."
+    ),
+  modelIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to these models, identified by their model id (e.g. " +
+        "'claude-sonnet-4-5'), as returned by a 'model' ranking."
+    ),
+  apiKeyNames: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to these API key names, as returned by an 'api_key' ranking."
+    ),
+  groupIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to members of these group sIds, as returned by a 'group' ranking."
+    ),
+  toolNames: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to these MCP server names, as returned by a 'tool' ranking."
+    ),
+  skillIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to these skill sIds, as returned by a 'skill' ranking."
+    ),
+};
+
+const consumptionFilterInputSchema = z.object(consumptionFilterSchema);
+
+export type ConsumptionFilterInput = z.input<
+  typeof consumptionFilterInputSchema
+>;
+
+export type ConsumptionScope = {
+  filter: ConsumptionScopeFilter;
+  extraFilters: estypes.QueryDslQueryContainer[];
+};
+
+// Agent tags are the one input with no filter key: a document carries its
+// agent's tags but no dimension is defined over them, so they go through as a
+// raw clause.
+export function toConsumptionScope(
+  input: ConsumptionFilterInput
+): ConsumptionScope {
+  const agentTagIds = input.agentTagIds?.filter((id) => id.length > 0) ?? [];
+
+  return {
+    filter: {
+      sources: input.sources,
+      agents: input.agentIds,
+      users: input.userIds,
+      models: input.modelIds,
+      api_keys: input.apiKeyNames,
+      groups: input.groupIds,
+      tools: input.toolNames,
+      skills: input.skillIds,
+    },
+    extraFilters:
+      agentTagIds.length > 0
+        ? [{ terms: { [AGENT_TAG_IDS_FIELD]: agentTagIds } }]
+        : [],
+  };
+}
+
+// `resolveTimeWindow` reports an inclusive end instant, because the legacy index
+// is queried with `lte`. The consumption index uses a half-open range, so its
+// bound is the following millisecond. Goes away with the last legacy tool.
+export function toConsumptionPeriod(
+  window: ResolvedTimeWindow
+): ConsumptionPeriod {
+  return {
+    startDate: window.startDate,
+    endDate: new Date(new Date(window.endDate).getTime() + 1).toISOString(),
+  };
+}
 
 type TimeWindowInput = z.input<typeof timeWindowInputSchema>;
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -35,6 +35,7 @@ describe("workspace_analytics tools", () => {
     "get_credit_usage",
     "get_credit_timeseries",
     "get_usage_timeseries",
+    "get_top_entities_by_credits",
   ])("%s refuses callers below manager", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -11,7 +11,14 @@ import {
   DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
   resolveTimeWindow,
+  toConsumptionPeriod,
+  toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
+import {
+  fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
+} from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
   fetchContextOriginBreakdown,
@@ -41,6 +48,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import moment from "moment-timezone";
 
 function scopedBaseQuery(
@@ -973,6 +981,73 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       default:
         return assertNever(selectedMetric);
     }
+  },
+  get_top_entities_by_credits: async (
+    { dimension, limit, ...input },
+    { auth }
+  ) => {
+    const denied = workspaceManagerGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow(input);
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+    const { filter, extraFilters } = toConsumptionScope(input);
+
+    const result = await fetchConsumptionTopGroups(auth, {
+      dimension,
+      period: toConsumptionPeriod(window.value),
+      limit: limit ?? DEFAULT_RESULTS,
+      filter,
+      extraFilters,
+      // A single window has no vs-previous column to fill, and the lookup is a
+      // second round trip.
+      includePreviousCredits: false,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to rank ${dimension} by credits: ${result.error.message}`
+        )
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+    const { groups, totalCredits } = result.value;
+
+    if (groups.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No ${dimension} consumption recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
+    const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
+    const lines = rows.map(
+      (row, index) =>
+        `${index + 1}. ${row.name} [${row.key}] — ` +
+        `${row.credits.toFixed(2)} credits, ` +
+        `${row.count} ${unit}${pluralize(row.count)} ` +
+        `(${row.avgCredits.toFixed(4)} per ${unit})`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Top ${dimension} by credits for ${label} (${tz}), most expensive ` +
+          `first:\n${lines.join("\n")}\n\n` +
+          `Credits over the whole window, every row included: ` +
+          `${totalCredits.toFixed(2)}.`,
+      },
+    ]);
   },
 };
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -134,9 +134,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -203,9 +203,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -272,9 +272,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -341,9 +341,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -399,9 +399,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_agent_details: async ({ agentId }, { auth }) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const agents = await getAgentConfigurations(auth, {
@@ -470,9 +470,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -537,9 +537,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -611,9 +611,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -681,9 +681,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow({ period, startDate, endDate, timezone });
@@ -764,9 +764,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow(
@@ -900,9 +900,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow(
@@ -986,23 +986,23 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     { dimension, limit, ...input },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
 
     const window = resolveTimeWindow(input);
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
-    const { filter, extraFilters } = toConsumptionScope(input);
+    const { filter, agentTagIds } = toConsumptionScope(input);
 
     const result = await fetchConsumptionTopGroups(auth, {
       dimension,
       period: toConsumptionPeriod(window.value),
       limit: limit ?? DEFAULT_RESULTS,
       filter,
-      extraFilters,
+      agentTagIds,
       // A single window has no vs-previous column to fill, and the lookup is a
       // second round trip.
       includePreviousCredits: false,

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -3,7 +3,7 @@ import { fetchConsumptionFacets } from "@app/lib/api/analytics/consumption/facet
 import type { DimensionLabel } from "@app/lib/api/analytics/consumption/labels";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
+import type { ConsumptionTopDimension } from "@app/lib/api/analytics/consumption/scope";
 import {
   ElasticsearchError,
   searchConsumptionAnalytics,
@@ -459,7 +459,7 @@ describe("fetchConsumptionFacets", () => {
         });
       }
     );
-    const labels: Partial<Record<ConsumptionScopeDimension, DimensionLabel>> = {
+    const labels: Partial<Record<ConsumptionTopDimension, DimensionLabel>> = {
       agent: {
         name: "Used agent",
         pictureUrl: "https://example.com/agent.png",

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -13,6 +13,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TagFactory } from "@app/tests/utils/TagFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { getTierForModel } from "@app/types/assistant/models/model_tiers";
@@ -94,6 +95,31 @@ describe("resolveDimensionDisplayNames", () => {
   it("returns nothing for an empty breakdown", async () => {
     expect(await resolveDimensionDisplayNames(auth, "agent", [])).toEqual(
       new Map()
+    );
+  });
+
+  it("names agent tags from their tag names", async () => {
+    const workspace = auth.getNonNullableWorkspace();
+    const tag = await TagFactory.create(workspace, { name: "Support" });
+
+    const names = await resolveDimensionDisplayNames(auth, "tag", [tag.sId]);
+
+    expect(names.get(tag.sId)).toBe("Support");
+  });
+
+  it("falls back to the key for a tag or conversation it cannot read", async () => {
+    const tags = await resolveDimensionDisplayNames(auth, "tag", [
+      "deleted_tag",
+    ]);
+    const conversations = await resolveDimensionDisplayNames(
+      auth,
+      "conversation",
+      ["deleted_conversation"]
+    );
+
+    expect(tags.get("deleted_tag")).toBe("deleted_tag");
+    expect(conversations.get("deleted_conversation")).toBe(
+      "deleted_conversation"
     );
   });
 });

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -3,10 +3,12 @@ import {
   resolveDimensionDisplayNames,
   resolveDimensionLabels,
 } from "@app/lib/api/analytics/consumption/labels";
+import { resolveConsumptionGroupLabels } from "@app/lib/api/analytics/consumption/top";
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -107,20 +109,22 @@ describe("resolveDimensionDisplayNames", () => {
     expect(names.get(tag.sId)).toBe("Support");
   });
 
-  it("falls back to the key for a tag or conversation it cannot read", async () => {
+  it("falls back to the key for an unresolvable tag", async () => {
     const tags = await resolveDimensionDisplayNames(auth, "tag", [
       "deleted_tag",
     ]);
+
+    expect(tags.get("deleted_tag")).toBe("deleted_tag");
+  });
+
+  it("drops a conversation it cannot resolve, rather than falling back to the key", async () => {
     const conversations = await resolveDimensionDisplayNames(
       auth,
       "conversation",
       ["deleted_conversation"]
     );
 
-    expect(tags.get("deleted_tag")).toBe("deleted_tag");
-    expect(conversations.get("deleted_conversation")).toBe(
-      "deleted_conversation"
-    );
+    expect(conversations.has("deleted_conversation")).toBe(false);
   });
 });
 
@@ -279,5 +283,60 @@ describe("resolveDimensionLabels", () => {
       description: null,
       icon: server.icon,
     });
+  });
+});
+
+describe("resolveConsumptionGroupLabels and private conversations", () => {
+  it("omits a private conversation's id and credits from a workspace-manager ranking", async () => {
+    const { authenticator: ownerAuth, workspace } = await createResourceTest({
+      role: "user",
+    });
+
+    const manager = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, manager, { role: "manager" });
+    const managerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      manager.sId,
+      workspace.sId
+    );
+
+    const privateSpace = await SpaceFactory.regular(workspace);
+    const privateConversation = await ConversationFactory.create(ownerAuth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+    });
+    await ConversationFactory.setRequestedSpaceIdsForTest(
+      privateConversation.id,
+      workspace.id,
+      [privateSpace.id]
+    );
+
+    const readableConversation = await ConversationFactory.create(ownerAuth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+    });
+
+    const rows = await resolveConsumptionGroupLabels(
+      managerAuth,
+      "conversation",
+      [
+        {
+          key: privateConversation.sId,
+          credits: 12,
+          count: 3,
+          previousCredits: null,
+        },
+        {
+          key: readableConversation.sId,
+          credits: 4,
+          count: 1,
+          previousCredits: null,
+        },
+      ]
+    );
+
+    expect(rows.map((row) => row.key)).toEqual([readableConversation.sId]);
+    expect(rows.some((row) => row.name === privateConversation.sId)).toBe(
+      false
+    );
   });
 });

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -1,14 +1,17 @@
-import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
+import type { ConsumptionTopDimension } from "@app/lib/api/analytics/consumption/scope";
 import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
@@ -30,6 +33,8 @@ import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
  * - "tool": MCP server names
  * - "skill": skill sIds
  * - "source": origin slugs
+ * - "conversation": conversation sIds
+ * - "tag": agent tag sIds
  */
 
 export type DimensionLabel = {
@@ -62,7 +67,7 @@ function labelsFromNames(
 
 export async function resolveDimensionLabels(
   auth: Authenticator,
-  dimension: ConsumptionScopeDimension,
+  dimension: ConsumptionTopDimension,
   keys: string[]
 ): Promise<Map<string, DimensionLabel>> {
   if (keys.length === 0) {
@@ -188,6 +193,35 @@ export async function resolveDimensionLabels(
         new Map(keys.map((key) => [key, sourceLabelForOrigin(key) ?? key]))
       );
 
+    case "conversation": {
+      // Deleted conversations still hold consumption, so keep them and let the
+      // key stand in for a title we can no longer read.
+      const conversations = await ConversationResource.fetchByIds(auth, keys, {
+        includeDeleted: true,
+      });
+      const titlesById = new Map(
+        conversations.map((conversation) => [
+          conversation.sId,
+          getConversationDisplayTitle({
+            created: conversation.createdAt.getTime(),
+            forkingData: conversation.forkingData,
+            title: conversation.title,
+          }),
+        ])
+      );
+      return labelsFromNames(
+        new Map(keys.map((key) => [key, titlesById.get(key) ?? key]))
+      );
+    }
+
+    case "tag": {
+      const tags = await TagResource.fetchByIds(auth, keys);
+      const namesById = new Map(tags.map((tag) => [tag.sId, tag.name]));
+      return labelsFromNames(
+        new Map(keys.map((key) => [key, namesById.get(key) ?? key]))
+      );
+    }
+
     default:
       assertNever(dimension);
   }
@@ -195,7 +229,7 @@ export async function resolveDimensionLabels(
 
 export async function resolveDimensionDisplayNames(
   auth: Authenticator,
-  dimension: ConsumptionScopeDimension,
+  dimension: ConsumptionTopDimension,
   groupKeys: string[]
 ): Promise<Map<string, string>> {
   const labels = await resolveDimensionLabels(auth, dimension, groupKeys);

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -19,6 +19,7 @@ import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
+import capitalize from "lodash/capitalize";
 
 /**
  * Resolve display names / labels (and pictureUrl where applicable)
@@ -194,8 +195,6 @@ export async function resolveDimensionLabels(
       );
 
     case "conversation": {
-      // Deleted conversations still hold consumption, so keep them and let the
-      // key stand in for a title we can no longer read.
       const conversations = await ConversationResource.fetchByIds(auth, keys, {
         includeDeleted: true,
       });
@@ -209,9 +208,7 @@ export async function resolveDimensionLabels(
           }),
         ])
       );
-      return labelsFromNames(
-        new Map(keys.map((key) => [key, titlesById.get(key) ?? key]))
-      );
+      return labelsFromNames(titlesById);
     }
 
     case "tag": {
@@ -221,6 +218,11 @@ export async function resolveDimensionLabels(
         new Map(keys.map((key) => [key, namesById.get(key) ?? key]))
       );
     }
+
+    case "reasoning_effort":
+      return labelsFromNames(
+        new Map(keys.map((key) => [key, capitalize(key)]))
+      );
 
     default:
       assertNever(dimension);

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -54,10 +54,18 @@ export function uniqueMessagesCardinalityAgg(): estypes.AggregationsAggregationC
   };
 }
 
+// The scope dimensions plus the two that can be ranked but not filtered on, and
+// are therefore not scope dimensions: conversation, and the agent tag a
+// document inherits from the agent that produced it.
+export const CONSUMPTION_TOP_DIMENSIONS = [
+  ...CONSUMPTION_SCOPE_DIMENSIONS,
+  "conversation",
+  "tag",
+  "reasoning_effort",
+] as const;
+
 export type ConsumptionTopDimension =
-  | ConsumptionScopeDimension
-  | "conversation"
-  | "reasoning_effort";
+  (typeof CONSUMPTION_TOP_DIMENSIONS)[number];
 
 export const CONSUMPTION_DIMENSION_FIELDS: Record<
   ConsumptionScopeDimension,
@@ -75,12 +83,16 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
   source: "normalized_origin",
 };
 
+export const AGENT_TAG_IDS_FIELD = "agent.tag_ids";
+
 export const CONSUMPTION_TOP_DIMENSION_FIELDS: Record<
   ConsumptionTopDimension,
   string
 > = {
   ...CONSUMPTION_DIMENSION_FIELDS,
   conversation: CONVERSATION_ID_FIELD,
+  // Multi-valued: an agent can carry several tags at once.
+  tag: AGENT_TAG_IDS_FIELD,
   reasoning_effort: "model.reasoning_effort",
 };
 
@@ -106,8 +118,19 @@ export const CONSUMPTION_TOP_DIMENSION_UNIT: Record<
 > = {
   ...CONSUMPTION_DIMENSION_UNIT,
   conversation: "message",
+  tag: "message",
   reasoning_effort: "message",
 };
+
+// Conversation and tag can be ranked but carry no filter key, so anything keyed
+// by scope dimension — filters, facets — has to narrow first.
+export function isConsumptionScopeDimension(
+  dimension: ConsumptionTopDimension
+): dimension is ConsumptionScopeDimension {
+  return CONSUMPTION_SCOPE_DIMENSIONS.some(
+    (scopeDimension) => scopeDimension === dimension
+  );
+}
 
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -122,16 +122,6 @@ export const CONSUMPTION_TOP_DIMENSION_UNIT: Record<
   reasoning_effort: "message",
 };
 
-// Conversation and tag can be ranked but carry no filter key, so anything keyed
-// by scope dimension — filters, facets — has to narrow first.
-export function isConsumptionScopeDimension(
-  dimension: ConsumptionTopDimension
-): dimension is ConsumptionScopeDimension {
-  return CONSUMPTION_SCOPE_DIMENSIONS.some(
-    (scopeDimension) => scopeDimension === dimension
-  );
-}
-
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 
 export type ConsumptionMetric = (typeof CONSUMPTION_METRICS)[number];
@@ -190,6 +180,12 @@ function termFilter(
       ? { term: { [field]: nonEmpty[0] } }
       : { terms: { [field]: nonEmpty } },
   ];
+}
+
+export function agentTagIdsFilter(
+  agentTagIds: string[]
+): estypes.QueryDslQueryContainer[] {
+  return termFilter(AGENT_TAG_IDS_FIELD, agentTagIds);
 }
 
 /**

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,6 +1,7 @@
 import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets } from "@app/lib/api/analytics/consumption/top";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
 import { fetchConsumptionTopConversations } from "@app/lib/api/analytics/consumption/top_conversations";
@@ -871,5 +872,46 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       order: { credit_micro: "asc" },
     });
+  });
+});
+
+// The two options the analytics tools rely on and the page never sets.
+describe("fetchConsumptionTopGroups options", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips the previous-period search when the caller opts out", async () => {
+    const { auth } = await setup();
+    mockAggs({
+      buckets: [{ key: "a", credit_micro: { value: 1 } }],
+      totalMicro: 1,
+    });
+
+    await fetchConsumptionTopGroupBuckets(auth, {
+      dimension: "agent",
+      period: PERIOD,
+      limit: 5,
+      includePreviousCredits: false,
+    });
+
+    expect(vi.mocked(searchConsumptionAnalytics)).toHaveBeenCalledTimes(1);
+  });
+
+  it("scopes on extraFilters the filter keys do not cover", async () => {
+    const { auth } = await setup();
+    mockAggs({ buckets: [], totalMicro: 0 });
+    const tagClause = { terms: { "agent.tag_ids": ["tag_1"] } };
+
+    await fetchConsumptionTopGroupBuckets(auth, {
+      dimension: "agent",
+      period: PERIOD,
+      limit: 5,
+      extraFilters: [tagClause],
+      includePreviousCredits: false,
+    });
+
+    const [query] = lastSearchCall();
+    expect(query.bool?.filter).toContainEqual(tagClause);
   });
 });

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,7 +1,10 @@
 import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets } from "@app/lib/api/analytics/consumption/top";
+import {
+  fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets,
+  resolveConsumptionGroupLabels,
+} from "@app/lib/api/analytics/consumption/top";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
 import { fetchConsumptionTopConversations } from "@app/lib/api/analytics/consumption/top_conversations";
@@ -898,20 +901,58 @@ describe("fetchConsumptionTopGroups options", () => {
     expect(vi.mocked(searchConsumptionAnalytics)).toHaveBeenCalledTimes(1);
   });
 
-  it("scopes on extraFilters the filter keys do not cover", async () => {
+  it("scopes on agentTagIds, which no filter key covers", async () => {
     const { auth } = await setup();
     mockAggs({ buckets: [], totalMicro: 0 });
-    const tagClause = { terms: { "agent.tag_ids": ["tag_1"] } };
 
     await fetchConsumptionTopGroupBuckets(auth, {
       dimension: "agent",
       period: PERIOD,
       limit: 5,
-      extraFilters: [tagClause],
+      agentTagIds: ["tag_1"],
       includePreviousCredits: false,
     });
 
     const [query] = lastSearchCall();
-    expect(query.bool?.filter).toContainEqual(tagClause);
+    expect(query.bool?.filter).toContainEqual({
+      term: { "agent.tag_ids": "tag_1" },
+    });
+  });
+});
+
+describe("resolveConsumptionGroupLabels", () => {
+  it("drops a conversation row resolveDimensionLabels omitted, rather than falling back to its id", async () => {
+    const { auth } = await setup();
+    mockLabels({ readable_conversation: "Readable" });
+
+    const rows = await resolveConsumptionGroupLabels(auth, "conversation", [
+      {
+        key: "private_conversation",
+        credits: 12,
+        count: 3,
+        previousCredits: null,
+      },
+      {
+        key: "readable_conversation",
+        credits: 4,
+        count: 1,
+        previousCredits: null,
+      },
+    ]);
+
+    expect(rows.map((row) => row.key)).toEqual(["readable_conversation"]);
+  });
+
+  it("falls back to the raw key for every other dimension", async () => {
+    const { auth } = await setup();
+    mockLabels({});
+
+    const rows = await resolveConsumptionGroupLabels(auth, "model", [
+      { key: "deleted-model", credits: 4, count: 1, previousCredits: null },
+    ]);
+
+    expect(rows).toEqual([
+      expect.objectContaining({ key: "deleted-model", name: "deleted-model" }),
+    ]);
   });
 });

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -3,7 +3,6 @@ import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/label
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
-  ConsumptionScopeDimension,
   ConsumptionScopeFilter,
   ConsumptionTopDimension,
   ConsumptionTopSortOrder,
@@ -17,6 +16,7 @@ import {
   CONSUMPTION_TOP_DIMENSION_FIELDS,
   CONSUMPTION_TOP_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
+  isConsumptionScopeDimension,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -152,7 +152,7 @@ async function resolveConsumptionTopSearchFilter(
     search?: string;
   }
 ): Promise<estypes.QueryDslQueryContainer | null> {
-  if (dimension === "conversation") {
+  if (!isConsumptionScopeDimension(dimension)) {
     return null;
   }
 
@@ -245,11 +245,13 @@ async function fetchConsumptionPreviousCredits(
     dimension,
     previousPeriod,
     filter,
+    extraFilters,
     keys,
   }: {
     dimension: ConsumptionTopDimension;
     previousPeriod: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
+    extraFilters?: estypes.QueryDslQueryContainer[];
     keys: string[];
   }
 ): Promise<Result<Map<string, number>, ElasticsearchError>> {
@@ -262,6 +264,7 @@ async function fetchConsumptionPreviousCredits(
     startDate: previousPeriod.startDate,
     endDate: previousPeriod.endDate,
     filter,
+    extraFilters,
   });
 
   const result = await searchConsumptionAnalytics<never, PreviousCreditsAggs>(
@@ -312,7 +315,9 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    extraFilters,
     sortOrder = "desc",
+    includePreviousCredits = true,
   }: {
     dimension: ConsumptionTopDimension;
     period: ConsumptionPeriod;
@@ -320,7 +325,9 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    extraFilters?: estypes.QueryDslQueryContainer[];
     sortOrder?: ConsumptionTopSortOrder;
+    includePreviousCredits?: boolean;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const searchFilter = await resolveConsumptionTopSearchFilter(auth, {
@@ -333,6 +340,7 @@ export async function fetchConsumptionTopGroups(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
+    extraFilters,
   });
 
   const requestedBucketCount = offset + limit;
@@ -395,7 +403,8 @@ export async function fetchConsumptionTopGroups(
     dimension,
     previousPeriod: previousConsumptionPeriod(period),
     filter,
-    keys: pagedGroups.map((group) => group.key),
+    extraFilters,
+    keys: includePreviousCredits ? pagedGroups.map((group) => group.key) : [],
   });
   // The prior-period lookup only feeds the vs-prev display column: a failure
   // there should not take down the current-period ranking, which already
@@ -451,7 +460,7 @@ export type ResolvedConsumptionGroup = {
 
 export async function resolveConsumptionGroupLabels(
   auth: Authenticator,
-  dimension: ConsumptionScopeDimension,
+  dimension: ConsumptionTopDimension,
   groups: ConsumptionTopGroup[]
 ): Promise<ResolvedConsumptionGroup[]> {
   const labels = await resolveDimensionLabels(

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -10,13 +10,13 @@ import type {
 } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
+  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_TOP_DIMENSION_FIELDS,
   CONSUMPTION_TOP_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
-  isConsumptionScopeDimension,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -152,7 +152,7 @@ async function resolveConsumptionTopSearchFilter(
     search?: string;
   }
 ): Promise<estypes.QueryDslQueryContainer | null> {
-  if (!isConsumptionScopeDimension(dimension)) {
+  if (dimension === "conversation" || dimension === "tag") {
     return null;
   }
 
@@ -245,13 +245,13 @@ async function fetchConsumptionPreviousCredits(
     dimension,
     previousPeriod,
     filter,
-    extraFilters,
+    agentTagIds,
     keys,
   }: {
     dimension: ConsumptionTopDimension;
     previousPeriod: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
-    extraFilters?: estypes.QueryDslQueryContainer[];
+    agentTagIds?: string[];
     keys: string[];
   }
 ): Promise<Result<Map<string, number>, ElasticsearchError>> {
@@ -264,7 +264,7 @@ async function fetchConsumptionPreviousCredits(
     startDate: previousPeriod.startDate,
     endDate: previousPeriod.endDate,
     filter,
-    extraFilters,
+    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const result = await searchConsumptionAnalytics<never, PreviousCreditsAggs>(
@@ -315,7 +315,7 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
-    extraFilters,
+    agentTagIds,
     sortOrder = "desc",
     includePreviousCredits = true,
   }: {
@@ -325,7 +325,7 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    extraFilters?: estypes.QueryDslQueryContainer[];
+    agentTagIds?: string[];
     sortOrder?: ConsumptionTopSortOrder;
     includePreviousCredits?: boolean;
   }
@@ -340,7 +340,7 @@ export async function fetchConsumptionTopGroups(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters,
+    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const requestedBucketCount = offset + limit;
@@ -403,7 +403,7 @@ export async function fetchConsumptionTopGroups(
     dimension,
     previousPeriod: previousConsumptionPeriod(period),
     filter,
-    extraFilters,
+    agentTagIds,
     keys: includePreviousCredits ? pagedGroups.map((group) => group.key) : [],
   });
   // The prior-period lookup only feeds the vs-prev display column: a failure
@@ -469,7 +469,12 @@ export async function resolveConsumptionGroupLabels(
     groups.map((group) => group.key)
   );
 
-  return groups.map((group) => ({
+  const visibleGroups =
+    dimension === "conversation"
+      ? groups.filter((group) => labels.has(group.key))
+      : groups;
+
+  return visibleGroups.map((group) => ({
     key: group.key,
     name: labels.get(group.key)?.name ?? group.key,
     pictureUrl: labels.get(group.key)?.pictureUrl ?? null,

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -37,9 +37,10 @@ export const workspaceAnalyticsSkill = {
     "- Never build a trend by calling a snapshot tool (get_credit_usage, " +
     "get_top_*) once per day or in parallel per period — it is slower and " +
     "unnecessary, the timeseries tools already bucket over time.\n" +
-    "- Use get_credit_usage for a single window's total credits or to " +
-    "attribute spend to the top agents, users or models, not for per-day " +
-    "trends.\n" +
+    "- To attribute spend — which agents, users, models, tools, skills, " +
+    "sources, API keys, groups, tags or conversations cost the most — call " +
+    "get_top_entities_by_credits with that dimension. Use get_credit_usage " +
+    "only for a single window's total credits.\n" +
     "- For a credit trend split by agent, user or model (e.g. 'how did each " +
     "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
     "call returns the top groups plus an 'other' series. Do not make one " +
@@ -54,15 +55,12 @@ export const workspaceAnalyticsSkill = {
     `${GET_SKILL_DETAILS_TOOL_NAME} to inspect a single one.\n` +
     `- Listing the agents other members have not published is admin-only, so ` +
     `fall back to the default view if it reports an authorization error.\n` +
-    "- Chart timeseries results so the admin can see the trend.\n" +
-    "- Credit figures are estimates; when reporting them, tell the admin they " +
-    "are approximate and point to the workspace Usage page for exact billed " +
-    "amounts.",
+    "- Chart timeseries results so the admin can see the trend.",
   mcpServers: [
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 5,
+  version: 6,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -187,6 +187,17 @@ export class ConversationFactory {
     );
   }
 
+  static async setRequestedSpaceIdsForTest(
+    conversationId: ModelId,
+    workspaceId: ModelId,
+    requestedSpaceIds: ModelId[]
+  ): Promise<void> {
+    await ConversationModel.update(
+      { requestedSpaceIds },
+      { where: { id: conversationId, workspaceId } }
+    );
+  }
+
   static async setUpdatedAtForTest(
     auth: Authenticator,
     conversationId: ModelId,


### PR DESCRIPTION
## Description

`front.agent_message_analytics` is being deleted, so `@analyst` has to move onto the consumption index. This is the base of that stack, and the first thing the workspace Analytics page can answer that `@analyst` cannot: `get_top_entities_by_credits` ranks any dimension by billed credits, taking the dimension as a parameter.

It is a thin adapter over `fetchConsumptionTopGroups` — the same call the page's nine `consumption/top_*.ts` wrappers each make with a different `dimension`. Three things it needs that the page never did, all three called from the new handler:

- `extraFilters` passthrough, so `agentTagIds` can scope on `agent.tag_ids`, which no filter key covers.
- `includePreviousCredits`, off here: a single window has no vs-previous column to fill, and the lookup is a second round trip.
- A `tag` top dimension over `agent.tag_ids`, already in the mapping — no index change. Like `conversation` it can be ranked but not filtered on, so `isConsumptionScopeDimension` narrows before anything keyed by scope dimension. `resolveDimensionLabels` grows a `tag` and a `conversation` case so every dimension the tool ranks resolves in one place.

`consumptionFilterSchema` is separate from the legacy `usageFilterSchema` rather than shared: the old tools take a singular `source` over `context_origin`, this one takes `sources` over `normalized_origin`, so every value a ranking returns is directly usable as a filter. The legacy one goes away with the last legacy tool, and so does `toConsumptionPeriod`, which converts the inclusive end instant those tools query with `lte` into the half-open bound consumption uses.

Nothing is removed. `get_credit_usage` still answers a window's total; the skill instructions send attribution here instead.

## Tests

Unit tests + Tested locally :

- Which agents cost the most credits this month ?	
- Which conversations were the most expensive?
- Rank our agent tags by credits
- Which API keys spend the most
- Which models cost the most for agents tagged

## Risk

Low. The new options default to today's behaviour and the page is untouched.

## Deploy Plan

Standard deploy. Base of a 4-PR stack: credits ranking → count rankings → overview → timeseries, each replacing its legacy tools as it lands.
