### PR TITLE
feat(front): let admins allow Slack workflows from the automations page

### DIFF
--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,25 +1,41 @@
 import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
+import { SlackWorkflowsTab } from "@app/components/workspace/analytics/automations/SlackWorkflowsTab";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   TRACKING_ACTIONS,
   TRACKING_AREAS,
   trackEvent,
 } from "@app/lib/tracking";
-import { Page } from "@dust-tt/sparkle";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { isAdmin } from "@app/types/user";
+import {
+  Page,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
+
+type AutomationsTab = "triggers" | "slack-workflows";
 
 export function AnalyticsAutomationsPage() {
   const owner = useWorkspace();
+  const { subscription } = useAuth();
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
   const [filter, setFilter] = useState<AutomationsFilter>({});
+  const [tab, setTab] = useState<AutomationsTab>("triggers");
+
+  const canManageSlackWorkflows =
+    isAdmin(owner) && isCreditPricedPlan(subscription.plan);
 
   useEffect(() => {
     trackEvent({
@@ -51,14 +67,37 @@ export function AnalyticsAutomationsPage() {
           }
         />
 
-        <AutomationsOverview owner={owner} period={period} />
-
-        <AutomationsTriggersTable
-          owner={owner}
-          period={period}
-          filter={filter}
-          onFilterChange={setFilter}
-        />
+        <Tabs
+          value={tab}
+          onValueChange={(value) =>
+            setTab(
+              value === "slack-workflows" ? "slack-workflows" : "triggers"
+            )
+          }
+        >
+          <TabsList className="mb-4">
+            <TabsTrigger value="triggers" label="Triggers" />
+            {canManageSlackWorkflows && (
+              <TabsTrigger value="slack-workflows" label="Slack workflows" />
+            )}
+          </TabsList>
+          <TabsContent value="triggers">
+            <div className="flex flex-col gap-4">
+              <AutomationsOverview owner={owner} period={period} />
+              <AutomationsTriggersTable
+                owner={owner}
+                period={period}
+                filter={filter}
+                onFilterChange={setFilter}
+              />
+            </div>
+          </TabsContent>
+          {canManageSlackWorkflows && (
+            <TabsContent value="slack-workflows">
+              <SlackWorkflowsTab owner={owner} period={period} />
+            </TabsContent>
+          )}
+        </Tabs>
       </Page.Vertical>
     </AdminPageContainer>
   );

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -13,6 +13,7 @@ import {
   trackEvent,
 } from "@app/lib/tracking";
 import { isCreditPricedPlan } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
   Page,
@@ -67,38 +68,66 @@ export function AnalyticsAutomationsPage() {
           }
         />
 
-        <Tabs
-          value={tab}
-          onValueChange={(value) =>
-            setTab(
-              value === "slack-workflows" ? "slack-workflows" : "triggers"
-            )
-          }
-        >
-          <TabsList className="mb-4">
-            <TabsTrigger value="triggers" label="Triggers" />
-            {canManageSlackWorkflows && (
+        {canManageSlackWorkflows ? (
+          <Tabs
+            value={tab}
+            onValueChange={(value) =>
+              setTab(
+                value === "slack-workflows" ? "slack-workflows" : "triggers"
+              )
+            }
+          >
+            <TabsList className="mb-4">
+              <TabsTrigger value="triggers" label="Triggers" />
               <TabsTrigger value="slack-workflows" label="Slack workflows" />
-            )}
-          </TabsList>
-          <TabsContent value="triggers">
-            <div className="flex flex-col gap-4">
-              <AutomationsOverview owner={owner} period={period} />
-              <AutomationsTriggersTable
+            </TabsList>
+            <TabsContent value="triggers">
+              <TriggersSection
                 owner={owner}
                 period={period}
                 filter={filter}
                 onFilterChange={setFilter}
               />
-            </div>
-          </TabsContent>
-          {canManageSlackWorkflows && (
+            </TabsContent>
             <TabsContent value="slack-workflows">
               <SlackWorkflowsTab owner={owner} period={period} />
             </TabsContent>
-          )}
-        </Tabs>
+          </Tabs>
+        ) : (
+          <TriggersSection
+            owner={owner}
+            period={period}
+            filter={filter}
+            onFilterChange={setFilter}
+          />
+        )}
       </Page.Vertical>
     </AdminPageContainer>
+  );
+}
+
+interface TriggersSectionProps {
+  owner: LightWorkspaceType;
+  period: ConsumptionPeriodSelection;
+  filter: AutomationsFilter;
+  onFilterChange: (filter: AutomationsFilter) => void;
+}
+
+function TriggersSection({
+  owner,
+  period,
+  filter,
+  onFilterChange,
+}: TriggersSectionProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <AutomationsOverview owner={owner} period={period} />
+      <AutomationsTriggersTable
+        owner={owner}
+        period={period}
+        filter={filter}
+        onFilterChange={onFilterChange}
+      />
+    </div>
   );
 }

--- a/front/components/workspace/analytics/automations/AllowSlackWorkflowDialog.tsx
+++ b/front/components/workspace/analytics/automations/AllowSlackWorkflowDialog.tsx
@@ -1,0 +1,213 @@
+import { useAllowSlackWorkflow } from "@app/lib/swr/slack_workflows";
+import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
+import { GLOBAL_SPACE_NAME } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuTrigger,
+  Input,
+  Label,
+  Spinner,
+  XClose,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+interface SelectedSpace {
+  sId: string;
+  name: string;
+}
+
+interface AllowSlackWorkflowDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+}
+
+export function AllowSlackWorkflowDialog({
+  isOpen,
+  onClose,
+  owner,
+}: AllowSlackWorkflowDialogProps) {
+  const [botName, setBotName] = useState("");
+  const [selectedSpaces, setSelectedSpaces] = useState<SelectedSpace[]>([]);
+  const [spaceSearch, setSpaceSearch] = useState("");
+  const [isSpaceMenuOpen, setIsSpaceMenuOpen] = useState(false);
+
+  const { spaces, isSpacesLoading } = useSpacesAsAdmin({
+    workspaceId: owner.sId,
+    disabled: !isSpaceMenuOpen,
+  });
+  const { doAllowSlackWorkflow, isAllowing } = useAllowSlackWorkflow({ owner });
+
+  const selectableSpaces = useMemo(
+    () =>
+      spaces
+        .filter((space) => space.kind === "regular" || space.kind === "project")
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [spaces]
+  );
+
+  const searchedSpaces = useMemo(() => {
+    const search = spaceSearch.trim().toLowerCase();
+    const selectedIds = new Set(selectedSpaces.map((space) => space.sId));
+    return selectableSpaces.filter(
+      (space) =>
+        !selectedIds.has(space.sId) && space.name.toLowerCase().includes(search)
+    );
+  }, [selectableSpaces, selectedSpaces, spaceSearch]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setBotName("");
+      setSelectedSpaces([]);
+      setSpaceSearch("");
+      setIsSpaceMenuOpen(false);
+      onClose();
+    }
+  };
+
+  const handleAllow = async () => {
+    const allowed = await doAllowSlackWorkflow({
+      botName: botName.trim(),
+      spaceIds: selectedSpaces.map((space) => space.sId),
+    });
+    if (allowed) {
+      handleOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Allow a Slack workflow</DialogTitle>
+          <DialogDescription>
+            Anyone who can run the workflow in Slack will be able to summon
+            agents through it, guests included.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-2">
+              <Label>Workflow name</Label>
+              <Input
+                placeholder="e.g. Weekly report"
+                value={botName}
+                onChange={(e) => setBotName(e.target.value)}
+              />
+              <span className="text-xs text-muted-foreground">
+                The sender name Slack shows on the workflow's messages. It has
+                to match exactly, spelling and capitalization included.
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label>Spaces it can reach</Label>
+              <div>
+                <DropdownMenu
+                  open={isSpaceMenuOpen}
+                  onOpenChange={setIsSpaceMenuOpen}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      label="Add spaces"
+                      size="sm"
+                      isSelect
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-72"
+                    align="start"
+                    dropdownHeaders={
+                      <DropdownMenuSearchbar
+                        name="slackWorkflowSpaceSearch"
+                        placeholder="Search spaces"
+                        value={spaceSearch}
+                        onChange={setSpaceSearch}
+                      />
+                    }
+                  >
+                    {isSpacesLoading && (
+                      <div className="flex items-center justify-center py-4">
+                        <Spinner size="sm" />
+                      </div>
+                    )}
+                    {!isSpacesLoading && searchedSpaces.length === 0 && (
+                      <div className="flex items-center justify-center py-4 text-sm">
+                        No space found
+                      </div>
+                    )}
+                    {searchedSpaces.map((space) => (
+                      <DropdownMenuItem
+                        key={space.sId}
+                        label={space.name}
+                        onSelect={(e) => e.preventDefault()}
+                        onClick={() =>
+                          setSelectedSpaces([
+                            ...selectedSpaces,
+                            { sId: space.sId, name: space.name },
+                          ])
+                        }
+                      />
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              <div className="flex flex-wrap gap-1">
+                <Button
+                  label={GLOBAL_SPACE_NAME}
+                  size="xs"
+                  variant="outline"
+                  disabled
+                />
+                {selectedSpaces.map((space) => (
+                  <Button
+                    key={space.sId}
+                    label={space.name}
+                    icon={XClose}
+                    size="xs"
+                    variant="ghost"
+                    onClick={() =>
+                      setSelectedSpaces(
+                        selectedSpaces.filter(
+                          (selected) => selected.sId !== space.sId
+                        )
+                      )
+                    }
+                  />
+                ))}
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {`The workflow always reaches agents shared in ${GLOBAL_SPACE_NAME}. Add spaces to let it summon their agents too.`}
+              </span>
+            </div>
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Allow",
+            variant: "primary",
+            onClick: handleAllow,
+            disabled: botName.trim().length === 0,
+            isLoading: isAllowing,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/analytics/automations/AllowSlackWorkflowDialog.tsx
+++ b/front/components/workspace/analytics/automations/AllowSlackWorkflowDialog.tsx
@@ -107,8 +107,8 @@ export function AllowSlackWorkflowDialog({
                 onChange={(e) => setBotName(e.target.value)}
               />
               <span className="text-xs text-muted-foreground">
-                The sender name Slack shows on the workflow's messages. It has
-                to match exactly, spelling and capitalization included.
+                The sender name showed in Slack on the workflow's messages. It
+                has to match exactly, spelling and capitalization included.
               </span>
             </div>
             <div className="flex flex-col gap-2">

--- a/front/components/workspace/analytics/automations/SlackWorkflowsTab.tsx
+++ b/front/components/workspace/analytics/automations/SlackWorkflowsTab.tsx
@@ -1,7 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { AllowSlackWorkflowDialog } from "@app/components/workspace/analytics/automations/AllowSlackWorkflowDialog";
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
-import { useDebounce } from "@app/hooks/useDebounce";
 import { useSlackWorkflowsOverview } from "@app/hooks/useSlackWorkflowsOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatCredits } from "@app/lib/client/credits";
@@ -26,7 +25,6 @@ import {
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import { useCallback, useContext, useMemo, useState } from "react";
 
-const SEARCH_DEBOUNCE_DELAY_MS = 300;
 const WORKFLOWS_PAGE_SIZE = 25;
 
 interface SlackWorkflowRowData {
@@ -124,9 +122,7 @@ function SlackWorkflowsCard({
   const { doRevokeSlackWorkflow, isRevoking } = useRevokeSlackWorkflow({
     owner,
   });
-  const { inputValue, debouncedValue, setValue } = useDebounce("", {
-    delay: SEARCH_DEBOUNCE_DELAY_MS,
-  });
+  const [search, setSearch] = useState("");
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: WORKFLOWS_PAGE_SIZE,
@@ -229,8 +225,8 @@ function SlackWorkflowsCard({
         <SearchInput
           name="slack-workflows-search"
           placeholder="Search…"
-          value={inputValue}
-          onChange={setValue}
+          value={search}
+          onChange={setSearch}
           className="flex-1"
         />
         <Button
@@ -244,7 +240,7 @@ function SlackWorkflowsCard({
       <SlackWorkflowsTableBody
         columns={columns}
         rows={rows}
-        search={debouncedValue}
+        search={search}
         isSlackBotConnected={isSlackBotConnected}
         isLoading={isLoading}
         pagination={pagination}

--- a/front/components/workspace/analytics/automations/SlackWorkflowsTab.tsx
+++ b/front/components/workspace/analytics/automations/SlackWorkflowsTab.tsx
@@ -1,0 +1,333 @@
+import { ConfirmContext } from "@app/components/Confirm";
+import { AllowSlackWorkflowDialog } from "@app/components/workspace/analytics/automations/AllowSlackWorkflowDialog";
+import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
+import { useDebounce } from "@app/hooks/useDebounce";
+import { useSlackWorkflowsOverview } from "@app/hooks/useSlackWorkflowsOverview";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { formatCredits } from "@app/lib/client/credits";
+import {
+  useRevokeSlackWorkflow,
+  useSlackWorkflows,
+} from "@app/lib/swr/slack_workflows";
+import { timeAgoFrom } from "@app/lib/utils";
+import type { SlackWorkflowType } from "@app/types/api/slack/workflows";
+import { GLOBAL_SPACE_NAME } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  DataTable,
+  DataTableLoadingSkeleton,
+  LoadingBlock,
+  Plus,
+  SearchInput,
+  Tooltip,
+  Trash01,
+} from "@dust-tt/sparkle";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { useCallback, useContext, useMemo, useState } from "react";
+
+const SEARCH_DEBOUNCE_DELAY_MS = 300;
+const WORKFLOWS_PAGE_SIZE = 25;
+
+interface SlackWorkflowRowData {
+  botName: string;
+  spaceNames: string[];
+  createdAt: number;
+  onClick?: () => void;
+}
+
+interface SlackWorkflowsTabProps {
+  owner: LightWorkspaceType;
+  period: ConsumptionPeriodSelection;
+}
+
+export function SlackWorkflowsTab({ owner, period }: SlackWorkflowsTabProps) {
+  const { workflows, isSlackBotConnected, isWorkflowsLoading } =
+    useSlackWorkflows({ owner });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SlackWorkflowsOverview
+        owner={owner}
+        period={period}
+        workflowCount={workflows.length}
+      />
+      <SlackWorkflowsCard
+        owner={owner}
+        workflows={workflows}
+        isSlackBotConnected={isSlackBotConnected}
+        isLoading={isWorkflowsLoading}
+      />
+    </div>
+  );
+}
+
+interface SlackWorkflowsOverviewProps {
+  owner: LightWorkspaceType;
+  period: ConsumptionPeriodSelection;
+  workflowCount: number;
+}
+
+function SlackWorkflowsOverview({
+  owner,
+  period,
+  workflowCount,
+}: SlackWorkflowsOverviewProps) {
+  const { overview, isOverviewLoading, isOverviewError } =
+    useSlackWorkflowsOverview({ workspaceId: owner.sId, period });
+
+  if (isOverviewLoading) {
+    return <LoadingBlock className="h-24 w-full rounded-xl" />;
+  }
+
+  if (isOverviewError || !overview) {
+    return null;
+  }
+
+  const { slackWorkflowCredits, workspaceTotalCredits } = overview;
+
+  return (
+    <div className="flex items-stretch gap-6">
+      <SummaryCard
+        label="Credits"
+        value={formatCredits(slackWorkflowCredits)}
+        hint={
+          workspaceTotalCredits > 0
+            ? `${Math.round((slackWorkflowCredits / workspaceTotalCredits) * 100)}% of workspace consumption`
+            : null
+        }
+      />
+      <SummaryCard
+        label="Workflows allowed"
+        value={workflowCount.toLocaleString()}
+        hint={null}
+      />
+    </div>
+  );
+}
+
+interface SlackWorkflowsCardProps {
+  owner: LightWorkspaceType;
+  workflows: SlackWorkflowType[];
+  isSlackBotConnected: boolean;
+  isLoading: boolean;
+}
+
+function SlackWorkflowsCard({
+  owner,
+  workflows,
+  isSlackBotConnected,
+  isLoading,
+}: SlackWorkflowsCardProps) {
+  const confirm = useContext(ConfirmContext);
+  const [isAllowDialogOpen, setIsAllowDialogOpen] = useState(false);
+  const { doRevokeSlackWorkflow, isRevoking } = useRevokeSlackWorkflow({
+    owner,
+  });
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: SEARCH_DEBOUNCE_DELAY_MS,
+  });
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: WORKFLOWS_PAGE_SIZE,
+  });
+
+  const handleRevoke = useCallback(
+    async (botName: string) => {
+      const confirmed = await confirm({
+        title: "Revoke this Slack workflow?",
+        message: `"${botName}" will no longer be able to summon agents from Slack.`,
+        validateLabel: "Revoke",
+        validateVariant: "warning",
+      });
+
+      if (confirmed) {
+        await doRevokeSlackWorkflow({ botName });
+      }
+    },
+    [confirm, doRevokeSlackWorkflow]
+  );
+
+  const columns: ColumnDef<SlackWorkflowRowData>[] = useMemo(
+    () => [
+      {
+        id: "botName",
+        accessorKey: "botName",
+        header: "Workflow",
+        enableSorting: true,
+        meta: { className: "w-64 truncate", headerAlign: "left" },
+        cell: (info) => (
+          <DataTable.CellContent className="w-full justify-start text-left">
+            <span className="truncate text-sm font-semibold">
+              {info.row.original.botName}
+            </span>
+          </DataTable.CellContent>
+        ),
+      },
+      {
+        id: "spaceNames",
+        accessorKey: "spaceNames",
+        header: "Spaces",
+        enableSorting: false,
+        meta: { className: "w-full truncate", headerAlign: "left" },
+        cell: (info) => (
+          <SpacesCell spaceNames={info.row.original.spaceNames} />
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: "Added",
+        enableSorting: true,
+        meta: { className: "w-28", headerAlign: "left" },
+        cell: (info) => (
+          <DataTable.BasicCellContent
+            className="whitespace-nowrap"
+            label={`${timeAgoFrom(info.row.original.createdAt, {
+              useLongFormat: true,
+            })} ago`}
+          />
+        ),
+      },
+      {
+        id: "revoke",
+        header: "",
+        enableSorting: false,
+        meta: { className: "w-10", headerAlign: "right" },
+        cell: (info) => (
+          <DataTable.CellContent className="w-full justify-end">
+            <div className="transition-opacity duration-150 ease-out motion-reduce:transition-none pointer-fine:opacity-0 pointer-fine:group-hover/dt-row:opacity-100 pointer-fine:focus-within:opacity-100">
+              <Button
+                icon={Trash01}
+                tooltip="Revoke workflow"
+                size="xs"
+                variant="ghost-secondary"
+                disabled={isRevoking}
+                onClick={() => void handleRevoke(info.row.original.botName)}
+              />
+            </div>
+          </DataTable.CellContent>
+        ),
+      },
+    ],
+    [handleRevoke, isRevoking]
+  );
+
+  const rows: SlackWorkflowRowData[] = useMemo(
+    () =>
+      workflows.map((workflow) => ({
+        botName: workflow.botName,
+        spaceNames: workflow.spaces.map((space) => space.name),
+        createdAt: workflow.createdAt,
+      })),
+    [workflows]
+  );
+
+  return (
+    <div className="rounded-lg border border-border bg-panel-background p-4">
+      <div className="mb-4 flex items-center gap-2">
+        <SearchInput
+          name="slack-workflows-search"
+          placeholder="Search…"
+          value={inputValue}
+          onChange={setValue}
+          className="flex-1"
+        />
+        <Button
+          label="Allow a workflow"
+          variant="outline"
+          size="sm"
+          icon={Plus}
+          onClick={() => setIsAllowDialogOpen(true)}
+        />
+      </div>
+      <SlackWorkflowsTableBody
+        columns={columns}
+        rows={rows}
+        search={debouncedValue}
+        isSlackBotConnected={isSlackBotConnected}
+        isLoading={isLoading}
+        pagination={pagination}
+        setPagination={setPagination}
+      />
+      <AllowSlackWorkflowDialog
+        isOpen={isAllowDialogOpen}
+        onClose={() => setIsAllowDialogOpen(false)}
+        owner={owner}
+      />
+    </div>
+  );
+}
+
+interface SlackWorkflowsTableBodyProps {
+  columns: ColumnDef<SlackWorkflowRowData>[];
+  rows: SlackWorkflowRowData[];
+  search: string;
+  isSlackBotConnected: boolean;
+  isLoading: boolean;
+  pagination: PaginationState;
+  setPagination: (pagination: PaginationState) => void;
+}
+
+function SlackWorkflowsTableBody({
+  columns,
+  rows,
+  search,
+  isSlackBotConnected,
+  isLoading,
+  pagination,
+  setPagination,
+}: SlackWorkflowsTableBodyProps) {
+  if (isLoading) {
+    return (
+      <DataTableLoadingSkeleton showSelectionColumn={false} showTrailingCell />
+    );
+  }
+
+  if (!isSlackBotConnected) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Connect the Dust Slack bot to let Slack workflows summon agents.
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No Slack workflow can summon agents yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <DataTable
+        columns={columns}
+        data={rows}
+        filter={search}
+        filterColumn="botName"
+        pagination={pagination}
+        setPagination={setPagination}
+      />
+    </div>
+  );
+}
+
+function SpacesCell({ spaceNames }: { spaceNames: string[] }) {
+  if (spaceNames.length === 0) {
+    return <DataTable.BasicCellContent label={GLOBAL_SPACE_NAME} />;
+  }
+
+  const label = spaceNames.join(", ");
+
+  return (
+    <DataTable.CellContent>
+      <Tooltip
+        label={label}
+        tooltipTriggerAsChild
+        trigger={<span className="truncate text-sm">{label}</span>}
+      />
+    </DataTable.CellContent>
+  );
+}

--- a/front/components/workspace/analytics/automations/SlackWorkflowsTab.tsx
+++ b/front/components/workspace/analytics/automations/SlackWorkflowsTab.tsx
@@ -75,7 +75,12 @@ function SlackWorkflowsOverview({
     useSlackWorkflowsOverview({ workspaceId: owner.sId, period });
 
   if (isOverviewLoading) {
-    return <LoadingBlock className="h-24 w-full rounded-xl" />;
+    return (
+      <div className="flex items-stretch gap-6">
+        <LoadingBlock className="h-24 w-full rounded-xl" />
+        <LoadingBlock className="h-24 w-full rounded-xl" />
+      </div>
+    );
   }
 
   if (isOverviewError || !overview) {
@@ -119,9 +124,8 @@ function SlackWorkflowsCard({
 }: SlackWorkflowsCardProps) {
   const confirm = useContext(ConfirmContext);
   const [isAllowDialogOpen, setIsAllowDialogOpen] = useState(false);
-  const { doRevokeSlackWorkflow, isRevoking } = useRevokeSlackWorkflow({
-    owner,
-  });
+  const [revokingBotName, setRevokingBotName] = useState<string | null>(null);
+  const { doRevokeSlackWorkflow } = useRevokeSlackWorkflow({ owner });
   const [search, setSearch] = useState("");
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -138,7 +142,9 @@ function SlackWorkflowsCard({
       });
 
       if (confirmed) {
+        setRevokingBotName(botName);
         await doRevokeSlackWorkflow({ botName });
+        setRevokingBotName(null);
       }
     },
     [confirm, doRevokeSlackWorkflow]
@@ -198,7 +204,7 @@ function SlackWorkflowsCard({
                 tooltip="Revoke workflow"
                 size="xs"
                 variant="ghost-secondary"
-                disabled={isRevoking}
+                disabled={revokingBotName === info.row.original.botName}
                 onClick={() => void handleRevoke(info.row.original.botName)}
               />
             </div>
@@ -206,7 +212,7 @@ function SlackWorkflowsCard({
         ),
       },
     ],
-    [handleRevoke, isRevoking]
+    [handleRevoke, revokingBotName]
   );
 
   const rows: SlackWorkflowRowData[] = useMemo(
@@ -220,8 +226,8 @@ function SlackWorkflowsCard({
   );
 
   return (
-    <div className="rounded-lg border border-border bg-panel-background p-4">
-      <div className="mb-4 flex items-center gap-2">
+    <div className="flex flex-col gap-4 rounded-lg border border-border bg-panel-background p-4">
+      <div className="flex items-center gap-2">
         <SearchInput
           name="slack-workflows-search"
           placeholder="Search…"

--- a/front/hooks/useSlackWorkflowsOverview.ts
+++ b/front/hooks/useSlackWorkflowsOverview.ts
@@ -1,0 +1,34 @@
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionPeriodBody } from "@app/lib/api/analytics/consumption/schema";
+import type { GetSlackWorkflowsOverviewResponse } from "@app/lib/api/analytics/slack_workflows/overview";
+
+export function useSlackWorkflowsOverview({
+  workspaceId,
+  period,
+  disabled,
+}: {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  disabled?: boolean;
+}) {
+  const url = `/api/w/${workspaceId}/slack-workflows/overview`;
+  const body: ConsumptionPeriodBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+  };
+
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
+    ConsumptionPeriodBody,
+    GetSlackWorkflowsOverviewResponse
+  >({ url, body, disabled });
+
+  return {
+    overview: data ?? null,
+    isOverviewLoading: !error && isLoading,
+    isOverviewError: error,
+    isOverviewValidating: isValidating,
+  };
+}

--- a/front/lib/swr/slack_workflows.ts
+++ b/front/lib/swr/slack_workflows.ts
@@ -1,0 +1,142 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type {
+  GetSlackWorkflowsResponseBody,
+  SlackWorkflowType,
+} from "@app/types/api/slack/workflows";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+import type { Fetcher } from "swr";
+
+function slackWorkflowsUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/slack-workflows`;
+}
+
+export function useSlackWorkflows({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const workflowsFetcher: Fetcher<GetSlackWorkflowsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    slackWorkflowsUrl(owner.sId),
+    workflowsFetcher,
+    { disabled }
+  );
+
+  return {
+    isSlackBotConnected: data?.isSlackBotConnected ?? false,
+    workflows: data?.workflows ?? emptyArray<SlackWorkflowType>(),
+    isWorkflowsLoading: !error && !data && !disabled,
+    isWorkflowsError: !!error,
+    mutateWorkflows: mutate,
+  };
+}
+
+export function useAllowSlackWorkflow({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isAllowing, setIsAllowing] = useState(false);
+  const { mutateWorkflows } = useSlackWorkflows({ owner, disabled: true });
+
+  const doAllowSlackWorkflow = useCallback(
+    async ({
+      botName,
+      spaceIds,
+    }: {
+      botName: string;
+      spaceIds: string[];
+    }): Promise<boolean> => {
+      setIsAllowing(true);
+      const res = await clientFetch(slackWorkflowsUrl(owner.sId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ botName, spaceIds }),
+      });
+
+      if (!res.ok) {
+        const error = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to allow Slack workflow",
+          description: error.message,
+        });
+        setIsAllowing(false);
+
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Slack workflow allowed",
+        description: `"${botName}" can now summon agents in Slack.`,
+      });
+      await mutateWorkflows();
+      setIsAllowing(false);
+
+      return true;
+    },
+    [owner.sId, mutateWorkflows, sendNotification]
+  );
+
+  return { doAllowSlackWorkflow, isAllowing };
+}
+
+export function useRevokeSlackWorkflow({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isRevoking, setIsRevoking] = useState(false);
+  const { mutateWorkflows } = useSlackWorkflows({ owner, disabled: true });
+
+  const doRevokeSlackWorkflow = useCallback(
+    async ({ botName }: { botName: string }): Promise<boolean> => {
+      setIsRevoking(true);
+      const res = await clientFetch(slackWorkflowsUrl(owner.sId), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ botName }),
+      });
+
+      if (!res.ok) {
+        const error = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to revoke Slack workflow",
+          description: error.message,
+        });
+        setIsRevoking(false);
+
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Slack workflow revoked",
+        description: `"${botName}" can no longer summon agents in Slack.`,
+      });
+      await mutateWorkflows();
+      setIsRevoking(false);
+
+      return true;
+    },
+    [owner.sId, mutateWorkflows, sendNotification]
+  );
+
+  return { doRevokeSlackWorkflow, isRevoking };
+}

--- a/front/lib/swr/slack_workflows.ts
+++ b/front/lib/swr/slack_workflows.ts
@@ -14,10 +14,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";
 
-function slackWorkflowsUrl(workspaceId: string): string {
-  return `/api/w/${workspaceId}/slack-workflows`;
-}
-
 export function useSlackWorkflows({
   owner,
   disabled,
@@ -29,7 +25,7 @@ export function useSlackWorkflows({
   const workflowsFetcher: Fetcher<GetSlackWorkflowsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    slackWorkflowsUrl(owner.sId),
+    `/api/w/${owner.sId}/slack-workflows`,
     workflowsFetcher,
     { disabled }
   );
@@ -61,7 +57,7 @@ export function useAllowSlackWorkflow({
       spaceIds: string[];
     }): Promise<boolean> => {
       setIsAllowing(true);
-      const res = await clientFetch(slackWorkflowsUrl(owner.sId), {
+      const res = await clientFetch(`/api/w/${owner.sId}/slack-workflows`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ botName, spaceIds }),
@@ -107,7 +103,7 @@ export function useRevokeSlackWorkflow({
   const doRevokeSlackWorkflow = useCallback(
     async ({ botName }: { botName: string }): Promise<boolean> => {
       setIsRevoking(true);
-      const res = await clientFetch(slackWorkflowsUrl(owner.sId), {
+      const res = await clientFetch(`/api/w/${owner.sId}/slack-workflows`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ botName }),


### PR DESCRIPTION
## Description

Third PR of the stack (#31293, #31294). Automations page gains a Slack workflows tab: lists allowed workflows with the spaces each reaches, when they were added, and a revoke button. Adding one takes the exact sender name Slack shows on the workflow's messages plus the spaces it may reach, since workflows can't be enumerated from the Slack API. Carries its own credits card next to the triggers one. Legacy-plan admins don't see the tab and keep using poke.

## Tests

Covered end to end by the endpoint suites in #31293 and #31294. Checked the tab against a dev workspace seeded with `slack_workflow` consumption and 30 allowed workflows spread over several spaces: search, sorting on name and date, pagination, allow, revoke, and the empty state for a workspace with no Slack bot.

## Risk

An admin on a credit-priced plan can now grant a Slack workflow access to their spaces' agents without us. That is the point, and it stays scoped to spaces the admin already administers. Anyone who can run the workflow in Slack can summon those agents, guests included, which the dialog states.

## Deploy Plan

Deploy front. Nothing to do on connectors: the message the bot posts when it refuses an unknown workflow still points at support.
