### PR TITLE
Persist Frames v2 function artifacts

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1,3 +1,4 @@
+import type { FramePublicationFunctionArtifact } from "@app/lib/api/frames/publication_storage";
 import {
   activateFramePublication,
   loadFramePublicationManifest,
@@ -12,10 +13,15 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { FrameManifestSchema } from "@app/types/api/frame_manifest";
 import {
+  getFramePublicationFunctionBundlePath,
+  getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
 } from "@app/types/api/frame_storage";
-import { frameV2ContentType } from "@app/types/files";
+import {
+  frameV2ContentType,
+  sandboxFunctionContentType,
+} from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -68,6 +74,33 @@ const sourceFiles = [
   },
 ];
 
+const sourceFilesWithFunction = [
+  ...sourceFiles,
+  {
+    relativePath: "functions/add_task.ts",
+    content: Buffer.from("export async function run() {}"),
+    contentType: "text/typescript" as const,
+  },
+];
+
+const functionArtifacts = [
+  {
+    name: "add-task",
+    bundleCode: "export async function run() {}",
+    userIdentity: "workspace_user_required",
+    inputSchema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+    },
+  },
+] satisfies FramePublicationFunctionArtifact[];
+
 beforeEach(() => {
   fileStorageMock.reset();
 });
@@ -78,6 +111,7 @@ describe("storeFramePublication", () => {
 
     const result = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -114,11 +148,68 @@ describe("storeFramePublication", () => {
     ).toBe(false);
   });
 
+  it("stores function artifacts before the manifest commit marker", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    const identity = {
+      workspaceId,
+      frameId: frame.sId,
+      publicationId: result.value.publicationId,
+    };
+    const bundlePath = getFramePublicationFunctionBundlePath({
+      ...identity,
+      functionName: "add-task",
+    });
+    const schemaPath = getFramePublicationFunctionSchemaPath({
+      ...identity,
+      functionName: "add-task",
+    });
+    const savedPaths = fileStorageMock.saveFileCalls.map(
+      ({ filePath }) => filePath
+    );
+
+    expect(savedPaths).toContain(bundlePath);
+    expect(savedPaths).toContain(schemaPath);
+    expect(savedPaths.at(-1)).toBe(getFramePublicationManifestPath(identity));
+    expect(fileStorageMock.getObject(bundlePath)).toBe(
+      functionArtifacts[0].bundleCode
+    );
+    expect(fileStorageMock.getObject(schemaPath)).toBe(
+      JSON.stringify({
+        userIdentity: functionArtifacts[0].userIdentity,
+        inputSchema: functionArtifacts[0].inputSchema,
+        outputSchema: functionArtifacts[0].outputSchema,
+      })
+    );
+    expect(
+      fileStorageMock.saveFileCalls.find(
+        ({ filePath }) => filePath === bundlePath
+      )?.contentType
+    ).toBe(sandboxFunctionContentType);
+    expect(
+      fileStorageMock.saveFileCalls.find(
+        ({ filePath }) => filePath === schemaPath
+      )?.contentType
+    ).toBe("application/json");
+  });
+
   it("rejects a publication whose UI entry point is missing", async () => {
     const { auth, frame } = await setupFrame();
 
     const result = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles: sourceFiles.slice(1),
     });
