### PR TITLE
[front] Consolidate duplicate day/hour millisecond constants

### DIFF
--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -10,12 +10,10 @@ import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { isCreditPricedPlan } from "@app/types/plan";
-import { ordinalDay } from "@app/types/shared/utils/date_utils";
+import { DAY_MS, ordinalDay } from "@app/types/shared/utils/date_utils";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { ProgressBar, Separator, Spinner, Stars02 } from "@dust-tt/sparkle";
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 interface PersonalUsageCardProps {
   owner: WorkspaceType;
@@ -93,7 +91,7 @@ export function PersonalUsageCard({
       now.getUTCDate()
     );
     const daysUntilAvailable = Math.round(
-      (availableDayMs - currentDayMs) / MS_PER_DAY
+      (availableDayMs - currentDayMs) / DAY_MS
     );
 
     if (daysUntilAvailable === 0) {

--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -10,7 +10,7 @@ import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { isCreditPricedPlan } from "@app/types/plan";
-import { DAY_MS, ordinalDay } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS, ordinalDay } from "@app/types/shared/utils/date_utils";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { ProgressBar, Separator, Spinner, Stars02 } from "@dust-tt/sparkle";
@@ -91,7 +91,7 @@ export function PersonalUsageCard({
       now.getUTCDate()
     );
     const daysUntilAvailable = Math.round(
-      (availableDayMs - currentDayMs) / DAY_MS
+      (availableDayMs - currentDayMs) / ONE_DAY_MS
     );
 
     if (daysUntilAvailable === 0) {

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -5,12 +5,12 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { Button, cn } from "@dust-tt/sparkle";
 import { useMemo, useRef } from "react";
 
 const SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
-const THRESHOLD_MS = SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS * DAY_MS;
+const THRESHOLD_MS = SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS * ONE_DAY_MS;
 
 function isSubscriptionManagementRoute(path: string) {
   return (
@@ -56,7 +56,7 @@ export function SubscriptionEndBanner({
     }
 
     const hasEnded = endDate < now;
-    const daysRemaining = Math.max(0, Math.ceil((endDate - now) / DAY_MS));
+    const daysRemaining = Math.max(0, Math.ceil((endDate - now) / ONE_DAY_MS));
 
     return { hasEnded, daysRemaining };
   }, [endDate]);

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -5,13 +5,12 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import { Button, cn } from "@dust-tt/sparkle";
 import { useMemo, useRef } from "react";
 
 const SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
-const THRESHOLD_MS =
-  SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
-const DAY_MS = 24 * 60 * 60 * 1000;
+const THRESHOLD_MS = SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS * DAY_MS;
 
 function isSubscriptionManagementRoute(path: string) {
   return (

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -13,6 +13,7 @@ import type {
   CheckSummary,
   CheckSummaryStatus,
 } from "@app/types/production_checks";
+import { DAY_MS as ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { conjugate, pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Button,
@@ -29,7 +30,6 @@ import type React from "react";
 import type { ComponentProps } from "react";
 import { useCallback, useMemo, useState } from "react";
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_VISIBLE = 5;
 
 const STATUS_CHIP_CONFIG: Record<

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -13,7 +13,7 @@ import type {
   CheckSummary,
   CheckSummaryStatus,
 } from "@app/types/production_checks";
-import { DAY_MS as ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { conjugate, pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Button,

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -28,7 +28,7 @@ import type { AwuUsageAnalyticsResponse } from "@app/lib/api/analytics/awu_usage
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { useAwuUsageFromAnalytics } from "@app/lib/swr/workspaces";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import {
   Button,
   Chip,
@@ -127,12 +127,12 @@ export function formatBucketRange(
     now.getUTCDate()
   );
   // Mirrors the server-side window from daysToInstantRange(days, "UTC").
-  const windowStartMs = todayMs - (days - 1) * DAY_MS;
+  const windowStartMs = todayMs - (days - 1) * ONE_DAY_MS;
 
   const bucketStart = new Date(bucketStartMs);
   const bucketEndMs =
     granularity === "week"
-      ? bucketStartMs + 6 * DAY_MS
+      ? bucketStartMs + 6 * ONE_DAY_MS
       : Date.UTC(
           bucketStart.getUTCFullYear(),
           bucketStart.getUTCMonth() + 1,

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -28,6 +28,7 @@ import type { AwuUsageAnalyticsResponse } from "@app/lib/api/analytics/awu_usage
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { useAwuUsageFromAnalytics } from "@app/lib/swr/workspaces";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import {
   Button,
   Chip,
@@ -101,8 +102,6 @@ function getColorClassName(
   }
   return getIndexedColor(groupKey, allKeys);
 }
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 function formatUtcMonthDay(date: Date): string {
   return date.toLocaleDateString("en-US", {

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -12,6 +12,7 @@ import { SEAT_PRODUCT_YEARLY_SUFFIX } from "@app/lib/metronome/constants";
 import type { SupportedCurrency } from "@app/types/currency";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   AlertCircle,
@@ -140,8 +141,6 @@ function formatAwuCredits(info: SeatTypeInfo): string {
   }`;
 }
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 // Preview endpoints return a monthly-equivalent figure for every cadence
 // (e.g. annual price / 12), treating it as a steady-state run rate. Seats
 // don't actually bill that way at any cadence: every seat subscription is
@@ -175,13 +174,13 @@ function prorateAmountForCurrentPeriod({
 }): { amountCents: number; daysRemaining: number } | null {
   const startMs = new Date(currentBillingPeriod.startsAt).getTime();
   const endMs = new Date(currentBillingPeriod.endsAt).getTime();
-  const totalDays = (endMs - startMs) / MS_PER_DAY;
+  const totalDays = (endMs - startMs) / DAY_MS;
   if (!(totalDays > 0)) {
     return null;
   }
   const daysRemaining = Math.min(
     totalDays,
-    Math.max(0, (endMs - Date.now()) / MS_PER_DAY)
+    Math.max(0, (endMs - Date.now()) / DAY_MS)
   );
   return {
     amountCents: Math.round(amountCents * (daysRemaining / totalDays)),

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -12,7 +12,7 @@ import { SEAT_PRODUCT_YEARLY_SUFFIX } from "@app/lib/metronome/constants";
 import type { SupportedCurrency } from "@app/types/currency";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   AlertCircle,
@@ -174,13 +174,13 @@ function prorateAmountForCurrentPeriod({
 }): { amountCents: number; daysRemaining: number } | null {
   const startMs = new Date(currentBillingPeriod.startsAt).getTime();
   const endMs = new Date(currentBillingPeriod.endsAt).getTime();
-  const totalDays = (endMs - startMs) / DAY_MS;
+  const totalDays = (endMs - startMs) / ONE_DAY_MS;
   if (!(totalDays > 0)) {
     return null;
   }
   const daysRemaining = Math.min(
     totalDays,
-    Math.max(0, (endMs - Date.now()) / DAY_MS)
+    Math.max(0, (endMs - Date.now()) / ONE_DAY_MS)
   );
   return {
     amountCents: Math.round(amountCents * (daysRemaining / totalDays)),

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -32,7 +32,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 
 type PodTaskUpdateItem = {
   taskId: string;
@@ -233,7 +233,7 @@ export function createProjectTasksTools(
           });
         }
 
-        const cutoff = new Date(Date.now() - daysAgo * DAY_MS);
+        const cutoff = new Date(Date.now() - daysAgo * ONE_DAY_MS);
 
         if (statusFilter === "open") {
           rows = rows.filter((t) => t.status !== "done");

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -32,8 +32,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 
 type PodTaskUpdateItem = {
   taskId: string;
@@ -234,7 +233,7 @@ export function createProjectTasksTools(
           });
         }
 
-        const cutoff = new Date(Date.now() - daysAgo * MS_PER_DAY);
+        const cutoff = new Date(Date.now() - daysAgo * DAY_MS);
 
         if (statusFilter === "open") {
           rows = rows.filter((t) => t.status !== "done");

--- a/front/lib/api/analytics/active_users_export.ts
+++ b/front/lib/api/analytics/active_users_export.ts
@@ -9,7 +9,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -49,7 +49,7 @@ function computeRollingActiveUsers(
   endTimestampMs: number,
   windowDays: number
 ): number {
-  const startMs = endTimestampMs - (windowDays - 1) * DAY_MS;
+  const startMs = endTimestampMs - (windowDays - 1) * ONE_DAY_MS;
   const uniqueUsers = new Set<string>();
 
   for (const [ts, users] of usersByDay) {

--- a/front/lib/api/analytics/active_users_export.ts
+++ b/front/lib/api/analytics/active_users_export.ts
@@ -9,6 +9,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -39,7 +40,6 @@ interface ActiveUsersExportAggs {
 const WAU_WINDOW_DAYS = 7;
 const MAU_WINDOW_DAYS = 28;
 const COMPOSITE_AGG_SIZE = 10_000;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
  * Computes the count of unique users over a rolling window ending at the given timestamp.
@@ -49,7 +49,7 @@ function computeRollingActiveUsers(
   endTimestampMs: number,
   windowDays: number
 ): number {
-  const startMs = endTimestampMs - (windowDays - 1) * MS_PER_DAY;
+  const startMs = endTimestampMs - (windowDays - 1) * DAY_MS;
   const uniqueUsers = new Set<string>();
 
   for (const [ts, users] of usersByDay) {

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -1,6 +1,6 @@
 import {
-  DAY_MS,
   getTimestampsForWindow,
+  ONE_DAY_MS,
 } from "@app/lib/api/analytics/time_utils";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
@@ -296,7 +296,7 @@ export async function getProgrammaticCost(
     getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
   // Cap periodEnd to 10 days in the future to avoid too big empty chart areas.
-  const TEN_DAYS_MS = 10 * DAY_MS;
+  const TEN_DAYS_MS = 10 * ONE_DAY_MS;
   const cappedPeriodEnd = new Date(
     Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
   );

--- a/front/lib/api/analytics/time_utils.ts
+++ b/front/lib/api/analytics/time_utils.ts
@@ -1,20 +1,20 @@
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { DAY_MS, HOUR_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS, ONE_HOUR_MS } from "@app/types/shared/utils/date_utils";
 
-export { DAY_MS, HOUR_MS };
+export { ONE_DAY_MS, ONE_HOUR_MS };
 
-const FOUR_HOURS_MS = 4 * HOUR_MS;
+const FOUR_HOURS_MS = 4 * ONE_HOUR_MS;
 
 export type WindowSize = "HOUR" | "FOUR_HOURS" | "DAY";
 
 function getWindowSizeMs(windowSize: WindowSize): number {
   switch (windowSize) {
     case "HOUR":
-      return HOUR_MS;
+      return ONE_HOUR_MS;
     case "FOUR_HOURS":
       return FOUR_HOURS_MS;
     case "DAY":
-      return DAY_MS;
+      return ONE_DAY_MS;
     default:
       assertNever(windowSize);
   }

--- a/front/lib/api/analytics/time_utils.ts
+++ b/front/lib/api/analytics/time_utils.ts
@@ -1,8 +1,9 @@
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { DAY_MS, HOUR_MS } from "@app/types/shared/utils/date_utils";
 
-export const HOUR_MS = 3_600_000;
+export { DAY_MS, HOUR_MS };
+
 const FOUR_HOURS_MS = 4 * HOUR_MS;
-export const DAY_MS = 24 * HOUR_MS;
 
 export type WindowSize = "HOUR" | "FOUR_HOURS" | "DAY";
 

--- a/front/lib/api/assistant/inactivity/policy.ts
+++ b/front/lib/api/assistant/inactivity/policy.ts
@@ -3,7 +3,7 @@ import type { TriggerKind, TriggerStatus } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 
 /**
  * Pure business rules for automatic archival of inactive agents: no database, no Temporal, no
@@ -11,7 +11,7 @@ import { DAY_MS } from "@app/types/shared/utils/date_utils";
  * infrastructure.
  */
 
-export const ONE_DAY_MS = DAY_MS;
+export { ONE_DAY_MS };
 
 export const MIN_INACTIVITY_THRESHOLD_DAYS = 2;
 export const MAX_INACTIVITY_THRESHOLD_DAYS = 366;

--- a/front/lib/api/assistant/inactivity/policy.ts
+++ b/front/lib/api/assistant/inactivity/policy.ts
@@ -3,6 +3,7 @@ import type { TriggerKind, TriggerStatus } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 
 /**
  * Pure business rules for automatic archival of inactive agents: no database, no Temporal, no
@@ -10,7 +11,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
  * infrastructure.
  */
 
-export const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+export const ONE_DAY_MS = DAY_MS;
 
 export const MIN_INACTIVITY_THRESHOLD_DAYS = 2;
 export const MAX_INACTIVITY_THRESHOLD_DAYS = 366;

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -5,6 +5,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
@@ -45,7 +46,6 @@ interface ActiveUsersAggs {
 const WAU_WINDOW_DAYS = 7;
 const MAU_WINDOW_DAYS = 28;
 const COMPOSITE_AGG_SIZE = 10000;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
  * Computes the count of unique users over a rolling window ending at the given timestamp.
@@ -55,7 +55,7 @@ function computeRollingActiveUsers(
   endTimestamp: number,
   windowDays: number
 ): number {
-  const startMs = endTimestamp - (windowDays - 1) * MS_PER_DAY;
+  const startMs = endTimestamp - (windowDays - 1) * DAY_MS;
   const uniqueUsers = new Set<string>();
 
   for (const [ts, users] of usersByDay) {

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -5,7 +5,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
@@ -55,7 +55,7 @@ function computeRollingActiveUsers(
   endTimestamp: number,
   windowDays: number
 ): number {
-  const startMs = endTimestamp - (windowDays - 1) * DAY_MS;
+  const startMs = endTimestamp - (windowDays - 1) * ONE_DAY_MS;
   const uniqueUsers = new Set<string>();
 
   for (const [ts, users] of usersByDay) {

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -13,6 +13,7 @@ import type {
   MaxMessagesTimeframeType,
 } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
 export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE = 100;
@@ -92,7 +93,6 @@ export const makeFairUseAwuCreditsRateLimitKeyForUser = (
 
 export const PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK = 25;
 export const PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS = 7 * 24 * 60 * 60;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export const makePremiumModelMessageRateLimitKeyForUser = (
   workspace: Pick<LightWorkspaceType, "id">,
@@ -162,7 +162,7 @@ function getPremiumModelDailyUsage({
   for (
     let dayStartMs = firstDayStartMs;
     dayStartMs <= lastDayStartMs;
-    dayStartMs += MS_PER_DAY
+    dayStartMs += DAY_MS
   ) {
     const date = new Date(dayStartMs).toISOString().slice(0, 10);
     dailyUsage.push({ date, usedMessages: usageByDay.get(date) ?? 0 });

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -13,7 +13,7 @@ import type {
   MaxMessagesTimeframeType,
 } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
 export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE = 100;
@@ -162,7 +162,7 @@ function getPremiumModelDailyUsage({
   for (
     let dayStartMs = firstDayStartMs;
     dayStartMs <= lastDayStartMs;
-    dayStartMs += DAY_MS
+    dayStartMs += ONE_DAY_MS
   ) {
     const date = new Date(dayStartMs).toISOString().slice(0, 10);
     dailyUsage.push({ date, usedMessages: usageByDay.get(date) ?? 0 });

--- a/front/lib/api/billing/migrate_to_business.ts
+++ b/front/lib/api/billing/migrate_to_business.ts
@@ -37,7 +37,7 @@ import logger from "@app/logger/logger";
 import type { PlanType } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // One-off free AWU credit granted per workspace member at migration time. The
@@ -179,7 +179,7 @@ export function remainingPrepaidDays(
 ): number {
   return Math.max(
     0,
-    Math.ceil((currentPeriodEndMs - migrationDate.getTime()) / DAY_MS)
+    Math.ceil((currentPeriodEndMs - migrationDate.getTime()) / ONE_DAY_MS)
   );
 }
 

--- a/front/lib/api/billing/migrate_to_business.ts
+++ b/front/lib/api/billing/migrate_to_business.ts
@@ -37,6 +37,7 @@ import logger from "@app/logger/logger";
 import type { PlanType } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // One-off free AWU credit granted per workspace member at migration time. The
@@ -124,8 +125,6 @@ export function migrationDateInWindow(
   return null;
 }
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 /**
  * Resolve the migration instant for a workspace inside the rollout window.
  *  - monthly: the workspace's own monthly renewal boundary that lands in the
@@ -180,7 +179,7 @@ export function remainingPrepaidDays(
 ): number {
   return Math.max(
     0,
-    Math.ceil((currentPeriodEndMs - migrationDate.getTime()) / MS_PER_DAY)
+    Math.ceil((currentPeriodEndMs - migrationDate.getTime()) / DAY_MS)
   );
 }
 

--- a/front/lib/api/mcp_server/tools/pods/get_tasks.ts
+++ b/front/lib/api/mcp_server/tools/pods/get_tasks.ts
@@ -1,11 +1,10 @@
 import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mcpError, mcpJsonResponse } from "../response";
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const inputSchema = {
   podId: z.string().describe("Pod id to list tasks for."),
@@ -67,7 +66,7 @@ export function registerPodsGetTasksTool(server: McpServer) {
         });
       }
 
-      const cutoff = new Date(Date.now() - daysAgo * MS_PER_DAY);
+      const cutoff = new Date(Date.now() - daysAgo * DAY_MS);
 
       if (statusFilter === "open") {
         rows = rows.filter((task) => task.status !== "done");

--- a/front/lib/api/mcp_server/tools/pods/get_tasks.ts
+++ b/front/lib/api/mcp_server/tools/pods/get_tasks.ts
@@ -1,7 +1,7 @@
 import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mcpError, mcpJsonResponse } from "../response";
@@ -66,7 +66,7 @@ export function registerPodsGetTasksTool(server: McpServer) {
         });
       }
 
-      const cutoff = new Date(Date.now() - daysAgo * DAY_MS);
+      const cutoff = new Date(Date.now() - daysAgo * ONE_DAY_MS);
 
       if (statusFilter === "open") {
         rows = rows.filter((task) => task.status !== "done");

--- a/front/lib/api/projects/restriction_impact.ts
+++ b/front/lib/api/projects/restriction_impact.ts
@@ -6,7 +6,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { PodRestrictionImpactType } from "@app/types/api/projects/restriction_impact";
 import { POD_RESTRICTION_IMPACT_WINDOW_DAYS } from "@app/types/api/projects/restriction_impact";
 import type { ModelId } from "@app/types/shared/model_id";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 
 // Who still reaches the Pod once the global group is gone: its own member and editor groups, plus
 // workspace admins, who administrate every space. Function reads go through
@@ -47,7 +47,7 @@ export async function getPodRestrictionImpact(
 ): Promise<PodRestrictionImpactType> {
   const sandboxFunctions = await SandboxFunctionResource.listBySpace(auth, pod);
   const since = new Date(
-    Date.now() - POD_RESTRICTION_IMPACT_WINDOW_DAYS * DAY_MS
+    Date.now() - POD_RESTRICTION_IMPACT_WINDOW_DAYS * ONE_DAY_MS
   );
   const countsByUserModelId =
     await SandboxFunctionInvocationResource.countByUserSince(auth, {

--- a/front/lib/api/projects/restriction_impact.ts
+++ b/front/lib/api/projects/restriction_impact.ts
@@ -6,8 +6,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { PodRestrictionImpactType } from "@app/types/api/projects/restriction_impact";
 import { POD_RESTRICTION_IMPACT_WINDOW_DAYS } from "@app/types/api/projects/restriction_impact";
 import type { ModelId } from "@app/types/shared/model_id";
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 
 // Who still reaches the Pod once the global group is gone: its own member and editor groups, plus
 // workspace admins, who administrate every space. Function reads go through
@@ -48,7 +47,7 @@ export async function getPodRestrictionImpact(
 ): Promise<PodRestrictionImpactType> {
   const sandboxFunctions = await SandboxFunctionResource.listBySpace(auth, pod);
   const since = new Date(
-    Date.now() - POD_RESTRICTION_IMPACT_WINDOW_DAYS * MS_PER_DAY
+    Date.now() - POD_RESTRICTION_IMPACT_WINDOW_DAYS * DAY_MS
   );
   const countsByUserModelId =
     await SandboxFunctionInvocationResource.countByUserSince(auth, {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -19,7 +19,7 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import { isMembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { DAY_MS, HOUR_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS, ONE_HOUR_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import Metronome, { BadRequestError, ConflictError } from "@metronome/sdk";
@@ -69,7 +69,9 @@ export function getMetronomeClient(): Metronome {
 
 // Metronome requires dates on specific boundaries (hour for contracts, midnight for usage).
 export function floorToHourISO(date: Date): string {
-  return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
+  return new Date(
+    Math.floor(date.getTime() / ONE_HOUR_MS) * ONE_HOUR_MS
+  ).toISOString();
 }
 
 /** Convert an epoch-seconds timestamp (e.g. from Stripe) to an hour-floored ISO string. */
@@ -78,7 +80,9 @@ export function epochSecondsToFloorHourISO(epochSeconds: number): string {
 }
 
 export function ceilToHourISO(date: Date): string {
-  return new Date(Math.ceil(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
+  return new Date(
+    Math.ceil(date.getTime() / ONE_HOUR_MS) * ONE_HOUR_MS
+  ).toISOString();
 }
 
 export function floorToMidnightUTC(d: Date): Date {
@@ -90,7 +94,7 @@ export function floorToMidnightUTC(d: Date): Date {
 export function ceilToMidnightUTC(d: Date): Date {
   const floored = floorToMidnightUTC(d);
   return floored.getTime() < d.getTime()
-    ? new Date(floored.getTime() + DAY_MS)
+    ? new Date(floored.getTime() + ONE_DAY_MS)
     : floored;
 }
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -19,6 +19,7 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import { isMembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { DAY_MS, HOUR_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import Metronome, { BadRequestError, ConflictError } from "@metronome/sdk";
@@ -67,9 +68,6 @@ export function getMetronomeClient(): Metronome {
 }
 
 // Metronome requires dates on specific boundaries (hour for contracts, midnight for usage).
-const HOUR_MS = 3_600_000;
-const DAY_MS = 24 * HOUR_MS;
-
 export function floorToHourISO(date: Date): string {
   return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
 }

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -3,6 +3,7 @@ import type {
   WakeUpType,
 } from "@app/types/assistant/wakeups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
@@ -53,13 +54,11 @@ export function getNextWakeUpFireAtFromScheduleConfig(
   }
 }
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-
 // Compact label for the sidebar conversation-list wake-up indicator. When
 // the next firing is more than a day away the time of day on its own gives
 // the viewer no sense of when — show the abbreviated weekday instead.
 export function formatWakeUpSidebarLabel(timestamp: number): string {
-  if (timestamp - Date.now() > ONE_DAY_MS) {
+  if (timestamp - Date.now() > DAY_MS) {
     return new Date(timestamp).toLocaleDateString("en-US", {
       weekday: "short",
     });

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -3,7 +3,7 @@ import type {
   WakeUpType,
 } from "@app/types/assistant/wakeups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
@@ -58,7 +58,7 @@ export function getNextWakeUpFireAtFromScheduleConfig(
 // the next firing is more than a day away the time of day on its own gives
 // the viewer no sense of when — show the abbreviated weekday instead.
 export function formatWakeUpSidebarLabel(timestamp: number): string {
-  if (timestamp - Date.now() > DAY_MS) {
+  if (timestamp - Date.now() > ONE_DAY_MS) {
     return new Date(timestamp).toLocaleDateString("en-US", {
       weekday: "short",
     });

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -7,7 +7,7 @@ import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { AgentMessageAnalyticsData } from "@app/types/assistant/analytics";
 import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
 const TOKEN_PROMPT_RANGE = { min: 100, max: 5000 };
@@ -24,7 +24,7 @@ function randomInt(min: number, max: number): number {
 
 function randomDate(daysBack: number): Date {
   const now = Date.now();
-  const pastMs = daysBack * DAY_MS;
+  const pastMs = daysBack * ONE_DAY_MS;
   const randomOffset = Math.random() * pastMs;
   return new Date(now - randomOffset);
 }

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -7,6 +7,7 @@ import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { AgentMessageAnalyticsData } from "@app/types/assistant/analytics";
 import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
 const TOKEN_PROMPT_RANGE = { min: 100, max: 5000 };
@@ -16,7 +17,6 @@ const COST_MICRO_USD_RANGE = { min: 1_000_000, max: 10_000_000 };
 const LATENCY_MS_RANGE = { min: 100, max: 2000 };
 const AGENT_COUNT = 5;
 const API_KEY_COUNT = 3;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -24,7 +24,7 @@ function randomInt(min: number, max: number): number {
 
 function randomDate(daysBack: number): Date {
   const now = Date.now();
-  const pastMs = daysBack * MS_PER_DAY;
+  const pastMs = daysBack * DAY_MS;
   const randomOffset = Math.random() * pastMs;
   return new Date(now - randomOffset);
 }

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -22,6 +22,7 @@ import type {
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
+import { DAY_MS, HOUR_MS } from "@app/types/shared/utils/date_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 import type { SeedContext } from "./types";
@@ -42,8 +43,6 @@ const SEED_CONSUMPTION_KEY_PREFIX = "seed-consumption";
 const DEFAULT_DAYS_BACK = 90;
 const DEFAULT_MESSAGES_PER_DAY = 12;
 const BULK_CHUNK_SIZE = 500;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-const MS_PER_HOUR = 60 * 60 * 1000;
 
 const LLM_CREDIT_RANGE = { min: 0.2, max: 8 };
 const TOOL_DIRECT_CREDIT_RANGE = { min: 0.01, max: 0.4 };
@@ -248,7 +247,7 @@ function planDayMessages(
     const index = startIndex + messages.length;
     const completedAtMs = Math.min(
       dayStartMs +
-        randomInt(random, FIRST_HOUR_UTC, LAST_HOUR_UTC) * MS_PER_HOUR +
+        randomInt(random, FIRST_HOUR_UTC, LAST_HOUR_UTC) * HOUR_MS +
         randomInt(random, 0, 59) * 60 * 1000,
       nowMs
     );
@@ -498,12 +497,12 @@ function planDocuments(
 ): AgentMessageConsumptionAnalyticsData[] {
   const random = makeRandom(daysBack * 1000 + messagesPerDay);
   const nowMs = Date.now();
-  const todayStartMs = Math.floor(nowMs / MS_PER_DAY) * MS_PER_DAY;
+  const todayStartMs = Math.floor(nowMs / DAY_MS) * DAY_MS;
   const documents: AgentMessageConsumptionAnalyticsData[] = [];
   let messageIndex = 0;
 
   for (let dayOffset = daysBack - 1; dayOffset >= 0; dayOffset--) {
-    const dayStartMs = todayStartMs - dayOffset * MS_PER_DAY;
+    const dayStartMs = todayStartMs - dayOffset * DAY_MS;
     const dayOfWeek = new Date(dayStartMs).getUTCDay();
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
     // A trend and a weekly rhythm, rather than noise around a flat line.

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -22,7 +22,7 @@ import type {
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
-import { DAY_MS, HOUR_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS, ONE_HOUR_MS } from "@app/types/shared/utils/date_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 import type { SeedContext } from "./types";
@@ -247,7 +247,7 @@ function planDayMessages(
     const index = startIndex + messages.length;
     const completedAtMs = Math.min(
       dayStartMs +
-        randomInt(random, FIRST_HOUR_UTC, LAST_HOUR_UTC) * HOUR_MS +
+        randomInt(random, FIRST_HOUR_UTC, LAST_HOUR_UTC) * ONE_HOUR_MS +
         randomInt(random, 0, 59) * 60 * 1000,
       nowMs
     );
@@ -497,12 +497,12 @@ function planDocuments(
 ): AgentMessageConsumptionAnalyticsData[] {
   const random = makeRandom(daysBack * 1000 + messagesPerDay);
   const nowMs = Date.now();
-  const todayStartMs = Math.floor(nowMs / DAY_MS) * DAY_MS;
+  const todayStartMs = Math.floor(nowMs / ONE_DAY_MS) * ONE_DAY_MS;
   const documents: AgentMessageConsumptionAnalyticsData[] = [];
   let messageIndex = 0;
 
   for (let dayOffset = daysBack - 1; dayOffset >= 0; dayOffset--) {
-    const dayStartMs = todayStartMs - dayOffset * DAY_MS;
+    const dayStartMs = todayStartMs - dayOffset * ONE_DAY_MS;
     const dayOfWeek = new Date(dayStartMs).getUTCDay();
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
     // A trend and a weekly rhythm, rather than noise around a flat line.

--- a/front/temporal/triggers/schedule_client.ts
+++ b/front/temporal/triggers/schedule_client.ts
@@ -15,7 +15,7 @@ import {
 } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { DAY_MS } from "@app/types/shared/utils/date_utils";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { ScheduleOptions, ScheduleSpec } from "@temporalio/client";
 import {
@@ -56,7 +56,7 @@ function computeIntervalOffsetMs(config: IntervalScheduleConfig): number {
     // Week-aligned: offset to reach target day-of-week from epoch Thursday.
     const epochDayOfWeek = 4; // Thursday
     const offsetDays = (config.dayOfWeek - epochDayOfWeek + 7) % 7;
-    return offsetDays * DAY_MS + utcTimeMs;
+    return offsetDays * ONE_DAY_MS + utcTimeMs;
   }
 
   // Pure day interval: just set the time-of-day offset.
@@ -79,7 +79,7 @@ function buildScheduleSpec(config: ScheduleConfig): ScheduleSpec {
   }
 
   // Interval-based (N-day, N-week).
-  const everyMs = config.intervalDays * DAY_MS;
+  const everyMs = config.intervalDays * ONE_DAY_MS;
   const offsetMs = computeIntervalOffsetMs(config);
   return {
     intervals: [{ every: everyMs, offset: offsetMs }],

--- a/front/temporal/triggers/schedule_client.ts
+++ b/front/temporal/triggers/schedule_client.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { DAY_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { ScheduleOptions, ScheduleSpec } from "@temporalio/client";
 import {
@@ -22,8 +23,6 @@ import {
   ScheduleOverlapPolicy,
 } from "@temporalio/client";
 import moment from "moment-timezone";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Convert local hour/minute in a given IANA timezone to a UTC-based

--- a/front/types/shared/utils/date_utils.ts
+++ b/front/types/shared/utils/date_utils.ts
@@ -1,7 +1,7 @@
 import { format } from "date-fns";
 
-export const HOUR_MS = 3_600_000;
-export const DAY_MS = 24 * HOUR_MS;
+export const ONE_HOUR_MS = 60 * 60 * 1000;
+export const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
 export function isValidDate(date: Date) {
   return !isNaN(date.valueOf());

--- a/front/types/shared/utils/date_utils.ts
+++ b/front/types/shared/utils/date_utils.ts
@@ -1,5 +1,8 @@
 import { format } from "date-fns";
 
+export const HOUR_MS = 3_600_000;
+export const DAY_MS = 24 * HOUR_MS;
+
 export function isValidDate(date: Date) {
   return !isNaN(date.valueOf());
 }


### PR DESCRIPTION
## Description

`DAY_MS` / `MS_PER_DAY` / `ONE_DAY_MS` (24 * 60 * 60 * 1000) was redefined locally in ~15 files across components, scripts, temporal, and lib/api. Copy-pasted constants like this spread fast with AI-assisted edits, each new file tends to redefine the constant instead of finding the existing one, so the duplication multiplies over time instead of staying at one bad instance. 

## Tests

## Risk

Pure refactor, no behavior change: all sites now point at the same constant value they already had inline.

## Deploy Plan

