### PR TITLE
[front] enh: tweak description of sandbox + google drive tool

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -125,7 +125,9 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     schema: {
       fileId: z
         .string()
-        .describe("The ID of the file to retrieve content from. Can be extracted from the URL of a file, typically found at its end."),
+        .describe(
+          "The ID of the file to retrieve content from. Can be extracted from the URL of a file, typically found at its end."
+        ),
       offset: z
         .number()
         .default(0)

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -125,7 +125,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     schema: {
       fileId: z
         .string()
-        .describe("The ID of the file to retrieve content from."),
+        .describe("The ID of the file to retrieve content from. Can be extracted from the URL of a file, typically found at its end."),
       offset: z
         .number()
         .default(0)

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -396,8 +396,8 @@ export const sandboxSkill = {
     "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
     "process data, manipulate files, or perform any task requiring shell access. " +
     "You must enable this skill proactively as soon as the user uploads files or you need to work with files, " +
-    "including PDFs, spreadsheets, archives, or generated artifacts. Use it to extract text from files, " +
-    "parse lengthy tool outputs, run code and shell commands, process data, manipulate files, or perform " +
+    "including PDFs, spreadsheets, archives, generated artifacts, or data pulled from tools. Use it to extract text " +
+    "from files, parse lengthy tool outputs, run code and shell commands, process data, manipulate files, or perform " +
     "any computer-related task. " +
     "Always call this environment 'the Computer' in any text you send to the user.",
   fetchInstructions: async (


### PR DESCRIPTION
## Description

This PR tweaks the description of the sandbox skill + the `get_file_content` tool from Google Drive.
Addresses a specific flow observed where the goal is to replace a custom agent with a skill. The agent uses tables query on a Google Sheet, the skill port fails in 2 different ways: sometimes fails to extract sheet IDs from URLs, and sometimes fails to enable the Computer skill to process the data.

## Tests

## Risk

## Deploy Plan

- Deploy front.