### PR TITLE
Fix: path, scripts etc for the dev container to work in cursor cloud

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -48,12 +48,24 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
-# Rust (core-api, oauth) + dev process runners (bacon, mprocs)
+# Rust toolchain (core-api, oauth dev)
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain 1.94.1 \
-  && cargo install bacon mprocs
+    | sh -s -- -y --default-toolchain 1.94.1
+
+# bacon — no prebuilt binaries; install to /usr/local/bin (Cursor cloud agents replace image PATH)
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo install --locked bacon \
+  && install -m 0755 /usr/local/cargo/bin/bacon /usr/local/bin/bacon \
+  && bacon --version
+
+# mprocs — prebuilt binary to /usr/local/bin (same PATH reason as bacon/temporal)
+ARG MPROCS_VERSION=0.9.6
+RUN curl -fsSL "https://github.com/pvolok/mprocs/releases/download/v${MPROCS_VERSION}/mprocs-${MPROCS_VERSION}-linux-x86_64-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin \
+  && mprocs --version
 
 # Temporal dev server
 RUN curl -sSf https://temporal.download/cli.sh | sh \

--- a/dev/bashrc
+++ b/dev/bashrc
@@ -21,6 +21,17 @@ export FORCE_COLOR="${FORCE_COLOR:-1}"
 export CLICOLOR="${CLICOLOR:-1}"
 export CLICOLOR_FORCE="${CLICOLOR_FORCE:-1}"
 
+# Cursor cloud-agent terminals replace image PATH; restore Rust/Qdrant tool locations.
+for _dev_bin_dir in /usr/local/cargo/bin /opt/qdrant; do
+  if [ -d "${_dev_bin_dir}" ]; then
+    case ":${PATH}:" in
+      *":${_dev_bin_dir}:"*) ;;
+      *) export PATH="${_dev_bin_dir}:${PATH}" ;;
+    esac
+  fi
+done
+unset _dev_bin_dir
+
 shopt -s checkwinsize histappend globstar 2>/dev/null || true
 
 HISTCONTROL=ignoreboth:erasedups

--- a/dev/scripts/common.sh
+++ b/dev/scripts/common.sh
@@ -59,6 +59,31 @@ ensure_client_built() {
   fi
 }
 
+elasticsearch_create_index_bin() {
+  echo "${DUST_REPO_ROOT}/core/target/debug/elasticsearch_create_index"
+}
+
+ensure_elasticsearch_create_index_built() {
+  local bin
+  bin="$(elasticsearch_create_index_bin)"
+  if [ -x "$bin" ]; then
+    return 0
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    log "cargo not found on PATH; rebuild dev/Dockerfile or source dev/scripts/env.sh"
+    return 1
+  fi
+  log "Building elasticsearch_create_index (core)..."
+  (
+    cd "${DUST_REPO_ROOT}/core"
+    cargo build --bin elasticsearch_create_index
+  )
+  if [ ! -x "$bin" ]; then
+    log "elasticsearch_create_index binary missing after cargo build"
+    return 1
+  fi
+}
+
 write_gcp_service_account_file() {
   if [ -n "${GCP_SERVICE_ACCOUNT:-}" ]; then
     printf '%s' "$GCP_SERVICE_ACCOUNT" >"${SERVICE_ACCOUNT:-/tmp/dust-dev-sa.json}"

--- a/dev/scripts/env.sh
+++ b/dev/scripts/env.sh
@@ -28,13 +28,16 @@ export TEMPORAL_ADDRESS="${TEMPORAL_ADDRESS:-127.0.0.1:7233}"
 export DUST_LOCAL_TEMPORAL_ADDRESS="${DUST_LOCAL_TEMPORAL_ADDRESS:-127.0.0.1:7233}"
 
 # Temporal CLI is installed to /usr/local/bin in the dev image; also check the installer path.
-for _temporal_dir in /usr/local/bin /root/.temporalio/bin; do
-  if [ -x "${_temporal_dir}/temporal" ]; then
-    export PATH="${_temporal_dir}:${PATH}"
-    break
+# Cursor cloud-agent terminals replace image PATH — prepend other dev tool dirs when missing.
+for _dev_bin_dir in /usr/local/bin /usr/local/cargo/bin /opt/qdrant /root/.temporalio/bin; do
+  if [ -d "${_dev_bin_dir}" ]; then
+    case ":${PATH}:" in
+      *":${_dev_bin_dir}:"*) ;;
+      *) export PATH="${_dev_bin_dir}:${PATH}" ;;
+    esac
   fi
 done
