### PR TITLE
Skills: Store manually requested spaces 4/4: seed the builder from the stored list

### DIFF
--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.test.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.test.tsx
@@ -1,0 +1,197 @@
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
+import type { SkillSpaceRestrictionsContextType } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The real sheet pulls in the whole space/pod picker. The stub keeps the contract the section
+// depends on: it receives the draft selection, lets the test read it, and saves it back.
+interface SpaceSelectionSheetStubProps {
+  alreadyRequestedSpaceIds: Set<string>;
+  onSave: () => void;
+  open: boolean;
+  selectedSpaces: string[];
+}
+
+vi.mock(
+  "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage",
+  () => ({
+    SpaceSelectionSheet: ({
+      alreadyRequestedSpaceIds,
+      onSave,
+      open,
+      selectedSpaces,
+    }: SpaceSelectionSheetStubProps) =>
+      open ? (
+        <div>
+          <span data-testid="sheet-draft">{selectedSpaces.join(",")}</span>
+          <span data-testid="sheet-locked">
+            {[...alreadyRequestedSpaceIds].join(",")}
+          </span>
+          <button onClick={onSave}>Save spaces</button>
+        </div>
+      ) : null,
+  })
+);
+
+vi.mock("@app/components/shared/SpaceChips", () => ({
+  SpaceChips: () => null,
+}));
+
+vi.mock("@app/components/skill_builder/useRemoveSkillSpace", () => ({
+  useRemoveSkillSpace: () => ({
+    removeSpace: vi.fn(),
+    isRemovalDisabled: false,
+  }),
+}));
+
+let restrictionsContextMock: SkillSpaceRestrictionsContextType;
+
+vi.mock("@app/components/skill_builder/SkillSpaceRestrictionsContext", () => ({
+  useSkillSpaceRestrictionsContext: () => restrictionsContextMock,
+}));
+
+function makeRestrictionsContext(
+  overrides: Partial<SkillSpaceRestrictionsContextType>
+): SkillSpaceRestrictionsContextType {
+  return {
+    actionsBySpaceId: {},
+    allSpaces: [],
+    areSpaceRequirementsReady: true,
+    editorsWithoutSpaceAccess: [],
+    globalSpace: undefined,
+    initialRequestedSpaceIds: undefined,
+    knowledgeBySpaceId: {},
+    missingSpaceIds: [],
+    nonGlobalSpacesUsedBySkill: [],
+    nonGlobalSpacesWithRestrictions: [],
+    skillsBySpaceId: {},
+    spaceIdsUsedBySkill: new Set<string>(),
+    ...overrides,
+  };
+}
+
+function AdditionalSpacesProbe() {
+  const additionalSpaces = useWatch<SkillBuilderFormData, "additionalSpaces">({
+    name: "additionalSpaces",
+  });
+
+  return (
+    <span data-testid="additional-spaces">
+      {(additionalSpaces ?? []).join(",")}
+    </span>
+  );
+}
+
+function renderSection({ additionalSpaces }: { additionalSpaces: string[] }) {
+  // Defined once per render call so a rerender keeps the same component type, and with it the
+  // form state: the tests below need the field to survive a context change.
+  function Wrapper() {
+    const form = useForm<SkillBuilderFormData>({
+      defaultValues: { additionalSpaces },
+    });
+
+    return (
+      <FormProvider {...form}>
+        <SkillBuilderRequestedSpacesSection />
+        <AdditionalSpacesProbe />
+      </FormProvider>
+    );
+  }
+
+  const { rerender } = render(<Wrapper />);
+
+  return { rerenderSection: () => rerender(<Wrapper />) };
+}
+
+describe("SkillBuilderRequestedSpacesSection", () => {
+  beforeEach(() => {
+    restrictionsContextMock = makeRestrictionsContext({});
+  });
+
+  it("keeps a manually selected space that knowledge also requires when the sheet is saved", async () => {
+    // Space A was picked by hand and knowledge from Space A was attached afterwards, so the space
+    // is both manually selected and automatically required.
+    restrictionsContextMock = makeRestrictionsContext({
+      spaceIdsUsedBySkill: new Set(["space-a"]),
+    });
+
+    renderSection({ additionalSpaces: ["space-a"] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    // The draft must carry the space even though something else requires it too.
+    expect(screen.getByTestId("sheet-draft")).toHaveTextContent("space-a");
+    expect(screen.getByTestId("sheet-locked")).toHaveTextContent("space-a");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save spaces" }));
+
+    expect(screen.getByTestId("additional-spaces")).toHaveTextContent(
+      "space-a"
+    );
+  });
+
+  it("does not turn an automatically required space into a manual selection", async () => {
+    // Space B is only required by knowledge. The sheet renders it selected and locked, so saving
+    // must not record it as a manual choice.
+    restrictionsContextMock = makeRestrictionsContext({
+      spaceIdsUsedBySkill: new Set(["space-b"]),
+    });
+
+    renderSection({ additionalSpaces: [] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    expect(screen.getByTestId("sheet-draft")).toBeEmptyDOMElement();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save spaces" }));
+
+    expect(screen.getByTestId("additional-spaces")).toBeEmptyDOMElement();
+  });
+
+  it("keeps a manual space after the knowledge that also required it is removed", async () => {
+    // The reported flow: Space A is selected by hand and knowledge from Space A is attached, the
+    // Manage screen is opened and saved, then the knowledge is removed.
+    restrictionsContextMock = makeRestrictionsContext({
+      spaceIdsUsedBySkill: new Set(["space-a"]),
+    });
+
+    const { rerenderSection } = renderSection({
+      additionalSpaces: ["space-a"],
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save spaces" }));
+
+    // The knowledge goes away, so nothing requires the space automatically any more. The manual
+    // selection is what keeps it.
+    restrictionsContextMock = makeRestrictionsContext({
+      spaceIdsUsedBySkill: new Set<string>(),
+    });
+    rerenderSection();
+
+    expect(screen.getByTestId("additional-spaces")).toHaveTextContent(
+      "space-a"
+    );
+
+    // And it is still offered as a manual selection when the sheet is reopened.
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+    expect(screen.getByTestId("sheet-draft")).toHaveTextContent("space-a");
+  });
+
+  it("keeps manual selections that nothing else requires", async () => {
+    renderSection({ additionalSpaces: ["space-c"] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    expect(screen.getByTestId("sheet-draft")).toHaveTextContent("space-c");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save spaces" }));
+
+    expect(screen.getByTestId("additional-spaces")).toHaveTextContent(
+      "space-c"
+    );
+  });
+});

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -5,16 +5,14 @@ import { useSkillSpaceRestrictionsContext } from "@app/components/skill_builder/
 import { useRemoveSkillSpace } from "@app/components/skill_builder/useRemoveSkillSpace";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Button, Planet } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useState } from "react";
-import { useController, useFormContext } from "react-hook-form";
+import { useMemo, useState } from "react";
+import { useController } from "react-hook-form";
 
 export function SkillBuilderRequestedSpacesSection() {
-  const { resetField } = useFormContext<SkillBuilderFormData>();
-
-  const {
-    field: additionalSpacesField,
-    fieldState: additionalSpacesFieldState,
-  } = useController<SkillBuilderFormData, "additionalSpaces">({
+  const { field: additionalSpacesField } = useController<
+    SkillBuilderFormData,
+    "additionalSpaces"
+  >({
     name: "additionalSpaces",
   });
   const isReadOnly = additionalSpacesField.disabled ?? false;
@@ -25,8 +23,6 @@ export function SkillBuilderRequestedSpacesSection() {
   const {
     areSpaceRequirementsReady,
     globalSpace,
-    initialAdditionalSpaces,
-    initialRequestedSpaceIds,
     missingSpaceIds,
     nonGlobalSpacesUsedBySkill,
     spaceIdsUsedBySkill,
@@ -34,26 +30,6 @@ export function SkillBuilderRequestedSpacesSection() {
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [draftSelectedSpaces, setDraftSelectedSpaces] = useState<string[]>([]);
-
-  useEffect(() => {
-    if (
-      !areSpaceRequirementsReady ||
-      !initialRequestedSpaceIds ||
-      additionalSpacesFieldState.isDirty
-    ) {
-      return;
-    }
-
-    resetField("additionalSpaces", {
-      defaultValue: initialAdditionalSpaces,
-    });
-  }, [
-    areSpaceRequirementsReady,
-    additionalSpacesFieldState.isDirty,
-    initialAdditionalSpaces,
-    initialRequestedSpaceIds,
-    resetField,
-  ]);
 
   const handleOpenSheet = () => {
     if (!areSpaceRequirementsReady) {

--- a/front/components/skill_builder/SkillBuilderVersionComparisonFooter.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonFooter.tsx
@@ -29,6 +29,14 @@ export function SkillBuilderVersionComparisonFooter() {
     setValue("fileAttachments", compareVersion.fileAttachments, {
       shouldDirty: true,
     });
+    // The version's hand-picked spaces.
+    // The spaces the current knowledge/tools/skills require are recomputed on save
+    // and are unaffected by this.
+    setValue(
+      "additionalSpaces",
+      compareVersion.manuallyRequestedSpaceIds ?? [],
+      { shouldDirty: true }
+    );
     exitDiffMode();
   };
 

--- a/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
+++ b/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
@@ -21,13 +21,12 @@ export interface EditorWithoutSpaceAccess {
   missingSpaces: SpaceType[];
 }
 
-interface SkillSpaceRestrictionsContextType {
+export interface SkillSpaceRestrictionsContextType {
   actionsBySpaceId: ReturnType<typeof getSpaceIdToActionsMap>;
   allSpaces: EnrichedSpaceType[];
   areSpaceRequirementsReady: boolean;
   editorsWithoutSpaceAccess: EditorWithoutSpaceAccess[];
   globalSpace: EnrichedSpaceType | undefined;
-  initialAdditionalSpaces: string[];
   initialRequestedSpaceIds?: string[];
   knowledgeBySpaceId: Record<string, AttachedKnowledgeFormData[]>;
   missingSpaceIds: string[];
@@ -142,20 +141,6 @@ export function SkillSpaceRestrictionsProvider({
     return skillsBySpace;
   }, [referencedSkills]);
 
-  const initialAdditionalSpaces = useMemo(() => {
-    if (!areSpaceRequirementsReady || !initialRequestedSpaceIds?.length) {
-      return [];
-    }
-
-    return initialRequestedSpaceIds.filter(
-      (spaceId) => !spaceIdsUsedBySkill.has(spaceId)
-    );
-  }, [
-    areSpaceRequirementsReady,
-    initialRequestedSpaceIds,
-    spaceIdsUsedBySkill,
-  ]);
-
   const additionalSpaceIds = useMemo(() => {
     return new Set(additionalSpaces ?? []);
   }, [additionalSpaces]);
@@ -228,7 +213,6 @@ export function SkillSpaceRestrictionsProvider({
       areSpaceRequirementsReady,
       editorsWithoutSpaceAccess,
       globalSpace,
-      initialAdditionalSpaces,
       initialRequestedSpaceIds,
       knowledgeBySpaceId,
       missingSpaceIds,
@@ -243,7 +227,6 @@ export function SkillSpaceRestrictionsProvider({
       areSpaceRequirementsReady,
       editorsWithoutSpaceAccess,
       globalSpace,
-      initialAdditionalSpaces,
       initialRequestedSpaceIds,
       knowledgeBySpaceId,
       missingSpaceIds,

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -26,7 +26,7 @@ export function transformSkillTypeToFormData(
     icon: skill.icon ?? null,
     availability: skill.availability,
     reinforcement: skill.reinforcement,
-    additionalSpaces: [],
+    additionalSpaces: skill.manuallyRequestedSpaceIds ?? [],
     referencedSkills:
       skill.relations?.childSkills.map((childSkill) => ({
         id: childSkill.sId,


### PR DESCRIPTION
## Description:
closes https://github.com/dust-tt/tasks/issues/9896

The Skill Builder derived its manual space selection by subtracting the spaces the skill currently requires from the ones it requested, which forgot any space that both a person and some knowledge had asked for. The form now starts from `manuallyRequestedSpaceIds` as served by the API, which also removes the hydration effect that had to wait for the skill's knowledge and nested skills to load before it could guess.

This closes the reported bug: a manually selected space stays under Data and access until someone removes it, and an automatically required one disappears when nothing in the skill needs it any more.

## Tests

Added UI tests

## Deploy plan

Deploy front.