### PR TITLE
feat(front): key the Slack workflow whitelist on spaces instead of groups

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/slack-workflows.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/slack-workflows.test.ts
@@ -12,38 +12,34 @@ vi.mock("@app/lib/api/audit/workos_audit", async () => {
 });
 
 import { emitAuditLogEvent } from "@app/lib/api/audit/workos_audit";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import {
+  connectSlackBot,
+  createSpaceWithMemberGroup,
+  mockRevokeSlackWorkflow,
+  mockSummoningWhitelist,
+  SLACK_BOT_CONNECTOR_ID,
+  SLACK_WORKFLOW_BOT_NAME,
+  SLACK_WORKFLOW_CREATED_AT_MS,
+} from "@app/tests/utils/slack_workflows";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import { Err, Ok } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-
-const CONNECTOR_ID = "1234";
-const BOT_NAME = "Weekly report";
-const CREATED_AT = 1756166400000;
-
-function mockSlackBotDataSource({ connected }: { connected: boolean }) {
-  vi.spyOn(DataSourceResource, "listByConnectorProvider").mockImplementation(((
-    _auth: unknown,
-    provider: string
-  ) =>
-    Promise.resolve(
-      provider === "slack_bot" && connected
-        ? [{ connectorId: CONNECTOR_ID }]
-        : []
-    )) as unknown as typeof DataSourceResource.listByConnectorProvider);
-}
 
 async function setupTest({
   isSuperUser = true,
+  withSlackBot = true,
 }: {
   isSuperUser?: boolean;
+  withSlackBot?: boolean;
 } = {}) {
   const setup = await createPrivateApiMockRequest({
     isSuperUser,
     role: "admin",
   });
-  mockSlackBotDataSource({ connected: true });
+  if (withSlackBot) {
+    await connectSlackBot(setup.workspace, setup.systemSpace);
+  }
 
   return setup;
 }
