### PR TITLE
Rename reserved `host` metric tag on llm_flex_fallback

### DIFF
--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -138,8 +138,6 @@ export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConv
     const reason =
       err instanceof APIConnectionTimeoutError ? "timeout" : "error";
     const { model, host, region } = this.metadata();
-    // `host` is reserved by the Datadog agent (it overrides the metric's
-    // hostname), so the endpoint host ships under its own tag name.
     const tags = [
       `model_id:${model}`,
       `endpoint_host:${host}`,

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -138,9 +138,11 @@ export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConv
     const reason =
       err instanceof APIConnectionTimeoutError ? "timeout" : "error";
     const { model, host, region } = this.metadata();
+    // `host` is reserved by the Datadog agent (it overrides the metric's
+    // hostname), so the endpoint host ships under its own tag name.
     const tags = [
       `model_id:${model}`,
-      `host:${host}`,
+      `endpoint_host:${host}`,
       `region:${region}`,
       `reason:${reason}`,
     ];


### PR DESCRIPTION
## Description

Follow-up to review feedback on the OpenAI flex fallback telemetry: `host` is a reserved field name on Datadog and in our infra.

The Datadog agent interprets a client-sent `host:` tag as a hostname override, so `host:openai-responses` on `llm_flex_fallback.count` re-attributed the metric to a non-existent host (this is the same behavior our own `statsDMetrics` helper relies on when it sends an empty `host:` to drop the tag — see `front/lib/utils/statsd.ts`).

The endpoint host now ships as `endpoint_host:<host>` instead, with a short comment so the next person doesn't reintroduce it. The same `tags` array is also attached to the `logger.warn` call, so the log field is renamed along with it.

## Tests

No behavior change beyond the tag name; no test or dashboard in the repo referenced the old tag. `npm run tsgo` could not be run locally in this worktree (dependencies are not installed there), so the typecheck is left to CI — the change is a string literal plus a comment.

## Risk

Very low. `llm_flex_fallback.count` is a new metric with no dashboards or monitors built on it yet, so renaming the tag does not break anything downstream. Safe to roll back.

## Deploy Plan

Standard deploy, no ordering constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)