### PR TITLE
[Admin Governance] Backfill stable agent identities

### DIFF
--- a/front/migrations/20260828_backfill_agent_identities.test.ts
+++ b/front/migrations/20260828_backfill_agent_identities.test.ts
@@ -2,6 +2,7 @@ import {
   AgentConfigurationModel,
   AgentModel,
 } from "@app/lib/models/agent/agent";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { backfillAgentIdentities } from "@app/migrations/20260828_backfill_agent_identities";
 import baseLogger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -69,16 +70,10 @@ describe("backfillAgentIdentities", () => {
     });
     const firstAgent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
-    const secondAgent = await AgentConfigurationFactory.createTestAgent(
-      authenticator,
-      { name: "Second agent" }
-    );
-    const secondIdentity = await AgentModel.findOne({
-      where: { sId: secondAgent.sId, workspaceId: workspace.id },
+    const secondIdentity = await AgentModel.create({
+      sId: generateRandomModelSId(),
+      workspaceId: workspace.id,
     });
-    if (!secondIdentity) {
-      throw new Error("Expected the second agent identity to exist.");
-    }
     await AgentConfigurationModel.update(
       { agentId: secondIdentity.id },
       { where: { sId: firstAgent.sId, workspaceId: workspace.id } }

--- a/front/migrations/20260828_backfill_agent_identities.test.ts
+++ b/front/migrations/20260828_backfill_agent_identities.test.ts
@@ -1,0 +1,93 @@
+import {
+  AgentConfigurationModel,
+  AgentModel,
+} from "@app/lib/models/agent/agent";
+import { backfillAgentIdentities } from "@app/migrations/20260828_backfill_agent_identities";
+import baseLogger from "@app/logger/logger";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+const logger = baseLogger.child({}, { level: "silent" });
+
+describe("backfillAgentIdentities", () => {
+  it("creates one identity per agent and attaches every version idempotently", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const firstVersion =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      firstVersion.sId
+    );
+    await AgentConfigurationModel.update(
+      { agentId: null },
+      { where: { sId: firstVersion.sId, workspaceId: workspace.id } }
+    );
+    await AgentModel.destroy({
+      where: { sId: firstVersion.sId, workspaceId: workspace.id },
+    });
+
+    const dryRun = await backfillAgentIdentities({
+      execute: false,
+      logger,
+      workspace,
+    });
+    expect(dryRun).toMatchObject({
+      logicalAgentCount: 1,
+      identitiesToCreate: 1,
+      versionsToAttach: 2,
+      orphanIdentityCount: 0,
+    });
+    expect(
+      await AgentModel.findOne({
+        where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      })
+    ).toBeNull();
+
+    await backfillAgentIdentities({ execute: true, logger, workspace });
+    const versions = await AgentConfigurationModel.findAll({
+      where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      attributes: ["agentId"],
+    });
+    expect(versions.every(({ agentId }) => agentId !== null)).toBe(true);
+    expect(new Set(versions.map(({ agentId }) => agentId)).size).toBe(1);
+
+    const rerun = await backfillAgentIdentities({
+      execute: true,
+      logger,
+      workspace,
+    });
+    expect(rerun.identitiesToCreate).toBe(0);
+    expect(rerun.versionsToAttach).toBe(0);
+  });
+
+  it("rejects a version linked to another agent's identity", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const firstAgent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const secondAgent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Second agent" }
+    );
+    const secondIdentity = await AgentModel.findOne({
+      where: { sId: secondAgent.sId, workspaceId: workspace.id },
+    });
+    if (!secondIdentity) {
+      throw new Error("Expected the second agent identity to exist.");
+    }
+    await AgentConfigurationModel.update(
+      { agentId: secondIdentity.id },
+      { where: { sId: firstAgent.sId, workspaceId: workspace.id } }
+    );
+
+    await expect(
+      backfillAgentIdentities({ execute: true, logger, workspace })
+    ).rejects.toThrow(
+      `Agent ${firstAgent.sId} is linked to an invalid identity.`
+    );
+  });
+});

--- a/front/migrations/20260828_backfill_agent_identities.ts
+++ b/front/migrations/20260828_backfill_agent_identities.ts
@@ -8,7 +8,7 @@ import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Op } from "sequelize";
+import { literal, Op } from "sequelize";
 
 type MigrationWorkspace = Pick<LightWorkspaceType, "id" | "sId">;
 
