### PR TITLE
[Admin Governance] Add agent permissions migration plan

### DIFF
--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -3,8 +3,9 @@
 This plan migrates workspace-agent editor permissions from the `agent_editors` group kind and
 `group_agents` join table to the `regular_auto` group kind and `group_permissions` table.
 
-Each numbered item is one PR. A PR should contain one behavior and aim to stay below 300 changed
-lines. Operational gates and production backfill runs are not PRs.
+Each numbered item is one PR. The 300-line target is a soft bound: combine related changes when an
+intermediate state has no review or operational value. Split at real deploy, backfill, observation,
+or rollback boundaries.
 
 ## Decisions
 
@@ -17,175 +18,118 @@ lines. Operational gates and production backfill runs are not PRs.
 
 ## 0. Preserve editors on archived agents
 
-### PR 0: Freeze core mutations on archived agents
+### PR 0: Freeze archived-agent definition mutations
 
-Add a shared archived-agent mutation guard and apply it to configuration and editor mutations.
-Restore remains allowed.
+Add a shared archived-agent mutation guard across configuration, editors, scope, tags, skills, and
+batch or auxiliary definition routes. Restore remains allowed; runtime data such as feedback and
+memories stays outside this freeze.
 
-### PR 1: Freeze remaining definition mutations
-
-Apply the same guard to scope, tags, skills, and other batch or auxiliary routes that mutate an
-agent's definition. Keep runtime data such as feedback and memories out of this freeze.
-
-### PR 2: Keep archived-agent editors active
+### PR 1: Keep archived-agent editors active
 
 Stop suspending/restoring `agent_editors` memberships and backfill memberships already suspended
 by archive. Keep runtime effects such as disabling and restoring triggers and wake-ups.
 
 ## 1. Add a stable logical agent id
 
-### PR 3: Expand the schema
+### PR 2: Expand the schema
 
 Create `agents(id, sId, workspaceId)` with `id` as the primary key and `sId` unique. Add an indexed,
 nullable `agentId` foreign key to `agent_configurations` in a pre-deploy migration.
 
-### PR 4: Create and reuse agent identities
+### PR 3: Wire the agent identity lifecycle
 
-Create the identity with a pending/new agent and reuse its `agentId` for every later version.
-Creating a version never creates a second identity; archive and restore leave it unchanged.
+Create the identity with a pending/new agent and reuse its `agentId` for every later version. Delete
+it only when the whole logical agent is hard-deleted and no configuration remains; archive, restore,
+and failed-version cleanup leave it unchanged.
 
-### PR 5: Clean up identities on logical hard delete
-
-Delete the identity only when the whole logical agent is hard-deleted, including abandoned pending
-agents. After failed-version cleanup, delete it only when no configuration remains.
-
-### PR 6: Backfill agent identities
+### PR 4: Backfill agent identities
 
 Create one identity per existing `sId`, attach every version to it, and report duplicates or missing
-rows. Run this idempotent backfill only after PRs 4 and 5 are deployed.
+rows. Run this idempotent backfill only after PR 3 is deployed.
 
-**Operational gate:** run the backfill and verify that every configuration has exactly one logical
-agent before enforcing constraints.
+**Operational gate:** verify every configuration has the expected identity before enforcing the
+constraints.
 
-### PR 7: Enforce identity invariants
+### PR 5: Enforce identity invariants
 
 Make `agent_configurations.agentId` non-null and add uniqueness on `(agentId, version)` in a
 post-deploy migration. Keep `sId` on configurations for the future head/version refactor.
 
 ## 2. Build and verify the grants path
 
-### PR 8: Preserve editor administration semantics
+### PR 6: Preserve editor administration semantics
 
 Add `admin` to the `agent.editor` registry role, with focused registry tests. This defines the final
-role semantics without creating or serving agent grants yet.
+role semantics independently of the agent resource.
 
-### PR 9: Add the thin Agent Resource
+### PR 7: Add the thin Agent Resource
 
