### PR TITLE
feat(sandbox): Pod scope selector + Computer-admin access hook

### DIFF
--- a/front/components/sandbox/SandboxScopeSelector.test.tsx
+++ b/front/components/sandbox/SandboxScopeSelector.test.tsx
@@ -1,0 +1,89 @@
+import type { SandboxScopeSelection } from "@app/components/sandbox/SandboxScopeSelector";
+import { labelForSelection } from "@app/components/sandbox/SandboxScopeSelector";
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import { describe, expect, it } from "vitest";
+
+const pods: SandboxAdminPod[] = [
+  { sId: "vlt_a", name: "Alpha", isRestricted: false },
+  { sId: "vlt_b", name: "Beta", isRestricted: true },
+  { sId: "vlt_c", name: "Gamma", isRestricted: false },
+];
+
+function selection(
+  overrides: Partial<SandboxScopeSelection> = {}
+): SandboxScopeSelection {
+  return { includeWorkspace: false, podIds: [], ...overrides };
+}
+
+describe("labelForSelection", () => {
+  it("returns the placeholder when nothing is selected", () => {
+    expect(labelForSelection(selection(), pods)).toBe("Select scope");
+  });
+
+  it("labels the workspace alone", () => {
+    expect(labelForSelection(selection({ includeWorkspace: true }), pods)).toBe(
+      "Workspace"
+    );
+  });
+
+  it("names a single selected Pod", () => {
+    expect(labelForSelection(selection({ podIds: ["vlt_b"] }), pods)).toBe(
+      "Beta"
+    );
+  });
+
+  it("counts multiple selected Pods", () => {
+    expect(
+      labelForSelection(selection({ podIds: ["vlt_a", "vlt_b"] }), pods)
+    ).toBe("2 Pods");
+  });
+
+  it("collapses every Pod to 'all Pods'", () => {
+    expect(
+      labelForSelection(
+        selection({ podIds: ["vlt_a", "vlt_b", "vlt_c"] }),
+        pods
+      )
+    ).toBe("all Pods");
+  });
+
+  it("combines the workspace and a Pod", () => {
+    expect(
+      labelForSelection(
+        selection({ includeWorkspace: true, podIds: ["vlt_a"] }),
+        pods
+      )
+    ).toBe("Workspace + Alpha");
+  });
+
+  it("returns 'All scopes' when the workspace and every Pod are selected", () => {
+    expect(
+      labelForSelection(
+        selection({
+          includeWorkspace: true,
+          podIds: ["vlt_a", "vlt_b", "vlt_c"],
+        }),
+        pods
+      )
+    ).toBe("All scopes");
+  });
+
+  it("ignores selected Pods that are no longer in the list", () => {
+    expect(
+      labelForSelection(
+        selection({ includeWorkspace: true, podIds: ["vlt_a", "vlt_gone"] }),
+        pods
+      )
+    ).toBe("Workspace + Alpha");
+  });
+
+  it("does not read as 'All scopes' when a stale id pads the count", () => {
+    // Two selected ids but only one still exists: not every current Pod.
+    expect(
+      labelForSelection(
+        selection({ includeWorkspace: true, podIds: ["vlt_a", "vlt_gone"] }),
+        [pods[0], pods[1]]
+      )
+    ).toBe("Workspace + Alpha");
+  });
+});

