### PR TITLE
[front] enh: show more rows in manage table skeletons

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -48,6 +48,8 @@ import type { CellContext, HeaderContext } from "@tanstack/react-table";
 import type { ComponentType, ReactNode } from "react";
 import { useMemo, useState } from "react";
 
+const SKELETON_ROW_COUNT = 16;
+
 type RowData = {
   sId: string;
   name: string;
@@ -70,7 +72,7 @@ type RowData = {
 };
 
 const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
-  { length: 20 },
+  { length: SKELETON_ROW_COUNT },
   (_, index) => ({
     sId: `assistant-skeleton-${index}`,
     name: "",

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -70,7 +70,7 @@ type RowData = {
 };
 
 const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
-  { length: 5 },
+  { length: 10 },
   (_, index) => ({
     sId: `assistant-skeleton-${index}`,
     name: "",
@@ -91,6 +91,8 @@ const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
 );
 
 function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
+  const rowVariant = rowIndex % 5;
+
   switch (columnId) {
     case "select":
       return (
@@ -108,7 +110,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex]
+                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowVariant]
                   )}
                 />
               </div>
@@ -116,7 +118,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex]
+                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowVariant]
                   )}
                 />
               </div>
@@ -132,7 +134,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
             <LoadingBlock
               className={classNames(
                 "ml-2 hidden h-3 @xl:block",
-                ["w-20", "w-24", "w-16", "w-28", "w-20"][rowIndex]
+                ["w-20", "w-24", "w-16", "w-28", "w-20"][rowVariant]
               )}
             />
           </div>
@@ -144,7 +146,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-6 rounded-[9px]",
-              ["w-20", "w-24", "w-20", "w-24", "w-20"][rowIndex]
+              ["w-20", "w-24", "w-20", "w-24", "w-20"][rowVariant]
             )}
           />
         </DataTable.CellContent>
@@ -168,7 +170,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3 max-w-full",
-              ["w-14", "w-20", "w-12", "w-24", "w-16"][rowIndex]
+              ["w-14", "w-20", "w-12", "w-24", "w-16"][rowVariant]
             )}
           />
         </DataTable.CellContent>
@@ -180,7 +182,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex]
+              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowVariant]
             )}
           />
         </DataTable.CellContent>
@@ -191,7 +193,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex]
+              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowVariant]
             )}
           />
         </DataTable.CellContent>

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -70,7 +70,7 @@ type RowData = {
 };
 
 const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
-  { length: 10 },
+  { length: 20 },
   (_, index) => ({
     sId: `assistant-skeleton-${index}`,
     name: "",

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -33,6 +33,8 @@ import type {
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
+const SKELETON_ROW_COUNT = 16;
+
 // A Dust-provided skill can never be edited, and a "members and agents"
 // skill can only be batch-edited by someone who can make skills auto-discoverable.
 export function isSkillSelectable(
@@ -62,7 +64,7 @@ type RowData = {
 };
 
 const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
-  { length: 20 },
+  { length: SKELETON_ROW_COUNT },
   (_, index) => ({
     sId: `skill-skeleton-${index}`,
     name: "",

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -62,7 +62,7 @@ type RowData = {
 };
 
 const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
-  { length: 10 },
+  { length: 20 },
   (_, index) => ({
     sId: `skill-skeleton-${index}`,
     name: "",

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -62,7 +62,7 @@ type RowData = {
 };
 
 const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
-  { length: 5 },
+  { length: 10 },
   (_, index) => ({
     sId: `skill-skeleton-${index}`,
     name: "",
@@ -81,6 +81,8 @@ const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
 );
 
 function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
+  const rowVariant = rowIndex % 5;
+
   switch (columnId) {
     case "select":
       return (
@@ -98,7 +100,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex]
+                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowVariant]
                   )}
                 />
               </div>
@@ -106,7 +108,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex]
+                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowVariant]
                   )}
                 />
               </div>
@@ -120,7 +122,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-6 rounded-[9px]",
-              ["w-20", "w-28", "w-24", "w-28", "w-20"][rowIndex]
+              ["w-20", "w-28", "w-24", "w-28", "w-20"][rowVariant]
             )}
           />
         </DataTable.CellContent>
@@ -131,7 +133,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-5 rounded-md",
-              ["w-14", "w-16", "w-12", "w-20", "w-14"][rowIndex]
+              ["w-14", "w-16", "w-12", "w-20", "w-14"][rowVariant]
             )}
           />
         </div>
@@ -142,7 +144,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex]
+              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowVariant]
             )}
           />
         </DataTable.CellContent>
@@ -166,7 +168,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex]
+              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowVariant]
             )}
           />
         </DataTable.CellContent>


### PR DESCRIPTION
## Description

Manage Agents and Manage Skills currently show only five rows while their tables load, leaving the loading state visually sparse.

Increase both table skeletons to ten rows and cycle the existing width variants so every added row keeps the same destination-shaped cell geometry.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.