### PR TITLE
Skills: Store manually requested spaces 2/4: add the column and write it

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -106,6 +106,7 @@ describe("GET /api/w/:wId/files/:fileId", () => {
       instructions: skill.instructions,
       mcpServerViews: [],
       name: skill.name,
+      manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
       requestedSpaceIds: skill.requestedSpaceIds,
       userFacingDescription: skill.userFacingDescription,
     });
@@ -442,6 +443,7 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
       attachedKnowledge: [],
       icon: skill.icon,
       instructions: skill.instructions,
+      manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
       mcpServerViews: [],
       name: skill.name,
       requestedSpaceIds: skill.requestedSpaceIds,

--- a/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.test.ts
@@ -57,6 +57,7 @@ describe("GET /api/w/:wId/skills/:sId/files/:fileId/content", () => {
       attachedKnowledge: [],
       icon: skill.icon,
       instructions: skill.instructions,
+      manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
       mcpServerViews: [],
       name: skill.name,
       requestedSpaceIds: skill.requestedSpaceIds,
@@ -92,6 +93,7 @@ describe("GET /api/w/:wId/skills/:sId/files/:fileId/content", () => {
     });
     const restrictedSpace = await SpaceFactory.regular(workspace);
     const skill = await SkillFactory.create(auth, {
+      manuallyRequestedSpaceIds: [],
       requestedSpaceIds: [restrictedSpace.id],
     });
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -918,6 +918,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       instructionsHtml: skill.instructionsHtml,
       mcpServerViews: [],
       name: skill.name,
+      manuallyRequestedSpaceIds: [],
       requestedSpaceIds: [openSpace.id],
       userFacingDescription: skill.userFacingDescription,
     });
@@ -957,6 +958,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       instructionsHtml: skill.instructionsHtml,
       mcpServerViews: [],
       name: skill.name,
+      manuallyRequestedSpaceIds: [],
       requestedSpaceIds: [openSpace.id],
       userFacingDescription: skill.userFacingDescription,
     });
@@ -1074,6 +1076,119 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.dataSourceConfigurations).toHaveLength(2);
+  });
+});
+
+describe("PATCH /api/w/:wId/skills/:sId - manually requested spaces", () => {
+  // Sets up an open space the request user can read, plus a folder in it so knowledge attached
+  // from that space makes it required automatically as well as manually.
+  async function setupSpaceWithKnowledge(options: {
+    requestUserRole: "admin";
+  }) {
+    const test = await setupTest(options);
+    const { workspace, globalGroup, requestUserAuth, requestUser } = test;
+
+    const space = await SpaceFactory.regular(workspace);
+    await SpaceFactory.attachGroup(space, globalGroup);
+    // An open space confers read through the global group's `reader` grant, and an Authenticator
+    // resolves its grants once, at construction.
+    await requestUserAuth.refresh();
+
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      space,
+      requestUser
+    );
+
+    return { ...test, space, dataSourceView };
+  }
+
+  function patchBody(
+    skill: {
+      name: string;
+      agentFacingDescription: string;
+      userFacingDescription: string;
+      instructions: string;
+    },
+    overrides: Record<string, unknown>
+  ) {
+    return {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      ...overrides,
+    };
+  }
+
+  it("stores the manually selected spaces, and snapshots them on the version", async () => {
+    const { workspace, skill, requestUserAuth, space } =
+      await setupSpaceWithKnowledge({ requestUserRole: "admin" });
+
+    const response = await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, { additionalRequestedSpaceIds: [space.sId] })
+    );
+    expect(await response.json()).not.toHaveProperty("error");
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill?.manuallyRequestedSpaceIds).toEqual([space.id]);
+    expect(updatedSkill?.requestedSpaceIds).toContain(space.id);
+
+    // Patch again so a version is snapshotted from the state above.
+    await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, { additionalRequestedSpaceIds: [space.sId] })
+    );
+    const versionWhere: WhereOptions<SkillVersionModel> = {
+      workspaceId: workspace.id,
+      skillConfigurationId: skill.id,
+    };
+    const versions = await SkillVersionModel.findAll({ where: versionWhere });
+    expect(
+      versions.some((version) =>
+        version.manuallyRequestedSpaceIds.includes(space.id)
+      )
+    ).toBe(true);
+  });
+
+  it("keeps a manual space that attached knowledge also requires", async () => {
+    const { workspace, skill, requestUserAuth, space, dataSourceView } =
+      await setupSpaceWithKnowledge({ requestUserRole: "admin" });
+
+    // Manually selected AND required by knowledge
+    const response = await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, {
+        additionalRequestedSpaceIds: [space.sId],
+        attachedKnowledge: [
+          {
+            dataSourceViewId: dataSourceView.sId,
+            nodeId: "folder1",
+            spaceId: space.sId,
+            title: "Folder 1",
+          },
+        ],
+      })
+    );
+    expect(await response.json()).not.toHaveProperty("error");
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill?.manuallyRequestedSpaceIds).toEqual([space.id]);
+    expect(updatedSkill?.requestedSpaceIds).toContain(space.id);
   });
 });
 
