### PR TITLE
[front] fix: distinguish unavailable reasoning efforts from locked ones

### DIFF
--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.ts
@@ -36,12 +36,12 @@ export function getSelectableEffortsForSlashMenu(
     return [];
   }
 
-  const unlocked = getEffortStops(model, { lockPremiumEfforts })
-    .filter((stop) => !stop.locked)
+  const selectableEfforts = getEffortStops(model, { lockPremiumEfforts })
+    .filter((stop) => stop.unavailabilityReason === null)
     .map((stop) => stop.effort);
 
-  if (unlocked.length > 0) {
-    return unlocked;
+  if (selectableEfforts.length > 0) {
+    return selectableEfforts;
   }
 
   return ["none"];

--- a/front/components/model_picker/ReasoningEffortSlider.tsx
+++ b/front/components/model_picker/ReasoningEffortSlider.tsx
@@ -12,10 +12,10 @@ interface ReasoningEffortSliderProps {
 }
 
 // A stepped slider for reasoning effort. It always shows the three canonical
-// levels (Light/Medium/High); efforts the model does not support or the
-// workspace's tier does not grant are rendered locked (padlock) and skipped
-// when snapping. When at most one level is selectable there is nothing to
-// choose, so the whole slider is disabled.
+// levels (Light/Medium/High). Unsupported efforts render with a slash; efforts
+// outside the member's access render with a padlock. Both are skipped when
+// snapping. When at most one level is selectable there is nothing to choose,
+// so the whole slider is disabled.
 export function ReasoningEffortSlider({
   stops,
   value,
@@ -26,15 +26,27 @@ export function ReasoningEffortSlider({
     0
   );
   const lockedSteps = stops.flatMap((stop, index) =>
-    stop.locked ? [index] : []
+    stop.unavailabilityReason !== null &&
+    stop.unavailabilityReason !== "unsupported"
+      ? [index]
+      : []
+  );
+  const unavailableSteps = stops.flatMap((stop, index) =>
+    stop.unavailabilityReason === "unsupported" ? [index] : []
   );
   const lastIndex = Math.max(stops.length - 1, 1);
-  const unlockedStops = stops.filter((stop) => !stop.locked);
+  const availableStops = stops.filter(
+    (stop) => stop.unavailabilityReason === null
+  );
   // With a single (or no) selectable level there is nothing to slide.
-  const isDisabled = unlockedStops.length <= 1;
+  const isDisabled = availableStops.length <= 1;
 
   const selectStop = (stop: EffortStop) => {
-    if (!isDisabled && !stop.locked && stop.effort !== value) {
+    if (
+      !isDisabled &&
+      stop.unavailabilityReason === null &&
+      stop.effort !== value
+    ) {
       onChange(stop.effort);
     }
   };
@@ -50,6 +62,7 @@ export function ReasoningEffortSlider({
         stepCount={stops.length}
         value={valueIndex}
         lockedSteps={lockedSteps}
+        unavailableSteps={unavailableSteps}
         disabled={isDisabled}
         stepTooltips={stops.map(getEffortStopTooltip)}
         onChange={(index) => {
@@ -65,7 +78,8 @@ export function ReasoningEffortSlider({
         {stops.map((stop, index) => {
           const isFirst = index === 0;
           const isLast = index === stops.length - 1;
-          const buttonDisabled = stop.locked || isDisabled;
+          const buttonDisabled =
+            stop.unavailabilityReason !== null || isDisabled;
           return (
             <button
               key={stop.effort}
@@ -81,7 +95,7 @@ export function ReasoningEffortSlider({
                 stop.effort === value
                   ? "font-medium text-foreground"
                   : "text-muted-foreground",
-                stop.locked ? "opacity-50" : ""
+                stop.unavailabilityReason !== null ? "opacity-50" : ""
               )}
               style={{
                 left: `${(index / lastIndex) * 100}%`,

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -30,10 +30,12 @@ import { describe, expect, it } from "vitest";
 const GATED = { lockPremiumEfforts: true };
 const UNGATED = { lockPremiumEfforts: false };
 
-const lockedReasonByEffort = (
+const unavailabilityReasonByEffort = (
   stops: ReturnType<typeof getEffortStops>
 ): Record<string, string | null> =>
-  Object.fromEntries(stops.map((stop) => [stop.effort, stop.lockedReason]));
+  Object.fromEntries(
+    stops.map((stop) => [stop.effort, stop.unavailabilityReason])
+  );
 
 describe("modelPickerUtils premium gating", () => {
   describe("getTierForModel", () => {
@@ -60,7 +62,7 @@ describe("modelPickerUtils premium gating", () => {
     it("locks premium efforts with reason 'premium' when gated (mixed model)", () => {
       // Sonnet 5: light=cost_efficient, medium=balanced, high=premium.
       const stops = getEffortStops(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED);
-      expect(lockedReasonByEffort(stops)).toEqual({
+      expect(unavailabilityReasonByEffort(stops)).toEqual({
         light: null,
         medium: null,
         high: "premium",
@@ -70,7 +72,7 @@ describe("modelPickerUtils premium gating", () => {
     it("locks every premium effort of a mid-tier reasoning model", () => {
       // Gemini 2.5 Pro: light=balanced, medium=premium, high=premium.
       const stops = getEffortStops(GEMINI_2_5_PRO_MODEL_CONFIG, GATED);
-      expect(lockedReasonByEffort(stops)).toEqual({
+      expect(unavailabilityReasonByEffort(stops)).toEqual({
         light: null,
         medium: "premium",
         high: "premium",
@@ -82,38 +84,36 @@ describe("modelPickerUtils premium gating", () => {
         CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
         UNGATED
       );
-      expect(stops.every((stop) => !stop.locked)).toBe(true);
+      expect(stops.every((stop) => stop.unavailabilityReason === null)).toBe(
+        true
+      );
     });
   });
 
   describe("getEffortStopTooltip", () => {
-    it("only explains locked efforts", () => {
+    it("explains why an effort is unselectable", () => {
       expect(
         getEffortStopTooltip({
           effort: "light",
-          locked: false,
-          lockedReason: null,
+          unavailabilityReason: null,
         })
       ).toBeNull();
       expect(
         getEffortStopTooltip({
           effort: "high",
-          locked: true,
-          lockedReason: "unsupported",
+          unavailabilityReason: "unsupported",
         })
       ).toBe("This model doesn't support High reasoning.");
       expect(
         getEffortStopTooltip({
           effort: "high",
-          locked: true,
-          lockedReason: "premium",
+          unavailabilityReason: "premium",
         })
       ).toBe(PREMIUM_MODEL_LOCKED_TOOLTIP);
       expect(
         getEffortStopTooltip({
           effort: "medium",
-          locked: true,
-          lockedReason: "model_tier",
+          unavailabilityReason: "model_tier",
         })
       ).toBe(
         "Your current model access doesn't include this option. " +

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -207,14 +207,15 @@ export interface ModelPickerSelectionModel {
   onRevert?: () => void;
 }
 
-export type EffortLockReason = "unsupported" | "premium" | "model_tier";
+export type ModelLockReason = "premium" | "model_tier";
+export type EffortUnavailabilityReason = "unsupported" | ModelLockReason;
 
-// One stop of the reasoning-effort slider. A stop is `locked` when the level is
-// not selectable; a null `lockedReason` explicitly means it is available.
+// One stop of the reasoning-effort slider. A null reason means it is available.
+// Unsupported efforts are unavailable; premium and model-tier efforts are
+// locked behind access controls.
 export interface EffortStop {
   effort: ReasoningEffort;
-  locked: boolean;
-  lockedReason: EffortLockReason | null;
+  unavailabilityReason: EffortUnavailabilityReason | null;
 }
 
 // The reasoning-effort slider always presents these three canonical levels so
@@ -345,8 +346,7 @@ export function getEffortStops(
     if (!allowed.has(effort)) {
       return {
         effort,
-        locked: true,
-        lockedReason: modelSupportsEffortStatically(
+        unavailabilityReason: modelSupportsEffortStatically(
           enabledModel.modelId,
           effort
         )
@@ -358,14 +358,14 @@ export function getEffortStops(
       lockPremiumEfforts &&
       getTierForModel(enabledModel.modelId, effort) === "premium"
     ) {
-      return { effort, locked: true, lockedReason: "premium" };
+      return { effort, unavailabilityReason: "premium" };
     }
-    return { effort, locked: false, lockedReason: null };
+    return { effort, unavailabilityReason: null };
   });
 }
 
 // The reasoning effort to use when a model is freshly selected: its default when
-// that is allowed, otherwise the first unlocked stop.
+// that is allowed, otherwise the first available stop.
 export function getInitialEffort(
   enabledModel: ModelConfigurationType,
   options: LockPremiumOptions = {}
@@ -373,12 +373,15 @@ export function getInitialEffort(
   const stops = getEffortStops(enabledModel, options);
   const preferred = stops.find(
     (stop) =>
-      stop.effort === enabledModel.defaultReasoningEffort && !stop.locked
+      stop.effort === enabledModel.defaultReasoningEffort &&
+      stop.unavailabilityReason === null
   );
   if (preferred) {
     return preferred.effort;
   }
-  return stops.find((stop) => !stop.locked)?.effort ?? "none";
+  return (
+    stops.find((stop) => stop.unavailabilityReason === null)?.effort ?? "none"
+  );
 }
 
 function isReasoningModel(modelId: ModelIdType): boolean {
@@ -395,7 +398,9 @@ export function isPremiumModel(
   { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
 ): boolean {
   const stops = getEffortStops(enabledModel, { lockPremiumEfforts });
-  const hasUsableSliderEffort = stops.some((stop) => !stop.locked);
+  const hasUsableSliderEffort = stops.some(
+    (stop) => stop.unavailabilityReason === null
+  );
 
   if (isReasoningModel(enabledModel.modelId) && !hasUsableSliderEffort) {
     return true;
@@ -405,15 +410,15 @@ export function isPremiumModel(
     return false;
   }
   const supportedSlider = stops.filter(
-    (stop) => stop.lockedReason !== "unsupported"
+    (stop) => stop.unavailabilityReason !== "unsupported"
   );
   if (supportedSlider.length > 0) {
-    return supportedSlider.every((stop) => stop.lockedReason === "premium");
+    return supportedSlider.every(
+      (stop) => stop.unavailabilityReason === "premium"
+    );
   }
   return getTierForModel(enabledModel.modelId, "none") === "premium";
 }
-
-export type ModelLockReason = "premium" | "model_tier";
 
 export function getModelLockReason(
   enabledModel: ModelConfigurationType,
@@ -438,11 +443,7 @@ export function getModelLockTooltip(reason: ModelLockReason): string {
 }
 
 export function getEffortStopTooltip(stop: EffortStop): string | null {
-  if (!stop.locked) {
-    return null;
-  }
-
-  switch (stop.lockedReason) {
+  switch (stop.unavailabilityReason) {
     case "premium":
       return PREMIUM_MODEL_LOCKED_TOOLTIP;
     case "model_tier":
@@ -452,7 +453,7 @@ export function getEffortStopTooltip(stop: EffortStop): string | null {
     case null:
       return null;
     default:
-      assertNeverAndIgnore(stop.lockedReason);
+      assertNeverAndIgnore(stop.unavailabilityReason);
       return null;
   }
 }

--- a/sparkle/src/components/SliderSteps.tsx
+++ b/sparkle/src/components/SliderSteps.tsx
@@ -185,7 +185,10 @@ export function SliderSteps({
           return StepMarker ? (
             <span
               key={index}
-              className="pointer-events-none absolute top-1/2 -translate-x-1/2 -translate-y-1/2 text-white"
+              className={cn(
+                "pointer-events-none absolute top-1/2 -translate-x-1/2 -translate-y-1/2",
+                index <= value ? "text-white" : "text-muted-foreground"
+              )}
               style={{ left: stepCenter(index, lastIndex) }}
             >
               <StepMarker aria-hidden className="h-3 w-3" />

--- a/sparkle/src/components/SliderSteps.tsx
+++ b/sparkle/src/components/SliderSteps.tsx
@@ -185,7 +185,7 @@ export function SliderSteps({
           return StepMarker ? (
             <span
               key={index}
-              className="pointer-events-none absolute top-1/2 -translate-x-1/2 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute top-1/2 -translate-x-1/2 -translate-y-1/2 text-white"
               style={{ left: stepCenter(index, lastIndex) }}
             >
               <StepMarker aria-hidden className="h-3 w-3" />

--- a/sparkle/src/components/SliderSteps.tsx
+++ b/sparkle/src/components/SliderSteps.tsx
@@ -5,13 +5,13 @@ import {
   TooltipRoot,
   TooltipTrigger,
 } from "@sparkle/components/Tooltip";
-import { Lock01 } from "@sparkle/icons/v2-stroke";
+import { Lock01, SlashCircle01 } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
 
 // Radix keeps the thumb inside the track bounds by shifting it by up to half
-// its width at the extremities. Step markers (dots, locks) and the hover
-// preview must apply the same shift to land exactly where the thumb does, so
+// its width at the extremities. Step markers and the hover preview must apply
+// the same shift to land exactly where the thumb does, so
 // this must match the measured size of the Thumb element exactly.
 // The thumb spans the full track height; the visible ball is drawn 4px
 // smaller inside it, so the fill (which extends half a thumb past the thumb
@@ -33,20 +33,23 @@ export interface SliderStepsProps {
   onChange: (index: number) => void;
   /** 0-based indices rendered with a padlock and skipped when snapping. */
   lockedSteps?: number[];
+  /** 0-based indices rendered with a slash and skipped when snapping. */
+  unavailableSteps?: number[];
   disabled?: boolean;
   className?: string;
   ariaLabel?: string;
-  /** Per-step tooltip content, shown for the step under the pointer (locked steps included). */
+  /** Per-step tooltip content, shown for the step under the pointer (unselectable steps included). */
   stepTooltips?: React.ReactNode[];
 }
 
 /**
  * A stepped slider for choosing one of a few ordered levels, from the same family as
  * `SliderToggle` (same track, fill and knob). Dots mark the available positions, hovering
- * past the knob previews the fill up to the step it would snap to, and `lockedSteps` are
- * rendered with a padlock and skipped when snapping. Use it for a setting with a small
- * ordered scale that applies immediately (e.g. reasoning effort levels), rendering your
- * own labels beneath it; for a binary setting, prefer `SliderToggle`.
+ * past the knob previews the fill up to the step it would snap to. Locked steps use a
+ * padlock; unavailable steps use a slash. Both are skipped when snapping. Use it for a
+ * setting with a small ordered scale that applies immediately (e.g. reasoning effort
+ * levels), rendering your own labels beneath it; for a binary setting, prefer
+ * `SliderToggle`.
  *
  * @summary Stepped slider for ordered levels.
  */
@@ -55,6 +58,7 @@ export function SliderSteps({
   value,
   onChange,
   lockedSteps,
+  unavailableSteps,
   disabled = false,
   className,
   ariaLabel,
@@ -63,19 +67,19 @@ export function SliderSteps({
   const [hoveredIndex, setHoveredIndex] = React.useState<number | null>(null);
 
   const lastIndex = Math.max(stepCount - 1, 1);
-  const lockedSet = React.useMemo(
-    () => new Set(lockedSteps ?? []),
-    [lockedSteps]
-  );
+  const lockedSet = new Set(lockedSteps);
+  const unavailableSet = new Set(unavailableSteps);
+  const isSelectable = (index: number) =>
+    !lockedSet.has(index) && !unavailableSet.has(index);
 
-  const nearestUnlocked = (target: number): number | null => {
+  const nearestSelectable = (target: number): number | null => {
     for (let distance = 0; distance < stepCount; distance++) {
       const below = target - distance;
       const above = target + distance;
-      if (below >= 0 && !lockedSet.has(below)) {
+      if (below >= 0 && isSelectable(below)) {
         return below;
       }
-      if (above < stepCount && !lockedSet.has(above)) {
+      if (above < stepCount && isSelectable(above)) {
         return above;
       }
     }
@@ -83,7 +87,7 @@ export function SliderSteps({
   };
 
   const handleValueChange = ([raw]: number[]) => {
-    const next = nearestUnlocked(raw);
+    const next = nearestSelectable(raw);
     if (next !== null && next !== value) {
       onChange(next);
     }
@@ -98,15 +102,14 @@ export function SliderSteps({
       Math.max((e.clientX - rect.left) / rect.width, 0),
       1
     );
-    // Track the raw step under the pointer (locked ones included) so a locked
-    // step surfaces its OWN tooltip on hover. Selection/preview snap to the
-    // nearest unlocked step separately.
+    // Track the raw step under the pointer so an unselectable step surfaces its
+    // own tooltip. Selection and preview snap separately.
     setHoveredIndex(Math.round(ratio * lastIndex));
   };
 
-  // Where selecting would land: the nearest unlocked step to the raw hover.
+  // Where selecting would land: the nearest selectable step to the raw hover.
   const snappedHoverIndex =
-    hoveredIndex !== null ? nearestUnlocked(hoveredIndex) : null;
+    hoveredIndex !== null ? nearestSelectable(hoveredIndex) : null;
 
   // Decided at render time so the preview vanishes as soon as the hovered step
   // becomes the value (click/drag), without waiting for the next pointer move.
@@ -115,8 +118,7 @@ export function SliderSteps({
       ? snappedHoverIndex
       : null;
 
-  // The tooltip reflects the raw hovered step (so a locked step explains why it
-  // is locked), not the step selection would snap to.
+  // The tooltip reflects the raw hovered step, not where selection would snap.
   const activeTooltip =
     hoveredIndex !== null ? (stepTooltips?.[hoveredIndex] ?? null) : null;
 
@@ -137,15 +139,15 @@ export function SliderSteps({
       onPointerLeave={() => setHoveredIndex(null)}
     >
       <SliderPrimitive.Track className="relative h-full w-full grow rounded-full bg-slider-toggle-bg-idle">
-        {/* Dots on the available positions, painted under the fill. */}
+        {/* Dots on the selectable positions, painted under the fill. */}
         {Array.from({ length: stepCount }, (_, index) =>
-          lockedSet.has(index) ? null : (
+          isSelectable(index) ? (
             <span
               key={index}
               className="absolute top-1/2 h-1 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-400"
               style={{ left: stepCenter(index, lastIndex) }}
             />
-          )
+          ) : null
         )}
         {/* Fill up to the knob. Drawn by hand instead of Radix's Range: Range
             stops at the raw value percent while the thumb is shifted inward to
@@ -172,18 +174,24 @@ export function SliderSteps({
                 : 0,
           }}
         />
-        {/* Locks sit on the track at their step position. */}
-        {Array.from({ length: stepCount }, (_, index) =>
-          lockedSet.has(index) ? (
+        {/* Access locks and unavailable markers sit at their step positions. */}
+        {Array.from({ length: stepCount }, (_, index) => {
+          const StepMarker = lockedSet.has(index)
+            ? Lock01
+            : unavailableSet.has(index)
+              ? SlashCircle01
+              : null;
+
+          return StepMarker ? (
             <span
               key={index}
               className="pointer-events-none absolute top-1/2 -translate-x-1/2 -translate-y-1/2 text-muted-foreground"
               style={{ left: stepCenter(index, lastIndex) }}
             >
-              <Lock01 className="h-3 w-3" />
+              <StepMarker aria-hidden className="h-3 w-3" />
             </span>
-          ) : null
-        )}
+          ) : null;
+        })}
         {/* SliderToggle's inset shadow, as a topmost transparent overlay so it
             reads over the fill too (the fill would otherwise paint above a
             shadow set on the track itself). */}

--- a/sparkle/src/stories/SliderSteps.stories.tsx
+++ b/sparkle/src/stories/SliderSteps.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `A stepped slider for choosing one of a few ordered levels, from the same family as **SliderToggle** (same track, fill and knob). Dots mark the available positions, hovering past the knob previews the fill up to the step it would snap to, and **lockedSteps** are rendered with a padlock and skipped when snapping.
+        component: `A stepped slider for choosing one of a few ordered levels, from the same family as **SliderToggle** (same track, fill and knob). Dots mark the available positions, hovering past the knob previews the fill up to the step it would snap to, and unselectable steps are skipped when snapping. Use **lockedSteps** for access-gated steps and **unavailableSteps** for unsupported steps.
 
 **When to use**
 - For a setting with a small ordered scale that applies immediately (e.g. reasoning effort levels).
@@ -31,7 +31,7 @@ type Story = StoryObj<typeof meta>;
 const THIRD_STEP_TOOLTIP = "This step requires a higher plan.";
 const FOURTH_STEP_TOOLTIP = "This step requires the highest plan.";
 
-async function expectLockedStepTooltips(canvasElement: HTMLElement) {
+async function expectStepTooltips(canvasElement: HTMLElement) {
   const slider = within(canvasElement).getByRole("slider");
   const root = slider.parentElement?.parentElement;
   if (!root) {
@@ -95,22 +95,23 @@ export const Default: Story = {
 };
 
 /**
- * Steps listed in `lockedSteps` render a padlock and are skipped when the
- * knob snaps — e.g. levels gated behind a higher plan.
- * @summary Slider with locked (gated) steps.
+ * Locked steps render a padlock; unavailable steps render a slash. Both are
+ * skipped when the knob snaps.
+ * @summary Slider with unselectable steps.
  */
-export const WithLockedSteps: Story = {
+export const WithUnselectableSteps: Story = {
   args: {
     stepCount: 4,
     value: 1,
-    lockedSteps: [2, 3],
+    lockedSteps: [2],
+    unavailableSteps: [3],
     stepTooltips: [null, null, THIRD_STEP_TOOLTIP, FOURTH_STEP_TOOLTIP],
     ariaLabel: "Level",
     onChange: fn(),
   },
   render: ControlledSliderSteps,
   play: async ({ canvasElement }) => {
-    await expectLockedStepTooltips(canvasElement);
+    await expectStepTooltips(canvasElement);
   },
 };
 
@@ -131,6 +132,6 @@ export const Disabled: Story = {
   },
   render: ControlledSliderSteps,
   play: async ({ canvasElement }) => {
-    await expectLockedStepTooltips(canvasElement);
+    await expectStepTooltips(canvasElement);
   },
 };


### PR DESCRIPTION
## Description

In the model picker some combinations of model x reasoning effort cannot be selected for various reasons: they can either be prohibited (admin decided that the user can't access to a certain tier of models/workspace does not have access to premium models) or simply not exist.

In both cases we currently show a padlock on the reasoning effort slider, this PR changes that to show a slash circle in the 2nd case instead (keeping the lock in the first case).

Current live version

<img width="644" height="599" alt="image" src="https://github.com/user-attachments/assets/c314c33c-bc93-4367-8157-b1d93c946d28" />

Proposal

<img width="629" height="595" alt="image" src="https://github.com/user-attachments/assets/b689ddaf-5129-4842-b778-d10e5355eaf9" />

## Tests

- Updated model picker and SliderSteps story coverage.

## Risk

- Low. Limited to reasoning-effort state presentation.

## Deploy Plan

- Deploy front.
