### PR TITLE
[Admin Governance] Add stable agent identity schema

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -19,6 +19,7 @@ import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfigurationModel,
+  AgentModel,
   AgentUserRelationModel,
   GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
@@ -217,6 +218,7 @@ export function loadAllModels() {
     CouponRedemptionModel,
     ProgrammaticUsageConfigurationModel,
     CreditUsageConfigurationModel,
+    AgentModel,
     AgentConfigurationModel,
     AgentUserRelationModel,
     GlobalAgentSettingsModel,

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -47,7 +47,10 @@ AgentModel.init(
   {
     modelName: "agent",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["sId"], unique: true }],
+    indexes: [
+      { fields: ["sId"], unique: true },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
   }
 );
 

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -20,6 +20,37 @@ import type {
 } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
+export class AgentModel extends WorkspaceAwareModel<AgentModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare sId: string;
+}
+
+AgentModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "agent",
+    sequelize: frontSequelize,
+    indexes: [{ fields: ["sId"], unique: true }],
+  }
+);
+
 /**
  * Agent configuration
  */
@@ -29,6 +60,7 @@ export class AgentConfigurationModel extends WorkspaceAwareModel<AgentConfigurat
 
   declare sId: string;
   declare version: number;
+  declare agentId: ForeignKey<AgentModel["id"]> | null;
 
   declare status: AgentStatus;
   declare scope: Exclude<AgentConfigurationScope, "global">;
@@ -86,6 +118,10 @@ AgentConfigurationModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+    },
+    agentId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
     },
     status: {
       type: DataTypes.STRING,
@@ -203,6 +239,7 @@ AgentConfigurationModel.init(
       },
       { fields: ["sId"] },
       { fields: ["sId", "version"], unique: true },
+      { fields: ["agentId"], concurrently: true },
       { fields: ["workspaceId", "authorId", "sId"] },
       {
         name: "agent_configuration_unique_active_name",
@@ -216,6 +253,15 @@ AgentConfigurationModel.init(
     ],
   }
 );
+
+AgentModel.hasMany(AgentConfigurationModel, {
+  foreignKey: { name: "agentId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+AgentConfigurationModel.belongsTo(AgentModel, {
+  foreignKey: { name: "agentId", allowNull: true },
+  onDelete: "RESTRICT",
+});
 
 // Agent config <> Author
 UserModel.hasMany(AgentConfigurationModel, {

--- a/front/migrations/pre-deploy/20260828103155_add_agent_identity.sql
+++ b/front/migrations/pre-deploy/20260828103155_add_agent_identity.sql
@@ -21,12 +21,19 @@ CREATE UNIQUE INDEX CONCURRENTLY agents_s_id ON public.agents USING btree ("sId"
 /*
 Statement 2
 */
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agents_workspace_id ON public.agents USING btree ("workspaceId");
+
+/*
+Statement 3
+*/
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agent_configurations" ADD COLUMN "agentId" bigint;
 
 /*
-Statement 3
+Statement 4
   - INDEX_BUILD: Concurrent index builds avoid locking out writes on agent_configurations.
 */
 SET SESSION statement_timeout = 1200000;
@@ -34,28 +41,28 @@ SET SESSION lock_timeout = 3000;
 CREATE INDEX CONCURRENTLY agent_configurations_agent_id ON public.agent_configurations USING btree ("agentId");
 
 /*
-Statement 4
+Statement 5
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agent_configurations" ADD CONSTRAINT "agent_configurations_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES agents(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
 
 /*
-Statement 5
+Statement 6
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agent_configurations" VALIDATE CONSTRAINT "agent_configurations_agentId_fkey";
 
 /*
-Statement 6
+Statement 7
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agents" ADD CONSTRAINT "agents_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
 
 /*
-Statement 7
+Statement 8
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;

--- a/front/migrations/pre-deploy/20260828103155_add_agent_identity.sql
+++ b/front/migrations/pre-deploy/20260828103155_add_agent_identity.sql
@@ -1,0 +1,62 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."agents" (
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL,
+    "sId" character varying(255) COLLATE "pg_catalog"."default" NOT NULL,
+    "workspaceId" bigint NOT NULL,
+    "id" bigserial PRIMARY KEY
+);
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY agents_s_id ON public.agents USING btree ("sId");
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "agentId" bigint;
+
+/*
+Statement 3
+  - INDEX_BUILD: Concurrent index builds avoid locking out writes on agent_configurations.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_configurations_agent_id ON public.agent_configurations USING btree ("agentId");
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_configurations" ADD CONSTRAINT "agent_configurations_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES agents(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_configurations" VALIDATE CONSTRAINT "agent_configurations_agentId_fkey";
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agents" ADD CONSTRAINT "agents_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agents" VALIDATE CONSTRAINT "agents_workspaceId_fkey";

--- a/front/migrations/pre-deploy/20260828103155_add_agent_identity.sql
+++ b/front/migrations/pre-deploy/20260828103155_add_agent_identity.sql
@@ -8,7 +8,8 @@ CREATE TABLE "public"."agents" (
     "updatedAt" timestamp with time zone NOT NULL,
     "sId" character varying(255) COLLATE "pg_catalog"."default" NOT NULL,
     "workspaceId" bigint NOT NULL,
-    "id" bigserial PRIMARY KEY
+    "id" bigserial PRIMARY KEY,
+    CONSTRAINT "agents_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 /*
@@ -53,17 +54,3 @@ Statement 6
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agent_configurations" VALIDATE CONSTRAINT "agent_configurations_agentId_fkey";
-
-/*
-Statement 7
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agents" ADD CONSTRAINT "agents_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
-
-/*
-Statement 8
-*/
-SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agents" VALIDATE CONSTRAINT "agents_workspaceId_fkey";


### PR DESCRIPTION
## Description

Introduces a stable numeric identity for workspace agents without changing current agent behavior. Adds `agents(id, sId, workspaceId)` and a nullable, indexed `agentId` foreign key on versioned agent configurations.

This is the expand step for the agent grants migration. Existing rows remain valid until the backfill.

## Risks

Blast radius: front database schema and agent configuration model registration.

Risk level: standard. The schema is additive and the new foreign key remains nullable.

## Deploy Plan

- Run `20260828103155_add_agent_identity.sql` as a pre-deploy migration.
- Deploy front and front-api.

## Tests

- Applied the additive migration locally.