### PR TITLE
Build Frames v2 UI publication artifacts

### DIFF
--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
@@ -12,6 +14,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FrameManifestSchema } from "@app/types/api/frame_manifest";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { frameV2ContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
@@ -53,10 +56,18 @@ const manifest = FrameManifestSchema.parse({
   ],
 });
 
+const uiOnlyManifest = FrameManifestSchema.parse({
+  version: 1,
+  name: "Task List",
+  description: "Track tasks.",
+});
+
 const sourceFiles = [
   {
     relativePath: "index.tsx",
-    content: Buffer.from("export default function App() {}"),
+    content: Buffer.from(
+      "export default function App() { return <main>Tasks</main>; }"
+    ),
     contentType: "text/typescript" as const,
   },
   {
@@ -119,6 +130,31 @@ beforeEach(() => {
 });
 
 describe("buildAndPublishFramePublication", () => {
+  it("builds and publishes the UI without starting a sandbox", async () => {
+    const { auth, conversation, frame } = await setup();
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest: uiOnlyManifest,
+      sourceFiles: sourceFiles.slice(0, 1),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(ensureConversationSandboxReadyWithScope).not.toHaveBeenCalled();
+    const uiBundlePath = getFramePublicationUiBundlePath({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      frameId: frame.sId,
+      publicationId: result.value.publicationId,
+    });
+    expect(fileStorageMock.getObject(uiBundlePath)).toContain(
+      'data-source="index.tsx:'
+    );
+  });
+
   it("builds every declared function before publishing", async () => {
     const { auth, conversation, frame, sandbox, space } = await setup();
     vi.mocked(ensureConversationSandboxReadyWithScope).mockResolvedValue(
@@ -187,7 +223,7 @@ describe("buildAndPublishFramePublication", () => {
       fileStorageMock.saveFileCalls.filter(({ filePath }) =>
         filePath.endsWith("/bundle.js")
       )
-    ).toHaveLength(2);
+    ).toHaveLength(3);
 
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
@@ -218,6 +254,34 @@ describe("buildAndPublishFramePublication", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBeUndefined();
+  });
+
+  it("keeps the active publication when the UI build fails", async () => {
+    const { auth, conversation, frame } = await setup();
+    const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    await frame.setActiveFramePublication(activePublicationId);
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest,
+      sourceFiles: [
+        {
+          ...sourceFiles[0],
+          content: Buffer.from("export default function App( {"),
+        },
+        ...sourceFiles.slice(1),
+      ],
+    });
+
+    expect(result.isErr() && result.error.code).toBe("ui_build_failed");
+    expect(ensureConversationSandboxReadyWithScope).not.toHaveBeenCalled();
+    expect(buildSandboxFunctionOnReadySandbox).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      activePublicationId
+    );
   });
 
   it("rejects an unsafe snapshot path before staging or building", async () => {

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -12,6 +12,7 @@ import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/li
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { buildFrameBundle } from "@app/lib/api/viz/build_frame_bundle";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -19,15 +20,49 @@ import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 const FRAME_BUILD_STAGING_ROOT = "/tmp/dust-frame-publication-builds";
 const FRAME_BUILD_STAGING_CONCURRENCY = 8;
 
+async function buildFrameUiBundle({
+  manifest,
+  sourceFiles,
+}: {
+  manifest: FrameManifest;
+  sourceFiles: FramePublicationSourceFile[];
+}): Promise<Result<string, FramePublicationError>> {
+  const sourceByPath = new Map(
+    sourceFiles.map((sourceFile) => [
+      sourceFile.relativePath,
+      sourceFile.content,
+    ])
+  );
+  const buildResult = await buildFrameBundle({
+    entryRelPath: manifest.uiEntryPoint,
+    reader: {
+      list: async () => [...sourceByPath.keys()],
+      read: async (relativePath) =>
+        sourceByPath.get(relativePath)?.toString("utf8") ?? null,
+    },
+  });
+
+  if (buildResult.isErr()) {
+    return new Err(
+      new FramePublicationError(
+        "ui_build_failed",
+        `Failed to build Frame UI: ${buildResult.error.message}`
+      )
+    );
+  }
+
+  return new Ok(buildResult.value.code);
+}
+
 /**
- * Stage one captured source snapshot in the invoking conversation's DSBX, build every function
- * declared by the manifest from that snapshot, then atomically publish the source and artifacts.
- * No publication storage is touched until every build has succeeded.
+ * Build the UI and every declared function from one captured source snapshot, then atomically
+ * publish the source and artifacts. Function builds stage the snapshot in the invoking
+ * conversation's DSBX. No publication storage is touched until every build has succeeded.
  */
 export async function buildAndPublishFramePublication(
   auth: Authenticator,
@@ -48,15 +83,6 @@ export async function buildAndPublishFramePublication(
     FramePublicationError | SandboxFunctionError
   >
 > {
-  if (manifest.functions.length === 0) {
-    return publishFramePublication(auth, {
-      frame,
-      functionArtifacts: [],
-      manifest,
-      sourceFiles,
-    });
-  }
-
   const seenSourcePaths = new Set<string>();
   for (const sourceFile of sourceFiles) {
     if (
@@ -71,6 +97,21 @@ export async function buildAndPublishFramePublication(
       );
     }
     seenSourcePaths.add(sourceFile.relativePath);
+  }
+
+  const uiBundle = await buildFrameUiBundle({ manifest, sourceFiles });
+  if (uiBundle.isErr()) {
+    return uiBundle;
+  }
+
+  if (manifest.functions.length === 0) {
+    return publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode: uiBundle.value,
+    });
   }
 
   const ensureResult = await ensureConversationSandboxReadyWithScope(
@@ -132,6 +173,7 @@ export async function buildAndPublishFramePublication(
       functionArtifacts,
       manifest,
       sourceFiles,
+      uiBundleCode: uiBundle.value,
     });
   } finally {
     await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -17,8 +17,10 @@ import {
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
+  getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import {
+  frameContentType,
   frameV2ContentType,
   sandboxFunctionContentType,
 } from "@app/types/files";
@@ -83,6 +85,8 @@ const sourceFilesWithFunction = [
   },
 ];
 
+const uiBundleCode = "export default function App() {}";
+
 const functionArtifacts = [
   {
     name: "add-task",
@@ -106,7 +110,7 @@ beforeEach(() => {
 });
 
 describe("storeFramePublication", () => {
-  it("stores immutable source files before the manifest commit marker", async () => {
+  it("stores the UI bundle and immutable source before the manifest commit marker", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
 
     const result = await storeFramePublication(auth, {
@@ -114,6 +118,7 @@ describe("storeFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
@@ -127,6 +132,7 @@ describe("storeFramePublication", () => {
     );
     expect(new Set(savedPaths.slice(0, -1))).toEqual(
       new Set([
+        getFramePublicationUiBundlePath(identity),
         getFramePublicationSourcePath({
           ...identity,
           relativePath: "index.tsx",
@@ -141,6 +147,13 @@ describe("storeFramePublication", () => {
     expect(fileStorageMock.saveFileCalls.at(-1)?.contentType).toBe(
       frameV2ContentType
     );
+    const uiBundlePath = getFramePublicationUiBundlePath(identity);
+    expect(fileStorageMock.getObject(uiBundlePath)).toBe(uiBundleCode);
+    expect(
+      fileStorageMock.saveFileCalls.find(
+        ({ filePath }) => filePath === uiBundlePath
+      )?.contentType
+    ).toBe(frameContentType);
     expect(
       fileStorageMock.saveFileCalls.some(({ filePath }) =>
         filePath.startsWith("files/w/")
@@ -156,6 +169,7 @@ describe("storeFramePublication", () => {
       functionArtifacts,
       manifest: manifestWithFunction,
       sourceFiles: sourceFilesWithFunction,
+      uiBundleCode,
     });
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
@@ -212,6 +226,7 @@ describe("storeFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles: sourceFiles.slice(1),
+      uiBundleCode,
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_source");
@@ -226,6 +241,7 @@ describe("storeFramePublication", () => {
       functionArtifacts,
       manifest: manifestWithFunction,
       sourceFiles,
+      uiBundleCode,
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_source");
@@ -266,6 +282,7 @@ describe("storeFramePublication", () => {
       functionArtifacts,
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
 
     expect(result.isErr() && result.error.code).toBe(
@@ -285,6 +302,7 @@ describe("storeFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles: invalidSourceFiles,
+      uiBundleCode,
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_source");
@@ -300,6 +318,7 @@ describe("storeFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_frame");
@@ -318,6 +337,7 @@ describe("storeFramePublication", () => {
         functionArtifacts: [],
         manifest,
         sourceFiles,
+        uiBundleCode,
       })
     ).rejects.toThrow("Simulated GCS write failure");
     expect(
@@ -336,6 +356,7 @@ describe("Frame publication reads", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
     expect(stored.isOk()).toBe(true);
     if (stored.isErr()) {
@@ -408,6 +429,7 @@ describe("Frame publication reads", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
     expect(stored.isOk()).toBe(true);
     if (stored.isErr()) {
@@ -445,6 +467,7 @@ describe("activateFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
     expect(stored.isOk()).toBe(true);
     if (stored.isErr()) {
@@ -470,6 +493,7 @@ describe("activateFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
     expect(stored.isOk()).toBe(true);
     if (stored.isErr()) {
@@ -505,6 +529,7 @@ describe("publishFramePublication", () => {
       functionArtifacts: [],
       manifest,
       sourceFiles,
+      uiBundleCode,
     });
 
     expect(published.isOk()).toBe(true);
@@ -531,6 +556,7 @@ describe("publishFramePublication", () => {
         functionArtifacts,
         manifest: manifestWithFunction,
         sourceFiles: sourceFilesWithFunction,
+        uiBundleCode,
       })
     ).rejects.toThrow("Simulated GCS write failure");
     expect(

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -22,10 +22,12 @@ import {
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
+  getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import {
+  frameContentType,
   frameV2ContentType,
   sandboxFunctionContentType,
 } from "@app/types/files";
@@ -58,6 +60,7 @@ export class FramePublicationError extends Error {
       | "invalid_source"
       | "publication_not_found"
       | "source_not_found"
+      | "ui_build_failed"
       | "unauthorized",
     message: string
   ) {
@@ -96,11 +99,13 @@ export async function storeFramePublication(
     functionArtifacts,
     manifest,
     sourceFiles,
+    uiBundleCode,
   }: {
     frame: FileResource;
     functionArtifacts: FramePublicationFunctionArtifact[];
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
+    uiBundleCode: string;
   }
 ): Promise<Result<{ publicationId: string }, FramePublicationError>> {
   const frameIdentity = getFrameIdentity(auth, frame);
@@ -188,6 +193,11 @@ export async function storeFramePublication(
   const storage = getPrivateUploadBucket();
 
   const publicationFiles = [
+    {
+      filePath: getFramePublicationUiBundlePath(identity),
+      content: uiBundleCode,
+      contentType: frameContentType,
+    },
     ...sourceFiles.map((sourceFile) => ({
       filePath: getFramePublicationSourcePath({
         ...identity,
@@ -336,11 +346,13 @@ export async function publishFramePublication(
     functionArtifacts,
     manifest,
     sourceFiles,
+    uiBundleCode,
   }: {
     frame: FileResource;
     functionArtifacts: FramePublicationFunctionArtifact[];
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
+    uiBundleCode: string;
   }
 ): Promise<Result<{ publicationId: string }, FramePublicationError>> {
   const publication = await storeFramePublication(auth, {
@@ -348,6 +360,7 @@ export async function publishFramePublication(
     functionArtifacts,
     manifest,
     sourceFiles,
+    uiBundleCode,
   });
   if (publication.isErr()) {
     return publication;

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   publishFrameFromSource,
   publishFrameV2FromSource,

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -4,6 +4,7 @@ import {
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
   getFramePublicationSourcePath,
+  getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import { describe, expect, it } from "vitest";
 
@@ -26,6 +27,9 @@ describe("Frames v2 GCS paths", () => {
       })
     ).toBe(
       "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/source/src/index.tsx"
+    );
+    expect(getFramePublicationUiBundlePath(IDS)).toBe(
+      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/ui/bundle.js"
     );
     expect(
       getFramePublicationFunctionBundlePath({

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -71,6 +71,14 @@ export function getFramePublicationSourcePath({
   return `${getFramePublicationSourceBasePath(args)}${relativePath}`;
 }
 
+export function getFramePublicationUiBundlePath(args: {
+  workspaceId: string;
+  frameId: string;
+  publicationId: string;
+}): string {
+  return `${getFramePublicationBasePath(args)}ui/bundle.js`;
+}
+
 export function getFramePublicationFunctionBasePath({
   functionName,
   ...args


### PR DESCRIPTION
## Description

- Build the Frame UI from the captured publication snapshot with the existing Frame bundler.
- Store the immutable bundle at `ui/bundle.js` before the manifest commit marker.
- Keep the active publication unchanged when the UI build fails.

## Tests

Added coverage for UI-only publishing, the GCS artifact contract, and failed UI builds preserving the active publication. Exercised the sandbox publish endpoint locally.

## Risk

Feature-flagged. Publishing now rejects invalid UI source before writing or activating a publication. Existing active publications are unchanged.

## Deploy Plan

Standard deploy. No migration or backfill.