### PR TITLE
Swap the + dropdown for Spaces, Attach knowledge, and Capabilities

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -173,7 +173,10 @@ interface CapabilitiesPickerProps {
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
   onOpenChange?: (open: boolean) => void;
-  type?: "dropdown" | "subdropdown";
+  // "inline" renders the picker's own content bare — no trigger, no
+  // DropdownMenu/Sub wrapper — for a parent that owns a single
+  // DropdownMenuContent and swaps between its own root and this picker.
+  type?: "dropdown" | "subdropdown" | "inline";
   externalOpen?: boolean;
   onExternalOpenChange?: (open: boolean) => void;
   anchorRef?: React.RefObject<HTMLElement | null>;
@@ -414,6 +417,68 @@ export function CapabilitiesPicker({
   const shouldShowCapabilityDropdownList =
     capabilityPickerItems.length > 0 || hasNoVisibleItems;
 
+  const searchbar = (
+    <div className="sticky top-0 z-10 bg-overlay-background">
+      <DropdownMenuSearchbar
+        autoFocus={!isMobile}
+        name="search-capabilities"
+        placeholder="Search capabilities"
+        value={searchText}
+        onChange={setSearchText}
+      />
+      <DropdownMenuSeparator />
+    </div>
+  );
+
+  const body = (
+    <>
+      {(!isSkillsDataReady || !isToolsDataReady) && (
+        <CapabilitiesPickerLoading />
+      )}
+
+      {shouldShowCapabilityDropdownList && (
+        <CapabilitiesPickerItemsList
+          emptyMessage={
+            normalizedSearchText.length > 0
+              ? "No capabilities found"
+              : "No more capabilities to select"
+          }
+          items={capabilityPickerItems}
+          onItemSelect={selectCapabilityPickerItem}
+          onSkillDetails={(skillId) => {
+            setSelectedSkillIdForDetails(skillId);
+            setIsOpen(false);
+          }}
+          onToolDetails={(serverView) => {
+            setSelectedServerViewForDetails(serverView);
+            setIsOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+
+  const detailsSheets = (
+    <CapabilityDetailsSheets
+      owner={owner}
+      user={user}
+      selectedSkillId={selectedSkillIdForDetails}
+      selectedMCPServerView={selectedServerViewForDetails}
+      onCloseSkill={() => setSelectedSkillIdForDetails(null)}
+      onCloseTool={() => setSelectedServerViewForDetails(null)}
+    />
+  );
+
+  if (type === "inline") {
+    return (
+      <>
+        {searchbar}
+        {body}
+        {detailsSheets}
+      </>
+    );
+  }
+
   const Wrapper = type === "dropdown" ? DropdownMenu : DropdownMenuSub;
   const ContentWrapper =
     type === "dropdown" ? DropdownMenuContent : DropdownMenuSubContent;
@@ -476,53 +541,13 @@ export function CapabilitiesPicker({
                 onInteractOutside: () => setIsOpen(false),
               }
             : {})}
-          dropdownHeaders={
-            <>
-              <DropdownMenuSearchbar
-                autoFocus={!isMobile}
-                name="search-capabilities"
-                placeholder="Search capabilities"
-                value={searchText}
-                onChange={setSearchText}
-              />
-              <DropdownMenuSeparator />
-            </>
-          }
+          dropdownHeaders={searchbar}
         >
-          {(!isSkillsDataReady || !isToolsDataReady) && (
-            <CapabilitiesPickerLoading />
-          )}
-
-          {shouldShowCapabilityDropdownList && (
-            <CapabilitiesPickerItemsList
-              emptyMessage={
-                normalizedSearchText.length > 0
-                  ? "No capabilities found"
-                  : "No more capabilities to select"
-              }
-              items={capabilityPickerItems}
-              onItemSelect={selectCapabilityPickerItem}
-              onSkillDetails={(skillId) => {
-                setSelectedSkillIdForDetails(skillId);
-                setIsOpen(false);
-              }}
-              onToolDetails={(serverView) => {
-                setSelectedServerViewForDetails(serverView);
-                setIsOpen(false);
-              }}
-            />
-          )}
+          {body}
         </ContentWrapper>
       </Wrapper>
 
-      <CapabilityDetailsSheets
-        owner={owner}
-        user={user}
-        selectedSkillId={selectedSkillIdForDetails}
-        selectedMCPServerView={selectedServerViewForDetails}
-        onCloseSkill={() => setSelectedSkillIdForDetails(null)}
-        onCloseTool={() => setSelectedServerViewForDetails(null)}
-      />
+      {detailsSheets}
     </>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -91,7 +91,10 @@ interface InputBarAttachmentsPickerProps {
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   attachedNodes: DataSourceViewContentNode[];
-  type: "dropdown" | "subdropdown";
+  // "inline" renders the picker's own content bare — no trigger, no
+  // DropdownMenu/Sub wrapper — for a parent that owns a single
+  // DropdownMenuContent and swaps between its own root and this picker.
+  type: "dropdown" | "subdropdown" | "inline";
   isLoading?: boolean;
   buttonLabel?: string;
   buttonVariant?: ButtonVariantType;
@@ -545,6 +548,203 @@ export const InputBarAttachmentsPicker = ({
   );
 
   const allUnselected = selectedFilterKeys.length === 0;
+
+  const headers = (
+    <>
+      <Input
+        type="file"
+        ref={fileInputRef}
+        containerClassName="hidden"
+        onChange={async (e) => {
+          setIsOpen(false);
+          await fileUploaderService.handleFileChange(e);
+          onFileChange?.();
+          if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+          }
+        }}
+        multiple={true}
+      />
+      <DropdownMenuSearchbar
+        autoFocus={!isMobile}
+        name="search-files"
+        placeholder="Search"
+        value={search}
+        onChange={setSearch}
+        disabled={false}
+        isLoading={showLoader}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            const firstMenuItem = itemsContainerRef.current?.querySelector(
+              '[role="menuitemcheckbox"]'
+            );
+            (firstMenuItem as HTMLElement)?.focus();
+          }
+        }}
+        button={
+          <Button
+            icon={UploadCloud02}
+            label="Upload File"
+            onClick={() => fileInputRef.current?.click()}
+            className="ml-4"
+          />
+        }
+      />
+      <DropdownMenuSeparator />
+    </>
+  );
+
+  const body = searchQuery ? (
+    <div ref={itemsContainerRef}>
+      <div className="flex flex-wrap items-center">
+        <DropdownMenuFilters
+          filters={availableSources}
+          selectedValues={selectedFilterKeys}
+          onSelectFilter={handleFilterClick}
+        />
+
+        {availableSources.length === 0 && showLoader && (
+          <LoadingBlock
+            // LoadingBlock defaults to, same as the menu
+            // surface, so skeletons read as invisible; match menu row hover contrast.
+
+            className="h-7 w-20 bg-muted-background p-2 mt-2"
+          />
+        )}
+      </div>
+
+      {showSearchResultPlaceholders ? (
+        <div className="flex flex-col gap-2 px-2 py-2">
+          {Array.from({ length: SEARCH_RESULTS_PLACEHOLDER_COUNT }, (_, i) => (
+            <LoadingBlock
+              key={i}
+              // LoadingBlock defaults to, same as the menu
+              // surface, so skeletons read as invisible; match menu row hover contrast.
+
+              className="h-11 w-full bg-muted-background"
+            />
+          ))}
+        </div>
+      ) : (
+        <>
+          {(allUnselected || selectedDataSourcesAndTools[PROJECT_FILTER_KEY]) &&
+            projectFilesWithResults.map((f) => (
+              <ProjectFileItem
+                key={`project-file-${f.fileId}`}
+                item={f}
+                projectName={projectName}
+                isAttached={attachedFileIds.has(f.fileId)}
+                isDisabled={isLoading || disabled}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    fileUploaderService.addUploadedFile({
+                      fileId: f.fileId,
+                      filename: f.title,
+                      // We only fetch `type=file` from the project context endpoint.
+                      contentType: f.contentType as any,
+                      size: 0,
+                      id: f.fileId,
+                    });
+                  } else {
+                    fileUploaderService.removeFile(f.fileId);
+                  }
+                  onFileChange?.();
+                }}
+              />
+            ))}
+          {Object.keys(serversWithResults).length === 0 ? (
+            // No tools results, show knowledge nodes as returned by the search.
+            dataSourcesNodes
+              .filter(
+                (item) =>
+                  allUnselected ||
+                  selectedDataSourcesAndTools[
+                    getKeyForDataSource(item.dataSource)
+                  ]
+              )
+              .map((item) => (
+                <KnowledgeNodeCheckboxItem
+                  key={`knowledge-${item.dataSourceView.dataSource.sId}-${item.internalId}`}
+                  item={item}
+                  owner={owner}
+                  attachedNodes={attachedNodes}
+                  onNodeSelect={onNodeSelect}
+                  onNodeUnselect={onNodeUnselect}
+                  spacesMap={spacesMap}
+                />
+              ))
+          ) : (
+            // Show grouped knowledge nodes, then tools (project files are rendered above).
+            <>
+              {Object.entries(dataSourcesWithResults).map(([key, r]) => {
+                const isSelected =
+                  allUnselected || selectedDataSourcesAndTools[key];
+                return isSelected
+                  ? r.results.map((item) => (
+                      <KnowledgeNodeCheckboxItem
+                        key={`knowledge-${item.dataSourceView.dataSource.sId}-${item.internalId}`}
+                        item={item}
+                        owner={owner}
+                        attachedNodes={attachedNodes}
+                        onNodeSelect={onNodeSelect}
+                        onNodeUnselect={onNodeUnselect}
+                        spacesMap={spacesMap}
+                      />
+                    ))
+                  : null;
+              })}
+              {Object.entries(serversWithResults).map(([key, r]) => {
+                const isSelected =
+                  allUnselected || selectedDataSourcesAndTools[key];
+                return isSelected
+                  ? r.results.map((item) => (
+                      <ToolFileCheckboxItem
+                        key={`tool-${getToolFileKey(item)}`}
+                        item={item}
+                        isLoading={isLoading}
+                        isToolFileAttached={isToolFileAttached}
+                        isToolFileUploading={isToolFileUploading}
+                        uploadToolFile={uploadToolFile}
+                        removeToolFile={removeToolFile}
+                      />
+                    ))
+                  : null;
+              })}
+            </>
+          )}
+        </>
+      )}
+      {availableSources.length === 0 && !showLoader && (
+        <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+          No results found
+        </div>
+      )}
+
+      <InfiniteScroll
+        nextPage={nextPage}
+        hasMore={hasMore}
+        showLoader={showLoader}
+        loader={<div />}
+      />
+    </div>
+  ) : (
+    <div className="flex h-40 w-full items-center justify-center">
+      <div className="flex flex-col items-center justify-center gap-0 text-center text-base font-semibold text-primary-400">
+        <Icon visual={SearchMd} size="sm" />
+        Search knowledge
+      </div>
+    </div>
+  );
+
+  if (type === "inline") {
+    return (
+      <>
+        <div className="sticky top-0 z-10 bg-overlay-background">{headers}</div>
+        {body}
+      </>
+    );
+  }
 
   const Wrapper = type === "dropdown" ? DropdownMenu : DropdownMenuSub;
   const ContentWrapper =

--- a/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
@@ -19,6 +19,7 @@ import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
+  ArrowLeft,
   Attachment01,
   Button,
   cn,
@@ -30,7 +31,8 @@ import {
   Plus,
   ShapesPlus,
 } from "@dust-tt/sparkle";
-import { useRef, useState } from "react";
+import type React from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 const PLUS_BUTTON_CLASSNAME = cn(
   INPUT_BAR_PILL_SURFACE_CLASSNAME,
@@ -39,6 +41,7 @@ const PLUS_BUTTON_CLASSNAME = cn(
 
 const MOBILE_PICKERS = ["capabilities", "attachments", "spaces"] as const;
 type MobilePicker = (typeof MOBILE_PICKERS)[number];
+type SubPicker = MobilePicker;
 
 interface InputBarPlusMenuProps {
   owner: WorkspaceType;
@@ -104,8 +107,19 @@ export function InputBarPlusMenu({
   // menu to be opened once, which matches when desktop mounts them inside
   // DropdownMenuContent.
   const [hasOpenedMenu, setHasOpenedMenu] = useState(false);
+  const [activeSubPicker, setActiveSubPicker] = useState<SubPicker | null>(
+    null
+  );
   const plusButtonRef = useRef<HTMLDivElement>(null);
   const shouldPrefetch = isOpen || hasHovered || openMobilePicker !== null;
+
+  // The root view's own slide-in would otherwise also play on the very first
+  // paint, stacking on top of the dropdown's own open animation. Only
+  // animate it on a genuine swap back to root, not on the initial mount.
+  const isInitialRenderRef = useRef(true);
+  useLayoutEffect(() => {
+    isInitialRenderRef.current = false;
+  }, []);
 
   const hasAnyEntry = !hideCapabilities || !hideAttachments || spaces != null;
   if (!hasAnyEntry) {
@@ -198,6 +212,68 @@ export function InputBarPlusMenu({
     />
   );
 
+  const inlineCapabilitiesPicker = (
+    <CapabilitiesPicker
+      type="inline"
+      owner={owner}
+      user={user}
+      selectedMCPServerViews={selectedMCPServerViews}
+      onSelect={onMCPServerViewSelect}
+      onSkillSelect={onSkillSelect}
+      onSetupServer={onSetupServer}
+      onOpenChange={onCapabilitiesPickerOpenChange}
+      buttonSize={buttonSize}
+      disabled={disabled}
+    />
+  );
+
+  const inlineAttachmentsPicker = (
+    <InputBarAttachmentsPicker
+      type="inline"
+      owner={owner}
+      fileUploaderService={fileUploaderService}
+      isLoading={false}
+      onNodeSelect={onNodeSelect}
+      onNodeUnselect={onNodeUnselect}
+      attachedNodes={attachedNodes}
+      buttonSize={buttonSize}
+      onOpenChange={onAttachmentsPickerOpenChange}
+      toolFileUpload={{
+        useCase: "conversation",
+        useCaseMetadata: {
+          conversationId: conversation?.sId,
+        },
+      }}
+      spaceId={spaceId}
+      disabled={disabled}
+      prefetch={shouldPrefetch}
+    />
+  );
+
+  const inlineSpacesPicker = (
+    <InputBarSpacesPicker
+      type="inline"
+      canDeselectSelectedSpaces={canDeselectSelectedSpaces ?? true}
+      disabled={disabled}
+      isLoading={!!isSpacesLoading}
+      selectedSpaceIds={selectedSpaceIds}
+      onSelectedSpaceIdsChange={onSelectedSpaceIdsChange}
+      spaces={spaces ?? []}
+    />
+  );
+
+  const subPickerLabel: Record<SubPicker, string> = {
+    capabilities: "Capabilities",
+    attachments: "Attach knowledge",
+    spaces: spacesLabel,
+  };
+
+  const subPickerContent: Record<SubPicker, React.ReactNode> = {
+    capabilities: inlineCapabilitiesPicker,
+    attachments: inlineAttachmentsPicker,
+    spaces: inlineSpacesPicker,
+  };
+
   const plusButton = (
     <DropdownMenuTrigger asChild>
       <Button
@@ -219,6 +295,8 @@ export function InputBarPlusMenu({
     onOpenChange?.(open);
     if (open) {
       setHasOpenedMenu(true);
+    } else {
+      setActiveSubPicker(null);
     }
   };
 
@@ -277,9 +355,53 @@ export function InputBarPlusMenu({
     <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
       {plusButton}
       <DropdownMenuContent align="start" className="w-64">
-        {!hideCapabilities && capabilitiesPicker}
-        {!hideAttachments && attachmentsPicker}
-        {spaces != null && spacesPicker}
+        {activeSubPicker ? (
+          <div
+            key={activeSubPicker}
+            className="animate-in slide-in-from-right-4 duration-200 motion-reduce:animate-none"
+          >
+            <DropdownMenuItem
+              label={subPickerLabel[activeSubPicker]}
+              icon={ArrowLeft}
+              onClick={() => setActiveSubPicker(null)}
+              onSelect={(e) => e.preventDefault()}
+            />
+            {subPickerContent[activeSubPicker]}
+          </div>
+        ) : (
+          <div
+            key="root"
+            className={cn(
+              "animate-in duration-200 motion-reduce:animate-none",
+              !isInitialRenderRef.current && "slide-in-from-left-4"
+            )}
+          >
+            {!hideCapabilities && (
+              <DropdownMenuItem
+                label="Capabilities"
+                icon={ShapesPlus}
+                disabled={disabled}
+                onClick={() => setActiveSubPicker("capabilities")}
+              />
+            )}
+            {!hideAttachments && (
+              <DropdownMenuItem
+                label="Attach knowledge"
+                icon={Attachment01}
+                disabled={disabled}
+                onClick={() => setActiveSubPicker("attachments")}
+              />
+            )}
+            {spaces != null && (
+              <DropdownMenuItem
+                label={spacesLabel}
+                icon={Planet}
+                disabled={disabled}
+                onClick={() => setActiveSubPicker("spaces")}
+              />
+            )}
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -35,7 +35,10 @@ interface InputBarSpacesPickerProps {
   onSelectedSpaceIdsChange: (spaceIds: string[]) => void;
   selectedSpaceIds: string[];
   spaces: SelectableConversationSpaceType[];
-  type?: "dropdown" | "subdropdown";
+  // "inline" renders the picker's own content bare — no trigger, no
+  // DropdownMenu/Sub wrapper — for a parent that owns a single
+  // DropdownMenuContent and swaps between its own root and this picker.
+  type?: "dropdown" | "subdropdown" | "inline";
   externalOpen?: boolean;
   onExternalOpenChange?: (open: boolean) => void;
   anchorRef?: React.RefObject<HTMLElement | null>;
@@ -96,6 +99,70 @@ export function InputBarSpacesPicker({
     onSelectedSpaceIdsChange(selectedSpaceIds.filter((id) => id !== spaceId));
   };
 
+  const body = (
+    <>
+      <DropdownMenuCheckboxItem label="Agent's Spaces" checked disabled />
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel label="Additional Spaces" />
+      {isLoading ? (
+        <DropdownMenuItem
+          label="Loading"
+          disabled
+          endComponent={<Spinner size="xs" />}
+        />
+      ) : spaces.length === 0 ? (
+        <DropdownMenuItem label="No Spaces available" disabled />
+      ) : filteredSpaces.length === 0 ? (
+        <DropdownMenuItem label="No matching Spaces" disabled />
+      ) : (
+        <div>
+          {filteredSpaces.map((space) => {
+            const checked = selectedSpaceIdsSet.has(space.sId);
+
+            return (
+              <DropdownMenuCheckboxItem
+                key={space.sId}
+                label={space.name}
+                icon={getSpaceIcon(space)}
+                checked={checked}
+                disabled={checked && !canDeselectSelectedSpaces}
+                onCheckedChange={(nextChecked) =>
+                  handleSpaceCheckedChange(space.sId, nextChecked === true)
+                }
+                onSelect={(event) => {
+                  event.preventDefault();
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+
+  const searchbar = (
+    <div className="sticky top-0 z-10 bg-overlay-background">
+      <DropdownMenuSearchbar
+        autoFocus
+        name="search-spaces"
+        placeholder="Search Spaces"
+        value={searchText}
+        onChange={setSearchText}
+        disabled={isLoading}
+      />
+      <DropdownMenuSeparator />
+    </div>
+  );
+
+  if (type === "inline") {
+    return (
+      <>
+        {searchbar}
+        {body}
+      </>
+    );
+  }
+
   const Wrapper = type === "dropdown" ? DropdownMenu : DropdownMenuSub;
   const ContentWrapper =
     type === "dropdown" ? DropdownMenuContent : DropdownMenuSubContent;
@@ -136,56 +203,9 @@ export function InputBarSpacesPicker({
               onInteractOutside: () => setIsOpen(false),
             }
           : {})}
-        dropdownHeaders={
-          <>
-            <DropdownMenuSearchbar
-              autoFocus
-              name="search-spaces"
-              placeholder="Search Spaces"
-              value={searchText}
-              onChange={setSearchText}
-              disabled={isLoading}
-            />
-            <DropdownMenuSeparator />
-          </>
-        }
+        dropdownHeaders={searchbar}
       >
-        <DropdownMenuCheckboxItem label="Agent's Spaces" checked disabled />
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel label="Additional Spaces" />
-        {isLoading ? (
-          <DropdownMenuItem
-            label="Loading"
-            disabled
-            endComponent={<Spinner size="xs" />}
-          />
-        ) : spaces.length === 0 ? (
-          <DropdownMenuItem label="No Spaces available" disabled />
-        ) : filteredSpaces.length === 0 ? (
-          <DropdownMenuItem label="No matching Spaces" disabled />
-        ) : (
-          <div>
-            {filteredSpaces.map((space) => {
-              const checked = selectedSpaceIdsSet.has(space.sId);
-
-              return (
-                <DropdownMenuCheckboxItem
-                  key={space.sId}
-                  label={space.name}
-                  icon={getSpaceIcon(space)}
-                  checked={checked}
-                  disabled={checked && !canDeselectSelectedSpaces}
-                  onCheckedChange={(nextChecked) =>
-                    handleSpaceCheckedChange(space.sId, nextChecked === true)
-                  }
-                  onSelect={(event) => {
-                    event.preventDefault();
-                  }}
-                />
-              );
-            })}
-          </div>
-        )}
+        {body}
       </ContentWrapper>
     </Wrapper>
   );


### PR DESCRIPTION
## Summary
- Extends the model picker's drill-down swap pattern (see #inputBarPickersSwap's parent work in `modelPickerImprovement`) to the input bar's "+" menu.
- Each of `InputBarSpacesPicker`, `CapabilitiesPicker`, and `InputBarAttachmentsPicker` gains a bare `type="inline"` render mode (no trigger, no own `DropdownMenu`/`DropdownMenuSub` wrapper).
- `InputBarPlusMenu` (desktop only) now owns an `activeSubPicker` state: the root view lists the three entries, clicking one swaps the whole dropdown content to that picker's inline view with a back row, using the same directional slide + initial-render guard established in the model picker.
- Mobile behavior is unchanged.

## Test plan
- [ ] `npx tsgo -p front --noEmit` and `npx biome check` pass on the changed files
- [ ] Manually verify in the deploy preview: open the "+" menu, click Capabilities/Attach knowledge/Spaces, confirm the swap animation and back navigation work as in the model picker
- [ ] Confirm mobile "+" menu still opens each picker as before