### PR TITLE
Override plans limit: move SSO and SCIM to the WorkspacePlanLimitOverrideModel

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -456,6 +456,23 @@ function PlanLimitValue({ value, isOverridden }: PlanLimitValueProps) {
   );
 }
 
+interface PlanFlagValueProps {
+  label: string;
+  value: boolean;
+  isOverridden: boolean;
+}
+
+function PlanFlagValue({ label, value, isOverridden }: PlanFlagValueProps) {
+  return (
+    <span>
+      {label} {value ? "✅" : "❌"}
+      {isOverridden && (
+        <span className="text-warning-500 pl-1 font-bold">(overridden)</span>
+      )}
+    </span>
+  );
+}
+
 interface PlanLimitationsTableProps {
   subscription: SubscriptionType;
   planLimitOverride: PlanLimitOverride | null;
@@ -483,10 +500,16 @@ export function PlanLimitationsTable({
               <PokeTableRow>
                 <PokeTableCell>SSO/SCIM features</PokeTableCell>
                 <PokeTableCell>
-                  {activePlan.limits.users.isSSOAllowed ? "SSO ✅" : "SSO ❌"}
-                  {activePlan.limits.users.isSCIMAllowed
-                    ? " SCIM ✅"
-                    : " SCIM ❌"}
+                  <PlanFlagValue
+                    label="SSO"
+                    value={activePlan.limits.users.isSSOAllowed}
+                    isOverridden={planLimitOverride?.isSSOAllowed != null}
+                  />{" "}
+                  <PlanFlagValue
+                    label="SCIM"
+                    value={activePlan.limits.users.isSCIMAllowed}
+                    isOverridden={planLimitOverride?.isSCIMAllowed != null}
+                  />
                 </PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>

--- a/front/lib/api/plan_limit_overrides.test.ts
+++ b/front/lib/api/plan_limit_overrides.test.ts
@@ -24,6 +24,9 @@ const PLAN_MAX_LIFETIME_FREE_USERS = 3;
 const PLAN_MAX_VAULTS = 5;
 const PLAN_MAX_DATA_SOURCES = 6;
 const PLAN_MAX_CONNECTIONS = 3;
+// One gate off and one on, so overrides can be tested in both directions.
+const PLAN_IS_SSO_ALLOWED = false;
+const PLAN_IS_SCIM_ALLOWED = true;
 
 describe("workspace plan limit overrides", () => {
   let workspace: LightWorkspaceType;
@@ -37,6 +40,8 @@ describe("workspace plan limit overrides", () => {
       maxVaultsInWorkspace: PLAN_MAX_VAULTS,
       maxDataSourcesCount: PLAN_MAX_DATA_SOURCES,
       maxConnectionsCount: PLAN_MAX_CONNECTIONS,
+      isSSOAllowed: PLAN_IS_SSO_ALLOWED,
+      isSCIMAllowed: PLAN_IS_SCIM_ALLOWED,
     });
     workspace = await WorkspaceFactory.fromPlan(plan);
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -68,6 +73,58 @@ describe("workspace plan limit overrides", () => {
     expect(limits.vaults.maxVaults).toBe(PLAN_MAX_VAULTS);
     expect(limits.dataSources.count).toBe(PLAN_MAX_DATA_SOURCES);
     expect(limits.connections.count).toBe(PLAN_MAX_CONNECTIONS);
+    expect(limits.users.isSSOAllowed).toBe(PLAN_IS_SSO_ALLOWED);
+    expect(limits.users.isSCIMAllowed).toBe(PLAN_IS_SCIM_ALLOWED);
+  });
+
+  it("grants SSO to a workspace whose plan does not allow it", async () => {
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ isSSOAllowed: true })
+    );
+    expect(res.isOk()).toBe(true);
+
+    const limits = await effectiveUserLimits();
+    expect(limits.isSSOAllowed).toBe(true);
+    // Not overridden: still the plan value.
+    expect(limits.isSCIMAllowed).toBe(PLAN_IS_SCIM_ALLOWED);
+  });
+
+  it("denies SCIM to a workspace whose plan allows it", async () => {
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ isSCIMAllowed: false })
+    );
+    expect(res.isOk()).toBe(true);
+
+    expect((await effectiveUserLimits()).isSCIMAllowed).toBe(false);
+  });
+
+  it("persists a `false` gate override rather than treating it as cleared", async () => {
+    await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ isSCIMAllowed: false })
+    );
+
+    // `false` is a real override, so the row must survive the round-trip.
+    expect(await getWorkspacePlanLimitOverrides(auth)).toEqual(
+      override({ isSCIMAllowed: false })
+    );
+  });
+
+  it("clears a gate override and falls back to the plan value", async () => {
+    await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ isSSOAllowed: true })
+    );
+    expect((await effectiveUserLimits()).isSSOAllowed).toBe(true);
+
+    await setWorkspacePlanLimitOverrides(auth, EMPTY_PLAN_LIMIT_OVERRIDE);
+
+    expect(await getWorkspacePlanLimitOverrides(auth)).toBeNull();
+    expect((await effectiveUserLimits()).isSSOAllowed).toBe(
+      PLAN_IS_SSO_ALLOWED
+    );
   });
 
   it("applies the space, data-source and connection overrides", async () => {

--- a/front/lib/api/poke/plugins/workspaces/override_plan_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/override_plan_limits.ts
@@ -22,12 +22,16 @@ const PlanLimitOverridesSchema = z.object({
   maxDataSources: z.number().int().min(UNLIMITED).optional(),
   overrideMaxConnections: z.boolean(),
   maxConnections: z.number().int().min(UNLIMITED).optional(),
+  overrideSSO: z.boolean(),
+  isSSOAllowed: z.boolean().optional(),
+  overrideSCIM: z.boolean(),
+  isSCIMAllowed: z.boolean().optional(),
 });
 
-function resolveOverride(
+function resolveOverride<T extends number | boolean>(
   enabled: boolean,
-  value: number | undefined
-): number | null {
+  value: T | undefined
+): T | null {
   return enabled && value !== undefined ? value : null;
 }
 
@@ -38,14 +42,21 @@ function describeLimit(value: number | null): string {
   return value === UNLIMITED ? "unlimited" : `${value}`;
 }
 
+function describeFlag(value: boolean | null): string {
+  if (value === null) {
+    return "plan value";
+  }
+  return value ? "allowed" : "denied";
+}
+
 export const overridePlanLimitsPlugin = createPlugin({
   manifest: {
     id: "override-plan-limits",
     name: "Override Plan Limits",
     description:
-      "Override this workspace's seat, space and data-source limits without creating a " +
-      "dedicated plan. Each limit falls back to the plan value when its toggle is off. " +
-      "Use -1 for unlimited.",
+      "Override this workspace's seat, space and data-source limits, and its SSO/SCIM " +
+      "entitlements, without creating a dedicated plan. Each setting falls back to the " +
+      "plan value when its toggle is off. Use -1 for unlimited.",
     explanation:
       "Overrides are workspace-scoped: they survive plan changes and renewals, and they " +
       "also win over the trial limits. They cap what can be created or assigned and what " +
@@ -152,6 +163,39 @@ export const overridePlanLimitsPlugin = createPlugin({
         async: true,
         dependsOn: { field: "overrideMaxConnections", value: true },
       },
+      overrideSSO: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override SSO entitlement",
+        async: true,
+        asyncDescription: true,
+      },
+      isSSOAllowed: {
+        type: "boolean",
+        variant: "toggle",
+        label: "SSO allowed",
+        description:
+          "Whether this workspace can configure SSO, regardless of its plan.",
+        async: true,
+        dependsOn: { field: "overrideSSO", value: true },
+      },
+      overrideSCIM: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override SCIM entitlement",
+        async: true,
+        asyncDescription: true,
+      },
+      isSCIMAllowed: {
+        type: "boolean",
+        variant: "toggle",
+        label: "SCIM allowed",
+        description:
+          "Whether this workspace can configure SCIM user provisioning, regardless of " +
+          "its plan.",
+        async: true,
+        dependsOn: { field: "overrideSCIM", value: true },
+      },
     },
     requiredRoles: ["billing"],
   },
@@ -189,6 +233,14 @@ export const overridePlanLimitsPlugin = createPlugin({
       overrideMaxConnectionsDescription:
         "Override the plan's connection cap for this workspace only.",
       maxConnections: limits.connections.count,
+      overrideSSO: override?.isSSOAllowed != null,
+      overrideSSODescription:
+        "Override the plan's SSO entitlement for this workspace only.",
+      isSSOAllowed: limits.users.isSSOAllowed,
+      overrideSCIM: override?.isSCIMAllowed != null,
+      overrideSCIMDescription:
+        "Override the plan's SCIM entitlement for this workspace only.",
+      isSCIMAllowed: limits.users.isSCIMAllowed,
     });
   },
 
@@ -217,6 +269,10 @@ export const overridePlanLimitsPlugin = createPlugin({
       maxDataSources,
       overrideMaxConnections,
       maxConnections,
+      overrideSSO,
+      isSSOAllowed,
+      overrideSCIM,
+      isSCIMAllowed,
     } = parseResult.data;
 
     const override: PlanLimitOverride = {
@@ -238,6 +294,8 @@ export const overridePlanLimitsPlugin = createPlugin({
         overrideMaxConnections,
         maxConnections
       ),
+      isSSOAllowed: resolveOverride(overrideSSO, isSSOAllowed),
+      isSCIMAllowed: resolveOverride(overrideSCIM, isSCIMAllowed),
     };
 
     const res = await setWorkspacePlanLimitOverrides(auth, override);
@@ -254,6 +312,8 @@ export const overridePlanLimitsPlugin = createPlugin({
         `Max spaces: ${describeLimit(override.maxVaultsInWorkspace)}.`,
         `Max data sources: ${describeLimit(override.maxDataSourcesCount)}.`,
         `Max connections: ${describeLimit(override.maxConnectionsCount)}.`,
+        `SSO: ${describeFlag(override.isSSOAllowed)}.`,
+        `SCIM: ${describeFlag(override.isSCIMAllowed)}.`,
       ].join(" "),
     });
   },

--- a/front/lib/plans/plan_limit_overrides.test.ts
+++ b/front/lib/plans/plan_limit_overrides.test.ts
@@ -15,6 +15,8 @@ const PLAN = {
   maxVaultsInWorkspace: 2,
   maxDataSourcesCount: 7,
   maxConnectionsCount: 4,
+  isSSOAllowed: false,
+  isSCIMAllowed: true,
 };
 
 function override(partial: Partial<PlanLimitOverride>): PlanLimitOverride {
@@ -41,6 +43,26 @@ describe("applyPlanLimitOverrides", () => {
     expect(res.maxVaultsInWorkspace).toBe(2);
     expect(res.maxDataSourcesCount).toBe(7);
     expect(res.maxConnectionsCount).toBe(4);
+    expect(res.isSSOAllowed).toBe(false);
+    expect(res.isSCIMAllowed).toBe(true);
+  });
+
+  it("grants a feature gate the plan does not include", () => {
+    const res = applyPlanLimitOverrides(PLAN, override({ isSSOAllowed: true }));
+
+    expect(res.isSSOAllowed).toBe(true);
+    // Untouched: overriding one gate leaves the other on its plan value.
+    expect(res.isSCIMAllowed).toBe(true);
+  });
+
+  it("denies a feature gate the plan includes", () => {
+    const res = applyPlanLimitOverrides(
+      PLAN,
+      override({ isSCIMAllowed: false })
+    );
+
+    expect(res.isSCIMAllowed).toBe(false);
+    expect(res.isSSOAllowed).toBe(false);
   });
 
   it("overrides the space, data-source and connection limits", () => {
@@ -98,6 +120,15 @@ describe("hasAnyPlanLimitOverride", () => {
       hasAnyPlanLimitOverride(override({ maxLifetimeFreeUsersInWorkspace: 0 }))
     ).toBe(true);
     expect(hasAnyPlanLimitOverride(override({ maxUsersInWorkspace: -1 }))).toBe(
+      true
+    );
+  });
+
+  it("is true when only a feature gate is set, including when denied", () => {
+    expect(hasAnyPlanLimitOverride(override({ isSSOAllowed: true }))).toBe(
+      true
+    );
+    expect(hasAnyPlanLimitOverride(override({ isSCIMAllowed: false }))).toBe(
       true
     );
   });

--- a/front/lib/plans/plan_limit_overrides.ts
+++ b/front/lib/plans/plan_limit_overrides.ts
@@ -16,10 +16,25 @@ export const OVERRIDABLE_PLAN_LIMITS = [
 export type OverridablePlanLimit = (typeof OVERRIDABLE_PLAN_LIMITS)[number];
 
 /**
- * A per-workspace override of the plan limits. `null` means "not overridden,
- * use the plan value"; `-1` keeps its plan meaning (unlimited).
+ * The plan feature gates that can be overridden per workspace. Same mechanism
+ * as {@link OVERRIDABLE_PLAN_LIMITS}, but the value is a boolean: `true` grants
+ * the feature to a workspace whose plan does not include it, and `false` denies
+ * it to one whose plan does.
  */
-export type PlanLimitOverride = Record<OverridablePlanLimit, number | null>;
+export const OVERRIDABLE_PLAN_FLAGS = [
+  "isSSOAllowed",
+  "isSCIMAllowed",
+] as const satisfies readonly (keyof PlanAttributes)[];
+
+export type OverridablePlanFlag = (typeof OVERRIDABLE_PLAN_FLAGS)[number];
+
+/**
+ * A per-workspace override of the plan limits and feature gates. `null` means
+ * "not overridden, use the plan value"; for limits `-1` keeps its plan meaning
+ * (unlimited).
+ */
+export type PlanLimitOverride = Record<OverridablePlanLimit, number | null> &
+  Record<OverridablePlanFlag, boolean | null>;
 
 export const EMPTY_PLAN_LIMIT_OVERRIDE: PlanLimitOverride = {
   maxUsersInWorkspace: null,
@@ -28,16 +43,22 @@ export const EMPTY_PLAN_LIMIT_OVERRIDE: PlanLimitOverride = {
   maxVaultsInWorkspace: null,
   maxDataSourcesCount: null,
   maxConnectionsCount: null,
+  isSSOAllowed: null,
+  isSCIMAllowed: null,
 };
 
 export function hasAnyPlanLimitOverride(override: PlanLimitOverride): boolean {
-  return OVERRIDABLE_PLAN_LIMITS.some((key) => override[key] !== null);
+  return (
+    OVERRIDABLE_PLAN_LIMITS.some((key) => override[key] !== null) ||
+    OVERRIDABLE_PLAN_FLAGS.some((key) => override[key] !== null)
+  );
 }
 
 /**
- * Applies a workspace's plan-limit overrides on top of the plan attributes.
- * Applied last when resolving the plan for a workspace — after the trial limits
- * of `getTrialVersionForPlan` — so an explicit override always wins.
+ * Applies a workspace's plan-limit and feature-gate overrides on top of the plan
+ * attributes. Applied last when resolving the plan for a workspace — after the
+ * trial limits of `getTrialVersionForPlan` — so an explicit override always
+ * wins.
  */
 export function applyPlanLimitOverrides(
   plan: PlanAttributes,
@@ -49,6 +70,12 @@ export function applyPlanLimitOverrides(
 
   const overridden = { ...plan };
   for (const key of OVERRIDABLE_PLAN_LIMITS) {
+    const value = override[key];
+    if (value !== null) {
+      overridden[key] = value;
+    }
+  }
+  for (const key of OVERRIDABLE_PLAN_FLAGS) {
     const value = override[key];
     if (value !== null) {
       overridden[key] = value;

--- a/front/lib/resources/storage/models/workspace_plan_limit_override.ts
+++ b/front/lib/resources/storage/models/workspace_plan_limit_override.ts
@@ -14,8 +14,10 @@ import type { CreationOptional } from "sequelize";
  * `SubscriptionResource.determinePlanFromSubscription`), so every consumer of
  * `PlanType.limits` — enforcement and UI alike — sees the effective value.
  *
- * `null` means "not overridden, use the plan value". `-1` keeps its plan meaning
- * (unlimited), so raising a workspace to unlimited is expressible.
+ * `null` means "not overridden, use the plan value". For numeric limits `-1`
+ * keeps its plan meaning (unlimited), so raising a workspace to unlimited is
+ * expressible. Boolean columns are tri-state for the same reason: `true` grants
+ * a feature the plan does not include, `false` denies one it does.
  *
  * Columns are named exactly like their `PlanModel` counterparts so that the
  * merge in `applyPlanLimitOverrides` stays mechanical.
@@ -30,6 +32,9 @@ export class WorkspacePlanLimitOverrideModel extends WorkspaceAwareModel<Workspa
   declare maxVaultsInWorkspace: CreationOptional<number | null>;
   declare maxDataSourcesCount: CreationOptional<number | null>;
   declare maxConnectionsCount: CreationOptional<number | null>;
+
+  declare isSSOAllowed: CreationOptional<boolean | null>;
+  declare isSCIMAllowed: CreationOptional<boolean | null>;
 }
 
 WorkspacePlanLimitOverrideModel.init(
@@ -73,6 +78,16 @@ WorkspacePlanLimitOverrideModel.init(
     },
     maxConnectionsCount: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    isSSOAllowed: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: null,
+    },
+    isSCIMAllowed: {
+      type: DataTypes.BOOLEAN,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -129,11 +129,13 @@ function renderPlanLimitOverride(
     maxVaultsInWorkspace: row.maxVaultsInWorkspace,
     maxDataSourcesCount: row.maxDataSourcesCount,
     maxConnectionsCount: row.maxConnectionsCount,
+    isSSOAllowed: row.isSSOAllowed,
+    isSCIMAllowed: row.isSCIMAllowed,
   };
 }
 
-// A limit is `null` (not overridden), `-1` (unlimited) or a non-negative count,
-// matching the plan convention.
+// A numeric limit is `null` (not overridden), `-1` (unlimited) or a non-negative
+// count, matching the plan convention. Boolean flags need no range check.
 function validatePlanLimitOverride(
   override: PlanLimitOverride
 ): Result<undefined, Error> {

--- a/front/migrations/pre-deploy/20260827171452_add_sso_scim_overrides_to_workspace_plan_limit_overrides.sql
+++ b/front/migrations/pre-deploy/20260827171452_add_sso_scim_overrides_to_workspace_plan_limit_overrides.sql
@@ -1,0 +1,13 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD COLUMN "isSSOAllowed" boolean;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD COLUMN "isSCIMAllowed" boolean;


### PR DESCRIPTION
## Description

First part: introduce new columns in the DB to replace the flag.
Flags will be removed in coming PR, when I have migrated all workspaces using the flag to this.

Similar to the numerical override, these are plugged into the subscription plan values directly.

## Tests

tested the plugin locally

<img width="1324" height="676" alt="image" src="https://github.com/user-attachments/assets/b9cd4c98-a495-4668-948f-db622e3eee72" />


## Risk

low

## Deploy Plan

lock front
merge
pre deploy migration
deploy front
