### PR TITLE
[front] Agent loop: stop failing workflows on tool activity heartbeat timeouts

### DIFF
--- a/front/temporal/agent_loop/activities/finalize.test.ts
+++ b/front/temporal/agent_loop/activities/finalize.test.ts
@@ -25,7 +25,14 @@ describe("creditsExhaustedMessage", () => {
 });
 
 describe("logStuckToolsForErroredAgentMessage", () => {
-  const error = { message: "Activity task timed out", name: "ActivityFailure" };
+  const error = {
+    message: "Activity task timed out",
+    name: "ActivityFailure",
+    swallowed: true,
+    activityType: "runToolActivity",
+    retryState: "MAXIMUM_ATTEMPTS_REACHED",
+    timeoutType: "HEARTBEAT",
+  };
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -69,6 +76,8 @@ describe("logStuckToolsForErroredAgentMessage", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         workflowErrorName: "ActivityFailure",
+        swallowed: true,
+        activityType: "runToolActivity",
         stuckTools: [
           {
             actionModelId: action.id,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -174,6 +174,20 @@ export async function finalizeCreditStoppedAgentLoopActivity(
   ]);
 }
 
+// Plain-object error payload passed from the workflow (Error fields don't survive the
+// workflow→activity serialization). The optional fields carry terminal activity failure details;
+// `swallowed` is true when the workflow completes instead of failing (see
+// isSwallowableWorkflowFailure). All optional fields are absent for workflows started before
+// they were added.
+type WorkflowErrorPayload = {
+  message: string;
+  name: string;
+  swallowed?: boolean;
+  activityType?: string;
+  retryState?: string;
+  timeoutType?: string;
+};
+
 // Attribute the failure to the tools that never finished. The worker that ran them may have died
 // without logging anything (heartbeat timeouts), but the action rows it left behind in a
 // non-final status carry the tool identity. Diagnostic only: it must never fail the finalize
@@ -188,7 +202,7 @@ export async function logStuckToolsForErroredAgentMessage(
   }: {
     agentLoopArgs: Pick<AgentLoopArgs, "conversationId" | "agentMessageId">;
     agentMessageModelId: ModelId;
-    error: { message: string; name: string };
+    error: WorkflowErrorPayload;
   }
 ): Promise<void> {
   let stuckTools: {
@@ -226,6 +240,10 @@ export async function logStuckToolsForErroredAgentMessage(
       workspaceId: auth.getNonNullableWorkspace().sId,
       workflowErrorName: error.name,
       workflowErrorMessage: error.message,
+      swallowed: error.swallowed,
+      activityType: error.activityType,
+      retryState: error.retryState,
+      timeoutType: error.timeoutType,
       stuckTools,
     },
     "Agent loop finalized as errored"
@@ -235,7 +253,7 @@ export async function logStuckToolsForErroredAgentMessage(
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
-  error: { message: string; name: string }
+  error: WorkflowErrorPayload
 ): Promise<void> {
   const agentMessageModelId = await notifyWorkflowError(
     authType,

--- a/front/temporal/agent_loop/lib/wait_for_all_promises.test.ts
+++ b/front/temporal/agent_loop/lib/wait_for_all_promises.test.ts
@@ -1,6 +1,17 @@
+import {
+  ActivityFailure,
+  ApplicationFailure,
+  RetryState,
+  TimeoutFailure,
+  TimeoutType,
+} from "@temporalio/common";
 import { describe, expect, it } from "vitest";
 
 import { waitForAllPromises } from "./wait_for_all_promises";
+import {
+  isTerminalRunToolTimeout,
+  RUN_TOOL_ACTIVITY_NAME,
+} from "./workflow_failures";
 
 describe("waitForAllPromises", () => {
   it("preserves result order after every promise succeeds", async () => {
@@ -30,5 +41,55 @@ describe("waitForAllPromises", () => {
 
     resolveRemainingActivity?.();
     await expect(result).rejects.toBe(activityFailure);
+  });
+
+  it("propagates the preferred rejection over an earlier one", async () => {
+    const first = new Error("first");
+    const preferred = new Error("preferred");
+
+    await expect(
+      waitForAllPromises([Promise.reject(first), Promise.reject(preferred)], {
+        preferRejection: (reason) => reason === preferred,
+      })
+    ).rejects.toBe(preferred);
+  });
+
+  it("falls back to the first rejection when none is preferred", async () => {
+    const first = new Error("first");
+    const second = new Error("second");
+
+    await expect(
+      waitForAllPromises([Promise.reject(first), Promise.reject(second)], {
+        preferRejection: () => false,
+      })
+    ).rejects.toBe(first);
+  });
+
+  it("lets a sibling application failure win over a swallowable tool timeout", async () => {
+    // Regression: the agent loop must not swallow a real tool failure because a swallowable
+    // infrastructure timeout on a sibling tool rejected first.
+    const toolTimeout = new ActivityFailure(
+      "Activity task timed out",
+      RUN_TOOL_ACTIVITY_NAME,
+      "activity-id-1",
+      RetryState.MAXIMUM_ATTEMPTS_REACHED,
+      "worker-id",
+      new TimeoutFailure("activity timed out", undefined, TimeoutType.HEARTBEAT)
+    );
+    const applicationFailure = new ActivityFailure(
+      "Activity task failed",
+      RUN_TOOL_ACTIVITY_NAME,
+      "activity-id-2",
+      RetryState.MAXIMUM_ATTEMPTS_REACHED,
+      "worker-id",
+      ApplicationFailure.create({ message: "tool blew up" })
+    );
+
+    await expect(
+      waitForAllPromises(
+        [Promise.reject(toolTimeout), Promise.reject(applicationFailure)],
+        { preferRejection: (reason) => !isTerminalRunToolTimeout(reason) }
+      )
+    ).rejects.toBe(applicationFailure);
   });
 });

--- a/front/temporal/agent_loop/lib/wait_for_all_promises.ts
+++ b/front/temporal/agent_loop/lib/wait_for_all_promises.ts
@@ -2,24 +2,36 @@
  * Wait for every promise to settle, then preserve Promise.all's success and failure contract.
  * This prevents one cancelled activity from letting a workflow finalize while sibling activities
  * are still completing.
+ *
+ * When several promises reject, the first rejection in input order is thrown. `preferRejection`
+ * overrides that order: the first rejection matching the predicate wins, so a swallowable
+ * infrastructure timeout cannot mask a sibling's real failure.
  */
 export async function waitForAllPromises<T>(
-  promises: readonly Promise<T>[]
+  promises: readonly Promise<T>[],
+  { preferRejection }: { preferRejection?: (reason: unknown) => boolean } = {}
 ): Promise<T[]> {
   const results = await Promise.allSettled(promises);
   const values: T[] = [];
   let firstRejection: PromiseRejectedResult | undefined;
+  let firstPreferredRejection: PromiseRejectedResult | undefined;
 
   for (const result of results) {
     if (result.status === "fulfilled") {
       values.push(result.value);
-    } else if (!firstRejection) {
+      continue;
+    }
+    if (!firstRejection) {
       firstRejection = result;
+    }
+    if (!firstPreferredRejection && preferRejection?.(result.reason)) {
+      firstPreferredRejection = result;
     }
   }
 
-  if (firstRejection) {
-    throw firstRejection.reason;
+  const rejection = firstPreferredRejection ?? firstRejection;
+  if (rejection) {
+    throw rejection.reason;
   }
 
   return values;

--- a/front/temporal/agent_loop/lib/workflow_failures.test.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.test.ts
@@ -2,6 +2,7 @@ import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import type { ProtoFailure } from "@temporalio/common";
 import {
   ActivityFailure,
+  ApplicationFailure,
   RetryState,
   TimeoutFailure,
   TimeoutType,
@@ -10,9 +11,13 @@ import { describe, expect, it } from "vitest";
 
 import { makeRunModelLLMError } from "./run_model_errors";
 import {
+  getWorkflowFailureDetails,
   isRunModelLLMUnresponsiveError,
+  isSwallowableWorkflowFailure,
   isTerminalRunModelTimeout,
+  isTerminalRunToolTimeout,
   RUN_MODEL_ACTIVITY_NAME,
+  RUN_TOOL_ACTIVITY_NAME,
 } from "./workflow_failures";
 
 const LLM_TIMEOUT_MESSAGE =
@@ -62,10 +67,9 @@ function makeActivityFailure({
   );
 }
 
+// The production decision, with the tool-timeout patch active as it is for new executions.
 function shouldSwallowWorkflowFailure(error: unknown): boolean {
-  return (
-    isTerminalRunModelTimeout(error) && isRunModelLLMUnresponsiveError(error)
-  );
+  return isSwallowableWorkflowFailure(error, { swallowToolTimeouts: true });
 }
 
 describe("workflow failure predicates", () => {
@@ -115,12 +119,99 @@ describe("workflow failure predicates", () => {
       retryState: RetryState.IN_PROGRESS,
     });
     const unrelatedActivityFailure = makeActivityFailure({
-      activityType: "runToolActivity",
+      activityType: "checkCreditsActivity",
     });
 
     expect(isTerminalRunModelTimeout(nonTerminalFailure)).toBe(false);
     expect(shouldSwallowWorkflowFailure(nonTerminalFailure)).toBe(false);
     expect(isTerminalRunModelTimeout(unrelatedActivityFailure)).toBe(false);
     expect(shouldSwallowWorkflowFailure(unrelatedActivityFailure)).toBe(false);
+  });
+
+  it("matches terminal tool heartbeat timeouts, the single-attempt no_retry case included", () => {
+    // A no_retry tool activity has maximumAttempts 1: its first heartbeat timeout is terminal
+    // with MAXIMUM_ATTEMPTS_REACHED.
+    const failure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+    });
+
+    expect(isTerminalRunToolTimeout(failure)).toBe(true);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(true);
+  });
+
+  it("matches terminal tool StartToClose timeouts", () => {
+    const failure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+      retryState: RetryState.TIMEOUT,
+      timeoutType: TimeoutType.START_TO_CLOSE,
+    });
+
+    expect(isTerminalRunToolTimeout(failure)).toBe(true);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(true);
+  });
+
+  it("ignores non-terminal tool timeouts and non-timeout tool failures", () => {
+    const nonTerminalFailure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+      retryState: RetryState.IN_PROGRESS,
+    });
+    // A tool throwing an application error (not a timeout) must still fail the workflow.
+    const applicationFailure = new ActivityFailure(
+      "Activity task failed",
+      RUN_TOOL_ACTIVITY_NAME,
+      "activity-id",
+      RetryState.MAXIMUM_ATTEMPTS_REACHED,
+      "worker-id",
+      ApplicationFailure.create({ message: "tool blew up" })
+    );
+
+    expect(isTerminalRunToolTimeout(nonTerminalFailure)).toBe(false);
+    expect(shouldSwallowWorkflowFailure(nonTerminalFailure)).toBe(false);
+    expect(isTerminalRunToolTimeout(applicationFailure)).toBe(false);
+    expect(shouldSwallowWorkflowFailure(applicationFailure)).toBe(false);
+  });
+
+  it("keeps the legacy throw for tool timeouts when the patch is inactive", () => {
+    // Replays of histories that predate the "swallow-terminal-tool-timeouts" patch.
+    const toolTimeout = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+    });
+    const modelTimeout = makeActivityFailure();
+
+    expect(
+      isSwallowableWorkflowFailure(toolTimeout, { swallowToolTimeouts: false })
+    ).toBe(false);
+    // The model swallow predates the patch and is not affected by it.
+    expect(
+      isSwallowableWorkflowFailure(modelTimeout, { swallowToolTimeouts: false })
+    ).toBe(true);
+  });
+});
+
+describe("getWorkflowFailureDetails", () => {
+  it("extracts the activity type, retry state and timeout type", () => {
+    const failure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+    });
+
+    expect(getWorkflowFailureDetails(failure)).toEqual({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      retryState: "MAXIMUM_ATTEMPTS_REACHED",
+      timeoutType: "HEARTBEAT",
+    });
+  });
+
+  it("returns no details for non-activity failures", () => {
+    expect(getWorkflowFailureDetails(new Error("boom"))).toEqual({});
   });
 });

