### PR TITLE
feat(front-api): expose Slack workflow consumption

### DIFF
--- a/front-api/routes/w/[wId]/slack-workflows/index.test.ts
+++ b/front-api/routes/w/[wId]/slack-workflows/index.test.ts
@@ -23,6 +23,7 @@ import {
   SLACK_WORKFLOW_BOT_NAME,
   SLACK_WORKFLOW_CREATED_AT_MS,
 } from "@app/tests/utils/slack_workflows";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { MembershipRoleType } from "@app/types/memberships";

--- a/front-api/routes/w/[wId]/slack-workflows/index.test.ts
+++ b/front-api/routes/w/[wId]/slack-workflows/index.test.ts
@@ -23,7 +23,6 @@ import {
   SLACK_WORKFLOW_BOT_NAME,
   SLACK_WORKFLOW_CREATED_AT_MS,
 } from "@app/tests/utils/slack_workflows";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { MembershipRoleType } from "@app/types/memberships";

--- a/front-api/routes/w/[wId]/slack-workflows/index.ts
+++ b/front-api/routes/w/[wId]/slack-workflows/index.ts
@@ -14,6 +14,8 @@ import { slackWorkflowErrorToApiError } from "@front-api/routes/slack_workflow_e
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
 
+import overview from "./overview";
+
 export type { GetSlackWorkflowsResponseBody };
 
 const PostBodySchema = z.object({
@@ -27,6 +29,8 @@ const DeleteBodySchema = z.object({
 
 // Mounted at /api/w/:wId/slack-workflows.
 const app = workspaceApp();
+
+app.route("/overview", overview);
 
 /** @ignoreswagger */
 app.get(

--- a/front-api/routes/w/[wId]/slack-workflows/overview.test.ts
+++ b/front-api/routes/w/[wId]/slack-workflows/overview.test.ts
@@ -1,0 +1,100 @@
+import type { GetSlackWorkflowsOverviewResponse } from "@app/lib/api/analytics/slack_workflows/overview";
+import { fetchSlackWorkflowsOverview } from "@app/lib/api/analytics/slack_workflows/overview";
+import { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  import("@app/lib/api/analytics/slack_workflows/overview"),
+  async (orig) => {
+    const mod = await orig();
+    return {
+      ...mod,
+      fetchSlackWorkflowsOverview: vi.fn(),
+    };
+  }
+);
+
+const OVERVIEW: GetSlackWorkflowsOverviewResponse = {
+  period: {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  },
+  slackWorkflowCredits: 1240,
+  workspaceTotalCredits: 24000,
+};
+
+async function setupTest({
+  role = "admin",
+  workspace,
+}: {
+  role?: MembershipRoleType;
+  workspace?: WorkspaceType;
+} = {}) {
+  return createPrivateApiMockRequest({
+    role,
+    workspace: workspace ?? (await WorkspaceFactory.creditPriced()),
+  });
+}
+
+function postOverviewRequest(wId: string, body: Record<string, unknown> = {}) {
+  return honoApp.request(`/api/w/${wId}/slack-workflows/overview`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/slack-workflows/overview", () => {
+  it("returns 403 for managers", async () => {
+    const { workspace } = await setupTest({ role: "manager" });
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(fetchSlackWorkflowsOverview)).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 on a plan that is not credit-priced", async () => {
+    const { workspace } = await setupTest({
+      workspace: await WorkspaceFactory.basic(),
+    });
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "plan_limit_error" },
+    });
+    expect(vi.mocked(fetchSlackWorkflowsOverview)).not.toHaveBeenCalled();
+  });
+
+  it("returns the overview for admins", async () => {
+    vi.mocked(fetchSlackWorkflowsOverview).mockResolvedValue(new Ok(OVERVIEW));
+    const { workspace } = await setupTest();
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(OVERVIEW);
+  });
+
+  it("returns 500 when the search fails", async () => {
+    vi.mocked(fetchSlackWorkflowsOverview).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { workspace } = await setupTest();
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: { type: "internal_server_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/slack-workflows/overview.ts
+++ b/front-api/routes/w/[wId]/slack-workflows/overview.ts
@@ -1,0 +1,56 @@
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ConsumptionPeriodSchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import type { GetSlackWorkflowsOverviewResponse } from "@app/lib/api/analytics/slack_workflows/overview";
+import { fetchSlackWorkflowsOverview } from "@app/lib/api/analytics/slack_workflows/overview";
+import logger from "@app/logger/logger";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withCreditPricedPlan } from "@front-api/middlewares/with_credit_priced_plan";
+
+export type { GetSlackWorkflowsOverviewResponse };
+
+// Mounted at /api/w/:wId/slack-workflows/overview.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  withCreditPricedPlan(),
+  validate("json", ConsumptionPeriodSchema),
+  async (ctx): HandlerResult<GetSlackWorkflowsOverviewResponse> => {
+    const auth = ctx.get("auth");
+
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(ctx.req.valid("json"))
+    );
+
+    const result = await fetchSlackWorkflowsOverview(auth, { period });
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          err: result.error,
+        },
+        "[SlackWorkflowsAnalytics] Failed to retrieve overview."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to retrieve overview.",
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/slack-workflows/overview.ts
+++ b/front-api/routes/w/[wId]/slack-workflows/overview.ts
@@ -12,8 +12,6 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withCreditPricedPlan } from "@front-api/middlewares/with_credit_priced_plan";
 
-export type { GetSlackWorkflowsOverviewResponse };
-
 // Mounted at /api/w/:wId/slack-workflows/overview.
 const app = workspaceApp();
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -29,6 +29,8 @@ export const ConsumptionPeriodSchema = z.object({
     .default(DEFAULT_CONSUMPTION_PERIOD_DAYS),
 });
 
+export type ConsumptionPeriodBody = z.infer<typeof ConsumptionPeriodSchema>;
+
 // Every consumption endpoint takes at least this body: the period and the
 // filter (a map of dimension to selected ids). All of them are POST so the
 // filter can travel in the JSON body instead of a URL, which would cap the

--- a/front/lib/api/analytics/slack_workflows/overview.ts
+++ b/front/lib/api/analytics/slack_workflows/overview.ts
@@ -1,0 +1,83 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  buildConsumptionScopeQuery,
+  CREDIT_MICRO_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type SlackWorkflowsOverview = {
+  period: ConsumptionPeriod;
+  slackWorkflowCredits: number;
+  workspaceTotalCredits: number;
+};
+
+export type GetSlackWorkflowsOverviewResponse = SlackWorkflowsOverview;
+
+// `normalized_origin` folds slack_workflow into slack, so the raw origin is the
+// only way to isolate workflow consumption.
+const CONTEXT_ORIGIN_FIELD = "context_origin";
+const SLACK_WORKFLOW_ORIGIN = "slack_workflow";
+
+const WORKSPACE_TOTAL_AGG = "workspace_credit_micro";
+const SLACK_WORKFLOWS_AGG = "slack_workflows";
+const SLACK_WORKFLOW_CREDIT_AGG = "slack_workflow_credit_micro";
+
+type OverviewAggs = {
+  [WORKSPACE_TOTAL_AGG]?: estypes.AggregationsSumAggregate;
+  [SLACK_WORKFLOWS_AGG]?: {
+    [SLACK_WORKFLOW_CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+  };
+};
+
+export async function fetchSlackWorkflowsOverview(
+  auth: Authenticator,
+  { period }: { period: ConsumptionPeriod }
+): Promise<Result<SlackWorkflowsOverview, ElasticsearchError>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+  });
+
+  const searchResult = await searchConsumptionAnalytics<never, OverviewAggs>(
+    query,
+    {
+      aggregations: {
+        [WORKSPACE_TOTAL_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+        [SLACK_WORKFLOWS_AGG]: {
+          filter: {
+            term: { [CONTEXT_ORIGIN_FIELD]: SLACK_WORKFLOW_ORIGIN },
+          },
+          aggs: {
+            [SLACK_WORKFLOW_CREDIT_AGG]: {
+              sum: { field: CREDIT_MICRO_FIELD },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+  if (searchResult.isErr()) {
+    return searchResult;
+  }
+
+  const aggregations = searchResult.value.aggregations;
+
+  return new Ok({
+    period,
+    slackWorkflowCredits: microCreditsToCredits(
+      aggregations?.[SLACK_WORKFLOWS_AGG]?.[SLACK_WORKFLOW_CREDIT_AGG]?.value ??
+        0
+    ),
+    workspaceTotalCredits: microCreditsToCredits(
+      aggregations?.[WORKSPACE_TOTAL_AGG]?.value ?? 0
+    ),
+  });
+}

--- a/front/lib/api/analytics/slack_workflows/overview.ts
+++ b/front/lib/api/analytics/slack_workflows/overview.ts
@@ -68,7 +68,7 @@ export async function fetchSlackWorkflowsOverview(
     return searchResult;
   }
 
-  const aggregations = searchResult.value.aggregations;
+  const { aggregations } = searchResult.value;
 
   return new Ok({
     period,

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -62,6 +62,7 @@ const ORIGIN_WEIGHTS: { origin: UserMessageOrigin; weight: number }[] = [
   { origin: "web", weight: 40 },
   { origin: "triggered", weight: 22 },
   { origin: "slack", weight: 12 },
+  { origin: "slack_workflow", weight: 5 },
   { origin: "triggered_programmatic", weight: 8 },
   { origin: "api", weight: 7 },
   { origin: "extension", weight: 5 },


### PR DESCRIPTION
## Description

Second PR of the stack (#31293). Endpoint exposing the credits a workspace spent on Slack workflow messages, for the automations tab. Reads the raw `context_origin` field instead of `normalized_origin`, since normalization folds Slack workflow traffic into regular Slack. Same admin and plan gate as #31293. The consumption seed factory now produces Slack workflow messages so dev workspaces show a non-zero card.

## Tests

`front-api/routes/w/[wId]/slack-workflows/overview.test.ts`: non-admin and legacy plan rejections, the credits aggregation over a seeded period, and an Elasticsearch failure surfacing as 500.

## Risk

Read-only aggregation on an existing index, nothing calls it yet. Worst case the card shows a wrong number.

## Deploy Plan

Deploy front-api.