-unset _temporal_dir
+unset _dev_bin_dir
 
 export FRONT_DATABASE_URI="${FRONT_DATABASE_URI:-postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_front}"
 export FRONT_DATABASE_READ_REPLICA_URI="${FRONT_DATABASE_READ_REPLICA_URI:-$FRONT_DATABASE_URI}"

--- a/dev/scripts/infra.sh
+++ b/dev/scripts/infra.sh
@@ -73,12 +73,12 @@ log "Initializing databases..."
 bash "${SCRIPT_DIR}/init-databases.sh" || exit 1
 
 log "Ensuring Elasticsearch indices..."
-bash "${SCRIPT_DIR}/init-elasticsearch-indices.sh" \
-  >"${DUST_INFRA_LOG_DIR}/init-elasticsearch.log" 2>&1 || {
+bash "${SCRIPT_DIR}/init-elasticsearch-indices.sh" 2>&1 | tee "${DUST_INFRA_LOG_DIR}/init-elasticsearch.log"
+es_init_status=${PIPESTATUS[0]}
+if [ "$es_init_status" -ne 0 ]; then
   log "Elasticsearch index init failed; see ${DUST_INFRA_LOG_DIR}/init-elasticsearch.log"
-  tail -40 "${DUST_INFRA_LOG_DIR}/init-elasticsearch.log"
   exit 1
-}
+fi
 
 # Materialize 1Password env + local overrides for every subsequent shell/command.
 materialize_dev_environment || log "Continuing without a full 1Password env"

--- a/dev/scripts/init-elasticsearch-indices.sh
+++ b/dev/scripts/init-elasticsearch-indices.sh
@@ -16,6 +16,7 @@ export ELASTICSEARCH_PASSWORD="${ELASTICSEARCH_PASSWORD:-}"
 
 ensure_node_path
 ensure_client_built
