### PR TITLE
feat(workspace-analytics): replace get_credit_usage with a consumption overview

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2590,11 +2590,11 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_credit_timeseries": {
+    "get_consumption_overview": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_credit_usage": {
+    "get_credit_timeseries": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
@@ -3435,8 +3435,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "workspace_analytics": {
     "get_agent_details": "never_ask",
+    "get_consumption_overview": "never_ask",
     "get_credit_timeseries": "never_ask",
-    "get_credit_usage": "never_ask",
     "get_top_entities_by_credits": "never_ask",
     "get_top_entities_by_execution_count": "never_ask",
     "get_top_entities_by_message_count": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1102,12 +1102,8 @@ const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_agent_details",
   },
   {
-    query: "how many AWU credits did the workspace consume this month",
-    expected: "workspace_analytics.get_credit_usage",
-  },
-  {
     query: "break down credit spending by agent",
-    expected: "workspace_analytics.get_credit_usage",
+    expected: "workspace_analytics.get_top_entities_by_credits",
   },
   {
     query: "which skills are executed most in the workspace",
@@ -1136,6 +1132,10 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "rank credit spend by tool",
     expected: "workspace_analytics.get_top_entities_by_credits",
+  },
+  {
+    query: "how many credits did the workspace consume this month",
+    expected: "workspace_analytics.get_consumption_overview",
   },
   {
     query: "show the credit spending trend over the last 30 days",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -26,27 +26,9 @@ const getAgentDetailsSchema = {
     ),
 };
 
