### PR TITLE
feat(workspace-analytics): move get_credit_timeseries onto the consumption index

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
@@ -22,6 +22,7 @@ const TIMESERIES: GetConsumptionTimeseriesResponse = {
   granularity: "day",
   mode: "daily",
   metric: "credit_micro",
+  timezone: "UTC",
   breakdownBy: null,
   groups: [{ groupKey: "total", name: "Total" }],
   points: [],

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -12,6 +12,7 @@ import { ConsumptionPeriodSchema } from "@app/lib/api/analytics/consumption/sche
 import {
   CONSUMPTION_INVOCATION_DIMENSIONS,
   CONSUMPTION_MESSAGE_DIMENSIONS,
+  CONSUMPTION_SCOPE_DIMENSIONS,
   CONSUMPTION_TOP_DIMENSIONS,
 } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
@@ -34,18 +35,17 @@ const getConsumptionOverviewSchema = {
 
 const getCreditTimeseriesSchema = {
   ...timeWindowSchemaShape,
-  ...usageFilterSchema,
+  ...consumptionFilterSchema,
   granularity: z
     .enum(["day", "week", "month"])
     .optional()
     .describe("Bucket granularity for the credit trend (default day)."),
   breakdownBy: z
-    .enum(["agent", "user", "model"])
+    .enum(CONSUMPTION_SCOPE_DIMENSIONS)
     .optional()
     .describe(
-      "Split each bucket into the top agents, users or models by credits, " +
-        "plus an 'other' series for the rest. Omit for a single total-credits " +
-        "trend."
+      "Split each bucket by this dimension — its top groups plus an 'others' " +
+        "series for the rest. Omit for a single total-credits trend."
     ),
   breakdownLimit: z
     .number()
@@ -56,7 +56,7 @@ const getCreditTimeseriesSchema = {
     .describe(
       `Number of top groups to break out when breakdownBy is set ` +
         `(default ${DEFAULT_CREDIT_GROUPS}, max ${MAX_CREDIT_GROUPS}); the ` +
-        `remainder is folded into 'other'.`
+        `remainder is folded into 'others'.`
     ),
 };
 
@@ -205,24 +205,18 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_credit_timeseries",
     description:
-      "Return estimated credit consumption as a time series over a window " +
-      "(defaults to the last 30 days), bucketed by day, week, or month. Set " +
-      "breakdownBy to split each " +
-      "bucket into the top agents, users or models plus an 'other' series (a " +
-      "stacked trend). Use this for credit/spend TRENDS over time. Use " +
-      `${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} for a single window's total ` +
-      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute it. ` +
-      "These figures are ESTIMATES. Always tell the user they are " +
-      "approximate " +
-      "and point them to the workspace Usage page for exact, billed credit " +
-      "amounts. Chart the result. Optionally filter by source (context_origin), " +
-      "agent, user, tag, or model. Admin-only.",
+      "Return credit consumption as a time series over a window (defaults to " +
+      "the last 30 days), bucketed by day, week or month. Use this to answer " +
+      "'is credit spend trending up or down' or 'which week had the highest " +
+      `spend'. For a single window use ${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} ` +
+      `for the total and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} for the ` +
+      "breakdown. Chart the result.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Estimating credit trend",
-      done: "Estimated credit trend",
+      running: "Retrieving credit trend",
+      done: "Retrieved credit trend",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -45,6 +45,7 @@ import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messag
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -238,19 +239,16 @@ async function renderRanking(
   return new Ok([{ type: "text" as const, text }]);
 }
 
-function dayOf(timestampMs: number): string {
-  return new Date(timestampMs).toISOString().slice(0, 10);
-}
-
 function formatCreditLine(
   point: ConsumptionTimeseriesPoint,
-  groups: ConsumptionTimeseriesGroup[]
+  groups: ConsumptionTimeseriesGroup[],
+  tz: string
 ): string {
   const parts = groups.map(
     ({ groupKey, name }) =>
       `${name}: ${(point.values[groupKey] ?? 0).toFixed(2)}`
   );
-  return `${dayOf(point.timestamp)} — ${parts.join(", ")}`;
+  return `${formatDateFromMillis(point.timestamp, tz)} — ${parts.join(", ")}`;
 }
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
@@ -377,7 +375,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
-    const { filter, agentTagIds } = toConsumptionScope(input);
+    const filter = toConsumptionScope(input);
 
     const result = await fetchConsumptionTimeseries(auth, {
       period: toConsumptionPeriod(window.value),
@@ -386,7 +384,6 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       breakdownBy,
       breakdownCount: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
       filter,
-      agentTagIds,
       timezone: window.value.timezone,
     });
 
@@ -413,7 +410,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       ]);
     }
 
