### PR TITLE
[front] fix: restore the user's role on internal sub-agent message posts

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -6,8 +6,14 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { CLAUDE_OPUS_4_8_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
+}));
 
 vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
   isProgrammaticUsage: () => false,
@@ -32,6 +38,49 @@ function postMessage(
       },
       body: JSON.stringify(body),
     }
+  );
+}
+
+// `@analyst` is a global agent gated on the `managers` audience, so it only resolves for an
+// authenticator carrying an admin or manager role.
+async function postAnalystMention(
+  workspace: { sId: string },
+  key: { secret: string },
+  { role, asSubAgent }: { role: MembershipRoleType; asSubAgent: boolean }
+) {
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role });
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const conversation = await ConversationFactory.create(userAuth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    messagesCreatedAt: [],
+  });
+
+  return postMessage(
+    workspace,
+    conversation.sId,
+    key,
+    {
+      content: "Hello",
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.ANALYST }],
+      context: {
+        username: "sub-agent",
+        timezone: "Europe/Paris",
+        origin: "api",
+      },
+      ...(asSubAgent
+        ? {
+            agenticMessageData: {
+              type: "run_agent",
+              originMessageId: "msg_parent",
+            },
+          }
+        : {}),
+    },
+    { "x-api-user-email": user.email }
   );
 }
 