-Add a tested `AgentResource` that uses stable `agentId` for workspace agents and implements
-`getAccessControlLists` plus `canRead`, `canWrite`, and `canAdministrate`. Preserve visible-agent and
-`isAuthor` rules, and return static ACLs for code-defined global agents.
+Add a tested `AgentResource` using stable `agentId`, with `getAccessControlLists`, `canRead`,
+`canWrite`, and `canAdministrate`. Preserve visible-agent and `isAuthor` rules, and return static ACLs
+for code-defined global agents.
 
-### PR 10: Dual-write initial editor grants
+### PR 8: Dual-write editor additions
 
-When creating a pending/new agent, keep creating its legacy editor group and also grant its initial
-editors into the final `regular_auto` group.
+Keep legacy writes and grant initial or newly added editors into the final `regular_auto` group.
+Cover pending-agent creation, incremental additions, and additions from full editor-set updates.
 
-### PR 11: Dual-write editor additions
+### PR 9: Dual-write editor removals and deletion cleanup
 
-Keep legacy writes and grant newly added editors into the final group, including additions made by
-a full editor-set update.
+Keep legacy writes while revoking removed editors from the final group, including full editor-set
+updates. Reuse that grant-deletion path to remove permission rows and the final group when the whole
+logical agent is hard-deleted; version cleanup and archive leave grants unchanged.
 
-### PR 12: Dual-write editor removals
-
-Keep legacy writes and revoke removed editors from the final group, including removals made by a
-full editor-set update.
-
-### PR 13: Clean up grants on hard delete
-
-Delete the agent's permission rows and final `regular_auto` group when the logical agent is
-hard-deleted. Version cleanup and archive leave grants unchanged.
-
-### PR 14: Backfill agent editor grants
+### PR 10: Backfill agent editor grants
 
 Copy each legacy editor set into the final grant group, including archived agents. Make the script
 idempotent and report editor-set differences and authors who are not explicit editors.
 
-### PR 15: Shadow editor-list reads
+### PR 11: Shadow all grant-backed reads
 
-Add grant-backed `listEditors` and batch-list helpers to `AgentResource`. Continue serving the
-legacy editor list while comparing user sets under `group_permissions_shadow`.
-
-### PR 16: Shadow permission decisions
-
-Continue serving legacy `read`, `write`, and `admin` decisions while comparing `AgentResource`.
-Compare effective results, including visible-agent and `isAuthor` rules.
-
-### PR 17: Shadow agent-list filtering
-
-List/manage/archive views currently resolve editable agents through `group_agents` version ids.
-Keep serving that result while comparing stable ids from
-`auth.getResourceIdsWithVerb("agent", ...)`.
+Add grant-backed editor-list and batch-list helpers, permission checks, and editable-agent filters.
+Continue serving legacy results while comparing editor sets, effective `read`/`write`/`admin`
+decisions, and list/manage/archive stable-id results under one shadow switch.
 
 **Operational gate:** enable shadowing progressively and wait for editor-list, permission, listing,
 backfill, and cache-related mismatches to reach zero.
 
 ## 3. Flip and remove the legacy model
 
-### PR 18: Flip editor-list reads
+### PR 12: Flip all grant-backed reads
 
-Serve editor lists from `AgentResource`, while keeping legacy writes and a kill-switch fallback.
+Serve editor lists, permission decisions, and list/manage/archive filtering from grants at the same
+time, behind one operational switch with a single kill-switch fallback to legacy reads.
 
-**Operational gate:** observe the editor-list flip before removing its fallback.
+**Operational gate:** observe the complete read flip before removing the fallback.
 
-### PR 19: Remove the legacy editor-list fallback
+### PR 13: Remove legacy reads and rollout infrastructure
 
-Remove the legacy branch and shadow comparison for editor-list reads only.
+Remove all legacy read fallbacks and shadow comparisons. Remove `group_permissions_shadow`,
+`use_legacy_acls`, and shared migration helpers once no other resource migration uses them.
 
-### PR 20: Flip permission decisions
+### PR 14: Stop all legacy agent-editor writes
 