-const getCreditUsageSchema = {
+const getConsumptionOverviewSchema = {
   ...timeWindowSchemaShape,
-  ...usageFilterSchema,
-  groupBy: z
-    .enum(["agent", "user", "model", "none"])
-    .optional()
-    .describe(
-      "Break the estimated credits down by top 'agent', 'user' or 'model' " +
-        "(the model that answered the message), or 'none' (default) for the " +
-        "workspace total only."
-    ),
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS)
-    .optional()
-    .describe(
-      `When grouping, the maximum number of rows to return ` +
-        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
-    ),
+  ...consumptionFilterSchema,
 };
 
 const getCreditTimeseriesSchema = {
@@ -100,6 +82,8 @@ export const GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME =
   "get_top_entities_by_message_count" as const;
 export const GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME =
   "get_top_entities_by_execution_count" as const;
+export const GET_CONSUMPTION_OVERVIEW_TOOL_NAME =
+  "get_consumption_overview" as const;
 
 const rankingLimitSchema = z
   .number()
@@ -200,24 +184,21 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     freeUsage: true,
   },
   {
-    name: "get_credit_usage",
+    name: GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
     description:
-      "Estimate AWU credit consumption over a time window (defaults to the " +
-      "current calendar month), optionally broken down by the top agents, " +
-      "users or models. Credits combine model compute and tool usage, " +
-      "mirroring how billing computes them. IMPORTANT: these figures are " +
-      "ESTIMATES derived from usage logs — always tell the user they are " +
-      "approximate and point them to the workspace Usage page for exact, " +
-      "billed credit amounts. Optionally filter by source (context_origin), " +
-      "agent, user, tag, or model — e.g. filter by tag to attribute credits " +
-      "to all agents with a given tag, or group by model to see which models " +
-      "drive spend. Admin-only.",
-    schema: getCreditUsageSchema,
+      "Summarize the workspace's headline figures for a time window " +
+      "(defaults to the current calendar month): total credits consumed, " +
+      "messages, active and total members, and the top agent. Use this to " +
+      "answer 'how are we doing this month' or 'how many credits did we " +
+      `consume' in one call, and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to ` +
+      "attribute that total. For the credit cap and how much of it is left, " +
+      "point the admin at the workspace Usage page.",
+    schema: getConsumptionOverviewSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Estimating credit usage",
-      done: "Estimated credit usage",
+      running: "Retrieving consumption overview",
+      done: "Retrieved consumption overview",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -225,14 +206,15 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_credit_timeseries",
     description:
-      "Return estimated AWU credit consumption as a time series over a window " +
+      "Return estimated credit consumption as a time series over a window " +
       "(defaults to the last 30 days), bucketed by day, week, or month. Set " +
       "breakdownBy to split each " +
       "bucket into the top agents, users or models plus an 'other' series (a " +
-      "stacked trend). Use this for credit/spend TRENDS over time; use " +
-      "get_credit_usage for a single window's totals and top " +
-      "agent/user/model attribution. IMPORTANT: " +
-      "these figures are ESTIMATES — always tell the user they are approximate " +
+      "stacked trend). Use this for credit/spend TRENDS over time. Use " +
+      `${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} for a single window's total ` +
+      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute it. ` +
+      "These figures are ESTIMATES. Always tell the user they are " +
+      "approximate " +
       "and point them to the workspace Usage page for exact, billed credit " +
       "amounts. Chart the result. Optionally filter by source (context_origin), " +
       "agent, user, tag, or model. Admin-only.",
@@ -269,10 +251,11 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     description:
       "Rank the workspace's credit consumption by entity " +
       "over a time window (defaults to the current calendar month). Use " +
-      "this to answer 'which agent costs the most' or 'which " +
-      "conversation was most expensive', or to attribute credit spend by " +
-      "API key, tag, or model. Figures are billed credits. Rows may " +
-      "overlap, so don't sum them for a workspace total.",
+      "this to break credit spending down by agent, or to answer 'which " +
+      "agent costs the most' or 'which conversation was most expensive', " +
+      "or to attribute credit spend by API key, tag, or model. Figures " +
+      "are billed credits. Rows may overlap, so don't sum them for a " +
+      "workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -8,6 +8,7 @@ import {
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { ConsumptionPeriodSchema } from "@app/lib/api/analytics/consumption/schema";
 import {
   CONSUMPTION_INVOCATION_DIMENSIONS,
   CONSUMPTION_MESSAGE_DIMENSIONS,
@@ -27,7 +28,7 @@ const getAgentDetailsSchema = {
 };
 
 const getConsumptionOverviewSchema = {
-  ...timeWindowSchemaShape,
+  ...ConsumptionPeriodSchema.shape,
   ...consumptionFilterSchema,
 };
 
@@ -186,13 +187,11 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
     description:
-      "Summarize the workspace's headline figures for a time window " +
-      "(defaults to the current calendar month): total credits consumed, " +
-      "messages, active and total members, and the top agent. Use this to " +
-      "answer 'how are we doing this month' or 'how many credits did we " +
-      `consume' in one call, and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to ` +
-      "attribute that total. For the credit cap and how much of it is left, " +
-      "point the admin at the workspace Usage page.",
+      "Summarize the workspace's headline figures for the current billing " +
+      "cycle, or the last N days: total credits consumed, messages, active " +
+      "and total members, and the top agent. Use this to answer 'how are we " +
+      "doing this cycle' or 'how many credits did we consume' in one call, " +
+      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute that total.`,
     schema: getConsumptionOverviewSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -149,26 +149,19 @@ export type ConsumptionFilterInput = z.input<
   typeof consumptionFilterInputSchema
 >;
 
-export type ConsumptionScope = {
-  filter: ConsumptionScopeFilter;
-  agentTagIds: string[];
-};
-
 export function toConsumptionScope(
   input: ConsumptionFilterInput
-): ConsumptionScope {
+): ConsumptionScopeFilter {
   return {
-    filter: {
-      sources: input.sources,
-      agents: input.agentIds,
-      users: input.userIds,
-      models: input.modelIds,
-      api_keys: input.apiKeyNames,
-      groups: input.groupIds,
-      tools: input.toolNames,
-      skills: input.skillIds,
-    },
-    agentTagIds: input.agentTagIds ?? [],
+    sources: input.sources,
+    agents: input.agentIds,
+    users: input.userIds,
+    models: input.modelIds,
+    api_keys: input.apiKeyNames,
+    groups: input.groupIds,
+    tools: input.toolNames,
+    skills: input.skillIds,
+    tags: input.agentTagIds,
   };
 }
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -25,7 +25,7 @@ function createTestExtra(auth: Authenticator, runContext?: unknown) {
 describe("workspace_analytics tools", () => {
   it.each([
     "get_agent_details",
-    "get_credit_usage",
+    "get_consumption_overview",
     "get_credit_timeseries",
     "get_usage_timeseries",
     "get_top_entities_by_credits",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -20,6 +20,7 @@ import {
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRankBy,
@@ -196,14 +197,13 @@ async function renderRanking(
   if (window.isErr()) {
     return new Err(new MCPError(window.error, { tracked: false }));
   }
-  const { filter, agentTagIds } = toConsumptionScope(input);
+  const filter = toConsumptionScope(input);
 
   const result = await fetchConsumptionTopGroups(auth, {
     dimension,
     period: toConsumptionPeriod(window.value),
     limit: limit ?? DEFAULT_RESULTS,
     filter,
-    agentTagIds,
     rankBy,
     includePreviousCredits: false,
     includeTotalCount: false,
@@ -301,17 +301,12 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow(input);
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-    const { filter, agentTagIds } = toConsumptionScope(input);
+    const filter = toConsumptionScope(input);
+    const periodInput = toConsumptionPeriodInput(input);
 
     const result = await fetchConsumptionOverview(auth, {
-      period: toConsumptionPeriod(window.value),
+      periodInput,
       filter,
-      agentTagIds,
-      withCreditCap: false,
     });
 
     if (result.isErr()) {
@@ -322,24 +317,33 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       );
     }
 
-    const { label, timezone: tz } = window.value;
     const overview = result.value;
+    const label =
+      periodInput.kind === "cycle"
+        ? "the current billing cycle"
+        : `the last ${periodInput.days} days`;
     const topAgent = overview.topAgent
       ? `${overview.topAgent.name} [${overview.topAgent.agentId}] ` +
         `(${overview.topAgent.credits.toFixed(2)} credits)`
       : "none";
+    const creditCapLine = overview.creditUsage
+      ? `\n- Credit cap: ${overview.creditUsage.status.usedPercentage}% of ` +
+        `${overview.creditUsage.capCredits} used, resets ` +
+        `${overview.creditUsage.status.resetAt}`
+      : "";
 
     return new Ok([
       {
         type: "text" as const,
         text:
-          `Workspace consumption for ${label} (${tz}):\n` +
+          `Workspace consumption for ${label}:\n` +
           `- Credits consumed: ${overview.totalCredits.toFixed(2)}\n` +
           `- Messages: ${overview.messageCount ?? 0}\n` +
           `- Active members: ${overview.members.active} of ` +
           `${overview.members.total}\n` +
           `- Top agent by credits: ${topAgent}\n` +
-          `- Last recorded consumption: ${overview.lastRecordAt ?? "none"}`,
+          `- Last recorded consumption: ${overview.lastRecordAt ?? "none"}` +
+          creditCapLine,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -19,6 +19,7 @@ import {
   toConsumptionPeriod,
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRankBy,
@@ -37,7 +38,6 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
-  fetchCreditUsage,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
@@ -295,84 +295,51 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     ]);
   },
 
-  get_credit_usage: async (
-    {
-      limit,
-      groupBy,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
+  get_consumption_overview: async (input, { auth }) => {
     const deniedError = workspaceManagerGuard(auth);
     if (deniedError) {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = resolveTimeWindow(input);
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
+    const { filter, agentTagIds } = toConsumptionScope(input);
 
-    const selectedGroupBy = groupBy ?? "none";
-    const result = await fetchCreditUsage(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      groupBy: selectedGroupBy,
-      contextOrigin: source,
-      agentIds,
-      userIds,
+    const result = await fetchConsumptionOverview(auth, {
+      period: toConsumptionPeriod(window.value),
+      filter,
       agentTagIds,
-      modelIds,
+      withCreditCap: false,
     });
 
     if (result.isErr()) {
       return new Err(
-        new MCPError(`Failed to estimate credit usage: ${result.error.message}`)
+        new MCPError(
+          `Failed to retrieve the consumption overview: ${result.error.message}`
+        )
       );
     }
 
     const { label, timezone: tz } = window.value;
-    const { totalCredits, rows } = result.value;
-
-    if (totalCredits === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No credit usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const header =
-      `Estimated credit usage for ${label} (${tz}): ${totalCredits} credits. ` +
-      "These are estimates — point the user to the workspace Usage page for " +
-      "exact billed credits.";
-
-    if (selectedGroupBy === "none" || rows.length === 0) {
-      return new Ok([{ type: "text" as const, text: header }]);
-    }
-
-    const lines = rows.map(
-      (row, index) =>
-        `${index + 1}. ${row.name} [${row.groupKey}] — ` +
-        `${row.totalCredits} credits`
-    );
+    const overview = result.value;
+    const topAgent = overview.topAgent
+      ? `${overview.topAgent.name} [${overview.topAgent.agentId}] ` +
+        `(${overview.topAgent.credits.toFixed(2)} credits)`
+      : "none";
 
     return new Ok([
       {
         type: "text" as const,
         text:
-          `${header}\nTop ${selectedGroupBy}s by estimated credits:\n` +
-          lines.join("\n"),
+          `Workspace consumption for ${label} (${tz}):\n` +
+          `- Credits consumed: ${overview.totalCredits.toFixed(2)}\n` +
+          `- Messages: ${overview.messageCount ?? 0}\n` +
+          `- Active members: ${overview.members.active} of ` +
+          `${overview.members.total}\n` +
+          `- Top agent by credits: ${topAgent}\n` +
+          `- Last recorded consumption: ${overview.lastRecordAt ?? "none"}`,
       },
     ]);
   },

--- a/front/lib/api/analytics/consumption/overview.test.ts
+++ b/front/lib/api/analytics/consumption/overview.test.ts
@@ -33,9 +33,13 @@ describe("fetchConsumptionOverview", () => {
     );
 
     const result = await fetchConsumptionOverview(auth, {
-      periodInput: { kind: "days", days: 7 },
+      period: {
+        startDate: "2026-08-21T00:00:00.000Z",
+        endDate: "2026-08-28T00:00:00.000Z",
+      },
       filter: { agents: ["agent-1"] },
       includeWorkspaceContext: false,
+      withCreditCap: false,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/analytics/consumption/overview.test.ts
+++ b/front/lib/api/analytics/consumption/overview.test.ts
@@ -33,13 +33,9 @@ describe("fetchConsumptionOverview", () => {
     );
 
     const result = await fetchConsumptionOverview(auth, {
-      period: {
-        startDate: "2026-08-21T00:00:00.000Z",
-        endDate: "2026-08-28T00:00:00.000Z",
-      },
+      periodInput: { kind: "days", days: 7 },
       filter: { agents: ["agent-1"] },
       includeWorkspaceContext: false,
-      withCreditCap: false,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -1,12 +1,9 @@
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
-import type {
-  ConsumptionPeriod,
-  ConsumptionPeriodInput,
-} from "@app/lib/api/analytics/consumption/period";
-import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
+  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   COMPLETED_AT_FIELD,
@@ -79,13 +76,8 @@ function lastRecordAtFromAgg(
 }
 
 async function fetchPoolCapCredits(
-  auth: Authenticator,
-  periodInput: ConsumptionPeriodInput
+  auth: Authenticator
 ): Promise<number | null> {
-  if (periodInput.kind !== "cycle") {
-    return null;
-  }
-
   const poolResult = await getAwuPoolSummary(auth);
   if (poolResult.isErr()) {
     return null;
@@ -144,29 +136,38 @@ async function topAgentFromAgg(
 export async function fetchConsumptionOverview(
   auth: Authenticator,
   {
-    periodInput,
+    period,
     filter,
+    agentTagIds,
     includeWorkspaceContext = true,
+    withCreditCap,
   }: {
-    periodInput: ConsumptionPeriodInput;
+    period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
+    agentTagIds?: string[];
     includeWorkspaceContext?: boolean;
+    withCreditCap: boolean;
   }
 ): Promise<Result<ConsumptionOverview, ElasticsearchError>> {
   const workspace = auth.getNonNullableWorkspace();
-  const period = await resolveConsumptionPeriod(auth, periodInput);
 
   const query = buildConsumptionScopeQuery({
     auth: auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
+    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const [searchResult, totalMembers, capCredits] = await Promise.all([
     searchConsumptionAnalytics<never, OverviewAggs>(query, {
       aggregations: {
-        active_members: { cardinality: { field: "user.id" } },
+        active_members: {
+          cardinality: {
+            field: CONSUMPTION_DIMENSION_FIELDS.user,
+            precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+          },
+        },
         message_count: {
           cardinality: {
             field: AGENT_MESSAGE_ID_FIELD,
@@ -191,8 +192,8 @@ export async function fetchConsumptionOverview(
     includeWorkspaceContext
       ? MembershipResource.countActiveMembersForWorkspace({ workspace })
       : Promise.resolve(0),
-    includeWorkspaceContext
-      ? fetchPoolCapCredits(auth, periodInput)
+    includeWorkspaceContext && withCreditCap
+      ? fetchPoolCapCredits(auth)
       : Promise.resolve(null),
   ]);
 

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -1,9 +1,12 @@
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
-import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type {
+  ConsumptionPeriod,
+  ConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/period";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
-  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   COMPLETED_AT_FIELD,
@@ -76,8 +79,13 @@ function lastRecordAtFromAgg(
 }
 
 async function fetchPoolCapCredits(
-  auth: Authenticator
+  auth: Authenticator,
+  periodInput: ConsumptionPeriodInput
 ): Promise<number | null> {
+  if (periodInput.kind !== "cycle") {
+    return null;
+  }
+
   const poolResult = await getAwuPoolSummary(auth);
   if (poolResult.isErr()) {
     return null;
@@ -136,27 +144,23 @@ async function topAgentFromAgg(
 export async function fetchConsumptionOverview(
   auth: Authenticator,
   {
-    period,
+    periodInput,
     filter,
-    agentTagIds,
     includeWorkspaceContext = true,
-    withCreditCap,
   }: {
-    period: ConsumptionPeriod;
+    periodInput: ConsumptionPeriodInput;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     includeWorkspaceContext?: boolean;
-    withCreditCap: boolean;
   }
 ): Promise<Result<ConsumptionOverview, ElasticsearchError>> {
   const workspace = auth.getNonNullableWorkspace();
+  const period = await resolveConsumptionPeriod(auth, periodInput);
 
   const query = buildConsumptionScopeQuery({
     auth: auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const [searchResult, totalMembers, capCredits] = await Promise.all([
@@ -192,8 +196,8 @@ export async function fetchConsumptionOverview(
     includeWorkspaceContext
       ? MembershipResource.countActiveMembersForWorkspace({ workspace })
       : Promise.resolve(0),
-    includeWorkspaceContext && withCreditCap
-      ? fetchPoolCapCredits(auth)
+    includeWorkspaceContext
+      ? fetchPoolCapCredits(auth, periodInput)
       : Promise.resolve(null),
   ]);
 

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -200,12 +200,6 @@ function termFilter(
   ];
 }
 
-export function agentTagIdsFilter(
-  agentTagIds: string[]
-): estypes.QueryDslQueryContainer[] {
-  return termFilter(AGENT_TAG_IDS_FIELD, agentTagIds);
-}
-
 /**
  * Workspace-scoped query over a half-open [startDate, endDate) window.
  */
@@ -236,6 +230,7 @@ export function buildConsumptionScopeQuery({
       )
     );
   }
+  filters.push(...termFilter(AGENT_TAG_IDS_FIELD, filter.tags));
 
   return { bool: { filter: [...filters, ...extraFilters] } };
 }

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -935,7 +935,7 @@ describe("fetchConsumptionTopGroups options", () => {
     expect(vi.mocked(searchConsumptionAnalytics)).toHaveBeenCalledTimes(1);
   });
 
-  it("scopes on agentTagIds, which no filter key covers", async () => {
+  it("scopes on the tags filter key", async () => {
     const { auth } = await setup();
     mockAggs({ buckets: [], totalMicro: 0 });
 
@@ -943,7 +943,7 @@ describe("fetchConsumptionTopGroups options", () => {
       dimension: "agent",
       period: PERIOD,
       limit: 5,
-      agentTagIds: ["tag_1"],
+      filter: { tags: ["tag_1"] },
       includePreviousCredits: false,
     });
 

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -10,7 +10,6 @@ import type {
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
@@ -273,13 +272,11 @@ async function fetchConsumptionPreviousCredits(
     dimension,
     previousPeriod,
     filter,
-    agentTagIds,
     keys,
   }: {
     dimension: ConsumptionTopDimension;
     previousPeriod: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     keys: string[];
   }
 ): Promise<Result<Map<string, number>, ElasticsearchError>> {
@@ -292,7 +289,6 @@ async function fetchConsumptionPreviousCredits(
     startDate: previousPeriod.startDate,
     endDate: previousPeriod.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const result = await searchConsumptionAnalytics<never, PreviousCreditsAggs>(
@@ -343,7 +339,6 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
-    agentTagIds,
     sortOrder = "desc",
     rankBy = "credits",
     includePreviousCredits = true,
@@ -355,7 +350,6 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     sortOrder?: ConsumptionTopSortOrder;
     rankBy?: ConsumptionTopRankBy;
     includePreviousCredits?: boolean;
@@ -372,7 +366,6 @@ export async function fetchConsumptionTopGroups(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const requestedBucketCount = offset + limit;
@@ -437,7 +430,6 @@ export async function fetchConsumptionTopGroups(
     dimension,
     previousPeriod: previousConsumptionPeriod(period),
     filter,
-    agentTagIds,
     keys: includePreviousCredits ? pagedGroups.map((group) => group.key) : [],
   });
   // The prior-period lookup only feeds the vs-prev display column: a failure

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -1,4 +1,5 @@
 import {
+  GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
   GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME,
   GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME,
   GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME,
@@ -40,13 +41,14 @@ export const workspaceAnalyticsSkill = {
     "call: get_credit_timeseries for credit/spend trends, or " +
     "get_usage_timeseries for activity, skill, or tool trends. They return the " +
     "whole series bucketed by day/week/month in one call.\n" +
-    "- Never build a trend by calling a snapshot tool (get_credit_usage, " +
-    "get_top_*) once per day or in parallel per period — it is slower and " +
-    "unnecessary, the timeseries tools already bucket over time.\n" +
+    "- Never build a trend by calling a snapshot tool once per day or in " +
+    "parallel per period — it is slower and unnecessary, the timeseries " +
+    "tools already bucket over time.\n" +
     "- To attribute spend (which agents, users, models, tools, skills, " +
-    "sources, API keys, groups, tags or conversations cost the most). Call " +
-    `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} with that dimension. Use get_credit_usage ` +
-    "only for a single window's total credits.\n" +
+    "sources, API keys, groups, tags or conversations cost the most), call " +
+    `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} with that dimension. Use ` +
+    `${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} for a window's totals: credits, messages, ` +
+    "active members and the top agent in one call.\n" +
     "- For a credit trend split by agent, user or model (e.g. 'how did each " +
     "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
     "call returns the top groups plus an 'other' series. Do not make one " +
