### PR TITLE
[front] fix: track extension use without origin

### DIFF
--- a/front-api/routes/w/[wId]/extension/config.test.ts
+++ b/front-api/routes/w/[wId]/extension/config.test.ts
@@ -1,66 +1,29 @@
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import {
-  CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
-  FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
-} from "@app/types/extension";
+import { EXTENSION_LAST_USED_AT_METADATA_KEY } from "@app/types/extension";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
-const CHROME_EXTENSION_ORIGIN =
-  "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn";
-
 describe("GET /api/w/:wId/extension/config", () => {
-  it("records the latest Chrome extension use date", async () => {
+  it("records the latest extension use date without relying on Origin", async () => {
     const { user, workspace } = await createPrivateApiMockRequest();
     await user.setMetadata(
-      CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+      EXTENSION_LAST_USED_AT_METADATA_KEY,
       "2026-01-01T00:00:00.000Z"
     );
     const beforeRequestMs = Date.now();
 
     const response = await honoApp.request(
-      `/api/w/${workspace.sId}/extension/config`,
-      { headers: { origin: CHROME_EXTENSION_ORIGIN } }
+      `/api/w/${workspace.sId}/extension/config`
     );
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ blacklistedDomains: [] });
 
     const metadata = await user.getMetadata(
-      CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY
+      EXTENSION_LAST_USED_AT_METADATA_KEY
     );
     const lastUsedAtMs = Date.parse(metadata?.value ?? "");
     expect(lastUsedAtMs).toBeGreaterThanOrEqual(beforeRequestMs);
     expect(lastUsedAtMs).toBeLessThanOrEqual(Date.now());
-    expect(
-      await user.getMetadata(FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY)
-    ).toBeNull();
-  });
-
-  it("records the latest Firefox extension use date", async () => {
-    const { user, workspace } = await createPrivateApiMockRequest();
-    await user.setMetadata(
-      FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
-      "2026-01-01T00:00:00.000Z"
-    );
-    const beforeRequestMs = Date.now();
-
-    const response = await honoApp.request(
-      `/api/w/${workspace.sId}/extension/config`,
-      { headers: { origin: "moz-extension://dust" } }
-    );
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ blacklistedDomains: [] });
-
-    const metadata = await user.getMetadata(
-      FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY
-    );
-    const lastUsedAtMs = Date.parse(metadata?.value ?? "");
-    expect(lastUsedAtMs).toBeGreaterThanOrEqual(beforeRequestMs);
-    expect(lastUsedAtMs).toBeLessThanOrEqual(Date.now());
-    expect(
-      await user.getMetadata(CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY)
-    ).toBeNull();
   });
 });

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -1,9 +1,6 @@
 import type { GetExtensionConfigResponseBody } from "@app/lib/resources/extension";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
-import {
-  CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
-  FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
-} from "@app/types/extension";
+import { EXTENSION_LAST_USED_AT_METADATA_KEY } from "@app/types/extension";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -43,22 +40,12 @@ app.get("/", async (ctx): HandlerResult<GetExtensionConfigResponseBody> => {
 
   const config = await ExtensionConfigurationResource.fetchForWorkspace(auth);
 
-  const origin = ctx.req.header("origin");
-  if (origin?.startsWith("chrome-extension://")) {
-    await auth
-      .user()
-      ?.setMetadata(
-        CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
-        new Date().toISOString()
-      );
-  } else if (origin?.startsWith("moz-extension://")) {
-    await auth
-      .user()
-      ?.setMetadata(
-        FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
-        new Date().toISOString()
-      );
-  }
+  await auth
+    .user()
+    ?.setMetadata(
+      EXTENSION_LAST_USED_AT_METADATA_KEY,
+      new Date().toISOString()
+    );
 
   return ctx.json({
     blacklistedDomains: config?.blacklistedDomains ?? [],

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -35,8 +35,7 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
 import {
-  CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
-  FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
+  EXTENSION_LAST_USED_AT_METADATA_KEY,
   shouldShowExtensionMenu,
 } from "@app/types/extension";
 import type { SubscriptionType } from "@app/types/plan";
@@ -118,13 +117,10 @@ export function UserMenu({
 
   const isFirefox =
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
-  const extensionLastUsedAtMetadataKey = isFirefox
-    ? FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY
-    : CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY;
   const {
     metadata: extensionLastUsedAt,
     isMetadataLoading: isExtensionLastUsedAtLoading,
-  } = useUserMetadata(extensionLastUsedAtMetadataKey);
+  } = useUserMetadata(EXTENSION_LAST_USED_AT_METADATA_KEY);
   const showExtensionMenu =
     !isExtensionLastUsedAtLoading &&
     shouldShowExtensionMenu(extensionLastUsedAt?.value);

--- a/front/types/extension.ts
+++ b/front/types/extension.ts
@@ -1,9 +1,6 @@
 import type { ModelId } from "./shared/model_id";
 
-export const CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY =
-  "chromeExtensionLastUsedAt";
-export const FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY =
-  "firefoxExtensionLastUsedAt";
+export const EXTENSION_LAST_USED_AT_METADATA_KEY = "extension_last_used_at";
 
 // Resurface the install link after three months without extension activity.
 export const EXTENSION_MENU_REDISPLAY_THRESHOLD_MS = 90 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Description

Follow-up on #31144. The platform detection we put in place there did not work, Chrome extension config requests can omit the `Origin` header.

This PR replaces this to use a single key for both Chrome and Firefox that is always upserted.

## Tests

- Updated tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