--- a/front/temporal/agent_loop/lib/workflow_failures.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.ts
@@ -11,14 +11,7 @@ import {
 import { isRunModelLLMUnresponsiveFailureType } from "./run_model_errors";
 
 export const RUN_MODEL_ACTIVITY_NAME = "runModelAndCreateActionsActivity";
-
-function isRunModelActivityFailure(error: unknown): error is ActivityFailure {
-  if (!(error instanceof ActivityFailure)) {
-    return false;
-  }
-
-  return error.activityType === RUN_MODEL_ACTIVITY_NAME;
-}
+export const RUN_TOOL_ACTIVITY_NAME = "runToolActivity";
 
 function isTerminalRetryState(retryState: RetryState): boolean {
   return (
@@ -27,10 +20,14 @@ function isTerminalRetryState(retryState: RetryState): boolean {
   );
 }
 
-export function isTerminalRunModelTimeout(
-  error: unknown
+function isTerminalActivityTimeout(
+  error: unknown,
+  activityName: string
 ): error is ActivityFailure {
-  if (!isRunModelActivityFailure(error)) {
+  if (
+    !(error instanceof ActivityFailure) ||
+    error.activityType !== activityName
+  ) {
     return false;
   }
 
@@ -46,6 +43,63 @@ export function isTerminalRunModelTimeout(
     error.cause.timeoutType === TimeoutType.START_TO_CLOSE ||
     error.cause.timeoutType === TimeoutType.HEARTBEAT
   );
+}
+
+export function isTerminalRunModelTimeout(
+  error: unknown
+): error is ActivityFailure {
+  return isTerminalActivityTimeout(error, RUN_MODEL_ACTIVITY_NAME);
+}
+
+export function isTerminalRunToolTimeout(
+  error: unknown
+): error is ActivityFailure {
+  return isTerminalActivityTimeout(error, RUN_TOOL_ACTIVITY_NAME);
+}
+
+// Decides whether agentLoopWorkflow completes instead of failing after an error: the message is
+// finalized as errored either way, so swallowing only removes the FAILED status. Model timeouts
+// are swallowed when the failure chain proves the blocked work was an LLM provider timeout. Tool
+// activity timeouts are infrastructure failures (pod killed without drain, heartbeat starvation),
+// not tool errors (tools report those as events): swallowToolTimeouts carries the workflow's
+// patched() state so replays of histories predating the patch keep the legacy throw. Anything
+// else fails the workflow.
+export function isSwallowableWorkflowFailure(
+  error: unknown,
+  { swallowToolTimeouts }: { swallowToolTimeouts: boolean }
+): boolean {
+  if (
+    isTerminalRunModelTimeout(error) &&
+    isRunModelLLMUnresponsiveError(error)
+  ) {
+    return true;
+  }
+
+  return swallowToolTimeouts && isTerminalRunToolTimeout(error);
+}
+
+// Structured failure fields for the finalize activity's log: which activity failed, how its retry
+// policy ended and which timeout fired. Enum values are stringified since they cross the
+// workflow to activity payload boundary.
+export function getWorkflowFailureDetails(error: unknown): {
+  activityType?: string;
+  retryState?: string;
+  timeoutType?: string;
+} {
+  if (!(error instanceof ActivityFailure)) {
+    return {};
+  }
+
+  return {
+    activityType: error.activityType,
+    ...(error.retryState !== undefined
+      ? { retryState: RetryState[error.retryState] }
+      : {}),
+    ...(error.cause instanceof TimeoutFailure &&
+    error.cause.timeoutType !== undefined
+      ? { timeoutType: TimeoutType[error.cause.timeoutType] }
+      : {}),
+  };
 }
 
 export function isRunModelLLMUnresponsiveError(error: unknown): boolean {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -20,8 +20,9 @@ import {
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { waitForAllPromises } from "@app/temporal/agent_loop/lib/wait_for_all_promises";
 import {
-  isRunModelLLMUnresponsiveError,
-  isTerminalRunModelTimeout,
+  getWorkflowFailureDetails,
+  isSwallowableWorkflowFailure,
+  isTerminalRunToolTimeout,
 } from "@app/temporal/agent_loop/lib/workflow_failures";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
@@ -406,11 +407,16 @@ export async function agentLoopWorkflow({
     });
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
-    // The activity publishes user-facing model errors when our code regains control. We swallow
-    // only terminal Temporal timeouts whose failure chain proves the blocked work was an LLM
-    // provider timeout, so unrelated infrastructure timeouts still surface as workflow failures.
-    const shouldSwallowWorkflowFailure =
-      isTerminalRunModelTimeout(err) && isRunModelLLMUnresponsiveError(err);
+    // The message is finalized as errored below either way: swallowing only removes the FAILED
+    // workflow status (see isSwallowableWorkflowFailure). Swallowing a tool timeout turns the
+    // terminal command from fail into complete, so it is gated on a patch marker: replays of
+    // histories that predate the patch keep the legacy throw. The patch is only consulted (and
+    // its marker only recorded) when the error actually is a terminal tool timeout.
+    const shouldSwallowWorkflowFailure = isSwallowableWorkflowFailure(err, {
+      swallowToolTimeouts:
+        isTerminalRunToolTimeout(err) &&
+        patched("swallow-terminal-tool-timeouts"),
+    });
 
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     // Pass this execution's runIds and startStep to finalize so tracking
@@ -441,6 +447,8 @@ export async function agentLoopWorkflow({
         // before passing to the activity.
         message: workflowError.message,
         name: workflowError.name,
+        swallowed: shouldSwallowWorkflowFailure,
+        ...getWorkflowFailureDetails(err),
       })
     );
 
@@ -532,8 +540,13 @@ async function executeStepIteration({
           runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
         })
   );
-  const toolResults: ToolExecutionResult[] =
-    await waitForAllPromises(toolActivityPromises);
+  const toolResults: ToolExecutionResult[] = await waitForAllPromises(
+    toolActivityPromises,
+    {
+      // A swallowable infrastructure timeout must not mask a sibling tool's real failure.
+      preferRejection: (reason) => !isTerminalRunToolTimeout(reason),
+    }
+  );
 
   // Collect all deferred events from tool executions.
   const allDeferredEvents = toolResults.flatMap(


### PR DESCRIPTION
## Goal

When a worker pod dies, every in-flight `no_retry` tool activity fails its single attempt with a heartbeat timeout, and the whole agentLoopWorkflow goes FAILED. This is 62 of the 81 errored runs of the last 2 days ([dashboard](https://app.datadoghq.eu/dashboard/lists?q=Agent%20Loop%20%E2%80%94%20Failed%20Workflows)). The user-facing behavior is already correct (`finalizeErroredAgentLoopActivity` publishes the error message on this path), so the FAILED status is only noise that buries real bugs.

Goal of this PR: an errored run caused by a tool heartbeat timeout completes with the error instead of going FAILED. It does not reduce the number of errored runs: pods still die, runs still error. (The sibling problem, live workers falsely timed out in un-heartbeated stretches, is #31358.)

## What it does

**1. Swallow terminal tool timeouts** — `workflows.ts`, `workflow_failures.ts`

- New predicate `isTerminalRunToolTimeout`: `ActivityFailure` on `runToolActivity`, terminal retry state, cause is a heartbeat or StartToClose `TimeoutFailure`. Shares `isTerminalActivityTimeout` with the existing model predicate.
- The catch block's swallow decision moves into `isSwallowableWorkflowFailure` (exported, tested): the existing model-timeout condition, OR a terminal tool timeout.
- The tool half is gated on `patched("swallow-terminal-tool-timeouts")` because it changes the terminal command (complete instead of fail): replays of histories predating the patch keep the legacy throw. `patched()` is only called when the error actually is a tool timeout, so other failures record no marker.
- Anything else (tool application errors, non-terminal failures) still fails the workflow, test-pinned.

**2. A swallowable timeout cannot mask a sibling's real failure** — `wait_for_all_promises.ts`

`waitForAllPromises` previously threw the first rejection in input order: a timeout on tool A could hide a genuine error on tool B, and the workflow would wrongly complete. New optional `preferRejection` predicate: the first rejection matching it wins. The tool call site passes `(reason) => !isTerminalRunToolTimeout(reason)`.

**3. Failure details on the finalize log** — `finalize.ts`, `workflows.ts`

The workflow now passes `swallowed`, `activityType`, `retryState`, `timeoutType` (extracted by `getWorkflowFailureDetails`, enums stringified) to `finalizeErroredAgentLoopActivity`, and the existing "Agent loop finalized as errored" log emits them. Swallowed runs no longer produce the SDK's "Workflow failed" log, so this keeps the cause queryable, and the dashboard's infra/genuine split can use `@swallowed` instead of matching message text. Fields are optional (`WorkflowErrorPayload`): in-flight workflows started before the deploy call the activity without them.

## Review notes

- The swallow deliberately covers all terminal tool timeouts, unlike the model swallow which requires proof of an LLM-provider timeout in the failure chain. Rationale: tools report their own failures as events, never by throwing timeouts, so a tool activity timeout is infrastructure by construction.
- No command is added or reordered on any path: the catch schedules the same finalize activity; only the final throw/return differs, and that is patch-gated.
- Danger will warn about temporal file changes; no activity is added or renamed.

## Tests

`isSwallowableWorkflowFailure` (patched and unpatched), `isTerminalRunToolTimeout`, `getWorkflowFailureDetails`, `preferRejection` incl. the mixed sibling-failure regression, finalize log shape with the new fields. `workflows.test.ts` green, `tsgo --noEmit` clean.

## Risk

Terminal command change is patch-gated (see above). Standard patch caveat: workflows that recorded the marker must complete before rolling back to a build without it.

## Deploy Plan

- [ ] Deploy front.
- [ ] Dashboard "Workflow FAILED on heartbeat timeout" drops to ~0.
- [ ] Errored-run volume unchanged.
