### PR TITLE
Skills: Store manually requested spaces 3/4: read the stored list

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -15179,6 +15179,13 @@
             },
             "description": "Space identifiers the skill needs access to"
           },
+          "manuallyRequestedSpaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Subset of requestedSpaceIds that was selected by hand rather than derived from the skill's tools, knowledge or nested skills\n"
+          },
           "fileAttachments": {
             "type": "array",
             "items": {

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -728,6 +728,13 @@
  *           items:
  *             type: string
  *           description: Space identifiers the skill needs access to
+ *         manuallyRequestedSpaceIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: >
+ *             Subset of requestedSpaceIds that was selected by hand rather than derived from the
+ *             skill's tools, knowledge or nested skills
  *         fileAttachments:
  *           type: array
  *           items:

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -910,15 +910,16 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     const openSpace = await SpaceFactory.regular(workspace);
     await SpaceFactory.attachGroup(openSpace, globalGroup);
 
+    // The space was picked by hand, which is what the write paths now record alongside the union.
     await skill.updateSkill(requestUserAuth, {
       agentFacingDescription: skill.agentFacingDescription,
       attachedKnowledge: [],
       icon: skill.icon,
       instructions: skill.instructions,
       instructionsHtml: skill.instructionsHtml,
+      manuallyRequestedSpaceIds: [openSpace.id],
       mcpServerViews: [],
       name: skill.name,
-      manuallyRequestedSpaceIds: [],
       requestedSpaceIds: [openSpace.id],
       userFacingDescription: skill.userFacingDescription,
     });
@@ -1125,6 +1126,17 @@ describe("PATCH /api/w/:wId/skills/:sId - manually requested spaces", () => {
     };
   }
 
+  function knowledge(dataSourceView: { sId: string }, space: { sId: string }) {
+    return [
+      {
+        dataSourceViewId: dataSourceView.sId,
+        nodeId: "folder1",
+        spaceId: space.sId,
+        title: "Folder 1",
+      },
+    ];
+  }
+
   it("stores the manually selected spaces, and snapshots them on the version", async () => {
     const { workspace, skill, requestUserAuth, space } =
       await setupSpaceWithKnowledge({ requestUserRole: "admin" });
@@ -1171,14 +1183,7 @@ describe("PATCH /api/w/:wId/skills/:sId - manually requested spaces", () => {
       skill.sId,
       patchBody(skill, {
         additionalRequestedSpaceIds: [space.sId],
-        attachedKnowledge: [
-          {
-            dataSourceViewId: dataSourceView.sId,
-            nodeId: "folder1",
-            spaceId: space.sId,
-            title: "Folder 1",
-          },
-        ],
+        attachedKnowledge: knowledge(dataSourceView, space),
       })
     );
     expect(await response.json()).not.toHaveProperty("error");
@@ -1189,6 +1194,75 @@ describe("PATCH /api/w/:wId/skills/:sId - manually requested spaces", () => {
     );
     expect(updatedSkill?.manuallyRequestedSpaceIds).toEqual([space.id]);
     expect(updatedSkill?.requestedSpaceIds).toContain(space.id);
+  });
+
+  it("keeps a manual space after the knowledge from it is removed", async () => {
+    const { workspace, skill, requestUserAuth, space, dataSourceView } =
+      await setupSpaceWithKnowledge({ requestUserRole: "admin" });
+
+    // Select the space by hand, then attach knowledge from it.
+    await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, { additionalRequestedSpaceIds: [space.sId] })
+    );
+    await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, {
+        additionalRequestedSpaceIds: [space.sId],
+        attachedKnowledge: knowledge(dataSourceView, space),
+      })
+    );
+
+    // Remove the knowledge. The space was picked by hand, so it stays.
+    const response = await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, { additionalRequestedSpaceIds: [space.sId] })
+    );
+    expect(await response.json()).not.toHaveProperty("error");
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill?.requestedSpaceIds).toContain(space.id);
+    expect(updatedSkill?.manuallyRequestedSpaceIds).toEqual([space.id]);
+  });
+
+  it("drops a knowledge-only space when its last knowledge item is removed", async () => {
+    const { workspace, skill, requestUserAuth, space, dataSourceView } =
+      await setupSpaceWithKnowledge({ requestUserRole: "admin" });
+
+    await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, {
+        additionalRequestedSpaceIds: [],
+        attachedKnowledge: knowledge(dataSourceView, space),
+      })
+    );
+
+    const withKnowledge = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(withKnowledge?.requestedSpaceIds).toContain(space.id);
+
+    const response = await patchSkill(
+      workspace,
+      skill.sId,
+      patchBody(skill, { additionalRequestedSpaceIds: [] })
+    );
+    expect(await response.json()).not.toHaveProperty("error");
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill?.requestedSpaceIds).not.toContain(space.id);
+    expect(updatedSkill?.manuallyRequestedSpaceIds).toEqual([]);
   });
 });
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -386,35 +386,9 @@ app.patch(
       }
 
       additionalRequestedSpaceIds = additionalRequestedSpaceIdsRes.value;
