### PR TITLE
[front] Drop unused Authenticator group helpers and inlined shadow-compare

### DIFF
--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -103,7 +103,6 @@ export async function prepareAppContext(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         userId: auth.user()?.sId || "no_user",
         role: auth.role(),
-        groupIds: auth.groupIds(),
         actionConfig,
         dustAppConfiguration: actionConfig.dustAppConfiguration,
         appId: actionConfig.dustAppConfiguration?.appId,
@@ -124,7 +123,6 @@ export async function prepareAppContext(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         userId: auth.user()?.sId || "no_user",
         role: auth.role(),
-        groupIds: auth.groupIds(),
         appId: actionConfig.dustAppConfiguration.appId,
         actionConfig,
       },

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -75,7 +75,6 @@ import {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { decodeUtf8HeaderValue } from "@app/types/shared/utils/http_headers";
 import type {
@@ -1500,18 +1499,6 @@ export class Authenticator {
     return isDustInternal && isDustSuperUser;
   }
 
-  groupIds(): string[] {
-    const workspaceId = this._workspace?.id;
-    // Group are always tied to a workspace, so we can't have a group without a workspace.
-    if (!workspaceId) {
-      return [];
-    }
-
-    return this._groupModelIds.map((id) =>
-      GroupResource.modelIdToSId({ id, workspaceId })
-    );
-  }
-
   groupModelIds(): ModelId[] {
     return this._groupModelIds;
   }
@@ -1535,22 +1522,6 @@ export class Authenticator {
       ? globalGroupRes.value.id
       : null;
     return this._globalGroupModelId;
-  }
-
-  hasGroup(groupId: string): boolean {
-    const workspaceId = this._workspace?.id;
-    // Group are always tied to a workspace, so we can't have a group without a workspace.
-    if (!workspaceId) {
-      return false;
-    }
-
-    return this._groupModelIds.some(
-      (id) =>
-        GroupResource.modelIdToSId({
-          id,
-          workspaceId,
-        }) === groupId
-    );
   }
 
   hasGroupByModelId(groupId: ModelId): boolean {
@@ -1582,90 +1553,6 @@ export class Authenticator {
     verb: GrantVerb
   ): ResourcesWithVerb {
     return this._permissions.resourceIdsWithVerb(resourceType, verb);
-  }
-
-  /**
-   * Shadow-compare (#9479) for the group_permissions rollout: while the `group_permissions_shadow`
-   * flag is on for the workspace, compare two composed decisions for the same check — the served
-   * `getAccessControlLists` and the `candidateAcls` (the same roles routed through the
-   * group_permissions table) — and log mismatches so a Datadog monitor can confirm parity before a
-   * flip. The caller builds both shapes. Fire-and-forget: never changes the served result and
-   * swallows its own failures. (Inlined rather than reusing `lib/api/permissions/shadow` to avoid an
-   * auth <-> shadow import cycle.)
-   *
-   * Retained (currently unused) for the remaining resource migrations onto group_permissions —
-   * spaces no longer shadow-compare, but other resource types still need to.
-   */
-  shadowComparePermission(
-    verb: GrantVerb,
-    resource: WithAccessControl,
-    candidateAcls: AccessControlList[],
-    context?: Record<string, string | number | boolean | null>
-  ): void {
-    void this.runShadowComparePermission(
-      verb,
-      resource,
-      candidateAcls,
-      context
-    );
-  }
-
-  private async runShadowComparePermission(
-    verb: GrantVerb,
-    resource: WithAccessControl,
-    candidateAcls: AccessControlList[],
-    context?: Record<string, string | number | boolean | null>
-  ): Promise<void> {
-    try {
-      const flags = await getFeatureFlags(this);
-      if (!flags.includes("group_permissions_shadow")) {
-        return;
-      }
-
-      const currentAcl = resource.getAccessControlLists(this);
-      const currentResult = this.hasPermissionForAcls(verb, currentAcl);
-      const candidateResult = this.hasPermissionForAcls(verb, candidateAcls);
-
-      // The literal message is the Datadog monitor key — keep it stable.
-      if (currentResult !== candidateResult) {
-        const reloadedPermissions = await Authenticator.resolvePermissions({
-          workspace: this._workspace,
-          groupModelIds: this._groupModelIds,
-        });
-        const reloadedPermissionsAcl = resource.getAccessControlLists({
-          ...this,
-          _permissions: reloadedPermissions,
-        });
-        const reloadedPermissionsResult = this.hasPermissionForAcls(
-          verb,
-          reloadedPermissionsAcl
-        );
-
-        logger.warn(
-          {
-            ...context,
-            permission: verb,
-            userId: this.user()?.sId ?? null,
-            workspaceId: this.workspace()?.sId,
-            currentResult,
-            candidateResult,
-            currentAcl,
-            candidateAcls,
-            groups: this._groupModelIds,
-            permissions: this._permissions.toJSON(),
-            reloadedPermissionsAcl,
-            reloadedPermissionsResult,
-            reloadedPermission: reloadedPermissions.toJSON(),
-          },
-          "group_permissions_shadow_mismatch"
-        );
-      }
-    } catch (err) {
-      logger.error(
-        { ...context, err: normalizeError(err) },
-        "group_permissions_shadow_error"
-      );
-    }
   }
 
   /**
@@ -1775,7 +1662,9 @@ export class Authenticator {
       workspaceId: workspace.sId,
       userId: this._user?.sId ?? null,
       role: this._role,
-      groupIds: this.groupIds(),
+      groupIds: this._groupModelIds.map((id) =>
+        GroupResource.modelIdToSId({ id, workspaceId: workspace.id })
+      ),
       subscriptionId: this._subscription?.sId ?? null,
       isByok: this.plan()?.isByok ?? false,
       key: this._key,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -914,7 +914,6 @@ export class GroupResource extends BaseResource<GroupModel> {
           workspaceId: auth.getNonNullableWorkspace().sId,
           unreadableGroupIds: unreadableGroups.map((g) => g.sId),
           authRole: auth.role(),
-          authGroupIds: auth.groupIds(),
         },
         "[GroupResource.fetchByIds] User cannot read some groups"
       );

--- a/x/adrsimon/agentsearch/scripts/export_user_profile.ts
+++ b/x/adrsimon/agentsearch/scripts/export_user_profile.ts
@@ -66,7 +66,7 @@ makeScript(
         fullName: user.fullName(),
       },
       role: auth.role(),
-      groupIds: auth.groupIds(),
+      groupIds: groups.map((group) => group.sId),
       groups: groups.map((group) => ({
         sId: group.sId,
         name: group.name,


### PR DESCRIPTION
## What

Removes three now-dead members of `Authenticator`, part of the effort to eventually get rid of `auth._groupModelIds`:

- **`hasGroup(groupId: string)`** — no callers anywhere.
- **`groupIds()`** — its only remaining uses were diagnostic `logger` payloads (`group_resource.ts`, `run_dust_app/helpers.ts`, and a scratch script). Those log fields are dropped, and the model-id → sId mapping is inlined into `toJSON` (serialization must stay so `fromJSON` can reconstruct the auth).
- **`shadowComparePermission` / `runShadowComparePermission`** — the shadow-compare copy inlined in `auth.ts` had no callers. The standalone `lib/api/permissions/shadow.ts` module, its tests, and the `group_permissions_shadow` feature flag are untouched.

Also drops the now-unused `normalizeError` import from `auth.ts`.

## Notes

- `_groupModelIds` itself stays — it's still the input that feeds `resolvePermissions`. This PR only removes the dead accessors/logging around it.
- The legacy group path in `hasPermissionForAcl` and the agent/suggestion consumers of `groupModelIds()` are out of scope (separate migrations onto `group_permissions`).

## Test plan

- `npx tsgo --noEmit` in `front` passes.
- `biome check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)