### PR TITLE
Build Frame functions before publication

### DIFF
--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -1,0 +1,227 @@
+import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
+import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { FrameManifestSchema } from "@app/types/api/frame_manifest";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { frameV2ContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/lifecycle")>();
+  return { ...actual, ensureConversationSandboxReadyWithScope: vi.fn() };
+});
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+    return { ...actual, buildSandboxFunctionOnReadySandbox: vi.fn() };
+  }
+);
+
+const manifest = FrameManifestSchema.parse({
+  version: 1,
+  name: "Task List",
+  description: "Track tasks.",
+  functions: [
+    {
+      name: "add-task",
+      description: "Add a task.",
+      entryPoint: "functions/add_task.ts",
+    },
+    {
+      name: "list-tasks",
+      description: "List tasks.",
+      entryPoint: "functions/list_tasks.ts",
+    },
+  ],
+});
+
+const sourceFiles = [
+  {
+    relativePath: "index.tsx",
+    content: Buffer.from("export default function App() {}"),
+    contentType: "text/typescript" as const,
+  },
+  {
+    relativePath: "functions/add_task.ts",
+    content: Buffer.from("export async function run() {}"),
+    contentType: "text/typescript" as const,
+  },
+  {
+    relativePath: "functions/list_tasks.ts",
+    content: Buffer.from("export async function run() {}"),
+    contentType: "text/typescript" as const,
+  },
+];
+
+async function setup(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+  frame: FileResource;
+  sandbox: SandboxResource;
+  space: SpaceResource;
+}> {
+  const { workspace, user } = await createResourceTest({ role: "admin" });
+  const space = await SpaceFactory.project(workspace, user.id);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  assert(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 0,
+    status: "created",
+    useCase: "project_context",
+  });
+  const sandbox = await SandboxResource.makeNew(auth, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensureConversationSandboxReadyWithScope).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false, scope: { spaceId: null } })
+  );
+
+  return { auth, conversation, frame, sandbox, space };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+});
+
+describe("buildAndPublishFramePublication", () => {
+  it("builds every declared function before publishing", async () => {
+    const { auth, conversation, frame, sandbox, space } = await setup();
+    vi.mocked(ensureConversationSandboxReadyWithScope).mockResolvedValue(
+      new Ok({
+        sandbox,
+        freshlyCreated: false,
+        scope: { spaceId: space.sId },
+      })
+    );
+    vi.mocked(buildSandboxFunctionOnReadySandbox)
+      .mockResolvedValueOnce(
+        new Ok({
+          bundleCode: "export const addTask = true;",
+          userIdentity: "workspace_user_required",
+          inputSchema: { type: "object" },
+          outputSchema: { type: "object" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Ok({
+          bundleCode: "export const listTasks = true;",
+          userIdentity: "optional",
+          inputSchema: { type: "object" },
+          outputSchema: { type: "array" },
+        })
+      );
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest,
+      sourceDirectoryPath: `pod-${space.sId}/TaskList`,
+      sourceFiles,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(buildSandboxFunctionOnReadySandbox).toHaveBeenNthCalledWith(
+      1,
+      auth,
+      {
+        sandbox,
+        srcSandboxPath: `/files/pod-${space.sId}/TaskList/functions/add_task.ts`,
+      }
+    );
+    expect(buildSandboxFunctionOnReadySandbox).toHaveBeenNthCalledWith(
+      2,
+      auth,
+      {
+        sandbox,
+        srcSandboxPath: `/files/pod-${space.sId}/TaskList/functions/list_tasks.ts`,
+      }
+    );
+    expect(ensureConversationSandboxReadyWithScope).toHaveBeenCalledOnce();
+    expect(
+      fileStorageMock.saveFileCalls.filter(({ filePath }) =>
+        filePath.endsWith("/bundle.js")
+      )
+    ).toHaveLength(2);
+
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      result.isOk() ? result.value.publicationId : undefined
+    );
+  });
+
+  it("does not write a publication when a function build fails", async () => {
+    const { auth, conversation, frame } = await setup();
+    vi.mocked(buildSandboxFunctionOnReadySandbox).mockResolvedValue(
+      new Err(new SandboxFunctionError("build_failed", "Invalid export."))
+    );
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest,
+      sourceDirectoryPath: `conversation-${conversation.sId}/TaskList`,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error).toEqual(
+      new SandboxFunctionError(
+        "build_failed",
+        'Failed to build Frame function "add-task": Invalid export.'
+      )
+    );
+    expect(buildSandboxFunctionOnReadySandbox).toHaveBeenCalledTimes(1);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBeUndefined();
+  });
+
+  it("rejects source outside the resolved conversation filesystem before building", async () => {
+    const { auth, conversation, frame } = await setup();
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest,
+      sourceDirectoryPath: "conversation-other/TaskList",
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_path",
+    });
+    expect(ensureConversationSandboxReadyWithScope).toHaveBeenCalledOnce();
+    expect(buildSandboxFunctionOnReadySandbox).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+});

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -1,0 +1,117 @@
+import path from "node:path";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import type {
+  FramePublicationError,
+  FramePublicationFunctionArtifact,
+  FramePublicationSourceFile,
+} from "@app/lib/api/frames/publication_storage";
+import { publishFramePublication } from "@app/lib/api/frames/publication_storage";
+import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
+import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { FrameManifest } from "@app/types/api/frame_manifest";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+
+/**
+ * Build every function declared by a Frame manifest, then atomically publish the source and built
+ * artifacts in the invoking conversation's DSBX. The conversation filesystem may expose source
+ * from the conversation itself or its Pod. No publication storage is touched until every path has
+ * resolved and every build has succeeded.
+ */
+export async function buildAndPublishFramePublication(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifest,
+    sourceDirectoryPath,
+    sourceFiles,
+  }: {
+    conversation: ConversationType;
+    frame: FileResource;
+    manifest: FrameManifest;
+    sourceDirectoryPath: string;
+    sourceFiles: FramePublicationSourceFile[];
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  if (manifest.functions.length === 0) {
+    return publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+    });
+  }
+
+  const ensureResult = await ensureConversationSandboxReadyWithScope(
+    auth,
+    conversation
+  );
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+
+  const fsResult = await DustFileSystem.forConversation(auth, {
+    ...conversation,
+    spaceId: ensureResult.value.scope.spaceId,
+  });
+  if (fsResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("invalid_path", fsResult.error.message)
+    );
+  }
+
+  const buildInputs: { name: string; srcSandboxPath: string }[] = [];
+  for (const fn of manifest.functions) {
+    const sourcePath = path.posix.join(sourceDirectoryPath, fn.entryPoint);
+    const srcResult = fsResult.value.toSandboxPath(sourcePath);
+    if (srcResult.isErr()) {
+      return new Err(
+        new SandboxFunctionError(
+          "invalid_path",
+          `Invalid entry point for Frame function "${fn.name}": ${srcResult.error.message}`
+        )
+      );
+    }
+    buildInputs.push({ name: fn.name, srcSandboxPath: srcResult.value });
+  }
+
+  const functionArtifacts: FramePublicationFunctionArtifact[] = [];
+  for (const { name, srcSandboxPath } of buildInputs) {
+    const buildResult = await buildSandboxFunctionOnReadySandbox(auth, {
+      sandbox: ensureResult.value.sandbox,
+      srcSandboxPath,
+    });
+    if (buildResult.isErr()) {
+      return new Err(
+        new SandboxFunctionError(
+          buildResult.error.code,
+          `Failed to build Frame function "${name}": ${buildResult.error.message}`
+        )
+      );
+    }
+
+    functionArtifacts.push({ name, ...buildResult.value });
+  }
+
+  return publishFramePublication(auth, {
+    frame,
+    functionArtifacts,
+    manifest,
+    sourceFiles,
+  });
+}

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -13,6 +13,7 @@ import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
+import type { ConversationSandboxScope } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import type {
@@ -31,6 +32,9 @@ export interface EnsureSandboxReadyResult {
   sandbox: SandboxResource;
   freshlyCreated: boolean;
 }
+
+export type EnsureSandboxReadyWithScopeResult<TScope> =
+  EnsureSandboxReadyResult & { scope: TScope };
 
 type SandboxReadyConfig<TScope> = {
   ensureActive: () => Promise<Result<EnsureSandboxResult<TScope>, Error>>;
@@ -58,7 +62,7 @@ type SandboxReadyConfig<TScope> = {
 async function ensureOwnerSandboxReady<TScope>(
   auth: Authenticator,
   { ensureActive, deriveConfig }: SandboxReadyConfig<TScope>
-): Promise<Result<EnsureSandboxReadyResult, Error>> {
+): Promise<Result<EnsureSandboxReadyWithScopeResult<TScope>, Error>> {
   const startMs = performance.now();
   // cold is unknown until ensureActive returns; if it errors first (rare) we
   // record the failure as a warm attempt.
@@ -100,7 +104,7 @@ async function ensureOwnerSandboxReady<TScope>(
       }
 
       if (!shouldRefreshRuntime) {
-        return new Ok({ sandbox, freshlyCreated });
+        return new Ok({ sandbox, freshlyCreated, scope });
       }
 
       // Synchronous and cheap: not worth a span (it would always read ~0ms).
@@ -210,7 +214,7 @@ async function ensureOwnerSandboxReady<TScope>(
 
       await sandbox.updateLastRuntimeRefreshAt(new Date());
 
-      return new Ok({ sandbox, freshlyCreated });
+      return new Ok({ sandbox, freshlyCreated, scope });
     });
   } finally {
     recordSandboxStartupTotal(performance.now() - startMs, { cold }, status);
@@ -221,6 +225,15 @@ export async function ensureConversationSandboxReady(
   auth: Authenticator,
   conversation: ConversationType
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
+  return ensureConversationSandboxReadyWithScope(auth, conversation);
+}
+
+export async function ensureConversationSandboxReadyWithScope(
+  auth: Authenticator,
+  conversation: ConversationType
+): Promise<
+  Result<EnsureSandboxReadyWithScopeResult<ConversationSandboxScope>, Error>
+> {
   // Only the conversation's identity is trusted from the caller: it is
   // typically an agent-loop snapshot, and a move — possibly issued by this
   // very agent — can change the pod association mid-loop. The adapter

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -10,6 +10,7 @@ import {
   verifyStagingContent,
 } from "@app/lib/api/sandbox_functions/staging_integrity";
 import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { SANDBOX_FUNCTION_USER_IDENTITY_POLICIES } from "@app/types/api/sandbox_functions";
@@ -24,7 +25,7 @@ const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const BUILD_STAGING_ROOT = "/tmp/dust-sandbox-function-builds";
 const BUILD_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
 
-interface SandboxFunctionBuildResult {
+export interface SandboxFunctionBuildResult {
   bundleCode: string;
   userIdentity: SandboxFunctionUserIdentityPolicy;
   inputSchema: JSONSchema;
@@ -94,8 +95,24 @@ export async function buildSandboxFunctionOnSandbox(
       )
     );
   }
-  const { sandbox } = ensureResult.value;
 
+  return buildSandboxFunctionOnReadySandbox(auth, {
+    sandbox: ensureResult.value.sandbox,
+    srcSandboxPath,
+  });
+}
+
+/** Build a function in a sandbox whose owner-specific lifecycle setup has already completed. */
+export async function buildSandboxFunctionOnReadySandbox(
+  auth: Authenticator,
+  {
+    sandbox,
+    srcSandboxPath,
+  }: {
+    sandbox: SandboxResource;
+    srcSandboxPath: string;
+  }
+): Promise<Result<SandboxFunctionBuildResult, SandboxFunctionError>> {
   const buildDir = path.posix.join(BUILD_STAGING_ROOT, randomUUID());
   const bundlePath = path.posix.join(buildDir, "bundle.js");
   const schemaPath = path.posix.join(buildDir, "schema.json");


### PR DESCRIPTION
## Description

Add the Frames v2 publication coordinator that prepares the invoking conversation DSBX, derives its filesystem from the Pod scope resolved under the lifecycle lock, resolves declared function entrypoints, builds every function with the existing sandbox builder, and invokes the atomic publisher only after all builds succeed.

Frame ownership is not tied to a Pod. The resolved conversation filesystem supports source in the conversation itself or in its associated Pod. MCP exposure and runtime execution remain out of scope.

## Tests

- `npm test -- lib/api/frames/build_and_publish.test.ts lib/api/sandbox/lifecycle.test.ts lib/api/sandbox_functions/build_on_sandbox.test.ts lib/api/frames/publication_storage.test.ts`
- `npx biome check front/lib/api/frames/build_and_publish.ts front/lib/api/frames/build_and_publish.test.ts front/lib/api/sandbox/lifecycle.ts front/lib/api/sandbox_functions/build_on_sandbox.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` fails on the existing tsgo-only `checkers` option

## Risk

Low. This adds an uncalled backend coordinator, exposes the lifecycle-resolved conversation scope, and extracts the already-tested sandbox build body so a prepared conversation sandbox can reuse it. Path, sandbox, or build failures return before any publication files are written.

## Deploy Plan

Deploy normally. No migration or feature flag change is required for this unexposed slice.