### PR TITLE
Fix and improve unread conversations in pods.

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
@@ -118,6 +118,7 @@ app.get(
         spaceId: c.space?.sId ?? null,
         metadata: c.metadata,
         isRunningAgentLoop: c.isRunningAgentLoop,
+        isParticipant: false,
       }));
     } else {
       return apiError(ctx, {

--- a/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
@@ -55,6 +55,7 @@ const conversation: ConversationListItemType = {
   unread: false,
   updated: 1,
   isRunningAgentLoop: false,
+  isParticipant: false,
 };
 
 function makeAuthBlockedAction(

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.test.tsx
@@ -47,6 +47,7 @@ const conversation: ConversationWithoutContentType = {
   created: 1,
   hasError: false,
   isRunningAgentLoop: false,
+  isParticipant: false,
   lastReadMs: null,
   metadata: {},
   requestedSpaceIds: [],

--- a/front/components/assistant/conversation/utils.test.ts
+++ b/front/components/assistant/conversation/utils.test.ts
@@ -7,6 +7,7 @@ function makeConversation(
 ): ConversationListItemType {
   return {
     actionRequired: false,
+    isParticipant: false,
     created: 1,
     hasError: false,
     isRunningAgentLoop: false,

--- a/front/components/pod/conversation/PodConversationListItem.tsx
+++ b/front/components/pod/conversation/PodConversationListItem.tsx
@@ -17,7 +17,6 @@ export function PodConversationListItem({
 }: PodConversationListItemProps) {
   const router = useAppRouter();
   const time = moment(conversation.updated).fromNow();
-
   return (
     <>
       <ConversationListItem

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -113,6 +113,7 @@ export function useBranchConversation({
             unread: false,
             updated: nowMs,
             isRunningAgentLoop: false,
+            isParticipant: false,
           };
 
           void mutateConversations(

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -138,6 +138,7 @@ function createMockConversation(
     triggerId: null,
     metadata: {},
     isRunningAgentLoop: false,
+    isParticipant: false,
   };
 }
 

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -342,6 +342,7 @@ async function _getConversation<V extends "light" | "full">(
       })
     );
 
+    // TODO(seb) Instead of building it from scratch and duplicate logic, we should use enrichWithParticipationAndReadState and then ConversationResource.toJSON().
     const conversationType: LightConversationType & {
       hasMore?: boolean;
       lastValue?: number | null;
@@ -364,6 +365,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       isRunningAgentLoop: conversation.isRunningAgentLoop,
+      isParticipant: !!lastReadAt, // Not really true but mostly harmless here, the user could be a participant but not have read the conversation yet (eg: added by someone else) see TODO above.
       ...(forkingData && { forkingData }),
     };
 
@@ -442,6 +444,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       isRunningAgentLoop: conversation.isRunningAgentLoop,
+      isParticipant: !!lastReadAt, // Not really true but mostly harmless here, the user could be a participant but not have read the conversation yet (eg: added by someone else) see TODO above.
       ...(forkingData && { forkingData }),
     };
 

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -63,6 +63,7 @@ function createConversation(owner: LightWorkspaceType): ConversationType {
     metadata: {},
     requestedSpaceIds: [],
     isRunningAgentLoop: true,
+    isParticipant: false,
     owner,
     visibility: "unlisted",
     content: [],

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -195,6 +195,7 @@ describe("renderAllMessages", () => {
       triggerId: null,
       metadata: {},
       isRunningAgentLoop: false,
+      isParticipant: false,
     } as ConversationType;
   }
 

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -553,23 +553,36 @@ export async function toPodConversationListItem(
         })
       );
 
+      let unreadMessageCount =
+        rawMessagesByConversationId[conv.id]?.filter(
+          (message) =>
+            (message.agentMessage?.completedAt?.getTime() ??
+              message.updatedAt.getTime()) > (convJSON.lastReadMs ?? 0)
+        ).length ?? 0;
+
+      // The official rule for unread conversation is that it's updated AFTER the last read time as we don't look at individual messages timings.
+      // However, as here we are retrieving the exact count of unread messages, we DO look at the individual messages timings.
+      // In certain case, the user marked the conversation as read after the last message completion but something updated the conversation after that without adding a new message (for example, a title update).
+      // In this case, we force a unread count of 1 to make sure the conversation is displayed as unread in the Pod converations list.
+      if (
+        unreadMessageCount === 0 &&
+        conv.updatedAt > new Date(convJSON.lastReadMs ?? 0)
+      ) {
+        unreadMessageCount = 1;
+      }
+
       return {
         id: conv.sId,
         title: getConversationDisplayTitle(convJSON),
         created: conv.createdAt.getTime(),
         updated: conv.updatedAt.getTime(),
         replyCount: (rawMessagesByConversationId[conv.id]?.length ?? 1) - 1,
-        unreadMessageCount:
-          rawMessagesByConversationId[conv.id]?.filter(
-            (message) =>
-              (message.agentMessage?.completedAt?.getTime() ??
-                message.updatedAt.getTime()) >
-              (convJSON.lastReadMs ?? Date.now())
-          ).length ?? 0,
+        unreadMessageCount,
         description: firstUserMessage?.userMessage?.content ?? "",
         creator: avatars[0],
         avatars: uniqBy(avatars.slice(1).reverse(), "name"),
         isRunningAgentLoop: conv.isRunningAgentLoop,
+        isParticipant: convJSON.isParticipant,
       };
     })
   );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2057,30 +2057,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return new Err(new ConversationError("conversation_not_found"));
     }
 
-    const { actionRequired, lastReadAt } =
-      await ConversationResource.getActionRequiredAndLastReadAtForUser(
-        auth,
-        conversation.id
-      );
+    await this.enrichWithParticipationAndReadState(auth, [conversation]);
 
-    return new Ok({
-      actionRequired,
-      created: conversation.createdAt.getTime(),
-      depth: conversation.depth,
-      hasError: conversation.hasError,
-      id: conversation.id,
-      lastReadMs: lastReadAt?.getTime() ?? null,
-      metadata: conversation.metadata,
-      requestedGroupIds: [],
-      requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
-      sId: conversation.sId,
-      spaceId: conversation.space?.sId ?? null,
-      title: conversation.title,
-      triggerId: conversation.triggerSId,
-      unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
-      updated: conversation.updatedAt.getTime(),
-      isRunningAgentLoop: conversation.isRunningAgentLoop,
-    });
+    return new Ok(conversation.toJSON());
   }
 
   private static async update(
@@ -2376,21 +2355,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       };
     }
 
