### PR TITLE
Spaces members: fix issue where some members could be dropped from space on save

### DIFF
--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -1,5 +1,4 @@
 import { ConfirmContext } from "@app/components/Confirm";
-import type { SearchMemberType } from "@app/components/members/MemberSelectionTable";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
@@ -18,7 +17,7 @@ import type { GroupType } from "@app/types/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { PlanType } from "@app/types/plan";
 import type { SpaceType } from "@app/types/space";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Input,
   Page,
@@ -29,6 +28,7 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  Spinner,
 } from "@dust-tt/sparkle";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -58,8 +58,10 @@ export function CreateOrEditSpaceModal({
 }: CreateOrEditSpaceModalProps) {
   const confirm = React.useContext(ConfirmContext);
   const [spaceName, setSpaceName] = useState<string>(space?.name ?? "");
-  const [selectedMembers, setSelectedMembers] = useState<SearchMemberType[]>(
-    []
+  // The member selection is held as ids, not as user objects: the ids are what the save sends, so
+  // a member can never drop out of the space because the UI failed to resolve their user object.
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(
+    () => new Set()
   );
   const [selectedGroups, setSelectedGroups] = useState<GroupType[]>([]);
 
@@ -86,7 +88,7 @@ export function CreateOrEditSpaceModal({
 
   const router = useAppRouter();
 
-  const { spaceInfo, mutateSpaceInfo } = useSpaceInfo({
+  const { spaceInfo, mutateSpaceInfo, isSpaceInfoLoading } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId: space?.sId ?? null,
     includeAllMembers: true, // Always include all members so we can see suspended ones when switching modes
@@ -132,19 +134,17 @@ export function CreateOrEditSpaceModal({
         : (defaultRestricted ?? false);
       setIsRestricted(isRestricted);
 
-      let initialMembers: UserType[] = [];
+      let initialMemberIds: string[] = [];
       if (spaceMembers && space) {
-        initialMembers = spaceMembers;
-      } else if (!space) {
-        initialMembers = [];
+        initialMemberIds = spaceMembers.map((member) => member.sId);
       }
 
       // Auto-add current user when opening with restricted access for new spaces
-      if (isRestricted && !space && user && initialMembers.length === 0) {
-        initialMembers = [user];
+      if (isRestricted && !space && user && initialMemberIds.length === 0) {
+        initialMemberIds = [user.sId];
       }
 
-      setSelectedMembers(initialMembers);
+      setSelectedMemberIds(new Set(initialMemberIds));
     }
   }, [
     defaultRestricted,
@@ -165,7 +165,7 @@ export function CreateOrEditSpaceModal({
       // Reset state.
       setSpaceName("");
       setIsRestricted(false);
-      setSelectedMembers([]);
+      setSelectedMemberIds(new Set());
       setSelectedGroups([]);
       setManagementType("manual");
       setIsDeleting(false);
@@ -210,7 +210,7 @@ export function CreateOrEditSpaceModal({
       } else {
         await doUpdate(space, {
           isRestricted,
-          memberIds: selectedMembers.map((vm) => vm.sId),
+          memberIds: Array.from(selectedMemberIds),
           editorIds: [],
           managementMode: "manual",
           name: trimmedName,
@@ -234,7 +234,7 @@ export function CreateOrEditSpaceModal({
         createdSpace = await doCreate({
           name: trimmedName,
           isRestricted,
-          memberIds: selectedMembers.map((vm) => vm.sId),
+          memberIds: Array.from(selectedMemberIds),
           managementMode: "manual",
           spaceKind: "regular",
         });
@@ -257,7 +257,7 @@ export function CreateOrEditSpaceModal({
     onCreated,
     space,
     spaceInfo,
-    selectedMembers,
+    selectedMemberIds,
     spaceName,
     managementType,
     selectedGroups,
@@ -293,7 +293,7 @@ export function CreateOrEditSpaceModal({
 
     const canSave =
       !isRestricted ||
-      (managementType === "manual" && selectedMembers.length > 0) ||
+      (managementType === "manual" && selectedMemberIds.size > 0) ||
       (managementType === "group" && selectedGroups.length > 0);
 
     if (!spaceInfo) {
@@ -304,13 +304,19 @@ export function CreateOrEditSpaceModal({
   }, [
     isRestricted,
     managementType,
-    selectedMembers.length,
+    selectedMemberIds.size,
     selectedGroups.length,
     spaceInfo,
     isDirty,
     spaceName,
   ]);
   const isManual = !scimEnabled || managementType === "manual";
+
+  // When editing an existing space, hold the access section back until its members have loaded: the
+  // toggle's state and the member table's contents both come from `spaceInfo`, and the table seeds
+  // its display cache once, at mount. Rendering it early shows an empty member list.
+  // `isSpaceInfoLoading` stays true when there is no space (the hook is disabled), hence the guard.
+  const isLoadingSpaceInfo = !!space && isSpaceInfoLoading;
 
   const handleNameChange = useCallback((value: string) => {
     setSpaceName(value);
@@ -339,64 +345,75 @@ export function CreateOrEditSpaceModal({
               isDeleting={isDeleting}
             />
 
-            <RestrictedAccessHeader
-              isRestricted={isRestricted}
-              onToggle={() => {
-                const newRestricted = !isRestricted;
-                setIsRestricted(newRestricted);
-                setIsDirty(true);
-                if (
-                  newRestricted &&
-                  !space &&
-                  user &&
-                  selectedMembers.length === 0
-                ) {
-                  setSelectedMembers([user, ...selectedMembers]);
-                }
-              }}
-              restrictedDescription={
-                <>
-                  <span>Restricted access is active.</span>
-                  <span>
-                    Members can read the content of the space and write data
-                    into it (upload files, delete documents...).
-                  </span>
-                </>
-              }
-              unrestrictedDescription={
-                <>
-                  <span>Restricted access is disabled. The space is open.</span>
-                  <span>
-                    Anyone in the workspace can read the data from this space.
-                  </span>
-                  <span>
-                    Members of the space can also write data (upload files,
-                    delete documents...).
-                  </span>
-                </>
-              }
-            />
+            {isLoadingSpaceInfo ? (
+              <div className="flex justify-center p-8">
+                <Spinner />
+              </div>
+            ) : (
+              <>
+                <RestrictedAccessHeader
+                  isRestricted={isRestricted}
+                  onToggle={() => {
+                    const newRestricted = !isRestricted;
+                    setIsRestricted(newRestricted);
+                    setIsDirty(true);
+                    if (
+                      newRestricted &&
+                      !space &&
+                      user &&
+                      selectedMemberIds.size === 0
+                    ) {
+                      setSelectedMemberIds(new Set([user.sId]));
+                    }
+                  }}
+                  restrictedDescription={
+                    <>
+                      <span>Restricted access is active.</span>
+                      <span>
+                        Members can read the content of the space and write data
+                        into it (upload files, delete documents...).
+                      </span>
+                    </>
+                  }
+                  unrestrictedDescription={
+                    <>
+                      <span>
+                        Restricted access is disabled. The space is open.
+                      </span>
+                      <span>
+                        Anyone in the workspace can read the data from this
+                        space.
+                      </span>
+                      <span>
+                        Members of the space can also write data (upload files,
+                        delete documents...).
+                      </span>
+                    </>
+                  }
+                />
 
-            {/* Shown in both states: an open space still has members, and they are the ones who
-                can write to it. The toggle only controls who can read. */}
-            <RestrictedAccessBody
-              isManual={isManual}
-              scimEnabled={scimEnabled}
-              managementType={managementType}
-              owner={owner}
-              selectedMembers={selectedMembers}
-              selectedGroups={selectedGroups}
-              onManagementTypeChange={handleManagementTypeChange}
-              onMembersUpdated={(members) => {
-                setSelectedMembers(members);
-                setIsDirty(true);
-              }}
-              onGroupsUpdated={(groups) => {
-                setSelectedGroups(groups);
-                setIsDirty(true);
-              }}
-              initialMembers={spaceInfo?.members}
-            />
+                {/* Shown in both states: an open space still has members, and they are the ones
+                    who can write to it. The toggle only controls who can read. */}
+                <RestrictedAccessBody
+                  isManual={isManual}
+                  scimEnabled={scimEnabled}
+                  managementType={managementType}
+                  owner={owner}
+                  selectedMemberIds={selectedMemberIds}
+                  selectedGroups={selectedGroups}
+                  onManagementTypeChange={handleManagementTypeChange}
+                  onMemberIdsUpdated={(memberIds) => {
+                    setSelectedMemberIds(memberIds);
+                    setIsDirty(true);
+                  }}
+                  onGroupsUpdated={(groups) => {
+                    setSelectedGroups(groups);
+                    setIsDirty(true);
+                  }}
+                  initialMembers={spaceInfo?.members}
+                />
+              </>
+            )}
           </div>
         </SheetContainer>
         <SheetFooter

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -26,10 +26,10 @@ interface RestrictedAccessBodyProps {
   scimEnabled: boolean;
   managementType: MembersManagementType;
   owner: LightWorkspaceType;
-  selectedMembers: SearchMemberType[];
+  selectedMemberIds: Set<string>;
   selectedGroups: GroupType[];
   onManagementTypeChange: (managementType: MembersManagementType) => void;
-  onMembersUpdated: (members: SearchMemberType[]) => void;
+  onMemberIdsUpdated: (memberIds: Set<string>) => void;
   onGroupsUpdated: (groups: GroupType[]) => void;
   initialMembers?: SearchMemberType[];
 }
@@ -39,30 +39,22 @@ export function RestrictedAccessBody({
   scimEnabled,
   managementType,
   owner,
-  selectedMembers,
+  selectedMemberIds,
   selectedGroups,
   onManagementTypeChange,
-  onMembersUpdated,
+  onMemberIdsUpdated,
   onGroupsUpdated,
   initialMembers,
 }: RestrictedAccessBodyProps) {
   const confirm = useContext(ConfirmContext);
-
-  const selectedMemberIds = useMemo(
-    () => new Set(selectedMembers.map((m) => m.sId)),
-    [selectedMembers]
-  );
 
   const selectedGroupIds = useMemo(
     () => new Set(selectedGroups.map((g) => g.sId)),
     [selectedGroups]
   );
 
-  const handleMemberSelectionChange = (
-    _ids: Set<string>,
-    users: SearchMemberType[]
-  ) => {
-    onMembersUpdated(users);
+  const handleMemberSelectionChange = (ids: Set<string>) => {
+    onMemberIdsUpdated(ids);
   };
 
   const handleGroupSelectionChange = (
@@ -80,7 +72,7 @@ export function RestrictedAccessBody({
     if (
       managementType === "manual" &&
       newManagementType === "group" &&
-      selectedMembers.length > 0
+      selectedMemberIds.size > 0
     ) {
       const confirmed = await confirm({
         title: "Switch to groups",


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/10237

### What could happen

`PATCH /api/w/:wId/spaces/:spaceId/members` takes the **absolute** member list and diffs it server-side (`GroupResource.dangerouslySetMembers`): anyone not in the payload has their group membership ended. So a truncated payload silently removes members.

The space settings modal could build exactly such a truncated payload:

  1. `MemberSelectionTable` keeps an `sId -> user object` cache (`userMapRef`) that is seeded **once, at mount**, from `initialMembers` (`spaceInfo.members`).
  2. On every selection change it converted the (complete) set of selected ids back into user objects, **dropping any id the cache couldn't resolve**, and `RestrictedAccessBody` discarded the ids in favour of those objects. `onSave`  then re-derived `memberIds` from them — a lossy `ids → objects → ids` round trip.
  3. Since #31094 `RestrictedAccessBody` renders unconditionally instead of behind `isRestricted` (which was only ever true after `spaceInfo` had loaded), so the table can now mount while `useSpaceInfo({ includeAllMembers: true })` is still in flight — with an **empty** cache that is never re-seeded.

Result: on a space whose `GET` is slow (many members, categories + usage), an admin who opens the settings and ticks one new member before the fetch lands saves a member list reduced to whoever happened to pass through the search results. Fast / small workspaces never hit the window, which is why this doesn't reproduce easily.

### The two fixes

**1. Don't render the access section until the space info has loaded.**
`CreateOrEditSpaceModal` now gates `RestrictedAccessHeader` + `RestrictedAccessBody` on `isLoadingSpaceInfo` (a spinner in the meantime), so the table always mounts with a fully seeded cache. This also stops the modal from briefly showing an empty member list and an "unrestricted" toggle for a restricted space.

**2. Make ids the source of truth for the selection.**
`CreateOrEditSpaceModal` holds `selectedMemberIds: Set<string>` instead of `SearchMemberType[]`, and `RestrictedAccessBody` forwards the ids the table emits rather than the resolved objects. The user objects are now only used for rendering rows, so a cache miss can at worst cost a missing row — it can no longer drop a member from the saved payload. (Same pattern `GroupDialog` already uses.)

## Tests

not really tested as it is hard to reproduce
just tested that the UI still work as expected

## Risk

impact is only on the UI to manage space members

## Deploy Plan

deploy front
