### PR TITLE
Skills: Store manually requested spaces 1/4: keep manual spaces in the Manage draft

### DIFF
--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -60,9 +60,9 @@ export function SkillBuilderRequestedSpacesSection() {
       return;
     }
 
-    // Keep every manually selected space in the draft, including the ones something in the skill
+    // Keep every manually selected space in the draft, including the ones resources in the skill
     // also requires. The sheet renders those rows selected and locked, so they cannot be toggled
-    // off; dropping them here instead made saving the sheet forget that they were picked by hand.
+    // off.
     setDraftSelectedSpaces(selectedAdditionalSpaces);
     setIsSheetOpen(true);
   };

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -60,11 +60,10 @@ export function SkillBuilderRequestedSpacesSection() {
       return;
     }
 
-    setDraftSelectedSpaces(
-      selectedAdditionalSpaces.filter(
-        (spaceId) => !spaceIdsUsedBySkill.has(spaceId)
-      )
-    );
+    // Keep every manually selected space in the draft, including the ones something in the skill
+    // also requires. The sheet renders those rows selected and locked, so they cannot be toggled
+    // off; dropping them here instead made saving the sheet forget that they were picked by hand.
+    setDraftSelectedSpaces(selectedAdditionalSpaces);
     setIsSheetOpen(true);
   };
 


### PR DESCRIPTION
## Description:

Related to https://github.com/dust-tt/tasks/issues/9896

The Manage sheet under Data and access seeded its draft with the manually selected spaces minus the ones a tool, knowledge or nested skill also requires, so opening Manage and saving forgot that those spaces had been picked by hand. Those rows are rendered selected and locked by the sheet, so stripping them from the draft gained nothing.

### Before

https://github.com/user-attachments/assets/6e6a9536-e379-4899-aeea-d836aa48dd07

### After

https://github.com/user-attachments/assets/be381231-c78b-4e35-9e6d-b33f3332c89e


## Tests
tested manually

## Deploy plan
Deploy front. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)