-    const participationMap = await this.fetchParticipationMapForUser(
-      auth,
-      conversations.map((c) => c.id)
-    );
-    const participantConversationIds = new Set(participationMap.keys());
-
-    // Attach participation data and read state to all resources.
-    conversations.forEach((c) => {
-      const participation = participationMap.get(c.id);
-      if (participation) {
-        c.userParticipation = participation;
-      }
-    });
-
-    await this.enrichWithReadState(auth, conversations);
+    await this.enrichWithParticipationAndReadState(auth, conversations);
 
     // These conversations are used to display the unread count in the sidebar.
     // We do not count conversations the user does not participate in.
@@ -2402,7 +2367,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const nonParticipantUnreadConversations = conversations.filter(
       (c) =>
-        !participantConversationIds.has(c.id) &&
+        !c.userParticipation &&
         (c.userLastReadAt === null || c.updatedAt > c.userLastReadAt)
     );
 
@@ -2832,6 +2797,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         depth: c.depth,
         metadata: c.metadata,
         isRunningAgentLoop: c.isRunningAgentLoop,
+        isParticipant: !!participation,
       };
     });
   }
@@ -2893,6 +2859,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: c.depth,
       metadata: c.metadata,
       isRunningAgentLoop: c.isRunningAgentLoop,
+      isParticipant: false,
     }));
   }
 
@@ -5345,6 +5312,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         this.userLastReadAt === null || this.updatedAt > this.userLastReadAt,
       updated: this.updatedAt.getTime(),
       isRunningAgentLoop: this.isRunningAgentLoop,
+      isParticipant: !!this.userParticipation,
     };
   }
 

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -324,5 +324,6 @@ export function mockConversation(
     visibility: "unlisted",
     content: messages,
     isRunningAgentLoop: false,
+    isParticipant: false,
   };
 }

--- a/front/types/api/assistant/conversation/spaces.ts
+++ b/front/types/api/assistant/conversation/spaces.ts
@@ -18,6 +18,7 @@ export type PodConversationListItemType = {
   replyCount: number;
   unreadMessageCount: number;
   isRunningAgentLoop: boolean;
+  isParticipant: boolean;
   description: string;
   creator: {
     name: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -601,6 +601,7 @@ export type ConversationListItemType = {
   unread: boolean;
   updated: number;
   isRunningAgentLoop: boolean;
+  isParticipant: boolean;
 };
 
 /**


### PR DESCRIPTION
## Description

Normalize conversation serialization around `ConversationResource.enrichWithParticipationAndReadState()` and expose `isParticipant` consistently across conversation APIs and Pod list items. Fix Pod unread counts by preserving the conversation-level unread signal when metadata updates occur after the last message was read, while retaining exact message-based counts. UI behavior changed in Pod conversation lists; please attach a screenshot or GIF.

## Tests

Updated existing conversation, rendering, and blocked-action test fixtures to include `isParticipant`. No new behavioral test cases were added in this change.

## Risk

Low risk. The change affects conversation serialization and Pod unread-state calculation, with a contained impact on badges and participant-dependent counts. No schema or data changes; rollback is straightforward.

## Deploy Plan

Deploy `front`. No SQL migrations or infrastructure changes.