### PR TITLE
[front] feat: add Programmatic usage card to the workspace credit pool section

### DIFF
--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -176,6 +176,7 @@ export function PersonalUsageCard({
                 seatBalanceAwu={myUsage?.seatBalanceAwu ?? null}
                 effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
                 spendLimitSource={myUsage?.spendLimitSource ?? "none"}
+                spendLimitGroupName={myUsage?.spendLimitGroupName ?? null}
                 seatType={myUsage?.seatType ?? null}
                 isTotalAllowedUsagePending={false}
               />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -155,6 +155,7 @@ function memberFromUpgradeRequest(
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
+    spendLimitGroupName: null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -473,6 +473,7 @@ export function UsagePageRedesign() {
     excessConsumedCredits,
     excessCycleBreakdown,
     programmaticConsumedCredits,
+    otherConsumedCredits,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
     mutateAwuPoolSummary,
@@ -1286,6 +1287,7 @@ export function UsagePageRedesign() {
             excessConsumedCredits={excessConsumedCredits}
             excessCycleBreakdown={excessCycleBreakdown}
             programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
             poolSecondaryContent={
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2">

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -153,6 +153,7 @@ function memberFromUpgradeRequest(
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
+    spendLimitGroupName: null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -472,6 +472,7 @@ export function UsagePageRedesign() {
     cycleBreakdown,
     excessConsumedCredits,
     excessCycleBreakdown,
+    programmaticConsumedCredits,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
     mutateAwuPoolSummary,
@@ -1284,6 +1285,7 @@ export function UsagePageRedesign() {
             cycleBreakdown={cycleBreakdown}
             excessConsumedCredits={excessConsumedCredits}
             excessCycleBreakdown={excessCycleBreakdown}
+            programmaticConsumedCredits={programmaticConsumedCredits}
             poolSecondaryContent={
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2">

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -85,6 +85,7 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
     excessConsumedCredits,
     excessCycleBreakdown,
     programmaticConsumedCredits,
+    otherConsumedCredits,
   } = awuPoolSummary ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
@@ -96,6 +97,7 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
     excessConsumedCredits: null,
     excessCycleBreakdown: [] as AwuPoolCycleBreakdown[],
     programmaticConsumedCredits: null,
+    otherConsumedCredits: null,
   };
 
   const hasPool = totalActiveCredits > 0;
@@ -116,6 +118,7 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
       excessConsumedCredits={excessConsumedCredits}
       excessCycleBreakdown={excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
+      otherConsumedCredits={otherConsumedCredits}
       poolSecondaryContent={
         <div className="flex items-center gap-2">
           {overageCredits !== null && overageCredits > 0 && (

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -84,6 +84,7 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
     currentCycleEndMs,
     excessConsumedCredits,
     excessCycleBreakdown,
+    programmaticConsumedCredits,
   } = awuPoolSummary ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
@@ -94,6 +95,7 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
     currentCycleEndMs: null,
     excessConsumedCredits: null,
     excessCycleBreakdown: [] as AwuPoolCycleBreakdown[],
+    programmaticConsumedCredits: null,
   };
 
   const hasPool = totalActiveCredits > 0;
@@ -113,6 +115,7 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
       cycleBreakdown={cycleBreakdown}
       excessConsumedCredits={excessConsumedCredits}
       excessCycleBreakdown={excessCycleBreakdown}
+      programmaticConsumedCredits={programmaticConsumedCredits}
       poolSecondaryContent={
         <div className="flex items-center gap-2">
           {overageCredits !== null && overageCredits > 0 && (

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -91,6 +91,7 @@ type RowData = {
   consumedFromPoolAwuCredits: number;
   spendLimitAwuCredits: number | null;
   spendLimitSource: EffectiveSpendLimitSource;
+  spendLimitGroupName: string | null;
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
   isTotalAllowedUsagePending: boolean;
@@ -183,6 +184,9 @@ interface AwuUsageBarProps {
   effectiveLimit: number | null;
   // Where `effectiveLimit` comes from — shown as a tooltip on the limit figure.
   spendLimitSource: EffectiveSpendLimitSource;
+  // Name of the group behind `effectiveLimit` when `spendLimitSource` is
+  // `"group"`. Null for every other source.
+  spendLimitGroupName: string | null;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
   // Shows only the workspace-pool portion of usage (pool consumed / pool
@@ -196,13 +200,16 @@ interface AwuUsageBarProps {
 // Human-readable origin of the effective spend limit, or null when there is
 // nothing worth explaining (no limit configured).
 function spendLimitSourceLabel(
-  source: EffectiveSpendLimitSource
+  source: EffectiveSpendLimitSource,
+  groupName: string | null
 ): string | null {
   switch (source) {
     case "override":
       return "Limit set specifically for this member";
     case "group":
-      return "Limit from a group";
+      return groupName
+        ? `Limit inherited from the "${groupName}" group`
+        : "Limit from a group";
     case "default":
       return "Workspace default limit";
     case "none":
@@ -221,13 +228,17 @@ export function AwuUsageBar({
   seatBalanceAwu,
   effectiveLimit,
   spendLimitSource,
+  spendLimitGroupName,
   seatType,
   isTotalAllowedUsagePending: isPending,
   poolOnly = false,
 }: AwuUsageBarProps) {
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
-  const sourceLabel = spendLimitSourceLabel(spendLimitSource);
+  const sourceLabel = spendLimitSourceLabel(
+    spendLimitSource,
+    spendLimitGroupName
+  );
   // For free seats: use lifetime consumed (derived from the live Metronome
   // balance) instead of period spend, so the bar reflects remaining credit.
   const isFreeWithBalance =
@@ -584,6 +595,7 @@ function buildPoolCreditUsageColumn(
           seatBalanceAwu={info.row.original.seatBalanceAwu}
           effectiveLimit={info.row.original.spendLimitAwuCredits}
           spendLimitSource={info.row.original.spendLimitSource}
+          spendLimitGroupName={info.row.original.spendLimitGroupName}
           seatType={info.row.original.seatType}
           isTotalAllowedUsagePending={
             info.row.original.isTotalAllowedUsagePending
@@ -994,6 +1006,7 @@ export function MembersUsageTable({
           consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
           spendLimitAwuCredits: m.spendLimitAwuCredits,
           spendLimitSource: m.spendLimitSource,
+          spendLimitGroupName: m.spendLimitGroupName,
           scheduledSeatType: m.scheduledSeatType,
           scheduledSeatChangeAt: m.scheduledSeatChangeAt,
           isTotalAllowedUsagePending: totalAllowedUsagePendingMemberIds.has(

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -40,6 +40,7 @@ interface WorkspaceCreditPoolValueCardsProps {
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
   isLoading: boolean;
 }
 
@@ -49,6 +50,7 @@ export function WorkspaceCreditPoolValueCards({
   currentCycleStartMs,
   currentCycleEndMs,
   programmaticConsumedCredits,
+  otherConsumedCredits,
   isLoading,
 }: WorkspaceCreditPoolValueCardsProps) {
   const cycleDayLabel = formatCycleDayLabel(
@@ -85,13 +87,21 @@ export function WorkspaceCreditPoolValueCards({
         }
       />
       <ValueCard
-        title="Programmatic usage"
+        title="Programmatic / Other usage"
         isLoading={isLoading}
         content={
-          <div className="truncate text-2xl text-foreground">
-            {typeof programmaticConsumedCredits === "number"
-              ? formatCredits(programmaticConsumedCredits)
-              : "—"}
+          <div className="flex flex-col gap-1">
+            <div className="truncate text-2xl text-foreground">
+              {typeof programmaticConsumedCredits === "number"
+                ? formatCredits(programmaticConsumedCredits)
+                : "—"}
+            </div>
+            <span className="copy-sm text-muted-foreground">
+              Other:{" "}
+              {typeof otherConsumedCredits === "number"
+                ? formatCredits(otherConsumedCredits)
+                : "—"}
+            </span>
           </div>
         }
       />
@@ -104,6 +114,7 @@ interface WorkspaceExcessCreditsValueCardProps {
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
   isLoading: boolean;
 }
 
@@ -112,6 +123,7 @@ export function WorkspaceExcessCreditsValueCard({
   currentCycleStartMs,
   currentCycleEndMs,
   programmaticConsumedCredits,
+  otherConsumedCredits,
   isLoading,
 }: WorkspaceExcessCreditsValueCardProps) {
   const cycleDayLabel = formatCycleDayLabel(
@@ -139,13 +151,21 @@ export function WorkspaceExcessCreditsValueCard({
         }
       />
       <ValueCard
-        title="Programmatic usage"
+        title="Programmatic / Other usage"
         isLoading={isLoading}
         content={
-          <div className="truncate text-2xl text-foreground">
-            {typeof programmaticConsumedCredits === "number"
-              ? formatCredits(programmaticConsumedCredits)
-              : "—"}
+          <div className="flex flex-col gap-1">
+            <div className="truncate text-2xl text-foreground">
+              {typeof programmaticConsumedCredits === "number"
+                ? formatCredits(programmaticConsumedCredits)
+                : "—"}
+            </div>
+            <span className="copy-sm text-muted-foreground">
+              Other:{" "}
+              {typeof otherConsumedCredits === "number"
+                ? formatCredits(otherConsumedCredits)
+                : "—"}
+            </span>
           </div>
         }
       />
@@ -214,6 +234,7 @@ interface WorkspaceCreditPoolSectionProps {
   excessConsumedCredits: number | null;
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
   poolSecondaryContent?: ReactNode;
   footer?: ReactNode;
 }
@@ -234,6 +255,7 @@ export function WorkspaceCreditPoolSection({
   excessConsumedCredits,
   excessCycleBreakdown,
   programmaticConsumedCredits,
+  otherConsumedCredits,
   poolSecondaryContent,
   footer,
 }: WorkspaceCreditPoolSectionProps) {
@@ -267,6 +289,7 @@ export function WorkspaceCreditPoolSection({
             currentCycleStartMs={currentCycleStartMs}
             currentCycleEndMs={currentCycleEndMs}
             programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
             isLoading={false}
           />
           {poolSecondaryContent}
@@ -282,6 +305,7 @@ export function WorkspaceCreditPoolSection({
             currentCycleStartMs={currentCycleStartMs}
             currentCycleEndMs={currentCycleEndMs}
             programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
             isLoading={false}
           />
           <WorkspaceCreditPoolCycleHistoryTable

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -39,6 +39,7 @@ interface WorkspaceCreditPoolValueCardsProps {
   currentCycleConsumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
   isLoading: boolean;
 }
 
@@ -47,6 +48,7 @@ export function WorkspaceCreditPoolValueCards({
   currentCycleConsumedCredits,
   currentCycleStartMs,
   currentCycleEndMs,
+  programmaticConsumedCredits,
   isLoading,
 }: WorkspaceCreditPoolValueCardsProps) {
   const cycleDayLabel = formatCycleDayLabel(
@@ -54,7 +56,7 @@ export function WorkspaceCreditPoolValueCards({
     currentCycleEndMs
   );
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid grid-cols-3 gap-4">
       <ValueCard
         title="Remaining credits pool"
         isLoading={isLoading}
@@ -82,6 +84,17 @@ export function WorkspaceCreditPoolValueCards({
           </div>
         }
       />
+      <ValueCard
+        title="Programmatic usage"
+        isLoading={isLoading}
+        content={
+          <div className="truncate text-2xl text-foreground">
+            {typeof programmaticConsumedCredits === "number"
+              ? formatCredits(programmaticConsumedCredits)
+              : "—"}
+          </div>
+        }
+      />
     </div>
   );
 }
@@ -90,6 +103,7 @@ interface WorkspaceExcessCreditsValueCardProps {
   excessConsumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
   isLoading: boolean;
 }
 
@@ -97,6 +111,7 @@ export function WorkspaceExcessCreditsValueCard({
   excessConsumedCredits,
   currentCycleStartMs,
   currentCycleEndMs,
+  programmaticConsumedCredits,
   isLoading,
 }: WorkspaceExcessCreditsValueCardProps) {
   const cycleDayLabel = formatCycleDayLabel(
@@ -104,24 +119,37 @@ export function WorkspaceExcessCreditsValueCard({
     currentCycleEndMs
   );
   return (
-    <ValueCard
-      title="Consumed this cycle"
-      isLoading={isLoading}
-      content={
-        <div className="flex items-baseline gap-2">
+    <div className="grid grid-cols-2 gap-4">
+      <ValueCard
+        title="Consumed this cycle"
+        isLoading={isLoading}
+        content={
+          <div className="flex items-baseline gap-2">
+            <div className="truncate text-2xl text-foreground">
+              {typeof excessConsumedCredits === "number"
+                ? formatCredits(excessConsumedCredits)
+                : "—"}
+            </div>
+            {cycleDayLabel && (
+              <span className="copy-sm text-muted-foreground">
+                {cycleDayLabel}
+              </span>
+            )}
+          </div>
+        }
+      />
+      <ValueCard
+        title="Programmatic usage"
+        isLoading={isLoading}
+        content={
           <div className="truncate text-2xl text-foreground">
-            {typeof excessConsumedCredits === "number"
-              ? formatCredits(excessConsumedCredits)
+            {typeof programmaticConsumedCredits === "number"
+              ? formatCredits(programmaticConsumedCredits)
               : "—"}
           </div>
-          {cycleDayLabel && (
-            <span className="copy-sm text-muted-foreground">
-              {cycleDayLabel}
-            </span>
-          )}
-        </div>
-      }
-    />
+        }
+      />
+    </div>
   );
 }
 
@@ -185,6 +213,7 @@ interface WorkspaceCreditPoolSectionProps {
   cycleBreakdown: AwuPoolCycleBreakdown[];
   excessConsumedCredits: number | null;
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
+  programmaticConsumedCredits: number | null;
   poolSecondaryContent?: ReactNode;
   footer?: ReactNode;
 }
@@ -204,6 +233,7 @@ export function WorkspaceCreditPoolSection({
   cycleBreakdown,
   excessConsumedCredits,
   excessCycleBreakdown,
+  programmaticConsumedCredits,
   poolSecondaryContent,
   footer,
 }: WorkspaceCreditPoolSectionProps) {
@@ -236,6 +266,7 @@ export function WorkspaceCreditPoolSection({
             currentCycleConsumedCredits={currentCycleConsumedCredits}
             currentCycleStartMs={currentCycleStartMs}
             currentCycleEndMs={currentCycleEndMs}
+            programmaticConsumedCredits={programmaticConsumedCredits}
             isLoading={false}
           />
           {poolSecondaryContent}
@@ -250,6 +281,7 @@ export function WorkspaceCreditPoolSection({
             excessConsumedCredits={excessConsumedCredits}
             currentCycleStartMs={currentCycleStartMs}
             currentCycleEndMs={currentCycleEndMs}
+            programmaticConsumedCredits={programmaticConsumedCredits}
             isLoading={false}
           />
           <WorkspaceCreditPoolCycleHistoryTable

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,4 +1,7 @@
-import { getEsConsumedAwuCreditsForWorkspace } from "@app/lib/api/credits/members_usage";
+import {
+  getEsConsumedAwuCreditsForWorkspace,
+  sumActiveMembersPoolConsumedCredits,
+} from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
@@ -311,12 +314,18 @@ export async function getAwuPoolSummary(
     invoicesResult,
     poolCommitIdsResult,
     finalizedInvoicesResult,
+    membersPoolConsumedCredits,
   ] = await Promise.all([
     listMetronomeBalances(metronomeCustomerId),
     listMetronomeDraftInvoices(metronomeCustomerId),
     getPoolCommitIds({ metronomeCustomerId }),
     listMetronomeFinalizedInvoices(metronomeCustomerId, {
       limit: cycleHistoryLimit,
+    }),
+    sumActiveMembersPoolConsumedCredits({
+      workspace,
+      metronomeCustomerId,
+      metronomeContractId,
     }),
   ]);
 
@@ -422,6 +431,7 @@ export async function getAwuPoolSummary(
       excessConsumedCredits,
       excessCycleBreakdown,
       programmaticConsumedCredits,
+      otherConsumedCredits: null,
     });
   }
 
@@ -500,6 +510,21 @@ export async function getAwuPoolSummary(
         awuCreditTypeId,
       });
 
+  // Whatever is left of the cycle total once programmatic and per-member pool
+  // draw are subtracted — mainly usage the invoice tags as member usage
+  // (`usage_type: "user"`) for someone with no active membership anymore.
+  const otherConsumedCredits =
+    currentCycleConsumedCredits !== null &&
+    programmaticConsumedCredits !== null &&
+    membersPoolConsumedCredits !== null
+      ? Math.max(
+          0,
+          currentCycleConsumedCredits -
+            programmaticConsumedCredits -
+            membersPoolConsumedCredits
+        )
+      : null;
+
   return new Ok({
     totalRemainingCredits,
     totalActiveCredits,
@@ -513,5 +538,6 @@ export async function getAwuPoolSummary(
     excessConsumedCredits,
     excessCycleBreakdown,
     programmaticConsumedCredits,
+    otherConsumedCredits,
   });
 }

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,7 +1,4 @@
-import {
-  getEsConsumedAwuCreditsForWorkspace,
-  getEsConsumedProgrammaticAwuCredits,
-} from "@app/lib/api/credits/members_usage";
+import { getEsConsumedAwuCreditsForWorkspace } from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
@@ -16,6 +13,7 @@ import {
   getCreditTypeAwuId,
 } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
@@ -29,6 +27,7 @@ import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isNumber } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
 import { z } from "zod";
 
@@ -215,6 +214,31 @@ function computeExcessCycleBreakdown(
     .slice(0, cycleHistoryLimit);
 }
 
+// Read live from Metronome rather than ES: usage events already carry the
+// `usage_type` group key needed to isolate programmatic spend, so there's no
+// need to duplicate that split in our own analytics index. Returns `null` on
+// a Metronome read failure — callers must treat that as "unknown", not 0.
+async function fetchProgrammaticConsumedCreditsOrNull({
+  workspace,
+  metronomeCustomerId,
+}: {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string;
+}): Promise<number | null> {
+  const result = await fetchProgrammaticAwuSpend({
+    workspaceId: workspace.sId,
+    metronomeCustomerId,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, error: result.error },
+      "[AwuPoolSummary] Failed to fetch programmatic AWU spend from Metronome"
+    );
+    return null;
+  }
+  return result.value;
+}
+
 export class AwuPoolSummaryError extends Error {
   constructor(
     readonly type:
@@ -343,7 +367,10 @@ export async function getAwuPoolSummary(
     const excessConsumedCredits =
       await getEsConsumedAwuCreditsForWorkspace(workspace);
     const programmaticConsumedCredits =
-      await getEsConsumedProgrammaticAwuCredits(auth, {});
+      await fetchProgrammaticConsumedCreditsOrNull({
+        workspace,
+        metronomeCustomerId,
+      });
     return new Ok({
       totalRemainingCredits: 0,
       totalActiveCredits: 0,
@@ -421,27 +448,16 @@ export async function getAwuPoolSummary(
   // a distinct "not attributable to a member" figure shown alongside the
   // per-cycle total whether or not the workspace has an active pool.
   //
-  // This is ES-derived (all programmatic `cost.billable_awu` for the cycle,
-  // workspace-wide) while `currentCycleConsumedCredits` is ledger-derived
-  // (only what Metronome actually deducted from the pool) — two different
-  // sources measuring related but not identical things. Once the pool runs
-  // dry mid-cycle, further usage (including programmatic) spills into
-  // overage/PAYG, which the ES total still counts but the pool ledger never
-  // sees. Clamped to the ledger figure so this can never claim more
-  // programmatic pool draw than the pool actually recorded; `null` when the
-  // ledger read failed, since there's then no pool-draw figure to bound it by.
-  const rawProgrammaticConsumedCredits =
-    await getEsConsumedProgrammaticAwuCredits(auth, {
-      cycle: {
-        cycleStart: new Date(currentCycleStartMs),
-        cycleEnd: new Date(currentCycleEndMs),
-      },
-    });
+  // Read straight from Metronome's own `usage_type` breakdown for the current
+  // billing period, uncapped: programmatic spend and each member's pool draw
+  // are both sourced from the same underlying metering data, so they already
+  // partition `currentCycleConsumedCredits` without needing to be forced to
+  // fit it here.
   const programmaticConsumedCredits =
-    rawProgrammaticConsumedCredits !== null &&
-    currentCycleConsumedCredits !== null
-      ? Math.min(rawProgrammaticConsumedCredits, currentCycleConsumedCredits)
-      : null;
+    await fetchProgrammaticConsumedCreditsOrNull({
+      workspace,
+      metronomeCustomerId,
+    });
 
   return new Ok({
     totalRemainingCredits,

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -11,6 +11,8 @@ import {
   CREDIT_TYPE_GBP_ID,
   CREDIT_TYPE_USD_ID,
   getCreditTypeAwuId,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
@@ -214,10 +216,46 @@ function computeExcessCycleBreakdown(
     .slice(0, cycleHistoryLimit);
 }
 
+// Programmatic AWU spend against the pool, read straight from the current
+// draft invoice's own usage line items — the same snapshot backing
+// `currentCycleConsumedCredits` (via its pool-ledger deductions), instead of
+// a live Metronome usage query racing ahead of it with usage the ledger
+// hasn't caught up to yet.
+//
+// Scoped twice: `commit_id` must be one of `poolCommitIds` (only usage that
+// actually drew from the pool, not general workspace spend that spilled to
+// overage/PAYG), and `pricing_group_values` must carry
+// `usage_type: "programmatic"` (how the AWU rate cards are dimensioned — see
+// `setup_new_pricing.ts`).
+function sumProgrammaticPoolConsumedFromInvoice({
+  invoice,
+  poolCommitIds,
+  awuCreditTypeId,
+}: {
+  invoice: Invoice;
+  poolCommitIds: Set<string>;
+  awuCreditTypeId: string;
+}): number {
+  return invoice.line_items
+    .filter(
+      (item) =>
+        item.type === "usage" &&
+        item.commit_id != null &&
+        poolCommitIds.has(item.commit_id) &&
+        item.credit_type.id === awuCreditTypeId &&
+        item.pricing_group_values?.[USAGE_TYPE_GROUP_KEY] ===
+          USAGE_TYPE_PROGRAMMATIC
+    )
+    .reduce((sum, item) => sum + item.total, 0);
+}
+
 // Read live from Metronome rather than ES: usage events already carry the
 // `usage_type` group key needed to isolate programmatic spend, so there's no
 // need to duplicate that split in our own analytics index. Returns `null` on
 // a Metronome read failure — callers must treat that as "unknown", not 0.
+//
+// Only used as a fallback when there's no current draft invoice to read line
+// items from (see `sumProgrammaticPoolConsumedFromInvoice`).
 async function fetchProgrammaticConsumedCreditsOrNull({
   workspace,
   metronomeCustomerId,
@@ -448,16 +486,19 @@ export async function getAwuPoolSummary(
   // a distinct "not attributable to a member" figure shown alongside the
   // per-cycle total whether or not the workspace has an active pool.
   //
-  // Read straight from Metronome's own `usage_type` breakdown for the current
-  // billing period, uncapped: programmatic spend and each member's pool draw
-  // are both sourced from the same underlying metering data, so they already
-  // partition `currentCycleConsumedCredits` without needing to be forced to
-  // fit it here.
-  const programmaticConsumedCredits =
-    await fetchProgrammaticConsumedCreditsOrNull({
-      workspace,
-      metronomeCustomerId,
-    });
+  // Derived from the invoice, scoped to `poolCommitIds`, same as
+  // `currentCycleConsumedCredits` — so the two are directly comparable and
+  // programmatic no longer outpaces the ledger-derived total just because it
+  // was read live. `null` when `poolCommitIds` itself couldn't be determined
+  // (fetch failure above): without it there's no way to tell a pool-drawing
+  // line from any other usage line on the invoice.
+  const programmaticConsumedCredits = poolCommitIdsResult.isErr()
+    ? null
+    : sumProgrammaticPoolConsumedFromInvoice({
+        invoice: currentInvoice,
+        poolCommitIds,
+        awuCreditTypeId,
+      });
 
   return new Ok({
     totalRemainingCredits,

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,4 +1,7 @@
-import { getEsConsumedAwuCreditsForWorkspace } from "@app/lib/api/credits/members_usage";
+import {
+  getEsConsumedAwuCreditsForWorkspace,
+  getEsConsumedProgrammaticAwuCredits,
+} from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
@@ -339,6 +342,8 @@ export async function getAwuPoolSummary(
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
     const excessConsumedCredits =
       await getEsConsumedAwuCreditsForWorkspace(workspace);
+    const programmaticConsumedCredits =
+      await getEsConsumedProgrammaticAwuCredits(auth, {});
     return new Ok({
       totalRemainingCredits: 0,
       totalActiveCredits: 0,
@@ -351,6 +356,7 @@ export async function getAwuPoolSummary(
       cycleBreakdown,
       excessConsumedCredits,
       excessCycleBreakdown,
+      programmaticConsumedCredits,
     });
   }
 
@@ -411,6 +417,32 @@ export async function getAwuPoolSummary(
         })
       : null;
 
+  // Unlike `excessConsumedCredits`, computed regardless of pool state — it's
+  // a distinct "not attributable to a member" figure shown alongside the
+  // per-cycle total whether or not the workspace has an active pool.
+  //
+  // This is ES-derived (all programmatic `cost.billable_awu` for the cycle,
+  // workspace-wide) while `currentCycleConsumedCredits` is ledger-derived
+  // (only what Metronome actually deducted from the pool) — two different
+  // sources measuring related but not identical things. Once the pool runs
+  // dry mid-cycle, further usage (including programmatic) spills into
+  // overage/PAYG, which the ES total still counts but the pool ledger never
+  // sees. Clamped to the ledger figure so this can never claim more
+  // programmatic pool draw than the pool actually recorded; `null` when the
+  // ledger read failed, since there's then no pool-draw figure to bound it by.
+  const rawProgrammaticConsumedCredits =
+    await getEsConsumedProgrammaticAwuCredits(auth, {
+      cycle: {
+        cycleStart: new Date(currentCycleStartMs),
+        cycleEnd: new Date(currentCycleEndMs),
+      },
+    });
+  const programmaticConsumedCredits =
+    rawProgrammaticConsumedCredits !== null &&
+    currentCycleConsumedCredits !== null
+      ? Math.min(rawProgrammaticConsumedCredits, currentCycleConsumedCredits)
+      : null;
+
   return new Ok({
     totalRemainingCredits,
     totalActiveCredits,
@@ -423,5 +455,6 @@ export async function getAwuPoolSummary(
     cycleBreakdown,
     excessConsumedCredits,
     excessCycleBreakdown,
+    programmaticConsumedCredits,
   });
 }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -843,6 +843,86 @@ async function fetchFreeSeatCreditsForMembersTable({
 }
 
 /**
+ * Sum, across every active member, the portion of their AWU consumption that
+ * draws from the workspace pool rather than their own seat allowance — the
+ * same `consumedFromPoolAwuCredits` split shown per-row in the members table,
+ * but totaled workspace-wide instead of per page. Used to compute the
+ * "unattributed" pool consumption left over once member and programmatic
+ * usage are subtracted from the cycle total (see `getAwuPoolSummary`).
+ *
+ * Reuses the same batched, cached fetchers as the members table (per-user
+ * usage, seat allocations, free-seat allowances) so this stays a handful of
+ * Metronome calls regardless of workspace size, not one per member.
+ * Returns `null` when Metronome isn't configured for the workspace.
+ */
+export async function sumActiveMembersPoolConsumedCredits({
+  workspace,
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<number | null> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return null;
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  if (memberships.length === 0) {
+    return 0;
+  }
+  const users = await UserResource.fetchByModelIds(
+    memberships.map((m) => m.userId)
+  );
+  const userByModelId = new Map(users.map((u) => [u.id, u]));
+  const members = memberships.flatMap((m) => {
+    const user = userByModelId.get(m.userId);
+    return user ? [{ sId: user.sId, seatType: m.seatType ?? null }] : [];
+  });
+
+  const [usageByMetronomeUserId, seatDataByUserId, { freeStartingByUserId }] =
+    await Promise.all([
+      fetchPerUserUsageCreditsForMembersTable({
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        metronomeContractId,
+        userIds: members.map((m) =>
+          m.seatType === "free" ? toFreeMetronomeUserId(m.sId) : m.sId
+        ),
+      }),
+      fetchSeatDataForMembersTable({
+        metronomeCustomerId,
+        metronomeContractId,
+      }),
+      fetchFreeSeatCreditsForMembersTable({ metronomeCustomerId }),
+    ]);
+
+  let sumConsumedFromPoolAwuCredits = 0;
+  for (const member of members) {
+    const metronomeUserId =
+      member.seatType === "free"
+        ? toFreeMetronomeUserId(member.sId)
+        : member.sId;
+    const totalConsumedCredits =
+      usageByMetronomeUserId.get(metronomeUserId) ?? 0;
+    const effectiveAllocationAwu =
+      freeStartingByUserId.get(member.sId) ??
+      seatDataByUserId.get(member.sId)?.awuAllocation ??
+      0;
+    const consumedFromAllowanceAwuCredits = Math.min(
+      totalConsumedCredits,
+      effectiveAllocationAwu
+    );
+    sumConsumedFromPoolAwuCredits +=
+      totalConsumedCredits - consumedFromAllowanceAwuCredits;
+  }
+  return sumConsumedFromPoolAwuCredits;
+}
+
+/**
  * Resolve the inputs needed to compute the effective per-user spend limit for
  * the members table:
  *   - the per-seat-type default cap totals, derived from the pool-only

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -141,6 +141,10 @@ export type MemberUsageType = {
   // Where `spendLimitAwuCredits` comes from: a user-specific `override`, the
   // seat-type `default`, or `none` (no cap configured / unlimited).
   spendLimitSource: EffectiveSpendLimitSource;
+  // Name of the group behind `spendLimitAwuCredits` when `spendLimitSource`
+  // is `"group"` (the cap-eligible group with the highest pool cap among the
+  // member's groups). Null for every other source.
+  spendLimitGroupName: string | null;
   // Id of the Metronome alert backing the effective cap (override or default),
   // for deep-linking to the dashboard. Null when uncapped.
   spendLimitAlertId: string | null;
@@ -1492,17 +1496,18 @@ export async function getMemberUsage({
     return { member: null };
   }
 
-  const [groupNamesByUserModelId, groupCapByUserModelId] = await Promise.all([
-    GroupResource.listGroupNamesByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [userResource.id],
-      groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
-    }),
-    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [userResource.id],
-    }),
-  ]);
+  const [groupNamesByUserModelId, maxPoolCapGroupByUserModelId] =
+    await Promise.all([
+      GroupResource.listGroupNamesByUserModelIdInWorkspace({
+        workspace,
+        userModelIds: [userResource.id],
+        groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+      }),
+      GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
+        workspace,
+        userModelIds: [userResource.id],
+      }),
+    ]);
 
   const metronomeUserId =
     membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
@@ -1569,8 +1574,8 @@ export async function getMemberUsage({
 
   // Max group cap (pool-only) + seat allowance, matching override/default units.
   // Only pool-bearing seats (pro/max/workspace) get a group cap.
-  const groupPoolCapAwuCredits =
-    groupCapByUserModelId.get(userResource.id) ?? null;
+  const maxPoolCapGroup = maxPoolCapGroupByUserModelId.get(userResource.id);
+  const groupPoolCapAwuCredits = maxPoolCapGroup?.capAwuCredits ?? null;
   const groupCapAwuCredits =
     groupPoolCapAwuCredits !== null && normalizedSeatType !== null
       ? groupPoolCapAwuCredits +
@@ -1612,6 +1617,10 @@ export async function getMemberUsage({
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource,
+    spendLimitGroupName:
+      spendLimitSource === "group"
+        ? (maxPoolCapGroup?.groupName ?? null)
+        : null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,
@@ -1787,9 +1796,7 @@ type MembersUsagePagePrefetch = {
     ReturnType<typeof fetchEffectivePerUserSpendLimits>
   >;
   groupCapByUserModelId?: Awaited<
-    ReturnType<
-      typeof GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace
-    >
+    ReturnType<typeof GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace>
   >;
 };
 
@@ -1891,7 +1898,7 @@ async function resolveMembersUsagePageUsers({
               freeBalanceByUserId: new Map<string, number>(),
               freeStartingByUserId: new Map<string, number>(),
             }),
-        GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+        GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
           workspace,
           userModelIds: allUsers.map((u) => u.id),
         }),
@@ -1931,7 +1938,8 @@ async function resolveMembersUsagePageUsers({
           seatType !== "none"
             ? membership.poolCapOverrideAwuCredits + seatAllowance
             : null;
-        const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+        const groupPoolCapAwuCredits =
+          groupCapByUserModelId.get(u.id)?.capAwuCredits ?? null;
         const groupCapAwuCredits =
           groupPoolCapAwuCredits !== null && normalizedSeatType !== null
             ? groupPoolCapAwuCredits + seatAllowance
@@ -2224,7 +2232,7 @@ export async function getMembersUsage({
       groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     }),
     prefetch.groupCapByUserModelId ??
-      GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
         workspace,
         userModelIds: users.map((u) => u.id),
       }),
@@ -2406,7 +2414,8 @@ export async function getMembersUsage({
     // Max group cap (pool-only, stored on the group) + seat allowance, to match
     // the units of override/default above. Only pool-bearing seats
     // (pro/max/workspace) get a group cap; free/none have no pool.
-    const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+    const maxPoolCapGroup = groupCapByUserModelId.get(u.id);
+    const groupPoolCapAwuCredits = maxPoolCapGroup?.capAwuCredits ?? null;
     const groupCapAwuCredits =
       groupPoolCapAwuCredits !== null && normalizedSeatType !== null
         ? groupPoolCapAwuCredits +
@@ -2478,6 +2487,10 @@ export async function getMembersUsage({
           ? (metronomeConsumedByUserId.get(userId) ?? 0)
           : null,
         spendLimitSource,
+        spendLimitGroupName:
+          spendLimitSource === "group"
+            ? (maxPoolCapGroup?.groupName ?? null)
+            : null,
         spendLimitAlertId,
         spendLimitWarningAlertId,
         freeCreditLowAlert: freeCreditAlerts?.low ?? null,

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -934,6 +934,43 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("listMaxPoolCapGroupByUserModelIdInWorkspace", () => {
+    it("returns the winning group's name alongside its cap", async () => {
+      const capped500 = await GroupResource.makeNew(
+        {
+          name: "Capped 500",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-500",
+        },
+        { memberIds: [user.id] }
+      );
+      await capped500.updatePoolCap(authenticator, 500);
+
+      const capped800 = await GroupResource.makeNew(
+        {
+          name: "Capped 800",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-800",
+        },
+        { memberIds: [user.id] }
+      );
+      await capped800.updatePoolCap(authenticator, 800);
+
+      const result =
+        await GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
+          workspace,
+          userModelIds: [user.id],
+        });
+
+      expect(result.get(user.id)).toEqual({
+        capAwuCredits: 800,
+        groupName: "Capped 800",
+      });
+    });
+  });
+
   describe("listWorkspaceGroupsFromKey", () => {
     it("system key: populates cache on first call and serves from cache on second", async () => {
       const key = await KeyFactory.system(systemGroup);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1332,19 +1332,23 @@ export class GroupResource extends BaseResource<GroupModel> {
     return result;
   }
 
-  // For each user, the highest per-group pool cap (excluding seat allowance)
-  // among the cap-eligible (provisioned) groups they belong to. Users with no
-  // capped group are absent from the map (the caller falls back to the workspace
-  // default). Used to resolve the "max(group caps)" term of a user's effective
-  // spend limit.
-  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+  // For each user, the cap-eligible (provisioned) group with the highest pool
+  // cap (excluding seat allowance) among the groups they belong to, and the
+  // cap itself. Users with no capped group are absent from the map (the
+  // caller falls back to the workspace default). Used to resolve the
+  // "max(group caps)" term of a user's effective spend limit, and to name the
+  // group behind that term in the UI.
+  static async listMaxPoolCapGroupByUserModelIdInWorkspace({
     workspace,
     userModelIds,
   }: {
     workspace: LightWorkspaceType;
     userModelIds: ModelId[];
-  }): Promise<Map<ModelId, number>> {
-    const result = new Map<ModelId, number>();
+  }): Promise<Map<ModelId, { capAwuCredits: number; groupName: string }>> {
+    const result = new Map<
+      ModelId,
+      { capAwuCredits: number; groupName: string }
+    >();
     if (userModelIds.length === 0) {
       return result;
     }
@@ -1372,22 +1376,48 @@ export class GroupResource extends BaseResource<GroupModel> {
         poolCapAwuCredits: { [Op.ne]: null },
       },
     });
-    const capByGroupId = new Map(
-      groups.map((g) => [g.id, g.poolCapAwuCredits])
-    );
+    const cappedGroupById = new Map(groups.map((g) => [g.id, g]));
 
     for (const m of memberships) {
-      const cap = capByGroupId.get(m.groupId);
-      if (cap === undefined || cap === null) {
+      const group = cappedGroupById.get(m.groupId);
+      if (!group || group.poolCapAwuCredits === null) {
         continue;
       }
       const existing = result.get(m.userId);
-      if (existing === undefined || cap > existing) {
-        result.set(m.userId, cap);
+      if (
+        existing === undefined ||
+        group.poolCapAwuCredits > existing.capAwuCredits
+      ) {
+        result.set(m.userId, {
+          capAwuCredits: group.poolCapAwuCredits,
+          groupName: group.name,
+        });
       }
     }
 
     return result;
+  }
+
+  // Numeric-only view of `listMaxPoolCapGroupByUserModelIdInWorkspace`, for
+  // callers that only need the cap amount (spend-limit resolution) and not
+  // the group's identity.
+  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+  }): Promise<Map<ModelId, number>> {
+    const byGroup = await this.listMaxPoolCapGroupByUserModelIdInWorkspace({
+      workspace,
+      userModelIds,
+    });
+    return new Map(
+      [...byGroup].map(([userModelId, { capAwuCredits }]) => [
+        userModelId,
+        capAwuCredits,
+      ])
+    );
   }
 
   static async getMemberCountsForGroups(

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -261,6 +261,7 @@ export function useAwuPoolSummary({
     excessConsumedCredits: data?.excessConsumedCredits ?? null,
     excessCycleBreakdown: data?.excessCycleBreakdown ?? [],
     programmaticConsumedCredits: data?.programmaticConsumedCredits ?? null,
+    otherConsumedCredits: data?.otherConsumedCredits ?? null,
     isAwuPoolSummaryLoading: !error && !data && !disabled,
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -260,6 +260,7 @@ export function useAwuPoolSummary({
     currentCycleEndMs: data?.currentCycleEndMs ?? null,
     excessConsumedCredits: data?.excessConsumedCredits ?? null,
     excessCycleBreakdown: data?.excessCycleBreakdown ?? [],
+    programmaticConsumedCredits: data?.programmaticConsumedCredits ?? null,
     isAwuPoolSummaryLoading: !error && !data && !disabled,
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -175,6 +175,7 @@ export function usePokeAwuPoolSummary({
         currentCycleEndMs: data.currentCycleEndMs ?? null,
         excessConsumedCredits: data.excessConsumedCredits ?? null,
         excessCycleBreakdown: data.excessCycleBreakdown ?? [],
+        programmaticConsumedCredits: data.programmaticConsumedCredits ?? null,
       }
     : null;
 

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -176,6 +176,7 @@ export function usePokeAwuPoolSummary({
         excessConsumedCredits: data.excessConsumedCredits ?? null,
         excessCycleBreakdown: data.excessCycleBreakdown ?? [],
         programmaticConsumedCredits: data.programmaticConsumedCredits ?? null,
+        otherConsumedCredits: data.otherConsumedCredits ?? null,
       }
     : null;
 

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -42,12 +42,22 @@ export type AwuPoolSummaryResponseBody = {
    */
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   /**
-   * Live, Elasticsearch-derived AWU consumption for the current billing
-   * cycle from programmatic origins (API keys, webhooks, workflow/agent
-   * triggers) — usage not attributable to a member, so it doesn't appear in
-   * the members table's per-row totals but still draws from the same pool.
-   * `null` when there's no active cycle to resolve, or the analytics read
-   * failed.
+   * AWU consumption for the current billing cycle from programmatic origins
+   * (API keys, webhooks, workflow/agent triggers) — usage not attributable
+   * to a member, so it doesn't appear in the members table's per-row totals
+   * but still draws from the same pool. Read from the current draft
+   * invoice's own usage line items when available, falling back to a live
+   * Metronome usage query. `null` when there's no active cycle to resolve,
+   * or the read failed.
    */
   programmaticConsumedCredits: number | null;
+  /**
+   * The portion of `currentCycleConsumedCredits` attributable neither to
+   * programmatic usage nor to any active member: `currentCycleConsumedCredits
+   * - programmaticConsumedCredits - sum(active members' pool-drawn credits)`.
+   * Mainly usage the invoice tags as member usage (`usage_type: "user"`) for
+   * a user who no longer has an active membership (e.g. removed mid-cycle).
+   * `null` when any term of that computation is unknown.
+   */
+  otherConsumedCredits: number | null;
 };

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -41,4 +41,13 @@ export type AwuPoolSummaryResponseBody = {
    * credit pool, where `cycleBreakdown` (pool-ledger based) is always empty.
    */
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
+  /**
+   * Live, Elasticsearch-derived AWU consumption for the current billing
+   * cycle from programmatic origins (API keys, webhooks, workflow/agent
+   * triggers) — usage not attributable to a member, so it doesn't appear in
+   * the members table's per-row totals but still draws from the same pool.
+   * `null` when there's no active cycle to resolve, or the analytics read
+   * failed.
+   */
+  programmaticConsumedCredits: number | null;
 };


### PR DESCRIPTION
Consumption from API keys, webhooks, and workflow/agent triggers draws
from the same pool but has no member to attribute it to, so it never
shows up in the members table — leaving an unexplained gap between the
pool total and the sum of member rows. Surfaces it as its own figure
next to "Consumed this cycle" on both the customer usage page and its
Poke mirror.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
