### PR TITLE
[front] Ungate conversation credit breakdown

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6825,9 +6825,6 @@
               }
             }
           },
-          "403": {
-            "description": "The workspace does not have access to consumption details"
-          },
           "404": {
             "description": "Conversation not found"
           }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/consumption.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/consumption.test.ts
@@ -3,7 +3,6 @@ import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_me
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import { honoApp } from "@front-api/app";
@@ -71,8 +70,7 @@ function getConsumption({
 
 describe("GET /api/w/:wId/assistant/conversations/:cId/consumption", () => {
   it("returns the exact conversation bill while attribution is unavailable", async () => {
-    const { auth, workspace, conversation } = await setupConversation();
-    await FeatureFlagFactory.basic(auth, "conversation_consumption_details");
+    const { workspace, conversation } = await setupConversation();
 
     const response = await getConsumption({
       workspaceId: workspace.sId,
@@ -89,7 +87,6 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/consumption", () => {
   it("returns reconciled conversation, model, and agent totals", async () => {
     const { auth, workspace, conversation, agentMessage, runUsageModelId } =
       await setupConversation();
-    await FeatureFlagFactory.basic(auth, "conversation_consumption_details");
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation,
       agentMessageModelId: agentMessage.agentMessageId,
@@ -136,16 +133,5 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/consumption", () => {
         ],
       },
     });
-  });
-
-  it("rejects workspaces without the feature flag", async () => {
-    const { workspace, conversation } = await setupConversation();
-
-    const response = await getConsumption({
-      workspaceId: workspace.sId,
-      conversationId: conversation.sId,
-    });
-
-    expect(response.status).toBe(403);
   });
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/consumption.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/consumption.ts
@@ -5,7 +5,6 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -13,8 +12,6 @@ const ParamsSchema = z.object({
 });
 
 const app = workspaceApp();
-
-app.use(withFeatureFlag("conversation_consumption_details"));
 
 /**
  * @swagger
@@ -56,8 +53,6 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                   allOf:
  *                     - $ref: '#/components/schemas/PrivateConversationConsumptionDetails'
  *                   nullable: true
- *       403:
- *         description: The workspace does not have access to consumption details
  *       404:
  *         description: Conversation not found
  */

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -8,7 +8,7 @@ import { getParentConversationTitleLabel } from "@app/components/assistant/conve
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversation } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useActivationPod } from "@app/lib/swr/activation";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -40,7 +40,6 @@ const MOBILE_FORKED_TITLE_TRUNCATE_LENGTH = 35;
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
   const { user } = useAuth();
-  const { hasFeature } = useFeatureFlags();
   const { togglePanel } = useConversationSidePanelContext();
   const { conversation } = useConversation({
     conversationId: activeConversationId,
@@ -179,15 +178,13 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           currentTitle={currentTitle}
         />
         <div className="flex items-center gap-2">
-          {hasFeature("conversation_consumption_details") && (
-            <Button
-              size="sm"
-              label={isMobile ? undefined : "Credit usage"}
-              icon={CoinsStacked01}
-              variant="ghost"
-              onClick={() => togglePanel({ type: "credits" })}
-            />
-          )}
+          <Button
+            size="sm"
+            label={isMobile ? undefined : "Credit usage"}
+            icon={CoinsStacked01}
+            variant="ghost"
+            onClick={() => togglePanel({ type: "credits" })}
+          />
           <Button
             size="sm"
             label={isMobile ? undefined : "Files"}


### PR DESCRIPTION
## Description

This PR ungates the conversation credit breakdown. The message credits breakdown remains gated behind FF until we can display the full cost (including sub agents).

## Tests

## Risk

Low. This only broadens access to an existing read-only aggregate endpoint and UI panel. The message-level feature remains gated. Rollback is reverting this commit.

## Deploy Plan

Deploy normally. No migration or coordinated rollout is required.