@@ -1220,6 +1335,7 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
       instructions: skill.instructions,
       mcpServerViews: [],
       name: skill.name,
+      manuallyRequestedSpaceIds: [],
       requestedSpaceIds: [],
       userFacingDescription: skill.userFacingDescription,
     });

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -386,7 +386,15 @@ app.patch(
       }
 
       additionalRequestedSpaceIds = additionalRequestedSpaceIdsRes.value;
+    } else if (skill.manuallyRequestedSpaceIds.length > 0) {
+      // The skill has a stored manual list: keep it verbatim.
+      additionalRequestedSpaceIds = [...skill.manuallyRequestedSpaceIds];
     } else {
+      // TODO(skills-manual-spaces): drop this inference once every skill has been backfilled. It
+      // cannot tell a space that was picked by hand from one a tool or knowledge happens to
+      // require, which is why `manuallyRequestedSpaceIds` is now stored. An empty stored list is
+      // ambiguous until then — either never written, or written empty — and both resolve to the
+      // same answer here, since a skill with no manual spaces requests only what it derives.
       const previousAttachedKnowledge = await skill.getAttachedKnowledge(auth);
       const previousComputedRequestedSpaceIds =
         await SkillResource.computeRequestedSpaceIds(auth, {
@@ -485,6 +493,7 @@ app.patch(
       instructions: body.instructions,
       instructionsHtml: body.instructionsHtml,
       availability: requestedAvailability,
+      manuallyRequestedSpaceIds: additionalRequestedSpaceIds,
       mcpServerViews,
       name,
       reinforcement: body.reinforcement,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -537,6 +537,7 @@ app.post(
         instructionsHtml: body.instructionsHtml,
         editedBy: user.id,
         requestedSpaceIds,
+        manuallyRequestedSpaceIds: additionalRequestedSpaceIdsRes.value,
         icon,
         source: body.source ?? "web_app",
         sourceMetadata: body.sourceMetadata ?? null,

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -632,6 +632,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
           : skill.instructionsHtml,
       mcpServerViews: skill.mcpServerViews,
       name: trimmedName,
+      manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
       requestedSpaceIds: skill.requestedSpaceIds,
       userFacingDescription:
         userFacingDescription ?? skill.userFacingDescription,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -254,6 +254,7 @@ export async function importSkillsFromFiles(
         icon: existing.icon,
         mcpServerViews: existing.mcpServerViews,
         attachedKnowledge,
+        manuallyRequestedSpaceIds: existing.manuallyRequestedSpaceIds,
         requestedSpaceIds: existing.requestedSpaceIds,
         fileAttachments,
         source,

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -162,6 +162,7 @@ export async function importSkillsFromGitHub(
         icon: existing.icon,
         mcpServerViews: existing.mcpServerViews,
         attachedKnowledge,
+        manuallyRequestedSpaceIds: existing.manuallyRequestedSpaceIds,
         requestedSpaceIds: existing.requestedSpaceIds,
         fileAttachments,
         source: "github",

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1399,6 +1399,43 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       expect(skillAfter!.requestedSpaceIds).toHaveLength(0);
     });
 
+    it("should remove a deleted space from a skill's manually requested spaces", async () => {
+      // A manual selection survives everything else, but not the space going away: an id pointing
+      // at a missing space makes the skill unreadable for everyone.
+      const spaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Manually Selected Space",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(spaceResult.isOk()).toBe(true);
+      const space = spaceResult.isOk() ? spaceResult.value : null;
+      expect(space).not.toBeNull();
+
+      const skill = await SkillFactory.create(adminAuth, {
+        name: "Skill With Manual Space",
+        requestedSpaceIds: [space!.id],
+        manuallyRequestedSpaceIds: [space!.id],
+      });
+
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        space!,
+        true // force delete
+      );
+      expect(deleteResult.isOk()).toBe(true);
+
+      const skillAfter = await SkillResource.fetchById(adminAuth, skill.sId);
+      expect(skillAfter).not.toBeNull();
+      expect(skillAfter!.manuallyRequestedSpaceIds).not.toContain(space!.id);
+      expect(skillAfter!.requestedSpaceIds).not.toContain(space!.id);
+    });
+
     it("should clean an archived skill's requestedSpaceIds too", async () => {
       // An archived skill keeps its references, and a dangling one makes it unfetchable — so it
       // could never be restored. The cleanup must not be limited to active skills.

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -383,6 +383,8 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           (k) => !dataSourceViewIdSet.has(k.dataSourceView.id)
         );
 
+        // TODO(skills-manual-spaces): read `manuallyRequestedSpaceIds` here once every skill has
+        // been backfilled, and drop this inference.
         const previousComputedRequestedSpaceIds =
           await SkillResource.computeRequestedSpaceIds(auth, {
             mcpServerViews: skill.mcpServerViews,
@@ -396,6 +398,12 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
             spaceId !== space.id &&
             !previousComputedRequestedSpaceIdSet.has(spaceId)
         );
+
+        // A deleted space cannot stay a manual choice: nothing can grant access to it any more
+        const manuallyRequestedSpaceIds =
+          skill.manuallyRequestedSpaceIds.filter(
+            (spaceId) => spaceId !== space.id
+          );
 
         // Compute the new requestedSpaceIds from the filtered tools and knowledge.
         const computedRequestedSpaceIds =
@@ -428,6 +436,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           icon: skill.icon,
           mcpServerViews: filteredMCPServerViews,
           attachedKnowledge: filteredAttachedKnowledge,
+          manuallyRequestedSpaceIds,
           requestedSpaceIds,
         });
       }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -59,6 +59,11 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.ARRAY(DataTypes.BIGINT),
     allowNull: false,
   },
+  manuallyRequestedSpaceIds: {
+    type: DataTypes.ARRAY(DataTypes.BIGINT),
+    allowNull: false,
+    defaultValue: [],
+  },
   icon: {
     type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
@@ -126,6 +131,10 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare selfImprovementLock: CreationOptional<boolean>;
 
   declare requestedSpaceIds: number[];
+  // The subset of `requestedSpaceIds` a person picked by hand under "Data and access". The rest is
+  // derived from the skill's tools, attached knowledge and nested skills, and disappears with them;
+  // these stay until someone removes them explicitly.
+  declare manuallyRequestedSpaceIds: CreationOptional<number[]>;
 }
 
 SkillConfigurationModel.init(

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -271,6 +271,7 @@ describe("pruneOutdatedSkillEditSuggestions", () => {
         instructionsHtml: '<p data-block-id="block-2">New content.</p>',
         icon: skill.icon,
         mcpServerViews: skill.mcpServerViews,
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [],
         attachedKnowledge: [],
       });
@@ -305,6 +306,7 @@ describe("pruneOutdatedSkillEditSuggestions", () => {
           '<p data-block-id="block-1">Updated A.</p><p data-block-id="block-2">B.</p>',
         icon: skill.icon,
         mcpServerViews: skill.mcpServerViews,
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [],
         attachedKnowledge: [],
       });

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -697,6 +697,7 @@ describe("SkillResource", () => {
         availability: "users_and_agents",
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [],
       });
 
@@ -718,6 +719,7 @@ describe("SkillResource", () => {
         availability: "workspace_users",
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [],
       });
 
@@ -761,6 +763,7 @@ describe("SkillResource", () => {
         icon: skillResource.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [restrictedSpace.id],
       });
 
@@ -806,6 +809,7 @@ describe("SkillResource", () => {
         icon: skillResource.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [restrictedSpace.id],
       });
 
@@ -856,6 +860,7 @@ describe("SkillResource", () => {
         icon: skillResource.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [space1.id],
       });
 
@@ -912,6 +917,7 @@ describe("SkillResource", () => {
         icon: skill1.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [skill1OnlySpace.id],
       });
 
@@ -978,6 +984,7 @@ describe("SkillResource", () => {
         icon: parentSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: parentSkill.manuallyRequestedSpaceIds,
         requestedSpaceIds: parentSkill.requestedSpaceIds,
       });
 
@@ -1031,6 +1038,7 @@ describe("SkillResource", () => {
         icon: parentSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [restrictedSpace.id],
       });
 
@@ -1060,6 +1068,7 @@ describe("SkillResource", () => {
         icon: parentSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: parentSkill.manuallyRequestedSpaceIds,
         requestedSpaceIds: parentSkill.requestedSpaceIds,
       });
 
@@ -1085,6 +1094,8 @@ describe("SkillResource", () => {
         icon: updatedParentSkill!.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds:
+          updatedParentSkill!.manuallyRequestedSpaceIds,
         requestedSpaceIds: updatedParentSkill!.requestedSpaceIds,
       });
 
@@ -1112,6 +1123,7 @@ describe("SkillResource", () => {
         icon: skill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
         requestedSpaceIds: skill.requestedSpaceIds,
       });
 
@@ -1143,6 +1155,7 @@ describe("SkillResource", () => {
         icon: childSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [restrictedSpace.id],
       });
 
@@ -1164,6 +1177,7 @@ describe("SkillResource", () => {
         icon: childSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: [],
         requestedSpaceIds: [],
       });
 
@@ -1197,6 +1211,7 @@ describe("SkillResource", () => {
         icon: childSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: childSkill.manuallyRequestedSpaceIds,
         requestedSpaceIds: childSkill.requestedSpaceIds,
         status: "archived",
       });
@@ -1218,6 +1233,7 @@ describe("SkillResource", () => {
         icon: childSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: childSkill.manuallyRequestedSpaceIds,
         requestedSpaceIds: childSkill.requestedSpaceIds,
         status: "active",
       });
@@ -1252,6 +1268,7 @@ describe("SkillResource", () => {
         icon: newIcon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: childSkill.manuallyRequestedSpaceIds,
         requestedSpaceIds: childSkill.requestedSpaceIds,
       });
 
@@ -1381,6 +1398,7 @@ describe("SkillResource", () => {
         icon: parentSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds: parentSkill.manuallyRequestedSpaceIds,
         requestedSpaceIds: parentSkill.requestedSpaceIds,
       });
 
@@ -1473,6 +1491,7 @@ describe("SkillResource", () => {
           availability: "users_and_agents",
           mcpServerViews: [],
           attachedKnowledge: [],
+          manuallyRequestedSpaceIds: [],
           requestedSpaceIds: [],
         })
       ).rejects.toThrow(
@@ -1725,6 +1744,8 @@ describe("SkillResource", () => {
         icon: archivedParentSkill!.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
+        manuallyRequestedSpaceIds:
+          archivedParentSkill!.manuallyRequestedSpaceIds,
         requestedSpaceIds: archivedParentSkill!.requestedSpaceIds,
       });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -914,17 +914,27 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { withTools = true }: { withTools?: boolean } = {}
+    {
+      dangerouslySkipPermissionFiltering,
+      withTools = true,
+    }: {
+      dangerouslySkipPermissionFiltering?: boolean;
+      withTools?: boolean;
+    } = {}
   ): Promise<SkillResource[]> {
-    return this.baseFetch(auth, {
-      where: {
-        id: {
-          [Op.in]: ids,
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
+        onlyCustom: true,
+        withTools,
       },
-      onlyCustom: true,
-      withTools,
-    });
+      { dangerouslySkipPermissionFiltering }
+    );
   }
 
   static async fetchFileSkills(
@@ -2135,6 +2145,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         instructionsHtml: null,
         name: def.name,
         requestedSpaceIds: requestedSpaceModelIds,
+        manuallyRequestedSpaceIds: [],
         status: "active",
         updatedAt: new Date(),
         workspaceId,
@@ -2499,6 +2510,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           instructionsHtml: versionModel.instructionsHtml,
           icon: versionModel.icon,
           requestedSpaceIds: versionModel.requestedSpaceIds,
+          manuallyRequestedSpaceIds: versionModel.manuallyRequestedSpaceIds,
           source: versionModel.source,
           sourceMetadata: versionModel.sourceMetadata,
           availability: versionModel.availability,
@@ -3159,6 +3171,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions,
       instructionsHtml,
       mcpServerViews,
+      manuallyRequestedSpaceIds,
       name,
       reinforcement,
       requestedSpaceIds,
@@ -3174,6 +3187,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       icon: string | null;
       instructions: string;
       instructionsHtml?: string | null;
+      // The spaces a person picked by hand: the subset of `requestedSpaceIds` that stays when
+      // nothing in the skill requires it any more.
+      manuallyRequestedSpaceIds: ModelId[];
       mcpServerViews: MCPServerViewResource[];
       name: string;
       reinforcement?: SkillReinforcementMode;
@@ -3240,6 +3256,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(instructionsHtml !== undefined ? { instructionsHtml } : {}),
           icon,
           requestedSpaceIds,
+          manuallyRequestedSpaceIds,
           editedBy,
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
@@ -4565,6 +4582,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         instructions: skill.instructions,
         instructionsHtml: skill.instructionsHtml,
         requestedSpaceIds: skill.requestedSpaceIds,
+        manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
         editedBy: skill.editedBy,
         mcpServerViewIds: (mcpServerConfigsBySkillId[skill.id] ?? []).map(
           (config) => config.mcpServerViewId

--- a/front/migrations/20260814_rewrite_office_skill_customization_directive.ts
+++ b/front/migrations/20260814_rewrite_office_skill_customization_directive.ts
@@ -96,6 +96,7 @@ async function rewriteWorkspaceOfficeSkillDirectives(
       instructionsHtml: convertMarkdownToBlockHtml(instructions),
       mcpServerViews: skill.mcpServerViews,
       name: skill.name,
+      manuallyRequestedSpaceIds: skill.manuallyRequestedSpaceIds,
       requestedSpaceIds: skill.requestedSpaceIds,
       userFacingDescription: skill.userFacingDescription,
     });

--- a/front/migrations/20260828_backfill_skill_manually_requested_spaces.ts
+++ b/front/migrations/20260828_backfill_skill_manually_requested_spaces.ts
@@ -1,0 +1,310 @@
+import { getReferencedSkillSpaceModelIds } from "@app/lib/api/skills/space_requirements";
+import { Authenticator } from "@app/lib/auth";
+import {
+  SkillConfigurationModel,
+  SkillVersionModel,
+} from "@app/lib/models/skill";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+
+// Backfills `manuallyRequestedSpaceIds`, the spaces a person picked by hand under "Data and
+// access". Before that column existed the manual list was inferred by subtracting the spaces the
+// skill's own content requires from `requestedSpaceIds`, which cannot tell a space that was picked
+// by hand from one that a tool or knowledge happens to require too. This runs that subtraction one
+// last time, per skill and per version, and stores the answer.
+//
+// Only rows still at the empty default are touched. A skill saved since the dual-write deploy
+// already holds an authoritative list, and re-deriving it would undo exactly what this migration
+// exists to fix. On a row that has been written and holds `[]` the subtraction returns `[]` as
+// well, because `requestedSpaceIds` is then the derived set alone — so skipping non-empty rows
+// loses nothing.
+//
+// The derived set comes from the same code the write paths use, under an Authenticator holding
+// every group of the workspace: with narrower grants the resource layer would hide views and
+// knowledge in restricted spaces, and their spaces would then be misread as hand-picked.
+
+/** The spaces a skill's own content requires: tools, attached knowledge and nested skills. */
+async function computeDerivedSpaceIds(
+  auth: Authenticator,
+  skill: SkillResource
+): Promise<Set<ModelId>> {
+  const attachedKnowledge = await skill.getAttachedKnowledge(auth);
+
+  const computedSpaceIds = await SkillResource.computeRequestedSpaceIds(auth, {
+    mcpServerViews: skill.mcpServerViews,
+    attachedKnowledge,
+  });
+  const referencedSkillSpaceIds = await getReferencedSkillSpaceModelIds(
+    auth,
+    skill.instructions,
+    skill.sId
+  );
+
+  return new Set([...computedSpaceIds, ...referencedSkillSpaceIds]);
+}
+
+/**
+ * `requestedSpaceIds` minus what the content requires, restricted to spaces that still exist.
+ *
+ * A space that no longer exists must not become a manual choice: `canReadRequestedSpaces` requires
+ * every requested space to resolve, so a dangling id would hide the skill from everyone once the
+ * manual list starts feeding `requestedSpaceIds`.
+ */
+function classifyManualSpaceIds({
+  requestedSpaceIds,
+  derivedSpaceIds,
+  liveSpaceIds,
+}: {
+  requestedSpaceIds: readonly ModelId[];
+  derivedSpaceIds: Set<ModelId>;
+  liveSpaceIds: Set<ModelId>;
+}): ModelId[] {
+  return requestedSpaceIds.filter(
+    (spaceId) => !derivedSpaceIds.has(spaceId) && liveSpaceIds.has(spaceId)
+  );
+}
+
+async function fetchLiveSpaceIds(
+  workspace: LightWorkspaceType,
+  spaceIds: readonly ModelId[]
+): Promise<Set<ModelId>> {
+  const uniqueSpaceIds = [...new Set(spaceIds)];
+  if (uniqueSpaceIds.length === 0) {
+    return new Set();
+  }
+
+  // Soft-deleted spaces are excluded by the model's default scope, which is what we want: a
+  // soft-deleted space is as unreachable as a missing row.
+  const liveSpaces = await SpaceModel.findAll({
+    attributes: ["id"],
+    where: {
+      id: { [Op.in]: uniqueSpaceIds },
+      workspaceId: workspace.id,
+    },
+  });
+
+  return new Set(liveSpaces.map((space) => space.id));
+}
+
+/**
+ * Backfills the skill's historical versions.
+ *
+ * Versions snapshot their tools and instructions but not their attached knowledge, so a space that
+ * only some knowledge required at the time reads as hand-picked here. Version rows are only ever
+ * displayed — the history endpoint and Poke — and never written back into a skill, so the
+ * imprecision stays cosmetic, and erring this way lists the space rather than hiding it.
+ */
+async function backfillSkillVersions(
+  auth: Authenticator,
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType,
+  skill: SkillResource
+): Promise<void> {
+  // SkillVersionModel extends SkillConfigurationModel, so its own columns need the explicit type.
+  const pendingVersionsWhere: WhereOptions<SkillVersionModel> = {
+    workspaceId: workspace.id,
+    skillConfigurationId: skill.id,
+    requestedSpaceIds: { [Op.ne]: [] },
+    manuallyRequestedSpaceIds: [],
+  };
+  const pendingVersions = await SkillVersionModel.findAll({
+    attributes: ["id", "version"],
+    where: pendingVersionsWhere,
+  });
+  if (pendingVersions.length === 0) {
+    return;
+  }
+
+  // `listVersions` rebuilds each version with the skill's own model id, so the version number is
+  // what identifies the row to update.
+  const pendingRowIdByVersion = new Map(
+    pendingVersions.map((row) => [row.version, row.id])
+  );
+
+  // Each version comes back as a SkillResource carrying its snapshotted tools, so the derived set
+  // is computed by the same code as for the live skill.
+  const versions = await skill.listVersions(auth);
+
+  for (const version of versions) {
+    const versionRowId = pendingRowIdByVersion.get(version.version);
+    if (versionRowId === undefined) {
+      continue;
+    }
+
+    const derivedSpaceIds = await computeDerivedSpaceIds(auth, version);
+    const liveSpaceIds = await fetchLiveSpaceIds(
+      workspace,
+      version.requestedSpaceIds
+    );
+    const manuallyRequestedSpaceIds = classifyManualSpaceIds({
+      requestedSpaceIds: version.requestedSpaceIds,
+      derivedSpaceIds,
+      liveSpaceIds,
+    });
+    if (manuallyRequestedSpaceIds.length === 0) {
+      continue;
+    }
+
+    const context = {
+      workspaceId: workspace.sId,
+      skillId: skill.sId,
+      skillVersionModelId: versionRowId,
+      version: version.version,
+      requestedSpaceIds: version.requestedSpaceIds,
+      derivedSpaceIds: [...derivedSpaceIds],
+      manuallyRequestedSpaceIds,
+    };
+
+    if (!execute) {
+      logger.info(
+        context,
+        "Dry-run: would store manually requested spaces on version"
+      );
+      continue;
+    }
+
+    const versionUpdateWhere: WhereOptions<SkillVersionModel> = {
+      id: versionRowId,
+      workspaceId: workspace.id,
+    };
+    await SkillVersionModel.update(
+      { manuallyRequestedSpaceIds },
+      { where: versionUpdateWhere }
+    );
+
+    logger.info(context, "Stored manually requested spaces on version");
+  }
+}
+
+async function backfillWorkspaceSkills(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const pendingSkills = await SkillConfigurationModel.findAll({
+    attributes: ["id"],
+    where: {
+      workspaceId: workspace.id,
+      // Postgres: `<> '{}'` rather than a length check, so the filter stays index-friendly.
+      requestedSpaceIds: { [Op.ne]: [] },
+      // Never overwrite a list the application has already written.
+      manuallyRequestedSpaceIds: [],
+    },
+  });
+
+  const pendingVersionSkillsWhere: WhereOptions<SkillVersionModel> = {
+    workspaceId: workspace.id,
+    requestedSpaceIds: { [Op.ne]: [] },
+    manuallyRequestedSpaceIds: [],
+  };
+  const skillIdsWithPendingVersions = await SkillVersionModel.findAll({
+    attributes: ["skillConfigurationId"],
+    where: pendingVersionSkillsWhere,
+    group: ["skillConfigurationId"],
+  });
+
+  const skillModelIds = [
+    ...new Set([
+      ...pendingSkills.map((skill) => skill.id),
+      ...skillIdsWithPendingVersions.map(
+        (version) => version.skillConfigurationId
+      ),
+    ]),
+  ];
+  if (skillModelIds.length === 0) {
+    return;
+  }
+
+  // Every group of the workspace, so the resource layer hides nothing: skills in restricted spaces
+  // are the ones whose manual selections matter most.
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
+
+  // Skipping the permission filter is what lets the repair reach a skill that requests a space
+  // which no longer exists: `baseFetch` drops those, and they are precisely the rows whose stale
+  // ids need dropping from the manual list rather than being copied into it.
+  const skills = await SkillResource.fetchByModelIds(auth, skillModelIds, {
+    dangerouslySkipPermissionFiltering: true,
+  });
+  if (skills.length !== skillModelIds.length) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        requestedCount: skillModelIds.length,
+        fetchedCount: skills.length,
+      },
+      "Some skills could not be fetched and are left untouched"
+    );
+  }
+
+  const pendingSkillIds = new Set(pendingSkills.map((skill) => skill.id));
+
+  for (const skill of skills) {
+    if (pendingSkillIds.has(skill.id)) {
+      const derivedSpaceIds = await computeDerivedSpaceIds(auth, skill);
+      const liveSpaceIds = await fetchLiveSpaceIds(
+        workspace,
+        skill.requestedSpaceIds
+      );
+      const manuallyRequestedSpaceIds = classifyManualSpaceIds({
+        requestedSpaceIds: skill.requestedSpaceIds,
+        derivedSpaceIds,
+        liveSpaceIds,
+      });
+
+      if (manuallyRequestedSpaceIds.length > 0) {
+        const context = {
+          workspaceId: workspace.sId,
+          skillModelId: skill.id,
+          skillId: skill.sId,
+          skillStatus: skill.status,
+          requestedSpaceIds: skill.requestedSpaceIds,
+          derivedSpaceIds: [...derivedSpaceIds],
+          manuallyRequestedSpaceIds,
+        };
+
+        if (execute) {
+          await SkillConfigurationModel.update(
+            { manuallyRequestedSpaceIds },
+            { where: { id: skill.id, workspaceId: workspace.id } }
+          );
+          logger.info(context, "Stored manually requested spaces");
+        } else {
+          logger.info(
+            context,
+            "Dry-run: would store manually requested spaces"
+          );
+        }
+      }
+    }
+
+    await backfillSkillVersions(auth, execute, logger, workspace, skill);
+  }
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting skill manually-requested-spaces backfill");
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillWorkspaceSkills(execute, logger, workspace);
+      },
+      { concurrency: 8, wId }
+    );
+
+    logger.info("Skill manually-requested-spaces backfill completed");
+  }
+);

