### PR TITLE
Add appearance toggle to the cmd-k palette + cmd-k animation

### DIFF
--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
   CommandPaletteSearchPhase,
 } from "@app/components/command_palette/CommandPaletteSearchPhase";
 import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
+import type { Theme } from "@app/components/sparkle/ThemeContext";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
@@ -43,8 +44,6 @@ interface CommandPaletteProps {
   owner: LightWorkspaceType;
   user: UserType;
 }
-
-type Theme = "dark" | "light" | "system";
 
 const THEME_ORDER: Theme[] = ["light", "dark", "system"];
 
@@ -245,12 +244,19 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     [close, router, owner.sId]
   );
 
+  const executeCommand = useCallback(
+    (command: CommandPaletteCommand) => {
+      close();
+      setTheme(command.theme);
+    },
+    [close, setTheme]
+  );
+
   const handleItemSelect = useCallback(
     (item: CommandPaletteItem) => {
       switch (item.kind) {
         case "command":
-          close();
-          setTheme(item.command.theme);
+          executeCommand(item.command);
           return;
         case "pod":
           close();
@@ -274,7 +280,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
           assertNever(item);
       }
     },
-    [close, executeAction, owner.sId, router, setTheme]
+    [close, executeAction, executeCommand, owner.sId, router]
   );
 
   const handleBack = useCallback(() => {

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -9,7 +9,10 @@ import type {
   CommandPaletteCommand,
   CommandPaletteItem,
 } from "@app/components/command_palette/CommandPaletteSearchPhase";
-import { CommandPaletteSearchPhase } from "@app/components/command_palette/CommandPaletteSearchPhase";
+import {
+  CHANGE_THEME_COMMAND_PREFIX,
+  CommandPaletteSearchPhase,
+} from "@app/components/command_palette/CommandPaletteSearchPhase";
 import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAppRouter } from "@app/lib/platform";
@@ -142,7 +145,10 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     }
     const lowerQuery = debouncedQuery.toLowerCase();
     return allCommands.filter((c) =>
-      subFilter(lowerQuery, c.label.toLowerCase())
+      subFilter(
+        lowerQuery,
+        `${CHANGE_THEME_COMMAND_PREFIX} ${c.label}`.toLowerCase()
+      )
     );
   }, [allCommands, debouncedQuery]);
 

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -5,9 +5,13 @@ import type {
 } from "@app/components/command_palette/CommandPaletteActionPhase";
 import { CommandPaletteActionPhase } from "@app/components/command_palette/CommandPaletteActionPhase";
 import { useCommandPalette } from "@app/components/command_palette/CommandPaletteContext";
-import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
+import type {
+  CommandPaletteCommand,
+  CommandPaletteItem,
+} from "@app/components/command_palette/CommandPaletteSearchPhase";
 import { CommandPaletteSearchPhase } from "@app/components/command_palette/CommandPaletteSearchPhase";
 import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSkills } from "@app/lib/swr/skill_configurations";
