### PR TITLE
[front] read messages export from Postgres instead of the old analytics index

### DIFF
--- a/front/lib/api/analytics/feedback_export.test.ts
+++ b/front/lib/api/analytics/feedback_export.test.ts
@@ -1,0 +1,100 @@
+import { fetchFeedbackExportRows } from "@app/lib/api/analytics/feedback_export";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ModelId } from "@app/types/shared/model_id";
+import moment from "moment-timezone";
+import { describe, expect, it, vi } from "vitest";
+
+// fetchAgentMetadata reads from the read replica; in tests there is no
+// replica so point it at the primary test connection.
+vi.mock("@app/lib/resources/storage", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/resources/storage")>();
+  return {
+    ...actual,
+    getFrontReplicaDbConnection: () => actual.frontSequelize,
+  };
+});
+
+describe("fetchFeedbackExportRows", () => {
+  it("reads feedback from Postgres, resolving agent name, user sId/email, and the conversation URL", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "builder",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv.id as ModelId,
+      rank: 0,
+      agentConfigurationId: agent.sId,
+    });
+
+    const feedback = await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv.id as ModelId,
+      agentMessageId: messageRow.agentMessageId!,
+      userId: user.id,
+      thumbDirection: "up",
+      content: "Great answer",
+      isConversationShared: true,
+      dismissed: false,
+    });
+
+    const today = moment.utc();
+    const result = await fetchFeedbackExportRows({
+      owner: workspace,
+      startDate: today.clone().subtract(1, "day").format("YYYY-MM-DD"),
+      endDate: today.clone().add(1, "day").format("YYYY-MM-DD"),
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]).toEqual({
+      feedbackId: feedback.sId,
+      createdAt: moment(feedback.createdAt).utc().format("YYYY-MM-DD HH:mm:ss"),
+      assistantId: agent.sId,
+      assistantName: "Test Agent",
+      conversationUrl: expect.stringContaining(conv.sId),
+      userId: user.sId,
+      userEmail: user.email ?? "",
+      thumb: "up",
+      content: "Great answer",
+      dismissed: "false",
+    });
+  });
+
+  it("returns an empty array when there is no feedback in the requested window", async () => {
+    const { workspace } = await createResourceTest({ role: "builder" });
+
+    const result = await fetchFeedbackExportRows({
+      owner: workspace,
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toEqual([]);
+  });
+});

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -1,29 +1,12 @@
-import {
-  fetchAgentMetadata,
-  fetchFeedbackContents,
-  fetchUserEmails,
-} from "@app/lib/api/analytics/enrichment";
+import { fetchAgentMetadata } from "@app/lib/api/analytics/enrichment";
 import config from "@app/lib/api/config";