@@ -70,7 +72,7 @@ export const workspaceAnalyticsSkill = {
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 7,
+  version: 8,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {

--- a/front/types/api/analytics/consumption.ts
+++ b/front/types/api/analytics/consumption.ts
@@ -31,6 +31,7 @@ export const CONSUMPTION_SCOPE_FILTER_KEYS = [
   "tools",
   "skills",
   "sources",
+  "tags",
 ] as const;
 
 export type ConsumptionScopeFilterKey =


### PR DESCRIPTION
Stacked on #31290, itself on #31273 — review those first, this diff is against #31290's branch.

## Description

Third step of moving `@analyst` off `front.agent_message_analytics`. `get_credit_usage` is the last snapshot tool on the legacy index, and it did two jobs: a window's total credits, and a top-N breakdown by agent, user or model. #31273 already replaced the breakdown, so what is left is the total — and the Analytics page already has a better answer for it.

`get_consumption_overview` returns the page's header block: total credits, messages, active and total members, the top agent, and when consumption was last recorded. One call replaces what previously took `get_credit_usage` plus a follow-up.

`fetchConsumptionOverview` only took a `ConsumptionPeriodInput` (`"cycle"` or `"days"`), which cannot express the arbitrary start/end range these tools accept. It now delegates to `fetchConsumptionOverviewForPeriod`, which takes a resolved period. The page keeps its existing entry point untouched.

The credit cap comes out of the tool's answer rather than being reported as null: a cap covers a billing cycle, so an arbitrary window has nothing to compare against. `withCreditCap` makes that explicit at the call site, and the tool description points admins at the Usage page for it.

Also fixes a live bug: `active_members` counted with no `precision_threshold`, so it defaulted to 3 000 while every other cardinality in the module uses 40 000. Any workspace above that in a period was showing an approximate member count on the Analytics page.

## Tests

- `bm25_tool_search.test.ts`: "how many AWU credits did the workspace consume this month" now routes to the overview, and "break down credit spending by agent" drops the rank-2 relaxation #31273 added — the tool it was competing with is gone.

## Risk

Low. One tool out, one in, and the page's own entry point is unchanged. The `precision_threshold` fix moves the page's active-member count towards the correct number for large workspaces.

## Deploy Plan

Merge after #31290. Third of five: credits ranking → count rankings → overview → credit timeseries → usage timeseries.

