### PR TITLE
Check GCS file existence before signing download URLs

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -8,6 +8,7 @@ import { PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS } from ".";
 
 const getAllFilesByPrefixMock = vi.hoisted(() => vi.fn());
 const getSignedUrlMock = vi.hoisted(() => vi.fn());
+const fileExistsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@app/lib/file_storage/config", () => ({
   default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
@@ -49,7 +50,10 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
     getSignedUrlMock.mockReset();
     getSignedUrlMock.mockResolvedValue("https://signed.example/read");
+    fileExistsMock.mockReset();
+    fileExistsMock.mockResolvedValue([true]);
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ exists: fileExistsMock })),
       getAllFilesByPrefix: getAllFilesByPrefixMock,
       getSignedUrl: getSignedUrlMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -124,6 +124,7 @@ export interface FileSystemBackend {
   /**
    * Returns a short-lived signed URL for unauthenticated download.
    * `fileName` overrides the Content-Disposition filename hint.
+   * Returns `Err("not_found")` when the file does not exist.
    */
   getDownloadUrl(
     scopedPath: string,

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -698,12 +698,15 @@ describe("GCSFileSystemBackend.copy", () => {
 
 describe("GCSFileSystemBackend.getDownloadUrl", () => {
   let getSignedUrlMock: ReturnType<typeof vi.fn>;
+  let existsMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     getSignedUrlMock = vi
       .fn()
       .mockResolvedValue("https://signed.example.com/file.pdf");
+    existsMock = vi.fn().mockResolvedValue([true]);
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ exists: existsMock })),
       getSignedUrl: getSignedUrlMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
@@ -720,6 +723,20 @@ describe("GCSFileSystemBackend.getDownloadUrl", () => {
       `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
       { expirationDelayMs: DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS }
     );
+  });
+
+  it("returns Err(not_found) without signing when the file is missing", async () => {
+    existsMock.mockResolvedValue([false]);
+
+    const result = await makeBackend().getDownloadUrl(
+      `conversation-${CONV_ID}/missing.png`
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("not_found");
+    }
+    expect(getSignedUrlMock).not.toHaveBeenCalled();
   });
 
   it("returns Ok with the signed URL for a pod file", async () => {

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -656,6 +656,13 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
 
     try {
+      const [exists] = await getPrivateUploadBucket().file(gcsPath).exists();
+      if (!exists) {
+        return new Err(
+          new DustFileSystemError("not_found", `Path not found: ${scopedPath}`)
+        );
+      }
+
       const url = await getCachedPrivateUploadSignedUrl(gcsPath, {
         expirationDelayMs: opts?.expiresInMs,
       });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In a saga where LLMs drive you crazy…

We had this noisy monitor around LLM calls reporting:
```
Unable to download the file. Please verify the URL and try again.
```

Naturally, the signed URL was blamed. Expired signature? Provider networking? GCS permissions? Clock skew on the cache? 

## What the traces revealed

After inspecting the full LLM payload, we found a GCS signed URL embedded in a historical image tool result.

The URL had a one-hour lifetime and the provider request happened seconds after it was created. So it was not expired.

The actual sequence was:

1. A file tool returned an image backed by a conversation file.
2. Conversation rendering converted its file path into a signed GCS URL.
3. The agent inspected the image.
4. The temporary image was subsequently deleted (thru sandbox).
5. The historical tool result remained in the conversation.
6. On the next LLM request, Dust generated another perfectly valid signed URL (for an object that no longer existed).
7. The provider fetched it, received a 404, and translated that into a mysterious “unable to download” error.

GCS will happily sign a path without checking whether anything lives there. Cryptographically valid, existentially challenged.

## The fix

`GCSFileSystemBackend.getDownloadUrl()` now checks that the object exists before generating a signed URL.

When the object is missing, it returns `not_found`. The existing conversation renderer then replaces the image with an “Image unavailable” text block instead of sending a broken URL to the provider. 

This protects every provider consuming these rendered URLs, rather than special-casing one LLM or converting images to base64.

## Scope

This is a tactical guardrail. The longer-term solution is to persist tool-result images using stable, immutable references. This will burst the cache, we need a cache-friendly approach for longer term.

As we move towards a stateful context window (https://github.com/dust-tt/dust/pull/31128), already-materialized stateful contexts may still contain an old URL until their checkpoint is refreshed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
