### PR TITLE
feat(models): record model degradations in their own table

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -113,6 +113,7 @@ import {
 } from "@app/lib/resources/storage/models/labs_transcripts";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { MembershipUpgradeRequestModel } from "@app/lib/resources/storage/models/membership_upgrade_requests";
+import { ModelDegradationModel } from "@app/lib/resources/storage/models/model_degradations";
 import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
 import { PluginRunModel } from "@app/lib/resources/storage/models/plugin_runs";
 import { ProgrammaticUsageConfigurationModel } from "@app/lib/resources/storage/models/programmatic_usage_configurations";
@@ -254,6 +255,7 @@ export function loadAllModels() {
     FeatureFlagModel,
     GlobalFeatureFlagModel,
     KillSwitchModel,
+    ModelDegradationModel,
     LabsTranscriptsConfigurationModel,
     LabsTranscriptsHistoryModel,
     PluginRunModel,

--- a/front/lib/resources/model_degradation_resource.ts
+++ b/front/lib/resources/model_degradation_resource.ts
@@ -1,0 +1,91 @@
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { ModelDegradationModel } from "@app/lib/resources/storage/models/model_degradations";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, ModelStatic } from "sequelize";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ModelDegradationResource
+  extends ReadonlyAttributesType<ModelDegradationModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ModelDegradationResource extends BaseResource<ModelDegradationModel> {
+  static model: ModelStatic<ModelDegradationModel> = ModelDegradationModel;
+
+  constructor(
+    model: ModelStatic<ModelDegradationModel>,
+    blob: Attributes<ModelDegradationModel>
+  ) {
+    super(ModelDegradationModel, blob);
+  }
+
+  /**
+   * Marks a model degraded, or returns the degradation already ongoing for it.
+   *
+   * Idempotent so an operator submitting the same set twice does not open a
+   * second row; the partial unique index enforces the same invariant in the
+   * database.
+   */
+  static async startDegradation({
+    modelId,
+    providerId,
+  }: {
+    modelId: string;
+    providerId: ModelProviderIdType;
+  }): Promise<ModelDegradationResource> {
+    const ongoing = await ModelDegradationModel.findOne({
+      where: { modelId, status: "ongoing" },
+    });
+    if (ongoing) {
+      return new ModelDegradationResource(ModelDegradationModel, ongoing.get());
+    }
+
+    const degradation = await ModelDegradationModel.create({
+      modelId,
+      providerId,
+      startedAt: new Date(),
+      endedAt: null,
+      status: "ongoing",
+    });
+
+    return new ModelDegradationResource(
+      ModelDegradationModel,
+      degradation.get()
+    );
+  }
+
+  /**
+   * Closes the degradation ongoing for a model, if any. A no-op when the model
+   * is not currently degraded.
+   */
+  static async resolveDegradation(modelId: string): Promise<void> {
+    await ModelDegradationModel.update(
+      { endedAt: new Date(), status: "resolved" },
+      { where: { modelId, status: "ongoing" } }
+    );
+  }
+
+  static async listOngoing(): Promise<ModelDegradationResource[]> {
+    const degradations = await ModelDegradationModel.findAll({
+      where: { status: "ongoing" },
+    });
+
+    return degradations.map(
+      (d) => new ModelDegradationResource(ModelDegradationModel, d.get())
+    );
+  }
+
+  async delete(): Promise<Result<number | undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+      },
+    });
+
+    return new Ok(this.id);
+  }
+}

--- a/front/lib/resources/storage/models/model_degradations.ts
+++ b/front/lib/resources/storage/models/model_degradations.ts
@@ -1,0 +1,80 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { CreationOptional } from "sequelize";
+
+export type ModelDegradationStatus = "ongoing" | "resolved";
+
+/**
+ * One row per degradation of one model: the model was marked degraded at
+ * `startedAt`, and either still is (`status: "ongoing"`, `endedAt: null`) or
+ * stopped being at `endedAt` (`status: "resolved"`).
+ *
+ * The set of models degraded right now is the set of `"ongoing"` rows, so this
+ * table is both the live state and its own history: there is no separate switch
+ * to keep in sync.
+ */
+export class ModelDegradationModel extends BaseModel<ModelDegradationModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  // Widened to `string` for dynamic models coming from GCS, and because a model
+  // dropped from the catalog must not make its past degradations unreadable.
+  declare modelId: string;
+  declare providerId: ModelProviderIdType;
+  declare startedAt: Date;
+  declare endedAt: Date | null;
+  declare status: ModelDegradationStatus;
+}
+
+ModelDegradationModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    startedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    endedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "model_degradation",
+    tableName: "model_degradations",
+    sequelize: frontSequelize,
+    indexes: [
+      // At most one ongoing degradation per model: the invariant that lets the
+      // ongoing rows stand in for the live degraded set.
+      {
+        fields: ["modelId"],
+        unique: true,
+        name: "model_degradations_model_id_ongoing_unique_idx",
+        where: { status: "ongoing" },
+      },
+      { fields: ["startedAt"], name: "model_degradations_started_at_idx" },
+    ],
+  }
+);

