### PR TITLE
Add appearance toggle to the cmd-k palette

### DIFF
--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -54,9 +54,9 @@ const THEME_ICONS: Record<Theme, typeof Sun> = {
 };
 
 const THEME_LABELS: Record<Theme, string> = {
-  system: "Switch to system appearance",
-  light: "Switch to light appearance",
-  dark: "Switch to dark appearance",
+  system: "System",
+  light: "Light",
+  dark: "Dark",
 };
 
 export function CommandPalette({ owner, user }: CommandPaletteProps) {

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -142,7 +142,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     }
     const lowerQuery = debouncedQuery.toLowerCase();
     return allCommands.filter((c) =>
-      subFilter(lowerQuery, `change interface theme ${c.label}`.toLowerCase())
+      subFilter(lowerQuery, c.label.toLowerCase())
     );
   }, [allCommands, debouncedQuery]);
 

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -57,6 +57,21 @@ const THEME_LABELS: Record<Theme, string> = {
   dark: "Dark",
 };
 
+const COMMON_COMMAND_KEYWORDS = [
+  "settings",
+  "appearance",
+  "theme",
+  "interface",
+  "color scheme",
+  "display",
+];
+
+const COMMAND_SEARCH_KEYWORDS: Record<Theme, string[]> = {
+  system: [...COMMON_COMMAND_KEYWORDS, "system"],
+  light: [...COMMON_COMMAND_KEYWORDS, "light"],
+  dark: [...COMMON_COMMAND_KEYWORDS, "dark", "dark mode", "night mode"],
+};
+
 export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const { isOpen, close } = useCommandPalette();
   const router = useAppRouter();
@@ -142,7 +157,9 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     }
     const lowerQuery = debouncedQuery.toLowerCase();
     return allCommands.filter((c) =>
-      subFilter(lowerQuery, `change interface theme ${c.label}`.toLowerCase())
+      COMMAND_SEARCH_KEYWORDS[c.theme].some((keyword) =>
+        keyword.includes(lowerQuery)
+      )
     );
   }, [allCommands, debouncedQuery]);
 

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -142,7 +142,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     }
     const lowerQuery = debouncedQuery.toLowerCase();
     return allCommands.filter((c) =>
-      subFilter(lowerQuery, c.label.toLowerCase())
+      subFilter(lowerQuery, `change interface theme ${c.label}`.toLowerCase())
     );
   }, [allCommands, debouncedQuery]);
 

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -5,9 +5,13 @@ import type {
 } from "@app/components/command_palette/CommandPaletteActionPhase";
 import { CommandPaletteActionPhase } from "@app/components/command_palette/CommandPaletteActionPhase";
 import { useCommandPalette } from "@app/components/command_palette/CommandPaletteContext";
-import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
+import type {
+  CommandPaletteCommand,
+  CommandPaletteItem,
+} from "@app/components/command_palette/CommandPaletteSearchPhase";
 import { CommandPaletteSearchPhase } from "@app/components/command_palette/CommandPaletteSearchPhase";
 import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSkills } from "@app/lib/swr/skill_configurations";