-import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
-import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
-
-const PAGE_SIZE = 10000;
-
-interface FeedbackAgentMessageDocument extends ElasticsearchBaseDocument {
-  message_id: string;
-  conversation_id: string;
-  agent_id: string;
-  timestamp: string;
-  feedbacks: AgentMessageAnalyticsFeedback[];
-}
 
 export interface FeedbackExportRow {
   feedbackId: string;
@@ -51,41 +34,11 @@ export const FEEDBACK_EXPORT_HEADERS: (keyof FeedbackExportRow)[] = [
   "dismissed",
 ];
 
-async function fetchAllFeedbackDocuments(
-  query: estypes.QueryDslQueryContainer
-): Promise<Result<FeedbackAgentMessageDocument[], Error>> {
-  const allDocs: FeedbackAgentMessageDocument[] = [];
-  let searchAfter: estypes.SortResults | undefined;
-
-  while (true) {
-    const result = await searchAnalytics<FeedbackAgentMessageDocument>(query, {
-      size: PAGE_SIZE,
-      sort: [{ timestamp: "asc" }, { message_id: "asc" }],
-      search_after: searchAfter,
-    });
-
-    if (result.isErr()) {
-      return new Err(new Error(result.error.message));
-    }
-
-    const { hits } = result.value.hits;
-    for (const hit of hits) {
-      if (hit._source) {
-        allDocs.push(hit._source);
-      }
-    }
-
-    if (hits.length < PAGE_SIZE) {
-      break;
-    }
-
-    const lastHit = hits[hits.length - 1];
-    searchAfter = lastHit.sort;
-  }
-
-  return new Ok(allDocs);
-}
-
+/**
+ * Feedback (thumb, content, dismissed) lives entirely in Postgres — it was
+ * never in the consumption index, so this reads straight from
+ * AgentMessageFeedbackResource instead of Elasticsearch.
+ */
 export async function fetchFeedbackExportRows({
   owner,
   startDate,
@@ -97,90 +50,66 @@ export async function fetchFeedbackExportRows({
   endDate: string;
   timezone: string;
 }): Promise<Result<FeedbackExportRow[], Error>> {
-  // Feedback is filtered by the date the feedback was given (which can differ
-  // from the message timestamp), so we range on the nested feedbacks.created_at
-  // and post-filter each document's feedbacks to the requested window.
-  const startIso = `${startDate}T00:00:00.000Z`;
-  const endIso = `${endDate}T23:59:59.999Z`;
+  const startInstant = moment.tz(startDate, timezone).startOf("day").toDate();
+  const exclusiveEndInstant = moment
+    .tz(endDate, timezone)
+    .add(1, "day")
+    .startOf("day")
+    .toDate();
 
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter: [
-        { term: { workspace_id: owner.sId } },
-        {
-          nested: {
-            path: "feedbacks",
-            query: {
-              range: {
-                "feedbacks.created_at": { gte: startIso, lte: endIso },
-              },
-            },
-          },
-        },
-      ],
-    },
-  };
+  // Note: getFeedbackUsageDataForWorkspace filters out feedback whose author
+  // user record can no longer be resolved (e.g. deleted user), so those rows
+  // are silently excluded from the export.
+  const feedbacks =
+    await AgentMessageFeedbackResource.getFeedbackUsageDataForWorkspace({
+      startDate: startInstant,
+      endDate: exclusiveEndInstant,
+      workspace: owner,
+    });
 
-  const docsResult = await fetchAllFeedbackDocuments(query);
-  if (docsResult.isErr()) {
-    return new Err(docsResult.error);
+  if (feedbacks.length === 0) {
+    return new Ok([]);
   }
 
-  const docs = docsResult.value;
-
   const uniqueAgentIds = [
-    ...new Set(docs.map((d) => d.agent_id).filter(Boolean)),
+    ...new Set(feedbacks.map((f) => f.agentConfigurationId)),
   ];
-  const allFeedbacks = docs.flatMap((d) => d.feedbacks ?? []);
-  const uniqueUserIds = [
-    ...new Set(allFeedbacks.map((f) => f.user_id).filter(Boolean)),
-  ];
-  const uniqueFeedbackIds = [
-    ...new Set(allFeedbacks.map((f) => f.feedback_id).filter(Boolean)),
-  ];
+  const uniqueUserModelIds = [...new Set(feedbacks.map((f) => f.userId))];
 
-  const [agentMeta, userEmails, feedbackContents] = await Promise.all([
+  const [agentMeta, users] = await Promise.all([
     fetchAgentMetadata(uniqueAgentIds, owner),
-    fetchUserEmails(uniqueUserIds),
-    fetchFeedbackContents(uniqueFeedbackIds, owner),
+    UserResource.fetchByModelIds(uniqueUserModelIds),
   ]);
+  const userSIdByModelId = new Map(users.map((u) => [u.id, u.sId]));
+  const userEmailByModelId = new Map(users.map((u) => [u.id, u.email]));
 
-  const rows: FeedbackExportRow[] = [];
-  for (const doc of docs) {
-    const agent = agentMeta.get(doc.agent_id);
-    for (const feedback of doc.feedbacks ?? []) {
-      // A matched document can carry feedbacks outside the requested window;
-      // keep only the ones created within it.
-      if (feedback.created_at < startIso || feedback.created_at > endIso) {
-        continue;
-      }
-      rows.push({
-        // feedback_id is stored as the internal ModelId; expose the opaque sId.
-        feedbackId: AgentMessageFeedbackResource.modelIdToSId({
-          id: feedback.feedback_id,
-          workspaceId: owner.id,
-        }),
-        createdAt: moment(feedback.created_at)
-          .tz(timezone)
-          .format("YYYY-MM-DD HH:mm:ss"),
-        assistantId: doc.agent_id,
-        assistantName: agent?.name ?? doc.agent_id,
-        conversationUrl: feedback.is_conversation_shared
+  const rows: FeedbackExportRow[] = feedbacks.map((feedback) => {
+    const conversationId = feedback.toJSON().conversationId;
+    const agent = agentMeta.get(feedback.agentConfigurationId);
+
+    return {
+      feedbackId: feedback.sId,
+      createdAt: moment(feedback.createdAt)
+        .tz(timezone)
+        .format("YYYY-MM-DD HH:mm:ss"),
+      assistantId: feedback.agentConfigurationId,
+      assistantName: agent?.name ?? feedback.agentConfigurationId,
+      conversationUrl:
+        feedback.isConversationShared && conversationId
           ? getConversationRoute(
               owner.sId,
-              doc.conversation_id,
+              conversationId,
               undefined,
               config.getAppUrl()
             )
           : "",
-        userId: feedback.user_id,
-        userEmail: userEmails.get(feedback.user_id) ?? "",
-        thumb: feedback.thumb_direction,
-        content: feedbackContents.get(feedback.feedback_id) ?? "",
-        dismissed: feedback.dismissed ? "true" : "false",
-      });
-    }
-  }
+      userId: userSIdByModelId.get(feedback.userId) ?? "",
+      userEmail: userEmailByModelId.get(feedback.userId) ?? "",
+      thumb: feedback.thumbDirection,
+      content: feedback.content ?? "",
+      dismissed: feedback.dismissed ? "true" : "false",
+    };
+  });
 
   rows.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -1,7 +1,6 @@
 import { fetchAgentMetadata } from "@app/lib/api/analytics/enrichment";
 import config from "@app/lib/api/config";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -74,14 +73,8 @@ export async function fetchFeedbackExportRows({
   const uniqueAgentIds = [
     ...new Set(feedbacks.map((f) => f.agentConfigurationId)),
   ];
-  const uniqueUserModelIds = [...new Set(feedbacks.map((f) => f.userId))];
 
-  const [agentMeta, users] = await Promise.all([
-    fetchAgentMetadata(uniqueAgentIds, owner),
-    UserResource.fetchByModelIds(uniqueUserModelIds),
-  ]);
-  const userSIdByModelId = new Map(users.map((u) => [u.id, u.sId]));
-  const userEmailByModelId = new Map(users.map((u) => [u.id, u.email]));
+  const agentMeta = await fetchAgentMetadata(uniqueAgentIds, owner);
 
   const rows: FeedbackExportRow[] = feedbacks.map((feedback) => {
     const conversationId = feedback.toJSON().conversationId;
@@ -103,8 +96,8 @@ export async function fetchFeedbackExportRows({
               config.getAppUrl()
             )
           : "",
-      userId: userSIdByModelId.get(feedback.userId) ?? "",
-      userEmail: userEmailByModelId.get(feedback.userId) ?? "",
+      userId: feedback.user?.sId ?? "",
+      userEmail: feedback.user?.email ?? "",
       thumb: feedback.thumbDirection,
       content: feedback.content ?? "",
       dismissed: feedback.dismissed ? "true" : "false",

--- a/front/lib/api/analytics/messages_export.test.ts
+++ b/front/lib/api/analytics/messages_export.test.ts
@@ -1,17 +1,22 @@
 import { fetchMessageExportRows } from "@app/lib/api/analytics/messages_export";
-import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
+import { docxSkill } from "@app/lib/resources/skill/code_defined/global/docx";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TagFactory } from "@app/tests/utils/TagFactory";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
+import moment from "moment-timezone";
 import { describe, expect, it, vi } from "vitest";
 
-// Keep everything real; only stub the Elasticsearch query so the test does not
-// depend on a live cluster.
+// Keep everything real; only stub the Elasticsearch query (the consumption
+// index) so the test does not depend on a live cluster.
 vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
   const actual =
     await importActual<typeof import("@app/lib/api/elasticsearch")>();
-  return { ...actual, searchAnalytics: vi.fn() };
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
 });
 
 // The export reads from the read replica; in tests there is no replica so point
@@ -25,54 +30,116 @@ vi.mock("@app/lib/resources/storage", async (importActual) => {
   };
 });
 
-function mockMessageHits(docs: ElasticsearchBaseDocument[]) {
-  vi.mocked(searchAnalytics).mockClear();
-  vi.mocked(searchAnalytics).mockResolvedValue(
+function mockCreditsByMessage(creditMicroByMessageId: Record<string, number>) {
+  vi.mocked(searchConsumptionAnalytics).mockReset();
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValueOnce(
     new Ok({
       took: 1,
       timed_out: false,
       _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
-      hits: {
-        total: { value: docs.length, relation: "eq" },
-        hits: docs.map((doc) => ({ _index: "test", _source: doc })),
+      hits: { total: { value: 0, relation: "eq" }, hits: [] },
+      aggregations: {
+        by_message: {
+          buckets: Object.entries(creditMicroByMessageId).map(
+            ([messageId, creditMicro]) => ({
+              key: { value: messageId },
+              credit_micro: { value: creditMicro },
+            })
+          ),
+        },
       },
     })
   );
 }
 
-function messageDoc(
-  overrides: Record<string, unknown> = {}
-): ElasticsearchBaseDocument {
-  return {
-    workspace_id: "w_test",
-    message_id: "msg_1",
-    timestamp: "2026-07-01T12:00:00.000Z",
-    agent_id: "agent_1",
-    conversation_id: "conv_1",
-    user_id: "user_1",
-    context_origin: "web",
-    status: "succeeded",
-    ...overrides,
-  };
+async function exportForToday(params: {
+  auth: Parameters<typeof fetchMessageExportRows>[0]["auth"];
+  owner: Parameters<typeof fetchMessageExportRows>[0]["owner"];
+}) {
+  const today = moment.utc();
+  return fetchMessageExportRows({
+    auth: params.auth,
+    owner: params.owner,
+    startDate: today.clone().subtract(1, "day").format("YYYY-MM-DD"),
+    endDate: today.clone().add(1, "day").format("YYYY-MM-DD"),
+    timezone: "UTC",
+  });
 }
 
 describe("fetchMessageExportRows", () => {
-  it("correctly reports credits column", async () => {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
+  it("reads message rows from Postgres and credits from the consumption index", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "builder",
     });
 
-    mockMessageHits([
-      messageDoc({
-        cost: { full_awu: 10, llm_awu: 4, tool_awu: 3, billable_awu: 7 },
-      }),
-    ]);
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    const { messageRow: userMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth: authenticator,
+        workspace,
+        conversation: conv,
+        content: "Hello",
+        origin: "web",
+      });
+
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conv.id as ModelId,
+        rank: 1,
+        agentConfigurationId: agent.sId,
+        parentId: userMessageRow.id,
+      });
+
+    mockCreditsByMessage({ [agentMessageRow.sId]: 7_000_000 });
+
+    const result = await exportForToday({
+      auth: authenticator,
+      owner: workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]).toMatchObject({
+      messageId: agentMessageRow.sId,
+      assistantId: agent.sId,
+      assistantName: "Test Agent",
+      conversationId: conv.sId,
+      parentMessageId: "",
+      userId: user.sId,
+      userEmail: user.email ?? "",
+      source: "web",
+      toolsUsed: "",
+      skillsUsed: "",
+      credits: 7,
+    });
+  });
+
+  it("returns an empty array when there is no message in the requested window", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "builder",
+    });
+
+    mockCreditsByMessage({});
 
     const result = await fetchMessageExportRows({
       auth: authenticator,
       owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
       timezone: "UTC",
     });
 
@@ -80,31 +147,50 @@ describe("fetchMessageExportRows", () => {
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value).toHaveLength(1);
-    expect(result.value[0].credits).toBe(7);
+    expect(result.value).toEqual([]);
   });
 
-  it("does not filter on status, so failed messages keep their billable credits", async () => {
+  it("resolves the run_agent origin message id into parentMessageId", async () => {
     const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
+      role: "builder",
     });
 
-    // A multi-execution message whose terminal execution errored: still billed
-    // for the work of its successful executions.
-    mockMessageHits([
-      messageDoc({
-        message_id: "msg_failed",
-        status: "failed",
-        cost: { full_awu: 10, llm_awu: 4, tool_awu: 3, billable_awu: 5 },
-      }),
-    ]);
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Root Agent" }
+    );
 
-    const result = await fetchMessageExportRows({
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    // The sub-agent invocation's user message carries the sId of the agent
+    // message that triggered it via run_agent.
+    const { messageRow: subUserMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth: authenticator,
+        workspace,
+        conversation: conv,
+        content: "Sub-agent request",
+        agenticMessageType: "run_agent",
+        agenticOriginMessageId: "msg_origin",
+      });
+
+    const subAgentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conv.id as ModelId,
+        rank: 1,
+        agentConfigurationId: agent.sId,
+        parentId: subUserMessageRow.id,
+      });
+
+    mockCreditsByMessage({});
+
+    const result = await exportForToday({
       auth: authenticator,
       owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
     });
 
     expect(result.isOk()).toBe(true);
@@ -112,168 +198,169 @@ describe("fetchMessageExportRows", () => {
       throw result.error;
     }
     expect(result.value).toHaveLength(1);
-    expect(result.value[0].messageId).toBe("msg_failed");
-    expect(result.value[0].credits).toBe(5);
+    expect(result.value[0].messageId).toBe(subAgentMessageRow.sId);
+    expect(result.value[0].parentMessageId).toBe("msg_origin");
   });
 
-  it("resolves agent_tag_ids to sorted, distinct tag names in the assistantTags column", async () => {
+  it("resolves agent tags to sorted, distinct tag names", async () => {
     const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
+      role: "builder",
     });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Tagged Agent" }
+    );
 
     const [zeta, alpha] = await Promise.all([
       TagFactory.create(workspace, { name: "Zeta" }),
       TagFactory.create(workspace, { name: "Alpha" }),
     ]);
-
-    mockMessageHits([
-      messageDoc({ agent_tag_ids: [zeta.sId, alpha.sId, "tag_unknown"] }),
+    await Promise.all([
+      zeta.addToAgent(authenticator, agent),
+      alpha.addToAgent(authenticator, agent),
     ]);
 
-    const result = await fetchMessageExportRows({
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth: authenticator,
+        workspace,
+        conversation: conv,
+        content: "Hello",
+      });
+    await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv.id as ModelId,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessageRow.id,
+    });
+
+    mockCreditsByMessage({});
+
+    const result = await exportForToday({
       auth: authenticator,
       owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
     });
 
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
-    // Sorted, distinct, and unknown ids dropped.
+    expect(result.value).toHaveLength(1);
     expect(result.value[0].assistantTags).toBe("Alpha,Zeta");
-  });
-
-  it("leaves assistantTags empty for docs indexed before agent_tag_ids shipped", async () => {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
-    });
-
-    mockMessageHits([messageDoc()]);
-
-    const result = await fetchMessageExportRows({
-      auth: authenticator,
-      owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    expect(result.value[0].assistantTags).toBe("");
-  });
-
-  it("defaults credits to 0 for docs indexed before the cost fields shipped", async () => {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
-    });
-
-    mockMessageHits([messageDoc()]);
-
-    const result = await fetchMessageExportRows({
-      auth: authenticator,
-      owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    expect(result.value[0].credits).toBe(0);
   });
 
   it("reports the resolved model columns", async () => {
     const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
+      role: "builder",
     });
 
-    mockMessageHits([
-      messageDoc({
-        model: {
-          provider_id: "anthropic",
-          model_id: "claude-opus-5",
-          reasoning_effort: "medium",
-          resolution_method: "agent",
-        },
-      }),
-    ]);
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Model Agent" }
+    );
 
-    const result = await fetchMessageExportRows({
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth: authenticator,
+        workspace,
+        conversation: conv,
+        content: "Hello",
+      });
+    await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv.id as ModelId,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessageRow.id,
+      resolvedModel: {
+        providerId: "anthropic",
+        modelId: "claude-opus-5",
+        reasoningEffort: "medium",
+      },
+      modelResolutionMethod: "agent",
+    });
+
+    mockCreditsByMessage({});
+
+    const result = await exportForToday({
       auth: authenticator,
       owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
     });
 
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
+    expect(result.value).toHaveLength(1);
     expect(result.value[0].modelId).toBe("claude-opus-5");
     expect(result.value[0].modelProviderId).toBe("anthropic");
     expect(result.value[0].modelResolutionMethod).toBe("agent");
   });
 
