### PR TITLE
Support multi-interaction checkpoint continuations

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/conversation_window_core.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_core.ts
@@ -331,11 +331,6 @@ async function buildConversationWindow(
   const interactions = groupMessagesIntoInteractions(
     prepared.messagesWithTokens
   );
-  if (source.kind === "checkpoint_continuation" && interactions.length > 1) {
-    return new Err(
-      new Error("A checkpoint continuation must belong to one interaction")
-    );
-  }
   const budgetForInteractions = input.allowedTokenCount - baseTokens;
   const pruningTargetCeiling =
     input.model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -314,6 +314,53 @@ describe("seeded conversation window", () => {
     );
   });
 
+  it("appends new interactions created within a checkpoint continuation", async () => {
+    const conversation = createConversation(workspace);
+    const continuation = {
+      ...createConversation(workspace),
+      sId: "continuation",
+    };
+    const continuationMessages = [
+      assistantMessage("tool call"),
+      functionMessage("tool", "tool result"),
+      userMessage("enabled skill"),
+    ];
+    vi.mocked(renderAllMessages).mockResolvedValue(continuationMessages);
+    mockTokenCounter({
+      byContains: {
+        "tool call": 10,
+        "tool result": 10,
+        "enabled skill": 10,
+      },
+    });
+
+    const result = await renderConversationWindow(
+      auth,
+      {
+        model,
+        prompt: "PROMPT",
+        enabledSkills: [],
+        tools: "TOOLS",
+        allowedTokenCount: 100_000,
+      },
+      {
+        kind: "checkpoint_continuation",
+        conversation,
+        continuation,
+        checkpoint: checkpoint([userMessage("saved user")]),
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.modelConversation.messages).toEqual([
+      userMessage("saved user"),
+      ...continuationMessages,
+    ]);
+  });
+
   it("matches a full replay when a continuation crosses a pruning checkpoint", async () => {
     const conversation = createConversation(workspace);
     const continuation = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Stateful conversation rendering assumed that the output appended between two model steps always belonged to a single interaction.

This does not hold when a tool enables a skill. The rendered continuation can contain an assistant tool call, its function result, and a synthetic user message carrying the newly enabled skill. That user boundary correctly creates another interaction, but the checkpointed path rejected it before applying the continuation.

This removes the stale single-interaction guard. The existing continuation logic already appends the first interaction to the checkpoint and adds subsequent interactions independently.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
