### PR TITLE
feat(workspace-analytics): replace the legacy top-N tools with two consumption rankings

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2598,35 +2598,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_source_breakdown": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_agent_tags": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_agents": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
     "get_top_entities_by_credits": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_top_models": {
+    "get_top_entities_by_execution_count": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_top_skills": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_tools": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_users": {
+    "get_top_entities_by_message_count": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
@@ -3457,14 +3437,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_agent_details": "never_ask",
     "get_credit_timeseries": "never_ask",
     "get_credit_usage": "never_ask",
-    "get_source_breakdown": "never_ask",
-    "get_top_agent_tags": "never_ask",
-    "get_top_agents": "never_ask",
     "get_top_entities_by_credits": "never_ask",
-    "get_top_models": "never_ask",
-    "get_top_skills": "never_ask",
-    "get_top_tools": "never_ask",
-    "get_top_users": "never_ask",
+    "get_top_entities_by_execution_count": "never_ask",
+    "get_top_entities_by_message_count": "never_ask",
     "get_usage_timeseries": "never_ask",
   },
   "workspace_management": {

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1201,6 +1201,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "search the web for the latest AI research papers",
     expected: "web_search_&_browse.websearch",
+    maxRank: 2, // clari_copilot.get_call_details dilutes shared-token IDF
   },
   {
     query: "google this topic for me",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1079,19 +1079,7 @@ const QUERIES: LabeledQuery[] = [
     maxRank: 2,
   },
   {
-    query: "show me the top 10 most active agents this month",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
     query: "who are the most active users this month",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
-    query: "rank workspace members by messages sent",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
-    query: "rank member groups by message volume",
     expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
@@ -1103,10 +1091,6 @@ const QUERIES: LabeledQuery[] = [
     query: "which models did the workspace use most this month",
     expected: "workspace_analytics.get_top_entities_by_message_count",
     maxRank: 5,
-  },
-  {
-    query: "list the agent tags",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query:

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1075,24 +1075,38 @@ const QUERIES: LabeledQuery[] = [
   // --- workspace_analytics ---
   {
     query: "which agents are used most in the workspace",
-    expected: "workspace_analytics.get_top_agents",
-    maxRank: 2, // get_top_tools collides on "most used"
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+    maxRank: 2,
   },
   {
     query: "show me the top 10 most active agents this month",
-    expected: "workspace_analytics.get_top_agents",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query: "who are the most active users this month",
-    expected: "workspace_analytics.get_top_users",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query: "rank workspace members by messages sent",
-    expected: "workspace_analytics.get_top_users",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+  },
+  {
+    query: "rank member groups by message volume",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+  },
+  {
+    query: "where do workspace messages come from - slack, api, or browser",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+    maxRank: 10,
+  },
+  {
+    query: "which models did the workspace use most this month",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+    maxRank: 5,
   },
   {
     query: "list the agent tags",
-    expected: "workspace_analytics.get_top_agent_tags",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query:
@@ -1104,30 +1118,24 @@ const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_agent_details",
   },
   {
-    query: "which skills are executed most in the workspace",
-    expected: "workspace_analytics.get_top_skills",
-  },
-  {
-    query: "what are the top MCP tools used by agents",
-    expected: "workspace_analytics.get_top_tools",
-  },
-  {
-    query: "where do workspace messages come from - slack, api, or browser",
-    expected: "workspace_analytics.get_source_breakdown",
-    maxRank: 10,
-  },
-  {
-    query: "which models did the workspace use most this month",
-    expected: "workspace_analytics.get_top_models",
-    maxRank: 5,
-  },
-  {
     query: "how many AWU credits did the workspace consume this month",
     expected: "workspace_analytics.get_credit_usage",
   },
   {
     query: "break down credit spending by agent",
     expected: "workspace_analytics.get_credit_usage",
+  },
+  {
+    query: "which skills are executed most in the workspace",
+    expected: "workspace_analytics.get_top_entities_by_execution_count",
+  },
+  {
+    query: "what are the top MCP tools used by agents",
+    expected: "workspace_analytics.get_top_entities_by_execution_count",
+  },
+  {
+    query: "how many times did each integration run",
+    expected: "workspace_analytics.get_top_entities_by_execution_count",
   },
   {
     query: "which agents cost the most credits this month",
@@ -1139,6 +1147,10 @@ const QUERIES: LabeledQuery[] = [
   },
   {
     query: "attribute credit spend to our API keys",
+    expected: "workspace_analytics.get_top_entities_by_credits",
+  },
+  {
+    query: "rank credit spend by tool",
     expected: "workspace_analytics.get_top_entities_by_credits",
   },
   {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -155,8 +155,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top by message count",
-      done: "Retrieved top by message count",
+      running: "Retrieving top entities by message count",
+      done: "Retrieved top entities by message count",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -176,8 +176,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top by execution count",
-      done: "Retrieved top by execution count",
+      running: "Retrieving top entities by execution count",
+      done: "Retrieved top entities by execution count",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -8,41 +8,15 @@ import {
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
-import { CONSUMPTION_TOP_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
+import {
+  CONSUMPTION_INVOCATION_DIMENSIONS,
+  CONSUMPTION_MESSAGE_DIMENSIONS,
+  CONSUMPTION_TOP_DIMENSIONS,
+} from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
 export const GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME =
   "get_top_entities_by_credits" as const;
-
-const topListSchema = (entityPlural: string) => ({
-  ...timeWindowSchemaShape,
-  ...usageFilterSchema,
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS)
-    .optional()
-    .describe(
-      `Maximum number of ${entityPlural} to return ` +
-        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
-    ),
-});
-
-const getTopAgentsSchema = topListSchema("agents");
-const getTopUsersSchema = topListSchema("users");
-const getTopSkillsSchema = topListSchema("skills");
-const getTopToolsSchema = topListSchema("tools");
-const getTopAgentTagsSchema = topListSchema("agent tags");
-const getTopModelsSchema = topListSchema("models");
-
-const getSourceBreakdownSchema = {
-  ...timeWindowSchemaShape,
-  agentIds: usageFilterSchema.agentIds,
-  userIds: usageFilterSchema.userIds,
-  agentTagIds: usageFilterSchema.agentTagIds,
-  modelIds: usageFilterSchema.modelIds,
-};
 
 const getAgentDetailsSchema = {
   agentId: z
@@ -122,99 +96,88 @@ const getUsageTimeseriesSchema = {
     ),
 };
 
+export const GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME =
+  "get_top_entities_by_message_count" as const;
+export const GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME =
+  "get_top_entities_by_execution_count" as const;
+
+const rankingLimitSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(MAX_RESULTS)
+  .optional()
+  .describe(
+    `Maximum number of rows to return ` +
+      `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
+  );
+
+const GROUP_BY_DESCRIPTION = "What to group results by.";
+
 const getTopEntitiesByCreditsSchema = {
-  dimension: z
-    .enum(CONSUMPTION_TOP_DIMENSIONS)
-    .describe("What to group results by."),
+  dimension: z.enum(CONSUMPTION_TOP_DIMENSIONS).describe(GROUP_BY_DESCRIPTION),
   ...timeWindowSchemaShape,
   ...consumptionFilterSchema,
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS)
-    .optional()
-    .describe(
-      `Maximum number of rows to return ` +
-        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
-    ),
+  limit: rankingLimitSchema,
+};
+
+const getTopEntitiesByMessageCountSchema = {
+  dimension: z
+    .enum(CONSUMPTION_MESSAGE_DIMENSIONS)
+    .describe(GROUP_BY_DESCRIPTION),
+  ...timeWindowSchemaShape,
+  ...consumptionFilterSchema,
+  limit: rankingLimitSchema,
+};
+
+const getTopEntitiesByExecutionCountSchema = {
+  dimension: z
+    .enum(CONSUMPTION_INVOCATION_DIMENSIONS)
+    .describe(GROUP_BY_DESCRIPTION),
+  ...timeWindowSchemaShape,
+  ...consumptionFilterSchema,
+  limit: rankingLimitSchema,
 };
 
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
-    name: "get_top_agents",
+    name: GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME,
     description:
-      "Return the workspace's most-used and most active agents over a time " +
-      "window (defaults to the current calendar month), ranked by message " +
-      "count, with unique user count for each. Each row includes the agent's " +
-      "id. Use this to answer which agents are most popular, most used, or " +
-      "most active. Admin-only.",
-    schema: getTopAgentsSchema,
+      "Rank the workspace's entities by message volume over a " +
+      "time window (defaults to the current calendar month). Use this to " +
+      "answer 'which user is most active this month', 'which agent is " +
+      "used most', 'where do our messages come from, by source', or " +
+      "'list the agent tags, most-used tags first'. Every value it " +
+      "returns, including tag ids, can be fed back in as a filter on " +
+      `any of these tools. Use ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} ` +
+      "to rank by cost.",
+    schema: getTopEntitiesByMessageCountSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top agents",
-      done: "Retrieved top agents",
+      running: "Retrieving top by message count",
+      done: "Retrieved top by message count",
     },
     toolCostCategory: "basic",
     freeUsage: true,
   },
   {
-    name: "get_top_users",
+    name: GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME,
     description:
-      "Return the workspace's most active users and members over a time " +
-      "window (defaults to the current calendar month), ranked by number of " +
-      "messages sent, with the count of distinct agents each used. Each row " +
-      "includes the user's id. Use this to answer who the most active users " +
-      "are, rank members by usage, or find your top contributors. Admin-only.",
-    schema: getTopUsersSchema,
+      "Rank the workspace's skills, or its MCP tools and integrations, by how " +
+      "many times they were executed over a time window (defaults to the " +
+      "current calendar month). Use this to answer 'which are the top " +
+      "tools agents used most' or 'which skill runs most often'. One " +
+      "run attributed to several skills counts for each, so skill rows " +
+      "overlap. Use " +
+      `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to rank the same ` +
+      "entities by cost instead.",
+    schema: getTopEntitiesByExecutionCountSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top users",
-      done: "Retrieved top users",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_agent_tags",
-    description:
-      "List the agent tags applied across the workspace over a time window " +
-      "(defaults to the current calendar month), ranked by message volume, " +
-      "with the number of distinct agents bearing each tag. Each row includes " +
-      "the tag's id. Use this to enumerate which agent tags exist and obtain " +
-      "their ids, then supply those ids as the agentTagIds filter on the " +
-      "other analytics tools. Because an agent can bear several tags, per-tag " +
-      "counts overlap and may exceed the workspace total. Tags are fetched " +
-      "based on historical message data and may not reflect current agent tags. Admin-only.",
-    schema: getTopAgentTagsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top agent tags",
-      done: "Retrieved top agent tags",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_models",
-    description:
-      "List which LLM models (Claude, GPT, Gemini, ...) answered messages over " +
-      "a time window (defaults to the current calendar month), ranked by " +
-      "message volume, with each model's provider and its distinct agent and " +
-      "user counts. Use this to answer which model is used most, and to " +
-      "discover the model ids to pass as the modelIds filter of the other " +
-      "analytics tools; for credits per model use get_credit_usage with " +
-      "groupBy 'model'. Models come from historical message data, so retired " +
-      "models may appear. Admin-only.",
-    schema: getTopModelsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top models",
-      done: "Retrieved top models",
+      running: "Retrieving top by execution count",
+      done: "Retrieved top by execution count",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -232,65 +195,6 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     displayLabels: {
       running: "Retrieving agent details",
       done: "Retrieved agent details",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_skills",
-    description:
-      "Return the workspace's most-used skills over a time window (defaults " +
-      "to the current calendar month), ranked by execution count. Optionally " +
-      "filter by source (context_origin), agent, user, tag, or model. Use this " +
-      "to answer which skills are executed or used most. Admin-only.",
-    schema: getTopSkillsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top skills",
-      done: "Retrieved top skills",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_tools",
-    description:
-      "Return the workspace's most-used MCP tools and integrations over a " +
-      "time window (defaults to the current calendar month), ranked by " +
-      "execution count. Shows which MCP server tools are called most. Optionally " +
-      "filter by source (context_origin), agent, user, tag, or model. Use this " +
-      "to answer which tools are used most or which integrations agents " +
-      "rely on. Admin-only.",
-    schema: getTopToolsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top tools",
-      done: "Retrieved top tools",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_source_breakdown",
-    description:
-      "Return the workspace's message volume broken down by source — where " +
-      "messages originate (Conversation, Slack, API, Trigger, extension, and " +
-      "more) — over a time window (defaults to the current calendar month), " +
-      "most used first. Sources are labeled and merged exactly as the " +
-      "workspace Usage page's source chart, so the values line up with the " +
-      "dashboard. Use this to discover and compare which channels or " +
-      "integrations drive usage (including programmatic ones like API and " +
-      "triggers) — the source filter on the other tools only narrows to one " +
-      "source, this enumerates them all. Optionally filter by agent, user, " +
-      "tag, or model. Admin-only.",
-    schema: getSourceBreakdownSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving source breakdown",
-      done: "Retrieved source breakdown",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -365,9 +269,10 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     description:
       "Rank the workspace's credit consumption by entity " +
       "over a time window (defaults to the current calendar month). Use " +
-      "this to answer 'which agent is most expensive', or to attribute " +
-      "credit spend by API key, tag, or model. Figures are billed " +
-      "credits. Rows may overlap, so don't sum them for a workspace total.",
+      "this to answer 'which agent costs the most' or 'which " +
+      "conversation was most expensive', or to attribute credit spend by " +
+      "API key, tag, or model. Figures are billed credits. Rows may " +
+      "overlap, so don't sum them for a workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -85,15 +85,14 @@ export const usageFilterSchema = {
     .array(z.string())
     .optional()
     .describe(
-      "Restrict to messages from agents carrying any of these agent tag " +
-        "sIds, as returned by get_top_agent_tags."
+      "Restrict to messages from agents carrying any of these agent tag sIds"
     ),
   modelIds: z
     .array(z.string())
     .optional()
     .describe(
       "Restrict to messages answered by these models, identified by their " +
-        "model id (e.g. 'claude-sonnet-4-5'), as returned by get_top_models."
+        "model id (e.g. 'claude-sonnet-4-5')."
     ),
 };
 
@@ -185,7 +184,7 @@ export function toConsumptionPeriod(
   };
 }
 
-type TimeWindowInput = z.input<typeof timeWindowInputSchema>;
+export type TimeWindowInput = z.input<typeof timeWindowInputSchema>;
 
 export type ResolvedTimeWindow = {
   startDate: string;

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -24,18 +24,13 @@ function createTestExtra(auth: Authenticator, runContext?: unknown) {
 
 describe("workspace_analytics tools", () => {
   it.each([
-    "get_top_agents",
-    "get_top_users",
-    "get_top_agent_tags",
-    "get_top_models",
     "get_agent_details",
-    "get_top_skills",
-    "get_top_tools",
-    "get_source_breakdown",
     "get_credit_usage",
     "get_credit_timeseries",
     "get_usage_timeseries",
     "get_top_entities_by_credits",
+    "get_top_entities_by_message_count",
+    "get_top_entities_by_execution_count",
   ])("%s refuses callers below manager", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   ToolHandlerResult,
   ToolHandlers,
@@ -6,7 +7,11 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceManagerGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
-import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type {
+  ConsumptionFilterInput,
+  ResolvedTimeWindow,
+  TimeWindowInput,
+} from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import {
   DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
@@ -14,6 +19,10 @@ import {
   toConsumptionPeriod,
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type {
+  ConsumptionTopDimension,
+  ConsumptionTopRankBy,
+} from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
@@ -21,28 +30,13 @@ import {
 } from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
-  fetchContextOriginBreakdown,
-  toLabeledSources,
-} from "@app/lib/api/assistant/observability/context_origin";
-import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
   fetchCreditUsage,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  fetchAvailableSkills,
-  fetchSkillUsageMetrics,
-} from "@app/lib/api/assistant/observability/skill_usage";
-import {
-  fetchAvailableTools,
-  fetchToolUsageMetrics,
-  resolveServerDisplayNames,
-} from "@app/lib/api/assistant/observability/tool_usage";
-import { fetchTopAgentTags } from "@app/lib/api/assistant/observability/top_agent_tags";
-import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
-import { fetchTopModels } from "@app/lib/api/assistant/observability/top_models";
-import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
+import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
@@ -118,286 +112,94 @@ function renderExecutionSeries<
   ]);
 }
 
+async function renderRanking(
+  auth: Authenticator,
+  {
+    dimension,
+    rankBy,
+    limit,
+    input,
+  }: {
+    dimension: ConsumptionTopDimension;
+    rankBy: ConsumptionTopRankBy;
+    limit: number | undefined;
+    input: TimeWindowInput & ConsumptionFilterInput;
+  }
+): Promise<ToolHandlerResult> {
+  const window = resolveTimeWindow(input);
+  if (window.isErr()) {
+    return new Err(new MCPError(window.error, { tracked: false }));
+  }
+  const { filter, agentTagIds } = toConsumptionScope(input);
+
+  const result = await fetchConsumptionTopGroups(auth, {
+    dimension,
+    period: toConsumptionPeriod(window.value),
+    limit: limit ?? DEFAULT_RESULTS,
+    filter,
+    agentTagIds,
+    rankBy,
+    includePreviousCredits: false,
+    includeTotalCount: false,
+  });
+
+  if (result.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to rank ${dimension} by ${rankBy}: ${result.error.message}`
+      )
+    );
+  }
+
+  const { label, timezone: tz } = window.value;
+  const { totalCredits } = result.value;
+  const groups =
+    dimension === "tool"
+      ? result.value.groups.filter(
+          (group) => group.key !== SKILL_MANAGEMENT_SERVER_NAME
+        )
+      : result.value.groups;
+  const skillManagementCredits =
+    dimension === "tool"
+      ? (result.value.groups.find(
+          (group) => group.key === SKILL_MANAGEMENT_SERVER_NAME
+        )?.credits ?? 0)
+      : 0;
+
+  if (groups.length === 0) {
+    const noun = rankBy === "credits" ? "consumption" : "activity";
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `No ${dimension} ${noun} recorded for ${label} (${tz}).`,
+      },
+    ]);
+  }
+
+  const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
+  const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
+  const lines = rows.map(
+    (row, index) =>
+      `${index + 1}. ${row.name} [${row.key}] — ` +
+      `${row.credits.toFixed(2)} credits, ` +
+      `${row.count} ${unit}${pluralize(row.count)} ` +
+      `(${row.avgCredits.toFixed(4)} per ${unit})`
+  );
+
+  return new Ok([
+    {
+      type: "text" as const,
+      text:
+        `Top ${dimension} for ${label} (${tz}), ` +
+        `${rankBy === "credits" ? "most expensive" : `most ${unit}s`} first:\n` +
+        `${lines.join("\n")}\n\n` +
+        `Credits over the whole window, every row included: ` +
+        `${(totalCredits - skillManagementCredits).toFixed(2)}.`,
+    },
+  ]);
+}
+
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
-  get_top_agents: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopAgents(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top agents: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No agent activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map(
-      (agent, index) =>
-        `${index + 1}. ${agent.name} [${agent.agentId}] — ` +
-        `${agent.messageCount} messages, ${agent.userCount} users`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top agents for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_users: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopUsers(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top users: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No user activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map(
-      (user, index) =>
-        `${index + 1}. ${user.name} [${user.userId}] — ` +
-        `${user.messageCount} messages, ${user.agentCount} agents`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top users for ${label} (${tz}), most active first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_agent_tags: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopAgentTags(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top tags: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No agent tag activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map(
-      (tag, index) =>
-        `${index + 1}. ${tag.name} [${tag.tagId}] — ` +
-        `${tag.messageCount} messages, ${tag.agentCount} agents`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top agent tags for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_models: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopModels(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top models: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No model activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map((model, index) => {
-      const provider = model.providerId ? ` (${model.providerId})` : "";
-      return (
-        `${index + 1}. ${model.name}${provider} [${model.modelId}] — ` +
-        `${model.messageCount} messages, ${model.agentCount} agents, ` +
-        `${model.userCount} users`
-      );
-    });
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top models for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
   get_agent_details: async ({ agentId }, { auth }) => {
     const deniedError = workspaceManagerGuard(auth);
     if (deniedError) {
@@ -451,216 +253,6 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
           `- Tools: ${toolNames || "none"}\n\n` +
           "Instructions (full system prompt):\n" +
           `${agent.instructions ?? "(no instructions)"}`,
-      },
-    ]);
-  },
-
-  get_top_skills: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    const result = await fetchAvailableSkills(baseQuery);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve skill usage: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const skills = result.value.slice(0, limit ?? DEFAULT_RESULTS);
-
-    if (skills.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No skill usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = skills.map(
-      (skill, index) =>
-        `${index + 1}. ${skill.skillName} — ${skill.totalExecutions} executions`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Most-used skills for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_tools: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    const result = await fetchAvailableTools(baseQuery);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve tool usage: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const top = result.value.slice(0, limit ?? DEFAULT_RESULTS);
-
-    if (top.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No tool usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const displayNames = await resolveServerDisplayNames(
-      auth,
-      top.map((tool) => tool.serverName)
-    );
-
-    const lines = top.map((tool, index) => {
-      const displayName = displayNames.get(tool.serverName) ?? tool.displayName;
-      const name =
-        displayName === tool.serverName
-          ? displayName
-          : `${displayName} [${tool.serverName}]`;
-      return `${index + 1}. ${name} — ${tool.totalExecutions} executions`;
-    });
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Most-used tools for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_source_breakdown: async (
-    {
-      period,
-      startDate,
-      endDate,
-      timezone,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    const result = await fetchContextOriginBreakdown(baseQuery);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to retrieve source breakdown: ${result.error.message}`
-        )
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const sources = toLabeledSources(result.value);
-
-    if (sources.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No source activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const total = sources.reduce((sum, source) => sum + source.count, 0);
-    const lines = sources.map((source, index) => {
-      const percent = total > 0 ? Math.round((source.count / total) * 100) : 0;
-      return `${index + 1}. ${source.label} — ${source.count} messages (${percent}%)`;
-    });
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Message sources for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
       },
     ]);
   },
@@ -982,6 +574,28 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         return assertNever(selectedMetric);
     }
   },
+  get_top_entities_by_message_count: async (
+    { dimension, limit, ...input },
+    { auth }
+  ) => {
+    const denied = workspaceManagerGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+    return renderRanking(auth, { dimension, rankBy: "count", limit, input });
+  },
+
+  get_top_entities_by_execution_count: async (
+    { dimension, limit, ...input },
+    { auth }
+  ) => {
+    const denied = workspaceManagerGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+    return renderRanking(auth, { dimension, rankBy: "count", limit, input });
+  },
+
   get_top_entities_by_credits: async (
     { dimension, limit, ...input },
     { auth }
@@ -990,64 +604,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     if (deniedError) {
       return new Err(deniedError);
     }
-
-    const window = resolveTimeWindow(input);
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-    const { filter, agentTagIds } = toConsumptionScope(input);
-
-    const result = await fetchConsumptionTopGroups(auth, {
-      dimension,
-      period: toConsumptionPeriod(window.value),
-      limit: limit ?? DEFAULT_RESULTS,
-      filter,
-      agentTagIds,
-      // A single window has no vs-previous column to fill, and the lookup is a
-      // second round trip.
-      includePreviousCredits: false,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to rank ${dimension} by credits: ${result.error.message}`
-        )
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const { groups, totalCredits } = result.value;
-
-    if (groups.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No ${dimension} consumption recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
-    const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
-    const lines = rows.map(
-      (row, index) =>
-        `${index + 1}. ${row.name} [${row.key}] — ` +
-        `${row.credits.toFixed(2)} credits, ` +
-        `${row.count} ${unit}${pluralize(row.count)} ` +
-        `(${row.avgCredits.toFixed(4)} per ${unit})`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top ${dimension} by credits for ${label} (${tz}), most expensive ` +
-          `first:\n${lines.join("\n")}\n\n` +
-          `Credits over the whole window, every row included: ` +
-          `${totalCredits.toFixed(2)}.`,
-      },
-    ]);
+    return renderRanking(auth, { dimension, rankBy: "credits", limit, input });
   },
 };
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -22,8 +22,13 @@ import {
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRankBy,
+  ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionTopGroup,
+  ResolvedConsumptionGroup,
+} from "@app/lib/api/analytics/consumption/top";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -112,6 +117,67 @@ function renderExecutionSeries<
   ]);
 }
 
+function excludeSkillManagement(
+  dimension: ConsumptionTopDimension,
+  groups: ConsumptionTopGroup[]
+): { groups: ConsumptionTopGroup[]; skillManagementCredits: number } {
+  if (dimension !== "tool") {
+    return { groups, skillManagementCredits: 0 };
+  }
+  const skillManagementGroup = groups.find(
+    (group) => group.key === SKILL_MANAGEMENT_SERVER_NAME
+  );
+  return {
+    groups: groups.filter((group) => group !== skillManagementGroup),
+    skillManagementCredits: skillManagementGroup?.credits ?? 0,
+  };
+}
+
+function formatRankingText({
+  dimension,
+  label,
+  tz,
+  rankBy,
+  unit,
+  rows,
+  totalCredits,
+}: {
+  dimension: ConsumptionTopDimension;
+  label: string;
+  tz: string;
+  rankBy: ConsumptionTopRankBy;
+  unit: ConsumptionTopUnit;
+  rows: ResolvedConsumptionGroup[];
+  totalCredits: number;
+}): string {
+  const metricLabel = rankBy === "credits" ? "credits" : `${unit}s`;
+
+  if (rows.length === 0) {
+    return `No ${dimension} ${metricLabel} recorded for ${label} (${tz}).`;
+  }
+
+  const lines = rows.map(
+    (row, index) =>
+      `${index + 1}. ${row.name} [${row.key}] — ` +
+      `${row.credits.toFixed(2)} credits, ` +
+      `${row.count} ${unit}${pluralize(row.count)} ` +
+      `(${row.avgCredits.toFixed(2)} per ${unit})`
+  );
+
+  // e.g.:
+  // Top agents for July 2026 (UTC), by credits, highest first:
+  // 1. Support Bot [agentXYZ] — 152.30 credits, 42 messages (3.62 per message)
+  // 2. Sales Bot [agentABC] — 98.10 credits, 12 messages (8.18 per message)
+  //
+  // Credits over the whole window, every row included: 250.40.
+  return (
+    `Top ${dimension}s for ${label} (${tz}), by ${metricLabel}, highest first:\n` +
+    `${lines.join("\n")}\n\n` +
+    `Credits over the whole window, every row included: ` +
+    `${totalCredits.toFixed(2)}.`
+  );
+}
+
 async function renderRanking(
   auth: Authenticator,
   {
@@ -151,52 +217,24 @@ async function renderRanking(
     );
   }
 
-  const { label, timezone: tz } = window.value;
-  const { totalCredits } = result.value;
-  const groups =
-    dimension === "tool"
-      ? result.value.groups.filter(
-          (group) => group.key !== SKILL_MANAGEMENT_SERVER_NAME
-        )
-      : result.value.groups;
-  const skillManagementCredits =
-    dimension === "tool"
-      ? (result.value.groups.find(
-          (group) => group.key === SKILL_MANAGEMENT_SERVER_NAME
-        )?.credits ?? 0)
-      : 0;
-
-  if (groups.length === 0) {
-    const noun = rankBy === "credits" ? "consumption" : "activity";
-    return new Ok([
-      {
-        type: "text" as const,
-        text: `No ${dimension} ${noun} recorded for ${label} (${tz}).`,
-      },
-    ]);
-  }
-
-  const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
-  const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
-  const lines = rows.map(
-    (row, index) =>
-      `${index + 1}. ${row.name} [${row.key}] — ` +
-      `${row.credits.toFixed(2)} credits, ` +
-      `${row.count} ${unit}${pluralize(row.count)} ` +
-      `(${row.avgCredits.toFixed(4)} per ${unit})`
+  const { groups, skillManagementCredits } = excludeSkillManagement(
+    dimension,
+    result.value.groups
   );
+  const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
 
-  return new Ok([
-    {
-      type: "text" as const,
-      text:
-        `Top ${dimension} for ${label} (${tz}), ` +
-        `${rankBy === "credits" ? "most expensive" : `most ${unit}s`} first:\n` +
-        `${lines.join("\n")}\n\n` +
-        `Credits over the whole window, every row included: ` +
-        `${(totalCredits - skillManagementCredits).toFixed(2)}.`,
-    },
-  ]);
+  const { label, timezone: tz } = window.value;
+  const text = formatRankingText({
+    dimension,
+    label,
+    tz,
+    rankBy,
+    unit: CONSUMPTION_TOP_DIMENSION_UNIT[dimension],
+    rows,
+    totalCredits: result.value.totalCredits - skillManagementCredits,
+  });
+
+  return new Ok([{ type: "text" as const, text }]);
 }
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
@@ -578,9 +616,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     { dimension, limit, ...input },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
     return renderRanking(auth, { dimension, rankBy: "count", limit, input });
   },
@@ -589,9 +627,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     { dimension, limit, ...input },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
     return renderRanking(auth, { dimension, rankBy: "count", limit, input });
   },

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -1,4 +1,10 @@
-import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import {
+  buildConsumptionScopeQuery,
+  CONSUMPTION_INVOCATION_DIMENSIONS,
+  CONSUMPTION_MESSAGE_DIMENSIONS,
+  CONSUMPTION_TOP_DIMENSION_UNIT,
+  CONSUMPTION_TOP_DIMENSIONS,
+} from "@app/lib/api/analytics/consumption/scope";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
@@ -74,5 +80,25 @@ describe("buildConsumptionScopeQuery", () => {
     });
 
     expect(query.bool?.filter).toHaveLength(2);
+  });
+});
+
+describe("the top dimensions split by ranking unit", () => {
+  it("covers every top dimension exactly once", () => {
+    expect(
+      [
+        ...CONSUMPTION_MESSAGE_DIMENSIONS,
+        ...CONSUMPTION_INVOCATION_DIMENSIONS,
+      ].sort()
+    ).toEqual([...CONSUMPTION_TOP_DIMENSIONS].sort());
+  });
+
+  it("files each dimension under its own unit", () => {
+    for (const dimension of CONSUMPTION_MESSAGE_DIMENSIONS) {
+      expect(CONSUMPTION_TOP_DIMENSION_UNIT[dimension]).toBe("message");
+    }
+    for (const dimension of CONSUMPTION_INVOCATION_DIMENSIONS) {
+      expect(CONSUMPTION_TOP_DIMENSION_UNIT[dimension]).toBe("invocation");
+    }
   });
 });

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -122,6 +122,24 @@ export const CONSUMPTION_TOP_DIMENSION_UNIT: Record<
   reasoning_effort: "message",
 };
 
+export const CONSUMPTION_TOP_RANK_BY = ["credits", "count"] as const;
+
+export type ConsumptionTopRankBy = (typeof CONSUMPTION_TOP_RANK_BY)[number];
+
+export const CONSUMPTION_MESSAGE_DIMENSIONS = [
+  "agent",
+  "user",
+  "api_key",
+  "group",
+  "model",
+  "source",
+  "conversation",
+  "tag",
+  "reasoning_effort",
+] as const;
+
+export const CONSUMPTION_INVOCATION_DIMENSIONS = ["tool", "skill"] as const;
+
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 
 export type ConsumptionMetric = (typeof CONSUMPTION_METRICS)[number];

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -878,10 +878,44 @@ describe("consumption top rankings", () => {
   });
 });
 
-// The two options the analytics tools rely on and the page never sets.
 describe("fetchConsumptionTopGroups options", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      name: "credits sort on the credit sum",
+      dimension: "agent" as const,
+      rankBy: "credits" as const,
+      order: { credit_micro: "desc" },
+    },
+    {
+      name: "a message dimension counted sorts on distinct messages",
+      dimension: "agent" as const,
+      rankBy: "count" as const,
+      order: { messages: "desc" },
+    },
+    {
+      name: "an invocation dimension counted sorts on the bucket's own docs",
+      dimension: "tool" as const,
+      rankBy: "count" as const,
+      order: { _count: "desc" },
+    },
+  ])("$name", async ({ dimension, rankBy, order }) => {
+    const { auth } = await setup();
+    mockAggs({ buckets: [], totalMicro: 0 });
+
+    await fetchConsumptionTopGroupBuckets(auth, {
+      dimension,
+      period: PERIOD,
+      limit: 5,
+      rankBy,
+      includePreviousCredits: false,
+    });
+
+    const [, options] = lastSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({ order });
   });
 
   it("skips the previous-period search when the caller opts out", async () => {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -34,7 +34,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 import chunk from "lodash/chunk";
 
-type ConsumptionTopGroup = {
+export type ConsumptionTopGroup = {
   key: string;
   credits: number;
   // Distinct messages, or tool invocations, per the ranking's unit.

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,11 +5,11 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeFilter,
   ConsumptionTopDimension,
+  ConsumptionTopRankBy,
   ConsumptionTopSortOrder,
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  AGENT_MESSAGE_ID_FIELD,
   agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
@@ -17,6 +17,7 @@ import {
   CONSUMPTION_TOP_DIMENSION_FIELDS,
   CONSUMPTION_TOP_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
+  uniqueMessagesCardinalityAgg,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -75,7 +76,7 @@ function subAggs(unit: ConsumptionTopUnit) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
     ...(unit === "message"
-      ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
+      ? { [MESSAGES_AGG]: uniqueMessagesCardinalityAgg() }
       : {}),
   };
 }
@@ -183,18 +184,41 @@ async function resolveConsumptionTopSearchFilter(
   );
 }
 
+function rankingOrder(
+  dimension: ConsumptionTopDimension,
+  rankBy: ConsumptionTopRankBy,
+  sortOrder: ConsumptionTopSortOrder
+): Record<string, ConsumptionTopSortOrder> {
+  if (rankBy === "credits") {
+    return { [CREDIT_AGG]: sortOrder };
+  }
+
+  switch (CONSUMPTION_TOP_DIMENSION_UNIT[dimension]) {
+    case "message":
+      return { [MESSAGES_AGG]: sortOrder };
+    case "invocation":
+      return { _count: sortOrder };
+    default:
+      return assertNever(CONSUMPTION_TOP_DIMENSION_UNIT[dimension]);
+  }
+}
+
 function buildConsumptionTopAggregations({
   dimension,
   bucketCount,
   excludedKeys,
   searchFilter,
   sortOrder,
+  rankBy,
+  includeTotalCount,
 }: {
   dimension: ConsumptionTopDimension;
   bucketCount: number;
   excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
   sortOrder: ConsumptionTopSortOrder;
+  rankBy: ConsumptionTopRankBy;
+  includeTotalCount: boolean;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_TOP_DIMENSION_FIELDS[dimension];
@@ -204,17 +228,21 @@ function buildConsumptionTopAggregations({
       terms: {
         field: dimensionField,
         size: bucketCount,
-        order: { [CREDIT_AGG]: sortOrder },
+        order: rankingOrder(dimension, rankBy, sortOrder),
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
       aggs: subAggs(unit),
     },
-    [TOTAL_COUNT_AGG]: {
-      cardinality: {
-        field: dimensionField,
-        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-      },
-    },
+    ...(includeTotalCount
+      ? {
+          [TOTAL_COUNT_AGG]: {
+            cardinality: {
+              field: dimensionField,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
+      : {}),
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
   const rankingRootAggregations = searchFilter
@@ -317,7 +345,9 @@ export async function fetchConsumptionTopGroups(
     filter,
     agentTagIds,
     sortOrder = "desc",
+    rankBy = "credits",
     includePreviousCredits = true,
+    includeTotalCount = true,
   }: {
     dimension: ConsumptionTopDimension;
     period: ConsumptionPeriod;
@@ -327,7 +357,9 @@ export async function fetchConsumptionTopGroups(
     filter?: ConsumptionScopeFilter;
     agentTagIds?: string[];
     sortOrder?: ConsumptionTopSortOrder;
+    rankBy?: ConsumptionTopRankBy;
     includePreviousCredits?: boolean;
+    includeTotalCount?: boolean;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const searchFilter = await resolveConsumptionTopSearchFilter(auth, {
@@ -364,6 +396,8 @@ export async function fetchConsumptionTopGroups(
       excludedKeys: rankedGroups.map((group) => group.key),
       searchFilter,
       sortOrder,
+      rankBy,
+      includeTotalCount,
     });
     const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
       aggregations,

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -1,4 +1,9 @@
 import {
+  GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME,
+  GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME,
+  GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME,
+} from "@app/lib/api/actions/servers/workspace_analytics/metadata";
+import {
   GET_AGENT_DETAILS_TOOL_NAME,
   GET_SKILL_DETAILS_TOOL_NAME,
   LIST_AGENTS_TOOL_NAME,
@@ -38,18 +43,18 @@ export const workspaceAnalyticsSkill = {
     "- Never build a trend by calling a snapshot tool (get_credit_usage, " +
     "get_top_*) once per day or in parallel per period — it is slower and " +
     "unnecessary, the timeseries tools already bucket over time.\n" +
-    "- To attribute spend — which agents, users, models, tools, skills, " +
-    "sources, API keys, groups, tags or conversations cost the most — call " +
-    "get_top_entities_by_credits with that dimension. Use get_credit_usage " +
+    "- To attribute spend (which agents, users, models, tools, skills, " +
+    "sources, API keys, groups, tags or conversations cost the most). Call " +
+    `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} with that dimension. Use get_credit_usage ` +
     "only for a single window's total credits.\n" +
     "- For a credit trend split by agent, user or model (e.g. 'how did each " +
     "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
     "call returns the top groups plus an 'other' series. Do not make one " +
     "filtered call per agent, user or model.\n" +
-    "- For volume rather than spend — who is most active, which agents or " +
-    "models get used most, where messages come from — call " +
-    "get_top_entities_by_message_count with that dimension, and " +
-    "get_top_entities_by_execution_count for how often tools and skills ran.\n" +
+    "- For volume rather than spend: who is most active, which agents or " +
+    "models get used most, where messages come from. Call " +
+    `${GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME} with that dimension, and ` +
+    `${GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME} for how often tools and skills ran.\n` +
     "- The rankings return each row's id. Feed those ids back in as filters " +
     "(agentIds, userIds, modelIds, agentTagIds, sources, ...) to narrow any " +
     "other call — never guess an id from a display name.\n" +

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -46,9 +46,13 @@ export const workspaceAnalyticsSkill = {
     "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
     "call returns the top groups plus an 'other' series. Do not make one " +
     "filtered call per agent, user or model.\n" +
-    "- To scope any tool to specific models, call get_top_models first to get " +
-    "the exact model ids in use, then pass them as modelIds — never guess a " +
-    "model id from its display name.\n" +
+    "- For volume rather than spend — who is most active, which agents or " +
+    "models get used most, where messages come from — call " +
+    "get_top_entities_by_message_count with that dimension, and " +
+    "get_top_entities_by_execution_count for how often tools and skills ran.\n" +
+    "- The rankings return each row's id. Feed those ids back in as filters " +
+    "(agentIds, userIds, modelIds, agentTagIds, sources, ...) to narrow any " +
+    "other call — never guess an id from a display name.\n" +
     `- To inventory what EXISTS rather than what is used — which agents or ` +
     `skills the workspace has, whether they are published or discoverable, ` +
     `which ones nobody uses — call ${LIST_AGENTS_TOOL_NAME} or ` +
@@ -61,7 +65,7 @@ export const workspaceAnalyticsSkill = {
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 6,
+  version: 7,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {


### PR DESCRIPTION
Stacked on #31273 — review that one first, this diff is against its branch.

## Description

Second step of moving `@analyst` off `front.agent_message_analytics`. #31273 added the credits ranking; this one adds the two count rankings and retires the seven legacy top-N tools they replace.

- `get_top_entities_by_message_count` — agents, members, models, sources, API keys, groups, tags, conversations. Replaces `get_top_agents`, `get_top_users`, `get_top_models`, `get_top_agent_tags` and `get_source_breakdown`.
- `get_top_entities_by_execution_count` — tools and skills. Replaces `get_top_tools` and `get_top_skills`.

Both are the same `fetchConsumptionTopGroups` call as the credits tool with `rankBy: "count"`, so all three now share one `renderRanking`. That is where the −757 comes from: seven hand-rolled handlers and their aggregations collapse into one.

`rankBy` picks the ordering from the dimension's unit. Credits and invocation counts are free — a sum Elasticsearch already has, and the bucket's own `doc_count`. Ordering a message dimension by count is the expensive one: it sorts on the distinct-message cardinality, which every shard computes for every candidate bucket. That also makes the missing `precision_threshold` on that cardinality a real bug rather than a display detail, so it now uses the module's 40 000 like everything else.

Two counts change meaning, both narrower and less biased than before:

- **Skills.** The old count came from `AgentMessageSkillModel`, which `snapshotConversationSkillsForMessage` copies onto every message in the conversation — so a skill attached once scored on every later message whether or not it did anything. Consumption counts tool calls actually attributed to the skill. A skill that never calls a tool no longer appears.
- **Messages.** The consumption indexer skips failed and unbilled messages, so every message count is now billed messages.

## Tests

- `scope.test.ts`: the message and invocation dimension tuples cover every top dimension exactly once, and each sits under the unit `CONSUMPTION_TOP_DIMENSION_UNIT` gives it. Add a dimension and forget to file it and this fails.
- `top.test.ts`: the `order` clause each dimension/rankBy pair emits. Seeded data ranks the same either way, so this asserts on the aggregation rather than the result.
- `bm25_tool_search.test.ts`: the retired tools' queries now route to the two new ones.

## Risk

Medium. Nine tools become four, and two counts change definition as described. Callers are `@analyst` only — no endpoint or page reads these.

## Deploy Plan

Merge after #31273. Second of five: credits ranking → count rankings → overview → credit timeseries → usage timeseries.