-  it("leaves the model columns empty for docs indexed before the model fields shipped", async () => {
+  it("lists the global skill name used on the message in skillsUsed", async () => {
     const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
+      role: "builder",
     });
 
-    mockMessageHits([messageDoc()]);
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Skill Agent" }
+    );
 
-    const result = await fetchMessageExportRows({
+    const conv = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth: authenticator,
+        workspace,
+        conversation: conv,
+        content: "Hello",
+      });
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conv.id as ModelId,
+        rank: 1,
+        agentConfigurationId: agent.sId,
+        parentId: userMessageRow.id,
+      });
+
+    const skillLink = {
+      workspaceId: workspace.id,
+      conversationId: conv.id as ModelId,
+      agentMessageId: agentMessageRow.agentMessageId!,
+      agentConfigurationId: agent.sId,
+      globalSkillId: docxSkill.sId,
+      customSkillId: null,
+      source: "agent_enabled" as const,
+      addedByUserId: null,
+    };
+    await AgentMessageSkillModel.bulkCreate([skillLink]);
+
+    mockCreditsByMessage({});
+
+    const result = await exportForToday({
       auth: authenticator,
       owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
     });
 
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value[0].modelId).toBe("");
-    expect(result.value[0].modelProviderId).toBe("");
-    expect(result.value[0].modelResolutionMethod).toBe("");
-  });
-
-  it("reports the direct parent in parentMessageId and defaults to empty", async () => {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
-    });
-
-    mockMessageHits([
-      messageDoc({
-        message_id: "msg_child",
-        ancestor_message_ids: ["msg_parent"],
-      }),
-      messageDoc({ message_id: "msg_root" }),
-    ]);
-
-    const result = await fetchMessageExportRows({
-      auth: authenticator,
-      owner: workspace,
-      startDate: "2026-07-01",
-      endDate: "2026-07-02",
-      timezone: "UTC",
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    expect(result.value).toHaveLength(2);
-    expect(result.value[0].parentMessageId).toBe("msg_parent");
-    expect(result.value[1].parentMessageId).toBe("");
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].skillsUsed).toBe(docxSkill.name);
   });
 });

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -1,46 +1,41 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
+import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  buildConsumptionScopeQuery,
+  CREDIT_MICRO_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchAgentMetadata,
-  fetchTagNames,
   fetchUserEmails,
 } from "@app/lib/api/analytics/enrichment";
 import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  AgentMessageAnalyticsCost,
