### PR TITLE
[front] Agent loop: heartbeat for the whole tool activity

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -17,7 +17,10 @@ import { getShutdownSignal } from "@app/lib/shutdown_signal";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
-import { TOOL_SETUP_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
+import {
+  TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+  TOOL_SETUP_HEARTBEAT_INTERVAL_MS,
+} from "@app/temporal/agent_loop/config";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type {
@@ -91,6 +94,28 @@ function extractDataSourceIds(
 
 export async function runToolActivity(
   authType: AuthenticatorType,
+  params: {
+    actionId: ModelId;
+    runAgentArgs: AgentLoopArgsWithTiming;
+    step: number;
+    runIds?: string[];
+  }
+): Promise<ToolExecutionResult> {
+  // Several phases of a tool run (action state transitions, MCP server connection, event
+  // publication) sit outside the MCP call's own heartbeat loop and can stall past the heartbeat
+  // timeout under DB or network contention. Tools with the no_retry policy get a single attempt,
+  // so one missed heartbeat window fails the whole run: heartbeat immediately and periodically
+  // for the whole activity, same pattern as runModelAndCreateActionsActivity.
+  heartbeat();
+
+  return withPeriodicHeartbeat(() => _runToolActivity(authType, params), {
+    intervalMs: TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+    heartbeatFn: () => heartbeat(),
+  });
+}
+
+async function _runToolActivity(
+  authType: AuthenticatorType,
   {
     actionId,
     runAgentArgs,
@@ -103,13 +128,10 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  // The setup phase below is DB-bound and can stall past the heartbeat timeout under
-  // connection-pool contention. Tool activities are not retried, so a missed first heartbeat
-  // kills the whole run: heartbeat immediately and periodically until setup completes.
-  heartbeat();
-
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
+  // The activity-lifetime wrapper above already covers liveness: this inner wrapper is kept for
+  // its log, each firing meaning the DB-bound setup phase is stalling (DB pool contention).
   const { auth, runAgentDataRes, action } = await withPeriodicHeartbeat(
     async () => {
       const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -98,11 +98,22 @@ export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
 export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 export const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 
+// The worker's maxHeartbeatThrottleInterval: the SDK sends at most one heartbeat to the server
+// per interval, so a faster app-side cadence buys nothing. The activity cadences below derive
+// from it so the values cannot drift apart.
+export const HEARTBEAT_THROTTLE_INTERVAL_MS = 20 * 1000;
+
 // Heartbeat cadence for the whole model activity. Its setup phase (agent data loading, MCP
 // tools listing, conversation rendering) can stall past the heartbeat timeout, e.g. a hung MCP
-// server's tools/list call times out after 60s, exactly the heartbeat timeout. Aligned with the
-// worker's maxHeartbeatThrottleInterval.
-export const MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+// server's tools/list call times out after 60s, exactly the heartbeat timeout.
+export const MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS =
+  HEARTBEAT_THROTTLE_INTERVAL_MS;
+
+// Heartbeat cadence for the whole tool activity. Phases outside the MCP call loop (action state
+// transitions, input handling, MCP server connection, event publication) are DB/network-bound and
+// can stall past the heartbeat timeout under contention.
+export const TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS =
+  HEARTBEAT_THROTTLE_INTERVAL_MS;
 
 // Heartbeat cadence while tool result processing runs (file handling can take minutes): fire
 // comfortably within the heartbeat timeout.
@@ -114,5 +125,5 @@ export const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
 // Heartbeat cadence while the tool activity's DB-bound setup (auth + conversation + action
 // fetches) runs. Setup normally completes in well under a second, so a firing means the fetch
 // phase is stalling (DB contention): the log emitted alongside each firing is monitored in
-// Datadog. Aligned with the worker's maxHeartbeatThrottleInterval.
-export const TOOL_SETUP_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+// Datadog.
+export const TOOL_SETUP_HEARTBEAT_INTERVAL_MS = HEARTBEAT_THROTTLE_INTERVAL_MS;

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -27,6 +27,7 @@ import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activ
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import {
   BATCH_QUEUE_NAME,
+  HEARTBEAT_THROTTLE_INTERVAL_MS,
   INTERACTIVE_QUEUE_NAME,
   PROGRAMMATIC_QUEUE_NAME,
   SCHEDULES_QUEUE_NAME,
@@ -123,7 +124,7 @@ async function runAgentLoopWorkerForQueue({
     shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     // This also bounds the time until an activity may receive a cancellation signal.
     // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
-    maxHeartbeatThrottleInterval: "20 seconds",
+    maxHeartbeatThrottleInterval: HEARTBEAT_THROTTLE_INTERVAL_MS,
     maxConcurrentActivityTaskExecutions:
       MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS,
     interceptors: {


### PR DESCRIPTION
## Goal

The tool activity's heartbeats only cover setup, the MCP call loop, and result processing. The stretches between (action status update, MCP server connection, event publication) are uncovered: a worker that is alive but stalls there for more than the 60s heartbeat timeout is declared dead by the server, and since `no_retry` tools get a single attempt, the whole run fails. A traced production case was timed out at 60s in that gap and its tool then completed successfully into the void.

## What it does

- `runToolActivity` body moves to `_runToolActivity`; the export wraps it in `withPeriodicHeartbeat` (20s) for its whole lifetime, same pattern as `runModelAndCreateActionsActivity`. The inner setup wrapper stays: its log is the DB-stall signal, its heartbeat is now redundant (the SDK throttles duplicates).
- The worker's `maxHeartbeatThrottleInterval` and the three activity heartbeat cadences all hardcoded 20s separately; they now derive from a single `HEARTBEAT_THROTTLE_INTERVAL_MS` (`config.ts`, `worker.ts`).

No workflow change, no activity rename (`_runToolActivity` is module-private; the registered name is unchanged), so Danger's temporal warning can be ignored.

## Tests

Behavior is a heartbeat cadence; covered by existing suites. `tsgo --noEmit` clean.

## Risk

Worst case, extra heartbeat calls, which the SDK throttles to one per 20s. Safe to rollback.

## Deploy Plan

- [ ] Deploy front.
- [ ] Zombie cases (tool completes after its workflow already failed on heartbeat timeout) disappear from Datadog.