### PR TITLE
[Admin Governance] Preserve archived agent editors

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -798,7 +798,7 @@
       },
       "delete": {
         "summary": "Archive agent configuration",
-        "description": "Archive the agent configuration identified by {sId} in the workspace identified by {wId}. The agent is soft-archived and triggers/editor-group memberships associated with it are disabled.",
+        "description": "Archive the agent configuration identified by {sId} in the workspace identified by {wId}. The agent is soft-archived and its triggers are disabled.",
         "tags": [
           "Agents"
         ],

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -233,7 +233,7 @@ const VariantQuerySchema = z.object({
  *         description: Internal Server Error.
  *   delete:
  *     summary: Archive agent configuration
- *     description: Archive the agent configuration identified by {sId} in the workspace identified by {wId}. The agent is soft-archived and triggers/editor-group memberships associated with it are disabled.
+ *     description: Archive the agent configuration identified by {sId} in the workspace identified by {wId}. The agent is soft-archived and its triggers are disabled.
  *     tags:
  *       - Agents
  *     parameters:

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -602,7 +602,7 @@ describe("create agent capability", () => {
 });
 
 describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
-  it("suspends editor group memberships when archiving and restores them when restoring", async () => {
+  it("keeps editor group memberships active while archiving and restoring", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -613,13 +613,14 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
       authenticator,
       agent
     );
-    expect(editorGroupRes.isOk()).toBe(true);
-    const editorGroup = editorGroupRes.isOk() ? editorGroupRes.value : null;
-    expect(editorGroup).not.toBeNull();
+    if (editorGroupRes.isErr()) {
+      throw editorGroupRes.error;
+    }
+    const editorGroup = editorGroupRes.value;
 
     const membershipsBeforeArchive = await GroupMembershipModel.findAll({
       where: {
-        groupId: editorGroup!.id,
+        groupId: editorGroup.id,
         workspaceId: workspace.id,
       },
     });
@@ -633,13 +634,19 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
 
     const membershipsAfterArchive = await GroupMembershipModel.findAll({
       where: {
-        groupId: editorGroup!.id,
+        groupId: editorGroup.id,
         workspaceId: workspace.id,
       },
     });
-    expect(membershipsAfterArchive.every((m) => m.status === "suspended")).toBe(
+    expect(membershipsAfterArchive.every((m) => m.status === "active")).toBe(
       true
     );
+
+    const editorsAfterArchive =
+      await editorGroup.getActiveMembers(authenticator);
+    expect(editorsAfterArchive.map((editor) => editor.id)).toEqual([
+      authenticator.getNonNullableUser().id,
+    ]);
 
     const restoreResult = await restoreAgentConfiguration(
       authenticator,
@@ -650,7 +657,7 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
 
     const membershipsAfterRestore = await GroupMembershipModel.findAll({
       where: {
-        groupId: editorGroup!.id,
+        groupId: editorGroup.id,
         workspaceId: workspace.id,
       },
     });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1162,16 +1162,7 @@ export async function archiveAgentConfiguration(
     }
   );
 
-  // Suspend all editor group memberships for this agent
   if (updated[0] > 0) {
-    const editorGroupRes = await GroupResource.findEditorGroupForAgent(
-      auth,
-      agentConfig
-    );
-    if (editorGroupRes.isOk()) {
-      await editorGroupRes.value.suspendMembers(auth);
-    }
-
     void emitAuditLogEvent({
       auth,
       action: "agent.archived",
@@ -1262,15 +1253,8 @@ export async function restoreAgentConfiguration(
     }
   );
 
-  // Restore all editor group memberships (set suspended → active) and re-enable triggers
+  // Re-enable triggers.
   if (updated[0] > 0) {
-    const editorGroupRes = await GroupResource.findEditorGroupForAgent(auth, {
-      id: latestConfig.id,
-    } as LightAgentConfigurationType);
-    if (editorGroupRes.isOk()) {
-      await editorGroupRes.value.restoreMembers(auth);
-    }
-
     const triggers = await TriggerResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId

--- a/front/migrations/20260828_restore_agent_editor_memberships.ts
+++ b/front/migrations/20260828_restore_agent_editor_memberships.ts
@@ -1,0 +1,146 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+const WORKSPACE_CONCURRENCY = 8;
+
+// Restore every suspended agent-editors membership, not only archived agents: after this deploy
+// there is no valid path that suspends this group kind, and status-scoping would race restorations.
+async function listGroupsToRestore(
+  auth: Authenticator,
+  workspaceModelId: ModelId
+): Promise<{
+  groups: GroupResource[];
+  suspendedCountByGroupId: Map<ModelId, number>;
+}> {
+  const empty = {
+    groups: [],
+    suspendedCountByGroupId: new Map<ModelId, number>(),
+  };
+
+  const editorGroups = await GroupModel.findAll({
+    attributes: ["id"],
+    where: {
+      workspaceId: workspaceModelId,
+      kind: "agent_editors",
+    },
+  });
+  if (editorGroups.length === 0) {
+    return empty;
+  }
+
+  const now = new Date();
+  const suspendedMemberships = await GroupMembershipModel.findAll({
+    attributes: ["groupId", "userId"],
+    where: {
+      workspaceId: workspaceModelId,
+      groupId: editorGroups.map((group) => group.id),
+      status: "suspended",
+      startAt: { [Op.lte]: now },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+    },
+  });
+  if (suspendedMemberships.length === 0) {
+    return empty;
+  }
+
+  const suspendedCountByGroupId = new Map<ModelId, number>();
+  for (const membership of suspendedMemberships) {
+    suspendedCountByGroupId.set(
+      membership.groupId,
+      (suspendedCountByGroupId.get(membership.groupId) ?? 0) + 1
+    );
+  }
+
+  const groups = await GroupResource.fetchByModelIds(
+    auth,
+    [...suspendedCountByGroupId.keys()],
+    { groupKinds: ["agent_editors"] }
+  );
+
+  return { groups, suspendedCountByGroupId };
+}
+
+async function restoreWorkspaceAgentEditors(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
+  const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+  const { groups, suspendedCountByGroupId } = await listGroupsToRestore(
+    auth,
+    workspaceModelId
+  );
+  if (groups.length === 0) {
+    return;
+  }
+
+  let membershipsRestored = 0;
+
+  for (const group of groups) {
+    const suspendedCount = suspendedCountByGroupId.get(group.id) ?? 0;
+
+    if (!execute) {
+      membershipsRestored += suspendedCount;
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          groupId: group.id,
+          editorCount: suspendedCount,
+        },
+        "Dry run: would restore the agent's suspended editor memberships"
+      );
+      continue;
+    }
+
+    const restoredUserIds = await group.restoreMembers(auth);
+    membershipsRestored += restoredUserIds.length;
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        groupId: group.id,
+        editorCount: restoredUserIds.length,
+      },
+      "Restored the agent's suspended editor memberships"
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      groups: groups.length,
+      membershipsRestored,
+    },
+    "Completed agent editor membership restoration for workspace"
+  );
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting agent editor membership restoration");
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await restoreWorkspaceAgentEditors(execute, logger, workspace);
+      },
+      { concurrency: WORKSPACE_CONCURRENCY, wId }
+    );
+
+    logger.info("Agent editor membership restoration completed");
+  }
+);

--- a/front/migrations/20260828_restore_agent_editor_memberships.ts
+++ b/front/migrations/20260828_restore_agent_editor_memberships.ts
@@ -1,4 +1,3 @@
-import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -13,18 +12,9 @@ const WORKSPACE_CONCURRENCY = 8;
 
 // Restore every suspended agent-editors membership, not only archived agents: after this deploy
 // there is no valid path that suspends this group kind, and status-scoping would race restorations.
-async function listGroupsToRestore(
-  auth: Authenticator,
+async function listMembershipsToRestore(
   workspaceModelId: ModelId
-): Promise<{
-  groups: GroupResource[];
-  suspendedCountByGroupId: Map<ModelId, number>;
-}> {
-  const empty = {
-    groups: [],
-    suspendedCountByGroupId: new Map<ModelId, number>(),
-  };
-
+): Promise<GroupMembershipModel[]> {
   const editorGroups = await GroupModel.findAll({
     attributes: ["id"],
     where: {
@@ -33,12 +23,12 @@ async function listGroupsToRestore(
     },
   });
   if (editorGroups.length === 0) {
-    return empty;
+    return [];
   }
 
   const now = new Date();
-  const suspendedMemberships = await GroupMembershipModel.findAll({
-    attributes: ["groupId", "userId"],
+  return GroupMembershipModel.findAll({
+    attributes: ["id", "groupId", "userId"],
     where: {
       workspaceId: workspaceModelId,
       groupId: editorGroups.map((group) => group.id),
@@ -47,25 +37,6 @@ async function listGroupsToRestore(
       [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
     },
   });
-  if (suspendedMemberships.length === 0) {
-    return empty;
-  }
-
-  const suspendedCountByGroupId = new Map<ModelId, number>();
-  for (const membership of suspendedMemberships) {
-    suspendedCountByGroupId.set(
-      membership.groupId,
-      (suspendedCountByGroupId.get(membership.groupId) ?? 0) + 1
-    );
-  }
-
-  const groups = await GroupResource.fetchByModelIds(
-    auth,
-    [...suspendedCountByGroupId.keys()],
-    { groupKinds: ["agent_editors"] }
-  );
-
-  return { groups, suspendedCountByGroupId };
 }
 
 async function restoreWorkspaceAgentEditors(
@@ -73,55 +44,54 @@ async function restoreWorkspaceAgentEditors(
   logger: Logger,
   workspace: LightWorkspaceType
 ): Promise<void> {
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
-    dangerouslyRequestAllGroups: true,
-  });
-  const workspaceModelId = auth.getNonNullableWorkspace().id;
-
-  const { groups, suspendedCountByGroupId } = await listGroupsToRestore(
-    auth,
-    workspaceModelId
-  );
-  if (groups.length === 0) {
+  const memberships = await listMembershipsToRestore(workspace.id);
+  if (memberships.length === 0) {
     return;
   }
 
-  let membershipsRestored = 0;
-
-  for (const group of groups) {
-    const suspendedCount = suspendedCountByGroupId.get(group.id) ?? 0;
-
-    if (!execute) {
-      membershipsRestored += suspendedCount;
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          groupId: group.id,
-          editorCount: suspendedCount,
-        },
-        "Dry run: would restore the agent's suspended editor memberships"
-      );
-      continue;
-    }
-
-    const restoredUserIds = await group.restoreMembers(auth);
-    membershipsRestored += restoredUserIds.length;
-
+  const groupCount = new Set(
+    memberships.map((membership) => membership.groupId)
+  ).size;
+  if (!execute) {
     logger.info(
       {
         workspaceId: workspace.sId,
-        groupId: group.id,
-        editorCount: restoredUserIds.length,
+        groups: groupCount,
+        membershipsRestored: memberships.length,
       },
-      "Restored the agent's suspended editor memberships"
+      "Dry run: would restore suspended agent editor memberships"
     );
+    return;
   }
+
+  const [, restoredMemberships] = await GroupMembershipModel.update(
+    { status: "active" },
+    {
+      where: {
+        id: memberships.map((membership) => membership.id),
+        workspaceId: workspace.id,
+        status: "suspended",
+      },
+      returning: true,
+    }
+  );
+  const userModelIds = [
+    ...new Set(restoredMemberships.map((membership) => membership.userId)),
+  ];
+  await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+    userModelIds.map((userModelId) => [
+      {
+        user: { id: userModelId },
+        workspace: { id: workspace.id },
+      },
+    ])
+  );
 
   logger.info(
     {
       workspaceId: workspace.sId,
-      groups: groups.length,
-      membershipsRestored,
+      groups: groupCount,
+      membershipsRestored: restoredMemberships.length,
     },
     "Completed agent editor membership restoration for workspace"
   );


### PR DESCRIPTION
## Description

Follows #31326.

Archived agents currently suspend their editor-group memberships, which makes their editors disappear and prevents editor-only archived agents from remaining visible to those editors. Keep memberships active across archive and restore; agent status, guarded by the previous PR, now freezes definition changes instead of ACL suspension.

Adds an idempotent backfill restoring stale suspended memberships with one bulk update and one awaited cache invalidation per workspace. It targets all agent_editors groups so deploy and backfill order cannot strand editors if an agent is restored in between. These legacy groups will be removed from auth later in the governance rollout.

## Risks

Blast radius: archived-agent visibility and legacy agent editor memberships.
Risk: low

The temporary cost is that editor groups for archived agents re-enter user auth until the legacy groups are removed. The dry run reports the affected group and membership counts before execution.

## Tests

- [x] Archive and restore keep editor memberships active and editors listable
- [x] Focused tests, front and front-api type checks, formatting, and Swagger lint pass
- [x] Batched backfill passes the front type check

## Deploy Plan

- Deploy front and front-api
- From front/, dry-run: npx tsx migrations/20260828_restore_agent_editor_memberships.ts
- Review affected counts
- From front/, execute: npx tsx migrations/20260828_restore_agent_editor_memberships.ts --execute