-    const lines = active.map((point) => formatCreditLine(point, groups));
+    const lines = active.map((point) => formatCreditLine(point, groups, tz));
 
     return new Ok([
       {

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -28,6 +28,11 @@ import type {
 } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import type {
+  ConsumptionTimeseriesGroup,
+  ConsumptionTimeseriesPoint,
+} from "@app/lib/api/analytics/consumption/timeseries";
+import { fetchConsumptionTimeseries } from "@app/lib/api/analytics/consumption/timeseries";
+import type {
   ConsumptionTopGroup,
   ResolvedConsumptionGroup,
 } from "@app/lib/api/analytics/consumption/top";
@@ -36,10 +41,6 @@ import {
   resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import {
-  fetchCreditTimeseries,
-  fetchCreditTimeseriesBreakdown,
-} from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
@@ -237,6 +238,21 @@ async function renderRanking(
   return new Ok([{ type: "text" as const, text }]);
 }
 
+function dayOf(timestampMs: number): string {
+  return new Date(timestampMs).toISOString().slice(0, 10);
+}
+
+function formatCreditLine(
+  point: ConsumptionTimeseriesPoint,
+  groups: ConsumptionTimeseriesGroup[]
+): string {
+  const parts = groups.map(
+    ({ groupKey, name }) =>
+      `${name}: ${(point.values[groupKey] ?? 0).toFixed(2)}`
+  );
+  return `${dayOf(point.timestamp)} — ${parts.join(", ")}`;
+}
+
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   get_agent_details: async ({ agentId }, { auth }) => {
     const deniedError = workspaceManagerGuard(auth);
@@ -349,20 +365,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_credit_timeseries: async (
-    {
-      granularity,
-      breakdownBy,
-      breakdownLimit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
+    { granularity = "day", breakdownBy, breakdownLimit, ...input },
     { auth }
   ) => {
     const deniedError = workspaceManagerGuard(auth);
@@ -370,116 +373,53 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow(
-      { period, startDate, endDate, timezone },
-      "last_30_days"
-    );
+    const window = resolveTimeWindow(input, "last_30_days");
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
+    const { filter, agentTagIds } = toConsumptionScope(input);
 
-    const { label, timezone: tz } = window.value;
-    const interval = granularity ?? "day";
-    const estimateNote =
-      "These are estimates — point the user to the workspace Usage page for " +
-      "exact billed credits";
-
-    if (breakdownBy) {
-      const result = await fetchCreditTimeseriesBreakdown(auth, {
-        startDate: window.value.startDate,
-        endDate: window.value.endDate,
-        granularity: interval,
-        timezone: window.value.timezone,
-        breakdownBy,
-        limit: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
-        contextOrigin: source,
-        agentIds,
-        userIds,
-        agentTagIds,
-        modelIds,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to estimate credit trend: ${result.error.message}`
-          )
-        );
-      }
-
-      const { groups, points } = result.value;
-      if (
-        groups.length === 0 ||
-        points.every((point) => point.totalCredits === 0)
-      ) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `No credit usage recorded for ${label} (${tz}).`,
-          },
-        ]);
-      }
-
-      const series = [...groups.map((group) => group.name), "Other"].join(", ");
-      const lines = points.map((point) => {
-        const parts = groups.map(
-          (group, index) => `${group.name} ${point.groupCredits[index]}`
-        );
-        parts.push(`Other ${point.otherCredits}`);
-        return `${point.date}: ${parts.join(", ")} (total ${point.totalCredits})`;
-      });
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text:
-            `Estimated credit usage per ${interval} for ${label} (${tz}), top ` +
-            `${groups.length} ${breakdownBy}s plus 'other'. ${estimateNote}.\n` +
-            `Series: ${series}\n` +
-            lines.join("\n"),
-        },
-      ]);
-    }
-
-    const result = await fetchCreditTimeseries(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      granularity: interval,
-      timezone: window.value.timezone,
-      contextOrigin: source,
-      agentIds,
-      userIds,
+    const result = await fetchConsumptionTimeseries(auth, {
+      period: toConsumptionPeriod(window.value),
+      granularity,
+      mode: "daily",
+      breakdownBy,
+      breakdownCount: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
+      filter,
       agentTagIds,
-      modelIds,
+      timezone: window.value.timezone,
     });
 
     if (result.isErr()) {
       return new Err(
-        new MCPError(`Failed to estimate credit trend: ${result.error.message}`)
+        new MCPError(
+          `Failed to retrieve the credit trend: ${result.error.message}`
+        )
       );
     }
 
-    const points = result.value;
+    const { label, timezone: tz } = window.value;
+    const { groups, points } = result.value;
+    const active = points.filter((point) =>
+      Object.values(point.values).some((value) => value > 0)
+    );
 
-    if (points.every((point) => point.totalCredits === 0)) {
+    if (active.length === 0) {
       return new Ok([
         {
           type: "text" as const,
-          text: `No credit usage recorded for ${label} (${tz}).`,
+          text: `No credit consumption recorded for ${label} (${tz}).`,
         },
       ]);
     }
 
-    const lines = points.map(
-      (point) => `${point.date}: ${point.totalCredits} credits`
-    );
+    const lines = active.map((point) => formatCreditLine(point, groups));
 
     return new Ok([
       {
         type: "text" as const,
         text:
-          `Estimated credit usage per ${interval} for ${label} (${tz}). ` +
-          `${estimateNote}:\n` +
+          `Credits per ${granularity} for ${label} (${tz}):\n` +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -7,6 +7,7 @@ import type {
   ConsumptionScopeFilter,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
+  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
@@ -54,6 +55,7 @@ export type ConsumptionTimeseries = {
   granularity: ConsumptionGranularity;
   mode: ConsumptionTimeseriesMode;
   metric: ConsumptionMetric;
+  timezone: string;
   breakdownBy: ConsumptionBreakdownDimension | null;
   // In rank order, highest consumption first, with "others" last when present.
   groups: ConsumptionTimeseriesGroup[];
@@ -67,6 +69,7 @@ type ConsumptionTimeseriesScope = {
   granularity: ConsumptionGranularity;
   mode: ConsumptionTimeseriesMode;
   metric: ConsumptionMetric;
+  timezone: string;
 };
 
 type DateBucket = {
@@ -102,6 +105,8 @@ export async function fetchConsumptionTimeseries(
     breakdownBy,
     breakdownCount = DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
     filter,
+    agentTagIds,
+    timezone = "UTC",
   }: {
     period: ConsumptionPeriod;
     granularity: ConsumptionGranularity;
@@ -110,6 +115,8 @@ export async function fetchConsumptionTimeseries(
     breakdownBy?: ConsumptionBreakdownDimension | null;
     breakdownCount?: number;
     filter?: ConsumptionScopeFilter;
+    agentTagIds?: string[];
+    timezone?: string;
   }
 ): Promise<Result<ConsumptionTimeseries, ElasticsearchError>> {
   const query = buildConsumptionScopeQuery({
@@ -117,8 +124,9 @@ export async function fetchConsumptionTimeseries(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
+    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
-  const scope = { period, granularity, mode, metric };
+  const scope = { period, granularity, mode, metric, timezone };
 
   if (!breakdownBy) {
     return fetchTimeseries(query, scope);
@@ -138,6 +146,7 @@ async function fetchTimeseries(
   const bucketsResult = await fetchMetricTimeseries(query, {
     period: scope.period,
     granularity: scope.granularity,
+    timezone: scope.timezone,
     metric: scope.metric,
     breakdown: null,
   });
@@ -189,6 +198,7 @@ async function fetchTimeseriesBreakdown(
   const bucketsResult = await fetchMetricTimeseries(query, {
     period: scope.period,
     granularity: scope.granularity,
+    timezone: scope.timezone,
     metric: scope.metric,
     breakdown: { field, groupKeys: topDimensionKeys },
   });
@@ -231,11 +241,13 @@ async function fetchMetricTimeseries(
   {
     period,
     granularity,
+    timezone,
     metric,
     breakdown,
   }: {
     period: ConsumptionPeriod;
     granularity: ConsumptionGranularity;
+    timezone: string;
     metric: ConsumptionMetric;
     breakdown: ConsumptionBreakdown | null;
   }
@@ -248,7 +260,7 @@ async function fetchMetricTimeseries(
           date_histogram: {
             field: COMPLETED_AT_FIELD,
             calendar_interval: granularity,
-            time_zone: "UTC",
+            time_zone: timezone,
             min_doc_count: 0,
             extended_bounds: {
               min: new Date(period.startDate).getTime(),

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -7,7 +7,6 @@ import type {
   ConsumptionScopeFilter,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
@@ -105,7 +104,6 @@ export async function fetchConsumptionTimeseries(
     breakdownBy,
     breakdownCount = DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
     filter,
-    agentTagIds,
     timezone = "UTC",
   }: {
     period: ConsumptionPeriod;
@@ -115,7 +113,6 @@ export async function fetchConsumptionTimeseries(
     breakdownBy?: ConsumptionBreakdownDimension | null;
     breakdownCount?: number;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     timezone?: string;
   }
 ): Promise<Result<ConsumptionTimeseries, ElasticsearchError>> {
@@ -124,7 +121,6 @@ export async function fetchConsumptionTimeseries(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
   const scope = { period, granularity, mode, metric, timezone };
 


### PR DESCRIPTION
Fourth of five — on #31300, itself on #31290 and #31273. Review those first; this diff is against #31300's branch.

## Description

`get_credit_timeseries` is the last credit-trend reader of `front.agent_message_analytics`; re-pointed at the consumption index, same shape.

`fetchConsumptionTimeseries` covers the trend once it takes a `timezone` — it hardcoded `"UTC"`, which cut the first and last bucket in the wrong place for any caller resolving its window in another zone — plus the `extraFilters` passthrough the rest of the stack uses for agent tags.

`get_usage_timeseries` stays on the legacy index for now; it moves in the next PR of the stack.

## Tests

- `timeseries.test.ts`: timezone-aware bucketing.
- Review fix: date labels used a bare UTC slice instead of `formatDateFromMillis`, off by a day for timezones ahead of UTC.

## Risk

Medium. The tool changes index, and message counts become billed messages only — the consumption indexer skips failed and unbilled messages. Callers are `@analyst` only.

Note the legacy `lib/api/assistant/observability/*` fetchers stay: the old analytics UI, Poke pages and CSV exports still read them, and need their own audit before the index is dropped.

## Deploy Plan

Merge after #31300. Fourth of five: credits ranking → count rankings → overview → credit timeseries → usage timeseries.