--- a/front/migrations/pre-deploy/20260828113937_add_manually_requested_space_ids_to_skills.sql
+++ b/front/migrations/pre-deploy/20260828113937_add_manually_requested_space_ids_to_skills.sql
@@ -1,0 +1,17 @@
+/*
+Record which of a skill's requested spaces were picked by hand under "Data and access", so they can
+be kept when nothing in the skill requires them any more. The column is a subset of
+"requestedSpaceIds", which stays the single source of truth for access checks.
+*/
+
+/* Empty default: old code ignores the column, new code treats [] as "no manual spaces". */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations"
+  ADD COLUMN "manuallyRequestedSpaceIds" bigint[] DEFAULT ARRAY[]::bigint[] NOT NULL;
+
+/* Versions carry the same provenance so history and rollbacks stay consistent. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions"
+  ADD COLUMN "manuallyRequestedSpaceIds" bigint[] DEFAULT ARRAY[]::bigint[] NOT NULL;

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -26,6 +26,7 @@ type CreateSkillOverrides = Partial<{
   status: SkillStatus;
   version: number;
   requestedSpaceIds: ModelId[];
+  manuallyRequestedSpaceIds: ModelId[];
   addCurrentUserAsEditor: boolean;
   attachedKnowledge: SkillAttachedKnowledge[];
   mcpServerViews: MCPServerViewResource[];
@@ -84,6 +85,7 @@ export class SkillFactory {
     const status = overrides.status ?? "active";
     const editedBy = overrides.status === "suggested" ? null : user.id;
     const requestedSpaceIds = overrides.requestedSpaceIds ?? [];
+    const manuallyRequestedSpaceIds = overrides.manuallyRequestedSpaceIds ?? [];
     const attachedKnowledge = overrides.attachedKnowledge ?? [];
     const mcpServerViews = overrides.mcpServerViews ?? [];
 
@@ -97,6 +99,7 @@ export class SkillFactory {
         instructionsHtml: overrides.instructionsHtml,
         name,
         requestedSpaceIds,
+        manuallyRequestedSpaceIds,
         status,
         icon: SKILL_ICON.name,
         availability,
@@ -176,6 +179,7 @@ export class SkillFactory {
       icon: parentSkill.icon,
       mcpServerViews: parentSkill.mcpServerViews,
       attachedKnowledge: await parentSkill.getAttachedKnowledge(auth),
+      manuallyRequestedSpaceIds: parentSkill.manuallyRequestedSpaceIds,
       requestedSpaceIds: parentSkill.requestedSpaceIds,
     });
 


### PR DESCRIPTION
## Description:

Related to https://github.com/dust-tt/tasks/issues/9896

Adds `manuallyRequestedSpaceIds` to `skill_configurations` and `skill_versions`, and writes it on every path that touches a skill's spaces (create, update, space deletion), so the spaces a person picked by hand under Data and access are recorded instead of inferred. The old inference (`requestedSpaceIds` minus the spaces the skill's tools, knowledge and nested skills require) cannot represent a space that is both picked by hand and required automatically, which is how a manual selection gets forgotten.

The column is a subset of `requestedSpaceIds`, which stays the single source of truth for access checks. Reads still go through the inference in this PR

The backfill computes the derived set with the same resource-level code the write paths use under an Authenticator holding every group of the workspace so that nothing in a restricted space is hidden from it, and covers historical versions as well. 

Versions snapshot their tools and instructions but not their attached knowledge, so on a version a space that only knowledge required reads as hand-picked. Version rows are only displayed (history endpoint, Poke) and never written back into a skill, so that imprecision stays cosmetic, and it errs toward listing the space rather than hiding it.

## Tests

 - added unit tests
 - tested the backfill locally

## Deploy Plan
- merge and lock
- Run the pre-deploy migration `20260828113937_add_manually_requested_space_ids_to_skills.sql` 
- Deploy front.
- Run the backfill **after** the deploy, so live writes cannot race it:
   `npx tsx front/migrations/20260828_backfill_skill_manually_requested_spaces.ts --execute`