### PR TITLE
[front-api] declare openai dependency to avoid resolving a stale hoisted copy

### DIFF
--- a/front-api/package.json
+++ b/front-api/package.json
@@ -33,6 +33,7 @@
     "@hono/zod-validator": "^0.7.6",
     "hono": "^4.12.15",
     "jsonwebtoken": "^9.0.0",
+    "openai": "^6.46.0",
     "swagger-jsdoc": "^6.2.8",
     "zod": "^3.25.76",
     "zod-validation-error": "^3.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,6 +545,7 @@
         "@novu/framework": "^2.11.1",
         "hono": "^4.12.15",
         "jsonwebtoken": "^9.0.0",
+        "openai": "^6.46.0",
         "swagger-jsdoc": "^6.2.8",
         "umzug": "3.8.3",
         "zod": "^3.25.76",
@@ -724,6 +725,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "front-api/node_modules/openai": {
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
+      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "front-api/node_modules/remark-gfm": {


### PR DESCRIPTION
### Problem

Any OpenAI-Responses call from a locally-running `front-api` dev server fails with an opaque error. For example, generating a trigger schedule (`POST /api/w/:wId/assistant/agent_configurations/text_as_cron_rule`) returns a 500 with `LLM error: Unknown error from OpenAI`.

The cause is module resolution, not the provider. `front-api/esbuild.shared.ts` (`bundleEsmPlugin`) marks every bare import external, so `require("openai")` is resolved at runtime from `front-api/dist/`: `front-api/node_modules` → root `node_modules` → and only then `NODE_PATH`. `esbuild.dev.ts` sets `NODE_PATH=front/node_modules`, but NODE_PATH is a last-resort fallback that is consulted after the directory walk, so it never wins.

`connectors` depends on `@microsoft/teams-ai`, which pins `openai` at exactly `4.77.4`. A full local `npm install` therefore puts 4.77.4 in the root `node_modules`, shadowing `front/node_modules/openai@6.46.0`. openai 4.77.4 predates the Responses API, so `client.responses` is `undefined` in `front/lib/model_constructors/stream/clients/openai_responses.ts`, the call throws a `TypeError`, and `classifyStreamError` — which only recognizes `APIConnectionError` / `APIError` — maps it to `unknown_error`, i.e. "Unknown error from OpenAI".

Before:

```
$ cd front-api/dist && node -e "console.log(require.resolve('openai'))"
/Users/.../dust/node_modules/openai/index.js   # 4.77.4, client.responses === undefined
```

Production is not affected today: the front image runs `npm ci -w sdks/js -w sparkle -w front -w front-spa -w front-api`, so connectors' pin is not installed and the root copy is front's. That makes this a dev-only failure, but it is a failure that silently depends on which workspaces happen to be installed.

### Fix

Declare `openai` in `front-api/package.json`, next to `@anthropic-ai/sdk`, which is already there for the same reason. This gives front-api its own copy that wins the resolution walk regardless of what gets hoisted to the root. It is installed at `6.46.0` — the version front resolves — so the two workspaces stay on the same SDK.

After:

```
$ cd front-api/dist && node -e "console.log(require.resolve('openai'))"
/Users/.../dust/front-api/node_modules/openai/index.js   # 6.46.0, client.responses is an object
```

### Notes

Three other front dependencies are shadowed the same way at the root and are latent instances of this bug for front-api: `@notionhq/client` (front 5.13.0 vs root 2.3.0), `hot-shots` (12.1.0 vs 10.2.1), `lru-memoizer` (3.0.0 vs 2.3.0). Nothing currently fails on them, so they are left alone here. The broader alternative would be to stop externalizing these packages in the esbuild config so resolution happens at build time from `front/lib`.

### Test plan

- `cd front-api/dist && node -e "const C=require('openai'); console.log(typeof new (C.default||C)({apiKey:'x'}).responses)"` → `object`
- Restarted the dev server and generated a trigger schedule from natural language; it now returns a cron rule instead of a 500.