@@ -66,10 +62,7 @@ describe("GET /api/poke/workspaces/[wId]/slack-workflows", () => {
 
   it("returns 401 for non super users", async () => {
     const { workspace } = await setupTest({ isSuperUser: false });
-    const whitelist = vi.spyOn(
-      ConnectorsAPI.prototype,
-      "getSlackBotSummoningWhitelist"
-    );
+    const whitelist = mockSummoningWhitelist([]);
 
     const response = await pokeSlackWorkflowsRequest(workspace.sId, {
       method: "GET",
@@ -79,22 +72,16 @@ describe("GET /api/poke/workspaces/[wId]/slack-workflows", () => {
     expect(whitelist).not.toHaveBeenCalled();
   });
 
-  it("lists the allowed workflows with their group names", async () => {
+  it("lists the allowed workflows with their spaces", async () => {
     const { workspace, globalGroup } = await setupTest();
-    vi.spyOn(
-      ConnectorsAPI.prototype,
-      "getSlackBotSummoningWhitelist"
-    ).mockResolvedValue(
-      new Ok({
-        bots: [
-          {
-            botName: BOT_NAME,
-            groupIds: [globalGroup.sId],
-            createdAt: CREATED_AT,
-          },
-        ],
-      })
-    );
+    const { space, memberGroupId } =
+      await createSpaceWithMemberGroup(workspace);
+    mockSummoningWhitelist([
+      {
+        botName: SLACK_WORKFLOW_BOT_NAME,
+        groupIds: [memberGroupId, globalGroup.sId],
+      },
+    ]);
 
     const response = await pokeSlackWorkflowsRequest(workspace.sId, {
       method: "GET",
@@ -105,17 +92,16 @@ describe("GET /api/poke/workspaces/[wId]/slack-workflows", () => {
       isSlackBotConnected: true,
       workflows: [
         {
-          botName: BOT_NAME,
-          groups: [{ sId: globalGroup.sId, name: globalGroup.name }],
-          createdAt: CREATED_AT,
+          botName: SLACK_WORKFLOW_BOT_NAME,
+          spaces: [{ sId: space.sId, name: space.name }],
+          createdAt: SLACK_WORKFLOW_CREATED_AT_MS,
         },
       ],
     });
   });
 
   it("reports the Slack bot as disconnected instead of failing", async () => {
-    const { workspace } = await setupTest();
-    mockSlackBotDataSource({ connected: false });
+    const { workspace } = await setupTest({ withSlackBot: false });
 
     const response = await pokeSlackWorkflowsRequest(workspace.sId, {
       method: "GET",
@@ -136,24 +122,22 @@ describe("DELETE /api/poke/workspaces/[wId]/slack-workflows", () => {
 
   it("revokes a workflow and audits the support actor", async () => {
     const { workspace } = await setupTest();
-    const revoke = vi
-      .spyOn(ConnectorsAPI.prototype, "unwhitelistSlackBotToSummon")
-      .mockResolvedValue(new Ok({ success: true }));
+    const revoke = mockRevokeSlackWorkflow();
 
     const response = await pokeSlackWorkflowsRequest(workspace.sId, {
       method: "DELETE",
-      body: { botName: BOT_NAME },
+      body: { botName: SLACK_WORKFLOW_BOT_NAME },
     });
 
     expect(response.status).toBe(200);
     expect(revoke).toHaveBeenCalledWith({
-      connectorId: CONNECTOR_ID,
-      botName: BOT_NAME,
+      connectorId: SLACK_BOT_CONNECTOR_ID,
+      botName: SLACK_WORKFLOW_BOT_NAME,
     });
     expect(vi.mocked(emitAuditLogEvent)).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "slack_workflow.revoked",
-        metadata: { bot_name: BOT_NAME },
+        metadata: { bot_name: SLACK_WORKFLOW_BOT_NAME },
       })
     );
   });
@@ -169,7 +153,7 @@ describe("DELETE /api/poke/workspaces/[wId]/slack-workflows", () => {
 
     const response = await pokeSlackWorkflowsRequest(workspace.sId, {
       method: "DELETE",
-      body: { botName: BOT_NAME },
+      body: { botName: SLACK_WORKFLOW_BOT_NAME },
     });
 
     expect(response.status).toBe(404);

--- a/front-api/routes/slack_workflow_errors.ts
+++ b/front-api/routes/slack_workflow_errors.ts
@@ -15,6 +15,7 @@ export function slackWorkflowErrorToApiError(
         },
       };
     case "invalid_groups":
+    case "invalid_spaces":
       return {
         status_code: 400,
         api_error: {

--- a/front/admin/audit_log_schemas/slack_workflow.allowed.json
+++ b/front/admin/audit_log_schemas/slack_workflow.allowed.json
@@ -10,7 +10,7 @@
   ],
   "metadata": {
     "bot_name": "string",
-    "group_names": "string",
+    "space_names": "string",
     "actor_type": "string"
   }
 }

--- a/front/components/poke/data_sources/slack/workflows_table.tsx
+++ b/front/components/poke/data_sources/slack/workflows_table.tsx
@@ -8,7 +8,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 type SlackWorkflowRow = {
   botName: string;
-  groupNames: string;
+  spaceNames: string;
   createdAt: number;
 };
 
@@ -21,8 +21,8 @@ function makeColumnsForSlackWorkflows(
       header: () => <p>Workflow / Bot Name</p>,
     },
     {
-      accessorKey: "groupNames",
-      header: () => <p>Groups</p>,
+      accessorKey: "spaceNames",
+      header: () => <p>Spaces</p>,
     },
     {
       accessorKey: "createdAt",
@@ -52,7 +52,7 @@ function prepareSlackWorkflowsForDisplay(
 ): SlackWorkflowRow[] {
   return workflows.map((workflow) => ({
     botName: workflow.botName,
-    groupNames: workflow.groups.map((group) => group.name).join(", "),
+    spaceNames: workflow.spaces.map((space) => space.name).join(", "),
     createdAt: workflow.createdAt,
   }));
 }

--- a/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
+++ b/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
@@ -1,8 +1,10 @@
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
-import { allowSlackWorkflow } from "@app/lib/api/slack/summoning_whitelist";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  allowSlackWorkflow,
+  listSlackWorkflowSpaces,
+} from "@app/lib/api/slack/summoning_whitelist";
 import logger from "@app/logger/logger";
 import type { AdminCommandType } from "@app/types/connectors/admin/cli";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
@@ -94,11 +96,11 @@ export const slackWhitelistBotPlugin = createPlugin({
         label: "Bot/Workflow Name",
         description: "Name of the Slack bot or workflow to whitelist",
       },
-      groupIds: {
+      spaceIds: {
         type: "enum",
-        label: "Groups",
+        label: "Spaces",
         description:
-          "Groups the bot can access when summoning agents — only agents belonging to these groups will be available to the bot",
+          "Spaces the bot can reach when summoning agents — only agents shared in these spaces, plus the Company Space, will be available to the bot",
         async: true,
         values: [],
         multiple: true,
@@ -117,17 +119,17 @@ export const slackWhitelistBotPlugin = createPlugin({
       return new Err(new Error("Data source not found."));
     }
 
-    const groups = await GroupResource.listAllWorkspaceGroups(auth);
+    const spaces = await listSlackWorkflowSpaces(auth);
 
     return new Ok({
-      groupIds: groups.map((group) => ({
-        value: group.sId,
-        label: group.name,
+      spaceIds: spaces.map((space) => ({
+        value: space.sId,
+        label: space.name,
       })),
     });
   },
   execute: async (auth, resource, args) => {
-    const { botName, groupIds } = args;
+    const { botName, spaceIds } = args;
 
     if (!resource) {
       return new Err(new Error("Data source not found."));
@@ -137,13 +139,9 @@ export const slackWhitelistBotPlugin = createPlugin({
       return new Err(new Error("Bot name is required"));
     }
 
-    if (!groupIds || groupIds.length === 0) {
-      return new Err(new Error("Groups selection is required"));
-    }
-
     const allowRes = await allowSlackWorkflow(auth, {
       botName: botName.trim(),
-      groupIds,
+      spaceIds: spaceIds ?? [],
     });
     if (allowRes.isErr()) {
       return new Err(
@@ -153,7 +151,7 @@ export const slackWhitelistBotPlugin = createPlugin({
 
     return new Ok({
       display: "text",
-      value: `Successfully whitelisted Slack bot "${botName}" for agent summoning in the selected groups and the Workspace group.`,
+      value: `Successfully whitelisted Slack bot "${botName}" for agent summoning in the selected spaces and the Company Space.`,
     });
   },
 });

--- a/front/lib/api/slack/summoning_whitelist.test.ts
+++ b/front/lib/api/slack/summoning_whitelist.test.ts
@@ -1,0 +1,174 @@
+import type * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return {
+    ...actual,
+    emitAuditLogEvent: vi.fn(),
+  };
+});
+
+import {
+  allowSlackWorkflow,
+  listSlackWorkflows,
+} from "@app/lib/api/slack/summoning_whitelist";
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import {
+  connectSlackBot,
+  mockAllowSlackWorkflow,
+  mockSummoningWhitelist,
+  SLACK_WORKFLOW_BOT_NAME,
+} from "@app/tests/utils/slack_workflows";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+async function setupTest() {
+  const workspace = await WorkspaceFactory.basic();
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const { systemSpace } = await SpaceResource.makeDefaultsForWorkspace(auth, {
+    globalGroup,
+    systemGroup,
+  });
+  await connectSlackBot(workspace, systemSpace);
+
+  const space = await SpaceFactory.regular(workspace);
+  const memberGroup = await space.fetchManualMemberGroup(auth);
+
+  return { auth, workspace, globalGroup, space, memberGroup };
+}
+
+// A provisioned group can be attached to several spaces at once, so whichever groups the whitelist
+// stores have to be the space's own member group — see `listSpaceMemberGroups`.
+async function attachProvisionedGroup(
+  auth: Authenticator,
+  space: SpaceResource
+) {
+  const provisionedGroup = await GroupResource.makeNew({
+    name: "Provisioned Group",
+    workspaceId: auth.getNonNullableWorkspace().id,
+    kind: "provisioned",
+  });
+
+  const updateRes = await space.updatePermissions(auth, {
+    name: space.name,
+    isRestricted: true,
+    managementMode: "group",
+    groupIds: [provisionedGroup.sId],
+    editorGroupIds: [],
+  });
+  expect(updateRes.isOk()).toBe(true);
+
+  return provisionedGroup;
+}
+
+describe("allowSlackWorkflow", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("whitelists the space's own member group and the global group", async () => {
+    const { auth, globalGroup, space, memberGroup } = await setupTest();
+    const allow = mockAllowSlackWorkflow();
+
+    const result = await allowSlackWorkflow(auth, {
+      botName: SLACK_WORKFLOW_BOT_NAME,
+      spaceIds: [space.sId],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(allow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botName: SLACK_WORKFLOW_BOT_NAME,
+        groupIds: [globalGroup.sId, memberGroup.sId],
+      })
+    );
+  });
+
+  it("leaves out the groups the space shares with other spaces", async () => {
+    const { auth, globalGroup, space, memberGroup } = await setupTest();
+    const provisionedGroup = await attachProvisionedGroup(auth, space);
+    const allow = mockAllowSlackWorkflow();
+
+    const result = await allowSlackWorkflow(auth, {
+      botName: SLACK_WORKFLOW_BOT_NAME,
+      spaceIds: [space.sId],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(allow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupIds: [globalGroup.sId, memberGroup.sId],
+      })
+    );
+    expect(allow.mock.calls[0][0].groupIds).not.toContain(provisionedGroup.sId);
+  });
+
+  it("rejects a space the workspace does not have", async () => {
+    const { auth, space } = await setupTest();
+    const otherWorkspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(otherWorkspace);
+    const otherSpace = await SpaceFactory.regular(otherWorkspace);
+    const allow = mockAllowSlackWorkflow();
+
+    const result = await allowSlackWorkflow(auth, {
+      botName: SLACK_WORKFLOW_BOT_NAME,
+      spaceIds: [space.sId, otherSpace.sId],
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.type).toBe("invalid_spaces");
+    expect(allow).not.toHaveBeenCalled();
+  });
+});
+
+describe("listSlackWorkflows", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves a stored member group back to its space", async () => {
+    const { auth, globalGroup, space, memberGroup } = await setupTest();
+    mockSummoningWhitelist([
+      {
+        botName: SLACK_WORKFLOW_BOT_NAME,
+        groupIds: [globalGroup.sId, memberGroup.sId],
+      },
+    ]);
+
+    const result = await listSlackWorkflows(auth);
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value.workflows).toEqual([
+      expect.objectContaining({
+        botName: SLACK_WORKFLOW_BOT_NAME,
+        spaces: [{ sId: space.sId, name: space.name }],
+      }),
+    ]);
+  });
+
+  it("ignores stored groups that are not a space's member group", async () => {
+    const { auth, space } = await setupTest();
+    const provisionedGroup = await attachProvisionedGroup(auth, space);
+    mockSummoningWhitelist([
+      {
+        botName: SLACK_WORKFLOW_BOT_NAME,
+        groupIds: [provisionedGroup.sId],
+      },
+    ]);
+
+    const result = await listSlackWorkflows(auth);
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value.workflows).toEqual([
+      expect.objectContaining({ spaces: [] }),
+    ]);
+  });
+});

--- a/front/lib/api/slack/summoning_whitelist.test.ts
+++ b/front/lib/api/slack/summoning_whitelist.test.ts
@@ -11,6 +11,7 @@ vi.mock("@app/lib/api/audit/workos_audit", async () => {
   };
 });
 
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import {
   allowSlackWorkflow,
   listSlackWorkflows,
@@ -18,7 +19,10 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import {
   connectSlackBot,
@@ -26,6 +30,7 @@ import {
   mockSummoningWhitelist,
   SLACK_WORKFLOW_BOT_NAME,
 } from "@app/tests/utils/slack_workflows";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 
 async function setupTest() {
@@ -49,13 +54,16 @@ async function setupTest() {
 // stores have to be the space's own member group — see `listSpaceMemberGroups`.
 async function attachProvisionedGroup(
   auth: Authenticator,
-  space: SpaceResource
+  space: SpaceResource,
+  group?: GroupResource
 ) {
-  const provisionedGroup = await GroupResource.makeNew({
-    name: "Provisioned Group",
-    workspaceId: auth.getNonNullableWorkspace().id,
-    kind: "provisioned",
-  });
+  const provisionedGroup =
+    group ??
+    (await GroupResource.makeNew({
+      name: "Provisioned Group",
+      workspaceId: auth.getNonNullableWorkspace().id,
+      kind: "provisioned",
+    }));
 
   const updateRes = await space.updatePermissions(auth, {
     name: space.name,
@@ -170,5 +178,109 @@ describe("listSlackWorkflows", () => {
     expect(result.isOk() && result.value.workflows).toEqual([
       expect.objectContaining({ spaces: [] }),
     ]);
+  });
+});
+
+const REACH_AGENT_PREFIX = "reach-";
+const SPACE_AGENT_NAME = `${REACH_AGENT_PREFIX}space`;
+const OTHER_SPACE_AGENT_NAME = `${REACH_AGENT_PREFIX}other-space`;
+
+async function setupReachTest() {
+  const workspace = await WorkspaceFactory.basic();
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  await SpaceResource.makeDefaultsForWorkspace(auth, {
+    globalGroup,
+    systemGroup,
+  });
+
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "admin" });
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const space = await SpaceFactory.regular(workspace);
+  const memberGroup = await space.fetchManualMemberGroup(auth);
+  await AgentConfigurationFactory.createTestAgent(userAuth, {
+    name: SPACE_AGENT_NAME,
+    requestedSpaceIds: [space.id],
+  });
+
+  const systemKey = await KeyFactory.system(systemGroup);
+
+  // Connectors sends the whitelist's group ids in `X-Dust-Group-Ids`, which `Authenticator.fromKey`
+  // substitutes for the system key's own groups. Summoning then goes through the regular space
+  // permission checks, so what the workflow can call is exactly what those groups grant.
+  const summonableAgentNames = async (groupIds: string[]) => {
+    const { workspaceAuth } = await Authenticator.fromKey(
+      systemKey,
+      workspace.sId,
+      groupIds
+    );
+    const agents = await getAgentConfigurationsForView({
+      auth: workspaceAuth,
+      agentsGetView: "all",
+      variant: "light",
+    });
+
+    return agents
+      .map((agent) => agent.name)
+      .filter((name) => name.startsWith(REACH_AGENT_PREFIX))
+      .sort();
+  };
+
+  return {
+    auth,
+    userAuth,
+    workspace,
+    globalGroup,
+    space,
+    memberGroup,
+    summonableAgentNames,
+  };
+}
+
+describe("slack workflow reach", () => {
+  it("makes a space's agents summonable through its member group only", async () => {
+    const { globalGroup, memberGroup, summonableAgentNames } =
+      await setupReachTest();
+
+    expect(
+      await summonableAgentNames([globalGroup.sId, memberGroup.sId])
+    ).toEqual([SPACE_AGENT_NAME]);
+    expect(await summonableAgentNames([globalGroup.sId])).toEqual([]);
+  });
+
+  it("keeps a space's reach when its access moves to provisioned groups", async () => {
+    const {
+      auth,
+      userAuth,
+      workspace,
+      globalGroup,
+      space,
+      memberGroup,
+      summonableAgentNames,
+    } = await setupReachTest();
+    const provisionedGroup = await attachProvisionedGroup(auth, space);
+
+    expect(
+      await summonableAgentNames([globalGroup.sId, memberGroup.sId])
+    ).toEqual([SPACE_AGENT_NAME]);
+
+    const otherSpace = await SpaceFactory.regular(workspace);
+    await AgentConfigurationFactory.createTestAgent(userAuth, {
+      name: OTHER_SPACE_AGENT_NAME,
+      requestedSpaceIds: [otherSpace.id],
+    });
+    await attachProvisionedGroup(auth, otherSpace, provisionedGroup);
+
+    expect(
+      await summonableAgentNames([globalGroup.sId, memberGroup.sId])
+    ).toEqual([SPACE_AGENT_NAME]);
+    expect(
+      await summonableAgentNames([globalGroup.sId, provisionedGroup.sId])
+    ).toEqual([OTHER_SPACE_AGENT_NAME, SPACE_AGENT_NAME]);
   });
 });

--- a/front/lib/api/slack/summoning_whitelist.ts
+++ b/front/lib/api/slack/summoning_whitelist.ts
@@ -6,20 +6,28 @@ import {
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type {
   GetSlackWorkflowsResponseBody,
   SlackWorkflowType,
 } from "@app/types/api/slack/workflows";
-import { SLACK_WORKFLOW_GROUP_KINDS } from "@app/types/api/slack/workflows";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import type { GrantSpec } from "@app/types/group_permissions";
+import {
+  grantKey,
+  SPACE_MEMBER_GRANT_TYPE,
+} from "@app/types/group_permissions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 type SlackWorkflowErrorType =
   | "slack_bot_not_connected"
   | "invalid_groups"
+  | "invalid_spaces"
   | "not_found"
   | "connectors_error";
 
@@ -31,6 +39,11 @@ export class SlackWorkflowError extends Error {
     super(message);
   }
 }
+
+type SpaceMemberGroup = {
+  space: SpaceResource;
+  memberGroupId: string;
+};
 
 async function fetchSlackBotDataSource(
   auth: Authenticator
@@ -57,6 +70,55 @@ async function fetchSlackBotDataSource(
   return new Ok({ dataSource, connectorId: dataSource.connectorId });
 }
 
+function spaceMemberGrant(space: SpaceResource): GrantSpec {
+  return {
+    grantType: SPACE_MEMBER_GRANT_TYPE,
+    resourceType: "space",
+    resourceId: space.id,
+  };
+}
+
+// Connectors stores the whitelist as group ids, so a space has to be represented by one of its
+// groups. Only its own regular_auto member group will do: it lives and dies with the space and
+// cannot be attached to another one, so it grants exactly that space forever. A provisioned group
+// would drift the moment an admin attaches it elsewhere.
+async function listSpaceMemberGroups(
+  auth: Authenticator
+): Promise<SpaceMemberGroup[]> {
+  const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
+    includeProjectSpaces: true,
+  });
+  const selectableSpaces = spaces.filter(
+    (space) => space.isRegular() || space.isProject()
+  );
+
+  const memberGroupByGrantKey =
+    await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+      grants: selectableSpaces.map(spaceMemberGrant),
+    });
+
+  return removeNulls(
+    selectableSpaces.map((space) => {
+      const memberGroup = memberGroupByGrantKey.get(
+        grantKey(spaceMemberGrant(space))
+      );
+
+      return memberGroup ? { space, memberGroupId: memberGroup.sId } : null;
+    })
+  );
+}
+
+export async function listSlackWorkflowSpaces(
+  auth: Authenticator
+): Promise<{ sId: string; name: string }[]> {
+  const spaceMemberGroups = await listSpaceMemberGroups(auth);
+
+  return spaceMemberGroups.map(({ space }) => ({
+    sId: space.sId,
+    name: space.name,
+  }));
+}
+
 export async function listSlackWorkflows(
   auth: Authenticator
 ): Promise<Result<GetSlackWorkflowsResponseBody, SlackWorkflowError>> {
@@ -73,13 +135,11 @@ export async function listSlackWorkflows(
     logger
   );
 
-  const [whitelistRes, groups] = await Promise.all([
+  const [whitelistRes, spaceMemberGroups] = await Promise.all([
     connectorsAPI.getSlackBotSummoningWhitelist({
       connectorId: dataSourceRes.value.connectorId,
     }),
-    GroupResource.listAllWorkspaceGroups(auth, {
-      groupKinds: SLACK_WORKFLOW_GROUP_KINDS,
-    }),
+    listSpaceMemberGroups(auth),
   ]);
 
   if (whitelistRes.isErr()) {
@@ -88,14 +148,15 @@ export async function listSlackWorkflows(
     );
   }
 
-  const groupNameById = new Map(groups.map((g) => [g.sId, g.name]));
+  const spaceByMemberGroupId = new Map(
+    spaceMemberGroups.map(({ space, memberGroupId }) => [memberGroupId, space])
+  );
 
   const workflows: SlackWorkflowType[] = whitelistRes.value.bots.map((bot) => ({
     botName: bot.botName,
-    groups: bot.groupIds.map((sId) => ({
-      sId,
-      name: groupNameById.get(sId) ?? sId,
-    })),
+    spaces: removeNulls(
+      bot.groupIds.map((groupId) => spaceByMemberGroupId.get(groupId))
+    ).map((space) => ({ sId: space.sId, name: space.name })),
     createdAt: bot.createdAt,
   }));
 
@@ -104,7 +165,7 @@ export async function listSlackWorkflows(
 
 export async function allowSlackWorkflow(
   auth: Authenticator,
-  { botName, groupIds }: { botName: string; groupIds: string[] }
+  { botName, spaceIds }: { botName: string; spaceIds: string[] }
 ): Promise<Result<undefined, SlackWorkflowError>> {
   const dataSourceRes = await fetchSlackBotDataSource(auth);
   if (dataSourceRes.isErr()) {
@@ -112,22 +173,10 @@ export async function allowSlackWorkflow(
   }
   const { dataSource, connectorId } = dataSourceRes.value;
 
-  const groups = await GroupResource.listAllWorkspaceGroups(auth, {
-    groupKinds: SLACK_WORKFLOW_GROUP_KINDS,
-  });
-  const groupById = new Map(groups.map((g) => [g.sId, g]));
-
-  const unknownGroupIds = groupIds.filter((sId) => !groupById.has(sId));
-  if (unknownGroupIds.length > 0) {
-    return new Err(
-      new SlackWorkflowError(
-        "invalid_groups",
-        `Unknown groups: ${unknownGroupIds.join(", ")}.`
-      )
-    );
-  }
-
-  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+  const [spaceMemberGroups, globalGroupRes] = await Promise.all([
+    listSpaceMemberGroups(auth),
+    GroupResource.fetchWorkspaceGlobalGroup(auth),
+  ]);
   if (globalGroupRes.isErr()) {
     return new Err(
       new SlackWorkflowError(
@@ -137,9 +186,32 @@ export async function allowSlackWorkflow(
     );
   }
 
-  const allGroupIds = groupIds.includes(globalGroupRes.value.sId)
-    ? groupIds
-    : [...groupIds, globalGroupRes.value.sId];
+  const memberGroupIdBySpaceId = new Map(
+    spaceMemberGroups.map(({ space, memberGroupId }) => [
+      space.sId,
+      memberGroupId,
+    ])
+  );
+
+  const unknownSpaceIds = spaceIds.filter(
+    (spaceId) => !memberGroupIdBySpaceId.has(spaceId)
+  );
+  if (unknownSpaceIds.length > 0) {
+    return new Err(
+      new SlackWorkflowError(
+        "invalid_spaces",
+        `Unknown spaces: ${unknownSpaceIds.join(", ")}.`
+      )
+    );
+  }
+
+  // The global group grants the Company Space, which every workflow reaches.
+  const groupIds = [
+    globalGroupRes.value.sId,
+    ...removeNulls(
+      spaceIds.map((spaceId) => memberGroupIdBySpaceId.get(spaceId))
+    ),
+  ];
 
   const connectorsAPI = new ConnectorsAPI(
     config.getConnectorsAPIConfig(),
@@ -149,13 +221,17 @@ export async function allowSlackWorkflow(
   const whitelistRes = await connectorsAPI.whitelistSlackBotToSummon({
     connectorId,
     botName,
-    groupIds: allGroupIds,
+    groupIds,
   });
   if (whitelistRes.isErr()) {
     return new Err(
       new SlackWorkflowError("connectors_error", whitelistRes.error.message)
     );
   }
+
+  const spaceNameBySpaceId = new Map(
+    spaceMemberGroups.map(({ space }) => [space.sId, space.name])
+  );
 
   void emitAuditLogEvent({
     auth,
@@ -167,9 +243,9 @@ export async function allowSlackWorkflow(
     context: getAuditLogContext(auth),
     metadata: {
       bot_name: botName,
-      group_names: allGroupIds
-        .map((sId) => groupById.get(sId)?.name ?? globalGroupRes.value.name)
-        .join(", "),
+      space_names: removeNulls(
+        spaceIds.map((spaceId) => spaceNameBySpaceId.get(spaceId))
+      ).join(", "),
     },
   });
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -24,7 +24,10 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import tracer from "@app/logger/tracer";
 import type { GrantType, GrantVerb } from "@app/types/group_permissions";
-import { SPACE_EDITOR_GRANT_TYPE } from "@app/types/group_permissions";
+import {
+  SPACE_EDITOR_GRANT_TYPE,
+  SPACE_MEMBER_GRANT_TYPE,
+} from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
@@ -1989,7 +1992,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     if (this.isRegular() && isOpen) {
       return groups.map((group) => ({
         groupId: group.id,
-        grantType: group.isGlobal() ? "reader" : "member",
+        grantType: group.isGlobal() ? "reader" : SPACE_MEMBER_GRANT_TYPE,
       }));
     }
 
@@ -2007,14 +2010,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           return { groupId: group.id, grantType: "reader" };
         }
         // Every other group (the manual member group, provisioned member groups) reads and writes.
-        return { groupId: group.id, grantType: "member" };
+        return { groupId: group.id, grantType: SPACE_MEMBER_GRANT_TYPE };
       });
     }
 
     // Restricted regular space.
     return groups.map((group) => ({
       groupId: group.id,
-      grantType: "member",
+      grantType: SPACE_MEMBER_GRANT_TYPE,
     }));
   }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1687,8 +1687,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   // The space's auto-created (regular_auto) groups: its manual member group and, for projects, its
   // editor group. Resolved from `group_permissions`, filtered to regular_auto groups (a grant's
-  // type alone cannot tell a regular_auto group from the global group). Empty in group management
-  // mode, where the space's groups are provisioned (IdP-owned) rather than auto-created.
+  // type alone cannot tell a regular_auto group from the global group). Present in group management
+  // mode too: provisioned grants are added on top of the space's own groups, never in place of them.
   async fetchRegularAutoGroups(
     auth: Authenticator,
     transaction?: Transaction

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -32,7 +32,8 @@ export class DataSourceViewFactory {
     workspace: WorkspaceType,
     space: SpaceResource,
     connectorProvider: ConnectorProvider,
-    editedByUser?: UserResource | null
+    editedByUser?: UserResource | null,
+    overrides?: { connectorId?: string }
   ) {
     return DataSourceViewResource.createDataSourceAndDefaultView(
       {
@@ -43,6 +44,7 @@ export class DataSourceViewFactory {
           "dust-datasource-id" + faker.string.alphanumeric(8),
         workspaceId: workspace.id,
         connectorProvider: connectorProvider,
+        connectorId: overrides?.connectorId,
       },
       space,
       editedByUser

--- a/front/tests/utils/slack_workflows.ts
+++ b/front/tests/utils/slack_workflows.ts
@@ -1,0 +1,63 @@
+import { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { vi } from "vitest";
+
+export const SLACK_BOT_CONNECTOR_ID = "1234";
+export const SLACK_WORKFLOW_BOT_NAME = "Weekly report";
+export const SLACK_WORKFLOW_CREATED_AT_MS = 1756166400000;
+
+export async function connectSlackBot(
+  workspace: WorkspaceType,
+  space: SpaceResource
+) {
+  return DataSourceViewFactory.fromConnector(
+    workspace,
+    space,
+    "slack_bot",
+    null,
+    { connectorId: SLACK_BOT_CONNECTOR_ID }
+  );
+}
+
+// The whitelist is keyed on a space's own member group, so a test that seeds it needs both.
+export async function createSpaceWithMemberGroup(
+  workspace: WorkspaceType
+): Promise<{ space: SpaceResource; memberGroupId: string }> {
+  const space = await SpaceFactory.regular(workspace);
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const memberGroup = await space.fetchManualMemberGroup(auth);
+
+  return { space, memberGroupId: memberGroup.sId };
+}
+
+export function mockSummoningWhitelist(
+  bots: { botName: string; groupIds: string[] }[]
+) {
+  return vi
+    .spyOn(ConnectorsAPI.prototype, "getSlackBotSummoningWhitelist")
+    .mockResolvedValue(
+      new Ok({
+        bots: bots.map((bot) => ({
+          ...bot,
+          createdAt: SLACK_WORKFLOW_CREATED_AT_MS,
+        })),
+      })
+    );
+}
+
+export function mockAllowSlackWorkflow() {
+  return vi
+    .spyOn(ConnectorsAPI.prototype, "whitelistSlackBotToSummon")
+    .mockResolvedValue(new Ok({ success: true }));
+}
+
+export function mockRevokeSlackWorkflow() {
+  return vi
+    .spyOn(ConnectorsAPI.prototype, "unwhitelistSlackBotToSummon")
+    .mockResolvedValue(new Ok({ success: true }));
+}

--- a/front/types/api/slack/workflows.ts
+++ b/front/types/api/slack/workflows.ts
@@ -1,15 +1,6 @@
-import type { GroupKind } from "@app/types/groups";
-
-export const SLACK_WORKFLOW_GROUP_KINDS: GroupKind[] = [
-  "global",
-  "provisioned",
-  "regular_auto",
-  "regular_manual",
-];
-
 export type SlackWorkflowType = {
   botName: string;
-  groups: { sId: string; name: string }[];
+  spaces: { sId: string; name: string }[];
   createdAt: number;
 };
 

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -53,6 +53,11 @@ export type GrantType = (typeof GRANT_TYPES)[number];
 // grant (SpaceResource.spaceGroupRoles) and the code that reads it back (fetchManualEditorGroup).
 export const SPACE_EDITOR_GRANT_TYPE = "admin" satisfies GrantType;
 
+// A space's members are the groups holding the space-level `member` role. Its own regular_auto
+// member group always holds it, and holds it on that space only, which is what lets a caller map
+// between a space and a group without a snapshot going stale.
+export const SPACE_MEMBER_GRANT_TYPE = "member" satisfies GrantType;
+
 // Resource domains. "*" means "all resource types".
 export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "space",


### PR DESCRIPTION
## Stack

Self-serve Slack workflow whitelisting, split in four:

1. This PR: the whitelist speaks spaces instead of Dust groups.
2. #31293, admin endpoints to list, allow and revoke, gated on credit-priced plans.
3. #31294, the workflow consumption overview endpoint behind the credits card.
4. #31295, the automations page tab, table and allow dialog.

Only the last one is visible to admins. The first three land dead code on purpose.

## Description

Connectors stores the Dust group ids a Slack workflow may reach, which is the wrong currency for an admin: they grant access to spaces, not groups. The whitelist now takes and reports space ids, and a space is represented on the wire by its own `regular_auto` member group.

That group is the only one that can stand in for a space. It is created and deleted with the space and `MANAGEABLE_GROUP_KINDS` will not let an admin attach it anywhere else, so it grants exactly that space and keeps doing so. Storing every group that grants the space, which is what the first draft of this did, snapshots a set that goes stale: a provisioned group is shared, so as soon as someone attaches it to a second space the workflow silently gains that space, and as soon as someone detaches it the whitelist keeps granting whatever else it reaches. Neither is visible from the space's own settings.

Poke's plugin therefore picks spaces instead of groups and the table shows space names, `SLACK_WORKFLOW_GROUP_KINDS` and the group validation it fed are gone, and the audit event records `space_names`. `SPACE_MEMBER_GRANT_TYPE` joins `SPACE_EDITOR_GRANT_TYPE` so the code writing the grant and the code reading it back agree on which grant marks a member.

## Tests

New `front/lib/api/slack/summoning_whitelist.test.ts`: allowing a space whitelists its member group and the global group and leaves out a provisioned group attached to that same space, a space from another workspace is rejected, and listing resolves a stored member group back to its space while ignoring stored groups that are not one.

The same file also pins what the stored groups actually buy, through the real header path (`Authenticator.fromKey` with the whitelist's group ids, then `getAgentConfigurationsForView`): a space's agents are summonable only when its member group is in the set, that still holds once the space's access moves to provisioned groups, and attaching one of those provisioned groups to a second space widens what a provisioned-group whitelist would reach while the member group's reach stays put. That last assertion is the drift this PR exists to remove.

`front-api/routes/poke/workspaces/[wId]/slack-workflows.test.ts` moves onto the shared `front/tests/utils/slack_workflows.ts` helpers and seeds a real `slack_bot` data source instead of mocking `DataSourceResource`.

## Risk

Rows written by the old poke plugin hold arbitrary groups, so they list no spaces until they are allowed again through the plugin. Their access does not change: connectors keeps sending the group ids it already stored. There were under ten such rows last time I looked, and re-running the plugin fixes each one.

Access on new rows narrows rather than widens, since a picked space no longer drags in what its provisioned groups reach elsewhere.

## Deploy Plan

Deploy front and front-api, then register the changed audit schema:

- [ ] `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`
