### PR TITLE
[Admin Governance] Block mutation paths for archived agents

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -844,7 +844,7 @@
             }
           },
           "400": {
-            "description": "Bad Request. Invalid or missing parameters."
+            "description": "Bad Request. Invalid parameters or the agent is already archived."
           },
           "401": {
             "description": "Unauthorized. Invalid or missing authentication token."

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -6,7 +6,10 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
-import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgent,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 import details from "./details";
@@ -43,9 +46,8 @@ app.delete(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agentConfiguration);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agentConfiguration)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     await archiveAgentConfiguration(auth, agentConfiguration.sId);

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -6,6 +6,7 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
+import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 import details from "./details";
@@ -40,6 +41,11 @@ app.delete(
           message: "Could not find the agent configuration.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedAgent(ctx, agentConfiguration);
+    if (archivedError) {
+      return archivedError;
     }
 
     await archiveAgentConfiguration(auth, agentConfiguration.sId);

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -15,6 +15,7 @@ import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 import yaml from "./export/yaml";
@@ -258,7 +259,7 @@ const VariantQuerySchema = z.object({
  *                 success:
  *                   type: boolean
  *       400:
- *         description: Bad Request. Invalid or missing parameters.
+ *         description: Bad Request. Invalid parameters or the agent is already archived.
  *       401:
  *         description: Unauthorized. Invalid or missing authentication token.
  *       403:
@@ -408,6 +409,11 @@ app.delete(
           message: "The agent configuration you requested was not found.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedAgent(ctx, agentConfiguration);
+    if (archivedError) {
+      return archivedError;
     }
 
     // Space-scoping is enforced upstream: `getAgentConfiguration` (called above) returns null

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -15,7 +15,10 @@ import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgent,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 import yaml from "./export/yaml";
@@ -411,9 +414,8 @@ app.delete(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agentConfiguration);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agentConfiguration)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     // Space-scoping is enforced upstream: `getAgentConfiguration` (called above) returns null

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -1,4 +1,7 @@
-import { updateAgentPermissions } from "@app/lib/api/assistant/configuration/agent";
+import {
+  archiveAgentConfiguration,
+  updateAgentPermissions,
+} from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -116,6 +119,29 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/editors", () => {
 });
 
 describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => {
+  it("rejects editor changes on an archived agent", async () => {
+    const { workspace, agent } = await setupTest({
+      requestUserRole: "admin",
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await archiveAgentConfiguration(auth, agent.sId);
+
+    const newEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, newEditor, { role: "user" });
+
+    const response = await patchEditors(workspace, agent.sId, {
+      addEditorIds: [newEditor.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived agent cannot be updated. Restore it first.",
+      },
+    });
+  });
+
   it("admin should successfully add an editor", async () => {
     const { workspace, agent, agentOwner } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -14,7 +14,10 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgent,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -215,9 +218,8 @@ app.patch(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agent);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agent)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     const { addEditorIds = [], removeEditorIds = [] } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -14,6 +14,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -214,6 +215,11 @@ app.patch(
       });
     }
 
+    const archivedError = rejectArchivedAgent(ctx, agent);
+    if (archivedError) {
+      return archivedError;
+    }
+
     const { addEditorIds = [], removeEditorIds = [] } = ctx.req.valid("json");
 
     const usersToAdd = await UserResource.fetchByIds(addEditorIds);
@@ -264,6 +270,14 @@ app.patch(
             api_error: {
               type: "invalid_request_error",
               message: "Some of the passed ids are invalid.",
+            },
+          });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: updateRes.error.message,
             },
           });
         case "group_not_found":

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  archiveAgentConfiguration,
   createPendingAgentConfiguration,
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
@@ -175,6 +176,52 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId - non-editor adm
       variant: "light",
     });
     expect(unchanged?.instructions).toBe(agent.instructions);
+  });
+});
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId - archived agent", () => {
+  it("rejects updates until the agent is restored", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "PATCH",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await archiveAgentConfiguration(auth, agent.sId);
+
+    const response = await patch(workspace, agent.sId, {
+      assistant: {
+        name: agent.name,
+        description: agent.description,
+        instructions: "Updated instructions",
+        pictureUrl: agent.pictureUrl,
+        status: "active",
+        scope: agent.scope,
+        model: {
+          providerId: agent.model.providerId,
+          modelId: agent.model.modelId,
+          temperature: agent.model.temperature,
+        },
+        actions: [],
+        templateId: null,
+        tags: [],
+        editors: [{ sId: user.sId }],
+        skills: [],
+        additionalRequestedSpaceIds: [],
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived agent cannot be updated. Restore it first.",
+      },
+    });
+
+    const versions = await AgentConfigurationModel.findAll({
+      where: { sId: agent.sId, workspaceId: workspace.id },
+    });
+    expect(versions).toHaveLength(1);
   });
 });
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -11,7 +11,10 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgent,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 import analytics from "./analytics";
@@ -101,9 +104,8 @@ app.patch(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agent);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agent)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     // Editors only, admins included: an admin who wants to change an agent has to add themselves
@@ -186,9 +188,8 @@ app.delete(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agent);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agent)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     const archived = await archiveAgentConfiguration(auth, aId);

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -11,6 +11,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 import analytics from "./analytics";
@@ -100,6 +101,11 @@ app.patch(
       });
     }
 