@@ -22,7 +26,7 @@ import {
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import { isProjectType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { Dialog, DialogContent } from "@dust-tt/sparkle";
+import { Dialog, DialogContent, Moon01, Sun } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface CommandPaletteProps {
@@ -33,6 +37,7 @@ interface CommandPaletteProps {
 export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const { isOpen, close } = useCommandPalette();
   const router = useAppRouter();
+  const { isDark, setTheme } = useTheme();
 
   // Dialog state.
   const [searchQuery, setSearchQuery] = useState("");
@@ -97,6 +102,29 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const MAX_DISPLAYED_AGENTS = 5;
   const MAX_DISPLAYED_PODS = 5;
   const MAX_DISPLAYED_SKILLS = 5;
+
+  const allCommands: CommandPaletteCommand[] = useMemo(
+    () => [
+      {
+        id: "toggle_theme",
+        label: isDark
+          ? "Switch to light appearance"
+          : "Switch to dark appearance",
+        icon: isDark ? Sun : Moon01,
+      },
+    ],
+    [isDark]
+  );
+
+  const filteredCommands = useMemo(() => {
+    if (!debouncedQuery) {
+      return allCommands;
+    }
+    const lowerQuery = debouncedQuery.toLowerCase();
+    return allCommands.filter((c) =>
+      subFilter(lowerQuery, c.label.toLowerCase())
+    );
+  }, [allCommands, debouncedQuery]);
 
   const allFilteredAgents = useMemo(
     () =>
@@ -193,6 +221,13 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
 
   const handleItemSelect = useCallback(
     (item: CommandPaletteItem) => {
+      if (item.kind === "command") {
+        close();
+        if (item.command.id === "toggle_theme") {
+          setTheme(isDark ? "light" : "dark");
+        }
+        return;
+      }
       if (item.kind === "pod") {
         close();
         void router.push(getPodRoute(owner.sId, item.pod.sId));
@@ -206,7 +241,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
         setPhase("action");
       }
     },
-    [close, executeAction, owner.sId, router]
+    [close, executeAction, isDark, owner.sId, router, setTheme]
   );
 
   const handleBack = useCallback(() => {
@@ -240,6 +275,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
             <CommandPaletteSearchPhase
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
+              commands={filteredCommands}
               agents={filteredAgents}
               pods={filteredPods}
               skills={filteredSkills}

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -57,21 +57,6 @@ const THEME_LABELS: Record<Theme, string> = {
   dark: "Dark",
 };
 
-const COMMON_COMMAND_KEYWORDS = [
-  "settings",
-  "appearance",
-  "theme",
-  "interface",
-  "color scheme",
-  "display",
-];
-
-const COMMAND_SEARCH_KEYWORDS: Record<Theme, string[]> = {
-  system: [...COMMON_COMMAND_KEYWORDS, "system"],
-  light: [...COMMON_COMMAND_KEYWORDS, "light"],
-  dark: [...COMMON_COMMAND_KEYWORDS, "dark", "dark mode", "night mode"],
-};
-
 export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const { isOpen, close } = useCommandPalette();
   const router = useAppRouter();
@@ -157,9 +142,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     }
     const lowerQuery = debouncedQuery.toLowerCase();
     return allCommands.filter((c) =>
-      COMMAND_SEARCH_KEYWORDS[c.theme].some((keyword) =>
-        keyword.includes(lowerQuery)
-      )
+      subFilter(lowerQuery, `change interface theme ${c.label}`.toLowerCase())
     );
   }, [allCommands, debouncedQuery]);
 

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -24,9 +24,16 @@ import {
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isProjectType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { Dialog, DialogContent, Moon01, Sun } from "@dust-tt/sparkle";
+import {
+  Dialog,
+  DialogContent,
+  Monitor01,
+  Moon01,
+  Sun,
+} from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface CommandPaletteProps {
@@ -34,10 +41,32 @@ interface CommandPaletteProps {
   user: UserType;
 }
 
+type Theme = "dark" | "light" | "system";
+
+const THEME_ICONS: Record<Theme, typeof Sun> = {
+  system: Monitor01,
+  light: Sun,
+  dark: Moon01,
+};
+
+// Cycle: system -> light -> dark -> system.
+function getNextTheme(theme: Theme): Theme {
+  switch (theme) {
+    case "system":
+      return "light";
+    case "light":
+      return "dark";
+    case "dark":
+      return "system";
+    default:
+      return assertNever(theme);
+  }
+}
+
 export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const { isOpen, close } = useCommandPalette();
   const router = useAppRouter();
-  const { isDark, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
   // Dialog state.
   const [searchQuery, setSearchQuery] = useState("");
@@ -103,17 +132,17 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const MAX_DISPLAYED_PODS = 5;
   const MAX_DISPLAYED_SKILLS = 5;
 
+  const nextTheme = getNextTheme(theme);
+
   const allCommands: CommandPaletteCommand[] = useMemo(
     () => [
       {
         id: "toggle_theme",
-        label: isDark
-          ? "Switch to light appearance"
-          : "Switch to dark appearance",
-        icon: isDark ? Sun : Moon01,
+        label: `Switch to ${nextTheme} appearance`,
+        icon: THEME_ICONS[nextTheme],
       },
     ],
-    [isDark]
+    [nextTheme]
   );
 
   const filteredCommands = useMemo(() => {
@@ -224,7 +253,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
       if (item.kind === "command") {
         close();
         if (item.command.id === "toggle_theme") {
-          setTheme(isDark ? "light" : "dark");
+          setTheme(nextTheme);
         }
         return;
       }
@@ -241,7 +270,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
         setPhase("action");
       }
     },
-    [close, executeAction, isDark, owner.sId, router, setTheme]
+    [close, executeAction, nextTheme, owner.sId, router, setTheme]
   );
 
   const handleBack = useCallback(() => {

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -250,24 +250,33 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
 
   const handleItemSelect = useCallback(
     (item: CommandPaletteItem) => {
-      if (item.kind === "command") {
-        close();
-        if (item.command.id === "toggle_theme") {
-          setTheme(nextTheme);
-        }
-        return;
-      }
-      if (item.kind === "pod") {
-        close();
-        void router.push(getPodRoute(owner.sId, item.pod.sId));
-        return;
-      }
-      // Skills without administration access have only one action (view details).
-      if (item.kind === "skill" && !item.skill.canAdministrate) {
-        executeAction(item, "view_details");
-      } else {
-        setSelectedItem(item);
-        setPhase("action");
+      switch (item.kind) {
+        case "command":
+          close();
+          if (item.command.id === "toggle_theme") {
+            setTheme(nextTheme);
+          }
+          return;
+        case "pod":
+          close();
+          void router.push(getPodRoute(owner.sId, item.pod.sId));
+          return;
+        case "agent":
+          setSelectedItem(item);
+          setPhase("action");
+          return;
+        case "skill":
+          // Skills without administration access have only one action
+          // (view details).
+          if (!item.skill.canAdministrate) {
+            executeAction(item, "view_details");
+          } else {
+            setSelectedItem(item);
+            setPhase("action");
+          }
+          return;
+        default:
+          assertNever(item);
       }
     },
     [close, executeAction, nextTheme, owner.sId, router, setTheme]

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -43,25 +43,19 @@ interface CommandPaletteProps {
 
 type Theme = "dark" | "light" | "system";
 
+const THEME_ORDER: Theme[] = ["system", "light", "dark"];
+
 const THEME_ICONS: Record<Theme, typeof Sun> = {
   system: Monitor01,
   light: Sun,
   dark: Moon01,
 };
 
-// Cycle: system -> light -> dark -> system.
-function getNextTheme(theme: Theme): Theme {
-  switch (theme) {
-    case "system":
-      return "light";
-    case "light":
-      return "dark";
-    case "dark":
-      return "system";
-    default:
-      return assertNever(theme);
-  }
-}
+const THEME_LABELS: Record<Theme, string> = {
+  system: "Switch to system appearance",
+  light: "Switch to light appearance",
+  dark: "Switch to dark appearance",
+};
 
 export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const { isOpen, close } = useCommandPalette();
@@ -132,17 +126,15 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const MAX_DISPLAYED_PODS = 5;
   const MAX_DISPLAYED_SKILLS = 5;
 
-  const nextTheme = getNextTheme(theme);
-
+  // Offer the two themes the workspace isn't currently using.
   const allCommands: CommandPaletteCommand[] = useMemo(
-    () => [
-      {
-        id: "toggle_theme",
-        label: `Switch to ${nextTheme} appearance`,
-        icon: THEME_ICONS[nextTheme],
-      },
-    ],
-    [nextTheme]
+    () =>
+      THEME_ORDER.filter((t) => t !== theme).map((t) => ({
+        id: t,
+        label: THEME_LABELS[t],
+        icon: THEME_ICONS[t],
+      })),
+    [theme]
   );
 
   const filteredCommands = useMemo(() => {
@@ -253,9 +245,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
       switch (item.kind) {
         case "command":
           close();
-          if (item.command.id === "toggle_theme") {
-            setTheme(nextTheme);
-          }
+          setTheme(item.command.id);
           return;
         case "pod":
           close();
@@ -279,7 +269,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
           assertNever(item);
       }
     },
-    [close, executeAction, nextTheme, owner.sId, router, setTheme]
+    [close, executeAction, owner.sId, router, setTheme]
   );
 
   const handleBack = useCallback(() => {

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -43,8 +43,6 @@ interface CommandPaletteProps {
 
 type Theme = "dark" | "light" | "system";
 
-// "system" is last so that, once the current theme is filtered out, it
-// always shows up as the second (last) option.
 const THEME_ORDER: Theme[] = ["light", "dark", "system"];
 
 const THEME_ICONS: Record<Theme, typeof Sun> = {
@@ -128,11 +126,10 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const MAX_DISPLAYED_PODS = 5;
   const MAX_DISPLAYED_SKILLS = 5;
 
-  // Offer the two themes the workspace isn't currently using.
   const allCommands: CommandPaletteCommand[] = useMemo(
     () =>
       THEME_ORDER.filter((t) => t !== theme).map((t) => ({
-        id: t,
+        theme: t,
         label: THEME_LABELS[t],
         icon: THEME_ICONS[t],
       })),
@@ -247,7 +244,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
       switch (item.kind) {
         case "command":
           close();
-          setTheme(item.command.id);
+          setTheme(item.command.theme);
           return;
         case "pod":
           close();

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -43,7 +43,9 @@ interface CommandPaletteProps {
 
 type Theme = "dark" | "light" | "system";
 
-const THEME_ORDER: Theme[] = ["system", "light", "dark"];
+// "system" is last so that, once the current theme is filtered out, it
+// always shows up as the second (last) option.
+const THEME_ORDER: Theme[] = ["light", "dark", "system"];
 
 const THEME_ICONS: Record<Theme, typeof Sun> = {
   system: Monitor01,

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -14,7 +14,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 
 export type CommandPaletteAction = "view_details" | "edit" | "chat_with";
 
-// Pods navigate directly and never enter the action phase.
+// Pods navigate directly and commands execute directly; neither enters the action phase.
 export type ActionPhaseItem = Extract<
   CommandPaletteItem,
   { kind: "agent" | "skill" }

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -14,7 +14,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 
 export type CommandPaletteAction = "view_details" | "edit" | "chat_with";
 
-// Pods navigate directly and commands execute directly; neither enters the action phase.
+// Pods navigate directly and never enter the action phase.
 export type ActionPhaseItem = Extract<
   CommandPaletteItem,
   { kind: "agent" | "skill" }

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -9,10 +9,18 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { PodType } from "@app/types/space";
+import type { Sun } from "@dust-tt/sparkle";
 import { Avatar, cn, Icon, LoadingBlock, SearchInput } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
+export interface CommandPaletteCommand {
+  id: "toggle_theme";
+  label: string;
+  icon: typeof Sun;
+}
+
 export type CommandPaletteItem =
+  | { kind: "command"; command: CommandPaletteCommand }
   | { kind: "agent"; agent: LightAgentConfigurationType }
   | { kind: "pod"; pod: PodType }
   | { kind: "skill"; skill: SkillWithoutInstructionsAndToolsType };
@@ -20,6 +28,7 @@ export type CommandPaletteItem =
 interface CommandPaletteSearchPhaseProps {
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
+  commands: CommandPaletteCommand[];
   agents: LightAgentConfigurationType[];
   pods: PodType[];
   skills: SkillWithoutInstructionsAndToolsType[];
@@ -34,11 +43,15 @@ interface CommandPaletteSearchPhaseProps {
 }
 
 function getFlatItems(
+  commands: CommandPaletteCommand[],
   agents: LightAgentConfigurationType[],
   pods: PodType[],
   skills: SkillWithoutInstructionsAndToolsType[]
 ): CommandPaletteItem[] {
   return [
+    ...commands.map(
+      (command): CommandPaletteItem => ({ kind: "command", command })
+    ),
     ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),
     ...pods.map((pod): CommandPaletteItem => ({ kind: "pod", pod })),
     ...skills.map((skill): CommandPaletteItem => ({ kind: "skill", skill })),
@@ -48,6 +61,7 @@ function getFlatItems(
 export function CommandPaletteSearchPhase({
   searchQuery,
   onSearchQueryChange,
+  commands,
   agents,
   pods,
   skills,
@@ -61,8 +75,8 @@ export function CommandPaletteSearchPhase({
   onClose,
 }: CommandPaletteSearchPhaseProps) {
   const flatItems = useMemo(
-    () => getFlatItems(agents, pods, skills),
-    [agents, pods, skills]
+    () => getFlatItems(commands, agents, pods, skills),
+    [commands, agents, pods, skills]
   );
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -85,11 +99,17 @@ export function CommandPaletteSearchPhase({
   }, [selectedIndex, flatItems.length]);
 
   // Reset selection and trim stale refs when the number of results changes.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: agents.length, pods.length and skills.length are intentional triggers
+  // biome-ignore lint/correctness/useExhaustiveDependencies: commands.length, agents.length, pods.length and skills.length are intentional triggers
   useEffect(() => {
     itemRefs.current.length = flatItems.length;
     onSelectedIndexChange(0);
-  }, [agents.length, pods.length, skills.length, onSelectedIndexChange]);
+  }, [
+    commands.length,
+    agents.length,
+    pods.length,
+    skills.length,
+    onSelectedIndexChange,
+  ]);
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     const totalItems = flatItems.length;
@@ -164,29 +184,52 @@ export function CommandPaletteSearchPhase({
           </ItemEmptyState>
         )}
 
-        {agents.length > 0 && (
+        {commands.length > 0 && (
           <div>
-            <ItemTitle>Agents</ItemTitle>
-            {agents.map((agent, i) => (
+            <ItemTitle>Commands</ItemTitle>
+            {commands.map((command, i) => (
               <ItemRow
-                key={agent.sId}
+                key={command.id}
                 ref={(el) => {
                   itemRefs.current[i] = el;
                 }}
                 isSelected={selectedIndex === i}
-                onClick={() => onItemSelect({ kind: "agent", agent })}
+                onClick={() => onItemSelect({ kind: "command", command })}
                 onMouseMove={() => onSelectedIndexChange(i)}
               >
-                <Avatar visual={agent.pictureUrl} size="xs" />
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="shrink-0 font-medium">{agent.name}</span>
-                  <span className="shrink-0 text-muted-foreground">-</span>
-                  <span className="min-w-0 truncate text-muted-foreground">
-                    {agent.description}
-                  </span>
-                </div>
+                <Icon visual={command.icon} size="xs" />
+                <span className="font-medium">{command.label}</span>
               </ItemRow>
             ))}
+          </div>
+        )}
+
+        {agents.length > 0 && (
+          <div>
+            <ItemTitle>Agents</ItemTitle>
+            {agents.map((agent, i) => {
+              const globalIndex = commands.length + i;
+              return (
+                <ItemRow
+                  key={agent.sId}
+                  ref={(el) => {
+                    itemRefs.current[globalIndex] = el;
+                  }}
+                  isSelected={selectedIndex === globalIndex}
+                  onClick={() => onItemSelect({ kind: "agent", agent })}
+                  onMouseMove={() => onSelectedIndexChange(globalIndex)}
+                >
+                  <Avatar visual={agent.pictureUrl} size="xs" />
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 font-medium">{agent.name}</span>
+                    <span className="shrink-0 text-muted-foreground">-</span>
+                    <span className="min-w-0 truncate text-muted-foreground">
+                      {agent.description}
+                    </span>
+                  </div>
+                </ItemRow>
+              );
+            })}
             {hasMoreAgents && (
               <div className="px-3 py-2 text-xs text-muted-foreground">
                 More agents available. Type to filter.
@@ -199,7 +242,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Pods</ItemTitle>
             {pods.map((pod, i) => {
-              const globalIndex = agents.length + i;
+              const globalIndex = commands.length + agents.length + i;
               return (
                 <ItemRow
                   key={pod.sId}
@@ -239,7 +282,8 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
-              const globalIndex = agents.length + pods.length + i;
+              const globalIndex =
+                commands.length + agents.length + pods.length + i;
               const SkillAvatar = getSkillAvatarIcon(skill);
               return (
                 <ItemRow

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -21,8 +21,7 @@ import {
 import { useEffect, useMemo, useRef } from "react";
 
 export interface CommandPaletteCommand {
-  // The theme this command switches to when selected.
-  id: "light" | "dark" | "system";
+  theme: "light" | "dark" | "system";
   label: string;
   icon: typeof Sun;
 }
@@ -86,8 +85,6 @@ export function CommandPaletteSearchPhase({
   onItemSelect,
   onClose,
 }: CommandPaletteSearchPhaseProps) {
-  // When the query matches a Settings command, surface it above the
-  // fuzzy-matched entities instead of always burying it at the bottom.
   const commandsFirst = searchQuery.trim().length > 0 && commands.length > 0;
 
   const flatItems = useMemo(
@@ -128,10 +125,6 @@ export function CommandPaletteSearchPhase({
     }
   }, [selectedIndex, flatItems.length]);
 
-  // Reset selection and trim stale refs when the results (or their order)
-  // change. Sums the same counts as flatItems.length instead of depending
-  // on flatItems itself, since a new flatItems array is created every
-  // render and would defeat this effect's purpose.
   // biome-ignore lint/correctness/useExhaustiveDependencies: commandsFirst isn't read in the body, but a reorder (counts unchanged) must still reset the selection
   useEffect(() => {
     itemRefs.current.length =
@@ -182,7 +175,7 @@ export function CommandPaletteSearchPhase({
         const globalIndex = offsets.commands + i;
         return (
           <ItemRow
-            key={command.id}
+            key={command.theme}
             ref={(el) => {
               itemRefs.current[globalIndex] = el;
             }}

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -14,7 +14,8 @@ import { Avatar, cn, Icon, LoadingBlock, SearchInput } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 export interface CommandPaletteCommand {
-  id: "toggle_theme";
+  // The theme this command switches to when selected.
+  id: "light" | "dark" | "system";
   label: string;
   icon: typeof Sun;
 }

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -129,10 +129,13 @@ export function CommandPaletteSearchPhase({
   }, [selectedIndex, flatItems.length]);
 
   // Reset selection and trim stale refs when the results (or their order)
-  // change.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: commands.length, agents.length, pods.length, skills.length and commandsFirst are intentional triggers
+  // change. Sums the same counts as flatItems.length instead of depending
+  // on flatItems itself, since a new flatItems array is created every
+  // render and would defeat this effect's purpose.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: commandsFirst isn't read in the body, but a reorder (counts unchanged) must still reset the selection
   useEffect(() => {
-    itemRefs.current.length = flatItems.length;
+    itemRefs.current.length =
+      commands.length + agents.length + pods.length + skills.length;
     onSelectedIndexChange(0);
   }, [
     commands.length,

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -54,16 +54,20 @@ function getFlatItems(
   agents: LightAgentConfigurationType[],
   pods: PodType[],
   skills: SkillWithoutInstructionsAndToolsType[],
-  commands: CommandPaletteCommand[]
+  commands: CommandPaletteCommand[],
+  commandsFirst: boolean
 ): CommandPaletteItem[] {
-  return [
+  const commandItems = commands.map(
+    (command): CommandPaletteItem => ({ kind: "command", command })
+  );
+  const entityItems = [
     ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),
     ...pods.map((pod): CommandPaletteItem => ({ kind: "pod", pod })),
     ...skills.map((skill): CommandPaletteItem => ({ kind: "skill", skill })),
-    ...commands.map(
-      (command): CommandPaletteItem => ({ kind: "command", command })
-    ),
   ];
+  return commandsFirst
+    ? [...commandItems, ...entityItems]
+    : [...entityItems, ...commandItems];
 }
 
 export function CommandPaletteSearchPhase({
@@ -82,10 +86,28 @@ export function CommandPaletteSearchPhase({
   onItemSelect,
   onClose,
 }: CommandPaletteSearchPhaseProps) {
+  // When the query matches a Settings command, surface it above the
+  // fuzzy-matched entities instead of always burying it at the bottom.
+  const commandsFirst = searchQuery.trim().length > 0 && commands.length > 0;
+
   const flatItems = useMemo(
-    () => getFlatItems(agents, pods, skills, commands),
-    [agents, pods, skills, commands]
+    () => getFlatItems(agents, pods, skills, commands, commandsFirst),
+    [agents, pods, skills, commands, commandsFirst]
   );
+
+  const offsets = commandsFirst
+    ? {
+        commands: 0,
+        agents: commands.length,
+        pods: commands.length + agents.length,
+        skills: commands.length + agents.length + pods.length,
+      }
+    : {
+        agents: 0,
+        pods: agents.length,
+        skills: agents.length + pods.length,
+        commands: agents.length + pods.length + skills.length,
+      };
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -106,8 +128,9 @@ export function CommandPaletteSearchPhase({
     }
   }, [selectedIndex, flatItems.length]);
 
-  // Reset selection and trim stale refs when the number of results changes.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: commands.length, agents.length, pods.length and skills.length are intentional triggers
+  // Reset selection and trim stale refs when the results (or their order)
+  // change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: commands.length, agents.length, pods.length, skills.length and commandsFirst are intentional triggers
   useEffect(() => {
     itemRefs.current.length = flatItems.length;
     onSelectedIndexChange(0);
@@ -116,6 +139,7 @@ export function CommandPaletteSearchPhase({
     agents.length,
     pods.length,
     skills.length,
+    commandsFirst,
     onSelectedIndexChange,
   ]);
 
@@ -147,6 +171,35 @@ export function CommandPaletteSearchPhase({
         break;
     }
   }
+
+  const settingsSection = commands.length > 0 && (
+    <div>
+      <ItemTitle>Settings</ItemTitle>
+      {commands.map((command, i) => {
+        const globalIndex = offsets.commands + i;
+        return (
+          <ItemRow
+            key={command.id}
+            ref={(el) => {
+              itemRefs.current[globalIndex] = el;
+            }}
+            isSelected={selectedIndex === globalIndex}
+            onClick={() => onItemSelect({ kind: "command", command })}
+            onMouseMove={() => onSelectedIndexChange(globalIndex)}
+          >
+            <Icon visual={command.icon} size="xs" />
+            <div className="flex items-center gap-1.5">
+              <span className="text-muted-foreground">
+                Change interface theme
+              </span>
+              <Icon visual={ChevronRight} size="xs" />
+              <span className="font-medium">{command.label}</span>
+            </div>
+          </ItemRow>
+        );
+      })}
+    </div>
+  );
 
   return (
     <div className="flex flex-col">
@@ -192,11 +245,13 @@ export function CommandPaletteSearchPhase({
           </ItemEmptyState>
         )}
 
+        {commandsFirst && settingsSection}
+
         {agents.length > 0 && (
           <div>
             <ItemTitle>Agents</ItemTitle>
             {agents.map((agent, i) => {
-              const globalIndex = i;
+              const globalIndex = offsets.agents + i;
               return (
                 <ItemRow
                   key={agent.sId}
@@ -230,7 +285,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Pods</ItemTitle>
             {pods.map((pod, i) => {
-              const globalIndex = agents.length + i;
+              const globalIndex = offsets.pods + i;
               return (
                 <ItemRow
                   key={pod.sId}
@@ -270,7 +325,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
-              const globalIndex = agents.length + pods.length + i;
+              const globalIndex = offsets.skills + i;
               const SkillAvatar = getSkillAvatarIcon(skill);
               return (
                 <ItemRow
@@ -301,35 +356,7 @@ export function CommandPaletteSearchPhase({
           </div>
         )}
 
-        {commands.length > 0 && (
-          <div>
-            <ItemTitle>Settings</ItemTitle>
-            {commands.map((command, i) => {
-              const globalIndex =
-                agents.length + pods.length + skills.length + i;
-              return (
-                <ItemRow
-                  key={command.id}
-                  ref={(el) => {
-                    itemRefs.current[globalIndex] = el;
-                  }}
-                  isSelected={selectedIndex === globalIndex}
-                  onClick={() => onItemSelect({ kind: "command", command })}
-                  onMouseMove={() => onSelectedIndexChange(globalIndex)}
-                >
-                  <Icon visual={command.icon} size="xs" />
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-muted-foreground">
-                      Change interface theme
-                    </span>
-                    <Icon visual={ChevronRight} size="xs" />
-                    <span className="font-medium">{command.label}</span>
-                  </div>
-                </ItemRow>
-              );
-            })}
-          </div>
-        )}
+        {!commandsFirst && settingsSection}
       </div>
       <KeyboardHints
         hints={[

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -44,18 +44,18 @@ interface CommandPaletteSearchPhaseProps {
 }
 
 function getFlatItems(
-  commands: CommandPaletteCommand[],
   agents: LightAgentConfigurationType[],
   pods: PodType[],
-  skills: SkillWithoutInstructionsAndToolsType[]
+  skills: SkillWithoutInstructionsAndToolsType[],
+  commands: CommandPaletteCommand[]
 ): CommandPaletteItem[] {
   return [
-    ...commands.map(
-      (command): CommandPaletteItem => ({ kind: "command", command })
-    ),
     ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),
     ...pods.map((pod): CommandPaletteItem => ({ kind: "pod", pod })),
     ...skills.map((skill): CommandPaletteItem => ({ kind: "skill", skill })),
+    ...commands.map(
+      (command): CommandPaletteItem => ({ kind: "command", command })
+    ),
   ];
 }
 
@@ -76,8 +76,8 @@ export function CommandPaletteSearchPhase({
   onClose,
 }: CommandPaletteSearchPhaseProps) {
   const flatItems = useMemo(
-    () => getFlatItems(commands, agents, pods, skills),
-    [commands, agents, pods, skills]
+    () => getFlatItems(agents, pods, skills, commands),
+    [agents, pods, skills, commands]
   );
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -185,31 +185,11 @@ export function CommandPaletteSearchPhase({
           </ItemEmptyState>
         )}
 
-        {commands.length > 0 && (
-          <div>
-            <ItemTitle>Commands</ItemTitle>
-            {commands.map((command, i) => (
-              <ItemRow
-                key={command.id}
-                ref={(el) => {
-                  itemRefs.current[i] = el;
-                }}
-                isSelected={selectedIndex === i}
-                onClick={() => onItemSelect({ kind: "command", command })}
-                onMouseMove={() => onSelectedIndexChange(i)}
-              >
-                <Icon visual={command.icon} size="xs" />
-                <span className="font-medium">{command.label}</span>
-              </ItemRow>
-            ))}
-          </div>
-        )}
-
         {agents.length > 0 && (
           <div>
             <ItemTitle>Agents</ItemTitle>
             {agents.map((agent, i) => {
-              const globalIndex = commands.length + i;
+              const globalIndex = i;
               return (
                 <ItemRow
                   key={agent.sId}
@@ -243,7 +223,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Pods</ItemTitle>
             {pods.map((pod, i) => {
-              const globalIndex = commands.length + agents.length + i;
+              const globalIndex = agents.length + i;
               return (
                 <ItemRow
                   key={pod.sId}
@@ -283,8 +263,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
-              const globalIndex =
-                commands.length + agents.length + pods.length + i;
+              const globalIndex = agents.length + pods.length + i;
               const SkillAvatar = getSkillAvatarIcon(skill);
               return (
                 <ItemRow
@@ -312,6 +291,30 @@ export function CommandPaletteSearchPhase({
                 More skills available. Type to filter.
               </div>
             )}
+          </div>
+        )}
+
+        {commands.length > 0 && (
+          <div>
+            <ItemTitle>Commands</ItemTitle>
+            {commands.map((command, i) => {
+              const globalIndex =
+                agents.length + pods.length + skills.length + i;
+              return (
+                <ItemRow
+                  key={command.id}
+                  ref={(el) => {
+                    itemRefs.current[globalIndex] = el;
+                  }}
+                  isSelected={selectedIndex === globalIndex}
+                  onClick={() => onItemSelect({ kind: "command", command })}
+                  onMouseMove={() => onSelectedIndexChange(globalIndex)}
+                >
+                  <Icon visual={command.icon} size="xs" />
+                  <span className="font-medium">{command.label}</span>
+                </ItemRow>
+              );
+            })}
           </div>
         )}
       </div>

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -10,7 +10,14 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { PodType } from "@app/types/space";
 import type { Sun } from "@dust-tt/sparkle";
-import { Avatar, cn, Icon, LoadingBlock, SearchInput } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  ChevronRight,
+  cn,
+  Icon,
+  LoadingBlock,
+  SearchInput,
+} from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 export interface CommandPaletteCommand {
@@ -296,7 +303,7 @@ export function CommandPaletteSearchPhase({
 
         {commands.length > 0 && (
           <div>
-            <ItemTitle>Commands</ItemTitle>
+            <ItemTitle>Settings</ItemTitle>
             {commands.map((command, i) => {
               const globalIndex =
                 agents.length + pods.length + skills.length + i;
@@ -311,7 +318,13 @@ export function CommandPaletteSearchPhase({
                   onMouseMove={() => onSelectedIndexChange(globalIndex)}
                 >
                   <Icon visual={command.icon} size="xs" />
-                  <span className="font-medium">{command.label}</span>
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-muted-foreground">
+                      Change interface theme
+                    </span>
+                    <Icon visual={ChevronRight} size="xs" />
+                    <span className="font-medium">{command.label}</span>
+                  </div>
                 </ItemRow>
               );
             })}

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -80,7 +80,7 @@ type DialogVariantType = (typeof DIALOG_VARIANTS)[number];
 
 const overlayVariantClasses: Record<DialogVariantType, string> = {
   default: "duration-200 data-[state=closed]:duration-150",
-  command: "duration-150 data-[state=closed]:duration-100",
+  command: "duration-[220ms] data-[state=closed]:duration-[160ms]",
 };
 
 const variantClasses: Record<DialogVariantType, string> = {
@@ -91,7 +91,7 @@ const variantClasses: Record<DialogVariantType, string> = {
     "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
   ),
   command: cn(
-    "top-[20%] duration-150 ease-emphasized data-[state=closed]:duration-100 motion-reduce:animate-none",
+    "top-[20%] duration-[220ms] ease-[cubic-bezier(0.16,1,0.3,1)] data-[state=closed]:duration-[160ms] motion-reduce:animate-none",
     "data-[state=open]:animate-in data-[state=closed]:animate-out",
     "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
     "data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2"

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -94,11 +94,12 @@ const variantClasses: Record<DialogVariantType, string> = {
   ),
   command: cn(
     // Command palette opens on every keyboard shortcut invocation, so it
-    // gets a snappier timing than the default modal variant.
+    // gets a snappier timing than the default modal variant. No zoom/scale
+    // here (unlike the default variant) — a plain fade + slide reads as a
+    // quick glide instead of a "pop".
     "top-[20%] duration-150 ease-emphasized data-[state=closed]:duration-100 motion-reduce:animate-none",
     "data-[state=open]:animate-in data-[state=closed]:animate-out",
     "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-    "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
     "data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2"
   ),
 };

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -32,7 +32,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 duration-200 ease-emphasized data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-150 motion-reduce:animate-none",
+      "fixed inset-0 z-50 ease-emphasized data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none",
       "bg-muted-foreground/75 dark:bg-muted-background/75",
       className
     )}
@@ -78,6 +78,13 @@ const growHeightClasses: Record<DialogHeightType, string> = {
 const DIALOG_VARIANTS = ["default", "command"] as const;
 type DialogVariantType = (typeof DIALOG_VARIANTS)[number];
 
+// The overlay fades in/out in lockstep with the content, so its duration
+// must match the content's duration per variant (see variantClasses below).
+const overlayVariantClasses: Record<DialogVariantType, string> = {
+  default: "duration-200 data-[state=closed]:duration-150",
+  command: "duration-150 data-[state=closed]:duration-100",
+};
+
 const variantClasses: Record<DialogVariantType, string> = {
   default: cn(
     "top-[50%] translate-y-[-50%] duration-200 ease-emphasized data-[state=closed]:duration-150 motion-reduce:animate-none",
@@ -86,7 +93,9 @@ const variantClasses: Record<DialogVariantType, string> = {
     "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
   ),
   command: cn(
-    "top-[20%] duration-200 ease-emphasized data-[state=closed]:duration-150 motion-reduce:animate-none",
+    // Command palette opens on every keyboard shortcut invocation, so it
+    // gets a snappier timing than the default modal variant.
+    "top-[20%] duration-150 ease-emphasized data-[state=closed]:duration-100 motion-reduce:animate-none",
     "data-[state=open]:animate-in data-[state=closed]:animate-out",
     "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
     "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -172,7 +181,9 @@ const DialogContent = React.forwardRef<
 
     return (
       <DialogPortal container={mountPortalContainer}>
-        <DialogOverlay />
+        <DialogOverlay
+          className={overlayVariantClasses[variant ?? "default"]}
+        />
         <FocusScope trapped={trapFocusScope} asChild>
           <DialogPrimitive.Content
             ref={ref}

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -78,8 +78,6 @@ const growHeightClasses: Record<DialogHeightType, string> = {
 const DIALOG_VARIANTS = ["default", "command"] as const;
 type DialogVariantType = (typeof DIALOG_VARIANTS)[number];
 
-// The overlay fades in/out in lockstep with the content, so its duration
-// must match the content's duration per variant (see variantClasses below).
 const overlayVariantClasses: Record<DialogVariantType, string> = {
   default: "duration-200 data-[state=closed]:duration-150",
   command: "duration-150 data-[state=closed]:duration-100",
@@ -93,10 +91,6 @@ const variantClasses: Record<DialogVariantType, string> = {
     "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
   ),
   command: cn(
-    // Command palette opens on every keyboard shortcut invocation, so it
-    // gets a snappier timing than the default modal variant. No zoom/scale
-    // here (unlike the default variant) — a plain fade + slide reads as a
-    // quick glide instead of a "pop".
     "top-[20%] duration-150 ease-emphasized data-[state=closed]:duration-100 motion-reduce:animate-none",
     "data-[state=open]:animate-in data-[state=closed]:animate-out",
     "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",


### PR DESCRIPTION
## Summary
- Add a "Commands" section to the cmd-k palette with a "Switch to light/dark appearance" entry that toggles the theme via `ThemeContext`.
- The command icon and label reflect the current theme, and executing it closes the palette immediately (like pod navigation) rather than entering the action phase.

## Test plan
- [ ] Open cmd-k, confirm the "Switch to dark/light appearance" command appears and toggles the theme
- [ ] Confirm search filtering still matches the command by its label
- [ ] Confirm agents/pods/skills sections and keyboard navigation still work correctly with the new command entry