-    } else if (skill.manuallyRequestedSpaceIds.length > 0) {
-      // The skill has a stored manual list: keep it verbatim.
-      additionalRequestedSpaceIds = [...skill.manuallyRequestedSpaceIds];
     } else {
-      // TODO(skills-manual-spaces): drop this inference once every skill has been backfilled. It
-      // cannot tell a space that was picked by hand from one a tool or knowledge happens to
-      // require, which is why `manuallyRequestedSpaceIds` is now stored. An empty stored list is
-      // ambiguous until then — either never written, or written empty — and both resolve to the
-      // same answer here, since a skill with no manual spaces requests only what it derives.
-      const previousAttachedKnowledge = await skill.getAttachedKnowledge(auth);
-      const previousComputedRequestedSpaceIds =
-        await SkillResource.computeRequestedSpaceIds(auth, {
-          mcpServerViews: skill.mcpServerViews,
-          attachedKnowledge: previousAttachedKnowledge,
-        });
-      const previousReferencedSkillSpaceIds =
-        await getReferencedSkillSpaceModelIds(
-          auth,
-          skill.instructions,
-          skill.sId
-        );
-      const previousComputedRequestedSpaceIdsSet = new Set([
-        ...previousComputedRequestedSpaceIds,
-        ...previousReferencedSkillSpaceIds,
-      ]);
-
-      additionalRequestedSpaceIds = skill.requestedSpaceIds.filter(
-        (spaceId) => !previousComputedRequestedSpaceIdsSet.has(spaceId)
-      );
+      // A request that says nothing about the spaces leaves the manual selection as it is.
+      additionalRequestedSpaceIds = [...skill.manuallyRequestedSpaceIds];
     }
 
     const requestedSpaceIds = uniq([

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -366,6 +366,8 @@ app.patch(
       skill.sId
     );
 
+    // `additionalRequestedSpaceIds` is the wire name of the skill's manual space selection, stored
+    // as `manuallyRequestedSpaceIds`.
     let additionalRequestedSpaceIds: ModelId[];
 
     if (body.additionalRequestedSpaceIds !== undefined) {
@@ -391,10 +393,14 @@ app.patch(
       additionalRequestedSpaceIds = [...skill.manuallyRequestedSpaceIds];
     }
 
+    // A skill requests a space for one of four reasons: one of its tools lives there, some of its
+    // attached knowledge does, a skill it references requests it, or a person picked it by hand.
+    // Only the last one is stored; the other three are derived, and disappear with what pulled
+    // them in.
     const requestedSpaceIds = uniq([
-      ...computedRequestedSpaceIds,
-      ...referencedSkillSpaceIds,
-      ...additionalRequestedSpaceIds,
+      ...computedRequestedSpaceIds, // Tools and attached knowledge.
+      ...referencedSkillSpaceIds, // Nested skills.
+      ...additionalRequestedSpaceIds, // Picked by hand.
     ]);
 
     // Adding a restricted space can lock out editors that are already on the skill. `updateSkill`

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1519,6 +1519,8 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       const skill = await SkillFactory.create(adminAuth, {
         name: "Test Skill With Tool And Additional Space",
         requestedSpaceIds: [toolSpace!.id, additionalSpace!.id],
+        // Only the additional space was picked by hand; the tool space comes from the server view.
+        manuallyRequestedSpaceIds: [additionalSpace!.id],
         mcpServerViews: [serverView],
       });
 

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1566,7 +1566,9 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
         { ignoreWorkspaceLimit: true }
       );
       expect(childSpaceResult.isOk()).toBe(true);
-      const childSpace = childSpaceResult.isOk() ? childSpaceResult.value : null;
+      const childSpace = childSpaceResult.isOk()
+        ? childSpaceResult.value
+        : null;
 
       const server = await RemoteMCPServerFactory.create(workspace, {
         name: "Test Server",

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1537,6 +1537,85 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       expect(skillAfter!.requestedSpaceIds).toEqual([additionalSpace!.id]);
     });
 
+    it("should preserve a nested skill's spaces when deleting a dependency space", async () => {
+      // The parent requests two spaces for two different reasons: a tool of its own, and a child
+      // skill it references. Deleting the tool's space must not drop the child's.
+      const toolSpaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space With Parent Tool",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(toolSpaceResult.isOk()).toBe(true);
+      const toolSpace = toolSpaceResult.isOk() ? toolSpaceResult.value : null;
+
+      const childSpaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space With Child Tool",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(childSpaceResult.isOk()).toBe(true);
+      const childSpace = childSpaceResult.isOk() ? childSpaceResult.value : null;
+
+      const server = await RemoteMCPServerFactory.create(workspace, {
+        name: "Test Server",
+      });
+      const parentServerView = await MCPServerViewFactory.create(
+        workspace,
+        server.sId,
+        toolSpace!
+      );
+      const childServerView = await MCPServerViewFactory.create(
+        workspace,
+        server.sId,
+        childSpace!
+      );
+
+      const { parentSkill } = await SkillFactory.createWithNestedSkill(
+        adminAuth,
+        {
+          childOverrides: {
+            name: "Nested Child Skill",
+            requestedSpaceIds: [childSpace!.id],
+            mcpServerViews: [childServerView],
+          },
+          parentOverrides: {
+            name: "Nested Parent Skill",
+            requestedSpaceIds: [toolSpace!.id, childSpace!.id],
+            mcpServerViews: [parentServerView],
+          },
+        }
+      );
+
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        toolSpace!,
+        true // force delete
+      );
+      expect(deleteResult.isOk()).toBe(true);
+
+      const parentAfter = await SkillResource.fetchById(
+        adminAuth,
+        parentSkill.sId
+      );
+      expect(parentAfter).not.toBeNull();
+      expect(parentAfter!.requestedSpaceIds).not.toContain(toolSpace!.id);
+      // Requested through the child skill reference, not by hand.
+      expect(parentAfter!.requestedSpaceIds).toContain(childSpace!.id);
+      expect(parentAfter!.manuallyRequestedSpaceIds).toEqual([]);
+    });
+
     it("should only remove deleted space from agent requestedSpaceIds, keeping other spaces", async () => {
       // Create two non-restricted regular spaces (accessible via global group)
       const space1Result = await createSpaceAndGroup(

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -410,10 +410,12 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           )
         ).filter((spaceId) => spaceId !== space.id);
 
+        // Rebuilt from the same four reasons a skill requests a space as when it is saved, with
+        // the deleted space stripped from each of them.
         const requestedSpaceIds = uniq([
-          ...computedRequestedSpaceIds,
-          ...referencedSkillSpaceIds,
-          ...manuallyRequestedSpaceIds,
+          ...computedRequestedSpaceIds, // Tools and attached knowledge.
+          ...referencedSkillSpaceIds, // Nested skills.
+          ...manuallyRequestedSpaceIds, // Picked by hand.
         ]);
 
         // Log an error if the deleted space is still in requestedSpaceIds.

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -383,23 +383,8 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           (k) => !dataSourceViewIdSet.has(k.dataSourceView.id)
         );
 
-        // TODO(skills-manual-spaces): read `manuallyRequestedSpaceIds` here once every skill has
-        // been backfilled, and drop this inference.
-        const previousComputedRequestedSpaceIds =
-          await SkillResource.computeRequestedSpaceIds(auth, {
-            mcpServerViews: skill.mcpServerViews,
-            attachedKnowledge,
-          });
-        const previousComputedRequestedSpaceIdSet = new Set(
-          previousComputedRequestedSpaceIds
-        );
-        const additionalRequestedSpaceIds = skill.requestedSpaceIds.filter(
-          (spaceId) =>
-            spaceId !== space.id &&
-            !previousComputedRequestedSpaceIdSet.has(spaceId)
-        );
-
-        // A deleted space cannot stay a manual choice: nothing can grant access to it any more
+        // A deleted space cannot stay a manual choice: nothing can grant access to it any more,
+        // and an id pointing at a missing space would hide the skill from everyone.
         const manuallyRequestedSpaceIds =
           skill.manuallyRequestedSpaceIds.filter(
             (spaceId) => spaceId !== space.id
@@ -413,7 +398,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           });
         const requestedSpaceIds = uniq([
           ...computedRequestedSpaceIds,
-          ...additionalRequestedSpaceIds,
+          ...manuallyRequestedSpaceIds,
         ]);
 
         // Log an error if the deleted space is still in requestedSpaceIds.

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -11,6 +11,7 @@ import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/ag
 import { isDatabaseFileSystemPodName } from "@app/lib/api/file_system/storage_mode";
 import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects/connector";
 import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
