### PR TITLE
Add CellType and CellInfo

### DIFF
--- a/front/lib/api/cells/config.ts
+++ b/front/lib/api/cells/config.ts
@@ -1,0 +1,82 @@
+import type { CellInfo, CellType } from "@app/types/cell";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
+import { isDevelopment } from "@app/types/shared/env";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { EnvironmentConfig } from "@app/types/shared/utils/config";
+
+// Ensure we have a CellInfo entry for EVERY CellType by iterating SUPPORTED_CELLS.
+const CELLS: Record<CellType, CellInfo> = Object.fromEntries(
+  SUPPORTED_CELLS.map((cell) => {
+    switch (cell) {
+      // US Global
+      case "cell-00000":
+        return [
+          cell,
+          {
+            name: cell,
+            region: "us-central1",
+            url: EnvironmentConfig.getEnvVariable("DUST_US_URL"),
+          },
+        ];
+      // EU Global
+      case "cell-00001":
+        return [
+          cell,
+          {
+            name: cell,
+            region: "europe-west1",
+            url: EnvironmentConfig.getEnvVariable("DUST_EU_URL"),
+          },
+        ];
+      default:
+        // This ensures that if a new CellType is added, TypeScript will error until handled.
+        assertNever(cell);
+    }
+  })
+) satisfies Record<CellType, CellInfo>;
+
+const MAIN_CELL: CellType = "cell-00000";
+
+export const config = {
+  getCurrentCell: (): CellInfo => {
+    const cell = EnvironmentConfig.getEnvVariable("CELL");
+    if (!isCellType(cell)) {
+      throw new Error(`Invalid cell: ${cell}`);
+    }
+    return CELLS[cell];
+  },
+  getLookupApiSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("REGION_RESOLVER_SECRET");
+  },
+  getCellUrl(cell: CellType): string {
+    if (isDevelopment()) {
+      return "http://localhost:3000";
+    }
+
+    switch (cell) {
+      case "cell-00000":
+        return EnvironmentConfig.getEnvVariable("DUST_EU_URL");
+      case "cell-00001":
+        return EnvironmentConfig.getEnvVariable("DUST_US_URL");
+      default:
+        assertNever(cell);
+    }
+  },
+  isMainCell(): boolean {
+    return this.getCurrentCell().name === MAIN_CELL;
+  },
+  getOtherCells(): CellInfo[] {
+    const currentCell = this.getCurrentCell();
+    return Object.values(CELLS).filter(
+      (cell) => cell.name !== currentCell.name
+    );
+  },
+  getDustCellSyncEnabled: (): boolean => {
+    return (
+      EnvironmentConfig.getEnvVariable("CELL") !== MAIN_CELL || isDevelopment()
+    );
+  },
+  getDustCellSyncMasterUrl: (): string => {
+    return CELLS[MAIN_CELL].url;
+  },
+};

--- a/front/types/cell.ts
+++ b/front/types/cell.ts
@@ -1,0 +1,15 @@
+import type { RegionType } from "@app/types/region";
+
+// Cells are standalone deployments of a whole Dust environment.
+export const SUPPORTED_CELLS = ["cell-00000", "cell-00001"] as const;
+export type CellType = (typeof SUPPORTED_CELLS)[number];
+
+export interface CellInfo {
+  name: CellType;
+  region: RegionType;
+  url: string;
+}
+
+export function isCellType(cell: string): cell is CellType {
+  return SUPPORTED_CELLS.includes(cell as CellType);
+}

--- a/front/types/region.ts
+++ b/front/types/region.ts
@@ -3,7 +3,7 @@ export type RegionType = (typeof SUPPORTED_REGIONS)[number];
 
 export interface RegionInfo {
   name: RegionType;
-  url: string;
+  url: string; // TODO(single-tenant) from Seb: this is wrong as the URL belong to the Cell, not the Region. Kept for backward compatibility until we moved everything to Cells.
 }
 
 export function isRegionType(region: string): region is RegionType {


### PR DESCRIPTION
## Description

I add `CellType` and `CellInfo` to model standalone Dust deployments and introduce `config` helpers for resolving the current cell, cell URLs, peer cells, and cross-cell sync settings. `RegionInfo` retains its URL for backward compatibility during the migration to cell-owned URLs.

## Tests

Not run; this PR adds type definitions and configuration helpers only.

## Risk

Low. The new cell configuration is isolated, but production behavior depends on the `CELL`, `DUST_*_URL`, and `REGION_RESOLVER_SECRET` environment variables being configured correctly.

## Deploy Plan

Deploy `front`. No database migrations or infrastructure changes.