### PR TITLE
[front] canRead-gated group fetchers; API key scoping to restricted spaces/pods

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -53,7 +53,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    const group = await GroupFactory.regularAuto(workspace, "Engineering");
+    const group = await GroupFactory.regularManual(workspace, "Engineering");
     await GroupFactory.withMembers(auth, group, [user]);
 
     const response = await getGroups(workspace);
@@ -80,7 +80,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    const group = await GroupFactory.regularAuto(workspace, "Design");
+    const group = await GroupFactory.regularManual(workspace, "Design");
 
     const extraUsers = await Promise.all([
       UserFactory.basic(),
@@ -117,7 +117,7 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    await GroupFactory.regularAuto(workspace, "Empty");
+    await GroupFactory.regularManual(workspace, "Empty");
 
     const response = await getGroups(workspace);
 
@@ -135,22 +135,43 @@ describe("GET /api/w/:wId/groups", () => {
       role: "admin",
     });
 
-    const group = await GroupFactory.regularAuto(workspace, "Backend");
+    const group = await GroupFactory.regularManual(workspace, "Backend");
     await GroupFactory.withMembers(auth, group, [user]);
+    await GroupFactory.provisioned(workspace, "Directory");
 
-    const response = await getGroups(workspace, { kind: "regular_auto" });
+    const response = await getGroups(workspace, { kind: "regular_manual" });
 
     expect(response.status).toBe(200);
     const { groups } = await response.json();
 
     expect(
-      groups.every((g: { kind: string }) => g.kind === "regular_auto")
+      groups.every((g: { kind: string }) => g.kind === "regular_manual")
     ).toBe(true);
     const backendGroup = groups.find(
       (g: { name: string }) => g.name === "Backend"
     );
     expect(backendGroup).toBeDefined();
     expect(backendGroup.memberCount).toBe(1);
+  });
+
+  it("never lists internal group kinds, even when explicitly requested", async () => {
+    const { workspace, auth, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const group = await GroupFactory.regularAuto(workspace, "Backend");
+    await GroupFactory.withMembers(auth, group, [user]);
+
+    // `regular_auto` is an internal kind: it is never surfaced by this endpoint,
+    // even for an admin explicitly asking for it.
+    const response = await getGroups(workspace, { kind: "regular_auto" });
+
+    expect(response.status).toBe(200);
+    const { groups } = await response.json();
+    expect(groups.some((g: { name: string }) => g.name === "Backend")).toBe(
+      false
+    );
   });
 
   it("lets a manager list provisioned groups", async () => {

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -41,14 +41,6 @@ app.get(
               message: groupRes.error.message,
             },
           });
-        case "unauthorized":
-          return apiError(ctx, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
-              message: groupRes.error.message,
-            },
-          });
         case "group_not_found":
           return apiError(ctx, {
             status_code: 404,
@@ -114,14 +106,6 @@ app.patch(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: groupRes.error.message,
-            },
-          });
-        case "unauthorized":
-          return apiError(ctx, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
               message: groupRes.error.message,
             },
           });
@@ -222,14 +206,6 @@ app.delete(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: groupRes.error.message,
-            },
-          });
-        case "unauthorized":
-          return apiError(ctx, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
               message: groupRes.error.message,
             },
           });

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -41,6 +41,14 @@ app.get(
               message: groupRes.error.message,
             },
           });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: groupRes.error.message,
+            },
+          });
         case "group_not_found":
           return apiError(ctx, {
             status_code: 404,
@@ -106,6 +114,14 @@ app.patch(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
               message: groupRes.error.message,
             },
           });
