### PR TITLE
[front] poke: show conversation wake-ups

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -10,6 +10,7 @@ import config from "./config";
 import consumption from "./consumption";
 import reinforcementTestCase from "./reinforcement_test_case";
 import render from "./render";
+import wakeups from "./wakeups";
 
 export type PokeGetConversationResponseBody = {
   conversation: PokeConversationType;
@@ -43,5 +44,6 @@ app.route("/config", config);
 app.route("/consumption", consumption);
 app.route("/reinforcement_test_case", reinforcementTestCase);
 app.route("/render", render);
+app.route("/wakeups", wakeups);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/wakeups.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/wakeups.test.ts
@@ -1,0 +1,113 @@
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function setup() {
+  const { workspace, auth } = await createPrivateApiMockRequest({
+    isSuperUser: true,
+    role: "admin",
+  });
+
+  const agentConfiguration =
+    await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [new Date()],
+  });
+
+  return { agentConfiguration, auth, conversation, workspace };
+}
+
+function wakeUpsUrl(workspaceId: string, conversationId: string) {
+  return `/api/poke/workspaces/${workspaceId}/conversations/${conversationId}/wakeups`;
+}
+
+describe("GET /api/poke/workspaces/:wId/conversations/:cId/wakeups", () => {
+  beforeEach(() => {
+    vi.spyOn(
+      wakeUpClient,
+      "launchOrScheduleWakeUpTemporalWorkflow"
+    ).mockResolvedValue(new Ok(undefined));
+    vi.spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow").mockResolvedValue(
+      new Ok(undefined)
+    );
+  });
+
+  it("returns the conversation wake-ups", async () => {
+    const { agentConfiguration, auth, conversation, workspace } = await setup();
+
+    const wakeUp = await WakeUpFactory.cron(
+      auth,
+      conversation,
+      agentConfiguration,
+      { cronExpression: "0 7 * * *", reason: "daily digest" }
+    );
+
+    const response = await honoApp.request(
+      wakeUpsUrl(workspace.sId, conversation.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.wakeUps).toHaveLength(1);
+    expect(data.wakeUps[0]).toMatchObject({
+      sId: wakeUp.sId,
+      agentConfigurationId: agentConfiguration.sId,
+      reason: "daily digest",
+      status: "scheduled",
+      scheduleConfig: {
+        type: "cron",
+        cron: "0 7 * * *",
+        timezone: "Europe/Paris",
+      },
+    });
+  });
+
+  it("includes terminal wake-ups", async () => {
+    const { agentConfiguration, auth, conversation, workspace } = await setup();
+
+    const wakeUp = await WakeUpFactory.cron(
+      auth,
+      conversation,
+      agentConfiguration
+    );
+    const cancelRes = await wakeUp.cancel(auth);
+    expect(cancelRes.isOk()).toBe(true);
+
+    const response = await honoApp.request(
+      wakeUpsUrl(workspace.sId, conversation.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.wakeUps).toHaveLength(1);
+    expect(data.wakeUps[0].status).toBe("cancelled");
+  });
+
+  it("returns an empty list when the conversation has no wake-up", async () => {
+    const { conversation, workspace } = await setup();
+
+    const response = await honoApp.request(
+      wakeUpsUrl(workspace.sId, conversation.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.wakeUps).toEqual([]);
+  });
+
+  it("returns 404 for an unknown conversation", async () => {
+    const { workspace } = await setup();
+
+    const response = await honoApp.request(
+      wakeUpsUrl(workspace.sId, "unknown-conversation")
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/wakeups.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/wakeups.ts
@@ -1,0 +1,45 @@
+import type { PokeListConversationWakeUps } from "@app/lib/api/poke/conversations";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/wakeups.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeListConversationWakeUps> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
+
+    const conversation = await ConversationResource.fetchById(auth, cId, {
+      includeDeleted: true,
+    });
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    // Every status, not just the active ones: Poke is an inspection surface, so cancelled,
+    // fired and expired wake-ups are what makes the history readable.
+    const wakeUps = await WakeUpResource.listByConversation(auth, conversation);
+
+    return ctx.json({ wakeUps: wakeUps.map((w) => w.toJSON()) });
+  }
+);
+
+export default app;

--- a/front/components/poke/conversation/wakeups_inspector.tsx
+++ b/front/components/poke/conversation/wakeups_inspector.tsx
@@ -1,0 +1,179 @@
+import {
+  describeWakeUpSchedule,
+  getNextWakeUpFireAtFromScheduleConfig,
+} from "@app/lib/utils/wakeup_description";
+import { usePokeConversationWakeUps } from "@app/poke/swr/conversation_wakeups";
+import type { WakeUpStatus, WakeUpType } from "@app/types/assistant/wakeups";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+
+type ChipColor = NonNullable<ComponentProps<typeof Chip>["color"]>;
+
+function getWakeUpStatusColor(status: WakeUpStatus): ChipColor {
+  switch (status) {
+    case "scheduled":
+      return "highlight";
+    case "fired":
+      return "success";
+    case "cancelled":
+      return "primary";
+    case "expired":
+      return "warning";
+    default:
+      assertNeverAndIgnore(status);
+      return "primary";
+  }
+}
+
+interface WakeUpFieldProps {
+  label: string;
+  value: string;
+  mono?: boolean;
+}
+
+function WakeUpField({ label, value, mono }: WakeUpFieldProps) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
+      <span
+        className={
+          mono
+            ? "min-w-0 truncate font-mono text-xs tabular-nums text-foreground"
+            : "min-w-0 truncate text-xs text-foreground"
+        }
+        title={value}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface WakeUpEntryProps {
+  wakeUp: WakeUpType;
+}
+
+function WakeUpEntry({ wakeUp }: WakeUpEntryProps) {
+  // Only a still-scheduled wake-up has a firing ahead of it; for terminal ones the cron parser
+  // would happily keep projecting future dates that will never happen.
+  const nextFireAt =
+    wakeUp.status === "scheduled"
+      ? getNextWakeUpFireAtFromScheduleConfig(wakeUp.scheduleConfig)
+      : null;
+
+  return (
+    <div className="flex flex-col gap-1.5 p-4">
+      <div className="flex items-start justify-between gap-2">
+        <span className="min-w-0 text-sm font-medium text-foreground">
+          {wakeUp.reason}
+        </span>
+        <Chip
+          color={getWakeUpStatusColor(wakeUp.status)}
+          label={wakeUp.status}
+          size="mini"
+        />
+      </div>
+      <WakeUpField label="schedule" value={describeWakeUpSchedule(wakeUp)} />
+      {wakeUp.scheduleConfig.type === "cron" && (
+        <>
+          <WakeUpField label="cron" value={wakeUp.scheduleConfig.cron} mono />
+          <WakeUpField
+            label="timezone"
+            value={wakeUp.scheduleConfig.timezone}
+          />
+        </>
+      )}
+      {nextFireAt !== null && (
+        <WakeUpField
+          label="next fire"
+          value={new Date(nextFireAt).toLocaleString()}
+          mono
+        />
+      )}
+      <WakeUpField
+        label="fires"
+        value={`${wakeUp.fireCount} / ${wakeUp.maxFires}`}
+        mono
+      />
+      <WakeUpField label="owner" value={wakeUp.user.fullName} />
+      <WakeUpField label="agent" value={wakeUp.agentConfigurationId} mono />
+      <WakeUpField label="id" value={wakeUp.sId} mono />
+      <WakeUpField
+        label="created"
+        value={new Date(wakeUp.createdAt).toLocaleString()}
+        mono
+      />
+    </div>
+  );
+}
+
+interface PokeConversationWakeUpsInspectorProps {
+  conversationId: string;
+  owner: LightWorkspaceType;
+}
+
+export function PokeConversationWakeUpsInspector({
+  conversationId,
+  owner,
+}: PokeConversationWakeUpsInspectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { wakeUps, isWakeUpsError, isWakeUpsLoading } =
+    usePokeConversationWakeUps({
+      conversationId,
+      disabled: !isOpen,
+      owner,
+    });
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="overflow-hidden rounded-xl border border-border bg-background"
+    >
+      <CollapsibleTrigger className="min-h-11 w-full justify-between gap-3 p-4 text-left">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center">
+            <span className="text-sm font-semibold text-foreground">
+              Wake-ups
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Agent-scheduled wake-ups for this conversation, in any status.
+          </p>
+        </div>
+        {isWakeUpsLoading && <Spinner size="xs" />}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="border-t border-border">
+        {isWakeUpsError ? (
+          <p role="alert" className="p-4 text-sm text-warning">
+            Wake-ups could not be loaded.
+          </p>
+        ) : isWakeUpsLoading ? (
+          <div className="flex min-h-32 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : wakeUps.length === 0 ? (
+          <p className="p-4 text-sm text-muted-foreground">
+            No wake-up was ever scheduled in this conversation.
+          </p>
+        ) : (
+          <div className="divide-y divide-border">
+            {wakeUps.map((wakeUp) => (
+              <WakeUpEntry key={wakeUp.sId} wakeUp={wakeUp} />
+            ))}
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1,4 +1,5 @@
 import { PokeConversationConsumptionInspector } from "@app/components/poke/conversation/consumption_inspectors";
+import { PokeConversationWakeUpsInspector } from "@app/components/poke/conversation/wakeups_inspector";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import type { AgentMessageCreditsToolBreakdown } from "@app/lib/api/assistant/credit_cost";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -618,6 +619,9 @@ const UserMessageView = ({ message, useMarkdown }: UserMessageViewProps) => {
           )}
           <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
             <span>date: {new Date(message.created).toLocaleString()}</span>
+            {message.context.origin === "wakeup" && (
+              <StatusBadge label="wake-up" color="highlight" />
+            )}
             <StatusBadge
               label={
                 USER_VISIBILITY[message.visibility]?.label ?? message.visibility
@@ -1291,10 +1295,14 @@ export function ConversationPage() {
             </div>
           )}
           <div className="grid w-full grid-cols-1 gap-6 py-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
-            <aside className="xl:sticky xl:top-4 xl:col-start-2 xl:row-start-1 xl:self-start">
+            <aside className="flex flex-col gap-4 xl:sticky xl:top-4 xl:col-start-2 xl:row-start-1 xl:self-start">
               <PokeConversationConsumptionInspector
                 conversationId={conversationId}
                 workspaceId={owner.sId}
+              />
+              <PokeConversationWakeUpsInspector
+                conversationId={conversationId}
+                owner={owner}
               />
             </aside>
             <div className="flex min-w-0 flex-col justify-start gap-8 xl:col-start-1 xl:row-start-1">

--- a/front/lib/api/poke/conversations.ts
+++ b/front/lib/api/poke/conversations.ts
@@ -3,6 +3,7 @@ import type {
   ConversationVisibility,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { PokeSandboxType } from "@app/types/poke";
 
 export type PokeListConversationItem = ConversationWithoutContentType & {
@@ -15,6 +16,10 @@ export type PokeListConversations = {
   // filtering. Equal to the returned length on the trigger and reinforced-skill
   // listings, which are not paged.
   totalCount: number;
+};
+
+export type PokeListConversationWakeUps = {
+  wakeUps: WakeUpType[];
 };
 
 export type PokeGetConversationConfig = {

--- a/front/poke/swr/conversation_wakeups.ts
+++ b/front/poke/swr/conversation_wakeups.ts
@@ -1,0 +1,31 @@
+import type { PokeListConversationWakeUps } from "@app/lib/api/poke/conversations";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeConversationWakeUpsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  conversationId: string;
+}
+
+export function usePokeConversationWakeUps({
+  disabled,
+  owner,
+  conversationId,
+}: UsePokeConversationWakeUpsProps) {
+  const { fetcher } = useFetcher();
+  const wakeUpsFetcher: Fetcher<PokeListConversationWakeUps> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/wakeups`,
+    wakeUpsFetcher,
+    { disabled }
+  );
+
+  return {
+    wakeUps: data?.wakeUps ?? emptyArray(),
+    isWakeUpsLoading: !error && !data && !disabled,
+    isWakeUpsError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
Convo shows wake-ups:
<img width="1192" height="497" alt="Screenshot 2026-08-28 at 13 32 36" src="https://github.com/user-attachments/assets/45ba1e17-bed1-4016-b92e-7c78f7e3e9f4" />


And system message is tagged:
<img width="419" height="168" alt="Screenshot 2026-08-28 at 13 32 41" src="https://github.com/user-attachments/assets/278e1b98-7e1a-410e-b6e4-dddca9d28c23" />


### Description

Poke had no way to see wake-ups. Scheduled ones were entirely invisible, and a fired wake-up rendered as an ordinary user message with nothing marking where it came from — the only trace of the feature anywhere in the Poke tree was `WakeUpResource.deleteAllForUser` in the scrub activity.

This adds a wake-ups panel to the Poke conversation page and a badge on wake-up-triggered messages.

**Endpoint** — `GET /api/poke/workspaces/:wId/conversations/:cId/wakeups` lists every wake-up on the conversation in *any* status (scheduled, fired, cancelled, expired): Poke is an inspection surface, so the terminal ones are what make the history readable. It fetches the conversation with `includeDeleted: true`, like the sibling `config` route, so deleted conversations still show theirs.

**Panel** — a `Collapsible` in the conversation page's right-hand aside, mirroring `PokeConversationConsumptionInspector` (including `disabled: !isOpen`, so nothing is fetched while collapsed). Each entry shows the reason, a status chip, the human schedule phrase from `describeWakeUpSchedule`, raw cron + timezone for cron schedules, next fire time, `fireCount / maxFires`, owner, agent sId, wake-up sId and creation time. Next-fire is computed only for `scheduled` wake-ups — for terminal ones the cron parser would happily keep projecting firings that will never happen.

**Badge** — `UserMessageView` now renders a `wake-up` chip when `message.context.origin === "wakeup"`.

Read-only: no cancel plugin here. `WakeUpResource.cancel` already lets any workspace admin cancel, so whether Poke operators should be able to do it — and through `cancel` or `forceCancel` — felt worth deciding separately.

### Risk

Low. Additive: one new Poke endpoint, one new panel behind a collapsed disclosure, one badge. No change to wake-up behaviour or to any non-Poke surface.

### Deploy Plan

Deploy as usual.
