### PR TITLE
feat(front): send non-participant unread conversation IDs in space summary

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
@@ -62,7 +62,7 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
     number,
     {
       unreadConversations: ConversationWithoutContentType[];
-      nonParticipantUnreadConversations: ConversationWithoutContentType[];
+      nonParticipantUnreadConversationIds: string[];
     }
   >();
 
@@ -72,7 +72,7 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
       if (spaceModelId && spaceIdToSpaceMap.has(spaceModelId)) {
         const existing = conversationsBySpace.get(spaceModelId) ?? {
           unreadConversations: [],
-          nonParticipantUnreadConversations: [],
+          nonParticipantUnreadConversationIds: [],
         };
         existing.unreadConversations.push(conversation.toJSON());
         conversationsBySpace.set(spaceModelId, existing);
@@ -86,9 +86,9 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
       if (spaceModelId && spaceIdToSpaceMap.has(spaceModelId)) {
         const existing = conversationsBySpace.get(spaceModelId) ?? {
           unreadConversations: [],
-          nonParticipantUnreadConversations: [],
+          nonParticipantUnreadConversationIds: [],
         };
-        existing.nonParticipantUnreadConversations.push(conversation.toJSON());
+        existing.nonParticipantUnreadConversationIds.push(conversation.sId);
         conversationsBySpace.set(spaceModelId, existing);
       }
     }
@@ -117,9 +117,9 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
       },
       unreadConversations:
         conversationsBySpace.get(space.id)?.unreadConversations ?? [],
-      nonParticipantUnreadConversations:
-        conversationsBySpace.get(space.id)?.nonParticipantUnreadConversations ??
-        [],
+      nonParticipantUnreadConversationIds:
+        conversationsBySpace.get(space.id)
+          ?.nonParticipantUnreadConversationIds ?? [],
     })),
   });
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
@@ -120,6 +120,7 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
       nonParticipantUnreadConversationIds:
         conversationsBySpace.get(space.id)
           ?.nonParticipantUnreadConversationIds ?? [],
+      nonParticipantUnreadConversations: [],
     })),
   });
 });

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -746,7 +746,7 @@ export function AgentSidebarMenu({
     const hiddenOverflowHasActivity = hiddenStarredSummary.some(
       (s) =>
         s.unreadConversations.length > 0 ||
-        s.nonParticipantUnreadConversations.length > 0
+        s.nonParticipantUnreadConversationIds.length > 0
     );
 
     return (
@@ -793,7 +793,7 @@ export function AgentSidebarMenu({
     const hiddenOverflowHasActivity = hiddenSummary.some(
       (s) =>
         s.unreadConversations.length > 0 ||
-        s.nonParticipantUnreadConversations.length > 0
+        s.nonParticipantUnreadConversationIds.length > 0
     );
 
     return (

--- a/front/components/assistant/conversation/sidebar/PodList.tsx
+++ b/front/components/assistant/conversation/sidebar/PodList.tsx
@@ -213,7 +213,7 @@ export function renderPodsList({
   }
 
   return filteredSummary.map(
-    ({ space, unreadConversations, nonParticipantUnreadConversations }) => (
+    ({ space, unreadConversations, nonParticipantUnreadConversationIds }) => (
       <PodListItem
         key={space.sId}
         pod={space}
@@ -221,7 +221,7 @@ export function renderPodsList({
         unreadCount={unreadConversations.length}
         hasUnread={
           unreadConversations.length > 0 ||
-          nonParticipantUnreadConversations.length > 0
+          nonParticipantUnreadConversationIds.length > 0
         }
         owner={owner}
         moveConversationToPod={moveConversationToPod}

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -253,8 +253,8 @@ export function useConversationMarkAsRead({
             spaceSummary.unreadConversations.some(
               ({ sId }) => sId === conversationId
             ) ||
-            spaceSummary.nonParticipantUnreadConversations.some(
-              ({ sId }) => sId === conversationId
+            spaceSummary.nonParticipantUnreadConversationIds.includes(
+              conversationId
             )
         );
         if (!containsConversation) {
@@ -267,9 +267,9 @@ export function useConversationMarkAsRead({
             unreadConversations: spaceSummary.unreadConversations.filter(
               ({ sId }) => sId !== conversationId
             ),
-            nonParticipantUnreadConversations:
-              spaceSummary.nonParticipantUnreadConversations.filter(
-                ({ sId }) => sId !== conversationId
+            nonParticipantUnreadConversationIds:
+              spaceSummary.nonParticipantUnreadConversationIds.filter(
+                (id) => id !== conversationId
               ),
           })),
         };

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2371,11 +2371,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         (c.userLastReadAt === null || c.updatedAt > c.userLastReadAt)
     );
 
-    // Hydrate next wake-up only for conversations returned to the summary (sidebar inbox).
-    await this.enrichWithNextWakeupAt(auth, [
-      ...unreadConversations,
-      ...nonParticipantUnreadConversations,
-    ]);
+    // Hydrate next wake-up only for participant unread conversations, which are
+    // serialized into the sidebar inbox. Non-participant unread IDs are only
+    // used for the activity badge.
+    await this.enrichWithNextWakeupAt(auth, unreadConversations);
 
     const lastUserActivityBySpace = new Map<number, Date>();
 

--- a/front/types/api/assistant/conversation/spaces.ts
+++ b/front/types/api/assistant/conversation/spaces.ts
@@ -7,6 +7,8 @@ export type GetBySpacesSummaryResponseBody = {
     space: PodListItemType;
     unreadConversations: ConversationWithoutContentType[];
     nonParticipantUnreadConversationIds: string[];
+    // Always empty: kept so old clients that still read this field do not break.
+    nonParticipantUnreadConversations: [];
   }>;
 };
 

--- a/front/types/api/assistant/conversation/spaces.ts
+++ b/front/types/api/assistant/conversation/spaces.ts
@@ -6,7 +6,7 @@ export type GetBySpacesSummaryResponseBody = {
   summary: Array<{
     space: PodListItemType;
     unreadConversations: ConversationWithoutContentType[];
-    nonParticipantUnreadConversations: ConversationWithoutContentType[];
+    nonParticipantUnreadConversationIds: string[];
   }>;
 };
 


### PR DESCRIPTION
## Description

The space-summary endpoint now returns `nonParticipantUnreadConversationIds: string[]` instead of hydrating and serializing full conversation objects. The frontend uses these IDs for activity badges and optimistic mark-as-read updates, while `nextWakeupAt` enrichment runs only for participant unread conversations. This is a private API shape change, so `front-api` and `front` must stay in sync.

## Tests

Existing coverage in `conversation_resource.test.ts`, `forks.test.ts`, and `sortSpacesSummary.test.ts` covers the space unread summary and non-participant unread behavior. No new tests were added.

## Risk

Low. The change only reduces the private endpoint payload and updates its known consumers. Rollback is safe by reverting the commit; deploy `front-api` and `front` together to avoid a client/server shape mismatch.

## Deploy Plan

Deploy `front-api` and `front` together. No SQL migration or infrastructure change is required; the endpoint is `@ignoreswagger`.