### PR TITLE
Clear attribution search when adding a row to filters

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -437,6 +437,50 @@ describe("ConsumptionAttributionTable", () => {
     });
   });
 
+  it("clears the search when a row is added to the filters", async () => {
+    const onAddFilter = vi.fn();
+    const row = {
+      id: "user-1",
+      name: "Jane Doe",
+      pictureUrl: null,
+      credits: 100,
+      avgCredits: 10,
+    };
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [row],
+      totalCredits: 100,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="user"
+        onDimensionChange={vi.fn()}
+        onAddFilter={onAddFilter}
+        onRemoveFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search…");
+    fireEvent.change(searchInput, { target: { value: "Jane" } });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add Jane Doe to filters" })
+    );
+
+    expect(onAddFilter).toHaveBeenCalledWith(expect.objectContaining(row));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search…")).toHaveValue("");
+    });
+  });
+
   it("selects the API key dimension with a pointer", () => {
     const onDimensionChange = vi.fn();
     mockUseConsumptionTop.mockReturnValue({

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -69,7 +69,7 @@ import {
   useReducedMotion,
 } from "framer-motion";
 import type { ComponentType, Dispatch, ReactNode, SetStateAction } from "react";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type {
   AttributionRowData,
   ConsumptionAttributionRowsTableProps,
@@ -813,9 +813,20 @@ export function ConsumptionAttributionTableView({
   onConversationNavigate,
   AttributionRowsComponent,
 }: ConsumptionAttributionTableViewProps) {
-  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+  const { inputValue, debouncedValue, setValue, flush } = useDebounce("", {
     delay: SEARCH_DEBOUNCE_DELAY_MS,
   });
+
+  // The search usually targeted the row being pinned; keeping it would leave
+  // the freshly filtered table narrowed by a stale search.
+  const handleAddFilter = useCallback(
+    (row: ConsumptionTopRow) => {
+      setValue("");
+      flush();
+      onAddFilter(row);
+    },
+    [setValue, flush, onAddFilter]
+  );
   const [isConversationSelected, setIsConversationSelected] = useState(false);
   const isPersonal = analyticsScope.kind === "personal";
   const activeDimension =
@@ -949,7 +960,7 @@ export function ConsumptionAttributionTableView({
                       filter={filter}
                       analyticsScope={analyticsScope}
                       disabled={disabled}
-                      onAddFilter={onAddFilter}
+                      onAddFilter={handleAddFilter}
                       onAgentClick={onAgentClick}
                       onRemoveFilter={onRemoveFilter}
                       onSkillClick={onSkillClick}


### PR DESCRIPTION
On the analytics consumption page, searching for a row in the Attribution table and then clicking its funnel button keeps the search text, so the freshly filtered table stays narrowed by a stale search (often to the one row just pinned).

Clicking "Add to filters" now clears the search (with a debounce flush so the table refetches immediately). Removing a filter leaves the search untouched.



Bug repro: I want to see the agents used bu Aubin: I type "Aub" in Members and filter by Aubin, then I click on the Agents tab and I have to clear the search bar