### PR TITLE
[front] Replace SpaceResource.isOpen with isRestricted

### DIFF
--- a/front-api/middlewares/with_space.ts
+++ b/front-api/middlewares/with_space.ts
@@ -94,10 +94,9 @@ export function withSpace(options: WithSpaceOptions) {
     // and the emit is best-effort. Run the whole block off the critical path.
     void (async () => {
       // Only regular/project spaces are "restricted" (member-only); global and conversations spaces
-      // are workspace-wide and system is admin-only, so none of those is audited here. This is not
-      // simply `!isOpen`: a system space is not open, but is not restricted either.
-      const isRestricted =
-        (space.isRegular() || space.isProject()) && !(await space.isOpen(auth));
+      // are workspace-wide and system is admin-only, so none of those is audited here. `isRestricted`
+      // already encodes that: a system space is not open, but is not restricted either.
+      const isRestricted = await space.isRestricted(auth);
       if (isRestricted) {
         void emitAuditLogEvent({
           auth,

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].test.ts
@@ -1,0 +1,112 @@
+import { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function deleteMember(
+  workspace: { sId: string },
+  spaceId: string,
+  userId: string,
+  keySecret: string
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/spaces/${spaceId}/members/${userId}`,
+    {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${keySecret}` },
+    }
+  );
+}
+
+async function addMember(
+  workspace: { sId: string },
+  space: SpaceResource,
+  user: UserResource
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const res = await space.addMembers(adminAuth, { userIds: [user.sId] });
+  expect(res.isOk()).toBe(true);
+}
+
+describe("DELETE /api/v1/w/:wId/spaces/:spaceId/members/:userId", () => {
+  it("removes a member from a regular space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await addMember(workspace, space, user);
+
+    const response = await deleteMember(
+      workspace,
+      space.sId,
+      user.sId,
+      key.secret
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("removes a member from a project space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const project = await SpaceFactory.project(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await addMember(workspace, project, user);
+
+    const response = await deleteMember(
+      workspace,
+      project.sId,
+      user.sId,
+      key.secret
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects removing a user who is not a member", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const response = await deleteMember(
+      workspace,
+      space.sId,
+      user.sId,
+      key.secret
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a global space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const globalSpace = await SpaceFactory.global(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const response = await deleteMember(
+      workspace,
+      globalSpace.sId,
+      user.sId,
+      key.secret
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -41,15 +41,27 @@ app.delete(
       });
     }
 
-    if (space.managementMode === "group" || (await space.isOpen(auth))) {
+    // Members are editable on regular spaces and projects only — not global, system or conversations
+    // spaces — regardless of whether the space is open or restricted (an open space keeps an explicit
+    // member group whose grant confers write beyond the workspace-wide read). Group-managed spaces
+    // draw their membership from provisioned (IdP-owned) groups, so members can't be edited by API.
+    if (!space.isRegular() && !space.isProject()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "The space was not found.",
+        },
+      });
+    }
+
+    if (space.managementMode === "group") {
       return apiError(ctx, {
         status_code: 404,
         api_error: {
           type: "space_not_found",
           message:
-            space.managementMode === "group"
-              ? "Space is managed by provisioned group access, members can't be edited by API."
-              : "Non-restricted space's members can't be edited.",
+            "Space is managed by provisioned group access, members can't be edited by API.",
         },
       });
     }

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.test.ts
@@ -66,6 +66,25 @@ describe("POST /api/v1/w/:wId/spaces/:spaceId/members", () => {
     );
   });
 
+  it("adds a member to a project space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const project = await SpaceFactory.project(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const response = await postMembers(workspace, project.sId, key.secret, {
+      userIds: [user.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const { users } = await response.json();
+    expect(users).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sId: user.sId })])
+    );
+  });
+
   it("rejects a global space", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.test.ts
@@ -1,0 +1,83 @@
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function postMembers(
+  workspace: { sId: string },
+  spaceId: string,
+  keySecret: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/spaces/${spaceId}/members`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${keySecret}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("POST /api/v1/w/:wId/spaces/:spaceId/members", () => {
+  it("adds a member to a restricted regular space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const response = await postMembers(workspace, space.sId, key.secret, {
+      userIds: [user.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const { users } = await response.json();
+    expect(users).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sId: user.sId })])
+    );
+  });
+
+  it("adds a member to an open regular space", async () => {
+    // An open space (the workspace global group holds a reader grant) is still member-editable: the
+    // explicit member group confers write beyond the workspace-wide read.
+    const { workspace, globalGroup, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.regular(workspace);
+    await SpaceFactory.attachGroup(space, globalGroup);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const response = await postMembers(workspace, space.sId, key.secret, {
+      userIds: [user.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const { users } = await response.json();
+    expect(users).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sId: user.sId })])
+    );
+  });
+
+  it("rejects a global space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const globalSpace = await SpaceFactory.global(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const response = await postMembers(workspace, globalSpace.sId, key.secret, {
+      userIds: [user.sId],
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -31,8 +31,8 @@ type MembersCtx = PublicApiCtx & {
 
 /**
  * Fetches the space named by `:spaceId`, validates it exists and is editable
- * (not managed by provisioned groups, no global group). Used by GET and POST
- * below to dedupe the space lookup that the Next handler had inline.
+ * (a regular space or project, not managed by provisioned groups). Used by GET
+ * and POST below to dedupe the space lookup that the Next handler had inline.
  *
  * Reads `spaceId` from `ctx.req.valid("param")`, so a `validate("param", ...)`
  * with a schema containing `spaceId` must precede it in the handler chain.
@@ -58,15 +58,27 @@ const withEditableSpace = createMiddleware<
     });
   }
 
-  if (space.managementMode === "group" || (await space.isOpen(auth))) {
+  // Members are editable on regular spaces and projects only — not global, system or conversations
+  // spaces — regardless of whether the space is open or restricted (an open space keeps an explicit
+  // member group whose grant confers write beyond the workspace-wide read). Group-managed spaces
+  // draw their membership from provisioned (IdP-owned) groups, so members can't be edited by API.
+  if (!space.isRegular() && !space.isProject()) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space was not found.",
+      },
+    });
+  }
+
+  if (space.managementMode === "group") {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "space_not_found",
         message:
-          space.managementMode === "group"
-            ? "Space is managed by provisioned group access, members can't be edited by API."
-            : "Non-restricted space's members can't be edited.",
+          "Space is managed by provisioned group access, members can't be edited by API.",
       },
     });
   }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -29,7 +29,7 @@ app.post(
       });
     }
 
-    if (!(await space.isOpen(auth))) {
+    if (await space.isRestricted(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -55,7 +55,7 @@ app.patch(
       space.isProject() &&
       !body.isRestricted &&
       !areOpenPodsAllowed(owner) &&
-      !(await space.isOpen(auth))
+      (await space.isRestricted(auth))
     ) {
       return apiError(ctx, {
         status_code: 403,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -309,7 +309,7 @@ export function createProjectManagerTools(
           }
 
           const newIsRestricted = access !== "open";
-          const currentlyRestricted = !(await pod.isOpen(auth));
+          const currentlyRestricted = await pod.isRestricted(auth);
           if (newIsRestricted !== currentlyRestricted) {
             const { editorIds, memberIds } = await getPodMemberAndEditorSIds(
               auth,
@@ -703,7 +703,7 @@ export function createProjectManagerTools(
               id: pod.sId,
               name: pod.name,
               url: projectUrl,
-              access: (await pod.isOpen(auth)) ? "open" : "restricted",
+              access: (await pod.isRestricted(auth)) ? "restricted" : "open",
               description: metadata?.description ?? null,
               pinnedFramePath: metadata?.pinnedFramePath ?? null,
               defaultAgent,
@@ -1107,7 +1107,7 @@ export function createProjectManagerTools(
             pod: {
               id: pod.sId,
               title: pod.name,
-              access: (await pod.isOpen(auth)) ? "open" : "restricted",
+              access: (await pod.isRestricted(auth)) ? "restricted" : "open",
               dustPod: {
                 uri: makePodConfigurationURI(owner.sId, pod.sId),
                 mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2576,7 +2576,7 @@ describe("postUserMessage", () => {
     });
 
     it("should reject posting a message without an auth user to a restricted Pod even when user association is disabled", async () => {
-      expect(await projectSpace.isOpen(auth)).toBe(false);
+      expect(await projectSpace.isRestricted(auth)).toBe(true);
 
       const apiKey = await KeyFactory.regular(globalGroup);
       const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
@@ -2590,7 +2590,7 @@ describe("postUserMessage", () => {
         projectSpace.sId
       );
       expect(restrictedPod).not.toBeNull();
-      expect(await restrictedPod?.isOpen(apiKeyAuth)).toBe(false);
+      expect(await restrictedPod?.isRestricted(apiKeyAuth)).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource: projectConversationResource,
@@ -2637,7 +2637,7 @@ describe("postUserMessage", () => {
         projectSpace.sId
       );
       expect(openPod).not.toBeNull();
-      expect(await openPod?.isOpen(apiKeyAuth)).toBe(true);
+      expect(await openPod?.isRestricted(apiKeyAuth)).toBe(false);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource: projectConversationResource,
@@ -2683,7 +2683,7 @@ describe("postUserMessage", () => {
         projectSpace.sId
       );
       expect(openPod).not.toBeNull();
-      expect(await openPod?.isOpen(apiKeyAuth)).toBe(true);
+      expect(await openPod?.isRestricted(apiKeyAuth)).toBe(false);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource: projectConversationResource,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -590,7 +590,9 @@ export async function postUserMessage(
     // If the Pod is open and there is no user in the context (eg: slack bot message),
     // we allow the message to be posted.
     const skipMembershipCheck =
-      !auth.user() && doNotAssociateUser === true && (await pod.isOpen(auth));
+      !auth.user() &&
+      doNotAssociateUser === true &&
+      !(await pod.isRestricted(auth));
     if (!skipMembershipCheck && !pod.isMember(auth)) {
       return new Err({
         status_code: 403,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -834,7 +834,9 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
       // Regular spaces created by SpaceFactory.regular are restricted (no global group)
-      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
+      expect(await refreshedRestrictedSpace?.isRestricted(adminAuth)).toBe(
+        true
+      );
 
       // Create a user who is NOT a member of the restricted space
       const mentionedUser = await UserFactory.basic();
@@ -948,7 +950,7 @@ describe("createAgentMessages", () => {
         openSpace.sId
       );
       expect(refreshedOpenSpace).not.toBeNull();
-      expect(await refreshedOpenSpace?.isOpen(adminAuth)).toBe(true);
+      expect(await refreshedOpenSpace?.isRestricted(adminAuth)).toBe(false);
 
       // Create a user who can access the space (all users can access open spaces)
       const mentionedUser = await UserFactory.basic();
@@ -1044,7 +1046,9 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
       // Regular spaces created by SpaceFactory.regular are restricted (no global group)
-      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
+      expect(await refreshedRestrictedSpace?.isRestricted(adminAuth)).toBe(
+        true
+      );
 
       // Create a user who is NOT a member of the restricted space
       const mentionedUser = await UserFactory.basic();

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -908,7 +908,9 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
       // Regular spaces created by SpaceFactory.regular are restricted (no global group)
-      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
+      expect(await refreshedRestrictedSpace?.isRestricted(adminAuth)).toBe(
+        true
+      );
 
       // Refresh the conversation space to get updated permissions
       const refreshedConversationSpace = await SpaceResource.fetchById(
@@ -1052,7 +1054,9 @@ describe("createAgentMessages", () => {
         restrictedSpace.sId
       );
       expect(refreshedRestrictedSpace).not.toBeNull();
-      expect(await refreshedRestrictedSpace?.isOpen(adminAuth)).toBe(false);
+      expect(await refreshedRestrictedSpace?.isRestricted(adminAuth)).toBe(
+        true
+      );
 
       const refreshedConversationSpace = await SpaceResource.fetchById(
         userAuth,
@@ -1358,7 +1362,7 @@ describe("createAgentMessages", () => {
         openSpace.sId
       );
       expect(refreshedOpenSpace).not.toBeNull();
-      expect(await refreshedOpenSpace?.isOpen(adminAuth)).toBe(true);
+      expect(await refreshedOpenSpace?.isRestricted(adminAuth)).toBe(false);
       // Verify it's not global
       expect(refreshedOpenSpace?.isGlobal()).toBe(false);
 

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -239,7 +239,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
       }
 
       expect(openProjectHydrated.isProject()).toBe(true);
-      expect(await openProjectHydrated.isOpen(auth)).toBe(true);
+      expect(await openProjectHydrated.isRestricted(auth)).toBe(false);
 
       const manualMembers =
         await openProjectHydrated.fetchDistinctActiveManualGroupMembers(auth);

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -890,7 +890,7 @@ describe("DustFileSystem.forAgentLoop", () => {
         openProjectRes.value.sId
       );
       assert(openProject, "Open project not found after creation");
-      expect(await openProject.isOpen(adminAuth)).toBe(true);
+      expect(await openProject.isRestricted(adminAuth)).toBe(false);
 
       const podConversation = await ConversationFactory.create(
         refreshedAdminAuth,
@@ -945,7 +945,7 @@ describe("DustFileSystem.forAgentLoop", () => {
       const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
 
       const restrictedProject = await SpaceFactory.project(workspace, user.id);
-      expect(await restrictedProject.isOpen(userSessionAuth)).toBe(false);
+      expect(await restrictedProject.isRestricted(userSessionAuth)).toBe(true);
 
       const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
         user.sId,

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -128,7 +128,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.name).toBe("Test Regular Space");
         expect(space.kind).toBe("regular");
         expect(space.managementMode).toBe("manual");
-        expect(await space.isOpen(adminAuth)).toBe(false);
+        expect(await space.isRestricted(adminAuth)).toBe(true);
 
         // Verify the space has a group
         const groups = await space.fetchGroupResources(adminAuth);
@@ -189,7 +189,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.name).toBe("Test Group Space");
         expect(space.kind).toBe("regular");
         expect(space.managementMode).toBe("group");
-        expect(await space.isOpen(adminAuth)).toBe(false);
+        expect(await space.isRestricted(adminAuth)).toBe(true);
 
         // Verify groups were associated (from the space's group_permissions grants).
         const reloadedSpace = await SpaceResource.fetchById(
@@ -419,7 +419,7 @@ describe("createSpaceAndGroup", () => {
           space.sId
         );
         expect(reloadedSpace).not.toBeNull();
-        expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
+        expect(await reloadedSpace!.isRestricted(adminAuth)).toBe(false);
 
         // Verify global group was added (from the space's group_permissions grants).
         const associatedGroupIds = (
@@ -462,7 +462,7 @@ describe("createSpaceAndGroup", () => {
         result.value.sId
       );
 
-      expect(await asMember!.isOpen(memberAuth)).toBe(true);
+      expect(await asMember!.isRestricted(memberAuth)).toBe(false);
 
       // The member group confers write; the global group's `reader` grant only confers read.
       expect(asMember!.canRead(memberAuth)).toBe(true);
@@ -484,7 +484,7 @@ describe("createSpaceAndGroup", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         const space = result.value;
-        expect(await space.isOpen(adminAuth)).toBe(false);
+        expect(await space.isRestricted(adminAuth)).toBe(true);
 
         // Verify global group was NOT added (from the space's group_permissions grants).
         const associatedGroupIds = (await space.fetchGrantReferences()).map(
@@ -932,7 +932,7 @@ describe("createSpaceAndGroup", () => {
           adminAuth,
           space.sId
         );
-        expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
+        expect(await reloadedSpace!.isRestricted(adminAuth)).toBe(false);
 
         // Verify the global group holds a reader grant on the space (open regular space).
         const grants = await GroupPermissionResource.listForResource(
@@ -967,7 +967,7 @@ describe("createSpaceAndGroup", () => {
           space.sId
         );
         expect(reloadedSpace!.kind).toBe("project");
-        expect(await reloadedSpace!.isOpen(adminAuth)).toBe(true);
+        expect(await reloadedSpace!.isRestricted(adminAuth)).toBe(false);
 
         // Verify the global group holds a reader grant on the project (attached as viewer).
         const grants = await GroupPermissionResource.listForResource(

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1578,7 +1578,7 @@ describe("SpaceResource", () => {
     });
   });
 
-  describe("isOpen", () => {
+  describe("isRestricted", () => {
     let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
     let adminAuth: Authenticator;
 
@@ -1603,17 +1603,19 @@ describe("SpaceResource", () => {
       );
     });
 
-    // `isOpen` is read from the space's `group_permissions` grants, so re-fetch after each change
-    // rather than trusting the in-memory instance.
-    const refetchIsOpen = async (space: SpaceResource): Promise<boolean> => {
+    // `isRestricted` is read from the space's `group_permissions` grants, so re-fetch after each
+    // change rather than trusting the in-memory instance.
+    const refetchIsRestricted = async (
+      space: SpaceResource
+    ): Promise<boolean> => {
       const refetched = await SpaceResource.fetchById(adminAuth, space.sId);
       expect(refetched).not.toBeNull();
-      return refetched!.isOpen(adminAuth);
+      return refetched!.isRestricted(adminAuth);
     };
 
-    it("is false for a restricted space and true once opened", async () => {
+    it("is true for a restricted space and false once opened", async () => {
       const space = await SpaceFactory.regular(workspace);
-      expect(await refetchIsOpen(space)).toBe(false);
+      expect(await refetchIsRestricted(space)).toBe(true);
 
       const openResult = await space.updatePermissions(adminAuth, {
         name: space.name,
@@ -1624,10 +1626,10 @@ describe("SpaceResource", () => {
       });
       expect(openResult.isOk()).toBe(true);
 
-      expect(await refetchIsOpen(space)).toBe(true);
+      expect(await refetchIsRestricted(space)).toBe(false);
     });
 
-    it("flips back to false when an open space is restricted again", async () => {
+    it("flips back to true when an open space is restricted again", async () => {
       const space = await SpaceFactory.regular(workspace);
       const openResult = await space.updatePermissions(adminAuth, {
         name: space.name,
@@ -1637,7 +1639,7 @@ describe("SpaceResource", () => {
         editorIds: [],
       });
       expect(openResult.isOk()).toBe(true);
-      expect(await refetchIsOpen(space)).toBe(true);
+      expect(await refetchIsRestricted(space)).toBe(false);
 
       const opened = await SpaceResource.fetchById(adminAuth, space.sId);
       const restrictResult = await opened!.updatePermissions(adminAuth, {
@@ -1649,7 +1651,7 @@ describe("SpaceResource", () => {
       });
       expect(restrictResult.isOk()).toBe(true);
 
-      expect(await refetchIsOpen(space)).toBe(false);
+      expect(await refetchIsRestricted(space)).toBe(true);
     });
   });
 
@@ -2623,7 +2625,7 @@ describe("SpaceResource group_permissions enforcement", () => {
     // Refetched, not reused: `space` holds the grant snapshot from before the update.
     const openSpace = await SpaceResource.fetchById(adminAuth, space.sId);
     expect(openSpace).not.toBeNull();
-    expect(await openSpace!.isOpen(adminAuth)).toBe(true);
+    expect(await openSpace!.isRestricted(adminAuth)).toBe(false);
 
     // The member group confers write; the global group's `reader` grant only confers read.
     expect(openSpace!.canRead(memberAuth)).toBe(true);
@@ -2778,7 +2780,7 @@ describe("SpaceResource group_permissions enforcement", () => {
     // Refetched, not reused: `space` holds the grant snapshot from before the update.
     const openSpace = await SpaceResource.fetchById(adminAuth, space.sId);
     expect(openSpace).not.toBeNull();
-    expect(await openSpace!.isOpen(adminAuth)).toBe(true);
+    expect(await openSpace!.isRestricted(adminAuth)).toBe(false);
 
     // In group management mode the provisioned group is the space's member group, so it is what
     // carries write.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -2136,7 +2136,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // Users can add themselves to open projects; otherwise managing a space's members requires
     // administration rights (held by workspace admins and a project's editors) — a project's plain
     // members hold `write` but must not be able to add others, so this gates on `canAdministrate`.
-    if (this.isProject() && (await this.isOpen(auth))) {
+    if (this.isProject() && !(await this.isRestricted(auth))) {
       const currentUser = auth.getNonNullableUser();
       if (userId === currentUser.sId) {
         return true;
@@ -2189,13 +2189,22 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.kind === "project";
   }
 
-  // A space is open when the workspace global group holds a `reader` grant on it (that grant is what
-  // makes the space visible to every workspace member). Resolved from `group_permissions`. Prefer
-  // `listOpenSpaceModelIds` when checking several spaces to avoid one query per space.
-  async isOpen(auth: Authenticator): Promise<boolean> {
-    return (await SpaceResource.listOpenSpaceModelIds(auth, [this])).has(
-      this.id
-    );
+  // A regular space or project is restricted when it is member-only: the workspace global group
+  // holds no `reader` grant on it (an open space grants that group a `reader` grant, which is what
+  // makes it visible to every workspace member). Global, conversations and system spaces are never
+  // restricted. This is the resource-level equivalent of the serialized `EnrichedSpaceType.isRestricted`.
+  // Resolved from `group_permissions`; serialize a batch of spaces via `batchToJSONEnriched` to avoid
+  // one query per space.
+  async isRestricted(auth: Authenticator): Promise<boolean> {
+    if (!this.isRegular() && !this.isProject()) {
+      return false;
+    }
+
+    const isOpen = (
+      await SpaceResource.listOpenSpaceModelIds(auth, [this])
+    ).has(this.id);
+
+    return !isOpen;
   }
 
   // The model ids of the `spaces` that are open (the workspace global group holds a `reader` grant).

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -130,7 +130,7 @@ describe("governance seed script integration test", () => {
 
     // The restricted space holds the current user and Bob.
     expect(restrictedSpace).toBeDefined();
-    expect(await restrictedSpace!.isOpen(authenticator)).toBe(false);
+    expect(await restrictedSpace!.isRestricted(authenticator)).toBe(true);
     const spaceMembers =
       await restrictedSpace!.fetchDistinctActiveManualGroupMembers(
         authenticator
@@ -177,7 +177,7 @@ describe("governance seed script integration test", () => {
 
     // The private space holds Alfred only: the current user is not a member.
     expect(privateSpace).toBeDefined();
-    expect(await privateSpace!.isOpen(authenticator)).toBe(false);
+    expect(await privateSpace!.isRestricted(authenticator)).toBe(true);
     const privateSpaceMembers =
       await privateSpace!.fetchDistinctActiveManualGroupMembers(authenticator);
     expect(new Set(privateSpaceMembers.map((m) => m.sId))).toEqual(


### PR DESCRIPTION
## Description

Follow-up to #31157. Consolidates the confusing split between `SpaceResource.isOpen()` and the serialized `EnrichedSpaceType.isRestricted` field: removes `isOpen()`, adds `isRestricted(auth)` (regular/project spaces are restricted when the global group holds no `reader` grant; global/system/conversations never are). The batch primitive `listOpenSpaceModelIds` is kept.

Also aligns the public v1 members endpoints with the private API: member editing no longer gates on openness. Members are editable on any regular/project space (open or restricted), excluding global/system/conversations and group-managed spaces. Only allows more cases — not a breaking change.

## Tests

- `tsgo` clean in `front` and `front-api`.
- Migrated existing tests to `isRestricted`.
- New `v1/.../members/index.test.ts`: open space (200, previously 404), restricted (200), global (404).

## Risk

Low. `isOpen`/`!isRestricted` only differ for system spaces; every call site is kind-guarded. Safe to rollback.

## Deploy Plan

Standard.