### PR TITLE
[front] read feedback export from Postgres instead of Elasticsearch

### DIFF
--- a/front/lib/api/analytics/feedback_export.test.ts
+++ b/front/lib/api/analytics/feedback_export.test.ts
@@ -1,0 +1,100 @@
+import { fetchFeedbackExportRows } from "@app/lib/api/analytics/feedback_export";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ModelId } from "@app/types/shared/model_id";
+import moment from "moment-timezone";
+import { describe, expect, it, vi } from "vitest";
+
+// fetchAgentMetadata reads from the read replica; in tests there is no
+// replica so point it at the primary test connection.
+vi.mock("@app/lib/resources/storage", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/resources/storage")>();
+  return {
+    ...actual,
+    getFrontReplicaDbConnection: () => actual.frontSequelize,
+  };
+});
+
+describe("fetchFeedbackExportRows", () => {
+  it("reads feedback from Postgres, resolving agent name, user sId/email, and the conversation URL", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "builder",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv.id as ModelId,
+      rank: 0,
+      agentConfigurationId: agent.sId,
+    });
+
+    const feedback = await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv.id as ModelId,
+      agentMessageId: messageRow.agentMessageId!,
+      userId: user.id,
+      thumbDirection: "up",
+      content: "Great answer",
+      isConversationShared: true,
+      dismissed: false,
+    });
+
+    const today = moment.utc();
+    const result = await fetchFeedbackExportRows({
+      owner: workspace,
+      startDate: today.clone().subtract(1, "day").format("YYYY-MM-DD"),
+      endDate: today.clone().add(1, "day").format("YYYY-MM-DD"),
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]).toEqual({
+      feedbackId: feedback.sId,
+      createdAt: moment(feedback.createdAt).utc().format("YYYY-MM-DD HH:mm:ss"),
+      assistantId: agent.sId,
+      assistantName: "Test Agent",
+      conversationUrl: expect.stringContaining(conv.sId),
+      userId: user.sId,
+      userEmail: user.email ?? "",
+      thumb: "up",
+      content: "Great answer",
+      dismissed: "false",
+    });
+  });
+
+  it("returns an empty array when there is no feedback in the requested window", async () => {
+    const { workspace } = await createResourceTest({ role: "builder" });
+
+    const result = await fetchFeedbackExportRows({
+      owner: workspace,
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toEqual([]);
+  });
+});

--- a/front/lib/api/analytics/feedback_export.test.ts
+++ b/front/lib/api/analytics/feedback_export.test.ts
@@ -1,20 +1,36 @@
 import { fetchFeedbackExportRows } from "@app/lib/api/analytics/feedback_export";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import type { ModelId } from "@app/types/shared/model_id";
 import moment from "moment-timezone";
 import { describe, expect, it, vi } from "vitest";
 