+    const archivedError = rejectArchivedAgent(ctx, agent);
+    if (archivedError) {
+      return archivedError;
+    }
+
     // Editors only, admins included: an admin who wants to change an agent has to add themselves
     // as an editor first. Batch operations on agents are a separate, admin-only path.
     if (!agent.canEdit) {
@@ -178,6 +184,11 @@ app.delete(
           message: "Only editors can delete workspace agent.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedAgent(ctx, agent);
+    if (archivedError) {
+      return archivedError;
     }
 
     const archived = await archiveAgentConfiguration(auth, aId);

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -9,7 +9,10 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
-import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgent,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -87,9 +90,8 @@ app.patch(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agentConfiguration);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agentConfiguration)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     const connectorsAPI = new ConnectorsAPI(

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -9,6 +9,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
+import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -84,6 +85,11 @@ app.patch(
           message: "Only editors can modify agents.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedAgent(ctx, agentConfiguration);
+    if (archivedError) {
+      return archivedError;
     }
 
     const connectorsAPI = new ConnectorsAPI(

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -6,7 +6,10 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgent,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -64,9 +67,8 @@ app.patch(
       });
     }
 
-    const archivedError = rejectArchivedAgent(ctx, agent);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgent(agent)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     const { addTagIds = [], removeTagIds = [] } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -6,6 +6,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedAgent } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -61,6 +62,11 @@ app.patch(
             "Only editors of the agent or workspace admins can modify agent.",
         },
       });
+    }
+
+    const archivedError = rejectArchivedAgent(ctx, agent);
+    if (archivedError) {
+      return archivedError;
     }
 
     const { addTagIds = [], removeTagIds = [] } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.test.ts
@@ -1,4 +1,7 @@
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import {
+  archiveAgentConfiguration,
+  getAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -79,5 +82,22 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_scope", (
     });
 
     expect(response.status).toBe(403);
+  });
+
+  it("rejects a batch containing an archived agent", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await archiveAgentConfiguration(auth, agent.sId);
+
+    const response = await batchUpdateScope(workspace, {
+      agentIds: [agent.sId],
+      scope: "visible",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.message).toContain(agent.name);
   });
 });

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -1,3 +1,4 @@
+import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -119,6 +120,24 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", ()
         message: "Failed to add tags",
       },
     });
