### PR TITLE
[Admin Governance] Wire stable agent identity lifecycle

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -6,11 +6,15 @@ import {
   getAgentConfiguration,
   getAgentConfigurations,
   restoreAgentConfiguration,
+  unsafeHardDeleteAgentConfiguration,
   updateAgentConfigurationsScope,
 } from "@app/lib/api/assistant/configuration/agent";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import {
+  AgentConfigurationModel,
+  AgentModel,
+} from "@app/lib/models/agent/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -72,6 +76,84 @@ describe("getAgentConfigurations", () => {
       { sId: latestFirstAgent.sId, version: latestFirstAgent.version },
       { sId: latestSecondAgent.sId, version: latestSecondAgent.version },
     ]);
+  });
+});
+
+describe("stable agent identities", () => {
+  it("reuses one identity across agent versions", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const firstVersion =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      firstVersion.sId
+    );
+
+    const versions = await AgentConfigurationModel.findAll({
+      where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      attributes: ["agentId"],
+    });
+    const agentIds = new Set(versions.map((version) => version.agentId));
+
+    expect(versions).toHaveLength(2);
+    expect(agentIds.size).toBe(1);
+    expect([...agentIds][0]).not.toBeNull();
+  });
+
+  it("creates and attaches an identity when updating a legacy agent", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const firstVersion =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    await AgentConfigurationModel.update(
+      { agentId: null },
+      { where: { sId: firstVersion.sId, workspaceId: workspace.id } }
+    );
+    await AgentModel.destroy({
+      where: { sId: firstVersion.sId, workspaceId: workspace.id },
+    });
+
+    await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      firstVersion.sId
+    );
+
+    const versions = await AgentConfigurationModel.findAll({
+      where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      attributes: ["agentId"],
+    });
+    expect(versions).toHaveLength(2);
+    expect(versions.every((version) => version.agentId !== null)).toBe(true);
+    expect(new Set(versions.map((version) => version.agentId)).size).toBe(1);
+  });
+
+  it("deletes the identity only after its last version is deleted", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const firstVersion =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const secondVersion = await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      firstVersion.sId
+    );
+
+    await unsafeHardDeleteAgentConfiguration(authenticator, secondVersion);
+    expect(
+      await AgentModel.findOne({
+        where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      })
+    ).not.toBeNull();
+
+    await unsafeHardDeleteAgentConfiguration(authenticator, firstVersion);
+    expect(
+      await AgentModel.findOne({
+        where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      })
+    ).toBeNull();
   });
 });
 

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -95,11 +95,11 @@ describe("stable agent identities", () => {
       where: { sId: firstVersion.sId, workspaceId: workspace.id },
       attributes: ["agentId"],
     });
-    const agentIds = new Set(versions.map((version) => version.agentId));
+    const agentModelIds = new Set(versions.map((version) => version.agentId));
 
     expect(versions).toHaveLength(2);