-// fetchAgentMetadata reads from the read replica; in tests there is no
-// replica so point it at the primary test connection.
+// fetchAgentMetadata and fetchFeedbackExportRows read from the read replica;
+// in tests there is no replica, so point them at the primary test connection.
+// `.transaction()` is stubbed to reuse the per-test transaction bound by
+// vite.setup.ts instead of opening a genuinely separate one: a real second
+// transaction would run on its own connection and, under normal Postgres
+// isolation, would never see the still-uncommitted fixtures the test just
+// created.
 vi.mock("@app/lib/resources/storage", async (importActual) => {
   const actual =
     await importActual<typeof import("@app/lib/resources/storage")>();
   return {
     ...actual,
-    getFrontReplicaDbConnection: () => actual.frontSequelize,
+    getFrontReplicaDbConnection: () =>
+      new Proxy(actual.frontSequelize, {
+        get(target, prop, receiver) {
+          if (prop === "transaction") {
+            return (callback: (transaction: unknown) => unknown) =>
+              callback(getNamespace("test-namespace")?.get("transaction"));
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      }),
   };
 });
 
@@ -96,5 +112,118 @@ describe("fetchFeedbackExportRows", () => {
       throw result.error;
     }
     expect(result.value).toEqual([]);
+  });
+
+  it("includes feedback created exactly at the start-of-day boundary", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "builder",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv.id as ModelId,
+      rank: 0,
+      agentConfigurationId: agent.sId,
+    });
+
+    const startDate = moment.utc().format("YYYY-MM-DD");
+    const startOfDay = moment.utc(startDate, "YYYY-MM-DD").startOf("day");
+
+    const feedback = await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv.id as ModelId,
+      agentMessageId: messageRow.agentMessageId!,
+      userId: user.id,
+      thumbDirection: "up",
+      content: "Right at midnight",
+      isConversationShared: true,
+      dismissed: false,
+      createdAt: startOfDay.toDate(),
+    });
+
+    const result = await fetchFeedbackExportRows({
+      owner: workspace,
+      startDate,
+      endDate: startDate,
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.map((r) => r.feedbackId)).toContain(feedback.sId);
+  });
+
+  it("keeps the row with an empty user fallback when the feedback author was deleted", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "builder",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv.id as ModelId,
+      rank: 0,
+      agentConfigurationId: agent.sId,
+    });
+
+    const feedback = await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv.id as ModelId,
+      agentMessageId: messageRow.agentMessageId!,
+      userId: user.id,
+      thumbDirection: "up",
+      content: "Author gets deleted",
+      isConversationShared: true,
+      dismissed: false,
+    });
+
+    // Simulate the ON DELETE SET NULL that fires when the author's user row
+    // is deleted: the model's TS type doesn't allow a null userId (it
+    // predates the SET NULL constraint), so go through raw SQL instead.
+    // biome-ignore lint/plugin/noRawSql: simulating a DB-level FK nullification not representable via the typed model API.
+    await frontSequelize.query(
+      'UPDATE "agent_message_feedbacks" SET "userId" = NULL WHERE id = :id',
+      { replacements: { id: feedback.id } }
+    );
+
+    const today = moment.utc();
+    const result = await fetchFeedbackExportRows({
+      owner: workspace,
+      startDate: today.clone().subtract(1, "day").format("YYYY-MM-DD"),
+      endDate: today.clone().add(1, "day").format("YYYY-MM-DD"),
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const row = result.value.find((r) => r.feedbackId === feedback.sId);
+    expect(row).toBeDefined();
+    expect(row?.userId).toEqual("");
+    expect(row?.userEmail).toEqual("");
   });
 });

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -1,29 +1,12 @@
-import {
-  fetchAgentMetadata,
-  fetchFeedbackContents,
-  fetchUserEmails,
-} from "@app/lib/api/analytics/enrichment";
+import { fetchAgentMetadata } from "@app/lib/api/analytics/enrichment";
 import config from "@app/lib/api/config";
