### PR TITLE
chore(front): remove unused hasFeature after models_picker flag removal

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -50,7 +50,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
@@ -424,7 +424,6 @@ const InputBarContainer = ({
   onNodeSelectRef.current = onNodeSelect;
   const includeAttachKnowledgeRef = useRef(actions.includes("attachment"));
   includeAttachKnowledgeRef.current = actions.includes("attachment");
-  const { hasFeature } = useFeatureFlags();
   const includePickModelRef = useRef(false);
   includePickModelRef.current = actions.includes("model-picker");
   const modelSelectionCommitRef = useRef<


### PR DESCRIPTION
## Description

`31210` removed the `models_picker` feature-flag usage in `InputBarContainer` but left `const { hasFeature } = useFeatureFlags();` (and the now-unused import) behind. CI runs `biome ci --error-on-warnings .` over the whole repo, and `noUnusedVariables` trips on it — so format-check is currently red on `main` and blocks every open PR. This removes the dead declaration and orphaned import.

## Risk

None. Pure dead-code removal; no behavior change.