### PR TITLE
Add section about Cursor Cloud in Agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,9 @@ Storybook's component and documentation knowledge before answering or taking any
 
 Remember: A story name might not reflect the property name correctly, so always verify
 properties through documentation or example stories before using them.
+
+# Cursor Cloud specific instructions
+
+You are provided with credentials to login to the app via email & password.
+They are available in the runtime secrets as DEV_WORKOS_USER_EMAIL & DEV_WORKOS_USER_PASSWORD.
+Note that in the login flow, you'll have to enter the email, continue and then you'll be able to enter the password.

--- a/front/AGENTS.md
+++ b/front/AGENTS.md
@@ -45,7 +45,7 @@ API handlers are **not** here — they live in `front-api/routes/`, one file per
 - For changes related to Temporal, LLM, MCP servers, Elasticsearch, audit events, and webhook sources, and for testing, use the corresponding skills.
 
 # Running tests
-- Use `npm run test -- filetotest
+- Use `npm run test -- filetotest` directly, it will automatically use a test environment (db, redis..)
 
 @CODING_RULES.md
 


### PR DESCRIPTION
## Description

I document the Cursor Cloud login flow in `AGENTS.md`, including the runtime secret names and the email-first authentication sequence. I also correct the `front/AGENTS.md` test command so it uses the repository-managed test environment directly.

## Tests

Documentation-only change. No tests run.

## Risk

Low risk. The changes affect agent instructions only and are easily reversible.

## Deploy Plan

No deployment required.