### PR TITLE
fix(front): allow pod tab deletion when other tabs have stale paths

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -18,9 +18,16 @@ vi.mock("@app/temporal/project_task/client", () => ({
 }));
 
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType } from "@app/types/files";
+import {
+  DEFAULT_POD_FRAME_TAB_ICON,
+  normalizeTabsOrder,
+} from "@app/types/pod_frame_tab";
 
 import { honoApp } from "@front-api/app";
 
@@ -221,6 +228,72 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("allows removing a frame tab when another tab has a stale path", async () => {
+    const { workspace, auth, user } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    await FeatureFlagFactory.basic(auth, "pod_frame_tabs");
+
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+
+    const validFrame = await ProjectFileFactory.create(
+      auth,
+      user,
+      projectSpace,
+      {
+        contentType: frameContentType,
+        fileName: "MyView.tsx",
+        fileSize: 100,
+        status: "ready",
+      }
+    );
+    const validPath = validFrame.toScopedPath(auth);
+    if (!validPath) {
+      throw new Error("Expected a scoped Pod Frame path.");
+    }
+
+    const stalePath = `pod-${projectSpace.sId}/frames/Activity.tsx`;
+    const framePaths = [stalePath, validPath];
+
+    await ProjectMetadataResource.makeNew(auth, projectSpace, {
+      description: null,
+      frameTabs: [
+        {
+          path: stalePath,
+          title: "Activity",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+        {
+          path: validPath,
+          title: "My View",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ],
+      tabsOrder: normalizeTabsOrder([stalePath, validPath], framePaths),
+    });
+
+    const response = await patchMetadata(workspace, projectSpace.sId, {
+      frameTabs: [
+        {
+          path: stalePath,
+          title: "Activity",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ],
+      tabsOrder: normalizeTabsOrder([stalePath], [stalePath]),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).projectMetadata.frameTabs).toEqual([
+      {
+        path: stalePath,
+        title: "Activity",
+        icon: DEFAULT_POD_FRAME_TAB_ICON,
+      },
+    ]);
   });
 
   it("restarts project tasks workflow when unarchiving a project", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -14,6 +14,7 @@ import type {
   PatchPodMetadataResponseBody,
 } from "@app/types/api/projects/metadata";
 import { PatchPodMetadataBodySchema } from "@app/types/api/spaces";
+import { resolveCanonicalScopedPath } from "@app/types/mount_path";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -157,11 +158,27 @@ app.patch(
         });
       }
 
+      const existingMetadata = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        space
+      );
+      const existingFrameTabPaths = new Set(
+        (existingMetadata?.frameTabs ?? [])
+          .map((tab) =>
+            resolveCanonicalScopedPath(tab.path, {
+              conversationId: null,
+              spaceId: space.sId,
+            })
+          )
+          .filter((path): path is string => path !== null)
+      );
+
       const validation = await validatePodFrameTabs(
         auth,
         space,
         body.frameTabs,
-        body.tabsOrder
+        body.tabsOrder,
+        { existingFrameTabPaths }
       );
       if (validation.isErr()) {
         return apiError(ctx, {

--- a/front/lib/api/projects/frame_tabs.test.ts
+++ b/front/lib/api/projects/frame_tabs.test.ts
@@ -1,0 +1,135 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { validatePodFrameTabs } from "@app/lib/api/projects/frame_tabs";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { DustFileSystemError } from "@app/types/file_system";
+import { frameContentType } from "@app/types/files";
+import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("validatePodFrameTabs", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips file existence checks for existing frame tab paths", async () => {
+    const {
+      authenticator: auth,
+      workspace,
+      user,
+    } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const stalePath = `pod-${pod.sId}/frames/Activity.tsx`;
+    const newPath = `pod-${pod.sId}/frames/New.tsx`;
+
+    const stat = vi.fn(async (path: string) => {
+      if (path === newPath) {
+        return new Ok({ contentType: frameContentType, sizeBytes: 100 });
+      }
+      return new Ok(null);
+    });
+
+    vi.spyOn(DustFileSystem, "forPod").mockResolvedValue(
+      new Ok({ stat } as unknown as DustFileSystem)
+    );
+
+    const result = await validatePodFrameTabs(
+      auth,
+      pod,
+      [
+        {
+          path: stalePath,
+          title: "Activity",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+        {
+          path: newPath,
+          title: "New",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ],
+      [
+        "conversations",
+        "tasks",
+        "files",
+        "apps",
+        "connected_data",
+        stalePath,
+        newPath,
+      ],
+      { existingFrameTabPaths: new Set([stalePath]) }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(stat).not.toHaveBeenCalledWith(stalePath);
+    expect(stat).toHaveBeenCalledWith(newPath);
+  });
+
+  it("rejects new frame tabs whose files are missing", async () => {
+    const {
+      authenticator: auth,
+      workspace,
+      user,
+    } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const missingPath = `pod-${pod.sId}/frames/Missing.tsx`;
+
+    vi.spyOn(DustFileSystem, "forPod").mockResolvedValue(
+      new Ok({
+        stat: vi.fn(async () => new Ok(null)),
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await validatePodFrameTabs(
+      auth,
+      pod,
+      [
+        {
+          path: missingPath,
+          title: "Missing",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ],
+      ["conversations", "tasks", "files", "apps", "connected_data", missingPath]
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        `Frame tab file not found: ${missingPath}`
+      );
+    }
+  });
+
+  it("returns an error when the file system cannot be initialized", async () => {
+    const {
+      authenticator: auth,
+      workspace,
+      user,
+    } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    vi.spyOn(DustFileSystem, "forPod").mockResolvedValue(
+      new Err(new DustFileSystemError("unauthorized", "Unauthorized"))
+    );
+
+    const result = await validatePodFrameTabs(
+      auth,
+      pod,
+      [],
+      ["conversations", "tasks", "files", "apps", "connected_data"]
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Failed to initialize file system.");
+    }
+  });
+});

--- a/front/lib/api/projects/frame_tabs.ts
+++ b/front/lib/api/projects/frame_tabs.ts
@@ -23,7 +23,15 @@ export async function validatePodFrameTabs(
   auth: Authenticator,
   space: SpaceResource,
   frameTabs: PodFrameTab[],
-  tabsOrder: PodTabsOrder | undefined
+  tabsOrder: PodTabsOrder | undefined,
+  options?: {
+    /**
+     * Canonical frame tab paths already stored on the Pod. File existence is
+     * not re-checked for these paths so members can remove or reorder tabs
+     * even when another tab still points at a moved or deleted Frame.
+     */
+    existingFrameTabPaths?: ReadonlySet<string>;
+  }
 ): Promise<Result<{ frameTabs: PodFrameTab[]; tabsOrder: string[] }, Error>> {
   if (frameTabs.length > MAX_POD_FRAME_TABS) {
     return new Err(
@@ -56,17 +64,23 @@ export async function validatePodFrameTabs(
     seenPaths.add(normalizedPath);
     pathRemap.set(tab.path, normalizedPath);
 
-    const statResult = await fs.stat(normalizedPath);
-    if (statResult.isErr() || !statResult.value) {
-      return new Err(new Error(`Frame tab file not found: ${normalizedPath}`));
-    }
+    const isExistingTab =
+      options?.existingFrameTabPaths?.has(normalizedPath) ?? false;
+    if (!isExistingTab) {
+      const statResult = await fs.stat(normalizedPath);
+      if (statResult.isErr() || !statResult.value) {
+        return new Err(
+          new Error(`Frame tab file not found: ${normalizedPath}`)
+        );
+      }
 
-    if (!isInteractiveContentType(statResult.value.contentType)) {
-      return new Err(
-        new Error(
-          `Frame tab path is not an interactive frame: ${normalizedPath}`
-        )
-      );
+      if (!isInteractiveContentType(statResult.value.contentType)) {
+        return new Err(
+          new Error(
+            `Frame tab path is not an interactive frame: ${normalizedPath}`
+          )
+        );
+      }
     }
 
     normalized.push({


### PR DESCRIPTION
## Description

`validatePodFrameTabs` now permits updates to retain frame tab paths already stored on a Pod, even when the corresponding Frame file was moved or deleted. New tab paths still require an existing interactive Frame, so users can remove, reorder, or rename tabs without stale entries blocking metadata updates.

## Tests

- Added unit tests for existing-path leniency, new-tab validation, and file-system initialization errors.
- Added an API integration test covering removal of a valid tab while another persisted tab has a stale path.

## Risk

Low. The change only skips revalidation for paths already persisted in Pod metadata; new tabs retain the existing checks. Rollback is safe through the standard deploy rollback path.

## Deploy Plan

Deploy `front` and `front-api`. No SQL migration, infrastructure change, or script run required.