--- a/front/migrations/pre-deploy/20260827192857_create_model_degradations.sql
+++ b/front/migrations/pre-deploy/20260827192857_create_model_degradations.sql
@@ -1,0 +1,64 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."model_degradations_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."model_degradations" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"startedAt" timestamp with time zone NOT NULL,
+	"endedAt" timestamp with time zone,
+	"id" bigint DEFAULT nextval('model_degradations_id_seq'::regclass) NOT NULL,
+	"modelId" character varying(255) COLLATE "pg_catalog"."default" NOT NULL,
+	"providerId" character varying(255) COLLATE "pg_catalog"."default" NOT NULL,
+	"status" character varying(255) COLLATE "pg_catalog"."default" NOT NULL
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY model_degradations_pkey ON public.model_degradations USING btree (id);
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."model_degradations" ADD CONSTRAINT "model_degradations_pkey" PRIMARY KEY USING INDEX "model_degradations_pkey";
+
+/*
+Statement 4
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY model_degradations_model_id_ongoing_unique_idx ON public.model_degradations USING btree ("modelId") WHERE ((status)::text = 'ongoing'::text);
+
+/*
+Statement 5
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY model_degradations_started_at_idx ON public.model_degradations USING btree ("startedAt");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."model_degradations_id_seq" OWNED BY "public"."model_degradations"."id";


### PR DESCRIPTION
## Description

Adds `model_degradations`, one row per degradation of one model: the model was marked degraded at `startedAt`, and either still is (`status: "ongoing"`, `endedAt: null`) or stopped being at `endedAt` (`status: "resolved"`).

| column | |
|---|---|
| `modelId` | e.g. `claude-opus-5`, widened to `string` |
| `providerId` | denormalized, so a provider outage can be charted without a catalog join |
| `startedAt` / `endedAt` | the interval; `endedAt` is null while ongoing |
| `status` | `"ongoing"` / `"resolved"` |

Base of the degraded-models stack. The rest of the stack moves onto it: nothing reads the table in this PR.

**Why.** Today a degraded model is a `kill_switches` row typed `global_degraded_model:<modelId>`, and un-degrading it destroys the row. That leaves no history at all — the moment an incident ends, every trace of it is gone, so there is nothing to build a provider-outage timeseries from. It also costs the switch system its closed union: `KillSwitchType` had to widen to include `global_degraded_model:${string}`, so `isKillSwitchType` accepts an unbounded namespace and reading a model id back means slicing a prefix off a string.

A row per degradation fixes both. The set of models degraded right now is the set of `"ongoing"` rows, so the table is its own history: there is no separate switch to keep in sync, and no way for the live state and the record of it to disagree.

The partial unique index on `("modelId") WHERE status = 'ongoing'` is what makes that safe — at most one open degradation per model, enforced by the database rather than by the write path.

`modelId` is widened to `string`, matching the choice already made in `degradable_models.ts`: models can come dynamically from GCS, and a model dropped from the catalog must not make its past degradations unreadable.

## Tests

No automated tests: the table has no reader yet, and per [TEST1] we test at the endpoint level — the endpoints that use it are in the PRs above.

Exercised by hand against a local database:

- `startDegradation` is idempotent — calling it twice for a model returns the same row rather than opening a second one;
- `resolveDegradation` stamps `endedAt` / `status` and keeps the row, and is a no-op when the model is not degraded;
- a second incident on the same model opens a new row beside the resolved one, so history accumulates;
- a direct insert of two `"ongoing"` rows for one model is rejected by `model_degradations_model_id_ongoing_unique_idx`.

The existing `enabled_models`, `models` and `assistant` suites (65 tests) still pass.

## Risk

Low. A new table with no reader and no writer in this PR: nothing in the running system touches it until the PR above lands. Rollback is reverting the code — the empty table can stay.

## Deploy Plan

Pre-deploy migration (`CREATE TABLE`, `CREATE INDEX CONCURRENTLY`), safe to apply before the code goes live. Ship this PR before the ones above it, which are what start writing to the table.