-Serve `read`, `write`, and `admin` decisions from `AgentResource`, with a kill-switch fallback.
+Stop membership mutations, legacy editor-group creation, and new `group_agents` links. Grant-backed
+editor mutations become the only write path, and new agents or versions no longer extend the legacy
+model.
 
-**Operational gate:** observe the permission flip before removing its fallback.
-
-### PR 21: Remove the legacy permission fallback
-
-Remove the legacy branch and shadow comparison for permission decisions only.
-
-### PR 22: Flip agent-list filtering
-
-Use stable agent ids from `group_permissions` for list/manage/archive filtering, with a kill-switch
-fallback.
-
-**Operational gate:** observe the listing flip before removing its fallback.
-
-### PR 23: Remove the legacy listing fallback
-
-Remove the legacy branch and shadow comparison for agent-list filtering only.
-
-### PR 24: Remove migration switches
-
-Remove `group_permissions_shadow`, `use_legacy_acls`, and their shared helpers once no other resource
-migration uses them.
-
-### PR 25: Stop legacy editor-membership writes
-
-Stop mutating existing `agent_editors` memberships on editor-set, add, and remove operations.
-Grant-backed editor mutations become the only update path; initial legacy-group creation remains
-until the next PR.
-
-### PR 26: Stop creating legacy editor groups and links
-
-Stop creating `agent_editors` groups for new agents and stop adding `group_agents` links for new
-versions, including the initial legacy membership write. This follows PR 25 so no remaining update
-path expects those groups to exist.
-
-### PR 27: Delete legacy agent-editor groups
+### PR 15: Delete legacy agent-editor groups
 
 Delete all `agent_editors` groups and their memberships after verifying that no code reads or writes
 them. Verify that their associated `group_agents` rows are gone as well.
 
-### PR 28: Remove the `agent_editors` kind
+### PR 16: Remove the `agent_editors` kind
 
 Remove the enum value, guards, factories, tests, and remaining branches for the legacy group kind.
-This is safe only after PR 27 has removed all rows of that kind.
+This is safe only after PR 15 has removed all rows of that kind.
 
-### PR 29: Drop `group_agents`
+### PR 17: Drop `group_agents`
 
 Remove `GroupAgentModel` and its associations, then drop the table in a post-deploy migration.
 
 ## 4. Remove the author fallback separately
 
-### PR 30: Remove `isAuthor` as an authorization source
+### PR 18: Remove `isAuthor` as an authorization source
 
 Inspect authors without editor grants and decide how to handle those outliers. Then remove the
 fallback so explicit grants are the sole source of editorship; model ownership explicitly if the

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -1,121 +1,192 @@
 # Admin Governance - Agent Migration
 
-This plan migrates workspace-agent editor permissions from `agent_editors` group kind and
-`group_agents` join table to `regular_auto` group kind and `group_permissions` table. 
+This plan migrates workspace-agent editor permissions from the `agent_editors` group kind and
+`group_agents` join table to the `regular_auto` group kind and `group_permissions` table.
 
-Each numbered item is one PR. Observation and backfill execution gates are called out separately.
+Each numbered item is one PR. A PR should contain one behavior and aim to stay below 300 changed
+lines. Operational gates and production backfill runs are not PRs.
 
 ## Decisions
+
 - `agents.id` is the stable numeric permission id; `agent_configurations.id` remains a version id.
 - Existing agent `sId`s stay unchanged and remain the external identifier.
 - `agent.editor` grants `read`, `write`, and `admin`, preserving today's behavior.
 - Archiving keeps editor memberships active. The archived status, not the ACL, blocks mutations.
 - Keep the `isAuthor` fallback through the migration; remove it separately after measuring outliers.
-- code-defined global agents: the rules governing their permissions are static, and don't need the grants table. The logic can be implemented directly in the resource's `getAccessControlLists` method;
+- Code-defined global agents have static ACLs in `AgentResource` and no `group_permissions` rows.
 
 ## 0. Preserve editors on archived agents
 
-### PR 0: Stop suspending editors on archive
+### PR 0: Freeze core mutations on archived agents
 
