### PR TITLE
Fix: DockerFile

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -86,7 +86,8 @@ RUN curl -sSfLo /tmp/op.zip \
 
 # Postgres dev user (databases are created at agent start by init-databases.sh)
 RUN service postgresql start \
-  && sudo -u postgres psql -v ON_ERROR_STOP=1 -c "DO $$ BEGIN CREATE USER dev WITH PASSWORD 'dev' SUPERUSER; EXCEPTION WHEN duplicate_object THEN NULL; END $$;" \
+  && (sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='dev'" | grep -q 1 \
+      || sudo -u postgres psql -v ON_ERROR_STOP=1 -c "CREATE USER dev WITH PASSWORD 'dev' SUPERUSER;") \
   && sudo -u postgres psql -c "ALTER USER dev WITH SUPERUSER;" \
   && service postgresql stop
 

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -1,5 +1,3 @@
-// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
-import type { WorkOSOrganizationType } from "@dust-tt/client";
 import * as t from "io-ts";
 import { z } from "zod";
 import type {
@@ -28,6 +26,15 @@ function keyObject<T extends readonly string[]>(
     [K in T[number]]: null;
   };
 }
+
+type WorkOSOrganizationType = {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  externalId: string | null;
+  metadata: Record<string, string>;
+};
 
 export const RoleSchema = t.keyof(keyObject(ROLES));
 


### PR DESCRIPTION
## Description

Make the dev image's PostgreSQL role creation idempotent by checking `pg_roles` before creating `dev`, avoiding failures during image builds. Replace the `@dust-tt/client` `WorkOSOrganizationType` import in `front/types/user.ts` with a local structural type that satisfies the client-type lint boundary.

## Tests

No automated tests added or run. The changes are limited to development image provisioning and compile-time TypeScript types.

## Risk

Low. The Docker change only affects development image builds; the local type has no runtime behavior. Rollback is a single commit revert.

## Deploy Plan

Rebuild the shared development image to pick up the PostgreSQL initialization fix. No SQL migration or production deployment is required.