### PR TITLE
[front] enh: show selected model tier in model picker

### DIFF
--- a/front/components/model_picker/ModelPickerModelRow.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.tsx
@@ -1,4 +1,5 @@
 import { ModelPickerSelectionIndicator } from "@app/components/model_picker/ModelPickerSelectionIndicator";
+import { ModelTierChip } from "@app/components/model_picker/ModelTierChip";
 import type {
   EffortStop,
   ModelLockReason,
@@ -68,10 +69,13 @@ export function ModelPickerModelRow({
         truncateText
         endComponent={
           isSelected ? (
-            <ModelPickerSelectionIndicator
-              canRevert={canRevert}
-              onRevert={onRevert}
-            />
+            <div className="flex items-center gap-2">
+              <ModelTierChip model={model} reasoningEffort={effort} />
+              <ModelPickerSelectionIndicator
+                canRevert={canRevert}
+                onRevert={onRevert}
+              />
+            </div>
           ) : undefined
         }
         onClick={() => {

--- a/front/components/model_picker/ModelTierChip.tsx
+++ b/front/components/model_picker/ModelTierChip.tsx
@@ -1,0 +1,42 @@
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import {
+  getModelsTierDisplayName,
+  getTierForModel,
+} from "@app/types/assistant/models/model_tiers";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
+import { Chip } from "@dust-tt/sparkle";
+import type React from "react";
+
+type ChipColor = NonNullable<React.ComponentProps<typeof Chip>["color"]>;
+
+const MODEL_TIER_CHIP_COLORS: Record<ModelsTierName, ChipColor> = {
+  cost_efficient: "success",
+  balanced: "info",
+  premium: "warning",
+};
+
+interface ModelTierChipProps {
+  model: ModelConfigurationType;
+  reasoningEffort?: ReasoningEffort;
+}
+
+export function ModelTierChip({
+  model,
+  reasoningEffort = model.defaultReasoningEffort,
+}: ModelTierChipProps) {
+  const tier = getTierForModel(model.modelId, reasoningEffort);
+  if (!tier) {
+    return null;
+  }
+
+  return (
+    <Chip
+      size="mini"
+      color={MODEL_TIER_CHIP_COLORS[tier]}
+      label={getModelsTierDisplayName(tier)}
+    />
+  );
+}

--- a/front/components/model_picker/ModelTierChip.tsx
+++ b/front/components/model_picker/ModelTierChip.tsx
@@ -1,4 +1,3 @@
-import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   getModelsTierDisplayName,
   getTierForModel,
@@ -8,15 +7,6 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { Chip } from "@dust-tt/sparkle";
-import type React from "react";
-
-type ChipColor = NonNullable<React.ComponentProps<typeof Chip>["color"]>;
-
-const MODEL_TIER_CHIP_COLORS: Record<ModelsTierName, ChipColor> = {
-  cost_efficient: "success",
-  balanced: "info",
-  premium: "warning",
-};
 
 interface ModelTierChipProps {
   model: ModelConfigurationType;
@@ -32,11 +22,5 @@ export function ModelTierChip({
     return null;
   }
 
-  return (
-    <Chip
-      size="mini"
-      color={MODEL_TIER_CHIP_COLORS[tier]}
-      label={getModelsTierDisplayName(tier)}
-    />
-  );
+  return <Chip size="mini" label={getModelsTierDisplayName(tier)} />;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10235

This PR adds a chip in the model picker, on the same row as the model name to show which model tier the selection maps to: Basic, Standard, or Premium.

<img width="785" height="492" alt="image" src="https://github.com/user-attachments/assets/a4fb42e7-5f39-403b-a850-68eb0bac8c75" />

<img width="779" height="499" alt="image" src="https://github.com/user-attachments/assets/d524dbea-398c-4fa4-8d14-96afb149c437" />

Aligned to the right because the current implementation does not support aligning something to the left after the label. Can be revisited in a follow up PR if important.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