+import { getReferencedSkillSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
@@ -396,8 +397,22 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
             mcpServerViews: filteredMCPServerViews,
             attachedKnowledge: filteredAttachedKnowledge,
           });
+
+        // The skills this one references keep requesting their own spaces: deleting an unrelated
+        // space must not drop them. A child may still request the space being deleted and the
+        // cleanup order across skills is not guaranteed, so drop it here rather than let it come
+        // back through a reference.
+        const referencedSkillSpaceIds = (
+          await getReferencedSkillSpaceModelIds(
+            auth,
+            skill.instructions,
+            skill.sId
+          )
+        ).filter((spaceId) => spaceId !== space.id);
+
         const requestedSpaceIds = uniq([
           ...computedRequestedSpaceIds,
+          ...referencedSkillSpaceIds,
           ...manuallyRequestedSpaceIds,
         ]);
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -4437,12 +4437,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   toJSON(auth: Authenticator): SkillType {
-    const requestedSpaceIds = this.requestedSpaceIds.map((spaceId) =>
+    const toSpaceId = (spaceId: ModelId) =>
       SpaceResource.modelIdToSId({
         id: spaceId,
         workspaceId: this.workspaceId,
-      })
-    );
+      });
+
+    const requestedSpaceIds = this.requestedSpaceIds.map(toSpaceId);
+    const manuallyRequestedSpaceIds =
+      this.manuallyRequestedSpaceIds.map(toSpaceId);
 
     // Code-defined (global) skills hide their instructions from the front-end by
     // default; a skill opts in via `exposeInstructions` in its definition (e.g.