-Stop suspending/restoring `agent_editors` memberships, reject mutations on archived agents except
-restore, and keep runtime cleanup such as disabling triggers and wake-ups. Include an idempotent
-backfill for memberships already suspended by archive, so archived-agent editors remain visible.
+Add a shared archived-agent mutation guard and apply it to configuration and editor mutations.
+Restore remains allowed.
+
+### PR 1: Freeze remaining definition mutations
+
+Apply the same guard to scope, tags, skills, and other batch or auxiliary routes that mutate an
+agent's definition. Keep runtime data such as feedback and memories out of this freeze.
+
+### PR 2: Keep archived-agent editors active
+
+Stop suspending/restoring `agent_editors` memberships and backfill memberships already suspended
+by archive. Keep runtime effects such as disabling and restoring triggers and wake-ups.
 
 ## 1. Add a stable logical agent id
 
-### PR 1: Expand the schema
+### PR 3: Expand the schema
 
 Create `agents(id, sId, workspaceId)` with `id` as the primary key and `sId` unique. Add an indexed,
-nullable `agentId` foreign key to `agent_configurations`; nullable keeps the deploy compatible with
-old code and existing rows.
+nullable `agentId` foreign key to `agent_configurations` in a pre-deploy migration.
 
-### PR 2: Wire the agent identity lifecycle
+### PR 4: Create and reuse agent identities
 
 Create the identity with a pending/new agent and reuse its `agentId` for every later version.
-Archive and restore leave it unchanged; hard deletion removes it only when deleting the whole
-logical agent, not when cleaning up one failed version.
+Creating a version never creates a second identity; archive and restore leave it unchanged.
 
-### PR 3: Backfill agent identities
+### PR 5: Clean up identities on logical hard delete
+
+Delete the identity only when the whole logical agent is hard-deleted, including abandoned pending
+agents. After failed-version cleanup, delete it only when no configuration remains.
+
+### PR 6: Backfill agent identities
 
 Create one identity per existing `sId`, attach every version to it, and report duplicates or missing
-rows. The backfill must be idempotent and run after PR 2 is deployed so new writes cannot create
-more unlinked configurations.
+rows. Run this idempotent backfill only after PRs 4 and 5 are deployed.
 
-### PR 4: Enforce identity invariants
+**Operational gate:** run the backfill and verify that every configuration has exactly one logical
+agent before enforcing constraints.
 
-After verifying the backfill, make `agent_configurations.agentId` non-null and add uniqueness on
-`(agentId, version)`. Keep the existing `sId` columns and indexes for now; moving them belongs to a
-future head/version refactor.
+### PR 7: Enforce identity invariants
+
+Make `agent_configurations.agentId` non-null and add uniqueness on `(agentId, version)` in a
+post-deploy migration. Keep `sId` on configurations for the future head/version refactor.
 
 ## 2. Build and verify the grants path
 
-### PR 5: Add the thin Agent Resource and final ACL semantics
+### PR 8: Preserve editor administration semantics
 
-Add `AgentResource`, that uses the stable `agentId`, implements `getAccessControlLists`, editor listing helpers, and the current derived rules for
-visible agents and `isAuthor`;
+Add `admin` to the `agent.editor` registry role, with focused registry tests. This defines the final
+role semantics without creating or serving agent grants yet.
 
-also add `admin` to the `agent.editor` registry role. [=> separate PR]
+### PR 9: Add the thin Agent Resource
 
-### PR 6: Dual-write every editor mutation
+Add a tested `AgentResource` that uses stable `agentId` for workspace agents and implements
+`getAccessControlLists` plus `canRead`, `canWrite`, and `canAdministrate`. Preserve visible-agent and
+`isAuthor` rules, and return static ACLs for code-defined global agents.
 
-Keep legacy writes, but also grant/revoke membership in the `regular_auto` group holding
-`(editor, agent, agentId)`. Cover initial creator grants, full editor-set updates, editor add/remove,
-and hard-delete cleanup; version creation and archive must not alter grants.
+### PR 10: Dual-write initial editor grants
 
-### PR 7: Backfill agent editor grants
+When creating a pending/new agent, keep creating its legacy editor group and also grant its initial
+editors into the final `regular_auto` group.
 