+ensure_elasticsearch_create_index_built
 
 wait_for_elasticsearch() {
   log "Waiting for Elasticsearch at ${ELASTICSEARCH_URL}..."
@@ -34,51 +35,75 @@ output_already_exists() {
   grep -qi 'already exists' <<<"$1"
 }
 
+run_logged() {
+  local output_file
+  output_file="$(mktemp)"
+  trap 'rm -f "$output_file"' RETURN
+
+  if (
+    set -o pipefail
+    "$@" 2>&1 | tee "$output_file"
+  ); then
+    return 0
+  fi
+
+  if output_already_exists "$(cat "$output_file")"; then
+    return 2
+  fi
+  return 1
+}
+
 create_core_index() {
   local index_name="$1"
   local index_version="$2"
-  local output=""
+  local binary status
+  binary="$(elasticsearch_create_index_bin)"
 
   log "Ensuring core.${index_name}_${index_version}..."
-  output=$(
+  (
     cd "${DUST_REPO_ROOT}/core"
-    cargo run --bin elasticsearch_create_index -- \
+    run_logged "$binary" \
       --index-name "$index_name" \
       --index-version "$index_version" \
-      --skip-confirmation 2>&1
-  ) || {
-    if output_already_exists "$output"; then
-      log "core.${index_name}_${index_version} already exists"
-      return 0
-    fi
-    log "Failed to create core.${index_name}_${index_version}:"
-    echo "$output"
-    return 1
-  }
+      --skip-confirmation
+  )
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    return 0
+  fi
+  if [ "$status" -eq 2 ]; then
+    log "core.${index_name}_${index_version} already exists"
+    return 0
+  fi
+  log "Failed to create core.${index_name}_${index_version}"
+  return 1
 }
 
 create_front_index() {
   local index_name="$1"
   local index_version="$2"
-  local output=""
+  local status
 
   log "Ensuring front.${index_name}_${index_version}..."
-  output=$(
+  (
     cd "${DUST_REPO_ROOT}/front"
-    export PATH="${DUST_REPO_ROOT}/node_modules/.bin:${PATH}"
-    npx tsx ./scripts/create_elasticsearch_index.ts \
+    run_logged env PATH="${DUST_REPO_ROOT}/node_modules/.bin:${PATH}" \
+      npx tsx ./scripts/create_elasticsearch_index.ts \
       --index-name "$index_name" \
       --index-version "$index_version" \
-      --skip-confirmation 2>&1
-  ) || {
-    if output_already_exists "$output"; then
-      log "front.${index_name}_${index_version} already exists"
-      return 0
-    fi
-    log "Failed to create front.${index_name}_${index_version}:"
-    echo "$output"
-    return 1
-  }
+      --skip-confirmation \
+      --execute
+  )
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    return 0
+  fi
+  if [ "$status" -eq 2 ]; then
+    log "front.${index_name}_${index_version} already exists"
+    return 0
+  fi
+  log "Failed to create front.${index_name}_${index_version}"
+  return 1
 }
 
 wait_for_elasticsearch

--- a/dev/scripts/install.sh
+++ b/dev/scripts/install.sh
@@ -21,4 +21,6 @@ npm install
 log "Installing lefthook git hooks..."
 npx lefthook install -f
 
+ensure_elasticsearch_create_index_built
+
 log "Install complete"

--- a/front/scripts/create_elasticsearch_index.ts
+++ b/front/scripts/create_elasticsearch_index.ts
@@ -9,7 +9,7 @@ import * as readline from "readline";
  * Script to create an ElasticSearch index for front service
  *
  * Usage:
- * tsx front/scripts/create_elasticsearch_index.ts --index-name agent_message_analytics --index-version 1 [--skip-confirmation] [--remove-previous-alias]
+ * tsx front/scripts/create_elasticsearch_index.ts --index-name agent_message_analytics --index-version 1 [--skip-confirmation] [--remove-previous-alias] [--execute]
  *
  * The script looks up the index directory from INDEX_DIRECTORIES in lib/api/elasticsearch.ts
  * Then loads settings and mappings from [directory]/[index_name]_[version].settings.[region].json and [directory]/[index_name]_[version].mappings.json
@@ -40,7 +40,7 @@ makeScript(
     },
   },
   async (
-    { indexName, indexVersion, skipConfirmation, removePreviousAlias },
+    { indexName, indexVersion, skipConfirmation, removePreviousAlias, execute },
     logger
   ) => {
     if (removePreviousAlias && indexVersion === 1) {
@@ -131,7 +131,7 @@ makeScript(
       );
     }
 
-    if (!skipConfirmation) {
+    if (!skipConfirmation && execute) {
       logger.info(
         `CHECK: Create index '${indexFullname}' with alias '${indexAlias}' in region '${region}' (remove previous alias: ${removePreviousAlias})? (y to confirm)`
       );
@@ -151,6 +151,13 @@ makeScript(
       if (answer !== "y") {
         throw new Error("Aborted");
       }
+    }
+
+    if (!execute) {
+      logger.info(
+        `[DRY RUN] Would create index ${indexFullname} and alias ${indexAlias}`
+      );
+      return;
     }
 
     logger.info(`Creating index ${indexFullname}...`);

--- a/init_dev_container.sh
+++ b/init_dev_container.sh
@@ -44,8 +44,8 @@ cd -
 
 cd front/
 npm install
-npx tsx ./scripts/create_elasticsearch_index.ts --index-name agent_message_analytics --index-version 2 --skip-confirmation
-npx tsx ./scripts/create_elasticsearch_index.ts --index-name user_search --index-version 1 --skip-confirmation
+npx tsx ./scripts/create_elasticsearch_index.ts --index-name agent_message_analytics --index-version 2 --skip-confirmation --execute
+npx tsx ./scripts/create_elasticsearch_index.ts --index-name user_search --index-version 1 --skip-confirmation --execute
 cd -
 
 echo "--"

--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -219,7 +219,7 @@ async function initElasticsearchTS(
     const command = buildShell({
       sourceEnv: envShPath,
       sourceNvm: true,
-      run: `npx tsx ./scripts/create_elasticsearch_index.ts --index-name ${name} --index-version ${version} --skip-confirmation`,
+      run: `npx tsx ./scripts/create_elasticsearch_index.ts --index-name ${name} --index-version ${version} --skip-confirmation --execute`,
     });
 
     const proc = Bun.spawn(["bash", "-c", command], {


### PR DESCRIPTION
## Description

Make the shared dev container reliable in Cursor Cloud, where agent terminals replace the image `PATH`. Install `bacon` and `mprocs` in stable locations, restore Rust/Qdrant/Temporal paths in `dev/bashrc` and `dev/scripts/env.sh`, and build the core Elasticsearch index helper before initialization. Add explicit `--execute` handling so index scripts default to dry runs while bootstrap flows execute intentionally.

## Tests

Not run. This PR updates development-container bootstrap and shell/TypeScript scripts only.

## Risk

Low production risk because the changes are development tooling only. Container initialization and Elasticsearch index creation could regress; reverting the commit restores the previous bootstrap flow.

## Deploy Plan

No production deploy or SQL migration. Rebuild the Cursor Cloud/dev container image and refresh the development snapshot.