@@ -120,7 +120,7 @@ export async function backfillAgentIdentities({
             where: {
               sId,
               workspaceId: workspace.id,
-              agentId: { [Op.is]: null },
+              [Op.and]: literal('"agentId" IS NULL'),
             },
             transaction,
           }
@@ -132,7 +132,10 @@ export async function backfillAgentIdentities({
 
   if (execute) {
     const missingIdentityCount = await AgentConfigurationModel.count({
-      where: { workspaceId: workspace.id, agentId: { [Op.is]: null } },
+      where: {
+        workspaceId: workspace.id,
+        [Op.and]: literal('"agentId" IS NULL'),
+      },
     });
     if (missingIdentityCount > 0) {
       throw new Error(

--- a/front/migrations/20260828_backfill_agent_identities.ts
+++ b/front/migrations/20260828_backfill_agent_identities.ts
@@ -1,0 +1,163 @@
+import {
+  AgentConfigurationModel,
+  AgentModel,
+} from "@app/lib/models/agent/agent";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+type MigrationWorkspace = Pick<LightWorkspaceType, "id" | "sId">;
+
+export type AgentIdentityBackfillStats = {
+  logicalAgentCount: number;
+  identitiesToCreate: number;
+  versionsToAttach: number;
+  orphanIdentityCount: number;
+};
+
+function resolveIdentity(
+  sId: string,
+  configurations: AgentConfigurationModel[],
+  identitiesById: Map<number, AgentModel>,
+  identitiesBySId: Map<string, AgentModel>
+): AgentModel | null {
+  const linkedIds = new Set(
+    configurations.flatMap(({ agentId }) => (agentId === null ? [] : [agentId]))
+  );
+  if (linkedIds.size > 1) {
+    throw new Error(`Agent ${sId} is linked to multiple identities.`);
+  }
+
+  const linkedId = linkedIds.values().next().value;
+  const linkedIdentity =
+    linkedId === undefined ? undefined : identitiesById.get(linkedId);
+  if (linkedId !== undefined && linkedIdentity?.sId !== sId) {
+    throw new Error(`Agent ${sId} is linked to an invalid identity.`);
+  }
+
+  const identity = identitiesBySId.get(sId);
+  if (linkedId !== undefined && identity?.id !== linkedId) {
+    throw new Error(`Agent ${sId} has inconsistent identity links.`);
+  }
+
+  return identity ?? null;
+}
+
+export async function backfillAgentIdentities({
+  execute,
+  logger,
+  workspace,
+}: {
+  execute: boolean;
+  logger: Logger;
+  workspace: MigrationWorkspace;
+}): Promise<AgentIdentityBackfillStats> {
+  // Load each indexed workspace slice once, then validate and group it in memory to avoid
+  // per-agent reads before the writes below.
+  const [configurations, identities] = await Promise.all([
+    AgentConfigurationModel.findAll({
+      where: { workspaceId: workspace.id },
+      attributes: ["agentId", "sId"],
+    }),
+    AgentModel.findAll({
+      where: { workspaceId: workspace.id },
+      attributes: ["id", "sId"],
+    }),
+  ]);
+
+  const configurationsBySId = new Map<string, AgentConfigurationModel[]>();
+  for (const configuration of configurations) {
+    const versions = configurationsBySId.get(configuration.sId) ?? [];
+    versions.push(configuration);
+    configurationsBySId.set(configuration.sId, versions);
+  }
+
+  const identitiesById = new Map(identities.map((agent) => [agent.id, agent]));
+  const identitiesBySId = new Map(
+    identities.map((agent) => [agent.sId, agent])
+  );
+  const stats: AgentIdentityBackfillStats = {
+    logicalAgentCount: configurationsBySId.size,
+    identitiesToCreate: 0,
+    versionsToAttach: 0,
+    orphanIdentityCount: identities.filter(
+      ({ sId }) => !configurationsBySId.has(sId)
+    ).length,
+  };
+
+  await concurrentExecutor(
+    [...configurationsBySId],
+    async ([sId, versions]) => {
+      const currentIdentity = resolveIdentity(
+        sId,
+        versions,
+        identitiesById,
+        identitiesBySId
+      );
+      const versionsToAttach = versions.filter(
+        ({ agentId }) => agentId === null
+      ).length;
+      stats.identitiesToCreate += currentIdentity ? 0 : 1;
+      stats.versionsToAttach += versionsToAttach;
+
+      if (!execute || versionsToAttach === 0) {
+        return;
+      }
+
+      await withTransaction(async (transaction) => {
+        const [identity] = await AgentModel.findOrCreate({
+          where: { sId, workspaceId: workspace.id },
+          defaults: { sId, workspaceId: workspace.id },
+          transaction,
+        });
+        await AgentConfigurationModel.update(
+          { agentId: identity.id },
+          {
+            where: {
+              sId,
+              workspaceId: workspace.id,
+              agentId: { [Op.is]: null },
+            },
+            transaction,
+          }
+        );
+      });
+    },
+    { concurrency: 4 }
+  );
+
+  if (execute) {
+    const missingIdentityCount = await AgentConfigurationModel.count({
+      where: { workspaceId: workspace.id, agentId: { [Op.is]: null } },
+    });
+    if (missingIdentityCount > 0) {
+      throw new Error(
+        `Workspace ${workspace.sId} still has ${missingIdentityCount} versions without an identity.`
+      );
+    }
+  }
+
+  logger.info(
+    { workspaceId: workspace.sId, execute, ...stats },
+    "Agent identity backfill completed for workspace"
+  );
+  return stats;
+}
+
+if (process.argv[1]?.endsWith("20260828_backfill_agent_identities.ts")) {
+  makeScript(
+    { wId: { type: "string", required: false } },
+    async ({ execute, wId }, logger) => {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await backfillAgentIdentities({ execute, logger, workspace });
+        },
+        { concurrency: 4, wId }
+      );
+    }
+  );
+}


### PR DESCRIPTION
## Description

Follows #31329.

Adds an idempotent dry-run/execute backfill per workspace. It creates or reuses one identity per agent `sId`, attaches every version, rejects inconsistent links, and reports orphan or missing state.

## Risks

Blast radius: the one-time backfill of workspace agent configuration rows.

Risk level: standard. The migration supports dry runs, workspace-level execution, and safe retries.

## Deploy Plan

- Deploy front.
- Run the backfill in dry-run mode and inspect counts and mismatches.
- Execute it, optionally staged by workspace.
- Verify that no configuration is missing `agentId` before #31331.

## Tests

- Added focused coverage in `front/migrations/20260828_backfill_agent_identities.test.ts`.