--- a/front/components/sandbox/SandboxScopeSelector.tsx
+++ b/front/components/sandbox/SandboxScopeSelector.tsx
@@ -1,0 +1,205 @@
+import { podIcon } from "@app/components/sandbox/pod_icon";
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import {
+  Building04,
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+// The scopes edited together on the central Computer admin page: the workspace
+// baseline and/or any Pods. Every selected scope is a write target.
+export type SandboxScopeSelection = {
+  includeWorkspace: boolean;
+  podIds: string[];
+};
+
+export function labelForSelection(
+  selection: SandboxScopeSelection,
+  pods: SandboxAdminPod[]
+): string {
+  const podIds = new Set(selection.podIds);
+  // Count only Pods still present in the list: a selected Pod that lost its
+  // policy (and dropped out of `pods`) is no longer a real scope, so it must
+  // not inflate the label.
+  const selectedPods = pods.filter((pod) => podIds.has(pod.sId));
+  const allPodsSelected =
+    pods.length > 0 && selectedPods.length === pods.length;
+  if (selection.includeWorkspace && allPodsSelected) {
+    return "All scopes";
+  }
+
+  const parts: string[] = [];
+  if (selection.includeWorkspace) {
+    parts.push("Workspace");
+  }
+  if (selectedPods.length === 1) {
+    parts.push(selectedPods[0].name);
+  } else if (selectedPods.length > 1) {
+    parts.push(allPodsSelected ? "all Pods" : `${selectedPods.length} Pods`);
+  }
+  return parts.length === 0 ? "Select scope" : parts.join(" + ");
+}
+
+interface SandboxScopeSelectorProps {
+  pods: SandboxAdminPod[];
+  selection: SandboxScopeSelection;
+  onChange: (selection: SandboxScopeSelection) => void;
+  isLoading: boolean;
+  isError?: boolean;
+  disabled?: boolean;
+}
+
+export function SandboxScopeSelector({
+  pods,
+  selection,
+  onChange,
+  isLoading,
+  isError = false,
+  disabled = false,
+}: SandboxScopeSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchText, setSearchText] = useState("");
+
+  const selectedPodIds = useMemo(
+    () => new Set(selection.podIds),
+    [selection.podIds]
+  );
+
+  const filteredPods = useMemo(() => {
+    const query = searchText.trim().toLowerCase();
+    return query
+      ? pods.filter((pod) => pod.name.toLowerCase().includes(query))
+      : pods;
+  }, [searchText, pods]);
+
+  // Set-membership, not a length compare: a stale selected id (a Pod that
+  // dropped out of `pods`) must not make a partial selection read as "all".
+  const allPodsSelected =
+    pods.length > 0 && pods.every((pod) => selectedPodIds.has(pod.sId));
+
+  const togglePod = (podId: string, checked: boolean) => {
+    onChange({
+      ...selection,
+      podIds: checked
+        ? [...selection.podIds, podId]
+        : selection.podIds.filter((id) => id !== podId),
+    });
+  };
+
+  // The Pods area shows exactly one of: loading, error, empty, no-search-match,
+  // or the checkbox list.
+  const renderPodItems = () => {
+    if (isLoading) {
+      return (
+        <DropdownMenuItem
+          label="Loading"
+          disabled
+          endComponent={<Spinner size="xs" />}
+        />
+      );
+    }
+    if (isError) {
+      return <DropdownMenuItem label="Failed to load Pods" disabled />;
+    }
+    if (pods.length === 0) {
+      return (
+        <DropdownMenuItem label="No Pods with their own policy" disabled />
+      );
+    }
+    if (filteredPods.length === 0) {
+      return <DropdownMenuItem label="No matching Pods" disabled />;
+    }
+    return filteredPods.map((pod) => (
+      <DropdownMenuCheckboxItem
+        key={pod.sId}
+        label={pod.name}
+        icon={podIcon(pod)}
+        checked={selectedPodIds.has(pod.sId)}
+        onCheckedChange={(checked) => togglePod(pod.sId, checked === true)}
+        onSelect={(event) => {
+          event.preventDefault();
+        }}
+      />
+    ));
+  };
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open) {
+          setSearchText("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={labelForSelection(selection, pods)}
+          isSelect
+          disabled={disabled}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-80 max-w-[calc(100vw-1rem)]"
+        align="start"
+        collisionPadding={8}
+      >
+        <DropdownMenuCheckboxItem
+          label="Workspace"
+          icon={Building04}
+          checked={selection.includeWorkspace}
+          onCheckedChange={(checked) =>
+            onChange({ ...selection, includeWorkspace: checked === true })
+          }
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel label="Pods" />
+        <DropdownMenuSearchbar
+          autoFocus
+          name="search-pods"
+          placeholder="Search Pods"
+          value={searchText}
+          onChange={setSearchText}
+          disabled={isLoading}
+        />
+        <DropdownMenuItem
+          label={allPodsSelected ? "Clear all" : "Select all"}
+          disabled={pods.length === 0}
+          onClick={() =>
+            onChange({
+              ...selection,
+              podIds: allPodsSelected ? [] : pods.map((pod) => pod.sId),
+            })
+          }
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        />
+        {renderPodItems()}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          label="Reset"
+          disabled={selection.includeWorkspace && selection.podIds.length === 0}
+          onClick={() => onChange({ includeWorkspace: true, podIds: [] })}
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/sandbox/pod_icon.ts
+++ b/front/components/sandbox/pod_icon.ts
@@ -1,0 +1,11 @@
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import { Cube01, CubeOutline } from "@dust-tt/sparkle";
+import type { ComponentType, SVGProps } from "react";
+
+// Central Computer admin Pods are always project spaces, so the icon is just
+// open vs restricted (mirrors getSpaceIcon's project branch).
+export function podIcon(
+  pod: SandboxAdminPod
+): ComponentType<SVGProps<SVGSVGElement>> {
+  return pod.isRestricted ? CubeOutline : Cube01;
+}

--- a/front/hooks/useComputerAdminAccess.ts
+++ b/front/hooks/useComputerAdminAccess.ts
@@ -1,0 +1,25 @@
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
+
+// The single client-side capability check for administrating Computer
+// settings. Mirrors the API gates (`ensureIsAdmin` + the Computer feature on
+// the sandbox sub-apps); pod membership is deliberately not consulted. Change
+// both together.
+export function useComputerAdminAccess() {
+  const { isAdmin } = useAuth();
+  const { featureFlags } = useFeatureFlags();
+  const isComputerEnabled = isComputerFeatureEnabled(featureFlags);
+  const canAdministrateComputer = isAdmin && isComputerEnabled;
+  const hasSandboxFunctions = featureFlags.includes("sandbox_functions");
+  // The multi-Pod scope selector and Pod network editing ride the Pod Functions
+  // flag (sandbox_functions), on top of Computer admin access.
+  const canAdministratePodNetwork =
+    canAdministrateComputer && hasSandboxFunctions;
+
+  return {
+    isAdmin,
+    isComputerEnabled,
+    canAdministrateComputer,
+    canAdministratePodNetwork,
+  };
+}


### PR DESCRIPTION
## Description

Second of the 3-PR split (stacks on `31285`). Adds the Computer-admin access hook and the Pod scope-selector component that the multi-Pod editor consumes in the final PR.

- `useComputerAdminAccess` — the single client-side capability check (admin + Computer feature + Pod Functions flag), mirroring the API gates.
- `SandboxScopeSelector` — the Workspace/Pod dropdown (lists only Pods with their own policy); `labelForSelection` is unit-tested.
- `podIcon` — the open/restricted Pod icon helper.

> [!NOTE]
> These have no consumer yet — the multi-Pod editor in the next PR (`30996`) wires them into the page. Landing them separately keeps that PR focused.

## Tests
<img width="374" height="323" alt="Screenshot 2026-08-27 at 11 57 54 AM" src="https://github.com/user-attachments/assets/10d9ae3e-0e65-4972-addc-091babcc5e58" />

`tsc` clean. Unit test for `labelForSelection` (Workspace/Pod combinations + stale-id handling).

## Risk

Very low — additive, unconsumed components. Safe to roll back.

## Deploy Plan

Standard front deploy. No migration. Merge after `31285`.