-For every logical agent, copy the legacy editor set into its final `regular_auto` grant group.
-Include archived agents, make the script idempotent, and report editor-set differences and authors
-who are not explicit editors without silently changing their membership.
+### PR 11: Dual-write editor additions
 
-### PR 8: Shadow permission and editor-list reads
+Keep legacy writes and grant newly added editors into the final group, including additions made by
+a full editor-set update.
 
-Continue serving legacy results while comparing the grants path for `read`, `write`, `admin`, and
-the resolved editor list. Use the existing `group_permissions_shadow` flag and structured mismatch
-logs; compare effective decisions, including visible-agent and `isAuthor` rules.
+### PR 12: Dual-write editor removals
 
-### PR 9: Shadow agent-list filtering
+Keep legacy writes and revoke removed editors from the final group, including removals made by a
+full editor-set update.
 
-Agent list/manage/archive views currently find editable agents through `group_agents` version ids.
-Keep serving that result while comparing it with stable agent ids from
-`auth.getResourceIdsWithVerb("agent", ...)`, including hidden and archived views.
+### PR 13: Clean up grants on hard delete
 
-**Operational gate:** enable shadowing progressively and wait for the backfill and cache-related
-mismatches to reach zero before flipping.
+Delete the agent's permission rows and final `regular_auto` group when the logical agent is
+hard-deleted. Version cleanup and archive leave grants unchanged.
+
+### PR 14: Backfill agent editor grants
+
+Copy each legacy editor set into the final grant group, including archived agents. Make the script
+idempotent and report editor-set differences and authors who are not explicit editors.
+
+### PR 15: Shadow editor-list reads
+
+Add grant-backed `listEditors` and batch-list helpers to `AgentResource`. Continue serving the
+legacy editor list while comparing user sets under `group_permissions_shadow`.
+
+### PR 16: Shadow permission decisions
+
+Continue serving legacy `read`, `write`, and `admin` decisions while comparing `AgentResource`.
+Compare effective results, including visible-agent and `isAuthor` rules.
+
+### PR 17: Shadow agent-list filtering
+
+List/manage/archive views currently resolve editable agents through `group_agents` version ids.
+Keep serving that result while comparing stable ids from
+`auth.getResourceIdsWithVerb("agent", ...)`.
+
+**Operational gate:** enable shadowing progressively and wait for editor-list, permission, listing,
+backfill, and cache-related mismatches to reach zero.
 
 ## 3. Flip and remove the legacy model
 
-### PR 10: Flip reads to grants
+### PR 18: Flip editor-list reads
 
-Serve permission decisions, editor lists, and agent-list filtering from `AgentResource` /
-`group_permissions`. Keep legacy writes temporarily and retain a kill-switch fallback so the flip
-can be reverted without data loss.
+Serve editor lists from `AgentResource`, while keeping legacy writes and a kill-switch fallback.
 
-**Operational gate:** observe production before removing the fallback or legacy writes.
+**Operational gate:** observe the editor-list flip before removing its fallback.
 
-### PR 11: Stop all legacy reads and writes
+### PR 19: Remove the legacy editor-list fallback
 
-Remove `GroupResource` agent-editor resolution, `group_agents` links on new versions, and legacy
-editor-group mutations. `AgentResource` and `group_permissions` become the only editor path.
+Remove the legacy branch and shadow comparison for editor-list reads only.
 
-### PR 12: Delete legacy agent-editor groups
+### PR 20: Flip permission decisions
 
-Delete all `agent_editors` groups and their memberships after verifying that no code reads them.
-Verify that the associated `group_agents` rows are gone as well.
+Serve `read`, `write`, and `admin` decisions from `AgentResource`, with a kill-switch fallback.
 
-### PR 13: Remove the `agent_editors` kind
+**Operational gate:** observe the permission flip before removing its fallback.
 
-Remove the enum value, guards, factories, tests, and remaining code branches for the legacy group
-kind. This is safe only after PR 12 has removed all rows of that kind.
+### PR 21: Remove the legacy permission fallback
 
