### PR TITLE
Remove live_speech_to_text FF.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -48,7 +48,6 @@ import {
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
-import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -77,10 +76,7 @@ import {
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
-import {
-  assertNever,
-  assertNeverAndIgnore,
-} from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -1012,42 +1008,7 @@ const InputBarContainer = ({
     });
   }, [attachedNodes]);
 
-  const isLiveStt = hasFeature("live_speech_to_text");
-
-  const voiceTranscriberService = useVoiceTranscriberService({
-    owner,
-    fileUploaderService,
-    onTranscribeComplete: (transcript) => {
-      for (const message of transcript) {
-        switch (message.type) {
-          case "text":
-            editorService.insertText(message.text);
-            break;
-          case "mention": {
-            const agent = agentsById.get(message.id);
-            if (agent) {
-              handleSingleAgentSelect(toRichAgentMentionType(agent));
-            }
-            break;
-          }
-          default:
-            assertNever(message);
-        }
-      }
-      if (isCompactRef.current) {
-        void submitCompactVoiceMessageRef.current?.();
-      }
-    },
-    onError: (error) => {
-      sendNotification({
-        type: "error",
-        title: "Failed to transcribe voice",
-        description: normalizeError(error).message,
-      });
-    },
-  });
-
-  const voiceLiveTranscriberService = useVoiceLiveTranscriberService({
+  const activeVoiceService = useVoiceLiveTranscriberService({
     owner,
     onPartialTranscript: (text) => {
       editorService.setVoicePartialText(text);
@@ -1069,10 +1030,6 @@ const InputBarContainer = ({
       });
     },
   });
-
-  const activeVoiceService = isLiveStt
-    ? voiceLiveTranscriberService
-    : voiceTranscriberService;
 
   // Keep the editor non-editable while the input is fully disabled (e.g. a
   // non-owner viewing a conversation with an active wake-up). The placeholder

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -28,12 +28,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "tdraier",
   },
-  live_speech_to_text: {
-    description:
-      "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",
-    stage: "dust_only",
-    owner: "adrsimon",
-  },
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -813,7 +813,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_dust_keys"
   | "sensitivity_labels"
   | "use_vertex_for_supported_models"
-  | "live_speech_to_text"
   | "workspace_default_agent"
   | "whitelabel_frames"
   | "user_memory"


### PR DESCRIPTION
## Description

Removes the `live_speech_to_text` feature flag and the legacy `useVoiceTranscriberService` fallback from `InputBarContainer`. The input bar now uses `useVoiceLiveTranscriberService` unconditionally, and the JS SDK whitelist schema no longer exposes the retired flag.

## Tests

Not run; this is a frontend and SDK cleanup with no new test coverage.

## Risk

Low. The change removes a retired code path and makes the existing live transcription service authoritative. Rollback is a single revert.

## Deploy Plan

Deploy `front`. Publish the JS SDK package with the updated whitelistable feature type if SDK artifacts are released independently. No SQL migrations or infrastructure changes.