### PR TITLE
fix(front-api): declare openai explicitly so the bundle resolves the Responses SDK

### DIFF
--- a/front-api/package.json
+++ b/front-api/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@novu/framework": "^2.11.1",
+    "openai": "^6.46.0",
     "umzug": "3.8.3",
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^1.19.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,6 +545,7 @@
         "@novu/framework": "^2.11.1",
         "hono": "^4.12.15",
         "jsonwebtoken": "^9.0.0",
+        "openai": "^6.46.0",
         "swagger-jsdoc": "^6.2.8",
         "umzug": "3.8.3",
         "zod": "^3.25.76",
@@ -724,6 +725,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "front-api/node_modules/openai": {
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+      "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "front-api/node_modules/remark-gfm": {


### PR DESCRIPTION
## Description

Triggers natural language=>CRON don't work locally if we don't have the right dep 
<img width="745" height="246" alt="Screenshot 2026-08-27 at 16 40 35" src="https://github.com/user-attachments/assets/772d859d-26f3-44a3-9f12-f0b2f856729b" />

Re-declare `openai` as an explicit dependency of `front-api`, reverting the removal in #30770.

`front-api` has no `import ... from "openai"` in its own source, so the dependency looks unused —
but that is not what makes it load-bearing. `front-api` bundles `front`'s source through the
`@app/*` alias, including `front/lib/model_constructors/{stream,batch}/clients/openai_responses.ts`,
which imports the SDK. esbuild externalizes every bare specifier
(`front-api/esbuild.shared.ts`), so `require("openai")` is resolved by Node at runtime from
`front-api/dist/`. With no copy in `front-api/node_modules`, that walk-up reaches the hoisted root
copy, which in a full monorepo install is **openai 4.77.4** — the exact peer pin of
`@microsoft/teams-ai` (a `connectors` dependency). 4.77.4 predates the Responses API, so
`client.responses` is `undefined` and every Responses call fails with:

```
TypeError: Cannot read properties of undefined (reading 'create')
```

which `classifyStreamError` cannot recognise as an SDK error, so it surfaces to callers as the
opaque `LLM error: Unknown error from OpenAI`. Locally this breaks every front-api route that
reaches an OpenAI Responses endpoint (agent runs, `text_as_cron_rule`, similar-skill and
similar-agent discovery).

Production is unaffected today: the front image installs only
`-w sdks/js -w sparkle -w front -w front-spa -w front-api`, so `connectors` — and with it the
4.77.4 peer — is never installed, and `NODE_PATH=/app/front/node_modules` catches the resolution.
That makes correctness depend on which workspaces an install happens to include, and `NODE_PATH` is
only consulted *after* the `node_modules` walk-up, so it cannot override a wrong root copy. An
explicit dependency puts the right version first in the walk-up in every environment.

This restores what #29463 added (and the `Do not remove` comments in both OpenAI Responses clients
still refer to).

## Tests

Resolution from the bundle's directory, before and after:

```
# before
resolve("openai") from front-api/dist -> /dust/node_modules/openai      4.77.4  -> responses === undefined
# after
resolve("openai") from front-api/dist -> /dust/front-api/node_modules/openai  6.49.0  -> responses.create is a function
```

Verified the `text_as_cron_rule` path no longer fails on a local `front-api`.

## Risk

Low. Dependency-only change, no runtime code. `front-api` resolves 6.49.0 while `front` stays
pinned at 6.46.0 in the lockfile — same major, and the two are independent copies, as was already
the case between #29463 and #30770.

## Deploy Plan

None. Prod behaviour is unchanged; this removes the dependence on workspace-install layout.