-### PR 14: Drop `group_agents`
+Remove the legacy branch and shadow comparison for permission decisions only.
+
+### PR 22: Flip agent-list filtering
+
+Use stable agent ids from `group_permissions` for list/manage/archive filtering, with a kill-switch
+fallback.
+
+**Operational gate:** observe the listing flip before removing its fallback.
+
+### PR 23: Remove the legacy listing fallback
+
+Remove the legacy branch and shadow comparison for agent-list filtering only.
+
+### PR 24: Remove migration switches
+
+Remove `group_permissions_shadow`, `use_legacy_acls`, and their shared helpers once no other resource
+migration uses them.
+
+### PR 25: Stop legacy editor-membership writes
+
+Stop mutating existing `agent_editors` memberships on editor-set, add, and remove operations.
+Grant-backed editor mutations become the only update path; initial legacy-group creation remains
+until the next PR.
+
+### PR 26: Stop creating legacy editor groups and links
+
+Stop creating `agent_editors` groups for new agents and stop adding `group_agents` links for new
+versions, including the initial legacy membership write. This follows PR 25 so no remaining update
+path expects those groups to exist.
+
+### PR 27: Delete legacy agent-editor groups
+
+Delete all `agent_editors` groups and their memberships after verifying that no code reads or writes
+them. Verify that their associated `group_agents` rows are gone as well.
+
+### PR 28: Remove the `agent_editors` kind
+
+Remove the enum value, guards, factories, tests, and remaining branches for the legacy group kind.
+This is safe only after PR 27 has removed all rows of that kind.
+
+### PR 29: Drop `group_agents`
 
 Remove `GroupAgentModel` and its associations, then drop the table in a post-deploy migration.
 
 ## 4. Remove the author fallback separately
 
-### PR 15: Remove `isAuthor` as an authorization source
+### PR 30: Remove `isAuthor` as an authorization source
 
