### PR TITLE
[front] chore: enforce tracking known areas and actions

### DIFF
--- a/front/components/model_picker/modelPickerTracking.test.ts
+++ b/front/components/model_picker/modelPickerTracking.test.ts
@@ -31,14 +31,14 @@ const COMMON_EXTRA = {
 };
 
 describe("modelPickerTracking", () => {
-  it("emits assistant:model_picker:exposure with the shared properties", () => {
+  it("emits assistant:model_picker:view with the shared properties", () => {
     trackModelPickerExposure(BASE);
 
     expect(trackEventMock).toHaveBeenCalledTimes(1);
     expect(trackEventMock).toHaveBeenCalledWith({
       area: "assistant",
       object: "model_picker",
-      action: "exposure",
+      action: "view",
       extra: COMMON_EXTRA,
     });
   });

--- a/front/components/model_picker/modelPickerTracking.ts
+++ b/front/components/model_picker/modelPickerTracking.ts
@@ -1,7 +1,11 @@
 import type { SelectionDisplay } from "@app/components/model_picker/modelPickerUtils";
 import type { ClientType } from "@app/lib/context/clientType";
 import type { TrackingExtra } from "@app/lib/tracking";
-import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 
 // PostHog instrumentation for the model picker. All events share the
@@ -73,7 +77,7 @@ export function trackModelPickerExposure(base: ModelPickerBaseProps): void {
   trackEvent({
     area: TRACKING_AREAS.ASSISTANT,
     object: TRACKING_OBJECT,
-    action: "exposure",
+    action: TRACKING_ACTIONS.VIEW,
     extra: baseExtra(base),
   });
 }
@@ -83,7 +87,7 @@ export function trackModelPickerOpen(base: ModelPickerBaseProps): void {
   trackEvent({
     area: TRACKING_AREAS.ASSISTANT,
     object: TRACKING_OBJECT,
-    action: "open",
+    action: TRACKING_ACTIONS.OPEN,
     extra: baseExtra(base),
   });
 }
@@ -101,7 +105,7 @@ export function trackModelPickerSelect({
   trackEvent({
     area: TRACKING_AREAS.ASSISTANT,
     object: TRACKING_OBJECT,
-    action: "select",
+    action: TRACKING_ACTIONS.SELECT,
     extra: {
       ...baseExtra(base),
       trigger,

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -286,16 +286,6 @@ export const AddConnectionMenu = ({
           },
         });
         onCreated(createdManagedDataSource.dataSource);
-        // Track data source creation with ID
-        trackEvent({
-          area: TRACKING_AREAS.DATA_SOURCES,
-          object: "create",
-          action: "success",
-          extra: {
-            data_source_id: createdManagedDataSource.dataSource.sId,
-            provider: provider,
-          },
-        });
       } else {
         const error = await res.json();
         const errorMessage =

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -82,9 +82,9 @@ export type TrackingAction =
 export type TrackingExtra = Record<string, string | number | boolean>;
 
 interface TrackEventParams {
-  area: TrackingArea | string;
+  area: TrackingArea;
   object: string;
-  action?: TrackingAction | string;
+  action?: TrackingAction;
   extra?: TrackingExtra;
 }
 

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -127,7 +127,7 @@ export function trackEvent({
  * <Button onClick={withTracking(TRACKING_AREAS.DATA, "select", handleClick, { id: "123" })} />
  */
 export function withTracking<T extends Element = HTMLElement>(
-  area: TrackingArea | string,
+  area: TrackingArea,
   object: string,
   handler?: (e: React.MouseEvent<T>) => void | Promise<void>,
   extra?: TrackingExtra


### PR DESCRIPTION
## Description

We can currently pass any string as a tracking area or action.
This can lead to an inconsistent naming in the events.

This PR enforces passing known values from `TRACKING_AREAS` and `TRACKING_ACTIONS`.

Also renames the event `assistant:model_picker:exposure` into `assistant:model_picker:view` for the sake of uniformization and removes the `data_sources:create:success` event (duplicate with `data_sources:connection:create`).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