@@ -278,5 +327,51 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.message.user).toBeNull();
+  });
+  it("resolves a role-gated agent for a sub-agent post from an admin", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    const response = await postAnalystMention(workspace, key, {
+      role: "admin",
+      asSubAgent: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).agentMessages).toHaveLength(1);
+  });
+
+  it("keeps a role-gated agent out of reach of a sub-agent post from a regular member", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    const response = await postAnalystMention(workspace, key, {
+      role: "user",
+      asSubAgent: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).agentMessages).toHaveLength(0);
+  });
+
+  it("leaves impersonated posts outside the sub-agent path capped at the user role", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    // No `agenticMessageData`: this is the Slack/Teams/Discord shape, which stays capped at
+    // "user" even for an admin.
+    const response = await postAnalystMention(workspace, key, {
+      role: "admin",
+      asSubAgent: false,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).agentMessages).toHaveLength(0);
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -523,7 +523,7 @@ export function isUserMessageContextValid(
 }
 
 export async function postUserMessage(
-  auth: Authenticator,
+  requestAuth: Authenticator,
   {
     conversationResource,
     content,
@@ -554,10 +554,19 @@ export async function postUserMessage(
     APIErrorWithContentfulStatusCode
   >
 > {
-  const user = auth.user();
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
+  const user = requestAuth.user();
+  const owner = requestAuth.workspace();
+  const subscription = requestAuth.subscription();
   const plan = subscription?.plan;
+
+  // Internal sub-agent posts (`run_agent` and `agent_handover`) reach us through the public API
+  // with a system key impersonating the user, which caps the role at "user". Restore the user's
+  // real workspace role so role-gated global agents (e.g. `@analyst`) resolve here, in
+  // `runAgentLoopWorkflow` below, and in the child's own agent loop -- which all fetch the agent
+  // configuration again. The role comes from the active membership, never from the caller.
+  const auth = agenticMessageData
+    ? await requestAuth.withUserWorkspaceRole()
+    : requestAuth;
 
   const conversation: ConversationWithoutContentType =
     conversationResource.toJSON();

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1236,6 +1236,47 @@ export class Authenticator {
     });
   }
 
+  /**
+   * Returns a copy of this authenticator carrying the user's actual workspace role.
+   *
+   * `exchangeSystemKeyForUserAuthByEmail` deliberately caps impersonated authenticators at the
+   * "user" role. The internal sub-agent path (`run_agent` / `agent_handover`) needs the real role
+   * so that role-gated global agents (e.g. `@analyst`, audience `managers`) stay resolvable both
+   * when the child message is posted and in the child's own agent loop.
+   *
+   * The role is read from the user's active membership, never from the caller, so this can never
+   * grant more than the user already has in the workspace.
+   */
+  async withUserWorkspaceRole(): Promise<Authenticator> {
+    const user = this._user;
+    if (!user || !this._workspace) {
+      return this;
+    }
+
+    const role = await MembershipResource.getActiveRoleForUserInWorkspace({
+      user,
+      workspace: this.getNonNullableWorkspace(),
+    });
+    if (role === "none" || role === this._role) {
+      return this;
+    }
+
+    return new Authenticator({
+      authMethod: this.authMethod(),
+      key: this._key,
+      attributionKey: this._attributionKey,
+      role,
+      groupModelIds: this._groupModelIds,
+      user,
+      subscription: this._subscription,
+      workspace: this._workspace,
+      clientIp: this._clientIp,
+      providersHealth: this._providersHealth,
+      // Groups are unchanged and permissions do not depend on the role.
+      permissions: this._permissions,
+    });
+  }
+
   exchangeKey(key: KeyAuthType) {
     return new Authenticator({
       authMethod: this.authMethod(),


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/10198 — Criteo (and our demo workspace) could not invoke `@analyst` as a sub-agent even as a workspace admin.

Supersedes #31232, which fixed the same bug at the root (`exchangeSystemKeyForUserAuthByEmail` no longer capping the role) but changed behaviour for every impersonating caller. That was too wide, so this version scopes the change to the sub-agent path only.

### Root cause

Sub-agent posts reach the public API through `DustAPI` with a system key impersonating the user (`run_agent/index.ts`), and `exchangeSystemKeyForUserAuthByEmail` caps the resulting authenticator at the `"user"` role regardless of the user's real workspace role.

`@analyst` is a global agent with `audience: "managers"`, so `getGlobalAgents` filters it out via `canRoleSeeGlobalAgent`. In the child conversation the `@analyst` mention then resolved to nothing — and `postUserMessage` silently drops unresolvable mentions (`removeNulls`), returning 200 with zero agent messages. That is exactly what produced both reported symptoms:

- **"agent runs in the background"**: `run_agent` finds no agent message for the user message it just posted and reports `makeChildAgentUnavailableError` — the verbatim *"Agent @analyst is not available to the user running this conversation. Ask a workspace admin to grant access to the agent and its spaces."*
- **"agent responds in conversation"** (handoff): the message goes into the *main* conversation, the parent exits with "handoff successfully launched", and no agent ever replies — the conversation is broken forever.

### Fix

`postUserMessage` derives an authenticator carrying the user's real workspace role when `agenticMessageData` is set, via a new additive `Authenticator.withUserWorkspaceRole()`. The role is read from the user's active membership (Redis-cached), so it can never grant more than the user already has; the clone preserves key, groups, subscription, permissions and clientIp so API-key attribution and usage tracking are unaffected.

Everything outside the sub-agent path is untouched: Slack, Teams, Discord and the feedback API send no `agenticMessageData` and keep the `"user"` cap.

Two notes on the shape, both forced by the call graph rather than chosen:

**It keys off `agenticMessageData` presence, not `type === "run_agent"`.** Handoff posts carry `type: "agent_handover"` (`makeSubAgentMessage`), and that is the mode that leaves the conversation stuck forever, so gating on `run_agent` alone would have left the worse symptom unfixed.

**The derived auth covers the whole tail of `postUserMessage`, not just mention resolution.** The agent configuration is fetched three times on this path: at mention resolution, again in `runAgentLoopWorkflow` behind an `assert(...)` that would throw a 500, and a third time in the child's own agent loop from the serialized auth (`agent_run.ts:456`, `Agent configuration not found analyst`). Scoping the derived auth to the first fetch would have traded one broken conversation for another. Hence the parameter rename rather than a rebind — the body of the function is otherwise untouched.

On the trust boundary: `agenticMessageData` is request-body data, but the route already rejects it with a 401 unless the caller holds a system key (`messages/index.ts:169`), so it cannot be used to elevate an ordinary API key.

### Tests

Three functional tests on `POST /api/v1/w/:wId/assistant/conversations/:cId/messages`, all with a system key and `x-api-user-email`:

- admin, **with** `agenticMessageData` → one agent message for an `@analyst` mention. Fails without the fix: `expected [] to have a length of 1`.
- regular member, with `agenticMessageData` → zero. No escalation.
- admin, **without** `agenticMessageData` → zero. Pins the narrow scope: the Slack/Teams/Discord shape stays capped.

`lib/api/assistant/conversation`, `lib/auth` and `run_agent` suites pass (447 tests); `tsgo --noEmit` clean on both workspaces. Heads-up for the reviewer: a full `front-api` sweep exited non-zero on my last run and I did not get to diagnose which test it was, so that wants a look before merge.

### Follow-ups, deliberately out of scope

An admin delegating to `@analyst` **from Slack** still fails, because connectors post without the sub-agent path. One-line change in connectors if we want it.

`postUserMessage` silently dropping an inaccessible mention is a latent bug of its own: any genuinely inaccessible agent still yields a 200 with no agent message and a conversation that hangs. Fixing it would turn those into 400s on the public API.