### PR TITLE
Add feature-flagged Frames v2 publishing

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/index.test.ts
@@ -1,0 +1,45 @@
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
+import createInteractiveContentServer from "@app/lib/api/actions/servers/interactive_content";
+import { PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { describe, expect, it } from "vitest";
+
+async function getPublishDescription({
+  enableFramesV2,
+}: {
+  enableFramesV2: boolean;
+}) {
+  const { authenticator: auth, workspace } = await createResourceTest({});
+  if (enableFramesV2) {
+    await FeatureFlagResource.enable(workspace, "frames_v2");
+  }
+
+  const server = await createInteractiveContentServer(auth);
+  const client = new Client({
+    name: "interactive-content-test",
+    version: "1.0.0",
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryWithAuthTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  const { tools } = await client.listTools();
+  await client.close();
+  return tools.find(
+    (tool) => tool.name === PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+  )?.description;
+}
+
+describe("interactive_content", () => {
+  it("routes only flagged workspaces to the Frames v2 server", async () => {
+    await expect(
+      getPublishDescription({ enableFramesV2: false })
+    ).resolves.not.toContain("canonical `manifest.json`");
+    await expect(
+      getPublishDescription({ enableFramesV2: true })
+    ).resolves.toContain("canonical `manifest.json`");
+  });
+});

--- a/front/lib/api/actions/servers/interactive_content/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/index.ts
@@ -3,13 +3,19 @@ import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
+import createInteractiveContentV2Server from "@app/lib/api/actions/servers/interactive_content_v2";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
   toolContext?: ToolContext
 ): Promise<McpServer> {
+  if (await hasFeatureFlag(auth, "frames_v2")) {
+    return createInteractiveContentV2Server(auth, toolContext);
+  }
+
   const server = makeInternalMCPServer(INTERACTIVE_CONTENT_SERVER_NAME);
 
   const tools = await createInteractiveContentTools(auth, toolContext);

--- a/front/lib/api/actions/servers/interactive_content_v2/index.ts
+++ b/front/lib/api/actions/servers/interactive_content_v2/index.ts
@@ -1,0 +1,23 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContext } from "@app/lib/actions/types";
+import { INTERACTIVE_CONTENT_V2_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content_v2/metadata";
+import { createInteractiveContentV2Tools } from "@app/lib/api/actions/servers/interactive_content_v2/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export default async function createInteractiveContentV2Server(
+  auth: Authenticator,
+  toolContext?: ToolContext
+): Promise<McpServer> {
+  const server = makeInternalMCPServer(INTERACTIVE_CONTENT_V2_SERVER_NAME);
+  const tools = await createInteractiveContentV2Tools(auth, toolContext);
+
+  for (const tool of tools) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: INTERACTIVE_CONTENT_V2_SERVER_NAME,
+    });
+  }
+
+  return server;
+}