@@ -20,9 +24,16 @@ import {
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isProjectType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { Dialog, DialogContent } from "@dust-tt/sparkle";
+import {
+  Dialog,
+  DialogContent,
+  Monitor01,
+  Moon01,
+  Sun,
+} from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface CommandPaletteProps {
@@ -30,9 +41,26 @@ interface CommandPaletteProps {
   user: UserType;
 }
 
+type Theme = "dark" | "light" | "system";
+
+const THEME_ORDER: Theme[] = ["light", "dark", "system"];
+
+const THEME_ICONS: Record<Theme, typeof Sun> = {
+  system: Monitor01,
+  light: Sun,
+  dark: Moon01,
+};
+
+const THEME_LABELS: Record<Theme, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark",
+};
+
 export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const { isOpen, close } = useCommandPalette();
   const router = useAppRouter();
+  const { theme, setTheme } = useTheme();
 
   // Dialog state.
   const [searchQuery, setSearchQuery] = useState("");
@@ -97,6 +125,26 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const MAX_DISPLAYED_AGENTS = 5;
   const MAX_DISPLAYED_PODS = 5;
   const MAX_DISPLAYED_SKILLS = 5;
+
+  const allCommands: CommandPaletteCommand[] = useMemo(
+    () =>
+      THEME_ORDER.filter((t) => t !== theme).map((t) => ({
+        theme: t,
+        label: THEME_LABELS[t],
+        icon: THEME_ICONS[t],
+      })),
+    [theme]
+  );
+
+  const filteredCommands = useMemo(() => {
+    if (!debouncedQuery) {
+      return allCommands;
+    }
+    const lowerQuery = debouncedQuery.toLowerCase();
+    return allCommands.filter((c) =>
+      subFilter(lowerQuery, c.label.toLowerCase())
+    );
+  }, [allCommands, debouncedQuery]);
 
   const allFilteredAgents = useMemo(
     () =>
@@ -193,20 +241,34 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
 
   const handleItemSelect = useCallback(
     (item: CommandPaletteItem) => {
-      if (item.kind === "pod") {
-        close();
-        void router.push(getPodRoute(owner.sId, item.pod.sId));
-        return;
-      }
-      // Skills without administration access have only one action (view details).
-      if (item.kind === "skill" && !item.skill.canAdministrate) {
-        executeAction(item, "view_details");
-      } else {
-        setSelectedItem(item);
-        setPhase("action");
+      switch (item.kind) {
+        case "command":
+          close();
+          setTheme(item.command.theme);
+          return;
+        case "pod":
+          close();
+          void router.push(getPodRoute(owner.sId, item.pod.sId));
+          return;
+        case "agent":
+          setSelectedItem(item);
+          setPhase("action");
+          return;
+        case "skill":
+          // Skills without administration access have only one action
+          // (view details).
+          if (!item.skill.canAdministrate) {
+            executeAction(item, "view_details");
+          } else {
+            setSelectedItem(item);
+            setPhase("action");
+          }
+          return;
+        default:
+          assertNever(item);
       }
     },
-    [close, executeAction, owner.sId, router]
+    [close, executeAction, owner.sId, router, setTheme]
   );
 
   const handleBack = useCallback(() => {
@@ -240,6 +302,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
             <CommandPaletteSearchPhase
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
+              commands={filteredCommands}
               agents={filteredAgents}
               pods={filteredPods}
               skills={filteredSkills}

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -9,10 +9,25 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { PodType } from "@app/types/space";
-import { Avatar, cn, Icon, LoadingBlock, SearchInput } from "@dust-tt/sparkle";
+import type { Sun } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  ChevronRight,
+  cn,
+  Icon,
+  LoadingBlock,
+  SearchInput,
+} from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
+export interface CommandPaletteCommand {
+  theme: "light" | "dark" | "system";
+  label: string;
+  icon: typeof Sun;
+}
+
 export type CommandPaletteItem =
+  | { kind: "command"; command: CommandPaletteCommand }
   | { kind: "agent"; agent: LightAgentConfigurationType }
   | { kind: "pod"; pod: PodType }
   | { kind: "skill"; skill: SkillWithoutInstructionsAndToolsType };
@@ -20,6 +35,7 @@ export type CommandPaletteItem =
 interface CommandPaletteSearchPhaseProps {
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
+  commands: CommandPaletteCommand[];
   agents: LightAgentConfigurationType[];
   pods: PodType[];
   skills: SkillWithoutInstructionsAndToolsType[];
@@ -36,18 +52,27 @@ interface CommandPaletteSearchPhaseProps {
 function getFlatItems(
   agents: LightAgentConfigurationType[],
   pods: PodType[],
-  skills: SkillWithoutInstructionsAndToolsType[]
+  skills: SkillWithoutInstructionsAndToolsType[],
+  commands: CommandPaletteCommand[],
+  commandsFirst: boolean
 ): CommandPaletteItem[] {
-  return [
+  const commandItems = commands.map(
+    (command): CommandPaletteItem => ({ kind: "command", command })
+  );
+  const entityItems = [
     ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),
     ...pods.map((pod): CommandPaletteItem => ({ kind: "pod", pod })),
     ...skills.map((skill): CommandPaletteItem => ({ kind: "skill", skill })),
   ];
+  return commandsFirst
+    ? [...commandItems, ...entityItems]
+    : [...entityItems, ...commandItems];
 }
 
 export function CommandPaletteSearchPhase({
   searchQuery,
   onSearchQueryChange,
+  commands,
   agents,
   pods,
   skills,
@@ -60,10 +85,26 @@ export function CommandPaletteSearchPhase({
   onItemSelect,
   onClose,
 }: CommandPaletteSearchPhaseProps) {
+  const commandsFirst = searchQuery.trim().length > 0 && commands.length > 0;
+
   const flatItems = useMemo(
-    () => getFlatItems(agents, pods, skills),
-    [agents, pods, skills]
+    () => getFlatItems(agents, pods, skills, commands, commandsFirst),
+    [agents, pods, skills, commands, commandsFirst]
   );
+
+  const offsets = commandsFirst
+    ? {
+        commands: 0,
+        agents: commands.length,
+        pods: commands.length + agents.length,
+        skills: commands.length + agents.length + pods.length,
+      }
+    : {
+        agents: 0,
+        pods: agents.length,
+        skills: agents.length + pods.length,
+        commands: agents.length + pods.length + skills.length,
+      };
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -84,12 +125,19 @@ export function CommandPaletteSearchPhase({
     }
   }, [selectedIndex, flatItems.length]);
 
-  // Reset selection and trim stale refs when the number of results changes.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: agents.length, pods.length and skills.length are intentional triggers
+  // biome-ignore lint/correctness/useExhaustiveDependencies: commandsFirst isn't read in the body, but a reorder (counts unchanged) must still reset the selection
   useEffect(() => {
-    itemRefs.current.length = flatItems.length;
+    itemRefs.current.length =
+      commands.length + agents.length + pods.length + skills.length;
     onSelectedIndexChange(0);
-  }, [agents.length, pods.length, skills.length, onSelectedIndexChange]);
+  }, [
+    commands.length,
+    agents.length,
+    pods.length,
+    skills.length,
+    commandsFirst,
+    onSelectedIndexChange,
+  ]);
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     const totalItems = flatItems.length;
@@ -119,6 +167,35 @@ export function CommandPaletteSearchPhase({
         break;
     }
   }
+
+  const settingsSection = commands.length > 0 && (
+    <div>
+      <ItemTitle>Settings</ItemTitle>
+      {commands.map((command, i) => {
+        const globalIndex = offsets.commands + i;
+        return (
+          <ItemRow
+            key={command.theme}
+            ref={(el) => {
+              itemRefs.current[globalIndex] = el;
+            }}
+            isSelected={selectedIndex === globalIndex}
+            onClick={() => onItemSelect({ kind: "command", command })}
+            onMouseMove={() => onSelectedIndexChange(globalIndex)}
+          >
+            <Icon visual={command.icon} size="xs" />
+            <div className="flex items-center gap-1.5">
+              <span className="text-muted-foreground">
+                Change interface theme
+              </span>
+              <Icon visual={ChevronRight} size="xs" />
+              <span className="font-medium">{command.label}</span>
+            </div>
+          </ItemRow>
+        );
+      })}
+    </div>
+  );
 
   return (
     <div className="flex flex-col">
@@ -164,29 +241,34 @@ export function CommandPaletteSearchPhase({
           </ItemEmptyState>
         )}
 
+        {commandsFirst && settingsSection}
+
         {agents.length > 0 && (
           <div>
             <ItemTitle>Agents</ItemTitle>
-            {agents.map((agent, i) => (
-              <ItemRow
-                key={agent.sId}
-                ref={(el) => {
-                  itemRefs.current[i] = el;
-                }}
-                isSelected={selectedIndex === i}
-                onClick={() => onItemSelect({ kind: "agent", agent })}
-                onMouseMove={() => onSelectedIndexChange(i)}
-              >
-                <Avatar visual={agent.pictureUrl} size="xs" />
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="shrink-0 font-medium">{agent.name}</span>
-                  <span className="shrink-0 text-muted-foreground">-</span>
-                  <span className="min-w-0 truncate text-muted-foreground">
-                    {agent.description}
-                  </span>
-                </div>
-              </ItemRow>
-            ))}
+            {agents.map((agent, i) => {
+              const globalIndex = offsets.agents + i;
+              return (
+                <ItemRow
+                  key={agent.sId}
+                  ref={(el) => {
+                    itemRefs.current[globalIndex] = el;
+                  }}
+                  isSelected={selectedIndex === globalIndex}
+                  onClick={() => onItemSelect({ kind: "agent", agent })}
+                  onMouseMove={() => onSelectedIndexChange(globalIndex)}
+                >
+                  <Avatar visual={agent.pictureUrl} size="xs" />
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 font-medium">{agent.name}</span>
+                    <span className="shrink-0 text-muted-foreground">-</span>
+                    <span className="min-w-0 truncate text-muted-foreground">
+                      {agent.description}
+                    </span>
+                  </div>
+                </ItemRow>
+              );
+            })}
             {hasMoreAgents && (
               <div className="px-3 py-2 text-xs text-muted-foreground">
                 More agents available. Type to filter.
@@ -199,7 +281,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Pods</ItemTitle>
             {pods.map((pod, i) => {
-              const globalIndex = agents.length + i;
+              const globalIndex = offsets.pods + i;
               return (
                 <ItemRow
                   key={pod.sId}
@@ -239,7 +321,7 @@ export function CommandPaletteSearchPhase({
           <div>
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
-              const globalIndex = agents.length + pods.length + i;
+              const globalIndex = offsets.skills + i;
               const SkillAvatar = getSkillAvatarIcon(skill);
               return (
                 <ItemRow
@@ -269,6 +351,8 @@ export function CommandPaletteSearchPhase({
             )}
           </div>
         )}
+
+        {!commandsFirst && settingsSection}
       </div>
       <KeyboardHints
         hints={[

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -20,6 +20,8 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
+export const CHANGE_THEME_COMMAND_PREFIX = "Change interface theme";
+
 export interface CommandPaletteCommand {
   theme: "light" | "dark" | "system";
   label: string;
@@ -186,7 +188,7 @@ export function CommandPaletteSearchPhase({
             <Icon visual={command.icon} size="xs" />
             <div className="flex items-center gap-1.5">
               <span className="text-muted-foreground">
-                Change interface theme
+                {CHANGE_THEME_COMMAND_PREFIX}
               </span>
               <Icon visual={ChevronRight} size="xs" />
               <span className="font-medium">{command.label}</span>

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -4,6 +4,7 @@ import {
   ItemTitle,
   KeyboardHints,
 } from "@app/components/command_palette/CommandPaletteItems";
+import type { Theme } from "@app/components/sparkle/ThemeContext";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -23,7 +24,7 @@ import { useEffect, useMemo, useRef } from "react";
 export const CHANGE_THEME_COMMAND_PREFIX = "Change interface theme";
 
 export interface CommandPaletteCommand {
-  theme: "light" | "dark" | "system";
+  theme: Theme;
   label: string;
   icon: typeof Sun;
 }

--- a/front/components/sparkle/ThemeContext.tsx
+++ b/front/components/sparkle/ThemeContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-type Theme = "dark" | "light" | "system";
+export type Theme = "dark" | "light" | "system";
 
 interface ThemeContextType {
   theme: Theme;

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -32,7 +32,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 duration-200 ease-emphasized data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-150 motion-reduce:animate-none",
+      "fixed inset-0 z-50 ease-emphasized data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none",
       "bg-muted-foreground/75 dark:bg-muted-background/75",
       className
     )}
@@ -78,6 +78,11 @@ const growHeightClasses: Record<DialogHeightType, string> = {
 const DIALOG_VARIANTS = ["default", "command"] as const;
 type DialogVariantType = (typeof DIALOG_VARIANTS)[number];
 
+const overlayVariantClasses: Record<DialogVariantType, string> = {
+  default: "duration-200 data-[state=closed]:duration-150",
+  command: "duration-[220ms] data-[state=closed]:duration-[160ms]",
+};
+
 const variantClasses: Record<DialogVariantType, string> = {
   default: cn(
     "top-[50%] translate-y-[-50%] duration-200 ease-emphasized data-[state=closed]:duration-150 motion-reduce:animate-none",
@@ -86,10 +91,9 @@ const variantClasses: Record<DialogVariantType, string> = {
     "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
   ),
   command: cn(
-    "top-[20%] duration-200 ease-emphasized data-[state=closed]:duration-150 motion-reduce:animate-none",
+    "top-[20%] duration-[220ms] ease-[cubic-bezier(0.16,1,0.3,1)] data-[state=closed]:duration-[160ms] motion-reduce:animate-none",
     "data-[state=open]:animate-in data-[state=closed]:animate-out",
     "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-    "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
     "data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2"
   ),
 };
@@ -172,7 +176,9 @@ const DialogContent = React.forwardRef<
 
     return (
       <DialogPortal container={mountPortalContainer}>
-        <DialogOverlay />
+        <DialogOverlay
+          className={overlayVariantClasses[variant ?? "default"]}
+        />
         <FocusScope trapped={trapFocusScope} asChild>
           <DialogPrimitive.Content
             ref={ref}


### PR DESCRIPTION
## Summary
- Add a "Settings" section to the cmd-k palette letting users switch between light, dark, and system appearance directly from the palette.
- Only the two themes not currently active are offered, with "system" always shown second.
- The section surfaces above other results when the search query matches it.
- Trim the palette's own open/close animation: drop the scale/zoom for a plain fade + slide, with smoother timing.

https://github.com/user-attachments/assets/f7459135-9128-43a8-b401-98b88c2a5a49



