### PR TITLE
dev: base the shared dev image on Ubuntu 24.04 so Cursor's screen recorder works

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -6,7 +6,13 @@
 # Layer cache: keep this file stable — any ENV/RUN edit above the apt layer invalidates
 # all downstream steps (apt, rust, temporal, …). Shell/terminal defaults live in
 # dev/scripts/env.sh and dev/bashrc (bind-mounted at runtime).
-FROM node:24.16.0-bookworm
+#
+# Base is Ubuntu 24.04 rather than a node:* image because Cursor's in-container screen
+# recorder (/exec-daemon/polished-renderer.node) needs glibc >= 2.39 and the FFmpeg 6
+# sonames (libavutil.so.58, libav{codec,format,device}.so.60, libswscale.so.7). Debian 12
+# has glibc 2.36 + FFmpeg 5 and Debian 13 has FFmpeg 7, so neither can satisfy it; Node is
+# installed from the official tarball below.
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LEFTHOOK_EXCLUDE=front-lint-test-filenames,front-typecheck,front-circular,front-docs-check,connectors-lint-test-filenames,connectors-typecheck,lint-staged \
@@ -25,7 +31,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     gnupg \
   && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
     | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg \
-  && echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+  && echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list \
   && apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -42,11 +48,28 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     lsof \
     netcat-openbsd \
     unzip \
+    xz-utils \
     less \
     vim-tiny \
     bash-completion \
     tmux \
+    ffmpeg \
   && rm -rf /var/lib/apt/lists/*
+
+# Node — official tarball, checksum-verified (same artifact the node:* images ship)
+ARG NODE_VERSION=24.16.0
+RUN set -eu \
+  && archive="node-v${NODE_VERSION}-linux-x64.tar.xz" \
+  && curl -fsSLo /tmp/node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" \
+  && curl -fsSLo /tmp/node-shasums.txt "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" \
+  && expected="$(awk -v archive="$archive" '$2 == archive { print $1 }' /tmp/node-shasums.txt)" \
+  && [ -n "$expected" ] \
+  && echo "${expected}  /tmp/node.tar.xz" | sha256sum -c - \
+  && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --no-same-owner \
+  && rm /tmp/node.tar.xz /tmp/node-shasums.txt \
+  && ln -sf /usr/local/bin/node /usr/local/bin/nodejs \
+  && node --version \
+  && npm --version
 
 # Rust toolchain (core-api, oauth dev)
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \

--- a/dev/README.md
+++ b/dev/README.md
@@ -43,6 +43,15 @@ bash dev/scripts/docker-run.sh --shell
 
 Inside the container, compose-based mprocs procs (`docker-infra`, `kibana`, …) no-op when `DUST_IN_CONTAINER=1`.
 
+## Base image
+
+`dev/Dockerfile` builds on `ubuntu:24.04` and installs Node from the official tarball
+(`NODE_VERSION` build arg) instead of using a `node:*` image. Cursor's in-container screen
+recorder (`/exec-daemon/polished-renderer.node`) links against glibc 2.39 and the FFmpeg 6
+sonames shipped by Noble (`libavutil.so.58`, `libav{codec,format,device}.so.60`,
+`libswscale.so.7`), which Debian 12 (glibc 2.36, FFmpeg 5) and Debian 13 (FFmpeg 7) cannot
+provide. Keep the base on Noble and keep `ffmpeg` installed, or agents lose video capture.
+
 ## Cursor Cloud snapshots
 
 Cloud agents boot from a prebuilt environment snapshot: `/workspace` is the checkout baked when


### PR DESCRIPTION
## Description

The shared dev image now uses `ubuntu:24.04` to provide glibc 2.39 and FFmpeg 6 sonames required by Cursor's in-container screen recorder. It installs Node `24.16.0` from the checksum-verified official tarball, switches PGDG to `noble-pgdg`, and documents the base-image constraint; production images remain unchanged.

## Tests

Validated with a real Cursor environment build from this branch, including the full image build and `dev/scripts/install.sh`.

## Risk

Low risk and rollback-safe: the changes are isolated to the shared development image. The main risk is a failed image build or environment refresh, mitigated by checksum verification and reverting the Dockerfile base.

## Deploy Plan

Rebuild and publish the shared dev image, then refresh the Cursor Cloud environment snapshot. No production service deploy or database migration is required.