### PR TITLE
refactor(sandbox): shared egress-domain UI + standalone agent-request toggle

### DIFF
--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,5 +1,6 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
+import { AgentRequestedDomainsSetting } from "@app/components/sandbox/AgentRequestedDomainsSetting";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { ContentMessage, InfoCircle, Page } from "@dust-tt/sparkle";
@@ -28,6 +29,7 @@ export function SandboxPage() {
 
     return (
       <>
+        <AgentRequestedDomainsSetting />
         <NetworkSection />
         <EnvironmentSection />
       </>

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -7,32 +7,16 @@ import {
 import {
   useDismissWorkspaceEgressRequest,
   useUpdateWorkspaceEgressPolicy,
-  useUpdateWorkspaceSandboxAgentEgressRequests,
   useWorkspaceEgressPolicy,
 } from "@app/lib/swr/sandbox";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
-import {
-  ContentMessage,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  InfoCircle,
-  Page,
-  SliderToggle,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { useState } from "react";
+import { ContentMessage, InfoCircle, Page, Spinner } from "@dust-tt/sparkle";
 
 export function NetworkSection() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags();
   const hasSandboxAdmin = isComputerFeatureEnabled(featureFlags);
-  const [isEnableAgentRequestsDialogOpen, setIsEnableAgentRequestsDialogOpen] =
-    useState(false);
 
   const {
     policy,
@@ -47,27 +31,6 @@ export function NetworkSection() {
     useUpdateWorkspaceEgressPolicy({ owner });
   const { dismissWorkspaceEgressRequest, isDismissingRequest } =
     useDismissWorkspaceEgressRequest({ owner });
-  const {
-    allowAgentEgressRequests,
-    updateWorkspaceSandboxAgentEgressRequests,
-    isUpdatingWorkspaceSandboxAgentEgressRequests,
-  } = useUpdateWorkspaceSandboxAgentEgressRequests({ owner });
-
-  const handleToggleAgentEgressRequests = async () => {
-    if (allowAgentEgressRequests) {
-      await updateWorkspaceSandboxAgentEgressRequests(false);
-      return;
-    }
-
-    setIsEnableAgentRequestsDialogOpen(true);
-  };
-
-  const handleConfirmEnableAgentEgressRequests = async () => {
-    const success = await updateWorkspaceSandboxAgentEgressRequests(true);
-    if (success) {
-      setIsEnableAgentRequestsDialogOpen(false);
-    }
-  };
 
   const renderBody = () => {
     if (!isAdmin) {
@@ -104,27 +67,6 @@ export function NetworkSection() {
 
     return (
       <Page.Vertical align="stretch" gap="lg">
-        <div className="flex items-center justify-between gap-4 border-y border-border py-4">
-          <div className="flex min-w-0 flex-col">
-            <div className="heading-sm text-foreground">
-              Agent-requested domains
-            </div>
-            <div className="text-sm text-muted-foreground">
-              Allow agents using the Computer to ask for additional domains, one
-              approval per domain, during the conversation. When disabled,
-              agents cannot request new domains and should only rely on the
-              domains listed below.
-            </div>
-          </div>
-          <SliderToggle
-            selected={allowAgentEgressRequests}
-            onClick={() => {
-              void handleToggleAgentEgressRequests();
-            }}
-            disabled={isUpdatingWorkspaceSandboxAgentEgressRequests}
-          />
-        </div>
-
         <Page.SectionHeader
           title="Allowed domains"
           description="These domains apply to every Computer in this workspace. Hostnames are matched exactly. To allow both example.com and www.example.com, add each separately. A wildcard such as *.example.com allows subdomains, but not example.com itself. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
@@ -151,47 +93,5 @@ export function NetworkSection() {
     );
   };
 
-  return (
-    <>
-      <Dialog
-        open={isEnableAgentRequestsDialogOpen}
-        onOpenChange={(open) => {
-          if (!open) {
-            setIsEnableAgentRequestsDialogOpen(false);
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              Allow agents to request additional domains?
-            </DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            When enabled, any agent running in the Computer can ask the user to
-            allow additional domains during the conversation. Each request is
-            approval-gated, but a non-admin user in this workspace can grant
-            network access to a domain you have not pre-approved. Domains added
-            this way last only for the current Computer.
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => setIsEnableAgentRequestsDialogOpen(false),
-            }}
-            rightButtonProps={{
-              label: "Enable",
-              onClick: () => {
-                void handleConfirmEnableAgentEgressRequests();
-              },
-              isLoading: isUpdatingWorkspaceSandboxAgentEgressRequests,
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-
-      {renderBody()}
-    </>
-  );
+  return renderBody();
 }

--- a/front/components/sandbox/AgentRequestedDomainsSetting.tsx
+++ b/front/components/sandbox/AgentRequestedDomainsSetting.tsx
@@ -1,0 +1,104 @@
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useUpdateWorkspaceSandboxAgentEgressRequests } from "@app/lib/swr/sandbox";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  SliderToggle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+// Workspace-wide toggle for whether agents can request additional domains
+// during a conversation (add_egress_domain). Shown on its own so it stays
+// visible regardless of the scope being viewed on the Computer admin page.
+export function AgentRequestedDomainsSetting() {
+  const owner = useWorkspace();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const {
+    allowAgentEgressRequests,
+    updateWorkspaceSandboxAgentEgressRequests,
+    isUpdatingWorkspaceSandboxAgentEgressRequests,
+  } = useUpdateWorkspaceSandboxAgentEgressRequests({ owner });
+
+  const handleToggle = async () => {
+    if (allowAgentEgressRequests) {
+      await updateWorkspaceSandboxAgentEgressRequests(false);
+      return;
+    }
+    setIsDialogOpen(true);
+  };
+
+  const handleConfirmEnable = async () => {
+    const success = await updateWorkspaceSandboxAgentEgressRequests(true);
+    if (success) {
+      setIsDialogOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsDialogOpen(false);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Allow agents to request additional domains?
+            </DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            When enabled, any agent running in the Computer can ask the user to
+            allow additional domains during the conversation. Each request is
+            approval-gated, but a non-admin user in this workspace can grant
+            network access to a domain you have not pre-approved. Domains added
+            this way last only for the current Computer.
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setIsDialogOpen(false),
+            }}
+            rightButtonProps={{
+              label: "Enable",
+              onClick: () => {
+                void handleConfirmEnable();
+              },
+              isLoading: isUpdatingWorkspaceSandboxAgentEgressRequests,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <div className="flex items-center justify-between gap-4 border-y border-border py-4">
+        <div className="flex min-w-0 flex-col">
+          <div className="heading-xl text-foreground">
+            Agent-requested domains
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Applies to every Computer in this workspace, across all Pods. Allow
+            agents to ask for additional domains, one approval per domain,
+            during the conversation. When disabled, agents cannot request new
+            domains and rely only on the allowed domains configured per scope
+            below.
+          </div>
+        </div>
+        <SliderToggle
+          selected={allowAgentEgressRequests}
+          onClick={() => {
+            void handleToggle();
+          }}
+          disabled={isUpdatingWorkspaceSandboxAgentEgressRequests}
+        />
+      </div>
+    </>
+  );
+}

--- a/front/components/sandbox/DomainBadge.tsx
+++ b/front/components/sandbox/DomainBadge.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+// The domain "chip": a monospace domain in a muted rounded box, with optional
+// trailing badges (scope or status). Shared by the egress list editor and the
+// multi-Pod network section so the row chrome stays identical.
+export function DomainBadge({
+  domain,
+  children,
+}: {
+  domain: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      title={domain}
+      className="flex min-w-0 grow items-center gap-2 overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2"
+    >
+      <span className="font-mono text-sm text-foreground">{domain}</span>
+      {children}
+    </div>
+  );
+}

--- a/front/components/sandbox/DomainInputForm.test.tsx
+++ b/front/components/sandbox/DomainInputForm.test.tsx
@@ -1,0 +1,77 @@
+import { DomainInputForm } from "@app/components/sandbox/DomainInputForm";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const onSubmit = vi.fn(async () => true);
+
+function setup(
+  overrides: Partial<ComponentProps<typeof DomainInputForm>> = {}
+) {
+  render(
+    <DomainInputForm
+      duplicateMessage={() => null}
+      validMessage={(domain) => `Will be saved as ${domain}.`}
+      onSubmit={onSubmit}
+      submitLabel="Add domain"
+      isUpdating={false}
+      {...overrides}
+    />
+  );
+}
+
+describe("DomainInputForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onSubmit.mockResolvedValue(true);
+  });
+
+  it("shows the hint and disables submit when empty", () => {
+    setup();
+    expect(screen.getByText(/Use an exact domain/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add domain" })).toBeDisabled();
+  });
+
+  it("surfaces a normalization error and blocks submit", async () => {
+    setup();
+    await userEvent.type(screen.getByRole("textbox"), "bad*domain");
+    expect(screen.getByText(/Wildcards must use the form/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add domain" })).toBeDisabled();
+  });
+
+  it("shows the caller's duplicate message and blocks submit", async () => {
+    setup({
+      duplicateMessage: (domain) =>
+        domain === "api.openai.com" ? "Already allowed." : null,
+    });
+    await userEvent.type(screen.getByRole("textbox"), "api.openai.com");
+    expect(screen.getByText("Already allowed.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add domain" })).toBeDisabled();
+  });
+
+  it("submits the normalized domain and clears the input on success", async () => {
+    setup();
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "api.openai.com");
+    expect(
+      screen.getByText("Will be saved as api.openai.com.")
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add domain" }));
+
+    expect(onSubmit).toHaveBeenCalledWith("api.openai.com");
+    await waitFor(() => expect(input).toHaveValue(""));
+  });
+
+  it("keeps the input when the submit fails", async () => {
+    onSubmit.mockResolvedValue(false);
+    setup();
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "api.openai.com");
+    await userEvent.click(screen.getByRole("button", { name: "Add domain" }));
+
+    expect(onSubmit).toHaveBeenCalledWith("api.openai.com");
+    expect(input).toHaveValue("api.openai.com");
+  });
+});

--- a/front/components/sandbox/DomainInputForm.tsx
+++ b/front/components/sandbox/DomainInputForm.tsx
@@ -1,0 +1,92 @@
+import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
+import { Button, Input, Plus } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const DOMAIN_INPUT_HINT =
+  "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
+
+interface DomainInputFormProps {
+  // A message when the normalized domain is a duplicate for the current scope
+  // (which blocks submit), or null when it is addable.
+  duplicateMessage: (normalizedDomain: string) => string | null;
+  // Info message for a valid, non-duplicate domain (e.g. "Will be saved as X.").
+  validMessage: (normalizedDomain: string) => string;
+  // Persists the domain; resolves true on success so the input clears.
+  onSubmit: (normalizedDomain: string) => Promise<boolean>;
+  submitLabel: string;
+  isUpdating: boolean;
+}
+
+// The add/request domain input: normalization, validation, and the input +
+// submit button. Shared by the egress list editor and the multi-Pod network
+// section; each supplies the scope-specific duplicate/valid wording and submit.
+export function DomainInputForm({
+  duplicateMessage,
+  validMessage,
+  onSubmit,
+  submitLabel,
+  isUpdating,
+}: DomainInputFormProps) {
+  const [domainInput, setDomainInput] = useState("");
+
+  const hasDomainInput = domainInput.trim().length > 0;
+  const domainInputResult = hasDomainInput
+    ? normalizeEgressPolicyDomain(domainInput)
+    : null;
+  const normalizedDomain =
+    domainInputResult?.isOk() === true ? domainInputResult.value : null;
+  const duplicate =
+    normalizedDomain !== null ? duplicateMessage(normalizedDomain) : null;
+  const message =
+    domainInputResult?.isErr() === true
+      ? domainInputResult.error.message
+      : duplicate !== null
+        ? duplicate
+        : normalizedDomain !== null
+          ? validMessage(normalizedDomain)
+          : DOMAIN_INPUT_HINT;
+  const isInvalid = domainInputResult?.isErr() === true || duplicate !== null;
+  const canSubmit =
+    normalizedDomain !== null && duplicate === null && !isUpdating;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || normalizedDomain === null) {
+      return;
+    }
+    const success = await onSubmit(normalizedDomain);
+    if (success) {
+      setDomainInput("");
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-3 sm:flex-row sm:items-start"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
+      <div className="grow">
+        <Input
+          label="Domain"
+          name="domain"
+          placeholder="e.g. api.openai.com or *.mistral.ai"
+          value={domainInput}
+          message={message}
+          messageStatus={isInvalid ? "error" : "info"}
+          onChange={(event) => setDomainInput(event.target.value)}
+          disabled={isUpdating}
+        />
+      </div>
+      <Button
+        type="submit"
+        label={submitLabel}
+        icon={Plus}
+        disabled={!canSubmit}
+        isLoading={isUpdating}
+        className="mt-0 sm:mt-7"
+      />
+    </form>
+  );
+}

--- a/front/components/sandbox/EgressDomainListEditor.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.tsx
@@ -1,13 +1,12 @@
-import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
+import { DomainBadge } from "@app/components/sandbox/DomainBadge";
+import { DomainInputForm } from "@app/components/sandbox/DomainInputForm";
 import {
   Button,
+  Chip,
   ContentMessage,
-  Input,
-  Plus,
   Trash01,
   XClose,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
 
 interface EgressDomainListEditorProps {
   allowedDomains: string[];
@@ -29,9 +28,9 @@ interface EgressDomainListEditorProps {
 }
 
 // Add/remove editor for a sandbox egress allowlist, shared by the workspace
-// Network section and the Pod network section. Domain validation, dedupe, and
-// the input + list rendering live here; surface-specific chrome (headers,
-// toggles, load/error states) stays in the caller.
+// Network section and the Pod network section. The input and row chrome are
+// shared with the multi-Pod view (DomainInputForm, DomainBadge); surface
+// chrome (headers, toggles, load/error states) stays in the caller.
 export function EgressDomainListEditor({
   allowedDomains,
   onSave,
@@ -43,55 +42,10 @@ export function EgressDomainListEditor({
   readOnly = false,
   onRequestDomain,
 }: EgressDomainListEditorProps) {
-  const [domainInput, setDomainInput] = useState("");
-
   // Members can't edit the allowlist, but may submit a domain request when the
   // caller provides onRequestDomain — the input stays, everything else hides.
   const isRequestMode = readOnly && onRequestDomain !== undefined;
   const showDomainInput = !readOnly || isRequestMode;
-
-  const hasDomainInput = domainInput.trim().length > 0;
-  const domainInputResult = hasDomainInput
-    ? normalizeEgressPolicyDomain(domainInput)
-    : null;
-  const normalizedDomain =
-    domainInputResult?.isOk() === true ? domainInputResult.value : null;
-  const isAlreadyAllowed =
-    normalizedDomain !== null && allowedDomains.includes(normalizedDomain);
-  const isAlreadyPending =
-    isRequestMode &&
-    normalizedDomain !== null &&
-    (pendingRequests?.some((request) => request.domain === normalizedDomain) ??
-      false);
-  const isDuplicate = isAlreadyAllowed || isAlreadyPending;
-  const domainInputMessage =
-    domainInputResult?.isErr() === true
-      ? domainInputResult.error.message
-      : isAlreadyAllowed
-        ? "This domain is already allowed."
-        : isAlreadyPending
-          ? "This domain has already been requested."
-          : normalizedDomain
-            ? isRequestMode
-              ? `Will be requested as ${normalizedDomain}.`
-              : `Will be saved as ${normalizedDomain}.`
-            : "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
-  const isDomainInputInvalid =
-    domainInputResult?.isErr() === true || isDuplicate;
-  const canAddDomain = normalizedDomain !== null && !isDuplicate && !isUpdating;
-
-  const handleSubmitDomain = async () => {
-    if (!canAddDomain || normalizedDomain === null) {
-      return;
-    }
-
-    const success = isRequestMode
-      ? await onRequestDomain(normalizedDomain)
-      : await onSave([...allowedDomains, normalizedDomain]);
-    if (success) {
-      setDomainInput("");
-    }
-  };
 
   const handleRemoveDomain = async (domain: string) => {
     await onSave(allowedDomains.filter((d) => d !== domain));
@@ -100,34 +54,28 @@ export function EgressDomainListEditor({
   return (
     <>
       {showDomainInput && (
-        <form
-          className="flex flex-col gap-3 sm:flex-row sm:items-start"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void handleSubmitDomain();
-          }}
-        >
-          <div className="grow">
-            <Input
-              label="Domain"
-              name="domain"
-              placeholder="e.g. api.openai.com or *.mistral.ai"
-              value={domainInput}
-              message={domainInputMessage}
-              messageStatus={isDomainInputInvalid ? "error" : "info"}
-              onChange={(event) => setDomainInput(event.target.value)}
-              disabled={isUpdating}
-            />
-          </div>
-          <Button
-            type="submit"
-            label={isRequestMode ? "Request domain" : "Add domain"}
-            icon={Plus}
-            disabled={!canAddDomain}
-            isLoading={isUpdating}
-            className="mt-0 sm:mt-7"
-          />
-        </form>
+        <DomainInputForm
+          isUpdating={isUpdating}
+          submitLabel={isRequestMode ? "Request domain" : "Add domain"}
+          duplicateMessage={(domain) =>
+            allowedDomains.includes(domain)
+              ? "This domain is already allowed."
+              : isRequestMode &&
+                  (pendingRequests?.some((r) => r.domain === domain) ?? false)
+                ? "This domain has already been requested."
+                : null
+          }
+          validMessage={(domain) =>
+            isRequestMode
+              ? `Will be requested as ${domain}.`
+              : `Will be saved as ${domain}.`
+          }
+          onSubmit={(domain) =>
+            isRequestMode && onRequestDomain
+              ? onRequestDomain(domain)
+              : onSave([...allowedDomains, domain])
+          }
+        />
       )}
 
       {allowedDomains.length === 0 && (pendingRequests?.length ?? 0) === 0 ? (
@@ -138,17 +86,9 @@ export function EgressDomainListEditor({
         <div className="flex w-full flex-col divide-y divide-separator">
           {pendingRequests?.map((request) => (
             <div key={request.domain} className="flex items-center gap-3 py-3">
-              <div
-                title={request.domain}
-                className="flex min-w-0 grow items-center gap-2 overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2"
-              >
-                <span className="font-mono text-sm text-foreground">
-                  {request.domain}
-                </span>
-                <span className="shrink-0 rounded-full bg-golden-100 px-2 py-0.5 text-xs font-medium text-golden-800">
-                  Pending approval
-                </span>
-              </div>
+              <DomainBadge domain={request.domain}>
+                <Chip size="xs" color="warning" label="Pending approval" />
+              </DomainBadge>
               {!readOnly && (
                 <>
                   <Button
@@ -175,12 +115,7 @@ export function EgressDomainListEditor({
           ))}
           {allowedDomains.map((domain) => (
             <div key={domain} className="flex items-center gap-3 py-3">
-              <pre
-                title={domain}
-                className="min-w-0 grow overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2 text-sm text-foreground"
-              >
-                {domain}
-              </pre>
+              <DomainBadge domain={domain} />
               {!readOnly && (
                 <Button
                   variant="warning"


### PR DESCRIPTION
## Description

Refactor of the Computer admin network UI, ahead of the multi-Pod scope selector (follow-up PRs). No behavior change — first of a 3-PR split of the old `30996`.

- Extracts the domain input + row chrome into shared `DomainInputForm` / `DomainBadge`, now consumed by `EgressDomainListEditor` (the workspace + Pod network sections), prepping them for reuse by the multi-Pod view.
- Pulls the workspace agent-request toggle out of `NetworkSection` into a standalone `AgentRequestedDomainsSetting`, rendered above the network section. `NetworkSection` keeps the workspace egress list.

## Tests

`tsc` clean. New `DomainInputForm` unit test (normalize / duplicate-block / clear-on-success); `EgressDomainListEditor`'s existing tests guard the refactor (rendered output unchanged).

## Risk

Low — pure refactor, behavior-preserved (the toggle renders in the same spot, now as its own component; the shared components render identical markup). Safe to roll back.

## Deploy Plan

Standard front deploy. No migration.