@@ -206,6 +222,14 @@ app.delete(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
               message: groupRes.error.message,
             },
           });

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -5,7 +5,11 @@ import {
   type PostGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import type { GroupKind, GroupType } from "@app/types/groups";
-import { GroupKindCodec } from "@app/types/groups";
+import {
+  GroupKindCodec,
+  isUserVisibleGroupKind,
+  USER_VISIBLE_GROUP_KINDS,
+} from "@app/types/groups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -38,11 +42,16 @@ app.get(
     const auth = ctx.get("auth");
     const { kind, withMembers } = ctx.req.valid("query");
 
-    const groupKinds: GroupKind[] = kind
+    const requestedKinds: GroupKind[] = kind
       ? Array.isArray(kind)
         ? kind
         : [kind]
-      : ["global", "regular_auto"];
+      : [...USER_VISIBLE_GROUP_KINDS];
+
+    // This endpoint only ever exposes user-visible group kinds. Internal kinds
+    // (regular_auto, system, agent_editors) are never listed here, so we clamp
+    // whatever was requested to the visible set.
+    const groupKinds = requestedKinds.filter(isUserVisibleGroupKind);
 
     const groups = await GroupResource.listAllWorkspaceGroups(auth, {
       groupKinds,

--- a/front-api/routes/w/[wId]/keys/groups.test.ts
+++ b/front-api/routes/w/[wId]/keys/groups.test.ts
@@ -21,7 +21,10 @@ async function spaceMemberGroupName(
   const groupModelIds = [...referencesBySpaceModelId.values()]
     .flat()
     .map((reference) => reference.groupId);
-  const groups = await GroupResource.fetchByModelIds(auth, groupModelIds);
+  const groups = await GroupResource.dangerouslyFetchByModelIds(
+    auth,
+    groupModelIds
+  );
   const memberGroup = groups.find((group) => group.kind === "regular_auto");
   if (!memberGroup) {
     throw new Error("Expected a regular_auto member group for the space.");
@@ -30,7 +33,7 @@ async function spaceMemberGroupName(
 }
 
 describe("GET /api/w/:wId/keys/groups", () => {
-  it("lists the groups of regular restricted spaces, and only those", async () => {
+  it("lists the groups of restricted spaces (regular and pods), and only those", async () => {
     const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -62,21 +65,49 @@ describe("GET /api/w/:wId/keys/groups", () => {
     expect(names).not.toContain("Unassociated");
   });
 
-  it("excludes pod (project) groups", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+  it("includes restricted pod (project) groups", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    // Projects (pods) are not regular spaces, so their groups are never scopable.
-    await SpaceFactory.project(workspace, undefined, { name: "SecretPod" });
+    // Restricted pod: its member/editor groups are scopable.
+    const restrictedPod = await SpaceFactory.project(workspace, undefined, {
+      name: "SecretPod",
+    });
+    const restrictedPodGroupName = await spaceMemberGroupName(
+      auth,
+      restrictedPod
+    );
 
     const response = await getScopableGroups(workspace);
 
     expect(response.status).toBe(200);
     const { groups } = await response.json();
     const names = groups.map((g: { name: string }) => g.name);
-    expect(names.some((n: string) => n.includes("SecretPod"))).toBe(false);
+    expect(names).toContain(restrictedPodGroupName);
+  });
+
+  it("excludes open pod (project) groups", async () => {
+    const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Open pod (global group attached as viewer): not restricted, so its
+    // groups are excluded.
+    const openPod = await SpaceFactory.project(workspace, undefined, {
+      name: "OpenPod",
+    });
+    const openPodGroupName = await spaceMemberGroupName(auth, openPod);
+    await SpaceFactory.attachGroup(openPod, globalGroup, "project_viewer");
+
+    const response = await getScopableGroups(workspace);
+
+    expect(response.status).toBe(200);
+    const { groups } = await response.json();
+    const names = groups.map((g: { name: string }) => g.name);
+    expect(names).not.toContain(openPodGroupName);
   });
 
   it("returns 403 for a regular user", async () => {

--- a/front-api/routes/w/[wId]/keys/groups.test.ts
+++ b/front-api/routes/w/[wId]/keys/groups.test.ts
@@ -1,3 +1,6 @@
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -8,37 +11,65 @@ function getScopableGroups(workspace: { sId: string }) {
   return honoApp.request(`/api/w/${workspace.sId}/keys/groups`);
 }
 
+// The regular_auto member group name of a space, resolved from its grants.
+async function spaceMemberGroupName(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<string> {
+  const referencesBySpaceModelId =
+    await SpaceResource.listGrantReferencesBySpaceModelId([space]);
+  const groupModelIds = [...referencesBySpaceModelId.values()]
+    .flat()
+    .map((reference) => reference.groupId);
+  const groups = await GroupResource.fetchByModelIds(auth, groupModelIds);
+  const memberGroup = groups.find((group) => group.kind === "regular_auto");
+  if (!memberGroup) {
+    throw new Error("Expected a regular_auto member group for the space.");
+  }
+  return memberGroup.name;
+}
+
 describe("GET /api/w/:wId/keys/groups", () => {
-  it("returns the groups the caller is a member of, and only those", async () => {
-    const { workspace, user, auth } = await createPrivateApiMockRequest({
+  it("lists the groups of regular restricted spaces, and only those", async () => {
+    const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    const mine = await GroupFactory.regularManual(workspace, "Mine");
-    await GroupFactory.withMembers(auth, mine, [user]);
+    // Regular restricted space: its member group is scopable.
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const restrictedGroupName = await spaceMemberGroupName(
+      auth,
+      restrictedSpace
+    );
 
-    // A group the caller does not belong to must not be listed.
-    await GroupFactory.regularManual(workspace, "Theirs");
+    // Regular open space (global group attached): not restricted, so its group
+    // is excluded.
+    const openSpace = await SpaceFactory.regular(workspace);
+    const openGroupName = await spaceMemberGroupName(auth, openSpace);
+    await SpaceFactory.attachGroup(openSpace, globalGroup, "project_viewer");
+
+    // A group not associated to any space is excluded.
+    await GroupFactory.regularManual(workspace, "Unassociated");
 
     const response = await getScopableGroups(workspace);
 
     expect(response.status).toBe(200);
     const { groups } = await response.json();
     const names = groups.map((g: { name: string }) => g.name);
-    expect(names).toContain("Mine");
-    expect(names).not.toContain("Theirs");
+    expect(names).toContain(restrictedGroupName);
+    expect(names).not.toContain(openGroupName);
+    expect(names).not.toContain("Unassociated");
   });
 
-  it("excludes pod (project) groups even when the caller is a member", async () => {
-    const { workspace, user } = await createPrivateApiMockRequest({
+  it("excludes pod (project) groups", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    // The caller is a member of the pod's editor group (passed as creator), but
-    // pod groups must never be scopable — keys scope to regular spaces only.
-    await SpaceFactory.project(workspace, user.id, { name: "SecretPod" });
+    // Projects (pods) are not regular spaces, so their groups are never scopable.
+    await SpaceFactory.project(workspace, undefined, { name: "SecretPod" });
 
     const response = await getScopableGroups(workspace);
 

--- a/front-api/routes/w/[wId]/keys/groups.test.ts
+++ b/front-api/routes/w/[wId]/keys/groups.test.ts
@@ -1,0 +1,42 @@
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getScopableGroups(workspace: { sId: string }) {
+  return honoApp.request(`/api/w/${workspace.sId}/keys/groups`);
+}
+
+describe("GET /api/w/:wId/keys/groups", () => {
+  it("returns the groups the caller is a member of, and only those", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const mine = await GroupFactory.regularManual(workspace, "Mine");
+    await GroupFactory.withMembers(auth, mine, [user]);
+
+    // A group the caller does not belong to must not be listed.
+    await GroupFactory.regularManual(workspace, "Theirs");
+
+    const response = await getScopableGroups(workspace);
+
+    expect(response.status).toBe(200);
+    const { groups } = await response.json();
+    const names = groups.map((g: { name: string }) => g.name);
+    expect(names).toContain("Mine");
+    expect(names).not.toContain("Theirs");
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await getScopableGroups(workspace);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/keys/groups.test.ts
+++ b/front-api/routes/w/[wId]/keys/groups.test.ts
@@ -1,5 +1,6 @@
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -27,6 +28,24 @@ describe("GET /api/w/:wId/keys/groups", () => {
     const names = groups.map((g: { name: string }) => g.name);
     expect(names).toContain("Mine");
     expect(names).not.toContain("Theirs");
+  });
+
+  it("excludes pod (project) groups even when the caller is a member", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // The caller is a member of the pod's editor group (passed as creator), but
+    // pod groups must never be scopable — keys scope to regular spaces only.
+    await SpaceFactory.project(workspace, user.id, { name: "SecretPod" });
+
+    const response = await getScopableGroups(workspace);
+
+    expect(response.status).toBe(200);
+    const { groups } = await response.json();
+    const names = groups.map((g: { name: string }) => g.name);
+    expect(names.some((n: string) => n.includes("SecretPod"))).toBe(false);
   });
 
   it("returns 403 for a regular user", async () => {

--- a/front-api/routes/w/[wId]/keys/groups.ts
+++ b/front-api/routes/w/[wId]/keys/groups.ts
@@ -1,3 +1,4 @@
+import { listKeyScopableGroups } from "@app/lib/api/keys/scopable_groups";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { GetKeyScopableGroupsResponseBody } from "@app/types/api/keys";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -14,9 +15,9 @@ app.get(
   async (ctx): HandlerResult<GetKeyScopableGroupsResponseBody> => {
     const auth = ctx.get("auth");
 
-    // A key can only be scoped to groups the caller is a member of, so we list
-    // those rather than every workspace group.
-    const groups = await GroupResource.listMemberGroups(auth);
+    // The groups the caller may scope a key to: their member groups, excluding
+    // pod-related groups (keys scope to regular spaces only).
+    const groups = await listKeyScopableGroups(auth);
 
     return ctx.json({
       groups: await GroupResource.toJSONWithMemberCounts(auth, groups),

--- a/front-api/routes/w/[wId]/keys/groups.ts
+++ b/front-api/routes/w/[wId]/keys/groups.ts
@@ -1,0 +1,27 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { GetKeyScopableGroupsResponseBody } from "@app/types/api/keys";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/keys/groups.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetKeyScopableGroupsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    // A key can only be scoped to groups the caller is a member of, so we list
+    // those rather than every workspace group.
+    const groups = await GroupResource.listMemberGroups(auth);
+
+    return ctx.json({
+      groups: await GroupResource.toJSONWithMemberCounts(auth, groups),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -113,10 +113,10 @@ describe("POST /api/w/:wId/keys — role restrictions", () => {
 });
 
 describe("POST /api/w/:wId/keys — group scoping", () => {
-  it("rejects scoping to a group not tied to a regular restricted space", async () => {
+  it("rejects scoping to a group not tied to a restricted space or pod", async () => {
     const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
 
-    // This group is not associated to any regular restricted space, so it is
+    // This group is not associated to any restricted space or pod, so it is
     // not scopable — even for an admin.
     const group = await GroupFactory.regularManual(workspace, "Backend");
 

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -113,11 +113,11 @@ describe("POST /api/w/:wId/keys — role restrictions", () => {
 });
 
 describe("POST /api/w/:wId/keys — group scoping", () => {
-  it("rejects scoping to a group the caller is not a member of", async () => {
+  it("rejects scoping to a group not tied to a regular restricted space", async () => {
     const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
 
-    // The requesting admin is not a member of this group. Scoping is gated on
-    // membership, not on role or group visibility, so even an admin is rejected.
+    // This group is not associated to any regular restricted space, so it is
+    // not scopable — even for an admin.
     const group = await GroupFactory.regularManual(workspace, "Backend");
 
     const res = await honoApp.request(`/api/w/${workspace.sId}/keys`, {

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -1,5 +1,6 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import { honoApp } from "@front-api/app";
@@ -108,5 +109,24 @@ describe("POST /api/w/:wId/keys — role restrictions", () => {
     expect(key.role).toBe("user");
     const group = await GroupResource.fetchManualBuildersGroup(workspace);
     expect(group).toBeNull();
+  });
+});
+
+describe("POST /api/w/:wId/keys — group scoping", () => {
+  it("rejects scoping to a group the caller is not a member of", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    // The requesting admin is not a member of this group. Scoping is gated on
+    // membership, not on role or group visibility, so even an admin is rejected.
+    const group = await GroupFactory.regularManual(workspace, "Backend");
+
+    const res = await honoApp.request(`/api/w/${workspace.sId}/keys`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "scoped-key", group_ids: [group.sId] }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.type).toBe("workspace_auth_error");
   });
 });

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { listKeyScopableGroups } from "@app/lib/api/keys/scopable_groups";
 import {
   MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
   MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
@@ -175,17 +176,20 @@ app.post(
         : [];
 
     if (additionalGroupIds.length > 0) {
-      // A key can only be scoped to groups the caller is a member of.
-      const nonMemberGroupIds = additionalGroupIds.filter(
-        (gId) => !auth.hasGroup(gId)
+      // A key can only be scoped to groups of regular restricted spaces.
+      const scopableGroupIds = new Set(
+        (await listKeyScopableGroups(auth)).map((group) => group.sId)
       );
-      if (nonMemberGroupIds.length > 0) {
+      const invalidGroupIds = additionalGroupIds.filter(
+        (gId) => !scopableGroupIds.has(gId)
+      );
+      if (invalidGroupIds.length > 0) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
             message:
-              "You can only scope an API key to groups you are a member of.",
+              "An API key can only be scoped to groups of regular restricted spaces.",
           },
         });
       }

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -176,7 +176,7 @@ app.post(
         : [];
 
     if (additionalGroupIds.length > 0) {
-      // A key can only be scoped to groups of regular restricted spaces.
+      // A key can only be scoped to groups of restricted spaces or pods.
       const scopableGroupIds = new Set(
         (await listKeyScopableGroups(auth)).map((group) => group.sId)
       );
@@ -189,7 +189,7 @@ app.post(
           api_error: {
             type: "workspace_auth_error",
             message:
-              "An API key can only be scoped to groups of regular restricted spaces.",
+              "An API key can only be scoped to groups of restricted spaces or pods.",
           },
         });
       }

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -24,6 +24,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import keyId from "./[id]";
+import keyGroups from "./groups";
 
 const MAX_API_KEY_CREATION_PER_DAY = 30;
 
@@ -174,6 +175,21 @@ app.post(
         : [];
 
     if (additionalGroupIds.length > 0) {
+      // A key can only be scoped to groups the caller is a member of.
+      const nonMemberGroupIds = additionalGroupIds.filter(
+        (gId) => !auth.hasGroup(gId)
+      );
+      if (nonMemberGroupIds.length > 0) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You can only scope an API key to groups you are a member of.",
+          },
+        });
+      }
+
       const groupsRes = await GroupResource.fetchByIds(
         auth,
         additionalGroupIds
@@ -285,6 +301,7 @@ app.post(
   }
 );
 
+app.route("/groups", keyGroups);
 app.route("/:id", keyId);
 
 export default app;

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -15,7 +15,7 @@ import { formatCredits } from "@app/lib/client/credits";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { useKeys } from "@app/lib/swr/apps";
-import { useGroups } from "@app/lib/swr/groups";
+import { useKeyScopableGroups } from "@app/lib/swr/groups";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
@@ -124,7 +124,9 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
   const [editCapKey, setEditCapKey] = useState<KeyType | null>(null);
 
   const { isKeysError, isKeysLoading, keys } = useKeys(owner);
-  const { groups, isGroupsError, isGroupsLoading } = useGroups({ owner });
+  const { groups, isGroupsError, isGroupsLoading } = useKeyScopableGroups({
+    owner,
+  });
   const isDataLoading = isKeysLoading || isGroupsLoading;
   const isDataError = !!isKeysError || isGroupsError;
 

--- a/front/lib/api/groups/members.ts
+++ b/front/lib/api/groups/members.ts
@@ -81,10 +81,6 @@ export async function updateMemberGroupMembership(
         return new Err(
           new GroupMembershipError("invalid_group_id", groupRes.error.message)
         );
-      case "unauthorized":
-        return new Err(
-          new GroupMembershipError("unauthorized", groupRes.error.message)
-        );
       case "group_not_found":
         return new Err(
           new GroupMembershipError("group_not_found", groupRes.error.message)

--- a/front/lib/api/groups/members.ts
+++ b/front/lib/api/groups/members.ts
@@ -81,6 +81,10 @@ export async function updateMemberGroupMembership(
         return new Err(
           new GroupMembershipError("invalid_group_id", groupRes.error.message)
         );
+      case "unauthorized":
+        return new Err(
+          new GroupMembershipError("unauthorized", groupRes.error.message)
+        );
       case "group_not_found":
         return new Err(
           new GroupMembershipError("group_not_found", groupRes.error.message)

--- a/front/lib/api/keys/scopable_groups.ts
+++ b/front/lib/api/keys/scopable_groups.ts
@@ -3,27 +3,45 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 
 /**
- * The groups a new API key may be scoped to: exactly the groups associated to
- * the workspace's regular restricted spaces. Open spaces (readable by everyone
- * via the global group) and non-regular spaces (system, global, conversations,
- * projects/pods) are not scopable.
+ * The groups a new API key may be scoped to: the groups associated to the
+ * workspace's restricted spaces — both regular (spaces) and project (pods) —
+ * plus the workspace global group.
+ *
+ * A manageable group (regular_manual / provisioned) can be granted access to
+ * several restricted spaces at once, so scoping a key to it indirectly scopes
+ * the key to every restricted space that carries the group. Open spaces are
+ * readable through the global group and are not meaningful to scope to.
+ *
+ * The global group is included so that existing keys — which the backend always
+ * scopes to the global group in addition to any explicit selection — can be
+ * rendered by ids; the picker filters it out client-side.
  */
 export async function listKeyScopableGroups(
   auth: Authenticator
 ): Promise<GroupResource[]> {
-  // `listWorkspaceSpaces` excludes projects/pods by default. The enriched
-  // serialization carries the canonical `isRestricted` flag and the space's
-  // grant `groupIds`, so we just filter and collect.
-  const spaces = await SpaceResource.listWorkspaceSpaces(auth);
-  const enrichedSpaces = await SpaceResource.batchToJSONEnriched(auth, spaces);
+  const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
+    includeProjectSpaces: true,
+    includeOpen: false,
+  });
+  // `includeOpen: false` leaves the non-scopable unique kinds (system, global)
+  // in the result; narrow to the regular/project spaces we actually care about.
+  const restrictedSpaces = spaces.filter(
+    (space) => space.isRegular() || space.isProject()
+  );
+
+  const referencesBySpaceModelId =
+    await SpaceResource.listGrantReferencesBySpaceModelId(restrictedSpaces);
 
   const groupIds = new Set<string>();
-  for (const space of enrichedSpaces) {
-    if (space.kind === "regular" && space.isRestricted) {
-      for (const groupId of space.groupIds) {
-        groupIds.add(groupId);
-      }
+  for (const references of referencesBySpaceModelId.values()) {
+    for (const reference of references) {
+      groupIds.add(reference.groupSId);
     }
+  }
+
+  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+  if (globalGroupRes.isOk()) {
+    groupIds.add(globalGroupRes.value.sId);
   }
 
   const groupsRes = await GroupResource.fetchByIds(auth, [...groupIds]);

--- a/front/lib/api/keys/scopable_groups.ts
+++ b/front/lib/api/keys/scopable_groups.ts
@@ -1,0 +1,28 @@
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+/**
+ * The groups a new API key may be scoped to: the groups the caller is a member
+ * of, minus any group tied to a project (pod) space. Keys scope to regular
+ * spaces only, so pod member/editor groups are excluded even though the caller
+ * belongs to them.
+ */
+export async function listKeyScopableGroups(
+  auth: Authenticator
+): Promise<GroupResource[]> {
+  const memberGroups = await GroupResource.listMemberGroups(auth);
+
+  // Groups attached to the caller's pod spaces (member and editor groups) are
+  // not scopable. One batched grant lookup gives every such group id.
+  const podSpaces = await SpaceResource.listWorkspacePodsAsMember(auth);
+  const podGroupRefsBySpace =
+    await SpaceResource.listGrantReferencesBySpaceModelId(podSpaces);
+  const podGroupModelIds = new Set(
+    [...podGroupRefsBySpace.values()]
+      .flat()
+      .map((reference) => reference.groupId)
+  );
+
+  return memberGroups.filter((group) => !podGroupModelIds.has(group.id));
+}

--- a/front/lib/api/keys/scopable_groups.ts
+++ b/front/lib/api/keys/scopable_groups.ts
@@ -3,26 +3,32 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 
 /**
- * The groups a new API key may be scoped to: the groups the caller is a member
- * of, minus any group tied to a project (pod) space. Keys scope to regular
- * spaces only, so pod member/editor groups are excluded even though the caller
- * belongs to them.
+ * The groups a new API key may be scoped to: exactly the groups associated to
+ * the workspace's regular restricted spaces. Open spaces (readable by everyone
+ * via the global group) and non-regular spaces (system, global, conversations,
+ * projects/pods) are not scopable.
  */
 export async function listKeyScopableGroups(
   auth: Authenticator
 ): Promise<GroupResource[]> {
-  const memberGroups = await GroupResource.listMemberGroups(auth);
+  // `listWorkspaceSpaces` excludes projects/pods by default. The enriched
+  // serialization carries the canonical `isRestricted` flag and the space's
+  // grant `groupIds`, so we just filter and collect.
+  const spaces = await SpaceResource.listWorkspaceSpaces(auth);
+  const enrichedSpaces = await SpaceResource.batchToJSONEnriched(auth, spaces);
 
-  // Groups attached to the caller's pod spaces (member and editor groups) are
-  // not scopable. One batched grant lookup gives every such group id.
-  const podSpaces = await SpaceResource.listWorkspacePodsAsMember(auth);
-  const podGroupRefsBySpace =
-    await SpaceResource.listGrantReferencesBySpaceModelId(podSpaces);
-  const podGroupModelIds = new Set(
-    [...podGroupRefsBySpace.values()]
-      .flat()
-      .map((reference) => reference.groupId)
-  );
+  const groupIds = new Set<string>();
+  for (const space of enrichedSpaces) {
+    if (space.kind === "regular" && space.isRestricted) {
+      for (const groupId of space.groupIds) {
+        groupIds.add(groupId);
+      }
+    }
+  }
 
-  return memberGroups.filter((group) => !podGroupModelIds.has(group.id));
+  const groupsRes = await GroupResource.fetchByIds(auth, [...groupIds]);
+  if (groupsRes.isErr()) {
+    throw groupsRes.error;
+  }
+  return groupsRes.value;
 }

--- a/front/lib/api/poke/group_permissions.ts
+++ b/front/lib/api/poke/group_permissions.ts
@@ -30,7 +30,10 @@ async function serializeGroupPermissions(
   groupPermissions: GroupPermissionResource[]
 ): Promise<PokeGroupPermissionType[]> {
   const groupModelIds = [...new Set(groupPermissions.map((gp) => gp.groupId))];
-  const groups = await GroupResource.fetchByModelIds(auth, groupModelIds);
+  const groups = await GroupResource.dangerouslyFetchByModelIds(
+    auth,
+    groupModelIds
+  );
   const groupByModelId = new Map(groups.map((group) => [group.id, group]));
 
   return removeNulls(

--- a/front/lib/model_tiers/allowed_tiers.ts
+++ b/front/lib/model_tiers/allowed_tiers.ts
@@ -407,7 +407,7 @@ export async function listUserAllowedTierNames(
   }
 
   const groupIds = [...new Set(rows.map((row) => row.groupId))];
-  const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+  const groups = await GroupResource.dangerouslyFetchByModelIds(auth, groupIds);
   const autoGroups = groups.filter(
     (group) =>
       group.kind === "regular_auto" &&
@@ -480,7 +480,7 @@ export async function listGroupAllowedTierNames(
   }
 
   const groupIds = [...new Set(rows.map((row) => row.groupId))];
-  const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+  const groups = await GroupResource.dangerouslyFetchByModelIds(auth, groupIds);
   const overrideGroups = groups.filter((group) =>
     isModelTierOverrideGroupKind(group.kind)
   );
@@ -532,7 +532,7 @@ async function loadUserOverrideTierGrants({
   }
 
   const groupIds = [...new Set(rows.map((row) => row.groupId))];
-  const groups = await GroupResource.fetchByModelIds(auth, groupIds);
+  const groups = await GroupResource.dangerouslyFetchByModelIds(auth, groupIds);
   const autoGroups = groups.filter(
     (group) =>
       group.kind === "regular_auto" &&
@@ -568,7 +568,10 @@ async function listUserModelTierOverrideGroupModelIds(
     return [];
   }
 
-  const groups = await GroupResource.fetchByModelIds(auth, groupModelIds);
+  const groups = await GroupResource.dangerouslyFetchByModelIds(
+    auth,
+    groupModelIds
+  );
   return groups
     .filter((group) => isModelTierOverrideGroupKind(group.kind))
     .map((group) => group.id);

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -726,7 +726,7 @@ describe("GroupPermissionResource", () => {
       );
       expect(grants).toHaveLength(1);
 
-      const group = await GroupResource.fetchByModelIds(auth, [
+      const group = await GroupResource.dangerouslyFetchByModelIds(auth, [
         grants[0].groupId,
       ]);
       expect(group[0].kind).toBe("regular_auto");
@@ -762,9 +762,10 @@ describe("GroupPermissionResource", () => {
       );
       expect(grants).toHaveLength(1);
 
-      const [backingGroup] = await GroupResource.fetchByModelIds(auth, [
-        grants[0].groupId,
-      ]);
+      const [backingGroup] = await GroupResource.dangerouslyFetchByModelIds(
+        auth,
+        [grants[0].groupId]
+      );
       expect(await backingGroup.getMemberCount(auth)).toBe(1);
     });
 
@@ -886,7 +887,7 @@ describe("GroupPermissionResource", () => {
       );
       expect(grants).toHaveLength(1);
 
-      const [group] = await GroupResource.fetchByModelIds(auth, [
+      const [group] = await GroupResource.dangerouslyFetchByModelIds(auth, [
         grants[0].groupId,
       ]);
       expect(await group.isMember(user1)).toBe(false);

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -306,10 +306,14 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     const groupIds = [...new Set(grants.map((grant) => grant.groupId))];
-    const autoGroups = await GroupResource.fetchByModelIds(auth, groupIds, {
-      groupKinds: ["regular_auto"],
-      transaction,
-    });
+    const autoGroups = await GroupResource.dangerouslyFetchByModelIds(
+      auth,
+      groupIds,
+      {
+        groupKinds: ["regular_auto"],
+        transaction,
+      }
+    );
 
     return autoGroups[0] ?? null;
   }
@@ -344,7 +348,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       return [];
     }
 
-    return GroupResource.fetchByModelIds(auth, groupIds, {
+    return GroupResource.dangerouslyFetchByModelIds(auth, groupIds, {
       groupKinds: ["regular_auto"],
       transaction,
     });
@@ -383,10 +387,14 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     const groupIds = [...new Set(rows.map((row) => row.groupId))];
-    const autoGroups = await GroupResource.fetchByModelIds(auth, groupIds, {
-      groupKinds: ["regular_auto"],
-      transaction,
-    });
+    const autoGroups = await GroupResource.dangerouslyFetchByModelIds(
+      auth,
+      groupIds,
+      {
+        groupKinds: ["regular_auto"],
+        transaction,
+      }
+    );
     const autoGroupById = new Map(autoGroups.map((group) => [group.id, group]));
 
     for (const row of rows) {
@@ -1083,7 +1091,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       ),
     ];
     const groups = groupModelIds.length
-      ? await GroupResource.fetchByModelIds(auth, groupModelIds)
+      ? await GroupResource.dangerouslyFetchByModelIds(auth, groupModelIds)
       : [];
     const groupByModelId = new Map(groups.map((group) => [group.id, group]));
 

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -126,12 +126,19 @@ describe("GroupResource", () => {
       });
       const ids = [autoGroup.id, globalGroup.id, systemGroup.id];
 
-      const all = await GroupResource.fetchByModelIds(authenticator, ids);
+      const all = await GroupResource.dangerouslyFetchByModelIds(
+        authenticator,
+        ids
+      );
       expect(all.map((g) => g.id).sort()).toEqual([...ids].sort());
 
-      const autoOnly = await GroupResource.fetchByModelIds(authenticator, ids, {
-        groupKinds: ["regular_auto"],
-      });
+      const autoOnly = await GroupResource.dangerouslyFetchByModelIds(
+        authenticator,
+        ids,
+        {
+          groupKinds: ["regular_auto"],
+        }
+      );
       expect(autoOnly.map((g) => g.id)).toEqual([autoGroup.id]);
     });
   });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -841,7 +841,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groupModels.map((b) => new this(this.model, b.get()));
   }
 
-  static async fetchByModelIds(
+  static async dangerouslyFetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
     {
@@ -849,7 +849,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: { groupKinds?: GroupKind[]; transaction?: Transaction } = {}
   ): Promise<GroupResource[]> {
-    const groups = await this.baseFetch(
+    return this.baseFetch(
       auth,
       {
         where: {
@@ -861,7 +861,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
       transaction
     );
-    return groups.filter((group) => group.canRead(auth));
   }
 
   static async fetchById(
@@ -915,12 +914,12 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    const unreadable = groups.filter((group) => !group.canRead(auth));
-    if (unreadable.length > 0) {
+    const unreadableGroups = groups.filter((group) => !group.canRead(auth));
+    if (unreadableGroups.length > 0) {
       logger.error(
         {
           workspaceId: auth.getNonNullableWorkspace().sId,
-          unreadableGroupIds: unreadable.map((g) => g.sId),
+          unreadableGroupIds: unreadableGroups.map((g) => g.sId),
           authRole: auth.role(),
           authGroupIds: auth.groupIds(),
         },

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -493,6 +493,9 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok({ group, addedUsers: memberUsers });
   }
 
+  /**
+   * TODO(governance): to be removed, replaced by permissions checks
+   */
   static async findAgentIdsForGroups(
     auth: Authenticator,
     groupIds: ModelId[]
@@ -516,6 +519,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
+   * TODO(governance): to be removed, replaced by findRegularAutoGroupForGrant/listRegularAutoGroupsForResource
    * Finds the specific editor group associated with an agent configuration.
    */
   static async findEditorGroupForAgent(
@@ -563,6 +567,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
     });
 
+    // TODO(governance) group can be accessed if agent can be read
     const [group] = groups.filter((g) => g.canRead(auth));
     if (!group) {
       return new Err(
@@ -585,6 +590,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
+   * TODO(governance): to be removed, replaced by findRegularAutoGroupForGrant/listRegularAutoGroupsForResource
    * Finds the specific editor groups associated with a set of agent configuration.
    */
   static async findEditorGroupsForAgents(
@@ -618,6 +624,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
     });
 
+    // TODO(governance) group can be accessed if agent can be read
     const accessibleGroups = groups.filter((group) => group.canRead(auth));
     const groupMap: Record<ModelId, GroupResource> = {};
 
@@ -860,10 +867,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     id: string
   ): Promise<
-    Result<
-      GroupResource,
-      DustError<"group_not_found" | "unauthorized" | "invalid_id">
-    >
+    Result<GroupResource, DustError<"group_not_found" | "invalid_id">>
   > {
     const groupRes = await this.fetchByIds(auth, [id]);
 
@@ -878,10 +882,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     ids: string[]
   ): Promise<
-    Result<
-      GroupResource[],
-      DustError<"group_not_found" | "unauthorized" | "invalid_id">
-    >
+    Result<GroupResource[], DustError<"group_not_found" | "invalid_id">>
   > {
     const groupModelIds = removeNulls(
       ids.map((id) => getResourceIdFromSId(id))
@@ -903,25 +904,6 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError(
           "group_not_found",
           ids.length === 1 ? "Group not found" : "Some groups were not found"
-        )
-      );
-    }
-
-    const unreadableGroups = groups.filter((group) => !group.canRead(auth));
-    if (unreadableGroups.length > 0) {
-      logger.error(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          unreadableGroupIds: unreadableGroups.map((g) => g.sId),
-          authRole: auth.role(),
-          authGroupIds: auth.groupIds(),
-        },
-        "[GroupResource.fetchByIds] User cannot read some groups"
-      );
-      return new Err(
-        new DustError(
-          "unauthorized",
-          "Only `admins` or members can view groups"
         )
       );
     }
@@ -982,6 +964,9 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
   }
 
+  /**
+   * TODO(governance): to be removed, replaced by findRegularAutoGroupForGrant/listRegularAutoGroupsForResource
+   */
   static async fetchByAgentConfiguration({
     auth,
     agentConfiguration,
@@ -1038,6 +1023,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const [group] = groups;
 
+    // TODO(governance) group can be accessed if agent can be read
     if (!group.canRead(auth)) {
       return null;
     }
@@ -1095,15 +1081,29 @@ export class GroupResource extends BaseResource<GroupModel> {
     options: { groupKinds?: GroupKind[] } = {}
   ): Promise<GroupResource[]> {
     const { groupKinds = ["global", "regular_auto", "provisioned"] } = options;
-    const groups = await this.baseFetch(auth, {
+    // Visibility is a caller concern: callers pick which kinds to list (user-facing
+    // callers restrict to `USER_VISIBLE_GROUP_KINDS`, admin/poke callers may request
+    // anything). This method only scopes by kind and does not filter per-caller.
+    return this.baseFetch(auth, {
       where: {
         kind: {
           [Op.in]: groupKinds,
         },
       },
     });
+  }
 
-    return groups.filter((group) => group.canRead(auth));
+  /**
+   * The groups the caller is a member of. Membership (not visibility) is the rule
+   * here: e.g. an API key can only be scoped to groups its creator belongs to.
+   * Internal kinds (system, agent editors) are never surfaced.
+   */
+  static async listMemberGroups(auth: Authenticator): Promise<GroupResource[]> {
+    return this.fetchByModelIds(auth, auth.groupModelIds(), {
+      groupKinds: GROUP_KINDS.filter(
+        (k) => k !== "system" && !isAgentEditorGroupKind(k)
+      ),
+    });
   }
 
   /**

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -32,6 +32,7 @@ import {
   GROUP_KINDS,
   isAgentEditorGroupKind,
   isRegularManualGroupKind,
+  USER_VISIBLE_GROUP_KINDS,
 } from "@app/types/groups";
 import type { AccessControlList } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -459,8 +460,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const owner = auth.getNonNullableWorkspace();
 
-    const existing = await GroupResource.fetchByName(auth, name);
-    if (existing) {
+    if (await GroupResource.groupExistsByName(auth, name)) {
       return new Err(
         new DustError(
           "name_conflict",
@@ -848,8 +848,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       groupKinds,
       transaction,
     }: { groupKinds?: GroupKind[]; transaction?: Transaction } = {}
-  ) {
-    return this.baseFetch(
+  ): Promise<GroupResource[]> {
+    const groups = await this.baseFetch(
       auth,
       {
         where: {
@@ -861,13 +861,17 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
       transaction
     );
+    return groups.filter((group) => group.canRead(auth));
   }
 
   static async fetchById(
     auth: Authenticator,
     id: string
   ): Promise<
-    Result<GroupResource, DustError<"group_not_found" | "invalid_id">>
+    Result<
+      GroupResource,
+      DustError<"group_not_found" | "unauthorized" | "invalid_id">
+    >
   > {
     const groupRes = await this.fetchByIds(auth, [id]);
 
@@ -882,7 +886,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     ids: string[]
   ): Promise<
-    Result<GroupResource[], DustError<"group_not_found" | "invalid_id">>
+    Result<
+      GroupResource[],
+      DustError<"group_not_found" | "unauthorized" | "invalid_id">
+    >
   > {
     const groupModelIds = removeNulls(
       ids.map((id) => getResourceIdFromSId(id))
@@ -908,6 +915,25 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
+    const unreadable = groups.filter((group) => !group.canRead(auth));
+    if (unreadable.length > 0) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          unreadableGroupIds: unreadable.map((g) => g.sId),
+          authRole: auth.role(),
+          authGroupIds: auth.groupIds(),
+        },
+        "[GroupResource.fetchByIds] User cannot read some groups"
+      );
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "Only `admins` or members can view groups"
+        )
+      );
+    }
+
     return new Ok(groups);
   }
 
@@ -920,8 +946,26 @@ export class GroupResource extends BaseResource<GroupModel> {
         workOSGroupId,
       },
     });
+    if (!group || !group.canRead(auth)) {
+      return null;
+    }
+    return group;
+  }
 
-    return group ?? null;
+  // Returns whether a group of the given name exists in the workspace, without
+  // an ACL check. Used for name-conflict checks in `makeNew` and the
+  // regular_manual rename path — those must detect any group in the workspace
+  // regardless of caller visibility.
+  static async groupExistsByName(
+    auth: Authenticator,
+    name: string
+  ): Promise<boolean> {
+    const [group] = await this.baseFetch(auth, {
+      where: {
+        name,
+      },
+    });
+    return !!group;
   }
 
   static async fetchByName(
@@ -933,6 +977,9 @@ export class GroupResource extends BaseResource<GroupModel> {
         name,
       },
     });
+    if (group && !group.canRead(auth)) {
+      return null;
+    }
 
     return group ?? null;
   }
@@ -1031,16 +1078,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     return group;
   }
 
-  static async fetchWorkspaceSystemGroup(
+  // Fetches the system group without any ACL check. Only used in scripts and
+  // system-flow plumbing — the system group is deny-all in `getAccessControlLists`
+  // and must never be exposed to interactive callers.
+  static async dangerouslyFetchWorkspaceSystemGroup(
     auth: Authenticator
   ): Promise<Result<GroupResource, DustError>> {
-    // Only admins can fetch the system group.
-    if (!auth.isAdmin()) {
-      return new Err(
-        new DustError("unauthorized", "Only `admins` can view the system group")
-      );
-    }
-
     const [group] = await this.baseFetch(auth, {
       where: {
         kind: "system",
@@ -1080,17 +1123,17 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     options: { groupKinds?: GroupKind[] } = {}
   ): Promise<GroupResource[]> {
-    const { groupKinds = ["global", "regular_auto", "provisioned"] } = options;
-    // Visibility is a caller concern: callers pick which kinds to list (user-facing
-    // callers restrict to `USER_VISIBLE_GROUP_KINDS`, admin/poke callers may request
-    // anything). This method only scopes by kind and does not filter per-caller.
-    return this.baseFetch(auth, {
+    // Default to user-visible kinds only. Internal kinds (regular_auto, system,
+    // agent_editors) must be requested explicitly.
+    const { groupKinds = [...USER_VISIBLE_GROUP_KINDS] } = options;
+    const groups = await this.baseFetch(auth, {
       where: {
         kind: {
           [Op.in]: groupKinds,
         },
       },
     });
+    return groups.filter((group) => group.canRead(auth));
   }
 
   /**
@@ -2232,8 +2275,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     if (name !== undefined) {
-      const existing = await GroupResource.fetchByName(auth, name);
-      if (existing && existing.id !== this.id) {
+      // Only check for a collision when the name actually changes, so renaming
+      // to the same name never raises a conflict against self.
+      if (
+        name !== this.name &&
+        (await GroupResource.groupExistsByName(auth, name))
+      ) {
         return new Err(
           new DustError(
             "name_conflict",
@@ -2569,6 +2616,22 @@ export class GroupResource extends BaseResource<GroupModel> {
           roles: [
             { role: "admin", permissions: ["read", "write", "admin"] },
             { role: "manager", permissions: ["read"] },
+          ],
+          workspaceId: this.workspaceId,
+        },
+      ];
+    }
+
+    // regular_auto: read for every workspace member. Write/admin are gated through
+    // the associated resource (space/agent), not the group.
+    if (this.isRegularAuto()) {
+      return [
+        {
+          roles: [
+            { role: "admin", permissions: ["read", "write", "admin"] },
+            { role: "manager", permissions: ["read"] },
+            { role: "user", permissions: ["read"] },
+            { role: "builder", permissions: ["read"] },
           ],
           workspaceId: this.workspaceId,
         },

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1094,19 +1094,6 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
-   * The groups the caller is a member of. Membership (not visibility) is the rule
-   * here: e.g. an API key can only be scoped to groups its creator belongs to.
-   * Internal kinds (system, agent editors) are never surfaced.
-   */
-  static async listMemberGroups(auth: Authenticator): Promise<GroupResource[]> {
-    return this.fetchByModelIds(auth, auth.groupModelIds(), {
-      groupKinds: GROUP_KINDS.filter(
-        (k) => k !== "system" && !isAgentEditorGroupKind(k)
-      ),
-    });
-  }
-
-  /**
    * Group model ids the user was a member of at `at`, defaulting to now.
    *
    * Two caveats:

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2601,9 +2601,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       ];
     }
 
-    // Provisioned groups are directory-synced (SCIM), so membership is not editable in-app:
-    // managers get read (e.g. to grant them governance capabilities) but not write/admin.
-    if (this.isProvisioned()) {
+    // provisioned (SCIM-synced) and regular_auto: admin manages, manager reads,
+    // members read via the self-grant. #31360 switches these to pure roles.
+    if (this.isProvisioned() || this.isRegularAuto()) {
       return [
         {
           groups: [
@@ -2615,22 +2615,6 @@ export class GroupResource extends BaseResource<GroupModel> {
           roles: [
             { role: "admin", permissions: ["read", "write", "admin"] },
             { role: "manager", permissions: ["read"] },
-          ],
-          workspaceId: this.workspaceId,
-        },
-      ];
-    }
-
-    // regular_auto: read for every workspace member. Write/admin are gated through
-    // the associated resource (space/agent), not the group.
-    if (this.isRegularAuto()) {
-      return [
-        {
-          roles: [
-            { role: "admin", permissions: ["read", "write", "admin"] },
-            { role: "manager", permissions: ["read"] },
-            { role: "user", permissions: ["read"] },
-            { role: "builder", permissions: ["read"] },
           ],
           workspaceId: this.workspaceId,
         },

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1784,7 +1784,7 @@ describe("SkillResource", () => {
       expect(skillAfter).toBeNull();
 
       // The grant group existed only to hold this skill's grant, so it goes too.
-      const groupsAfter = await GroupResource.fetchByModelIds(
+      const groupsAfter = await GroupResource.dangerouslyFetchByModelIds(
         testContext.authenticator,
         [grantGroup!.id]
       );

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -358,7 +358,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [];
     }
 
-    const groups = await GroupResource.fetchByModelIds(
+    const groups = await GroupResource.dangerouslyFetchByModelIds(
       auth,
       references.map((group) => group.groupId),
       { transaction }
@@ -409,6 +409,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       includeConversationsSpace?: boolean;
       includeProjectSpaces?: boolean;
       includeDeleted?: boolean;
+      includeOpen?: boolean;
+      includeRestricted?: boolean;
     },
     t?: Transaction
   ): Promise<SpaceResource[]> {
@@ -434,7 +436,30 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         t
       );
 
-      return spaces;
+      const includeOpen = options?.includeOpen ?? true;
+      const includeRestricted = options?.includeRestricted ?? true;
+      assert(
+        includeOpen || includeRestricted,
+        "listWorkspaceSpaces: at least one of includeOpen / includeRestricted must be true."
+      );
+      if (includeOpen && includeRestricted) {
+        return spaces;
+      }
+
+      // Openness is determined by the presence of a reader grant for the
+      // workspace global group; resolved for regular/project spaces only.
+      const regularOrProject = spaces.filter(
+        (space) => space.isRegular() || space.isProject()
+      );
+      const openIds = await this.listOpenSpaceModelIds(auth, regularOrProject);
+
+      return spaces.filter((space) => {
+        if (!space.isRegular() && !space.isProject()) {
+          return true;
+        }
+        const open = openIds.has(space.id);
+        return open ? includeOpen : includeRestricted;
+      });
     });
   }
 
@@ -2354,7 +2379,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         allGroupModelIds.add(reference.groupId);
       }
     }
-    const allGroups = await GroupResource.fetchByModelIds(auth, [
+    const allGroups = await GroupResource.dangerouslyFetchByModelIds(auth, [
       ...allGroupModelIds,
     ]);
     const regularAutoGroups = allGroups.filter((group) =>

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -11,6 +11,7 @@ import type {
   PostMemberGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
+import type { GetKeyScopableGroupsResponseBody } from "@app/types/api/keys";
 import type { GroupKind } from "@app/types/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -63,6 +64,35 @@ export function useGroups({
     isGroupsLoading: !error && !data && !disabled,
     isGroupsError: !!error,
     mutateGroups: mutate,
+  };
+}
+
+// The groups the caller may scope a new API key to (the groups they are a
+// member of). Distinct from `useGroups`, which lists workspace groups by kind:
+// key scoping is gated on membership, not visibility.
+export function useKeyScopableGroups({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const groupsFetcher: Fetcher<GetKeyScopableGroupsResponseBody> = fetcher;
+
+  const {
+    data,
+    error,
+    mutate: mutateGroups,
+  } = useSWRWithDefaults(`/api/w/${owner.sId}/keys/groups`, groupsFetcher, {
+    disabled,
+  });
+
+  return {
+    groups: data?.groups ?? emptyArray(),
+    isGroupsLoading: !error && !data && !disabled,
+    isGroupsError: !!error,
+    mutateGroups,
   };
 }
 

--- a/front/migrations/20240731_backfill_keys.ts
+++ b/front/migrations/20240731_backfill_keys.ts
@@ -28,7 +28,8 @@ async function backfillApiKeys(
       );
     }
 
-    const systemGroup = await GroupResource.fetchWorkspaceSystemGroup(auth);
+    const systemGroup =
+      await GroupResource.dangerouslyFetchWorkspaceSystemGroup(auth);
     if (systemGroup.isOk()) {
       await KeyResource.model.update(
         // @ts-ignore -- Legacy migration: groupId column was removed.

--- a/front/migrations/20240829_backfill_keys_without_group_id.ts
+++ b/front/migrations/20240829_backfill_keys_without_group_id.ts
@@ -18,7 +18,8 @@ async function backfillApiKeys(
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   if (execute) {
-    const systemGroup = await GroupResource.fetchWorkspaceSystemGroup(auth);
+    const systemGroup =
+      await GroupResource.dangerouslyFetchWorkspaceSystemGroup(auth);
     if (systemGroup.isOk()) {
       await KeyResource.model.update(
         // @ts-ignore -- Legacy migration: groupId column was removed.

--- a/front/migrations/20241218_delete_dangling_groups.ts
+++ b/front/migrations/20241218_delete_dangling_groups.ts
@@ -14,7 +14,9 @@ const cleanDanglingGroups = async (
 ) => {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  const allGroups = await GroupResource.listAllWorkspaceGroups(auth);
+  const allGroups = await GroupResource.listAllWorkspaceGroups(auth, {
+    groupKinds: ["global", "regular_auto", "provisioned"],
+  });
 
   for (const group of allGroups) {
     frontSequelize.transaction(async (transaction) => {

--- a/front/migrations/20260625_backfill_productboard_skill.ts
+++ b/front/migrations/20260625_backfill_productboard_skill.ts
@@ -340,7 +340,7 @@ async function addAgentEditorsToSkill(
     return;
   }
 
-  const agentEditorGroups = await GroupResource.fetchByModelIds(
+  const agentEditorGroups = await GroupResource.dangerouslyFetchByModelIds(
     auth,
     agentEditorGroupModelIds
   );

--- a/front/migrations/20260728_backfill_space_group_permissions.ts
+++ b/front/migrations/20260728_backfill_space_group_permissions.ts
@@ -46,8 +46,12 @@ async function fetchAssociatedGroups(
     .map((gs) => gs.groupId);
 
   const [members, editors] = await Promise.all([
-    GroupResource.fetchByModelIds(auth, memberGroupIds, { transaction }),
-    GroupResource.fetchByModelIds(auth, editorGroupIds, { transaction }),
+    GroupResource.dangerouslyFetchByModelIds(auth, memberGroupIds, {
+      transaction,
+    }),
+    GroupResource.dangerouslyFetchByModelIds(auth, editorGroupIds, {
+      transaction,
+    }),
   ]);
 
   return { members, editors };

--- a/front/migrations/20260825_reset_open_space_members.ts
+++ b/front/migrations/20260825_reset_open_space_members.ts
@@ -65,7 +65,7 @@ async function resetWorkspaceOpenSpaceMembers(
       )
     ),
   ];
-  const memberGroups = await GroupResource.fetchByModelIds(
+  const memberGroups = await GroupResource.dangerouslyFetchByModelIds(
     auth,
     groupModelIds,
     {

--- a/front/migrations/20260828_restore_skill_editor_memberships.ts
+++ b/front/migrations/20260828_restore_skill_editor_memberships.ts
@@ -78,7 +78,7 @@ async function listGroupsToRestore(
     );
   }
 
-  const groups = await GroupResource.fetchByModelIds(
+  const groups = await GroupResource.dangerouslyFetchByModelIds(
     auth,
     [...suspendedCountByGroupId.keys()],
     { groupKinds: ["regular_auto"] }

--- a/front/scripts/restore_group_memberships_from_csv.ts
+++ b/front/scripts/restore_group_memberships_from_csv.ts
@@ -128,7 +128,7 @@ makeScript(
     }
 
     // Fetch all target groups.
-    const groups = await GroupResource.fetchByModelIds(auth, [
+    const groups = await GroupResource.dangerouslyFetchByModelIds(auth, [
       ...groupIdToUserIds.keys(),
     ]);
     const groupByModelId = new Map(groups.map((g) => [g.id, g]));

--- a/front/scripts/seed/factories/seedGroup.ts
+++ b/front/scripts/seed/factories/seedGroup.ts
@@ -15,13 +15,9 @@ export async function seedGroup(
 ): Promise<GroupResource | undefined> {
   const { auth, workspace, execute, logger } = ctx;
 
-  const existingGroup = await GroupResource.fetchByName(auth, name);
-  if (existingGroup) {
-    logger.info(
-      { sId: existingGroup.sId, name },
-      "Group already exists, skipping"
-    );
-    return existingGroup;
+  if (await GroupResource.groupExistsByName(auth, name)) {
+    logger.info({ name }, "Group already exists, skipping");
+    return undefined;
   }
 
   if (!execute) {

--- a/front/scripts/unrevoke_group_memberships.ts
+++ b/front/scripts/unrevoke_group_memberships.ts
@@ -83,7 +83,7 @@ makeScript(
     }
 
     // Fetch all groups and users
-    const groups = await GroupResource.fetchByModelIds(auth, [
+    const groups = await GroupResource.dangerouslyFetchByModelIds(auth, [
       ...groupIdToUserIds.keys(),
     ]);
     const allUserIds = [...new Set(memberships.map((m) => m.userId))];

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -84,9 +84,10 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     expect(agentAfter).toBeNull();
 
     // Editor group should be deleted too.
-    const groupsAfter = await GroupResource.fetchByModelIds(authenticator, [
-      editorGroupId,
-    ]);
+    const groupsAfter = await GroupResource.dangerouslyFetchByModelIds(
+      authenticator,
+      [editorGroupId]
+    );
     expect(groupsAfter).toHaveLength(0);
   });
 
@@ -111,9 +112,10 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     expect(agentAfter!.status).toBe("pending");
 
     // Editor group should survive too.
-    const groupsAfter = await GroupResource.fetchByModelIds(authenticator, [
-      editorGroupId,
-    ]);
+    const groupsAfter = await GroupResource.dangerouslyFetchByModelIds(
+      authenticator,
+      [editorGroupId]
+    );
     expect(groupsAfter).toHaveLength(1);
   });
 
@@ -164,9 +166,10 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     expect(agents[0].status).toBe("active");
 
     // Its editor group should survive too.
-    const groupsAfter = await GroupResource.fetchByModelIds(authenticator, [
-      editorGroupId,
-    ]);
+    const groupsAfter = await GroupResource.dangerouslyFetchByModelIds(
+      authenticator,
+      [editorGroupId]
+    );
     expect(groupsAfter).toHaveLength(1);
   });
 
@@ -211,7 +214,9 @@ describe("purgeExpiredPendingAgentsActivity", () => {
       })
     ).toBeNull();
     expect(
-      await GroupResource.fetchByModelIds(authenticator, [expiredGroupId])
+      await GroupResource.dangerouslyFetchByModelIds(authenticator, [
+        expiredGroupId,
+      ])
     ).toHaveLength(0);
 
     // Fresh pending agent + group: survived.
@@ -221,7 +226,9 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     expect(freshAfter).not.toBeNull();
     expect(freshAfter!.status).toBe("pending");
     expect(
-      await GroupResource.fetchByModelIds(authenticator, [freshGroupId])
+      await GroupResource.dangerouslyFetchByModelIds(authenticator, [
+        freshGroupId,
+      ])
     ).toHaveLength(1);
 
     // Active agent + group: survived.
@@ -231,7 +238,9 @@ describe("purgeExpiredPendingAgentsActivity", () => {
       })
     ).toHaveLength(1);
     expect(
-      await GroupResource.fetchByModelIds(authenticator, [activeGroupId])
+      await GroupResource.dangerouslyFetchByModelIds(authenticator, [
+        activeGroupId,
+      ])
     ).toHaveLength(1);
   });
 });

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -174,8 +174,8 @@ export class SpaceFactory {
     }
 
     const [members, editors] = await Promise.all([
-      GroupResource.fetchByModelIds(auth, [...memberGroupIds]),
-      GroupResource.fetchByModelIds(auth, [...editorGroupIds]),
+      GroupResource.dangerouslyFetchByModelIds(auth, [...memberGroupIds]),
+      GroupResource.dangerouslyFetchByModelIds(auth, [...editorGroupIds]),
     ]);
 
     await space.writeGroupPermissions(auth, { members, editors });

--- a/front/types/api/keys.ts
+++ b/front/types/api/keys.ts
@@ -1,7 +1,14 @@
+import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 
 export type GetKeysResponseBody = {
   keys: KeyType[];
+};
+
+// The groups the caller may scope a new API key to (the groups they are a
+// member of). Served by GET /api/w/:wId/keys/groups.
+export type GetKeyScopableGroupsResponseBody = {
+  groups: GroupType[];
 };
 
 export type PostKeysResponseBody = {

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -61,6 +61,20 @@ export function isManageableGroupKind(kind: GroupKind): boolean {
   return MANAGEABLE_GROUP_KINDS.some((k) => k === kind);
 }
 
+// Group kinds that any workspace member may see directly (e.g. in the workspace
+// Groups listing or when referencing a group by id). Internal kinds
+// (`regular_auto`, `system`, `agent_editors`) are never surfaced this way: they
+// are implementation details of spaces, permissions, and agent editors.
+export const USER_VISIBLE_GROUP_KINDS = [
+  "global",
+  "provisioned",
+  "regular_manual",
+] as const;
+
+export function isUserVisibleGroupKind(kind: GroupKind): boolean {
+  return USER_VISIBLE_GROUP_KINDS.some((k) => k === kind);
+}
+
 export function isGroupKind(value: unknown): value is GroupKind {
   return GROUP_KINDS.includes(value as GroupKind);
 }

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -66,9 +66,8 @@ export function isManageableGroupKind(kind: GroupKind): boolean {
 // (`regular_auto`, `system`, `agent_editors`) are never surfaced this way: they
 // are implementation details of spaces, permissions, and agent editors.
 export const USER_VISIBLE_GROUP_KINDS = [
+  ...MANAGEABLE_GROUP_KINDS,
   "global",
-  "provisioned",
-  "regular_manual",
 ] as const;
 
 export function isUserVisibleGroupKind(kind: GroupKind): boolean {


### PR DESCRIPTION
## Description

Rework the `GroupResource` fetcher layer around a `canRead` filter, split ACL-bypass paths behind explicit `dangerously*` accessors, and widen API key scoping to include restricted pods (projects) — per [dust-tt/tasks#10202](https://github.com/dust-tt/tasks/issues/10202#issuecomment-5441979766).

### `GroupResource` fetchers

Every named fetcher enforces `canRead` on the returned rows. Callers that must see rows regardless of the caller's ACL go through the explicit `dangerously*` opt-outs:

- `fetchById` / `fetchByIds` — filter on `canRead`; return `Err("unauthorized")` if any id resolves to a group the caller can't read.
- `fetchByName` — returns `null` when the row isn't readable.
- `fetchByWorkOSGroupId` — same shape; used by SCIM/WorkOS sync.
- `listAllWorkspaceGroups` — filter on `canRead` and default the kinds to a new `USER_VISIBLE_GROUP_KINDS = [...MANAGEABLE_GROUP_KINDS, "global"]`; callers that want internal kinds must ask explicitly.
- **`fetchByModelIds` → `dangerouslyFetchByModelIds`** (no `canRead`). Model ids never cross the client boundary (per SEC2) — they are internal identifiers used by permission plumbing to resolve groups referenced from grants/joins where the ACL is enforced on the parent resource. Applying `canRead` here would silently drop legitimate rows.
- **`fetchWorkspaceSystemGroup` → `dangerouslyFetchWorkspaceSystemGroup`** (no `isAdmin` gate). The system group is deny-all in the ACL; the only way to reach it is through this explicit opt-out from scripts / system plumbing.
- New **`groupExistsByName`** — cheap existence check used by `makeNew` / `updateRegularManualGroup` name-conflict paths and by `seedGroup`. No ACL — a name collision must be caught regardless of caller visibility.

### ACL

Only one ACL change here: **`regular_auto` is aligned with `provisioned`'s shape** (admin manages, manager reads, members read via the self-grant). The broader "everyone reads every non-system kind" simplification stays in #31360 to keep the two PRs focused.

### API keys — scoping (was `useGroups`, now dedicated endpoint)

Previously the API keys page used the generic `useGroups` hook, which listed every workspace group — including `regular_auto`, pod groups, etc. — as picker options. This PR replaces that with a dedicated `GET /keys/groups` endpoint served by `listKeyScopableGroups`:

- Returns the groups attached to the workspace's restricted regular spaces and restricted pods, plus the workspace global group so existing keys (always force-scoped to global by the backend) resolve their name in the keys table icon/tooltip. The picker filters global out client-side.
- Open spaces / open pods are excluded (readable via global — not meaningful to scope to).
- `POST /keys` group-scoping validation matches; error message updated to "restricted spaces or pods".

### `SpaceResource.listWorkspaceSpaces`

New `includeOpen` / `includeRestricted` options (default `true`, backward-compatible). Applies to regular/project spaces only; other kinds pass through. Both `false` fails a fail-fast assert. Used by the new `listKeyScopableGroups`.

## Tests

- `front` + `front-api` `npx tsgo --noEmit` clean.
- Group / space / permission resource suites (161 tests) pass.
- Keys route suites: added
  - "includes restricted pod groups" and "excludes open pod groups" for `GET /keys/groups`;
  - "rejects scoping to a group not tied to a restricted space or pod" for `POST /keys`.
- The manual test plan is in the PR review thread.

## Risk

- **`fetchByModelIds` semantic change (implicit ACL → explicit opt-out).** All existing callers were migrated in the same commit. Behavior is preserved (they were previously unfiltered and remain unfiltered via the renamed method).
- **`fetchWorkspaceSystemGroup` semantic change (rename + drop `isAdmin` gate).** Only two migrations call it, both under `internalAdminForWorkspace`. The gate was redundant given the caller auth; the rename makes the intent explicit.
- **API keys — scoping picker.** The picker now offers a curated set (restricted spaces + restricted pods + implicit global) instead of every workspace group. Restricted pod scoping — the common real case — is preserved. Any key already scoped to a group that no longer appears in the picker still works (the backend only rejects new scoping attempts to non-scopable groups).
- **`GET /w/:wId/groups` default kinds change** to `USER_VISIBLE_GROUP_KINDS`. No frontend caller relies on the default — every `useGroups({ kinds })` call passes explicit kinds — so the frontend is unaffected. The one runtime consumer of the default (a poke plugin picker) narrows from "everything visible" to "user-visible only", which is the intent.

Rollback: revert the PR; no data migrations, no schema changes.

## Deploy Plan

Standard `front` deploy. No migrations, no feature flags, no coordination required. #31360 stacks on top and can ship immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)