--- a/front/lib/api/actions/servers/interactive_content_v2/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content_v2/metadata.ts
@@ -1,0 +1,40 @@
+import {
+  INTERACTIVE_CONTENT_SERVER_NAME,
+  INTERACTIVE_CONTENT_TOOLS_METADATA,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
+import assert from "assert";
+
+const publishToolMetadata = INTERACTIVE_CONTENT_TOOLS_METADATA.find(
+  (
+    tool
+  ): tool is Extract<
+    (typeof INTERACTIVE_CONTENT_TOOLS_METADATA)[number],
+    { name: typeof PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME }
+  > => tool.name === PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+);
+assert(publishToolMetadata, "Legacy Frame publish metadata expected");
+
+export const INTERACTIVE_CONTENT_V2_SERVER_NAME =
+  INTERACTIVE_CONTENT_SERVER_NAME;
+
+export const INTERACTIVE_CONTENT_V2_PUBLISH_TOOL_METADATA = [
+  {
+    ...publishToolMetadata,
+    description:
+      "Publish a Frame from its current source. For a Frames v2 manifest, validate and snapshot " +
+      "the complete source folder, build every declared function, and atomically activate the new " +
+      "publication. For a legacy Frame, keep the existing single-entry-file publish behavior. " +
+      "Pass the Frame's `file_id` and its current scoped source path. For Frames v2, `path` must be " +
+      "the canonical `manifest.json` path. Fix any reported manifest, path, or build error and retry.",
+    schema: {
+      file_id: publishToolMetadata.schema.file_id.describe(
+        "The ID of the canonical Frame to publish (e.g. 'fil_abc123')."
+      ),
+      path: publishToolMetadata.schema.path.describe(
+        "Current scoped source path: the canonical `manifest.json` path for Frames v2, or the " +
+          "entry source file for a legacy Frame."
+      ),
+    },
+  },
+] as const;

--- a/front/lib/api/actions/servers/interactive_content_v2/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content_v2/tools/index.test.ts
@@ -1,0 +1,64 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolContext } from "@app/lib/actions/types";
+import { PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { createInteractiveContentV2Tools } from "@app/lib/api/actions/servers/interactive_content_v2/tools";
+import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { frameContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import { Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/viz/publish_frame", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/viz/publish_frame")>();
+  return { ...actual, publishFrame: vi.fn() };
+});
+
+describe("createInteractiveContentV2Tools", () => {
+  it("keeps legacy Frame publishing backward-compatible", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const framePath = `conversation-${conversation.sId}/Legacy.tsx`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Legacy.tsx",
+      fileSize: 10,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}Legacy.tsx`,
+    });
+    const toolContext = {
+      runContext: { contextType: "agent_loop", conversation },
+    } as unknown as ToolContext;
+    const tools = await createInteractiveContentV2Tools(auth, toolContext);
+    const publishTool = tools.find(
+      (tool) => tool.name === PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+    );
+    assert(publishTool);
+    vi.mocked(publishFrame).mockResolvedValue(new Ok({ warnings: [] }));
+
+    const result = await publishTool.handler(
+      { file_id: frame.sId, path: framePath },
+      {
+        auth,
+        runContext: toolContext.runContext,
+        sendNotification: vi.fn(),
+        signal: new AbortController().signal,
+      } as unknown as ToolHandlerExtra
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(publishFrame).toHaveBeenCalledOnce();
+  });
+});

--- a/front/lib/api/actions/servers/interactive_content_v2/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content_v2/tools/index.test.ts
@@ -1,11 +1,12 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolContext } from "@app/lib/actions/types";
 import { PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { createInteractiveContentV2Tools } from "@app/lib/api/actions/servers/interactive_content_v2/tools";
 import { publishFrame } from "@app/lib/api/viz/publish_frame";
-import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import {
+  makeExtra,
+  setupPlainConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { frameContentType } from "@app/types/files";
 import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { Ok } from "@app/types/shared/result";
@@ -20,11 +21,8 @@ vi.mock("@app/lib/api/viz/publish_frame", async (importOriginal) => {
 
 describe("createInteractiveContentV2Tools", () => {
   it("keeps legacy Frame publishing backward-compatible", async () => {
-    const { authenticator: auth, workspace } = await createResourceTest({});
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
-      messagesCreatedAt: [],
-    });
+    const { auth, conversation } = await setupPlainConversation();
+    const owner = auth.getNonNullableWorkspace();
     const framePath = `conversation-${conversation.sId}/Legacy.tsx`;
     const frame = await FileFactory.create(auth, null, {
       contentType: frameContentType,
@@ -34,13 +32,12 @@ describe("createInteractiveContentV2Tools", () => {
       useCase: "conversation",
       useCaseMetadata: { conversationId: conversation.sId },
       mountFilePath: `${getConversationFilesBasePath({
-        workspaceId: workspace.sId,
+        workspaceId: owner.sId,
         conversationId: conversation.sId,
       })}Legacy.tsx`,
     });
-    const toolContext = {
-      runContext: { contextType: "agent_loop", conversation },
-    } as unknown as ToolContext;
+    const extra = makeExtra(auth, conversation);
+    const toolContext: ToolContext = { runContext: extra.runContext };
     const tools = await createInteractiveContentV2Tools(auth, toolContext);
     const publishTool = tools.find(
       (tool) => tool.name === PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
@@ -50,12 +47,7 @@ describe("createInteractiveContentV2Tools", () => {
 
     const result = await publishTool.handler(
       { file_id: frame.sId, path: framePath },
-      {
-        auth,
-        runContext: toolContext.runContext,
-        sendNotification: vi.fn(),
-        signal: new AbortController().signal,
-      } as unknown as ToolHandlerExtra
+      extra
     );
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/actions/servers/interactive_content_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content_v2/tools/index.ts
@@ -1,0 +1,106 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolContext } from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
+import { PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
+import { INTERACTIVE_CONTENT_V2_PUBLISH_TOOL_METADATA } from "@app/lib/api/actions/servers/interactive_content_v2/metadata";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+
+function toMCPError(
+  error: FramePublicationError | SandboxFunctionError
+): MCPError {
+  if (error instanceof FramePublicationError) {
+    return new MCPError(error.message, { tracked: false });
+  }
+
+  return new MCPError(error.message, {
+    tracked: ["sandbox_unavailable", "reconcile_failed", "internal"].includes(
+      error.code
+    ),
+  });
+}
+
+export async function createInteractiveContentV2Tools(
+  auth: Authenticator,
+  toolContext?: ToolContext
+) {
+  const legacyTools = await createInteractiveContentTools(auth, toolContext);
+  const legacyPublishTool = legacyTools.find(
+    (tool) => tool.name === PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+  );
+  assert(legacyPublishTool, "Legacy Frame publish tool expected");
+
+  const handlers: ToolHandlers<
+    typeof INTERACTIVE_CONTENT_V2_PUBLISH_TOOL_METADATA
+  > = {
+    publish_interactive_content_file: async (
+      { file_id, path },
+      { sendNotification, _meta, ...extra }
+    ) => {
+      const file = await FileResource.fetchById(auth, file_id);
+      if (!file?.isFrameV2) {
+        return legacyPublishTool.handler(
+          { file_id, path },
+          { sendNotification, _meta, ...extra }
+        );
+      }
+
+      if (!isAgentLoopRunContext(toolContext?.runContext)) {
+        return new Err(
+          new MCPError(
+            "Frames v2 publishing requires a conversation context.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const result = await publishFrameV2FromSource(auth, {
+        conversation: toolContext.runContext.conversation,
+        frame: file,
+        manifestPath: path,
+      });
+      if (result.isErr()) {
+        return new Err(toMCPError(result.error));
+      }
+
+      if (_meta?.progressToken) {
+        const notification: MCPProgressNotificationType =
+          buildInteractiveContentFileNotification(
+            _meta.progressToken,
+            file,
+            "Publishing Frame..."
+          );
+        await sendNotification(notification);
+      }
+
+      return new Ok([
+        {
+          type: "text",
+          text: `Frame '${file.sId}' published successfully.`,
+        },
+      ]);
+    },
+  };
+
+  const [publishTool] = buildTools(
+    INTERACTIVE_CONTENT_V2_PUBLISH_TOOL_METADATA,
+    handlers
+  );
+  assert(publishTool, "Frames v2 publish tool expected");
+
+  return legacyTools.map((tool) =>
+    tool.name === PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+      ? publishTool
+      : tool
+  );
+}

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -787,6 +787,11 @@ export class DustFileSystem {
     return this.mounts;
   }
 
+  checkWriteAccess(scopedPath: string): Result<void, DustFileSystemError> {
+    const resolved = this.requireWriteMount(scopedPath);
+    return resolved.isErr() ? new Err(resolved.error) : new Ok(undefined);
+  }
+
   /**
    * Constructs the thumbnail API URL for an image file entry.
    * Lives here because the URL points to our application API, not to GCS.

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -102,6 +102,10 @@ async function setup(): Promise<{
     baseImage: "dust-base",
     version: "0.0.0-test",
   });
+  vi.spyOn(sandbox, "writeFile").mockResolvedValue(new Ok(undefined));
+  vi.spyOn(sandbox, "exec").mockResolvedValue(
+    new Ok({ exitCode: 0, stdout: "", stderr: "" })
+  );
   vi.mocked(ensureConversationSandboxReadyWithScope).mockResolvedValue(
     new Ok({ sandbox, freshlyCreated: false, scope: { spaceId: null } })
   );
@@ -146,17 +150,19 @@ describe("buildAndPublishFramePublication", () => {
       conversation,
       frame,
       manifest,
-      sourceDirectoryPath: `pod-${space.sId}/TaskList`,
       sourceFiles,
     });
 
     expect(result.isOk()).toBe(true);
+    expect(sandbox.writeFile).toHaveBeenCalledTimes(sourceFiles.length);
     expect(buildSandboxFunctionOnReadySandbox).toHaveBeenNthCalledWith(
       1,
       auth,
       {
         sandbox,
-        srcSandboxPath: `/files/pod-${space.sId}/TaskList/functions/add_task.ts`,
+        srcSandboxPath: expect.stringMatching(
+          /^\/tmp\/dust-frame-publication-builds\/[^/]+\/functions\/add_task\.ts$/
+        ),
       }
     );
     expect(buildSandboxFunctionOnReadySandbox).toHaveBeenNthCalledWith(
@@ -164,8 +170,17 @@ describe("buildAndPublishFramePublication", () => {
       auth,
       {
         sandbox,
-        srcSandboxPath: `/files/pod-${space.sId}/TaskList/functions/list_tasks.ts`,
+        srcSandboxPath: expect.stringMatching(
+          /^\/tmp\/dust-frame-publication-builds\/[^/]+\/functions\/list_tasks\.ts$/
+        ),
       }
+    );
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      auth,
+      expect.stringMatching(
+        /^rm -rf -- '\/tmp\/dust-frame-publication-builds\/[^/]+'$/
+      ),
+      { user: "agent-proxied" }
     );
     expect(ensureConversationSandboxReadyWithScope).toHaveBeenCalledOnce();
     expect(
@@ -190,7 +205,6 @@ describe("buildAndPublishFramePublication", () => {
       conversation,
       frame,
       manifest,
-      sourceDirectoryPath: `conversation-${conversation.sId}/TaskList`,
       sourceFiles,
     });
 
@@ -206,21 +220,28 @@ describe("buildAndPublishFramePublication", () => {
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBeUndefined();
   });
 
-  it("rejects source outside the resolved conversation filesystem before building", async () => {
-    const { auth, conversation, frame } = await setup();
+  it("rejects an unsafe snapshot path before staging or building", async () => {
+    const { auth, conversation, frame, sandbox } = await setup();
 
     const result = await buildAndPublishFramePublication(auth, {
       conversation,
       frame,
       manifest,
-      sourceDirectoryPath: "conversation-other/TaskList",
-      sourceFiles,
+      sourceFiles: [
+        ...sourceFiles,
+        {
+          relativePath: "../outside.ts",
+          content: Buffer.from("export const outside = true;"),
+          contentType: "text/typescript",
+        },
+      ],
     });
 
     expect(result.isErr() && result.error).toMatchObject({
-      code: "invalid_path",
+      code: "invalid_source",
     });
-    expect(ensureConversationSandboxReadyWithScope).toHaveBeenCalledOnce();
+    expect(ensureConversationSandboxReadyWithScope).not.toHaveBeenCalled();
+    expect(sandbox.writeFile).not.toHaveBeenCalled();
     expect(buildSandboxFunctionOnReadySandbox).not.toHaveBeenCalled();
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -1,26 +1,33 @@
+import { randomUUID } from "node:crypto";
 import path from "node:path";
-import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type {
-  FramePublicationError,
   FramePublicationFunctionArtifact,
   FramePublicationSourceFile,
 } from "@app/lib/api/frames/publication_storage";
-import { publishFramePublication } from "@app/lib/api/frames/publication_storage";
+import {
+  FramePublicationError,
+  publishFramePublication,
+} from "@app/lib/api/frames/publication_storage";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
+import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 
+const FRAME_BUILD_STAGING_ROOT = "/tmp/dust-frame-publication-builds";
+const FRAME_BUILD_STAGING_CONCURRENCY = 8;
+
 /**
- * Build every function declared by a Frame manifest, then atomically publish the source and built
- * artifacts in the invoking conversation's DSBX. The conversation filesystem may expose source
- * from the conversation itself or its Pod. No publication storage is touched until every path has
- * resolved and every build has succeeded.
+ * Stage one captured source snapshot in the invoking conversation's DSBX, build every function
+ * declared by the manifest from that snapshot, then atomically publish the source and artifacts.
+ * No publication storage is touched until every build has succeeded.
  */
 export async function buildAndPublishFramePublication(
   auth: Authenticator,
@@ -28,13 +35,11 @@ export async function buildAndPublishFramePublication(
     conversation,
     frame,
     manifest,
-    sourceDirectoryPath,
     sourceFiles,
   }: {
     conversation: ConversationType;
     frame: FileResource;
     manifest: FrameManifest;
-    sourceDirectoryPath: string;
     sourceFiles: FramePublicationSourceFile[];
   }
 ): Promise<
@@ -52,6 +57,22 @@ export async function buildAndPublishFramePublication(
     });
   }
 
+  const seenSourcePaths = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    if (
+      !isSafeFrameRelativePath(sourceFile.relativePath) ||
+      seenSourcePaths.has(sourceFile.relativePath)
+    ) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_source",
+          `Invalid Frame source path: ${sourceFile.relativePath}`
+        )
+      );
+    }
+    seenSourcePaths.add(sourceFile.relativePath);
+  }
+
   const ensureResult = await ensureConversationSandboxReadyWithScope(
     auth,
     conversation
@@ -64,54 +85,57 @@ export async function buildAndPublishFramePublication(
       )
     );
   }
+  const sandbox = ensureResult.value.sandbox;
+  const stagingDirectory = path.posix.join(
+    FRAME_BUILD_STAGING_ROOT,
+    randomUUID()
+  );
 
-  const fsResult = await DustFileSystem.forConversation(auth, {
-    ...conversation,
-    spaceId: ensureResult.value.scope.spaceId,
-  });
-  if (fsResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError("invalid_path", fsResult.error.message)
+  try {
+    const stagingResults = await concurrentExecutor(
+      sourceFiles,
+      (sourceFile) =>
+        sandbox.writeFile(
+          auth,
+          path.posix.join(stagingDirectory, sourceFile.relativePath),
+          Uint8Array.from(sourceFile.content).buffer
+        ),
+      { concurrency: FRAME_BUILD_STAGING_CONCURRENCY }
     );
-  }
-
-  const buildInputs: { name: string; srcSandboxPath: string }[] = [];
-  for (const fn of manifest.functions) {
-    const sourcePath = path.posix.join(sourceDirectoryPath, fn.entryPoint);
-    const srcResult = fsResult.value.toSandboxPath(sourcePath);
-    if (srcResult.isErr()) {
+    const stagingError = stagingResults.find((result) => result.isErr());
+    if (stagingError?.isErr()) {
       return new Err(
-        new SandboxFunctionError(
-          "invalid_path",
-          `Invalid entry point for Frame function "${fn.name}": ${srcResult.error.message}`
-        )
+        new SandboxFunctionError("internal", stagingError.error.message)
       );
     }
-    buildInputs.push({ name: fn.name, srcSandboxPath: srcResult.value });
-  }
 
-  const functionArtifacts: FramePublicationFunctionArtifact[] = [];
-  for (const { name, srcSandboxPath } of buildInputs) {
-    const buildResult = await buildSandboxFunctionOnReadySandbox(auth, {
-      sandbox: ensureResult.value.sandbox,
-      srcSandboxPath,
+    const functionArtifacts: FramePublicationFunctionArtifact[] = [];
+    for (const fn of manifest.functions) {
+      const buildResult = await buildSandboxFunctionOnReadySandbox(auth, {
+        sandbox,
+        srcSandboxPath: path.posix.join(stagingDirectory, fn.entryPoint),
+      });
+      if (buildResult.isErr()) {
+        return new Err(
+          new SandboxFunctionError(
+            buildResult.error.code,
+            `Failed to build Frame function "${fn.name}": ${buildResult.error.message}`
+          )
+        );
+      }
+
+      functionArtifacts.push({ name: fn.name, ...buildResult.value });
+    }
+
+    return publishFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest,
+      sourceFiles,
     });
-    if (buildResult.isErr()) {
-      return new Err(
-        new SandboxFunctionError(
-          buildResult.error.code,
-          `Failed to build Frame function "${name}": ${buildResult.error.message}`
-        )
-      );
-    }
-
-    functionArtifacts.push({ name, ...buildResult.value });
+  } finally {
+    await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {
+      user: "agent-proxied",
+    });
   }
-
-  return publishFramePublication(auth, {
-    frame,
-    functionArtifacts,
-    manifest,
-    sourceFiles,
-  });
 }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -57,7 +57,8 @@ export class FramePublicationError extends Error {
       | "invalid_manifest"
       | "invalid_source"
       | "publication_not_found"
-      | "source_not_found",
+      | "source_not_found"
+      | "unauthorized",
     message: string
   ) {
     super(message);

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -1,0 +1,128 @@
+import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { getFramePublicationSourcePath } from "@app/types/api/frame_storage";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const manifest = JSON.stringify({
+  version: 1,
+  name: "Status",
+  description: "Show the current status.",
+});
+const uiSource = "export default function Status() { return <p>Ready</p>; }";
+
+async function setup() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+  const gcsSourceDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(manifest),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: { conversationId: conversation.sId },
+    mountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+  });
+
+  const sourceByPath = new Map([
+    [`${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifest],
+    [`${gcsSourceDirectoryPath}/index.tsx`, uiSource],
+  ]);
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    prefix === `${gcsSourceDirectoryPath}/`
+      ? [...sourceByPath.entries()].map(([name, content]) => ({
+          name,
+          metadata: {
+            contentType: name.endsWith(".tsx")
+              ? "text/typescript"
+              : frameV2ContentType,
+            size: String(Buffer.byteLength(content)),
+          },
+        }))
+      : null
+  );
+  fileStorageMock.setFileContent(
+    (filePath) => sourceByPath.get(filePath) ?? null
+  );
+
+  return { auth, conversation, frame, manifestPath, workspace };
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+describe("publishFrameV2FromSource", () => {
+  it("snapshots the source folder and activates one publication", async () => {
+    const { auth, conversation, frame, manifestPath, workspace } =
+      await setup();
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation: conversation as ConversationType,
+      frame,
+      manifestPath,
+    });
+
+    assert(result.isOk());
+    const identity = {
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      publicationId: result.value.publicationId,
+    };
+    expect(
+      fileStorageMock.getObject(
+        getFramePublicationSourcePath({
+          ...identity,
+          relativePath: FRAME_MANIFEST_FILE,
+        })
+      )
+    ).toBe(manifest);
+    expect(
+      fileStorageMock.getObject(
+        getFramePublicationSourcePath({
+          ...identity,
+          relativePath: "index.tsx",
+        })
+      )
+    ).toBe(uiSource);
+
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      result.value.publicationId
+    );
+  });
+
+  it("rejects a path that does not match the Frame identity", async () => {
+    const { auth, conversation, frame } = await setup();
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation: conversation as ConversationType,
+      frame,
+      manifestPath: `conversation-${conversation.sId}/Other/manifest.json`,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+});

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -1,13 +1,18 @@
 import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
