### PR TITLE
Register Frames v2 from dsbx

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,8 +9,8 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FramePublishRequest, FramePublishResponse, MCPServerView,
-    SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FramePublishRequest, FramePublishResponse,
+    FrameRegisterRequest, FrameRegisterResponse, MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -140,6 +140,17 @@ impl DustApiClient {
                 manifest_path: source_path,
             },
             POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn register_frame(
+        &self,
+        manifest_path: &str,
+    ) -> anyhow::Result<FrameRegisterResponse> {
+        self.post(
+            "sandbox/frames/register",
+            &FrameRegisterRequest { manifest_path },
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/mod.rs
+++ b/cli/dust-sandbox/src/api/mod.rs
@@ -4,4 +4,4 @@ mod types;
 
 pub use client::DustApiClient;
 pub use error::DustApiError;
-pub use types::{parse_content_block, CallToolResult, ContentBlock, FramePublishResponse};
+pub use types::{parse_content_block, CallToolResult, ContentBlock};

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -9,6 +9,12 @@ pub struct FramePublishRequest<'a> {
     pub manifest_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameRegisterRequest<'a> {
+    pub manifest_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -18,6 +24,14 @@ pub struct FramePublishResponse {
     pub publication_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameRegisterResponse {
+    pub frame_id: String,
+    pub manifest_path: String,
+    pub created: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/dust-sandbox/src/commands/frame/create.rs
+++ b/cli/dust-sandbox/src/commands/frame/create.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{bail, Context};
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_manifest_path, FRAME_MANIFEST_FILE};
+
+const FRAME_UI_ENTRY_POINT: &str = "index.tsx";
+const DEFAULT_FRAME_SOURCE: &str = r#"export default function Frame() {
+  return <main>New Frame</main>;
+}
+"#;
+
+pub async fn run(directory: &Path, name: Option<&str>, description: &str) -> anyhow::Result<()> {
+    let manifest_path = directory.join(FRAME_MANIFEST_FILE);
+    let scoped_manifest_path = scoped_manifest_path(&manifest_path)?;
+    let frame_name = match name {
+        Some(name) => name.to_owned(),
+        None => directory
+            .file_name()
+            .and_then(|value| value.to_str())
+            .context("Frame folder must have a valid UTF-8 name")?
+            .to_owned(),
+    };
+    if frame_name.is_empty() {
+        bail!("Frame name cannot be empty");
+    }
+
+    scaffold(directory, &frame_name, description)?;
+
+    let client = DustApiClient::from_env()?;
+    let response = client.register_frame(&scoped_manifest_path).await?;
+    print_response(&response)
+}
+
+fn scaffold(directory: &Path, name: &str, description: &str) -> anyhow::Result<()> {
+    let manifest_path = directory.join(FRAME_MANIFEST_FILE);
+    let ui_path = directory.join(FRAME_UI_ENTRY_POINT);
+    if manifest_path.exists() || ui_path.exists() {
+        bail!("Frame source already exists in {}", directory.display());
+    }
+
+    fs::create_dir_all(directory)
+        .with_context(|| format!("failed to create {}", directory.display()))?;
+    let manifest = serde_json::to_string_pretty(&serde_json::json!({
+        "version": 1,
+        "name": name,
+        "description": description,
+    }))?;
+    fs::write(&manifest_path, format!("{manifest}\n"))
+        .with_context(|| format!("failed to write {}", manifest_path.display()))?;
+    fs::write(&ui_path, DEFAULT_FRAME_SOURCE)
+        .with_context(|| format!("failed to write {}", ui_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffolds_a_minimal_frame_without_overwriting() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let directory = temp.path().join("Status");
+
+        scaffold(&directory, "Status", "Current status").expect("scaffold");
+
+        let manifest =
+            fs::read_to_string(directory.join(FRAME_MANIFEST_FILE)).expect("read manifest");
+        let parsed: serde_json::Value = serde_json::from_str(&manifest).expect("parse manifest");
+        assert_eq!(parsed["name"], "Status");
+        assert!(directory.join(FRAME_UI_ENTRY_POINT).exists());
+        assert!(scaffold(&directory, "Other", "").is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,16 +1,36 @@
+mod create;
 mod publish;
+mod register;
 
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{bail, Context};
 use clap::Subcommand;
 
-use crate::api::FramePublishResponse;
-
+pub use create::run as cmd_frame_create;
 pub use publish::run as cmd_frame_publish;
+pub use register::run as cmd_frame_register;
+
+const FRAME_MANIFEST_FILE: &str = "manifest.json";
 
 #[derive(Subcommand)]
 pub enum FrameCommand {
+    /// Create and register a new Frame folder
+    Create {
+        /// Frame folder under /files/conversation-... or /files/pod-...
+        directory: PathBuf,
+        /// Display name (defaults to the folder name)
+        #[arg(long)]
+        name: Option<String>,
+        /// Frame description
+        #[arg(long, default_value = "")]
+        description: String,
+    },
+    /// Register an existing Frame manifest and assign its stable identity
+    Register {
+        /// Absolute /files/.../manifest.json path
+        manifest: PathBuf,
+    },
     /// Build and publish a Frame from its current source
     Publish {
         /// Absolute path to a v2 manifest or legacy Frame entry file under /files
@@ -36,7 +56,14 @@ fn scoped_path(path: &Path) -> anyhow::Result<String> {
         .context("path must be valid UTF-8")
 }
 
-fn print_response(response: &FramePublishResponse) -> anyhow::Result<()> {
+fn scoped_manifest_path(path: &Path) -> anyhow::Result<String> {
+    if path.file_name().and_then(|name| name.to_str()) != Some(FRAME_MANIFEST_FILE) {
+        bail!("Frame path must end in {FRAME_MANIFEST_FILE}");
+    }
+    scoped_path(path)
+}
+
+fn print_response(response: &impl serde::Serialize) -> anyhow::Result<()> {
     println!("{}", serde_json::to_string(response)?);
     Ok(())
 }

--- a/cli/dust-sandbox/src/commands/frame/register.rs
+++ b/cli/dust-sandbox/src/commands/frame/register.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_manifest_path};
+
+pub async fn run(manifest: &Path) -> anyhow::Result<()> {
+    let manifest_path = scoped_manifest_path(manifest)?;
+    let client = DustApiClient::from_env()?;
+    let response = client.register_frame(&manifest_path).await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
-pub use frame::cmd_frame_publish;
+pub use frame::{cmd_frame_create, cmd_frame_publish, cmd_frame_register};
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -34,7 +34,7 @@ enum Commands {
         #[command(subcommand)]
         command: commands::db::DbCommand,
     },
-    /// Publish Frames
+    /// Create, register, and publish Frames
     Frame {
         #[command(subcommand)]
         command: commands::frame::FrameCommand,
@@ -131,6 +131,14 @@ async fn run() -> anyhow::Result<()> {
             commands::db::DbCommand::Query { name } => commands::cmd_db_query(&name).await?,
         },
         Commands::Frame { command } => match command {
+            commands::frame::FrameCommand::Create {
+                directory,
+                name,
+                description,
+            } => commands::cmd_frame_create(&directory, name.as_deref(), &description).await?,
+            commands::frame::FrameCommand::Register { manifest } => {
+                commands::cmd_frame_register(&manifest).await?
+            }
             commands::frame::FrameCommand::Publish { source } => {
                 commands::cmd_frame_publish(&source).await?
             }
@@ -481,6 +489,7 @@ mod tests {
                     std::path::PathBuf::from("/files/pod-vlt_123/Status/manifest.json")
                 );
             }
+            Commands::Frame { .. } => panic!("expected publish"),
             _ => panic!("expected frame"),
         }
     }

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -10,6 +10,7 @@ import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
+import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/lock", async (importActual) => {
@@ -42,7 +43,22 @@ function requestFramePublish(
   });
 }
 
-async function setup() {
+function requestFrameRegister(
+  workspaceId: string,
+  token: string,
+  manifestPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/register`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ manifestPath }),
+  });
+}
+
+async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
   const sourceDirectoryPath = `conversation-${context.conversation.sId}/Status`;
@@ -51,15 +67,17 @@ async function setup() {
     workspaceId: context.workspace.sId,
     conversationId: context.conversation.sId,
   })}Status`;
-  const frame = await FileFactory.create(context.auth, null, {
-    contentType: frameV2ContentType,
-    fileName: FRAME_MANIFEST_FILE,
-    fileSize: Buffer.byteLength(manifest),
-    status: "created",
-    useCase: "conversation",
-    useCaseMetadata: { conversationId: context.conversation.sId },
-    mountFilePath: `${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`,
-  });
+  const frame = registered
+    ? await FileFactory.create(context.auth, null, {
+        contentType: frameV2ContentType,
+        fileName: FRAME_MANIFEST_FILE,
+        fileSize: Buffer.byteLength(manifest),
+        status: "created",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: context.conversation.sId },
+        mountFilePath: `${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+      })
+    : null;
   const sourceByPath = new Map([
     [`${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifest],
     [`${mountDirectoryPath}/index.tsx`, uiSource],
@@ -124,9 +142,32 @@ beforeEach(() => {
   fileStorageMock.reset();
 });
 
-describe("POST /api/v1/w/[wId]/sandbox/frames/publish", () => {
+describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
+  it("registers one stable Frame identity", async () => {
+    const context = await setup({ registered: false });
+
+    const firstResponse = await requestFrameRegister(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(firstResponse.status).toBe(200);
+    const first = await firstResponse.json();
+    expect(first.created).toBe(true);
+
+    const secondResponse = await requestFrameRegister(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(secondResponse.status).toBe(200);
+    const second = await secondResponse.json();
+    expect(second).toMatchObject({ frameId: first.frameId, created: false });
+  });
+
   it("publishes a registered Frame through the sandbox token", async () => {
     const context = await setup();
+    assert(context.frame);
 
     const response = await requestFramePublish(
       context.workspace.sId,

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -17,6 +17,8 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import register from "./register";
+
 const FramePublishRequestSchema = z.object({
   manifestPath: z.string().min(1),
 });
@@ -67,6 +69,7 @@ function frameErrorStatus(error: PublishFrameFromSourceError): 400 | 403 | 500 {
 const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
+app.route("/register", register);
 
 /**
  * @ignoreswagger

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/register.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/register.ts
@@ -1,0 +1,108 @@
+import {
+  type RegisterFrameV2FromSourceError,
+  registerFrameV2FromSource,
+} from "@app/lib/api/frames/register_from_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameRegisterRequestSchema = z.object({
+  manifestPath: z.string().min(1),
+});
+
+type FrameRegisterResponse = {
+  frameId: string;
+  manifestPath: string;
+  created: boolean;
+};
+
+function frameRegisterErrorStatus(
+  error: RegisterFrameV2FromSourceError
+): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+
+  return error.code === "unauthorized" ? 403 : 400;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameRegisterRequestSchema),
+  async (ctx): HandlerResult<FrameRegisterResponse> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot register Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { manifestPath } = ctx.req.valid("json");
+    const registration = await registerFrameV2FromSource(auth, {
+      conversation: conversation.toJSON(),
+      manifestPath,
+    });
+    if (registration.isErr()) {
+      const status = frameRegisterErrorStatus(registration.error);
+      return apiError(ctx, {
+        status_code: status,
+        api_error: {
+          type:
+            status === 500 ? "internal_server_error" : "invalid_request_error",
+          message: registration.error.message,
+        },
+      });
+    }
+
+    return ctx.json(
+      {
+        frameId: registration.value.frame.sId,
+        manifestPath,
+        created: registration.value.created,
+      },
+      200
+    );
+  }
+);
+
+export default app;

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -787,6 +787,10 @@ export class DustFileSystem {
     return this.mounts;
   }
 
+  isGCSBacked(): boolean {
+    return this.storageMode === "gcs";
+  }
+
   checkWriteAccess(scopedPath: string): Result<void, DustFileSystemError> {
     const resolved = this.requireWriteMount(scopedPath);
     return resolved.isErr() ? new Err(resolved.error) : new Ok(undefined);

--- a/front/lib/api/frames/register_from_source.test.ts
+++ b/front/lib/api/frames/register_from_source.test.ts
@@ -1,0 +1,87 @@
+import { registerFrameV2FromSource } from "@app/lib/api/frames/register_from_source";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const manifest = JSON.stringify({
+  version: 1,
+  name: "Status",
+  description: "Show the current status.",
+});
+
+async function setup() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const manifestPath = `conversation-${conversation.sId}/Status/${FRAME_MANIFEST_FILE}`;
+  const mountFilePath = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status/${FRAME_MANIFEST_FILE}`;
+  fileStorageMock.setFileContent((path) =>
+    path === mountFilePath ? manifest : null
+  );
+
+  return { auth, conversation, manifestPath, mountFilePath };
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+describe("registerFrameV2FromSource", () => {
+  it("registers one stable Frame identity for a manifest path", async () => {
+    const { auth, conversation, manifestPath, mountFilePath } = await setup();
+    // Registration adopts the mounted manifest; it must not try to copy a canonical upload.
+    fileStorageMock.setCopyFileFails(() => true);
+
+    const first = await registerFrameV2FromSource(auth, {
+      conversation,
+      manifestPath,
+    });
+    assert(first.isOk());
+    expect(first.value.created).toBe(true);
+    expect(first.value.frame.mountFilePath).toBe(mountFilePath);
+    expect(first.value.frame.isReady).toBe(true);
+
+    const second = await registerFrameV2FromSource(auth, {
+      conversation,
+      manifestPath,
+    });
+    assert(second.isOk());
+    expect(second.value.created).toBe(false);
+    expect(second.value.frame.sId).toBe(first.value.frame.sId);
+
+    const files = await FileResource.fetchByMountFilePaths(auth, [
+      mountFilePath,
+    ]);
+    expect(files).toHaveLength(1);
+  });
+
+  it("rejects an invalid manifest without creating a FileResource", async () => {
+    const { auth, conversation, manifestPath, mountFilePath } = await setup();
+    fileStorageMock.setFileContent((path) =>
+      path === mountFilePath ? "not json" : null
+    );
+
+    const result = await registerFrameV2FromSource(auth, {
+      conversation,
+      manifestPath,
+    });
+
+    assert(result.isErr());
+    expect(result.error.code).toBe("invalid_manifest");
+    expect(
+      await FileResource.fetchByMountFilePaths(auth, [mountFilePath])
+    ).toEqual([]);
+  });
+});

--- a/front/lib/api/frames/register_from_source.ts
+++ b/front/lib/api/frames/register_from_source.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import {
+  FRAME_MANIFEST_FILE,
+  parseFrameManifest,
+} from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import { frameV2ContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { UniqueConstraintError } from "sequelize";
+
+function registrationError(message: string) {
+  return new Err(new FramePublicationError("invalid_source", message));
+}
+
+async function existingFrameAtMountPath(
+  auth: Authenticator,
+  mountFilePath: string
+): Promise<Result<FileResource | null, RegisterFrameV2FromSourceError>> {
+  const [existing] = await FileResource.fetchByMountFilePaths(auth, [
+    mountFilePath,
+  ]);
+  if (!existing) {
+    return new Ok(null);
+  }
+  if (!existing.isFrameV2) {
+    return registrationError(
+      "A non-Frame file is already registered at this path."
+    );
+  }
+
+  await existing.markFrameV2AsReadyFromMount();
+  return new Ok(existing);
+}
+
+export type RegisterFrameV2FromSourceError =
+  | DustFileSystemError
+  | FramePublicationError;
+
+/** Register the manifest already present on the invoking conversation's mounted GCS filesystem. */
+export async function registerFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { frame: FileResource; created: boolean },
+    RegisterFrameV2FromSourceError
+  >
+> {
+  const normalizedPath = DustFileSystem.normalizeScopedPath(manifestPath);
+  if (
+    !normalizedPath ||
+    path.posix.basename(normalizedPath) !== FRAME_MANIFEST_FILE
+  ) {
+    return registrationError(
+      `Frame source must point to a ${FRAME_MANIFEST_FILE} file.`
+    );
+  }
+
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return registrationError(
+      "Frames v2 registration does not yet support the database-backed filesystem."
+    );
+  }
+
+  const writeAccess = dustFs.checkWriteAccess(normalizedPath);
+  if (writeAccess.isErr()) {
+    return new Err(writeAccess.error);
+  }
+
+  const manifestBufferResult = await dustFs.readBuffer(normalizedPath);
+  if (manifestBufferResult.isErr()) {
+    return new Err(manifestBufferResult.error);
+  }
+  if (manifestBufferResult.value === null) {
+    return registrationError(`Frame manifest not found: ${normalizedPath}`);
+  }
+  const manifestBuffer = manifestBufferResult.value;
+
+  const manifestResult = parseFrameManifest(manifestBuffer);
+  if (manifestResult.isErr()) {
+    return new Err(
+      new FramePublicationError("invalid_manifest", manifestResult.error)
+    );
+  }
+
+  const mount = dustFs
+    .getMounts()
+    .find(
+      (candidate) =>
+        normalizedPath.startsWith(`${candidate.scopedPrefix}/`) &&
+        candidate.permissions.canWrite
+    );
+  if (!mount || (mount.kind !== "conversation" && mount.kind !== "pod")) {
+    return registrationError(
+      "Frame source does not belong to a writable conversation or Pod mount."
+    );
+  }
+
+  const mountFilePath = dustFs.toMountFilePath(normalizedPath);
+  if (!mountFilePath) {
+    return registrationError(`Invalid Frame source path: ${normalizedPath}`);
+  }
+
+  const existingResult = await existingFrameAtMountPath(auth, mountFilePath);
+  if (existingResult.isErr()) {
+    return existingResult;
+  }
+  if (existingResult.value) {
+    return new Ok({ frame: existingResult.value, created: false });
+  }
+
+  const useCase: FileUseCase =
+    mount.kind === "pod" ? "project_context" : "conversation";
+  const useCaseMetadata: FileUseCaseMetadata =
+    mount.kind === "pod" ? { spaceId: mount.id } : { conversationId: mount.id };
+
+  try {
+    const frame = await FileResource.makeNew({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      userId: auth.user()?.id ?? null,
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: manifestBuffer.length,
+      useCase,
+      useCaseMetadata,
+      mountFilePath,
+      fileSystemNodeId: null,
+    });
+    await frame.markFrameV2AsReadyFromMount();
+    return new Ok({ frame, created: true });
+  } catch (error) {
+    if (!(error instanceof UniqueConstraintError)) {
+      throw error;
+    }
+
+    const concurrent = await existingFrameAtMountPath(auth, mountFilePath);
+    if (concurrent.isErr()) {
+      return concurrent;
+    }
+    assert(concurrent.value, "Frame not found after mount path conflict");
+    return new Ok({ frame: concurrent.value, created: false });
+  }
+}

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.98",
+      tag: "0.8.99",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.51/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.52/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.98";
-const DSBX_CLI_VERSION = "0.1.51";
+const DUST_BASE_IMAGE_VERSION = "0.8.99";
+const DSBX_CLI_VERSION = "0.1.52";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -651,6 +651,21 @@ export class FileResource extends BaseResource<FileModel> {
     return updateResult;
   }
 
+  /**
+   * Mark a Frames v2 manifest that already exists at its mount path as ready.
+   * Unlike markAsReady(), this must not copy from the canonical upload path.
+   */
+  async markFrameV2AsReadyFromMount() {
+    assert(this.isFrameV2, "Only Frames v2 can be adopted from a mount path");
+    assert(this.mountFilePath, "A mounted Frames v2 manifest requires a path");
+
+    if (this.status === "ready") {
+      return;
+    }
+
+    return this.update({ status: "ready" });
+  }
+
   get isReady(): boolean {
     return this.status === "ready";
   }

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -52,7 +52,7 @@ function agentLoopDataInPod(spaceId: string | null): AgentLoopExecutionData {
 }
 
 describe("framesSkill.fetchInstructions", () => {
-  it("uses dsbx publish and keeps the remaining MCP tools under Frames v2", async () => {
+  it("uses the dsbx lifecycle and keeps the remaining MCP tools under Frames v2", async () => {
     const { authenticator: auth } = await createResourceTest({});
     await FeatureFlagFactory.basic(auth, "frames_v2");
 
@@ -61,6 +61,8 @@ describe("framesSkill.fetchInstructions", () => {
     });
 
     expect(instructions).toContain("dsbx frame publish");
+    expect(instructions).toContain("dsbx frame create");
+    expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("package-like folder");
     expect(instructions).toContain("canonical Frame resource");
     expect(instructions).toContain("`index.tsx` by default");
@@ -77,8 +79,6 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("### React Component Rules");
     expect(instructions).toContain("legacy Frame");
     expect(instructions).toContain("<frame>.tsx");
-    expect(instructions).not.toContain("dsbx frame create");
-    expect(instructions).not.toContain("dsbx frame register");
     expect(instructions).toContain(
       "Other interactive-content tools remain available"
     );

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -4,7 +4,7 @@ export const FRAMES_V2_INSTRUCTIONS = `\
 # Frames v2
 
 Frames are interactive React applications. Use the Computer to edit their source and the
-\`dsbx frame\` CLI to publish them.
+\`dsbx frame\` CLI for their lifecycle.
 
 ## Frames v2 vs legacy Frames
 
@@ -17,6 +17,29 @@ Frames are interactive React applications. Use the Computer to edit their source
   file and its local imports, then updates the existing Frame through the legacy bundle pipeline.
 - \`dsbx frame publish\` supports both formats. Edit and publish an existing legacy Frame in place;
   do not recreate it just to make it v2.
+
+## Create a Frame
+
+Create and register a new Frame folder on the mounted file system:
+
+\`\`\`bash
+dsbx frame create /files/conversation-<conversationId>/<frame-folder> --name "<name>"
+\`\`\`
+
+In a Pod, create it under \`/files/pod-<podId>/...\` instead. The command scaffolds
+\`manifest.json\` and \`index.tsx\`, then assigns the Frame's stable identity. Edit the generated
+source before publishing it.
+
+## Register an existing Frame folder
+
+When \`manifest.json\` and its source folder already exist but do not have a Frame identity, run:
+
+\`\`\`bash
+dsbx frame register /files/<scope>/<frame-folder>/manifest.json
+\`\`\`
+
+Registration validates the manifest and assigns its stable Frame identity. Repeating the command
+for the same manifest path returns the same Frame. Registration does not publish the source.
 
 ## Frames v2 source layout
 


### PR DESCRIPTION
## Description

- Add `dsbx frame register <manifest>` to assign a stable Frames v2 `FileResource` identity to an existing mounted manifest.
- Make registration idempotent by GCS mount path and validate the manifest before creating the record.
- Add `dsbx frame create` to scaffold `manifest.json` and `index.tsx`, then register the Frame.
- Add an internal, feature-flagged sandbox registration endpoint. Publishing is unchanged.
- Pin `dust-base` 0.8.99 to `dsbx` 0.1.52 so the registration commands ship in the consuming sandbox image.

Initial registration supports writable GCS-backed conversation and Pod filesystems.

## Tests

- Frames targeted Vitest suites: 17 tests.
- Sandbox image registry Vitest suite: 21 tests.
- Front and front-api tsgo typechecks.
- `dsbx` focused Cargo tests and Clippy with warnings denied.
- Biome formatting and Swagger annotation lint.

## Risk

Feature-flagged and additive. Registration validates source access and the manifest before creating a record, adopts the existing mounted object without a canonical upload copy, rejects database-backed filesystems, and handles concurrent registration through the existing unique mount-path constraint.

The `dust-base` build requires the `dsbx-v0.1.52` release to exist first.

## Deploy Plan

Merge, release `dsbx` 0.1.52 from `main`, build and register `dust-base` 0.8.99, deploy front, request a kill of older `dust-base` versions from `/poke/kill`, then enable `frames_v2`. No migration or backfill.