@@ -132,6 +223,7 @@ describe("storeFramePublication", () => {
 
     const result = await storeFramePublication(auth, {
       frame,
+      functionArtifacts,
       manifest: manifestWithFunction,
       sourceFiles,
     });
@@ -144,6 +236,45 @@ describe("storeFramePublication", () => {
   });
 
   it.each([
+    {
+      name: "missing",
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      functionArtifacts: [],
+    },
+    {
+      name: "undeclared",
+      manifest,
+      sourceFiles,
+      functionArtifacts,
+    },
+    {
+      name: "duplicate",
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      functionArtifacts: [...functionArtifacts, ...functionArtifacts],
+    },
+  ])("rejects $name function artifacts before writing", async ({
+    manifest,
+    sourceFiles,
+    functionArtifacts,
+  }) => {
+    const { auth, frame } = await setupFrame();
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.code).toBe(
+      "invalid_function_artifact"
+    );
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it.each([
     ["an invalid path", [{ ...sourceFiles[0], relativePath: "../index.tsx" }]],
     ["a duplicate path", [sourceFiles[0], sourceFiles[0]]],
   ])("rejects %s before writing", async (_name, invalidSourceFiles) => {
@@ -151,6 +282,7 @@ describe("storeFramePublication", () => {
 
     const result = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles: invalidSourceFiles,
     });
@@ -165,6 +297,7 @@ describe("storeFramePublication", () => {
 
     const result = await storeFramePublication(otherAuth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -180,7 +313,12 @@ describe("storeFramePublication", () => {
     );
 
     await expect(
-      storeFramePublication(auth, { frame, manifest, sourceFiles })
+      storeFramePublication(auth, {
+        frame,
+        functionArtifacts: [],
+        manifest,
+        sourceFiles,
+      })
     ).rejects.toThrow("Simulated GCS write failure");
     expect(
       fileStorageMock.saveFileCalls.some(({ filePath }) =>
@@ -195,6 +333,7 @@ describe("Frame publication reads", () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -266,6 +405,7 @@ describe("Frame publication reads", () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -302,6 +442,7 @@ describe("activateFramePublication", () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -326,6 +467,7 @@ describe("activateFramePublication", () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -360,6 +502,7 @@ describe("publishFramePublication", () => {
 
     const published = await publishFramePublication(auth, {
       frame,
+      functionArtifacts: [],
       manifest,
       sourceFiles,
     });
@@ -374,17 +517,27 @@ describe("publishFramePublication", () => {
     );
   });
 
-  it("keeps the active publication when storage fails", async () => {
+  it("keeps the active publication when function artifact storage fails", async () => {
     const { auth, frame } = await setupFrame();
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
     await frame.setActiveFramePublication(activePublicationId);
     fileStorageMock.setFileSaveFails((filePath) =>
-      filePath.endsWith("/manifest.json")
+      filePath.endsWith("/schema.json")
     );
 
     await expect(
-      publishFramePublication(auth, { frame, manifest, sourceFiles })
+      publishFramePublication(auth, {
+        frame,
+        functionArtifacts,
+        manifest: manifestWithFunction,
+        sourceFiles: sourceFilesWithFunction,
+      })
     ).rejects.toThrow("Simulated GCS write failure");
+    expect(
+      fileStorageMock.saveFileCalls.some(({ filePath }) =>
+        filePath.endsWith("/manifest.json")
+      )
+    ).toBe(false);
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       activePublicationId

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -18,13 +18,20 @@ import {
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
 import {
+  getFramePublicationFunctionBundlePath,
+  getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
 } from "@app/types/api/frame_storage";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import type { AllSupportedFileContentType } from "@app/types/files";
-import { frameV2ContentType } from "@app/types/files";
+import {
+  frameV2ContentType,
+  sandboxFunctionContentType,
+} from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 
@@ -34,10 +41,19 @@ export type FramePublicationSourceFile = {
   contentType: AllSupportedFileContentType;
 };
 
+export type FramePublicationFunctionArtifact = {
+  name: string;
+  bundleCode: string;
+  userIdentity: SandboxFunctionUserIdentityPolicy;
+  inputSchema: JSONSchema;
+  outputSchema: JSONSchema;
+};
+
 export class FramePublicationError extends Error {
   constructor(
     readonly code:
       | "invalid_frame"
+      | "invalid_function_artifact"
       | "invalid_manifest"
       | "invalid_source"
       | "publication_not_found"
@@ -70,10 +86,12 @@ export async function storeFramePublication(
   auth: Authenticator,
   {
     frame,
+    functionArtifacts,
     manifest,
     sourceFiles,
   }: {
     frame: FileResource;
+    functionArtifacts: FramePublicationFunctionArtifact[];
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
   }
@@ -122,30 +140,92 @@ export async function storeFramePublication(
     }
   }
 
+  const declaredFunctionNames = new Set(
+    manifest.functions.map((fn) => fn.name)
+  );
+  const artifactNames = new Set<string>();
+  for (const artifact of functionArtifacts) {
+    if (artifactNames.has(artifact.name)) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_function_artifact",
+          `Duplicate Frame function artifact: ${artifact.name}`
+        )
+      );
+    }
+    if (!declaredFunctionNames.has(artifact.name)) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_function_artifact",
+          `Frame function artifact is not declared in the manifest: ${artifact.name}`
+        )
+      );
+    }
+    artifactNames.add(artifact.name);
+  }
+  for (const fn of manifest.functions) {
+    if (!artifactNames.has(fn.name)) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_function_artifact",
+          `Frame function artifact is missing: ${fn.name}`
+        )
+      );
+    }
+  }
+
   const identity = {
     ...frameIdentity.value,
     publicationId: randomUUID(),
   };
   const storage = getPrivateUploadBucket();
 
-  await concurrentExecutor(
-    sourceFiles,
-    (sourceFile) => {
-      const filePath = getFramePublicationSourcePath({
+  const publicationFiles = [
+    ...sourceFiles.map((sourceFile) => ({
+      filePath: getFramePublicationSourcePath({
         ...identity,
         relativePath: sourceFile.relativePath,
-      });
-      return storage.file(filePath).save(sourceFile.content, {
-        contentType: sourceFile.contentType,
+      }),
+      content: sourceFile.content,
+      contentType: sourceFile.contentType,
+    })),
+    ...functionArtifacts.flatMap((artifact) => [
+      {
+        filePath: getFramePublicationFunctionBundlePath({
+          ...identity,
+          functionName: artifact.name,
+        }),
+        content: artifact.bundleCode,
+        contentType: sandboxFunctionContentType,
+      },
+      {
+        filePath: getFramePublicationFunctionSchemaPath({
+          ...identity,
+          functionName: artifact.name,
+        }),
+        content: JSON.stringify({
+          userIdentity: artifact.userIdentity,
+          inputSchema: artifact.inputSchema,
+          outputSchema: artifact.outputSchema,
+        }),
+        contentType: "application/json",
+      },
+    ]),
+  ];
+
+  await concurrentExecutor(
+    publicationFiles,
+    ({ filePath, content, contentType }) =>
+      storage.file(filePath).save(content, {
+        contentType,
         preconditionOpts: {
           ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
         },
-      });
-    },
+      }),
     { concurrency: FRAME_PUBLICATION_UPLOAD_CONCURRENCY }
   );
 
-  // The manifest is the publication commit marker. Readers never observe a partial source write.
+  // The manifest is the publication commit marker. Readers never observe partial publication data.
   const manifestPath = getFramePublicationManifestPath(identity);
   await storage.file(manifestPath).save(Buffer.from(JSON.stringify(manifest)), {
     contentType: frameV2ContentType,
@@ -246,16 +326,19 @@ export async function publishFramePublication(
   auth: Authenticator,
   {
     frame,
+    functionArtifacts,
     manifest,
     sourceFiles,
   }: {
     frame: FileResource;
+    functionArtifacts: FramePublicationFunctionArtifact[];
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
   }
 ): Promise<Result<{ publicationId: string }, FramePublicationError>> {
   const publication = await storeFramePublication(auth, {
     frame,
+    functionArtifacts,
     manifest,
     sourceFiles,
   });

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -1,6 +1,7 @@
 import {
   getFrameBasePath,
   getFramePublicationFunctionBundlePath,
+  getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
 } from "@app/types/api/frame_storage";
@@ -33,6 +34,14 @@ describe("Frames v2 GCS paths", () => {
       })
     ).toBe(
       "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task/bundle.js"
+    );
+    expect(
+      getFramePublicationFunctionSchemaPath({
+        ...IDS,
+        functionName: "add-task",
+      })
+    ).toBe(
+      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task/schema.json"
     );
   });
 

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -91,3 +91,12 @@ export function getFramePublicationFunctionBundlePath(args: {
 }): string {
   return `${getFramePublicationFunctionBasePath(args)}bundle.js`;
 }
+
+export function getFramePublicationFunctionSchemaPath(args: {
+  workspaceId: string;
+  frameId: string;
+  publicationId: string;
+  functionName: string;
+}): string {
+  return `${getFramePublicationFunctionBasePath(args)}schema.json`;
+}


### PR DESCRIPTION
## Description

Persist prebuilt function bundles and extracted schemas with each immutable Frames v2 publication. Publication now requires an exact match between manifest functions and supplied artifacts, uploads all source and artifacts first, then writes the manifest commit marker.

## Tests

Added focused coverage for artifact paths and payloads, missing, extra, and duplicate artifacts, and failed artifact writes without activation.

## Risk

Low. There are no production callers yet. Failed uploads can leave uncommitted objects under a fresh publication ID, but readers cannot observe them without the manifest.

## Deploy Plan

Standard deploy.