@@ -4467,6 +4470,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions: hideInstructions ? null : this.instructions,
       instructionsHtml: hideInstructions ? null : this.instructionsHtml,
       requestedSpaceIds,
+      manuallyRequestedSpaceIds,
       icon: this.icon ?? null,
       reinforcement: this.reinforcement,
       lastReinforcementAnalysisAt:

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -81,6 +81,9 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   selfImprovementCostsCapMicroUsd: z.number().nullable(),
   selfImprovementCostsCapAwuCredits: z.number().nullable(),
   requestedSpaceIds: z.array(z.string()),
+  // The subset of `requestedSpaceIds` picked by hand under "Data and access". Optional so older
+  // clients that do not send it back are still accepted.
+  manuallyRequestedSpaceIds: z.array(z.string()).optional(),
   fileAttachments: z.array(
     z.object({
       fileId: z.string(),


### PR DESCRIPTION
## Description:
Related to https://github.com/dust-tt/tasks/issues/9896

Deletes the inference that guessed which requested spaces had been picked by hand, in the skill update route and in the space-deletion cleanup, and reads `manuallyRequestedSpaceIds` instead. Also serializes the field so the Skill Builder can stop guessing it in 4/4. A space required by a tool, knowledge or a nested skill now disappears when nothing needs it any more, while a hand-picked one stays until someone removes it.

Two existing tests set up their state by writing `requestedSpaceIds` without the manual list, which no write path does any more; their setup now records the manual space explicitly.

## Tests

new test cases

## Deploy plan

Need to run the migration for backfilling the manual spaces first
Deploy front