### PR TITLE
Fix linter

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -50,7 +50,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
@@ -424,7 +424,6 @@ const InputBarContainer = ({
   onNodeSelectRef.current = onNodeSelect;
   const includeAttachKnowledgeRef = useRef(actions.includes("attachment"));
   includeAttachKnowledgeRef.current = actions.includes("attachment");
-  const { hasFeature } = useFeatureFlags();
   const includePickModelRef = useRef(false);
   includePickModelRef.current = actions.includes("model-picker");
   const modelSelectionCommitRef = useRef<


### PR DESCRIPTION
## Description

I remove the unused `useFeatureFlags` import and `hasFeature` binding from `InputBarContainer`, clearing the linter error without changing runtime behavior.

## Tests

No local tests run; CI lint validates `InputBarContainer.tsx`.

## Risk

Low risk. The removed symbols were unused, so runtime behavior is unchanged. Rollback is a one-line revert.

## Deploy Plan

Deploy `front`.