-  AgentMessageAnalyticsModel,
-} from "@app/types/assistant/analytics";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
+import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import { TagResource } from "@app/lib/resources/tags_resource";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
+import type { WhereOptions } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
-const PAGE_SIZE = 10000;
-
-interface AgentMessageDocument extends ElasticsearchBaseDocument {
-  message_id: string;
-  timestamp: string;
-  agent_id: string;
-  // Optional: docs indexed before agent_tag_ids shipped don't carry it.
-  agent_tag_ids?: string[];
-  conversation_id: string;
-  // Ids of the agent messages that triggered this message through `run_agent`,
-  // direct parent first. Empty or absent for user-initiated messages.
-  ancestor_message_ids?: string[];
-  user_id: string;
-  context_origin: string;
-  status: string;
-  tools_used?: { server_name: string; tool_name: string }[];
-  skills_used?: { skill_name: string }[];
-  // Optional: docs indexed before the cost fields shipped don't carry it.
-  cost?: AgentMessageAnalyticsCost;
-  // Optional: docs indexed before the model fields shipped don't carry it.
-  model?: AgentMessageAnalyticsModel | null;
-}
+// Composite aggregation page size for the consumption index credits lookup.
+// Large enough that busy workspaces still resolve in a handful of pages.
+const CREDITS_COMPOSITE_PAGE_SIZE = 10_000;
 
 export interface MessageExportRow {
   messageId: string;
@@ -88,39 +83,293 @@ function joinDistinctSorted(values: (string | undefined | null)[]): string {
     .join(",");
 }
 
-async function fetchAllMessageDocuments(
-  query: estypes.QueryDslQueryContainer
-): Promise<Result<AgentMessageDocument[], Error>> {
-  const allDocs: AgentMessageDocument[] = [];
-  let searchAfter: estypes.SortResults | undefined;
+interface MessageBaseRow {
+  messageId: string;
+  createdAt: Date;
+  agentMessageModelId: ModelId;
+  assistantId: string;
+  conversationId: string;
+  parentMessageId: string | null;
+  userId: string | null;
+  source: string | null;
+  modelId: string | null;
+  modelProviderId: string | null;
+  modelResolutionMethod: string | null;
+}
 
-  while (true) {
-    const result = await searchAnalytics<AgentMessageDocument>(query, {
-      size: PAGE_SIZE,
-      sort: [{ timestamp: "asc" }, { message_id: "asc" }],
-      search_after: searchAfter,
-    });
-
-    if (result.isErr()) {
-      return new Err(new Error(result.error.message));
+// Base row set: every agent message in the workspace/date range, joined down
+// to the user message that triggered it to resolve the triggering user and,
+// for run_agent sub-messages, the origin agent message id.
+async function fetchBaseMessageRows(
+  owner: WorkspaceType,
+  startInstant: Date,
+  exclusiveEndInstant: Date
+): Promise<MessageBaseRow[]> {
+  const readReplica = getFrontReplicaDbConnection();
+  // biome-ignore lint/plugin/noRawSql: Matches existing Activity Report query pattern.
+  return readReplica.query<MessageBaseRow>(
+    `
+    SELECT
+      m."sId"                        AS "messageId",
+      m."createdAt"                  AS "createdAt",
+      am."id"                        AS "agentMessageModelId",
+      am."agentConfigurationId"      AS "assistantId",
+      am."resolvedModelId"           AS "modelId",
+      am."resolvedProviderId"        AS "modelProviderId",
+      am."modelResolutionMethod"     AS "modelResolutionMethod",
+      c."sId"                        AS "conversationId",
+      pum."agenticOriginMessageId"   AS "parentMessageId",
+      pum."userContextOrigin"        AS "source",
+      u."sId"                        AS "userId"
+    FROM "messages" m
+      JOIN "agent_messages" am ON am."id" = m."agentMessageId"
+      JOIN "conversations" c ON c."id" = m."conversationId"
+      LEFT JOIN "messages" pm ON pm."id" = m."parentId"
+      LEFT JOIN "user_messages" pum ON pum."id" = pm."userMessageId"
+      LEFT JOIN "users" u ON u."id" = pum."userId"
+    WHERE m."workspaceId" = :wId
+      AND m."agentMessageId" IS NOT NULL
+      AND m."createdAt" >= :startInstant
+      AND m."createdAt" < :exclusiveEndInstant
+    ORDER BY m."createdAt" ASC
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: {
+        wId: owner.id,
+        startInstant: startInstant.toISOString(),
+        exclusiveEndInstant: exclusiveEndInstant.toISOString(),
+      },
     }
+  );
+}
 
-    const { hits } = result.value.hits;
-    for (const hit of hits) {
-      if (hit._source) {
-        allDocs.push(hit._source);
-      }
-    }
+interface AssistantTagRow {
+  sId: string;
+  id: ModelId;
+}
 
-    if (hits.length < PAGE_SIZE) {
-      break;
-    }
-
-    const lastHit = hits[hits.length - 1];
-    searchAfter = lastHit.sort;
+// Current tags for each agent, keyed by the agent's sId. Mirrors the same
+// caveat as the analytics indexing job: this reflects the agent's tags today,
+// not necessarily at message time, since tags can be edited without bumping
+// the agent configuration version.
+async function fetchAssistantTagsByAgentId(
+  auth: Authenticator,
+  owner: WorkspaceType,
+  agentConfigurationIds: string[]
+): Promise<Map<string, string[]>> {
+  if (agentConfigurationIds.length === 0) {
+    return new Map();
   }
 
-  return new Ok(allDocs);
+  const readReplica = getFrontReplicaDbConnection();
+  // biome-ignore lint/plugin/noRawSql: Matches existing Activity Report query pattern.
+  const rows = await readReplica.query<AssistantTagRow>(
+    `
+    SELECT "sId", "id"
+    FROM "agent_configurations"
+    WHERE "workspaceId" = :wId
+      AND "sId" IN (:agentIds)
+      AND "status" = 'active'
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { wId: owner.id, agentIds: agentConfigurationIds },
+    }
+  );
+
+  if (rows.length === 0) {
+    return new Map();
+  }
+
+  const sIdByModelId = new Map(rows.map((r) => [r.id, r.sId]));
+  const tagsByAgentModelId = await TagResource.listForAgents(
+    auth,
+    rows.map((r) => r.id)
+  );
+
+  const tagsByAgentSId = new Map<string, string[]>();
+  for (const [modelId, tags] of Object.entries(tagsByAgentModelId)) {
+    const sId = sIdByModelId.get(Number(modelId));
+    if (sId) {
+      tagsByAgentSId.set(
+        sId,
+        tags.map((tag) => tag.name)
+      );
+    }
+  }
+  return tagsByAgentSId;
+}
+
+interface ToolUsed {
+  serverName: string;
+  toolName: string;
+}
+
+async function fetchToolsUsedByMessage(
+  auth: Authenticator,
+  agentMessageModelIds: ModelId[]
+): Promise<Map<ModelId, ToolUsed[]>> {
+  if (agentMessageModelIds.length === 0) {
+    return new Map();
+  }
+
+  const actions = await AgentMCPActionResource.listByAgentMessageIds(
+    auth,
+    agentMessageModelIds
+  );
+
+  const toolsByMessage = new Map<ModelId, ToolUsed[]>();
+  for (const action of actions) {
+    const { internalMCPServerName, mcpServerId } = action.metadata;
+    const toolUsed: ToolUsed = {
+      serverName: internalMCPServerName ?? mcpServerId ?? "unknown",
+      toolName: getToolNameFromFunctionCallName(action.functionCallName),
+    };
+    const list = toolsByMessage.get(action.agentMessageId) ?? [];
+    list.push(toolUsed);
+    toolsByMessage.set(action.agentMessageId, list);
+  }
+  return toolsByMessage;
+}
+
+async function fetchSkillsUsedByMessage(
+  auth: Authenticator,
+  agentMessageModelIds: ModelId[]
+): Promise<Map<ModelId, string[]>> {
+  if (agentMessageModelIds.length === 0) {
+    return new Map();
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const where: WhereOptions<AgentMessageSkillModel> = {
+    agentMessageId: { [Op.in]: agentMessageModelIds },
+    workspaceId,
+  };
+  const skillRecords = await AgentMessageSkillModel.findAll({
+    where,
+    include: [
+      {
+        model: SkillConfigurationModel,
+        as: "customSkill",
+        attributes: ["id", "name"],
+        required: false,
+      },
+    ],
+  });
+
+  const globalSkillIds = [
+    ...new Set(
+      skillRecords.flatMap((r) => (r.globalSkillId ? [r.globalSkillId] : []))
+    ),
+  ];
+
+  const globalSkillNameById = new Map<string, string>();
+  if (globalSkillIds.length > 0) {
+    const [globalSkills, systemSkills] = await Promise.all([
+      GlobalSkillsRegistry.findAll(auth, { sId: globalSkillIds }),
+      SystemSkillsRegistry.findAll(auth, { sId: globalSkillIds }),
+    ]);
+    for (const skill of [...globalSkills, ...systemSkills]) {
+      globalSkillNameById.set(skill.sId, skill.name);
+    }
+  }
+
+  const skillsByMessage = new Map<ModelId, string[]>();
+  for (const record of skillRecords) {
+    const name =
+      record.customSkillId && record.customSkill
+        ? record.customSkill.name
+        : record.globalSkillId
+          ? (globalSkillNameById.get(record.globalSkillId) ??
+            record.globalSkillId)
+          : null;
+    if (!name) {
+      continue;
+    }
+    const list = skillsByMessage.get(record.agentMessageId) ?? [];
+    list.push(name);
+    skillsByMessage.set(record.agentMessageId, list);
+  }
+  return skillsByMessage;
+}
+
+type MessageCreditsBucket = {
+  key: { value: string };
+  credit_micro?: estypes.AggregationsSumAggregate;
+};
+
+type MessageCreditsAggregations = {
+  by_message?: estypes.AggregationsCompositeAggregate & {
+    buckets: MessageCreditsBucket[];
+    after_key?: { value: string };
+  };
+};
+
+// Credits are not reliably available in Postgres: recent messages have not
+// gone through the async attribution/reconciliation pass yet. The consumption
+// analytics index reconciles credit_micro at write time, so it is the only
+// source that is both accurate and available immediately. Documents are
+// split per LLM step and per tool call, so bucket-and-sum by agent_message_id
+// (paginated via composite aggregation, since a busy workspace can exceed a
+// single page of distinct messages).
+async function fetchCreditsByMessageId(
+  auth: Authenticator,
+  startInstant: string,
+  exclusiveEndInstant: string
+): Promise<Result<Map<string, number>, ElasticsearchError>> {
+  const creditsByMessageId = new Map<string, number>();
+  let afterKey: { value: string } | undefined;
+
+  while (true) {
+    const result = await searchConsumptionAnalytics<
+      never,
+      MessageCreditsAggregations
+    >(
+      buildConsumptionScopeQuery({
+        auth,
+        startDate: startInstant,
+        endDate: exclusiveEndInstant,
+      }),
+      {
+        aggregations: {
+          by_message: {
+            composite: {
+              size: CREDITS_COMPOSITE_PAGE_SIZE,
+              sources: [
+                { value: { terms: { field: AGENT_MESSAGE_ID_FIELD } } },
+              ],
+              ...(afterKey ? { after: afterKey } : {}),
+            },
+            aggs: {
+              credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+            },
+          },
+        },
+        size: 0,
+      }
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    const aggregation = result.value.aggregations?.by_message;
+    const page = bucketsToArray<MessageCreditsBucket>(aggregation?.buckets);
+    for (const bucket of page) {
+      creditsByMessageId.set(
+        String(bucket.key.value),
+        Math.round(microCreditsToCredits(bucket.credit_micro?.value ?? 0))
+      );
+    }
+
+    afterKey = aggregation?.after_key;
+    if (!afterKey || page.length === 0) {
+      break;
+    }
+  }
+
+  return new Ok(creditsByMessageId);
 }
 
 export async function fetchMessageExportRows({
@@ -136,73 +385,102 @@ export async function fetchMessageExportRows({
   endDate: string;
   timezone: string;
 }): Promise<Result<MessageExportRow[], Error>> {
-  const query = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    startDate,
-    endDate,
-  });
+  const startInstant = moment.tz(startDate, timezone).startOf("day").toDate();
+  const exclusiveEndInstant = moment
+    .tz(endDate, timezone)
+    .add(1, "day")
+    .startOf("day")
+    .toDate();
 
-  const docsResult = await fetchAllMessageDocuments(query);
-  if (docsResult.isErr()) {
-    return new Err(docsResult.error);
+  const baseRows = await fetchBaseMessageRows(
+    owner,
+    startInstant,
+    exclusiveEndInstant
+  );
+
+  if (baseRows.length === 0) {
+    return new Ok([]);
   }
 
-  const docs = docsResult.value;
-
-  const uniqueAgentIds = [
-    ...new Set(docs.map((d) => d.agent_id).filter(Boolean)),
-  ];
+  const agentMessageModelIds = baseRows.map((row) => row.agentMessageModelId);
+  const uniqueAgentIds = [...new Set(baseRows.map((row) => row.assistantId))];
   const uniqueUserIds = [
-    ...new Set(docs.map((d) => d.user_id).filter(Boolean)),
-  ];
-  const uniqueTagIds = [
-    ...new Set(docs.flatMap((d) => d.agent_tag_ids ?? []).filter(Boolean)),
-  ];
-  const uniqueServerNames = [
     ...new Set(
-      docs.flatMap((d) => (d.tools_used ?? []).map((t) => t.server_name))
+      baseRows
+        .map((row) => row.userId)
+        .filter((id): id is string => Boolean(id))
     ),
   ];
 
-  const [agentMeta, userEmails, tagNames, serverDisplayNames] =
-    await Promise.all([
-      fetchAgentMetadata(uniqueAgentIds, owner),
-      fetchUserEmails(uniqueUserIds),
-      fetchTagNames(auth, uniqueTagIds),
-      resolveServerDisplayNames(auth, uniqueServerNames),
-    ]);
+  const [
+    agentMeta,
+    userEmails,
+    assistantTagsByAgentId,
+    toolsUsedByMessage,
+    skillsUsedByMessage,
+    creditsResult,
+  ] = await Promise.all([
+    fetchAgentMetadata(uniqueAgentIds, owner),
+    fetchUserEmails(uniqueUserIds),
+    fetchAssistantTagsByAgentId(auth, owner, uniqueAgentIds),
+    fetchToolsUsedByMessage(auth, agentMessageModelIds),
+    fetchSkillsUsedByMessage(auth, agentMessageModelIds),
+    fetchCreditsByMessageId(
+      auth,
+      startInstant.toISOString(),
+      exclusiveEndInstant.toISOString()
+    ),
+  ]);
 
-  const rows: MessageExportRow[] = docs.map((doc) => {
-    const agent = agentMeta.get(doc.agent_id);
+  if (creditsResult.isErr()) {
+    return new Err(new Error(creditsResult.error.message));
+  }
+  const creditsByMessageId = creditsResult.value;
+
+  const uniqueServerNames = [
+    ...new Set(
+      [...toolsUsedByMessage.values()].flatMap((tools) =>
+        tools.map((t) => t.serverName)
+      )
+    ),
+  ];
+  const serverDisplayNames = await resolveServerDisplayNames(
+    auth,
+    uniqueServerNames
+  );
+
+  const rows: MessageExportRow[] = baseRows.map((row) => {
+    const agent = agentMeta.get(row.assistantId);
+    const tools = toolsUsedByMessage.get(row.agentMessageModelId) ?? [];
+    const skills = skillsUsedByMessage.get(row.agentMessageModelId) ?? [];
+
     return {
-      messageId: doc.message_id,
-      createdAt: moment(doc.timestamp)
+      messageId: row.messageId,
+      createdAt: moment(row.createdAt)
         .tz(timezone)
         .format("YYYY-MM-DD HH:mm:ss"),
-      assistantId: doc.agent_id,
-      assistantName: agent?.name ?? doc.agent_id,
+      assistantId: row.assistantId,
+      assistantName: agent?.name ?? row.assistantId,
       assistantSettings: agent?.settings ?? "unknown",
       assistantTags: joinDistinctSorted(
-        (doc.agent_tag_ids ?? []).map((id) => tagNames.get(id))
+        assistantTagsByAgentId.get(row.assistantId) ?? []
       ),
-      conversationId: doc.conversation_id,
-      parentMessageId: doc.ancestor_message_ids?.[0] ?? "",
-      userId: doc.user_id,
-      userEmail: userEmails.get(doc.user_id) ?? "",
-      source: doc.context_origin ?? "",
+      conversationId: row.conversationId,
+      parentMessageId: row.parentMessageId ?? "",
+      userId: row.userId ?? "",
+      userEmail: row.userId ? (userEmails.get(row.userId) ?? "") : "",
+      source: row.source ?? "",
       toolsUsed: joinDistinctSorted(
-        (doc.tools_used ?? []).map(
+        tools.map(
           (t) =>
-            `${serverDisplayNames.get(t.server_name) ?? t.server_name}${TOOL_NAME_SEPARATOR}${t.tool_name}`
+            `${serverDisplayNames.get(t.serverName) ?? t.serverName}${TOOL_NAME_SEPARATOR}${t.toolName}`
         )
       ),
-      skillsUsed: joinDistinctSorted(
-        (doc.skills_used ?? []).map((s) => s.skill_name)
-      ),
-      modelId: doc.model?.model_id ?? "",
-      modelProviderId: doc.model?.provider_id ?? "",
-      modelResolutionMethod: doc.model?.resolution_method ?? "",
-      credits: Math.round(doc.cost?.billable_awu ?? 0),
+      skillsUsed: joinDistinctSorted(skills),
+      modelId: row.modelId ?? "",
+      modelProviderId: row.modelProviderId ?? "",
+      modelResolutionMethod: row.modelResolutionMethod ?? "",
+      credits: creditsByMessageId.get(row.messageId) ?? 0,
     };
   });
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -295,7 +295,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         {
           model: UserResource.model,
           as: "user",
-          attributes: ["name", "email"],
+          attributes: ["sId", "name", "email"],
         },
       ],
       order: [["id", "ASC"]],


### PR DESCRIPTION
## Summary
- Refactor `fetchMessageExportRows` (`front/lib/api/analytics/messages_export.ts`) to read messages, tools used, skills used, model info, tags, source, and parent/lineage from Postgres instead of the old per-message analytics Elasticsearch index.
- Credits still come from Elasticsearch, but from the newer consumption analytics index (`searchConsumptionAnalytics`, summed per `agent_message_id` via a paginated composite aggregation) rather than the old index — recent messages haven't gone through Postgres reconciliation yet, so the consumption index is the only source that's both accurate and immediately available.
- Public interface (`fetchMessageExportRows`, `MessageExportRow`, `MESSAGE_EXPORT_HEADERS`) is unchanged, so `export_tables.ts` needed no changes.

Stacked on `avervaet/export-feedback-postgres` (same pattern applied there to the feedback export).

## Test plan
- [x] `npx tsgo --noEmit` passes
- [x] `npm run test -- lib/api/analytics/messages_export.test.ts` (6 tests, rewritten to build real Postgres fixtures via `ConversationFactory`/`AgentConfigurationFactory` and mock only `searchConsumptionAnalytics`)
- [x] `npm run test -- lib/api/analytics/` (full analytics suite, 122 tests, all green — no regressions)