+import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { getFramePublicationSourcePath } from "@app/types/api/frame_storage";
 import { frameV2ContentType } from "@app/types/files";
-import { getConversationFilesBasePath } from "@app/types/mount_path";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
 import assert from "assert";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -63,7 +68,14 @@ async function setup() {
     (filePath) => sourceByPath.get(filePath) ?? null
   );
 
-  return { auth, conversation, frame, manifestPath, workspace };
+  return {
+    auth,
+    conversation,
+    frame,
+    gcsSourceDirectoryPath,
+    manifestPath,
+    workspace,
+  };
 }
 
 beforeEach(() => {
@@ -122,6 +134,84 @@ describe("publishFrameV2FromSource", () => {
     expect(result.isErr() && result.error).toMatchObject({
       code: "invalid_source",
     });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("rejects publication from a read-only Pod", async () => {
+    const {
+      authenticator: auth,
+      globalGroup,
+      user,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const space = await SpaceFactory.project(workspace);
+    await SpaceFactory.attachGroup(space, globalGroup, "project_viewer");
+    const viewerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    assert(viewerAuth);
+    expect(space.canRead(viewerAuth)).toBe(true);
+    expect(space.canWrite(viewerAuth)).toBe(false);
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const sourceDirectoryPath = `pod-${space.sId}/Status`;
+    const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const gcsSourceDirectoryPath = `${getPodFilesBasePath({
+      workspaceId: workspace.sId,
+      podId: space.sId,
+    })}Status`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(manifest),
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+      mountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    const accessibleFrame = await FileResource.fetchById(viewerAuth, frame.sId);
+    assert(accessibleFrame);
+
+    const result = await publishFrameV2FromSource(viewerAuth, {
+      conversation,
+      frame: accessibleFrame,
+      manifestPath,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "unauthorized",
+    });
+    expect(fileStorageMock.readStreamCalls).toHaveLength(0);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("bounds source listing before reading the folder", async () => {
+    const { auth, conversation, frame, gcsSourceDirectoryPath, manifestPath } =
+      await setup();
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix === `${gcsSourceDirectoryPath}/`
+        ? Array.from({ length: 2_000 }, (_, index) => ({
+            name: `${gcsSourceDirectoryPath}/file-${index}.txt`,
+            metadata: { contentType: "text/plain", size: "1" },
+          }))
+        : null
+    );
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame,
+      manifestPath,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+      message: "Frame source exceeds the publication file count limit.",
+    });
+    expect(fileStorageMock.readStreamCalls).toHaveLength(1);
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 });

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -6,7 +6,6 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { getFramePublicationSourcePath } from "@app/types/api/frame_storage";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import { frameV2ContentType } from "@app/types/files";
 import { getConversationFilesBasePath } from "@app/types/mount_path";
 import assert from "assert";
@@ -77,7 +76,7 @@ describe("publishFrameV2FromSource", () => {
       await setup();
 
     const result = await publishFrameV2FromSource(auth, {
-      conversation: conversation as ConversationType,
+      conversation,
       frame,
       manifestPath,
     });
@@ -115,7 +114,7 @@ describe("publishFrameV2FromSource", () => {
     const { auth, conversation, frame } = await setup();
 
     const result = await publishFrameV2FromSource(auth, {
-      conversation: conversation as ConversationType,
+      conversation,
       frame,
       manifestPath: `conversation-${conversation.sId}/Other/manifest.json`,
     });

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -86,6 +86,11 @@ export async function publishFrameV2FromSource(
   }
   const dustFs = fsResult.value;
 
+  const writeAccess = dustFs.checkWriteAccess(canonicalManifestPath);
+  if (writeAccess.isErr()) {
+    return frameError("unauthorized", writeAccess.error.message);
+  }
+
   const manifestBufferResult = await dustFs.readBuffer(canonicalManifestPath);
   if (manifestBufferResult.isErr()) {
     return frameError("invalid_source", manifestBufferResult.error.message);
@@ -104,9 +109,17 @@ export async function publishFrameV2FromSource(
   }
 
   const sourceDirectoryPath = path.posix.dirname(canonicalManifestPath);
-  const listResult = await dustFs.list(sourceDirectoryPath);
+  const listResult = await dustFs.list(sourceDirectoryPath, {
+    maxFiles: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+  });
   if (listResult.isErr()) {
     return frameError("invalid_source", listResult.error.message);
+  }
+  if (listResult.value.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+    return frameError(
+      "invalid_source",
+      "Frame source exceeds the publication file count limit."
+    );
   }
 
   const sourceEntries: Array<{
@@ -193,7 +206,6 @@ export async function publishFrameV2FromSource(
     conversation,
     frame,
     manifest: manifestResult.value,
-    sourceDirectoryPath,
     sourceFiles,
   });
 }

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -1,0 +1,199 @@
+import path from "node:path";
+
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  FRAME_MANIFEST_FILE,
+  isSafeFrameRelativePath,
+  parseFrameManifest,
+} from "@app/types/api/frame_manifest";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import {
+  isAllSupportedFileContentType,
+  normalizeMimeType,
+} from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+
+const FRAME_SOURCE_READ_CONCURRENCY = 8;
+const MAX_FRAME_SOURCE_FILE_COUNT = 1000;
+const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
+
+function frameError(code: FramePublicationError["code"], message: string) {
+  return new Err(new FramePublicationError(code, message));
+}
+
+/**
+ * Publish a Frames v2 FileResource from its current source folder. The FileResource path is the
+ * authority: callers cannot point a Frame identity at a different manifest or source tree.
+ */
+export async function publishFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifestPath,
+  }: {
+    conversation: ConversationType;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  if (!frame.isFrameV2) {
+    return frameError(
+      "invalid_frame",
+      `File '${frame.sId}' is not a Frames v2 manifest.`
+    );
+  }
+
+  const canonicalManifestPath = frame.toScopedPath(auth);
+  if (
+    !canonicalManifestPath ||
+    path.posix.basename(canonicalManifestPath) !== FRAME_MANIFEST_FILE
+  ) {
+    return frameError(
+      "invalid_source",
+      `Frame '${frame.sId}' has no canonical ${FRAME_MANIFEST_FILE} path.`
+    );
+  }
+
+  if (
+    DustFileSystem.normalizeScopedPath(manifestPath) !== canonicalManifestPath
+  ) {
+    return frameError(
+      "invalid_source",
+      `Frame '${frame.sId}' must be published from '${canonicalManifestPath}'.`
+    );
+  }
+
+  const fsResult = await DustFileSystem.fromScopedPath(
+    auth,
+    canonicalManifestPath
+  );
+  if (fsResult.isErr()) {
+    return frameError("invalid_source", fsResult.error.message);
+  }
+  const dustFs = fsResult.value;
+
+  const manifestBufferResult = await dustFs.readBuffer(canonicalManifestPath);
+  if (manifestBufferResult.isErr()) {
+    return frameError("invalid_source", manifestBufferResult.error.message);
+  }
+  if (manifestBufferResult.value === null) {
+    return frameError(
+      "invalid_source",
+      `Frame manifest not found: ${canonicalManifestPath}`
+    );
+  }
+  const manifestBuffer = manifestBufferResult.value;
+
+  const manifestResult = parseFrameManifest(manifestBuffer);
+  if (manifestResult.isErr()) {
+    return frameError("invalid_manifest", manifestResult.error);
+  }
+
+  const sourceDirectoryPath = path.posix.dirname(canonicalManifestPath);
+  const listResult = await dustFs.list(sourceDirectoryPath);
+  if (listResult.isErr()) {
+    return frameError("invalid_source", listResult.error.message);
+  }
+
+  const sourceEntries: Array<{
+    path: string;
+    relativePath: string;
+    contentType: FramePublicationSourceFile["contentType"];
+  }> = [];
+  for (const entry of listResult.value) {
+    if (entry.isDirectory) {
+      continue;
+    }
+
+    const relativePath = path.posix.relative(sourceDirectoryPath, entry.path);
+    if (!isSafeFrameRelativePath(relativePath)) {
+      return frameError(
+        "invalid_source",
+        `Invalid Frame source path: ${entry.path}`
+      );
+    }
+
+    const contentType = normalizeMimeType(entry.contentType);
+    if (!isAllSupportedFileContentType(contentType)) {
+      return frameError(
+        "invalid_source",
+        `Unsupported content type '${entry.contentType}' for Frame source '${relativePath}'.`
+      );
+    }
+
+    sourceEntries.push({ path: entry.path, relativePath, contentType });
+  }
+
+  const totalSizeBytes = listResult.value.reduce(
+    (total, entry) => total + entry.sizeBytes,
+    0
+  );
+  if (
+    sourceEntries.length > MAX_FRAME_SOURCE_FILE_COUNT ||
+    totalSizeBytes > MAX_FRAME_SOURCE_BYTES
+  ) {
+    return frameError(
+      "invalid_source",
+      "Frame source exceeds the publication size limit."
+    );
+  }
+  if (!sourceEntries.some((entry) => entry.path === canonicalManifestPath)) {
+    return frameError(
+      "invalid_source",
+      `Frame manifest not found in source folder: ${canonicalManifestPath}`
+    );
+  }
+
+  const sourceFileResults = await concurrentExecutor(
+    sourceEntries,
+    async (entry) => ({
+      ...entry,
+      content:
+        entry.path === canonicalManifestPath
+          ? manifestBuffer
+          : await dustFs.readBuffer(entry.path),
+    }),
+    { concurrency: FRAME_SOURCE_READ_CONCURRENCY }
+  );
+
+  const sourceFiles: FramePublicationSourceFile[] = [];
+  for (const sourceFileResult of sourceFileResults) {
+    const { content, contentType, relativePath } = sourceFileResult;
+    if (Buffer.isBuffer(content)) {
+      sourceFiles.push({ content, contentType, relativePath });
+      continue;
+    }
+    if (content.isErr()) {
+      return frameError("invalid_source", content.error.message);
+    }
+    if (content.value === null) {
+      return frameError(
+        "invalid_source",
+        `Frame source file not found: ${relativePath}`
+      );
+    }
+    sourceFiles.push({ content: content.value, contentType, relativePath });
+  }
+
+  return buildAndPublishFramePublication(auth, {
+    conversation,
+    frame,
+    manifest: manifestResult.value,
+    sourceDirectoryPath,
+    sourceFiles,
+  });
+}

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -22,7 +22,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 
 const FRAME_SOURCE_READ_CONCURRENCY = 8;
-const MAX_FRAME_SOURCE_FILE_COUNT = 1000;
+const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
 const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
 
 function frameError(code: FramePublicationError["code"], message: string) {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -477,6 +477,12 @@ class FileStorageMock {
           pageFetchCount: 1,
         })
       ),
+      getFiles: vi.fn(
+        ({ prefix, maxResults }: { prefix: string; maxResults: number }) =>
+          Promise.resolve(
+            (this._filesByPrefix(prefix) ?? []).slice(0, maxResults)
+          )
+      ),
       listSubdirectoryNames: vi.fn(({ prefix }: { prefix: string }) => {
         const normalized = prefix.endsWith("/") ? prefix : `${prefix}/`;
         const names = (this._subdirectoryNames(prefix) ?? []).filter(


### PR DESCRIPTION
## Description

Route the existing `interactive_content` MCP server to a Frames v2 implementation for workspaces with `frames_v2` enabled.

The v2 publish tool validates the canonical `manifest.json` FileResource path, snapshots the bounded source folder, builds declared functions, and atomically activates the publication. Legacy Frames continue through the existing publish path.

## Tests

- `npx tsgo --noEmit`
- Focused Vitest suite for feature flag routing, legacy compatibility, source snapshot publication, and the existing build/publish paths

## Risk

Low and gated by the Dust-only `frames_v2` feature flag. Disable the flag to restore the existing server. Source publication is bounded to 1,000 files and 100 MB.

## Deploy Plan

Deploy `front`, then enable `frames_v2` only for selected internal workspaces. No migration is required.