-    expect(agentIds.size).toBe(1);
-    expect([...agentIds][0]).not.toBeNull();
+    expect(agentModelIds.size).toBe(1);
+    expect([...agentModelIds][0]).not.toBeNull();
   });
 
   it("creates and attaches an identity when updating a legacy agent", async () => {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -21,6 +21,7 @@ import {
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfigurationModel,
+  AgentModel,
   AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
@@ -102,9 +103,17 @@ export async function createPendingAgentConfiguration(
   const { defaultModel } = await getModelsForAuth(auth);
 
   await withTransaction(async (t) => {
+    const agentIdentity = await AgentModel.create(
+      {
+        sId,
+        workspaceId: owner.id,
+      },
+      { transaction: t }
+    );
     const agent = await AgentConfigurationModel.create(
       {
         sId,
+        agentId: agentIdentity.id,
         version: 0,
         status: "pending",
         scope: "hidden",
@@ -641,6 +650,7 @@ export async function createAgentConfiguration(
               workspaceId: owner.id,
             },
             attributes: [
+              "agentId",
               "scope",
               "version",
               "id",
@@ -718,6 +728,22 @@ export async function createAgentConfiguration(
 
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const sId = agentConfigurationId || generateRandomModelSId();
+      let agentId = existingAgent?.agentId;
+      if (!agentId) {
+        const [agentIdentity] = await AgentModel.findOrCreate({
+          where: { sId, workspaceId: owner.id },
+          defaults: { sId, workspaceId: owner.id },
+          transaction: t,
+        });
+        agentId = agentIdentity.id;
+        await AgentConfigurationModel.update(
+          { agentId },
+          {
+            where: { sId, workspaceId: owner.id },
+            transaction: t,
+          }
+        );
+      }
 
       // Create or update Agent config.
       let agentConfigurationInstance: AgentConfigurationModel;
@@ -771,6 +797,7 @@ export async function createAgentConfiguration(
         agentConfigurationInstance = await AgentConfigurationModel.create(
           {
             sId,
+            agentId,
             version,
             status,
             scope,
@@ -1359,6 +1386,26 @@ export async function cleanupAgentScopedResourcesForHardDeletion(
   await AgentUserRelationResource.deleteForAgent(auth, agentConfigurationId);
 }
 
+async function deleteAgentIdentityIfUnused(
+  workspaceId: number,
+  sId: string,
+  transaction: Transaction
+): Promise<void> {
+  const remainingConfiguration = await AgentConfigurationModel.findOne({
+    where: { sId, workspaceId },
+    attributes: ["id"],
+    transaction,
+  });
+  if (remainingConfiguration) {
+    return;
+  }
+
+  await AgentModel.destroy({
+    where: { sId, workspaceId },
+    transaction,
+  });
+}
+
 // Should only be called when we need to clean up the agent configuration
 // right after creating it due to an error.
 export async function unsafeHardDeleteAgentConfiguration(
@@ -1444,6 +1491,8 @@ export async function unsafeHardDeleteAgentConfiguration(
       },
       transaction: t,
     });
+
+    await deleteAgentIdentityIfUnused(workspaceId, agentConfiguration.sId, t);
   });
 }
 
@@ -1495,6 +1544,10 @@ export async function batchHardDeletePendingAgentConfigurations(
       where: { id: agentIds, workspaceId },
       transaction: t,
     });
+
+    for (const sId of new Set(agents.map((agent) => agent.sId))) {
+      await deleteAgentIdentityIfUnused(workspaceId, sId, t);
+    }
   });
 }
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -728,16 +728,16 @@ export async function createAgentConfiguration(
 
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const sId = agentConfigurationId || generateRandomModelSId();
-      let agentId = existingAgent?.agentId;
-      if (!agentId) {
+      let agentModelId = existingAgent?.agentId;
+      if (!agentModelId) {
         const [agentIdentity] = await AgentModel.findOrCreate({
           where: { sId, workspaceId: owner.id },
           defaults: { sId, workspaceId: owner.id },
           transaction: t,
         });
-        agentId = agentIdentity.id;
+        agentModelId = agentIdentity.id;
         await AgentConfigurationModel.update(
-          { agentId },
+          { agentId: agentModelId },
           {
             where: { sId, workspaceId: owner.id },
             transaction: t,
@@ -797,7 +797,7 @@ export async function createAgentConfiguration(
         agentConfigurationInstance = await AgentConfigurationModel.create(
           {
             sId,
-            agentId,
+            agentId: agentModelId,
             version,
             status,
             scope,


### PR DESCRIPTION
## Description

Follows #31328.

Creates or reuses one numeric identity across a pending agent and all its later versions. Existing pre-backfill agents are lazily attached when updated. Failed-version cleanup preserves the identity while an older version remains, and removes it only after the final configuration is deleted.

## Risks

Blast radius: workspace-agent creation, versioning, failed-save cleanup, and pending-agent purge.

Risk level: standard. Existing stable agent identifiers and API behavior are unchanged.

## Deploy Plan

- Deploy front and front-api after the additive schema from #31328 is present.
- No migration is required for this PR.

## Tests

- Added focused lifecycle coverage in `front/lib/api/assistant/configuration/agent.test.ts`.