### PR TITLE
Define Frames v2 function artifact contract

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -42,6 +42,19 @@ const manifest = FrameManifestSchema.parse({
   description: "Track tasks.",
 });
 
+const manifestWithFunction = FrameManifestSchema.parse({
+  version: 1,
+  name: "Task List",
+  description: "Track tasks.",
+  functions: [
+    {
+      name: "add-task",
+      description: "Add a task.",
+      entryPoint: "functions/add_task.ts",
+    },
+  ],
+});
+
 const sourceFiles = [
   {
     relativePath: "index.tsx",
@@ -111,6 +124,22 @@ describe("storeFramePublication", () => {
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_source");
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("rejects a publication whose function entry point is missing", async () => {
+    const { auth, frame } = await setupFrame();
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      manifest: manifestWithFunction,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_source");
+    expect(result.isErr() && result.error.message).toContain(
+      "add-task (functions/add_task.ts)"
+    );
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -111,6 +111,16 @@ export async function storeFramePublication(
       )
     );
   }
+  for (const fn of manifest.functions) {
+    if (!sourcePaths.has(fn.entryPoint)) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_source",
+          `Frame function entry point not found: ${fn.name} (${fn.entryPoint})`
+        )
+      );
+    }
+  }
 
   const identity = {
     ...frameIdentity.value,

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -1,5 +1,6 @@
 import {
   getFrameBasePath,
+  getFramePublicationFunctionBundlePath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
 } from "@app/types/api/frame_storage";
@@ -25,6 +26,14 @@ describe("Frames v2 GCS paths", () => {
     ).toBe(
       "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/source/src/index.tsx"
     );
+    expect(
+      getFramePublicationFunctionBundlePath({
+        ...IDS,
+        functionName: "add-task",
+      })
+    ).toBe(
+      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task/bundle.js"
+    );
   });
 
   it("rejects path traversal and unsafe identity segments", () => {
@@ -37,5 +46,11 @@ describe("Frames v2 GCS paths", () => {
     expect(() =>
       getFrameBasePath({ workspaceId: "../other", frameId: IDS.frameId })
     ).toThrow("Invalid workspaceId");
+    expect(() =>
+      getFramePublicationFunctionBundlePath({
+        ...IDS,
+        functionName: "../other",
+      })
+    ).toThrow("Invalid functionName");
   });
 });

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -70,3 +70,24 @@ export function getFramePublicationSourcePath({
 
   return `${getFramePublicationSourceBasePath(args)}${relativePath}`;
 }
+
+export function getFramePublicationFunctionBasePath({
+  functionName,
+  ...args
+}: {
+  workspaceId: string;
+  frameId: string;
+  publicationId: string;
+  functionName: string;
+}): string {
+  return `${getFramePublicationBasePath(args)}functions/${safeSegment(functionName, "functionName")}/`;
+}
+
+export function getFramePublicationFunctionBundlePath(args: {
+  workspaceId: string;
+  frameId: string;
+  publicationId: string;
+  functionName: string;
+}): string {
+  return `${getFramePublicationFunctionBasePath(args)}bundle.js`;
+}


### PR DESCRIPTION
## Description

Add the canonical GCS path for immutable Frame function bundles and reject publications whose declared function entry points are absent from the source set. This gives function building and materialization a stable storage target.

## Tests

Added focused coverage for bundle paths, unsafe function names, and missing function entry points.

## Risk

Low. The new path has no callers yet. Validation only affects manifests that declare functions.

## Deploy Plan

Standard deploy.