+  });
+
+  it("rejects a batch containing an archived agent", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const tag = await TagFactory.create(workspace, { name: "governance" });
+    await archiveAgentConfiguration(auth, agent.sId);
+
+    const response = await batchUpdateTags(workspace, {
+      agentIds: [agent.sId],
+      addTagIds: [tag.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.message).toContain(agent.name);
   });
 
   it("returns 400 when removing tags fails", async () => {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -137,7 +137,12 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", ()
     });
 
     expect(response.status).toBe(400);
-    expect((await response.json()).error.message).toContain(agent.name);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "An archived agent cannot be updated. Restore it first.",
+      },
+    });
   });
 
   it("returns 400 when removing tags fails", async () => {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -3,6 +3,7 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { rejectArchivedAgents } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const BatchUpdateAgentTagsRequestBodySchema = z.object({
@@ -50,6 +51,11 @@ app.post(
       variant: "light",
       dangerouslySkipPermissionFiltering: auth.isAdmin(),
     });
+    const archivedError = rejectArchivedAgents(ctx, agents);
+    if (archivedError) {
+      return archivedError;
+    }
+
     const editableAgents = agents.filter(
       (agent) => agent.canEdit || auth.isAdmin()
     );

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -3,7 +3,10 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { rejectArchivedAgents } from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
+import {
+  ARCHIVED_AGENT_API_ERROR,
+  isArchivedAgents,
+} from "@front-api/routes/w/[wId]/assistant/agent_configurations/guards";
 import { z } from "zod";
 
 const BatchUpdateAgentTagsRequestBodySchema = z.object({
@@ -51,9 +54,8 @@ app.post(
       variant: "light",
       dangerouslySkipPermissionFiltering: auth.isAdmin(),
     });
-    const archivedError = rejectArchivedAgents(ctx, agents);
-    if (archivedError) {
-      return archivedError;
+    if (isArchivedAgents(agents)) {
+      return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
     const editableAgents = agents.filter(

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/guards.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/guards.ts
@@ -1,42 +1,20 @@
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { apiError } from "@front-api/middlewares/utils";
-import type { Context } from "hono";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 
-type ApiErrorResponse = ReturnType<typeof apiError>;
+export const ARCHIVED_AGENT_API_ERROR: APIErrorWithContentfulStatusCode = {
+  status_code: 400,
+  api_error: {
+    type: "invalid_request_error",
+    message: "An archived agent cannot be updated. Restore it first.",
+  },
+};
 
-export function rejectArchivedAgent(
-  ctx: Context,
-  agent: LightAgentConfigurationType
-): ApiErrorResponse | null {
-  if (agent.status !== "archived") {
-    return null;
-  }
-
-  return apiError(ctx, {
-    status_code: 400,
-    api_error: {
-      type: "invalid_request_error",
-      message: "An archived agent cannot be updated. Restore it first.",
-    },
-  });
+export function isArchivedAgent(agent: LightAgentConfigurationType): boolean {
+  return agent.status === "archived";
 }
 
-export function rejectArchivedAgents(
-  ctx: Context,
+export function isArchivedAgents(
   agents: LightAgentConfigurationType[]
-): ApiErrorResponse | null {
-  const archivedAgentNames = agents
-    .filter((agent) => agent.status === "archived")
-    .map((agent) => agent.name);
-  if (archivedAgentNames.length === 0) {
-    return null;
-  }
-
-  return apiError(ctx, {
-    status_code: 400,
-    api_error: {
-      type: "invalid_request_error",
-      message: `Archived agents cannot be updated: ${archivedAgentNames.join(", ")}. Restore them first.`,
-    },
-  });
+): boolean {
+  return agents.some(isArchivedAgent);
 }

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/guards.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/guards.ts
@@ -1,0 +1,42 @@
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+type ApiErrorResponse = ReturnType<typeof apiError>;
+
+export function rejectArchivedAgent(
+  ctx: Context,
+  agent: LightAgentConfigurationType
+): ApiErrorResponse | null {
+  if (agent.status !== "archived") {
+    return null;
+  }
+
+  return apiError(ctx, {
+    status_code: 400,
+    api_error: {
+      type: "invalid_request_error",
+      message: "An archived agent cannot be updated. Restore it first.",
+    },
+  });
+}
+
+export function rejectArchivedAgents(
+  ctx: Context,
+  agents: LightAgentConfigurationType[]
+): ApiErrorResponse | null {
+  const archivedAgentNames = agents
+    .filter((agent) => agent.status === "archived")
+    .map((agent) => agent.name);
+  if (archivedAgentNames.length === 0) {
+    return null;
+  }
+
+  return apiError(ctx, {
+    status_code: 400,
+    api_error: {
+      type: "invalid_request_error",
+      message: `Archived agents cannot be updated: ${archivedAgentNames.join(", ")}. Restore them first.`,
+    },
+  });
+}

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -678,6 +678,12 @@ export async function createAgentConfiguration(
         existingAgent = agentConfiguration;
 
         if (existingAgent) {
+          if (existingAgent.status === "archived") {
+            throw new Error(
+              "An archived agent cannot be updated. Restore it first."
+            );
+          }
+
           // Handle pending agent: update in place (don't bump version, preserve id for FK relationships)
           // Otherwise: archive old versions and bump version
           if (existingAgent.status === "pending") {
@@ -1578,9 +1584,19 @@ export async function updateAgentPermissions(
       | "user_not_member"
       | "user_already_member"
       | "group_requirements_not_met"
+      | "invalid_request_error"
     >
   >
 > {
+  if (agent.status === "archived") {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        "An archived agent cannot be updated. Restore it first."
+      )
+    );
+  }
+
   const editorGroupRes = await GroupResource.findEditorGroupForAgent(
     auth,
     agent
@@ -1725,6 +1741,17 @@ export async function updateAgentConfigurationsScope(
     variant: "light",
     dangerouslySkipPermissionFiltering: auth.isAdmin(),
   });
+
+  const archivedAgentNames = agentConfigs
+    .filter((agent) => agent.status === "archived")
+    .map((agent) => agent.name);
+  if (archivedAgentNames.length > 0) {
+    return new Err(
+      new Error(
+        `Archived agents cannot be updated: ${archivedAgentNames.join(", ")}. Restore them first.`
+      )
+    );
+  }
 
   const editableAgents = agentConfigs.filter(
     (a) => a.canEdit || auth.isAdmin()

--- a/front/lib/api/poke/plugins/agents/agent_editors.ts
+++ b/front/lib/api/poke/plugins/agents/agent_editors.ts
@@ -147,6 +147,6 @@ export const updateEditorsPlugin = createPlugin({
     if (!resource) {
       return false;
     }
-    return resource.status === "active" || resource.status === "archived";
+    return resource.status === "active";
   },
 });


### PR DESCRIPTION
## Description

Archived agents will keep their editor memberships active in the follow-up PR. Freeze all agent-definition mutation paths first so those retained grants cannot be used to edit an archived agent. Restore remains the only definition-changing action; feedback, memories, suggestions, and archive/restore runtime cleanup are unchanged.

This covers private, public v1, and Poke archive/save paths, editor and tag mutations, linked Slack channels, and batch scope/tag/model behavior.

## Risks

Blast radius: agent configuration, editor, tag, scope, and archive mutations for archived agents.
Risk: low

## Tests

- [x] Archived agent definition and editor updates are rejected
- [x] Archived agents are rejected atomically from scope and tag batches
- [x] Focused tests, front and front-api type checks, formatting, and Swagger lint pass

## Deploy Plan

- Deploy front-api
- Deploy front