-After the migration has been stable, inspect the shadow data for authors without editor grants and
-decide how to handle those outliers. Then remove the fallback so explicit grants are the sole source
-of editorship; if the product needs ownership, model it explicitly instead.
+Inspect authors without editor grants and decide how to handle those outliers. Then remove the
+fallback so explicit grants are the sole source of editorship; model ownership explicitly if the
+product needs it.

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -1,0 +1,121 @@
+# Admin Governance - Agent Migration
+
+This plan migrates workspace-agent editor permissions from `agent_editors` group kind and
+`group_agents` join table to `regular_auto` group kind and `group_permissions` table. 
+
+Each numbered item is one PR. Observation and backfill execution gates are called out separately.
+
+## Decisions
+- `agents.id` is the stable numeric permission id; `agent_configurations.id` remains a version id.
+- Existing agent `sId`s stay unchanged and remain the external identifier.
+- `agent.editor` grants `read`, `write`, and `admin`, preserving today's behavior.
+- Archiving keeps editor memberships active. The archived status, not the ACL, blocks mutations.
+- Keep the `isAuthor` fallback through the migration; remove it separately after measuring outliers.
+- code-defined global agents: the rules governing their permissions are static, and don't need the grants table. The logic can be implemented directly in the resource's `getAccessControlLists` method;
+
+## 0. Preserve editors on archived agents
+
+### PR 0: Stop suspending editors on archive
+
+Stop suspending/restoring `agent_editors` memberships, reject mutations on archived agents except
+restore, and keep runtime cleanup such as disabling triggers and wake-ups. Include an idempotent
+backfill for memberships already suspended by archive, so archived-agent editors remain visible.
+
+## 1. Add a stable logical agent id
+
+### PR 1: Expand the schema
+
+Create `agents(id, sId, workspaceId)` with `id` as the primary key and `sId` unique. Add an indexed,
+nullable `agentId` foreign key to `agent_configurations`; nullable keeps the deploy compatible with
+old code and existing rows.
+
+### PR 2: Wire the agent identity lifecycle
+
+Create the identity with a pending/new agent and reuse its `agentId` for every later version.
+Archive and restore leave it unchanged; hard deletion removes it only when deleting the whole
+logical agent, not when cleaning up one failed version.
+
+### PR 3: Backfill agent identities
+
+Create one identity per existing `sId`, attach every version to it, and report duplicates or missing
+rows. The backfill must be idempotent and run after PR 2 is deployed so new writes cannot create
+more unlinked configurations.
+
+### PR 4: Enforce identity invariants
+
+After verifying the backfill, make `agent_configurations.agentId` non-null and add uniqueness on
+`(agentId, version)`. Keep the existing `sId` columns and indexes for now; moving them belongs to a
+future head/version refactor.
+
+## 2. Build and verify the grants path
+
+### PR 5: Add the thin Agent Resource and final ACL semantics
+
+Add `AgentResource`, that uses the stable `agentId`, implements `getAccessControlLists`, editor listing helpers, and the current derived rules for
+visible agents and `isAuthor`;
+
+also add `admin` to the `agent.editor` registry role. [=> separate PR]
+
+### PR 6: Dual-write every editor mutation
+
+Keep legacy writes, but also grant/revoke membership in the `regular_auto` group holding
+`(editor, agent, agentId)`. Cover initial creator grants, full editor-set updates, editor add/remove,
+and hard-delete cleanup; version creation and archive must not alter grants.
+
+### PR 7: Backfill agent editor grants
+
+For every logical agent, copy the legacy editor set into its final `regular_auto` grant group.
+Include archived agents, make the script idempotent, and report editor-set differences and authors
+who are not explicit editors without silently changing their membership.
+
+### PR 8: Shadow permission and editor-list reads
+
+Continue serving legacy results while comparing the grants path for `read`, `write`, `admin`, and
+the resolved editor list. Use the existing `group_permissions_shadow` flag and structured mismatch
+logs; compare effective decisions, including visible-agent and `isAuthor` rules.
+
+### PR 9: Shadow agent-list filtering
+
+Agent list/manage/archive views currently find editable agents through `group_agents` version ids.
+Keep serving that result while comparing it with stable agent ids from
+`auth.getResourceIdsWithVerb("agent", ...)`, including hidden and archived views.
+
+**Operational gate:** enable shadowing progressively and wait for the backfill and cache-related
+mismatches to reach zero before flipping.
+
+## 3. Flip and remove the legacy model
+
+### PR 10: Flip reads to grants
+
+Serve permission decisions, editor lists, and agent-list filtering from `AgentResource` /
+`group_permissions`. Keep legacy writes temporarily and retain a kill-switch fallback so the flip
+can be reverted without data loss.
+
+**Operational gate:** observe production before removing the fallback or legacy writes.
+
+### PR 11: Stop all legacy reads and writes
+
+Remove `GroupResource` agent-editor resolution, `group_agents` links on new versions, and legacy
+editor-group mutations. `AgentResource` and `group_permissions` become the only editor path.
+
+### PR 12: Delete legacy agent-editor groups
+
+Delete all `agent_editors` groups and their memberships after verifying that no code reads them.
+Verify that the associated `group_agents` rows are gone as well.
+
+### PR 13: Remove the `agent_editors` kind
+
+Remove the enum value, guards, factories, tests, and remaining code branches for the legacy group
+kind. This is safe only after PR 12 has removed all rows of that kind.
+
+### PR 14: Drop `group_agents`
+
+Remove `GroupAgentModel` and its associations, then drop the table in a post-deploy migration.
+
+## 4. Remove the author fallback separately
+
+### PR 15: Remove `isAuthor` as an authorization source
+
+After the migration has been stable, inspect the shadow data for authors without editor grants and
+decide how to handle those outliers. Then remove the fallback so explicit grants are the sole source
+of editorship; if the product needs ownership, model it explicitly instead.


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48

Documents the incremental migration of agent editor permissions from agent_editors and group_agents to stable numeric agent identities and group_permissions. The sequence keeps each implementation PR focused and roughly below 300 changed lines, with explicit backfill, shadow, flip, and cleanup gates.

## Risks

Blast radius: Internal implementation documentation only.
Risk: none

## Deploy Plan

- Merge only; no service deployment or database migration.