-import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
-import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
-
-const PAGE_SIZE = 10000;
-
-interface FeedbackAgentMessageDocument extends ElasticsearchBaseDocument {
-  message_id: string;
-  conversation_id: string;
-  agent_id: string;
-  timestamp: string;
-  feedbacks: AgentMessageAnalyticsFeedback[];
-}
 
 export interface FeedbackExportRow {
   feedbackId: string;
@@ -51,41 +34,11 @@ export const FEEDBACK_EXPORT_HEADERS: (keyof FeedbackExportRow)[] = [
   "dismissed",
 ];
 
-async function fetchAllFeedbackDocuments(
-  query: estypes.QueryDslQueryContainer
-): Promise<Result<FeedbackAgentMessageDocument[], Error>> {
-  const allDocs: FeedbackAgentMessageDocument[] = [];
-  let searchAfter: estypes.SortResults | undefined;
-
-  while (true) {
-    const result = await searchAnalytics<FeedbackAgentMessageDocument>(query, {
-      size: PAGE_SIZE,
-      sort: [{ timestamp: "asc" }, { message_id: "asc" }],
-      search_after: searchAfter,
-    });
-
-    if (result.isErr()) {
-      return new Err(new Error(result.error.message));
-    }
-
-    const { hits } = result.value.hits;
-    for (const hit of hits) {
-      if (hit._source) {
-        allDocs.push(hit._source);
-      }
-    }
-
-    if (hits.length < PAGE_SIZE) {
-      break;
-    }
-
-    const lastHit = hits[hits.length - 1];
-    searchAfter = lastHit.sort;
-  }
-
-  return new Ok(allDocs);
-}
-
+/**
+ * Feedback (thumb, content, dismissed) lives entirely in Postgres — it was
+ * never in the consumption index, so this reads straight from
+ * AgentMessageFeedbackResource instead of Elasticsearch.
+ */
 export async function fetchFeedbackExportRows({
   owner,
   startDate,
@@ -97,90 +50,66 @@ export async function fetchFeedbackExportRows({
   endDate: string;
   timezone: string;
 }): Promise<Result<FeedbackExportRow[], Error>> {
-  // Feedback is filtered by the date the feedback was given (which can differ
-  // from the message timestamp), so we range on the nested feedbacks.created_at
-  // and post-filter each document's feedbacks to the requested window.
-  const startIso = `${startDate}T00:00:00.000Z`;
-  const endIso = `${endDate}T23:59:59.999Z`;
+  const startInstant = moment.tz(startDate, timezone).startOf("day").toDate();
+  const exclusiveEndInstant = moment
+    .tz(endDate, timezone)
+    .add(1, "day")
+    .startOf("day")
+    .toDate();
 
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter: [
-        { term: { workspace_id: owner.sId } },
-        {
-          nested: {
-            path: "feedbacks",
-            query: {
-              range: {
-                "feedbacks.created_at": { gte: startIso, lte: endIso },
-              },
-            },
-          },
-        },
-      ],
-    },
-  };
+  // Note: getFeedbackUsageDataForWorkspace filters out feedback whose author
+  // user record can no longer be resolved (e.g. deleted user), so those rows
+  // are silently excluded from the export.
+  const feedbacks =
+    await AgentMessageFeedbackResource.getFeedbackUsageDataForWorkspace({
+      startDate: startInstant,
+      endDate: exclusiveEndInstant,
+      workspace: owner,
+    });
 
-  const docsResult = await fetchAllFeedbackDocuments(query);
-  if (docsResult.isErr()) {
-    return new Err(docsResult.error);
+  if (feedbacks.length === 0) {
+    return new Ok([]);
   }
 
-  const docs = docsResult.value;
-
   const uniqueAgentIds = [
-    ...new Set(docs.map((d) => d.agent_id).filter(Boolean)),
+    ...new Set(feedbacks.map((f) => f.agentConfigurationId)),
   ];
-  const allFeedbacks = docs.flatMap((d) => d.feedbacks ?? []);
-  const uniqueUserIds = [
-    ...new Set(allFeedbacks.map((f) => f.user_id).filter(Boolean)),
-  ];
-  const uniqueFeedbackIds = [
-    ...new Set(allFeedbacks.map((f) => f.feedback_id).filter(Boolean)),
-  ];
+  const uniqueUserModelIds = [...new Set(feedbacks.map((f) => f.userId))];
 
-  const [agentMeta, userEmails, feedbackContents] = await Promise.all([
+  const [agentMeta, users] = await Promise.all([
     fetchAgentMetadata(uniqueAgentIds, owner),
-    fetchUserEmails(uniqueUserIds),
-    fetchFeedbackContents(uniqueFeedbackIds, owner),
+    UserResource.fetchByModelIds(uniqueUserModelIds),
   ]);
+  const userSIdByModelId = new Map(users.map((u) => [u.id, u.sId]));
+  const userEmailByModelId = new Map(users.map((u) => [u.id, u.email]));
 
-  const rows: FeedbackExportRow[] = [];
-  for (const doc of docs) {
-    const agent = agentMeta.get(doc.agent_id);
-    for (const feedback of doc.feedbacks ?? []) {
-      // A matched document can carry feedbacks outside the requested window;
-      // keep only the ones created within it.
-      if (feedback.created_at < startIso || feedback.created_at > endIso) {
-        continue;
-      }
-      rows.push({
-        // feedback_id is stored as the internal ModelId; expose the opaque sId.
-        feedbackId: AgentMessageFeedbackResource.modelIdToSId({
-          id: feedback.feedback_id,
-          workspaceId: owner.id,
-        }),
-        createdAt: moment(feedback.created_at)
-          .tz(timezone)
-          .format("YYYY-MM-DD HH:mm:ss"),
-        assistantId: doc.agent_id,
-        assistantName: agent?.name ?? doc.agent_id,
-        conversationUrl: feedback.is_conversation_shared
+  const rows: FeedbackExportRow[] = feedbacks.map((feedback) => {
+    const conversationId = feedback.toJSON().conversationId;
+    const agent = agentMeta.get(feedback.agentConfigurationId);
+
+    return {
+      feedbackId: feedback.sId,
+      createdAt: moment(feedback.createdAt)
+        .tz(timezone)
+        .format("YYYY-MM-DD HH:mm:ss"),
+      assistantId: feedback.agentConfigurationId,
+      assistantName: agent?.name ?? feedback.agentConfigurationId,
+      conversationUrl:
+        feedback.isConversationShared && conversationId
           ? getConversationRoute(
               owner.sId,
-              doc.conversation_id,
+              conversationId,
               undefined,
               config.getAppUrl()
             )
           : "",
-        userId: feedback.user_id,
-        userEmail: userEmails.get(feedback.user_id) ?? "",
-        thumb: feedback.thumb_direction,
-        content: feedbackContents.get(feedback.feedback_id) ?? "",
-        dismissed: feedback.dismissed ? "true" : "false",
-      });
-    }
-  }
+      userId: userSIdByModelId.get(feedback.userId) ?? "",
+      userEmail: userEmailByModelId.get(feedback.userId) ?? "",
+      thumb: feedback.thumbDirection,
+      content: feedback.content ?? "",
+      dismissed: feedback.dismissed ? "true" : "false",
+    };
+  });
 
   rows.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -33,11 +33,6 @@ export const FEEDBACK_EXPORT_HEADERS: (keyof FeedbackExportRow)[] = [
   "dismissed",
 ];
 
-/**
- * Feedback (thumb, content, dismissed) lives entirely in Postgres — it was
- * never in the consumption index, so this reads straight from
- * AgentMessageFeedbackResource instead of Elasticsearch.
- */
 export async function fetchFeedbackExportRows({
   owner,
   startDate,
@@ -56,9 +51,6 @@ export async function fetchFeedbackExportRows({
     .startOf("day")
     .toDate();
 
-  // Note: getFeedbackUsageDataForWorkspace filters out feedback whose author
-  // user record can no longer be resolved (e.g. deleted user), so those rows
-  // are silently excluded from the export.
   const feedbacks =
     await AgentMessageFeedbackResource.getFeedbackUsageDataForWorkspace({
       startDate: startInstant,

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -1,6 +1,7 @@
 import { fetchAgentMetadata } from "@app/lib/api/analytics/enrichment";
 import config from "@app/lib/api/config";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -51,12 +52,15 @@ export async function fetchFeedbackExportRows({
     .startOf("day")
     .toDate();
 
-  const feedbacks =
-    await AgentMessageFeedbackResource.getFeedbackUsageDataForWorkspace({
-      startDate: startInstant,
-      endDate: exclusiveEndInstant,
-      workspace: owner,
-    });
+  const feedbacks = await getFrontReplicaDbConnection().transaction(
+    async (transaction) =>
+      AgentMessageFeedbackResource.getFeedbackUsageDataForWorkspace({
+        startDate: startInstant,
+        endDate: exclusiveEndInstant,
+        workspace: owner,
+        transaction,
+      })
+  );
 
   if (feedbacks.length === 0) {
     return new Ok([]);

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -1,7 +1,6 @@
 import { fetchAgentMetadata } from "@app/lib/api/analytics/enrichment";
 import config from "@app/lib/api/config";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -74,14 +73,8 @@ export async function fetchFeedbackExportRows({
   const uniqueAgentIds = [
     ...new Set(feedbacks.map((f) => f.agentConfigurationId)),
   ];
-  const uniqueUserModelIds = [...new Set(feedbacks.map((f) => f.userId))];
 
-  const [agentMeta, users] = await Promise.all([
-    fetchAgentMetadata(uniqueAgentIds, owner),
-    UserResource.fetchByModelIds(uniqueUserModelIds),
-  ]);
-  const userSIdByModelId = new Map(users.map((u) => [u.id, u.sId]));
-  const userEmailByModelId = new Map(users.map((u) => [u.id, u.email]));
+  const agentMeta = await fetchAgentMetadata(uniqueAgentIds, owner);
 
   const rows: FeedbackExportRow[] = feedbacks.map((feedback) => {
     const conversationId = feedback.toJSON().conversationId;
@@ -103,8 +96,8 @@ export async function fetchFeedbackExportRows({
               config.getAppUrl()
             )
           : "",
-      userId: userSIdByModelId.get(feedback.userId) ?? "",
-      userEmail: userEmailByModelId.get(feedback.userId) ?? "",
+      userId: feedback.user?.sId ?? "",
+      userEmail: feedback.user?.email ?? "",
       thumb: feedback.thumbDirection,
       content: feedback.content ?? "",
       dismissed: feedback.dismissed ? "true" : "false",

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -295,7 +295,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         {
           model: UserResource.model,
           as: "user",
-          attributes: ["name", "email"],
+          attributes: ["sId", "name", "email"],
         },
       ],
       order: [["id", "ASC"]],

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -288,7 +288,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         // IMPORTANT: Necessary for global models who share ids across workspaces.
         workspaceId: workspace.id,
         createdAt: {
-          [Op.and]: [{ [Op.lt]: endDate }, { [Op.gt]: startDate }],
+          [Op.and]: [{ [Op.lt]: endDate }, { [Op.gte]: startDate }],
         },
       },
       include: [
@@ -318,14 +318,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       conversations.map((c) => [c.id, c.sId])
     );
 
-    return feedbackRows
-      .filter((feedback) => Boolean(feedback.user))
-      .map((feedback) => {
-        return new this(this.model, feedback.get(), {
-          user: feedback.user,
-          conversationId: conversationIdByModelId.get(feedback.conversationId),
-        });
+    return feedbackRows.map((feedback) => {
+      return new this(this.model, feedback.get(), {
+        user: feedback.user ?? undefined,
+        conversationId: conversationIdByModelId.get(feedback.conversationId),
       });
+    });
   }
 
   static async getFeedbackCountForAssistants(


### PR DESCRIPTION
## Description

Continues the export-tables migration ([#31267](https://github.com/dust-tt/dust/pull/31267), stacked on top), but for a different reason than the earlier tables: the `feedback` table's data was never in the consumption index — it lived entirely in Postgres already, with the old ES index only providing feedback id/thumb/dismissed/created_at. Since the legacy index is being retired, `fetchFeedbackExportRows` now reads straight from `AgentMessageFeedbackResource.getFeedbackUsageDataForWorkspace` (same Resource method already powering the older `workspace_usage.ts` CSV export), resolving agent name and user sId/email with a couple of batched Postgres lookups.

Behavior note: `getFeedbackUsageDataForWorkspace` silently drops feedback whose author user record can no longer be resolved (e.g. a deleted user) — the old ES-backed export kept those rows with an empty `userEmail` instead. Accepting this since it matches the existing, already-shipped Postgres path.

## Tests

- New `feedback_export.test.ts`: one test creating a real feedback row via factories and asserting the full row shape (agent name, user sId/email, conversation URL), one for the empty-window case.
- Full `lib/api/analytics` suite passes (123 tests) — `feedback_export`'s existing mock in the v1 export endpoint test still applies unchanged (same function name/signature).

## Risk

Low — feedback data was already 100% in Postgres, this doesn't compute or infer anything new. Main risk is the deleted-user-drops-the-row behavior noted above, which is a pre-existing, already-shipped semantic elsewhere in the codebase.

## Deploy Plan

Standard deploy, no migration or feature flag needed. Stacked on #31267.
