### PR TITLE
Drop the host tag from statsd distributions via a statsDMetrics wrapper

### DIFF
--- a/front-api/middlewares/request_instrumentation.ts
+++ b/front-api/middlewares/request_instrumentation.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import {
@@ -141,8 +141,8 @@ export const requestInstrumentation =
       `streaming:${streaming}`,
       `status_code:${statusCode}`,
     ];
-    getStatsDClient().increment("requests.count", 1, tags);
-    getStatsDClient().distribution(
+    statsDMetrics.increment("requests.count", 1, tags);
+    statsDMetrics.distribution(
       "requests.duration.distribution",
       durationMs,
       tags

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -1,4 +1,4 @@
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import { getSequelizeErrorDetails } from "@app/logger/withlogging";
@@ -67,7 +67,7 @@ export function apiError(
     span.setTag("error.stack", errorAttrs.stack);
   }
 
-  getStatsDClient().increment("api_errors.count", 1, [
+  statsDMetrics.increment("api_errors.count", 1, [
     `method:${ctx.req.method}`,
     `status_code:${err.status_code}`,
     `error_type:${err.api_error.type}`,
@@ -110,7 +110,7 @@ export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
       "Client API Error"
     );
 
-    getStatsDClient().increment("api_errors.count", 1, [
+    statsDMetrics.increment("api_errors.count", 1, [
       `method:${ctx.req.method}`,
       `status_code:${err.status}`,
       `error_type:${type}`,
@@ -143,7 +143,7 @@ export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
     "Unhandled API Error"
   );
 
-  getStatsDClient().increment("api_errors.count", 1, [
+  statsDMetrics.increment("api_errors.count", 1, [
     `method:${ctx.req.method}`,
     `status_code:500`,
     `error_type:unhandled_internal_server_error`,

--- a/front-api/routes/healthz.ts
+++ b/front-api/routes/healthz.ts
@@ -1,4 +1,4 @@
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { createHono } from "@front-api/lib/hono";
 
 import ready from "./healthz/ready";
@@ -12,7 +12,7 @@ healthzApp.get("/", (ctx) => {
   const response = ctx.text("ok", 200);
   const elapsedMs = performance.now() - startMs;
 
-  getStatsDClient().distribution("requests.health.check", elapsedMs);
+  statsDMetrics.distribution("requests.health.check", elapsedMs);
 
   return response;
 });

--- a/front-api/routes/healthz/ready.ts
+++ b/front-api/routes/healthz/ready.ts
@@ -1,5 +1,5 @@
 import { COMMIT_HASH } from "@app/lib/commit-hash";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { createHono } from "@front-api/lib/hono";
 
 /**
@@ -24,7 +24,7 @@ app.get("/", (ctx) => {
   const response = ctx.json({ status: "ready", commitHash: COMMIT_HASH }, 200);
 
   const durationMs = performance.now() - startMs;
-  getStatsDClient().distribution("healthz.ready.duration_ms", durationMs);
+  statsDMetrics.distribution("healthz.ready.duration_ms", durationMs);
 
   return response;
 });

--- a/front-api/routes/healthz/startup.ts
+++ b/front-api/routes/healthz/startup.ts
@@ -1,6 +1,6 @@
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
@@ -72,7 +72,7 @@ app.get("/", async (ctx) => {
       "Startup probe succeeded - dependencies connected"
     );
 
-    getStatsDClient().distribution("healthz.startup.duration_ms", durationMs, [
+    statsDMetrics.distribution("healthz.startup.duration_ms", durationMs, [
       "status:success",
     ]);
 
@@ -87,7 +87,7 @@ app.get("/", async (ctx) => {
     `Startup probe failed - ${failed.map((r) => r.name).join(", ")} not ready`
   );
 
-  getStatsDClient().distribution("healthz.startup.duration_ms", durationMs, [
+  statsDMetrics.distribution("healthz.startup.duration_ms", durationMs, [
     "status:failure",
   ]);
 

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -31,10 +31,10 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
 
 // Avoid UDP socket usage from StatsD in tests
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => ({
+  statsDMetrics: {
     increment: vi.fn(),
     distribution: vi.fn(),
-  }),
+  },
 }));
 
 vi.mock("@app/lib/file_storage", async (importOriginal) => {

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -8,7 +8,7 @@ import {
   HEADERS_ALLOWED_LIST,
   processWebhookRequest,
 } from "@app/lib/triggers/webhook";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { isString } from "@app/types/shared/utils/general";
 import type { PostWebhookTriggerResponseType } from "@dust-tt/client";
 import { createHono } from "@front-api/lib/hono";
@@ -156,7 +156,7 @@ app.post(
 
     const provider = webhookSource.provider ?? "custom";
 
-    getStatsDClient().increment("webhook_request.count", 1, [
+    statsDMetrics.increment("webhook_request.count", 1, [
       `provider:${provider}`,
       `workspace_id:${workspace.sId}`,
     ]);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -11,7 +11,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { InternalPostMessagesRequestBodySchema } from "@app/types/api/assistant";
 import type { PostMessagesResponseBody } from "@app/types/api/assistant/messages";
 import type {
@@ -240,7 +240,7 @@ app.get(
 
     const messageLatency = performance.now() - messageStartTime;
 
-    getStatsDClient().distribution(
+    statsDMetrics.distribution(
       "assistant.messages.fetch.latency",
       messageLatency
     );
@@ -248,10 +248,7 @@ app.get(
       JSON.stringify(messagesRes.value),
       "utf8"
     );
-    getStatsDClient().distribution(
-      "assistant.messages.fetch.raw_size",
-      rawSize
-    );
+    statsDMetrics.distribution("assistant.messages.fetch.raw_size", rawSize);
 
     return ctx.json(messagesRes.value);
   }

--- a/front-api/routes/w/[wId]/services/transcribe/index.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/index.ts
@@ -1,5 +1,5 @@
 import { findAgentsInMessage } from "@app/lib/utils/find_agents_in_message";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { transcribeStream } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -64,7 +64,7 @@ app.post("/", async (ctx) => {
   }
   const file = maybeFiles[0];
 
-  const statsd = getStatsDClient();
+  const statsd = statsDMetrics;
   const totalStartMs = performance.now();
   const wId = auth.getNonNullableWorkspace().sId;
 

--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -20,7 +20,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { fetchUserFromSession } from "@app/lib/iam/users";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -275,7 +275,7 @@ async function handleLogin(ctx: Context) {
     return redirect(ctx, authorizationUrl);
   } catch (error) {
     logger.error({ error }, "Error during WorkOS login");
-    getStatsDClient().increment("login.error", 1);
+    statsDMetrics.increment("login.error", 1);
     return redirect(ctx, "/login-error?type=workos-login");
   }
 }
@@ -647,7 +647,7 @@ async function handleCallback(ctx: Context) {
       });
     }
 
-    getStatsDClient().increment("login.callback.error", 1);
+    statsDMetrics.increment("login.callback.error", 1);
     return redirectTo(ctx, `/login-error?type=workos-callback`);
   }
 }

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -9,7 +9,7 @@ import {
   isSandboxFunctionRunContext,
 } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
@@ -189,7 +189,7 @@ function withToolLogging<T>(
     const tags = [`tool:${toolNameForMonitoring}`];
 
     if (enableAlerting) {
-      getStatsDClient().increment("use_tools.count", 1, tags);
+      statsDMetrics.increment("use_tools.count", 1, tags);
     }
     const startTime = performance.now();
 
@@ -200,7 +200,7 @@ function withToolLogging<T>(
     // When we get an Err, we monitor it if tracked and return it as a text content.
     if (result.isErr()) {
       if (enableAlerting && result.error.tracked) {
-        getStatsDClient().increment("use_tools_error.count", 1, [
+        statsDMetrics.increment("use_tools_error.count", 1, [
           "error_type:run_error",
           ...tags,
         ]);
@@ -238,7 +238,7 @@ function withToolLogging<T>(
     }
 
     if (enableAlerting) {
-      getStatsDClient().distribution(
+      statsDMetrics.distribution(
         "run_tool.duration.distribution",
         elapsed,
         tags

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -18,7 +18,7 @@ import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
@@ -171,7 +171,7 @@ export async function checkImageGenerationRateLimit(
   });
 
   if (remaining <= 0) {
-    getStatsDClient().increment("tools.image_generation.rate_limit_hit", 1, [
+    statsDMetrics.increment("tools.image_generation.rate_limit_hit", 1, [
       `provider:${providerId}`,
     ]);
 
@@ -198,12 +198,12 @@ export function trackTokenUsage({
   outputTokens: number;
   providerId: ModelProviderIdType;
 }): void {
-  getStatsDClient().increment(
+  statsDMetrics.increment(
     "tools.image_generation.usage.input_tokens",
     inputTokens,
     [`provider:${providerId}`]
   );
-  getStatsDClient().increment(
+  statsDMetrics.increment(
     "tools.image_generation.usage.output_tokens",
     outputTokens,
     [`provider:${providerId}`]
@@ -428,7 +428,7 @@ async function processSingleImageFile(
       "generate_image: File size exceeds maximum allowed size"
     );
 
-    getStatsDClient().increment(
+    statsDMetrics.increment(
       "tools.image_generation.file_size_limit_exceeded",
       1,
       [`provider:${providerId}`]

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -21,7 +21,7 @@ import type {
 } from "@app/lib/api/actions/servers/image_generation/imageGeneration";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
 import type { Authenticator } from "@app/lib/auth";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -65,7 +65,7 @@ export function createImageGenerationTools(
 
       const { providerId } = imageGenerationModel;
 
-      getStatsDClient().increment("tools.image_generation.generated", 1, [
+      statsDMetrics.increment("tools.image_generation.generated", 1, [
         `aspect_ratio:${aspectRatio}`,
         `image_count:${referenceImages?.length ?? 0}`,
         `quality:${quality}`,

--- a/front/lib/api/actions/servers/triggers_management/tools/index.ts
+++ b/front/lib/api/actions/servers/triggers_management/tools/index.ts
@@ -15,7 +15,7 @@ import {
 } from "@app/lib/resources/trigger_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import type {
@@ -239,7 +239,7 @@ export function createTriggersManagementTools(
         throw err;
       }
 
-      getStatsDClient().increment("tools.triggers_management.created", 1, [
+      statsDMetrics.increment("tools.triggers_management.created", 1, [
         `workspace_id:${owner.sId}`,
         `agent_id:${agentConfiguration.sId}`,
       ]);
@@ -289,7 +289,7 @@ export function createTriggersManagementTools(
         );
       }
 
-      getStatsDClient().increment("tools.triggers_management.listed", 1, [
+      statsDMetrics.increment("tools.triggers_management.listed", 1, [
         `workspace_id:${owner.sId}`,
         `agent_id:${agentConfiguration.sId}`,
       ]);
@@ -418,7 +418,7 @@ export function createTriggersManagementTools(
         );
       }
 
-      getStatsDClient().increment("tools.triggers_management.disabled", 1, [
+      statsDMetrics.increment("tools.triggers_management.disabled", 1, [
         `workspace_id:${owner.sId}`,
         `agent_id:${agentConfiguration.sId}`,
       ]);
@@ -442,7 +442,7 @@ export function createTriggersManagementTools(
 
       const views = await getAccessibleWebhookSourceViews(auth);
 
-      getStatsDClient().increment(
+      statsDMetrics.increment(
         "tools.triggers_management.event_sources_listed",
         1,
         [`workspace_id:${owner.sId}`, `agent_id:${agentConfiguration.sId}`]
@@ -628,7 +628,7 @@ export function createTriggersManagementTools(
         throw err;
       }
 
-      getStatsDClient().increment(
+      statsDMetrics.increment(
         "tools.triggers_management.event_trigger_created",
         1,
         [`workspace_id:${owner.sId}`, `agent_id:${agentConfiguration.sId}`]

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -130,7 +130,7 @@ import {
   rateLimiter,
 } from "@app/lib/utils/rate_limiter";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
@@ -2830,10 +2830,10 @@ async function checkPoolCreditConcurrencyLimit(
       "Pool credit concurrency limit triggered."
     );
 
-    getStatsDClient().increment(
+    statsDMetrics.increment(
       "assistant.rate_limiter.pool_credit.concurrency_limit_triggered",
       1,
-      { workspace_id: owner.sId }
+      [`workspace_id:${owner.sId}`]
     );
 
     return {
@@ -2878,10 +2878,10 @@ async function checkProgrammaticCreditConcurrencyLimit(
       "Programmatic credit concurrency limit triggered."
     );
 
-    getStatsDClient().increment(
+    statsDMetrics.increment(
       "assistant.rate_limiter.programmatic_credit.concurrency_limit_triggered",
       1,
-      { workspace_id: owner.sId }
+      [`workspace_id:${owner.sId}`]
     );
 
     return {
@@ -2933,10 +2933,10 @@ async function checkProgrammaticUsageRateLimit(
       "Pre-emptive rate limit triggered for programmatic usage."
     );
 
-    getStatsDClient().increment(
+    statsDMetrics.increment(
       "assistant.rate_limiter.programmatic_usage.credit_based_limit_triggered",
       1,
-      { workspace_id: owner.sId }
+      [`workspace_id:${owner.sId}`]
     );
 
     return {
@@ -2976,10 +2976,10 @@ async function checkProgrammaticUsageRateLimit(
           "Pre-emptive rate limit triggered for key cap."
         );
 
-        getStatsDClient().increment(
+        statsDMetrics.increment(
           "assistant.rate_limiter.key_cap.credit_based_limit_triggered",
           1,
-          { workspace_id: owner.sId }
+          [`workspace_id:${owner.sId}`]
         );
 
         return {

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -13,7 +13,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type {
   AgentMessageType,
   CompactionMessageType,
@@ -252,7 +252,7 @@ async function _getConversation<V extends "light" | "full">(
     );
 
     // Purely observational, see TOOL_OUTPUT_FETCH_BATCH_SIZE above.
-    getStatsDClient().distribution(
+    statsDMetrics.distribution(
       "conversation.interactions_count",
       interactions.length
     );

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -32,10 +32,10 @@ vi.mock(
 );
 
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => ({
+  statsDMetrics: {
     distribution: vi.fn(),
     increment: vi.fn(),
-  }),
+  },
 }));
 
 vi.mock("@app/lib/api/provider_credentials", () => ({

--- a/front/lib/api/assistant/conversation_rendering/instrumentation.ts
+++ b/front/lib/api/assistant/conversation_rendering/instrumentation.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ConversationPruningStats } from "@app/lib/api/assistant/conversation_rendering/window_types";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -67,7 +67,7 @@ export function emitConversationRenderingMetrics({
   tokensUsed: number;
 }): void {
   const metrics = computeConversationRenderingMetrics(stats);
-  const statsD = getStatsDClient();
+  const statsD = statsDMetrics;
   const baseTags = [
     `client_id:${providerId}`,
     `model_id:${modelId}`,
@@ -118,7 +118,7 @@ export function emitConversationRenderingError({
   providerId: ModelProviderIdType;
   modelId: ModelIdType;
 }): void {
-  getStatsDClient().increment("conversation_rendering.errors", 1, [
+  statsDMetrics.increment("conversation_rendering.errors", 1, [
     `client_id:${providerId}`,
     `model_id:${modelId}`,
     `caller:${caller}`,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -48,7 +48,7 @@ import { getUsageType } from "@app/lib/metronome/events";
 import type { UsageType } from "@app/lib/metronome/types";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
 
@@ -198,22 +198,18 @@ export abstract class LLM<
 
     switch (outcomeTelemetry.outcome) {
       case "error":
-        getStatsDClient().increment("llm_error.count", 1, [
+        statsDMetrics.increment("llm_error.count", 1, [
           ...baseTags,
           `error_type:${outcomeTelemetry.errorType}`,
           `error_source:${outcomeTelemetry.errorSource}`,
         ]);
         break;
       case "success":
-        getStatsDClient().increment("llm_success.count", 1, baseTags);
+        statsDMetrics.increment("llm_success.count", 1, baseTags);
         break;
       case "success_without_usage":
-        getStatsDClient().increment("llm_success.count", 1, baseTags);
-        getStatsDClient().increment(
-          "llm_success_without_usage.count",
-          1,
-          baseTags
-        );
+        statsDMetrics.increment("llm_success.count", 1, baseTags);
+        statsDMetrics.increment("llm_success_without_usage.count", 1, baseTags);
         break;
       default:
         assertNever(outcomeTelemetry);
@@ -313,7 +309,7 @@ export abstract class LLM<
 
     const metricTags = this.getTelemetryTags({ surface: "stream" });
 
-    getStatsDClient().increment("llm_interaction.count", 1, metricTags);
+    statsDMetrics.increment("llm_interaction.count", 1, metricTags);
 
     let currentEvent: LLMEvent | null = null;
     let timeToFirstEventMs: number | undefined;
@@ -769,7 +765,7 @@ export abstract class LLM<
           hasError = true;
           const errorType = event.content.type;
           const errorSource = event.content.errorSource;
-          getStatsDClient().increment("llm_error.count", 1, [
+          statsDMetrics.increment("llm_error.count", 1, [
             ...metricTags,
             `error_type:${errorType}`,
             `error_source:${errorSource}`,
@@ -805,9 +801,9 @@ export abstract class LLM<
       }
 
       if (!hasError) {
-        getStatsDClient().increment("llm_success.count", 1, metricTags);
+        statsDMetrics.increment("llm_success.count", 1, metricTags);
       }
-      getStatsDClient().increment("llm_interaction.count", 1, metricTags);
+      statsDMetrics.increment("llm_interaction.count", 1, metricTags);
 
       const { tokenUsage, ...rest } = buffer.currentOutput;
 

--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -18,7 +18,7 @@ import type { ModelResponseEvent } from "@app/lib/model_constructors/types/outpu
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import {
@@ -119,10 +119,10 @@ function makeTraceContext(
 
 function spyTelemetry() {
   const increment = vi
-    .spyOn(getStatsDClient(), "increment")
+    .spyOn(statsDMetrics, "increment")
     .mockImplementation(() => {});
   const distribution = vi
-    .spyOn(getStatsDClient(), "distribution")
+    .spyOn(statsDMetrics, "distribution")
     .mockImplementation(() => {});
   const error = vi.spyOn(logger, "error").mockImplementation(() => {});
   const info = vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -384,7 +384,7 @@ describe("non-batch LLM run persistence", () => {
     const { authenticator: auth } = await createResourceTest({});
     const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
     const increment = vi
-      .spyOn(getStatsDClient(), "increment")
+      .spyOn(statsDMetrics, "increment")
       .mockImplementation(() => {});
     const llm = makeNoopLLM(auth, DustNoopNoopGlobalNoopStream, {
       operationType: "agent_conversation",

--- a/front/lib/api/llm/telemetry.ts
+++ b/front/lib/api/llm/telemetry.ts
@@ -4,7 +4,7 @@
  */
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import type { ErrorSource } from "@app/lib/model_constructors/types/output/events";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type {
   ModelProviderIdType,
   ReasoningEffort,
@@ -56,7 +56,7 @@ export function emitLLMDurationMs({
       assertNever(outcomeTelemetry);
   }
 
-  getStatsDClient().distribution("llm_duration_ms", durationMs, durationTags);
+  statsDMetrics.distribution("llm_duration_ms", durationMs, durationTags);
 }
 
 export function emitLLMTimeToFirstEventMs(
@@ -66,7 +66,7 @@ export function emitLLMTimeToFirstEventMs(
   if (timeToFirstEventMs === undefined) {
     return;
   }
-  getStatsDClient().distribution(
+  statsDMetrics.distribution(
     "llm_time_to_first_event_ms",
     timeToFirstEventMs,
     tags
@@ -80,7 +80,7 @@ export function emitLLMTimeToFirstTokenMs(
   if (timeToFirstTokenMs === undefined) {
     return;
   }
-  getStatsDClient().distribution(
+  statsDMetrics.distribution(
     "llm_time_to_first_token_ms",
     timeToFirstTokenMs,
     tags

--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -14,7 +14,7 @@ import type {
 import type { SystemPromptInput } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getLLMTracesBucket } from "@app/lib/file_storage";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
@@ -197,19 +197,15 @@ export class LLMTraceBuffer {
 
     const { cacheCreationTokens, cachedTokens, inputTokens } = tokenUsage;
     if (cachedTokens) {
-      getStatsDClient().distribution(
-        "llm_cache.tokens_read",
-        cachedTokens,
-        tags
-      );
-      getStatsDClient().distribution(
+      statsDMetrics.distribution("llm_cache.tokens_read", cachedTokens, tags);
+      statsDMetrics.distribution(
         "llm_cache.token_hit_ratio",
         cachedTokens / inputTokens,
         tags
       );
     }
     if (cacheCreationTokens) {
-      getStatsDClient().distribution(
+      statsDMetrics.distribution(
         "llm_cache.tokens_written",
         cacheCreationTokens,
         tags

--- a/front/lib/api/llm/usage_metrics.ts
+++ b/front/lib/api/llm/usage_metrics.ts
@@ -12,10 +12,10 @@
  * provider never reports.
  */
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 
 export function emitTokenUsageMetrics(usage: TokenUsage, tags: string[]): void {
-  const statsD = getStatsDClient();
+  const statsD = statsDMetrics;
 
   const cacheHit = usage.cachedTokens ?? 0;
   // The flat total is only set when the provider reports no per-duration breakdown. Otherwise

--- a/front/lib/api/prestop.test.ts
+++ b/front/lib/api/prestop.test.ts
@@ -14,7 +14,7 @@ const { childLogger, statsDClient } = vi.hoisted(() => ({
 }));
 
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => statsDClient,
+  statsDMetrics: statsDClient,
 }));
 
 vi.mock("@app/logger/logger", () => ({

--- a/front/lib/api/prestop.ts
+++ b/front/lib/api/prestop.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type { WakeLockEntry } from "@app/lib/wake_lock";
 import { getWakeLockDetails, wakeLockIsFree } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
@@ -32,7 +32,7 @@ async function runPreStopOnce(drainDurationMs: number): Promise<void> {
     action: "preStop",
   });
 
-  getStatsDClient().increment("prestop.requests");
+  statsDMetrics.increment("prestop.requests");
 
   childLogger.info(
     { drainDurationMs },
@@ -54,14 +54,11 @@ async function runPreStopOnce(drainDurationMs: number): Promise<void> {
       );
 
       // Record initial wake lock metrics.
-      getStatsDClient().gauge(
-        "prestop.initial_wake_locks",
-        currentWakeLockCount
-      );
+      statsDMetrics.gauge("prestop.initial_wake_locks", currentWakeLockCount);
       if (currentWakeLockCount > 0) {
-        getStatsDClient().increment("prestop.has_wake_locks");
+        statsDMetrics.increment("prestop.has_wake_locks");
       } else {
-        getStatsDClient().increment("prestop.no_wake_locks");
+        statsDMetrics.increment("prestop.no_wake_locks");
       }
 
       // Log details of all active wake locks.
@@ -119,7 +116,7 @@ async function runPreStopOnce(drainDurationMs: number): Promise<void> {
       "Endpoint drain completed without active wake locks"
     );
 
-    getStatsDClient().increment("prestop.wake_locks_cleared");
+    statsDMetrics.increment("prestop.wake_locks_cleared");
   } else {
     childLogger.warn(
       {
@@ -133,17 +130,14 @@ async function runPreStopOnce(drainDurationMs: number): Promise<void> {
       "Endpoint drain deadline reached with active wake locks"
     );
 
-    getStatsDClient().increment("prestop.timeouts");
-    getStatsDClient().gauge(
+    statsDMetrics.increment("prestop.timeouts");
+    statsDMetrics.gauge(
       "prestop.timeout_wake_locks",
       finalWakeLockDetails.length
     );
-    getStatsDClient().distribution(
-      "prestop.timeout_duration_ms",
-      totalDurationMs
-    );
-    getStatsDClient().increment("prestop.wake_locks_forced");
-    getStatsDClient().distribution(
+    statsDMetrics.distribution("prestop.timeout_duration_ms", totalDurationMs);
+    statsDMetrics.increment("prestop.wake_locks_forced");
+    statsDMetrics.distribution(
       "prestop.wake_lock_forced_duration_ms",
       totalDurationMs
     );
@@ -155,6 +149,6 @@ async function runPreStopOnce(drainDurationMs: number): Promise<void> {
   );
 
   // Record total prestop duration.
-  getStatsDClient().increment("prestop.completions");
-  getStatsDClient().distribution("prestop.total_duration_ms", totalDurationMs);
+  statsDMetrics.increment("prestop.completions");
+  statsDMetrics.distribution("prestop.total_duration_ms", totalDurationMs);
 }

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -15,7 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { computeRunFingerprint } from "@app/lib/credits/agent_message_billing";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
 
@@ -225,11 +225,11 @@ export async function decreaseProgrammaticCredits(
       }
 
       // Emit both metrics for backwards compatibility with existing dashboards.
-      getStatsDClient().increment("credits.consumption.blocked", 1, [
+      statsDMetrics.increment("credits.consumption.blocked", 1, [
         `workspace_id:${workspace.sId}`,
         `origin:${userMessageOrigin}`,
       ]);
-      getStatsDClient().increment("credits.consumption.excess", 1, [
+      statsDMetrics.increment("credits.consumption.excess", 1, [
         `workspace_id:${workspace.sId}`,
         `origin:${userMessageOrigin}`,
       ]);
@@ -262,7 +262,7 @@ export async function decreaseProgrammaticCredits(
         },
         "[Programmatic Usage Tracking] Error consuming credit."
       );
-      getStatsDClient().increment("credits.consumption.error", 1, [
+      statsDMetrics.increment("credits.consumption.error", 1, [
         `workspace_id:${workspace.sId}`,
         `origin:${userMessageOrigin}`,
       ]);
@@ -281,7 +281,7 @@ export async function decreaseProgrammaticCredits(
     );
   }
 
-  getStatsDClient().increment("credits.consumption.success", 1, [
+  statsDMetrics.increment("credits.consumption.success", 1, [
     `workspace_id:${workspace.sId}`,
     `origin:${userMessageOrigin}`,
   ]);
@@ -412,7 +412,7 @@ export async function trackProgrammaticCost(
     );
     if (totalConsumedMicroUsd >= thresholdMicroUsd) {
       const workspace = auth.getNonNullableWorkspace();
-      getStatsDClient().increment("credits.consumption.alert", 1, [
+      statsDMetrics.increment("credits.consumption.alert", 1, [
         `workspace_id:${workspace.sId}`,
         `origin:${userMessageOrigin}`,
       ]);

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -1,7 +1,7 @@
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { createRedisStreamClient } from "@app/lib/api/redis";
 import { fromEvent } from "@app/lib/utils/events";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import tracer from "@app/logger/tracer";
@@ -276,7 +276,7 @@ class RedisHybridManager {
         const subscriptionClient = await this.getSubscriptionClient();
         const streamClient = await this.getStreamAndPublishClient();
         const clientsDurationMs = Date.now() - clientsStartMs;
-        getStatsDClient().distribution(
+        statsDMetrics.distribution(
           "sse.subscribe.get_clients_duration_ms",
           clientsDurationMs
         );
@@ -292,7 +292,7 @@ class RedisHybridManager {
           await subscriptionClient.subscribe(pubSubChannelName, this.onMessage);
         }
         const channelSetupDurationMs = Date.now() - channelSetupStartMs;
-        getStatsDClient().distribution(
+        statsDMetrics.distribution(
           "sse.subscribe.channel_setup_duration_ms",
           channelSetupDurationMs
         );
@@ -326,7 +326,7 @@ class RedisHybridManager {
               lastEventId || "0-0"
             );
           const historyFetchDurationMs = Date.now() - historyFetchStartMs;
-          getStatsDClient().distribution(
+          statsDMetrics.distribution(
             "sse.subscribe.history_fetch_duration_ms",
             historyFetchDurationMs
           );
@@ -356,7 +356,7 @@ class RedisHybridManager {
             history.sort((a, b) => a.id.localeCompare(b.id));
           }
           const dedupeDurationMs = Date.now() - dedupeStartMs;
-          getStatsDClient().distribution(
+          statsDMetrics.distribution(
             "sse.subscribe.dedupe_duration_ms",
             dedupeDurationMs
           );
@@ -370,15 +370,15 @@ class RedisHybridManager {
 
         // Track active subscription count for monitoring.
         this.activeSubscriptionCount++;
-        getStatsDClient().gauge(
+        statsDMetrics.gauge(
           "sse.active_subscriptions",
           this.activeSubscriptionCount
         );
-        getStatsDClient().increment("sse.subscription_established", 1);
+        statsDMetrics.increment("sse.subscription_established", 1);
 
         // Track total subscription establishment time.
         const subscribeDurationMs = Date.now() - subscribeStartMs;
-        getStatsDClient().timing(
+        statsDMetrics.timing(
           "sse.subscription.total_duration_ms",
           subscribeDurationMs
         );
@@ -393,7 +393,7 @@ class RedisHybridManager {
 
               // Track active subscription count for monitoring.
               this.activeSubscriptionCount--;
-              getStatsDClient().gauge(
+              statsDMetrics.gauge(
                 "sse.active_subscriptions",
                 this.activeSubscriptionCount
               );
@@ -464,11 +464,11 @@ class RedisHybridManager {
         const historyStartMs = Date.now();
 
         this.concurrentHistoryFetches++;
-        getStatsDClient().gauge(
+        statsDMetrics.gauge(
           "sse.history.concurrent_fetches",
           this.concurrentHistoryFetches
         );
-        getStatsDClient().increment("sse.history.fetch_started");
+        statsDMetrics.increment("sse.history.fetch_started");
 
         try {
           const xReadStartMs = Date.now();
@@ -482,7 +482,7 @@ class RedisHybridManager {
             })
             .then((events) => {
               const xReadDurationMs = Date.now() - xReadStartMs;
-              getStatsDClient().distribution(
+              statsDMetrics.distribution(
                 "sse.history.xread_duration_ms",
                 xReadDurationMs
               );
@@ -500,13 +500,13 @@ class RedisHybridManager {
                 const hasMore = eventCount >= HISTORY_FETCH_COUNT;
 
                 const parseDurationMs = Date.now() - parseStartMs;
-                getStatsDClient().distribution(
+                statsDMetrics.distribution(
                   "sse.history.parse_duration_ms",
                   parseDurationMs
                 );
 
                 // Track all event replays, including from-beginning fetches during deployment.
-                getStatsDClient().histogram(
+                statsDMetrics.histogram(
                   "sse.history.events_replayed",
                   eventCount
                 );
@@ -520,7 +520,7 @@ class RedisHybridManager {
             });
 
           const totalHistoryDurationMs = Date.now() - historyStartMs;
-          getStatsDClient().distribution(
+          statsDMetrics.distribution(
             "sse.history.total_duration_ms",
             totalHistoryDurationMs
           );
@@ -538,7 +538,7 @@ class RedisHybridManager {
           return await Promise.resolve({ events: [], hasMore: false });
         } finally {
           this.concurrentHistoryFetches--;
-          getStatsDClient().gauge(
+          statsDMetrics.gauge(
             "sse.history.concurrent_fetches",
             this.concurrentHistoryFetches
           );

--- a/front/lib/api/redis.test.ts
+++ b/front/lib/api/redis.test.ts
@@ -20,10 +20,10 @@ vi.mock("@app/logger/logger", () => ({
 }));
 
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => ({
+  statsDMetrics: {
     increment: vi.fn(),
     decrement: vi.fn(),
-  }),
+  },
 }));
 
 describe("getRedisStreamClient", () => {

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -1,7 +1,7 @@
 import { performance } from "node:perf_hooks";
 
 import config from "@app/lib/api/config";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import type { RedisClientType } from "redis";
@@ -119,15 +119,11 @@ async function createRedisClient({
       { origin, safeUri, elapsedMs: elapsed() },
       "Redis Client Connected"
     );
-    getStatsDClient().increment("redis.connection.count", 1, [
-      `origin:${origin}`,
-    ]);
+    statsDMetrics.increment("redis.connection.count", 1, [`origin:${origin}`]);
   });
   newClient.on("end", () => {
     logger.info({ origin, safeUri }, "Redis Client End");
-    getStatsDClient().decrement("redis.connection.count", 1, [
-      `origin:${origin}`,
-    ]);
+    statsDMetrics.decrement("redis.connection.count", 1, [`origin:${origin}`]);
   });
 
   logger.info({ origin, safeUri }, "Redis client connect starting");

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -1,6 +1,6 @@
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import tracer from "@app/logger/tracer";
 
 // Intentionally NOT tagged by workspace_id: region (+ operation/status) is
@@ -85,7 +85,7 @@ export function recordSandboxStartupTotal(
   { region, cold }: { region?: string; cold: boolean },
   status: "success" | "error"
 ): void {
-  getStatsDClient().distribution("sandbox.startup.total.duration", durationMs, [
+  statsDMetrics.distribution("sandbox.startup.total.duration", durationMs, [
     `region:${region ?? regionConfig.getCurrentRegion()}`,
     `cold:${cold}`,
     `status:${status}`,
@@ -95,9 +95,7 @@ export function recordSandboxStartupTotal(
 export function recordLifecycleOperation(
   operation: "create" | "wake" | "sleep" | "destroy"
 ): void {
-  getStatsDClient().increment(`sandbox.lifecycle.${operation}`, 1, [
-    regionTag(),
-  ]);
+  statsDMetrics.increment(`sandbox.lifecycle.${operation}`, 1, [regionTag()]);
 }
 
 /**
@@ -115,8 +113,8 @@ export function recordSandboxFunctionRun({
   durationMs: number;
 }): void {
   const tags = [regionTag(), `runner_kind:${runnerKind}`, `status:${status}`];
-  getStatsDClient().increment("sandbox.functions.run", 1, tags);
-  getStatsDClient().distribution(
+  statsDMetrics.increment("sandbox.functions.run", 1, tags);
+  statsDMetrics.distribution(
     "sandbox.functions.run.duration",
     durationMs,
     tags
@@ -127,7 +125,7 @@ export function recordStateDuration(
   previousStatus: SandboxStatus,
   durationMs: number
 ): void {
-  getStatsDClient().distribution("sandbox.lifecycle.duration", durationMs, [
+  statsDMetrics.distribution("sandbox.lifecycle.duration", durationMs, [
     regionTag(),
     `status:${previousStatus}`,
   ]);
@@ -138,7 +136,7 @@ export function recordToolDuration(
   durationMs: number,
   status: "success" | "error" = "success"
 ): void {
-  getStatsDClient().distribution("sandbox.tools.duration", durationMs, [
+  statsDMetrics.distribution("sandbox.tools.duration", durationMs, [
     `tool:${tool}`,
     `status:${status}`,
   ]);
@@ -148,7 +146,7 @@ export function recordToolDuration(
 // monitors page on the failure count; the stable logger.error message next to
 // each failing call site carries the cause.
 export function recordPodStateHealth(status: "success" | "failure"): void {
-  getStatsDClient().increment("sandbox.pod_state.health", 1, [
+  statsDMetrics.increment("sandbox.pod_state.health", 1, [
     regionTag(),
     `status:${status}`,
   ]);

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -56,7 +56,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchCleanMetronomeInvoiceWorkflow } from "@app/temporal/metronome_events_queue/client";
@@ -1068,7 +1068,7 @@ export async function processStripeWebhookEvent({
       );
 
       if (validStatus.isErr()) {
-        getStatsDClient().increment("stripe.subscription.invalid", 1, [
+        statsDMetrics.increment("stripe.subscription.invalid", 1, [
           "event_type:customer.subscription.created",
         ]);
 
@@ -1427,7 +1427,7 @@ export async function processStripeWebhookEvent({
       // on the odd chance the change is not compatible with our logic, we panic
       const validStatus = assertStripeSubscriptionIsValid(stripeSubscription);
       if (validStatus.isErr()) {
-        getStatsDClient().increment("stripe.subscription.invalid", 1, [
+        statsDMetrics.increment("stripe.subscription.invalid", 1, [
           "event_type:customer.subscription.updated",
         ]);
 

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -19,7 +19,7 @@ import {
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
@@ -52,7 +52,7 @@ export async function startCreditFromProOneOffInvoice({
       },
       "[Credit Purchase] Invalid credit amount in invoice metadata"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:pro",
@@ -73,7 +73,7 @@ export async function startCreditFromProOneOffInvoice({
       },
       "[Credit Purchase] Credit not found for invoice"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:pro",
@@ -93,14 +93,14 @@ export async function startCreditFromProOneOffInvoice({
       },
       "[Credit Purchase] Error starting credit"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:pro",
     ]);
     return new Err(startResult.error);
   }
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspace.sId}`,
     "type:committed",
     "customer:pro",
@@ -159,7 +159,7 @@ export async function startCreditFromEnterpriseOneOffInvoice({
       },
       "[Credit Purchase] Invalid credit amount in invoice metadata"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:enterprise",
@@ -181,7 +181,7 @@ export async function startCreditFromEnterpriseOneOffInvoice({
       },
       "[Credit Purchase] Credit not found for paid enterprise invoice"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:enterprise",
@@ -217,14 +217,14 @@ export async function startCreditFromEnterpriseOneOffInvoice({
       },
       "[Credit Purchase] Error starting enterprise credit from webhook"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:enterprise",
     ]);
     return new Err(startResult.error);
   }
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspace.sId}`,
     "type:committed",
     "customer:enterprise",
@@ -428,7 +428,7 @@ export async function createEnterpriseCreditPurchase({
       },
       "[Credit Purchase] Failed to start credit after creation"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:committed",
       "customer:enterprise",
@@ -436,7 +436,7 @@ export async function createEnterpriseCreditPurchase({
     return new Err(startResult.error);
   }
 
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspace.sId}`,
     "type:committed",
     "customer:enterprise",

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -11,7 +11,7 @@ import {
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -593,7 +593,7 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
       },
       "[Free Credits] Error starting credit"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspaceId}`,
       "type:free",
       `customer:${isEnterprise ? "enterprise" : "pro"}`,
@@ -601,7 +601,7 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
     return new Err(startResult.error);
   }
 
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspaceId}`,
     "type:free",
     `customer:${isEnterprise ? "enterprise" : "pro"}`,
@@ -773,7 +773,7 @@ export async function grantFreeCreditFromSubscriptionStateChangeYearly({
       },
       "[Free Credits Yearly] Error starting credit"
     );
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspaceId}`,
       "type:free_yearly",
       `customer:${isEnterprise ? "enterprise" : "pro"}`,
@@ -781,7 +781,7 @@ export async function grantFreeCreditFromSubscriptionStateChangeYearly({
     return new Err(startResult.error);
   }
 
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspaceId}`,
     "type:free_yearly",
     `customer:${isEnterprise ? "enterprise" : "pro"}`,

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import { isCreditPricedPlan } from "@app/types/plan";
@@ -46,7 +46,7 @@ function handlePAYGCreditCreationError({
         { workspaceId, error: error_message, panic: true },
         `[Credit PAYG] Failed to create PAYG credit for this period. Potentially blocking customer's automations`
       );
-      getStatsDClient().increment("credits.top_up.error", 1, [
+      statsDMetrics.increment("credits.top_up.error", 1, [
         `workspace_id:${workspaceId}`,
         "type:payg",
         "customer:enterprise",
@@ -163,7 +163,7 @@ export async function allocatePAYGCreditsOnCycleRenewal({
     },
     "[Credit PAYG] Allocated new PAYG credit for billing cycle"
   );
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspace.sId}`,
     "type:payg",
     "customer:enterprise",
@@ -205,7 +205,7 @@ export async function startOrResumeEnterprisePAYG({
   const config =
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
   if (!config) {
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:payg",
       "customer:enterprise",
@@ -221,7 +221,7 @@ export async function startOrResumeEnterprisePAYG({
     paygCapMicroUsd,
   });
   if (updateResult.isErr()) {
-    getStatsDClient().increment("credits.top_up.error", 1, [
+    statsDMetrics.increment("credits.top_up.error", 1, [
       `workspace_id:${workspace.sId}`,
       "type:payg",
       "customer:enterprise",
@@ -273,7 +273,7 @@ export async function startOrResumeEnterprisePAYG({
       );
     }
   }
-  getStatsDClient().increment("credits.top_up.success", 1, [
+  statsDMetrics.increment("credits.top_up.success", 1, [
     `workspace_id:${workspace.sId}`,
     "type:payg",
     "customer:enterprise",

--- a/front/lib/duration_recorder.ts
+++ b/front/lib/duration_recorder.ts
@@ -1,4 +1,4 @@
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 
 export class DurationRecorder {
   private readonly startTimeMs: number;
@@ -22,7 +22,7 @@ export class DurationRecorder {
 
   record(metricName: string): void {
     const durationMs = performance.now() - this.startTimeMs;
-    getStatsDClient().distribution(metricName, durationMs, this.tags);
+    statsDMetrics.distribution(metricName, durationMs, this.tags);
   }
 
   getElapsedMs(): number {

--- a/front/lib/model_constructors/utils/tool_search_logging.ts
+++ b/front/lib/model_constructors/utils/tool_search_logging.ts
@@ -1,4 +1,4 @@
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 interface ToolSearchLogContext {
@@ -28,7 +28,7 @@ export function logToolSearchRequest({
     `${providerName} tool search query`
   );
 
-  getStatsDClient().increment("llm_tool_search.requests", 1, [
+  statsDMetrics.increment("llm_tool_search.requests", 1, [
     `tool_name:${toolName}`,
     ...tags,
   ]);

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -61,7 +61,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type {
@@ -1232,12 +1232,12 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             }),
           ]);
 
-          getStatsDClient().increment(
+          statsDMetrics.increment(
             "mcp_output_items.fetch.count",
             gcsItems.length,
             ["storage:gcs"]
           );
-          getStatsDClient().increment(
+          statsDMetrics.increment(
             "mcp_output_items.fetch.count",
             legacyItems.length,
             ["storage:legacy"]
@@ -1253,7 +1253,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                 gcsPath: item.contentGcsPath!,
               }))
             );
-            getStatsDClient().distribution(
+            statsDMetrics.distribution(
               "mcp_output_items.gcs_hydrate.duration_ms",
               Date.now() - gcsStartMs
             );
@@ -1266,7 +1266,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                 }
               }
             } else {
-              getStatsDClient().increment(
+              statsDMetrics.increment(
                 "mcp_output_items.gcs_fallback_db.count",
                 gcsItems.length
               );

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -13,7 +13,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type {
   AgentFunctionCallContentType,
@@ -372,7 +372,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     });
 
     if (!cacheResult) {
-      getStatsDClient().increment(
+      statsDMetrics.increment(
         "agent_step_content.fetch.count",
         agentMessageIds.length,
         ["source:postgres", "cache:error"]
@@ -385,12 +385,12 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     const { hitsByAgentMessageId, missAgentMessageIds } = cacheResult;
 
-    getStatsDClient().increment(
+    statsDMetrics.increment(
       "agent_step_content.fetch.count",
       hitsByAgentMessageId.size,
       ["source:cache"]
     );
-    getStatsDClient().increment(
+    statsDMetrics.increment(
       "agent_step_content.fetch.count",
       missAgentMessageIds.length,
       ["source:postgres"]

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -11,7 +11,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import { defineCacheOperations } from "@app/lib/utils/cache_operations";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type {
   CapabilitySpec,
@@ -639,7 +639,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       return [];
     }
 
-    const statsDClient = getStatsDClient();
+    const statsDClient = statsDMetrics;
     const uniqueGroupModelIds = [...new Set(groupModelIds)];
 
     try {
@@ -699,7 +699,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     groupModelIds: ModelId[]
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
-    const statsDClient = getStatsDClient();
+    const statsDClient = statsDMetrics;
     try {
       const redis = await getRedisCacheClient({
         origin: "group_permissions_cache",

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -15,7 +15,7 @@ import {
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
 import type {
@@ -499,38 +499,38 @@ export class RunResource extends BaseResource<RunModel> {
         `model_id:${usage.modelId}`,
       ];
 
-      getStatsDClient().increment(
+      statsDMetrics.increment(
         "run_usage.prompt_tokens",
         usage.promptTokens,
         tags
       );
-      getStatsDClient().increment(
+      statsDMetrics.increment(
         "run_usage.completion_tokens",
         usage.completionTokens,
         tags
       );
-      getStatsDClient().increment(
+      statsDMetrics.increment(
         "run_usage.cost_micro_usd",
         usage.costMicroUsd,
         tags
       );
 
       if (usage.cachedTokens) {
-        getStatsDClient().increment(
+        statsDMetrics.increment(
           "run_usage.cached_tokens",
           usage.cachedTokens,
           tags
         );
       }
       if (usage.cacheCreationTokens) {
-        getStatsDClient().increment(
+        statsDMetrics.increment(
           "run_usage.cache_creation_tokens",
           usage.cacheCreationTokens,
           tags
         );
       }
       if (usage.reasoningTokens) {
-        getStatsDClient().increment(
+        statsDMetrics.increment(
           "run_usage.reasoning_tokens",
           usage.reasoningTokens,
           tags

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -23,10 +23,10 @@ const {
 }));
 
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => ({
+  statsDMetrics: {
     increment: vi.fn(),
     distribution: mockDistribution,
-  }),
+  },
 }));
 
 vi.mock("@app/lib/api/sandbox", () => ({

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -1,6 +1,6 @@
 import { SequelizeWithComments } from "@app/lib/api/database";
 import { dbConfig } from "@app/lib/resources/storage/config";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { isDevelopment } from "@app/types/shared/env";
 import assert from "assert";
 import type { Sequelize } from "sequelize";
@@ -70,10 +70,10 @@ function reportPoolMetrics(
     return;
   }
 
-  getStatsDClient().gauge("sequelize.pool.size", pool.size, tags);
-  getStatsDClient().gauge("sequelize.pool.available", pool.available, tags);
-  getStatsDClient().gauge("sequelize.pool.using", pool.using, tags);
-  getStatsDClient().gauge("sequelize.pool.waiting", pool.waiting, tags);
+  statsDMetrics.gauge("sequelize.pool.size", pool.size, tags);
+  statsDMetrics.gauge("sequelize.pool.available", pool.available, tags);
+  statsDMetrics.gauge("sequelize.pool.using", pool.using, tags);
+  statsDMetrics.gauge("sequelize.pool.waiting", pool.waiting, tags);
 }
 
 const POOL_TAGS = ["pool:front_master"];
@@ -101,7 +101,7 @@ export const frontSequelize = new SequelizeWithComments(
           return;
         }
 
-        getStatsDClient().distribution(
+        statsDMetrics.distribution(
           "sequelize.connection_acquisition.duration",
           Date.now() - startMs,
           POOL_TAGS

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -19,7 +19,7 @@ import {
   invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
 } from "@app/lib/utils/cache";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
@@ -438,10 +438,7 @@ export class UserResource extends BaseResource<UserModel> {
       const foundUserIds = new Set(users.map((u) => u.sId));
       const missingUserIds = userIds.filter((sId) => !foundUserIds.has(sId));
 
-      getStatsDClient().increment(
-        "user_search.revoked_users_in_results.count",
-        1
-      );
+      statsDMetrics.increment("user_search.revoked_users_in_results.count", 1);
 
       logger.error(
         {

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -1,6 +1,6 @@
 import { queryTracker } from "@app/lib/api/query_tracker";
 import { runWithTemporalActivityContext } from "@app/lib/temporal_activity_context";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type logger from "@app/logger/logger";
 import type { Logger } from "@app/logger/logger";
 
@@ -119,7 +119,7 @@ export class ActivityInboundLogInterceptor
         );
 
         tags.push(`error_type:${errorType}`);
-        getStatsDClient().increment("activity_failed.count", 1, tags);
+        statsDMetrics.increment("activity_failed.count", 1, tags);
       } else {
         this.logger.info(
           {
@@ -128,7 +128,7 @@ export class ActivityInboundLogInterceptor
           },
           "Activity completed."
         );
-        getStatsDClient().increment("activities_success.count", 1, tags);
+        statsDMetrics.increment("activities_success.count", 1, tags);
       }
     }
   }

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -18,7 +18,7 @@ import {
   checkTriggerForExecutionPerDayLimit,
   checkWebhookRequestForRateLimit,
 } from "@app/lib/triggers/rate_limits";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { verifySignature } from "@app/lib/webhook_source_server";
 import logger from "@app/logger/logger";
 import { launchTriggersWorkflows } from "@app/temporal/triggers/webhook_client";
@@ -352,7 +352,7 @@ async function checkWorkspaceRateLimit({
   }
 
   if (block !== null) {
-    getStatsDClient().increment("webhook_workspace_rate_limit.hit.count", 1, [
+    statsDMetrics.increment("webhook_workspace_rate_limit.hit.count", 1, [
       `provider:${provider}`,
       `workspace_id:${workspaceId}`,
       `block_status:${block.status}`,
@@ -393,7 +393,7 @@ async function checkTriggerRateLimit({
       { workspaceId, webhookRequestId, triggerId: trigger.sId },
       result.message
     );
-    getStatsDClient().increment("webhook_trigger_rate_limit.hit.count", 1, [
+    statsDMetrics.increment("webhook_trigger_rate_limit.hit.count", 1, [
       `provider:${provider}`,
       `workspace_id:${workspaceId}`,
       `trigger_id:${trigger.sId}`,
@@ -429,7 +429,7 @@ function matchesPayloadFilter({
     `workspace_id:${workspaceId}`,
     `trigger_id:${trigger.sId}`,
   ];
-  getStatsDClient().increment("webhook_filter.events_processed.count", 1, tags);
+  statsDMetrics.increment("webhook_filter.events_processed.count", 1, tags);
 
   const parsedFilterResult = parseMatcherExpression(filter);
   if (parsedFilterResult.isErr()) {
@@ -447,7 +447,7 @@ function matchesPayloadFilter({
 
   const payloadMatchesFilter = matchPayload(body, parsedFilterResult.value);
   if (payloadMatchesFilter) {
-    getStatsDClient().increment("webhook_filter.events_passed.count", 1, tags);
+    statsDMetrics.increment("webhook_filter.events_passed.count", 1, tags);
     return true;
   }
 
@@ -597,7 +597,7 @@ async function storePayloadInGCS(
         "Webhook request payload was already stored in GCS"
       );
 
-      getStatsDClient().increment("webhook_gcs_precondition.count", 1, [
+      statsDMetrics.increment("webhook_gcs_precondition.count", 1, [
         `provider:${provider}`,
         `workspace_id:${auth.getNonNullableWorkspace().sId}`,
       ]);
@@ -616,7 +616,7 @@ async function storePayloadInGCS(
       "Failed to store webhook request"
     );
 
-    getStatsDClient().increment("webhook_error.count", 1, [
+    statsDMetrics.increment("webhook_error.count", 1, [
       `provider:${provider}`,
       `workspace_id:${auth.getNonNullableWorkspace().sId}`,
     ]);

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -1,5 +1,5 @@
 import { getUpsertQueueBucket } from "@app/lib/file_storage";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import { launchUpsertDocumentWorkflow } from "@app/temporal/upsert_queue/client";
@@ -163,7 +163,7 @@ async function enqueueUpsert({
       return launchRes;
     }
 
-    getStatsDClient().increment("upsert_queue.enqueue.count", 1, []);
+    statsDMetrics.increment("upsert_queue.enqueue.count", 1, []);
 
     return new Ok(upsertQueueId);
   } catch (e) {

--- a/front/lib/utils/rate_limiter.test.ts
+++ b/front/lib/utils/rate_limiter.test.ts
@@ -15,11 +15,11 @@ import {
 vi.unmock("@app/lib/api/redis");
 
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => ({
+  statsDMetrics: {
     decrement: vi.fn(),
     distribution: vi.fn(),
     increment: vi.fn(),
-  }),
+  },
 }));
 
 const logger = {

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -1,6 +1,6 @@
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import type {
   MaxAwuCreditsTimeframeType,
   MaxMessagesTimeframeType,
@@ -108,19 +108,19 @@ export async function rateLimiter({
     })) as number;
 
     const totalTimeMs = new Date().getTime() - now.getTime();
-    getStatsDClient().distribution(
+    statsDMetrics.distribution(
       "ratelimiter.latency.distribution",
       totalTimeMs,
       tags
     );
 
     if (remaining <= 0) {
-      getStatsDClient().increment("ratelimiter.exceeded.count", 1, tags);
+      statsDMetrics.increment("ratelimiter.exceeded.count", 1, tags);
     }
 
     return remaining;
   } catch (e) {
-    getStatsDClient().increment("ratelimiter.error.count", 1, tags);
+    statsDMetrics.increment("ratelimiter.error.count", 1, tags);
     logger.error(
       {
         key,
@@ -201,9 +201,7 @@ export async function addRateLimiterCount({
       arguments: [windowMs.toString(), member],
     });
   } catch (e) {
-    getStatsDClient().increment("ratelimiter.error.count", 1, [
-      "operation:add",
-    ]);
+    statsDMetrics.increment("ratelimiter.error.count", 1, ["operation:add"]);
     logger.error({ key, incrementBy, error: e }, "addRateLimiterCount error");
   }
 }
@@ -411,7 +409,7 @@ export async function addFixedWindowCount({
   // runs on the message-send path, so a bad increment must never throw and
   // break the send — log and skip instead.
   if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
-    getStatsDClient().increment("ratelimiter.error.count", 1, [
+    statsDMetrics.increment("ratelimiter.error.count", 1, [
       "operation:add_fixed_window",
     ]);
     logger.error(
@@ -441,7 +439,7 @@ export async function addFixedWindowCount({
       arguments: [incrementBy.toString(), expireAtMs.toString()],
     });
   } catch (e) {
-    getStatsDClient().increment("ratelimiter.error.count", 1, [
+    statsDMetrics.increment("ratelimiter.error.count", 1, [
       "operation:add_fixed_window",
     ]);
     logger.error(
@@ -492,7 +490,7 @@ export async function setFixedWindowCount({
     });
     return new Ok(undefined);
   } catch (e) {
-    getStatsDClient().increment("ratelimiter.error.count", 1, [
+    statsDMetrics.increment("ratelimiter.error.count", 1, [
       "operation:set_fixed_window",
     ]);
     logger.error(
@@ -569,7 +567,7 @@ export async function seedFixedWindowCountIfAbsent({
     }
     return new Ok(count);
   } catch (e) {
-    getStatsDClient().increment("ratelimiter.error.count", 1, [
+    statsDMetrics.increment("ratelimiter.error.count", 1, [
       "operation:seed_fixed_window",
     ]);
     logger.error(

--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -3,7 +3,7 @@ import { StatsD } from "hot-shots";
 
 let statsDClient: StatsD | undefined = undefined;
 
-export function getStatsDClient(): StatsD {
+function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {
     statsDClient = new StatsD({
@@ -20,3 +20,96 @@ export function getStatsDClient(): StatsD {
   }
   return statsDClient;
 }
+
+// The Datadog agent interprets a client-sent `host:` tag as a hostname override; an empty
+// value submits the metric with no host tag at all. Each host multiplies the indexed
+// custom-metric count for every tag combination, so dropping it keeps cardinality (and
+// Datadog billing) flat as the fleet scales.
+const HOSTLESS_TAG = "host:";
+
+interface MetricOptions {
+  // Overrides the per-type host-tag default. Distributions drop the host tag by default:
+  // they are aggregated server-side, so the host adds cardinality without changing results.
+  // Counters, gauges, histograms and timings keep it: they are aggregated per host, and
+  // hostless series flushed by different nodes can collide on the same timestamp and lose
+  // points. Only opt a counter out of the host tag if sporadic undercounting is acceptable.
+  includeHostTag?: boolean;
+}
+
+function withHostPolicy(tags: string[], includeHostTag: boolean): string[] {
+  return includeHostTag ? tags : [...tags, HOSTLESS_TAG];
+}
+
+export const statsDMetrics = {
+  increment(
+    name: string,
+    value: number = 1,
+    tags: string[] = [],
+    { includeHostTag = true }: MetricOptions = {}
+  ): void {
+    getStatsDClient().increment(
+      name,
+      value,
+      withHostPolicy(tags, includeHostTag)
+    );
+  },
+
+  decrement(
+    name: string,
+    value: number = 1,
+    tags: string[] = [],
+    { includeHostTag = true }: MetricOptions = {}
+  ): void {
+    getStatsDClient().decrement(
+      name,
+      value,
+      withHostPolicy(tags, includeHostTag)
+    );
+  },
+
+  gauge(
+    name: string,
+    value: number,
+    tags: string[] = [],
+    { includeHostTag = true }: MetricOptions = {}
+  ): void {
+    getStatsDClient().gauge(name, value, withHostPolicy(tags, includeHostTag));
+  },
+
+  distribution(
+    name: string,
+    value: number,
+    tags: string[] = [],
+    { includeHostTag = false }: MetricOptions = {}
+  ): void {
+    getStatsDClient().distribution(
+      name,
+      value,
+      withHostPolicy(tags, includeHostTag)
+    );
+  },
+
+  // Prefer distribution() for new timing-style metrics: histograms and timings are
+  // aggregated per host by the agent, so they cannot safely drop the host tag.
+  histogram(
+    name: string,
+    value: number,
+    tags: string[] = [],
+    { includeHostTag = true }: MetricOptions = {}
+  ): void {
+    getStatsDClient().histogram(
+      name,
+      value,
+      withHostPolicy(tags, includeHostTag)
+    );
+  },
+
+  timing(
+    name: string,
+    value: number,
+    tags: string[] = [],
+    { includeHostTag = true }: MetricOptions = {}
+  ): void {
+    getStatsDClient().timing(name, value, withHostPolicy(tags, includeHostTag));
+  },
+};

--- a/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
+++ b/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import { Op } from "sequelize";
@@ -91,7 +91,7 @@ export async function checkCostAndSubagentsThresholds({
         "Agent loop cost threshold crossed"
       );
 
-      getStatsDClient().increment(COST_THRESHOLD_CROSSED_METRIC, 1, [
+      statsDMetrics.increment(COST_THRESHOLD_CROSSED_METRIC, 1, [
         `threshold_usd:${thresholdUsd}`,
         `workspace_id:${workspace.sId}`,
       ]);

--- a/front/temporal/agent_loop/activities/instrumentation.ts
+++ b/front/temporal/agent_loop/activities/instrumentation.ts
@@ -1,4 +1,4 @@
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 
 // StatsD metric names.
 export const METRICS = {
@@ -44,5 +44,5 @@ export const METRICS = {
 
 // Log start of complete agent loop - only called once per loop (from client.ts).
 export function logAgentLoopStart(): void {
-  getStatsDClient().increment(METRICS.LOOP_STARTS, 1);
+  statsDMetrics.increment(METRICS.LOOP_STARTS, 1);
 }

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider.test.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider.test.ts
@@ -29,10 +29,10 @@ vi.mock("@app/lib/tokenization", () => ({
 }));
 
 vi.mock("@app/lib/utils/statsd", () => ({
-  getStatsDClient: () => ({
+  statsDMetrics: {
     distribution: vi.fn(),
     increment: vi.fn(),
-  }),
+  },
 }));
 
 function emptyState(): ConversationWindowStateSnapshot {

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -10,7 +10,7 @@ import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getShutdownSignal } from "@app/lib/shutdown_signal";
 import { classifyTemporalAbortReason } from "@app/lib/temporal/cancellation";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { makeModelInterruptionError } from "@app/temporal/agent_loop/lib/run_model_errors";
 import type {
@@ -585,16 +585,12 @@ export async function getOutputFromLLMStream(
             `is_dust_like_agent:${isDustLikeAgent(agentConfiguration.sId)}`,
           ];
           // Count: how often each reason occurs.
-          getStatsDClient().increment(
-            "llm.cache_miss_reason.count",
-            1,
-            reasonTags
-          );
+          statsDMetrics.increment("llm.cache_miss_reason.count", 1, reasonTags);
           // Weighted by lost-cache tokens: which reason actually costs the most,
           // not just which happens most. Only the `*_changed` reasons carry this
           // (the inconclusive ones have no diverged prefix to measure).
           if (cacheMissReason.cacheMissedInputTokens !== undefined) {
-            getStatsDClient().distribution(
+            statsDMetrics.distribution(
               "llm.cache_miss_reason.missed_input_tokens",
               cacheMissReason.cacheMissedInputTokens,
               reasonTags

--- a/front/temporal/agent_loop/sinks.ts
+++ b/front/temporal/agent_loop/sinks.ts
@@ -1,4 +1,4 @@
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
@@ -55,7 +55,7 @@ export const instrumentationSinks: InjectedSinks<AgentLoopInstrumentationSinks> 
             { workspaceId, agentMessageId, conversationId, startStep },
             "Agent loop phase execution started"
           );
-          getStatsDClient().increment(METRICS.PHASE_STARTS, 1);
+          statsDMetrics.increment(METRICS.PHASE_STARTS, 1);
         },
       },
       logStepCompletion: {
@@ -71,13 +71,9 @@ export const instrumentationSinks: InjectedSinks<AgentLoopInstrumentationSinks> 
           const incrementTags = [`step:${step}`];
           const distributionTags = [`step:${step < 16 ? step : "16+"}`];
 
-          getStatsDClient().increment(METRICS.STEP_STARTS, 1, incrementTags);
-          getStatsDClient().increment(
-            METRICS.STEP_COMPLETIONS,
-            1,
-            incrementTags
-          );
-          getStatsDClient().distribution(
+          statsDMetrics.increment(METRICS.STEP_STARTS, 1, incrementTags);
+          statsDMetrics.increment(METRICS.STEP_COMPLETIONS, 1, incrementTags);
+          statsDMetrics.distribution(
             METRICS.STEP_DURATION,
             stepDurationMs,
             distributionTags
@@ -112,18 +108,12 @@ export const instrumentationSinks: InjectedSinks<AgentLoopInstrumentationSinks> 
             "Agent loop execution completed"
           );
 
-          getStatsDClient().increment(METRICS.PHASE_COMPLETIONS, 1);
-          getStatsDClient().distribution(
-            METRICS.PHASE_DURATION,
-            phaseDurationMs
-          );
-          getStatsDClient().histogram(METRICS.PHASE_STEPS, stepsCompleted);
+          statsDMetrics.increment(METRICS.PHASE_COMPLETIONS, 1);
+          statsDMetrics.distribution(METRICS.PHASE_DURATION, phaseDurationMs);
+          statsDMetrics.histogram(METRICS.PHASE_STEPS, stepsCompleted);
 
-          getStatsDClient().increment(METRICS.LOOP_COMPLETIONS, 1);
-          getStatsDClient().distribution(
-            METRICS.LOOP_DURATION,
-            totalDurationMs
-          );
+          statsDMetrics.increment(METRICS.LOOP_COMPLETIONS, 1);
+          statsDMetrics.distribution(METRICS.LOOP_DURATION, totalDurationMs);
         },
       },
     },

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -6,7 +6,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type { WorkflowError } from "@app/lib/temporal_monitoring";
 import { EnqueueUpsertDocument } from "@app/lib/upsert_queue";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
 import mainLogger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -143,12 +143,8 @@ export async function upsertDocumentActivity(
       },
       "[UpsertQueue] Failed document upsert"
     );
-    getStatsDClient().increment(
-      "upsert_queue_document_error.count",
-      1,
-      statsDTags
-    );
-    getStatsDClient().distribution(
+    statsDMetrics.increment("upsert_queue_document_error.count", 1, statsDTags);
+    statsDMetrics.distribution(
       "upsert_queue_upsert_document_error.duration.distribution",
       Date.now() - upsertTimestamp,
       []
@@ -170,17 +166,13 @@ export async function upsertDocumentActivity(
     },
     "[UpsertQueue] Successful document upsert"
   );
-  getStatsDClient().increment(
-    "upsert_queue_document_success.count",
-    1,
-    statsDTags
-  );
-  getStatsDClient().distribution(
+  statsDMetrics.increment("upsert_queue_document_success.count", 1, statsDTags);
+  statsDMetrics.distribution(
     "upsert_queue_upsert_document_success.duration.distribution",
     Date.now() - upsertTimestamp,
     []
   );
-  getStatsDClient().distribution(
+  statsDMetrics.distribution(
     "upsert_queue_document.duration.distribution",
     Date.now() - enqueueTimestamp,
     []

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -3,7 +3,7 @@ import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { WorkflowError } from "@app/lib/temporal_monitoring";
 import { EnqueueUpsertTable } from "@app/lib/upsert_queue";
-import { getStatsDClient } from "@app/lib/utils/statsd";
+import { statsDMetrics } from "@app/lib/utils/statsd";
 import mainLogger from "@app/logger/logger";
 
 import config from "@app/temporal/config";
@@ -105,12 +105,8 @@ export async function upsertTableActivity(
       },
       "[UpsertQueue] Failed table upsert"
     );
-    getStatsDClient().increment(
-      "upsert_queue_table_error.count",
-      1,
-      statsDTags
-    );
-    getStatsDClient().distribution(
+    statsDMetrics.increment("upsert_queue_table_error.count", 1, statsDTags);
+    statsDMetrics.distribution(
       "upsert_queue_upsert_table_error.duration.distribution",
       Date.now() - upsertTimestamp,
       []
@@ -134,17 +130,13 @@ export async function upsertTableActivity(
     },
     "[UpsertQueue] Successful table upsert"
   );
-  getStatsDClient().increment(
-    "upsert_queue_table_success.count",
-    1,
-    statsDTags
-  );
-  getStatsDClient().distribution(
+  statsDMetrics.increment("upsert_queue_table_success.count", 1, statsDTags);
+  statsDMetrics.distribution(
     "upsert_queue_upsert_table_success.duration.distribution",
     Date.now() - upsertTimestamp,
     []
   );
-  getStatsDClient().distribution(
+  statsDMetrics.distribution(
     "upsert_queue_table.duration.distribution",
     Date.now() - enqueueTimestamp,
     []


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Our custom metrics cardinality monitor keeps flickering. Digging into it, the main offender is not our own tags: it's the `host` tag that `dd-agent` stamps on every statsd metric. A distribution like `llm_time_to_first_event_ms` has ~50 legit tag combinations, but multiplied by ~150 hosts (x5 distribution aggregations) it lands at ~7900 indexed custom metrics. For a latency metric, host is a dimension nobody ever queries.

What I tried before landing here:
- **Fix it in infra**: there is no agent option to drop the host tag from `dogstatsd` metrics. It's been an open feature request since 2019 (DataDog/datadog-agent#3130). Tag cardinality is already at the minimum (`low`), nothing left to tune there.
- **Fix it in Datadog**: Metrics without Limits tag configs do work, but it's a one-time manual config *per metric*. Every new metric ships fat by default and someone has to remember to trim it. We used on many metrics so far, but let's be honest, it does not scale! 
- **Fix it at emission**: turns out the agent treats a client-sent `host:` tag as a hostname override, and an *empty* value submits the metric with no host at all. Undocumented but explicitly unit-tested in the agent (`TestConvertParseSingleWithEmptyHostTags`)[[source](https://github.com/DataDog/datadog-agent/blob/2dcbee145dfc903b105214ab95ee34478dfa8db4/comp/dogstatsd/server/impl/enrich_test.go#L200-L226)]. Verified it live with a vanity `dust.cardinality_canary` metric from a front pod (🙈 ): the `hostless` point shows `host: N/A` in [Datadog](https://app.datadoghq.eu/metric/explorer?fromUser=true&graph_layout=stacked&session_id=96b38de2-bf3b-4f01-9b12-7d9e9c069ffe&start=1787836262285&end=1787837807714&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMy0zqxkQHgBdKl9dfVdQKAwEDAB9DXxtAGMlZBB1BF1kyyoRDHUfM21-AxAwmnTVDGJkKDwNBAA6ZIxtKFEMNHEsONb8kuAAKh4AAgAjLFHgfrasCkYcRp5AkJAjDXkpLTiPasIVCHUtcNyQRqw0NNB5LsQENJAoHBg+5w0IZLLukTg4uUUykS3Sg31Ef3oTGUIns1TQgWCPD453k3QQAGEpMIYCgRE40DwgA), the control point shows the node. It works.

So this PR makes emission the fix. `statsd.ts` now exposes a `statsDMetrics` wrapper (raw `hot`-shots client is no longer exported) that appends the empty `host:` tag to **distributions** by default. Distributions are aggregated server-side so dropping host changes nothing about query results. Counters/gauges/histograms/timings keep the host tag: they're aggregated per host, and identical hostless series from two nodes can collide on a timestamp and silently lose points. Every method takes `{ includeHostTag }` to override either way.


> [!NOTE]
> Expectation: Drop cardinalities by at least size of the fleet and remains flat as spot nodes are being evicted/node scaled.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
