### PR TITLE
Always show one decimal in Credits / message column

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -24,7 +24,7 @@ import {
 import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
 import { WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE } from "@app/lib/analytics/consumption_scope";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import { formatCredits } from "@app/lib/client/credits";
+import { formatAvgCredits, formatCredits } from "@app/lib/client/credits";
 import { LinkWrapper } from "@app/lib/platform";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import type {
@@ -366,7 +366,7 @@ function buildColumns({
       cell: (info) => (
         <DataTable.BasicCellContent
           className="justify-end text-right tabular-nums"
-          label={formatCredits(info.row.original.avgCredits)}
+          label={formatAvgCredits(info.row.original.avgCredits)}
         />
       ),
     },

--- a/front/lib/client/credits.test.ts
+++ b/front/lib/client/credits.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { formatCreditResetCountdown, formatFairUseAllowance } from "./credits";
+import {
+  formatAvgCredits,
+  formatCreditResetCountdown,
+  formatFairUseAllowance,
+} from "./credits";
+
+describe("formatAvgCredits", () => {
+  it.each([
+    [310, "310.0"],
+    [46.12, "46.1"],
+    [1748.95, "1,749.0"],
+    [0, "0.0"],
+  ])("formats %s with exactly one decimal", (credits, expected) => {
+    expect(formatAvgCredits(credits)).toBe(expected);
+  });
+});
 
 describe("formatFairUseAllowance", () => {
   it.each([

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -9,6 +9,15 @@ export function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
 }
 
+// Format AWU credits with exactly one decimal (e.g. "310.0"), so values in
+// per-message average columns stay visually consistent.
+export function formatAvgCredits(credits: number): string {
+  return credits.toLocaleString("en-US", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
 // Format AWU credits with full fractional precision (up to 6 decimals,
 // trailing zeros trimmed). Used by Poke debugging views that surface
 // microcredit-derived figures (e.g. the rate-limiter counter), where an


### PR DESCRIPTION
In the analytics Attribution table, the Credits / message column mixes formats: 46.1 next to 310 or 911. Always show one decimal so values read consistently (310 renders as 310.0).

Adds a `formatAvgCredits` helper (min and max one fraction digit) and uses it in the avg column cell, which serves all Attribution tabs. `formatCredits` is unchanged so Total credits and cost menus keep their format.