### PR TITLE
Render active Frames v2 publications

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9047,7 +9047,7 @@
     "/api/w/{wId}/files/{fileId}": {
       "get": {
         "summary": "Get or download a file",
-        "description": "View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).",
+        "description": "View or download a file. Skill attachments require read access to their associated skill. Feature-flagged Frames v2 return the active published UI bundle when viewed. Use query parameters `version` (original, processed, public) and `action` (view, download).",
         "tags": [
           "Private Files"
         ],

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -1,11 +1,15 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,6 +32,7 @@ function fileUrl(workspace: { sId: string }, fileId: string, query = "") {
 describe("GET /api/w/:wId/files/:fileId", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fileStorageMock.reset();
   });
 
   it("should return 404 when file does not exist", async () => {
@@ -174,6 +179,79 @@ describe("GET /api/w/:wId/files/:fileId", () => {
     );
 
     expect(response.headers.get("content-type")).toBe("image/png");
+  });
+
+  it("serves the active Frames v2 UI bundle", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    await FeatureFlagFactory.basic(auth, "frames_v2");
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+    const publicationId = "active-publication";
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 128,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        activePublicationId: publicationId,
+        conversationId: conversation.sId,
+      },
+    });
+    const uiBundle = "export default function Frame() { return null; }";
+    fileStorageMock.setObject(
+      getFramePublicationUiBundlePath({
+        workspaceId: workspace.sId,
+        frameId: frame.sId,
+        publicationId,
+      }),
+      uiBundle
+    );
+
+    const response = await honoApp.request(
+      fileUrl(workspace, frame.sId, "?action=view")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(frameContentType);
+    expect(await response.text()).toBe(uiBundle);
+  });
+
+  it("returns 404 for an unpublished Frames v2 file", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    await FeatureFlagFactory.basic(auth, "frames_v2");
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 128,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const response = await honoApp.request(
+      fileUrl(workspace, frame.sId, "?action=view")
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "file_not_found",
+        message: "Published Frame not found.",
+      },
+    });
   });
 
   it("should return 404 when user cannot read space for folders_document", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -1,12 +1,13 @@
 import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { loadActiveFrameUiBundle } from "@app/lib/api/frames/publication_storage";
 import { addFileToProject } from "@app/lib/api/projects/context";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import { isConversationFileUseCase } from "@app/types/files";
+import { frameContentType, isConversationFileUseCase } from "@app/types/files";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
@@ -71,7 +72,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  * /api/w/{wId}/files/{fileId}:
  *   get:
  *     summary: Get or download a file
- *     description: View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).
+ *     description: View or download a file. Skill attachments require read access to their associated skill. Feature-flagged Frames v2 return the active published UI bundle when viewed. Use query parameters `version` (original, processed, public) and `action` (view, download).
  *     tags:
  *       - Private Files
  *     parameters:
@@ -221,6 +222,23 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
 
   const action = getSecureFileAction(ctx.req.query("action"), file);
   if (action === "view") {
+    if (file.isFrameV2 && (await hasFeatureFlag(auth, "frames_v2"))) {
+      const uiBundle = await loadActiveFrameUiBundle(auth, { frame: file });
+      if (uiBundle.isErr()) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "file_not_found",
+            message: "Published Frame not found.",
+          },
+        });
+      }
+
+      return ctx.body(uiBundle.value, 200, {
+        "Content-Type": frameContentType,
+      });
+    }
+
     const versionParam = ctx.req.query("version");
     // Default to the frame's renderable version (a published frame serves its built bundle);
     // non-frame files and unpublished frames resolve to "original". An explicit ?version wins.

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -54,6 +54,7 @@ interface FrameRendererProps {
   owner: LightWorkspaceType;
   lastEditedByAgentConfigurationId?: string;
   contentHash?: string;
+  renderMode: "legacy" | "v2";
 }
 
 export function FrameRenderer({
@@ -63,6 +64,7 @@ export function FrameRenderer({
   owner,
   lastEditedByAgentConfigurationId,
   contentHash,
+  renderMode,
 }: FrameRendererProps) {
   const { vizUrl } = useAuth();
   const { hasFeature } = useFeatureFlags();
@@ -366,71 +368,77 @@ export function FrameRenderer({
   return (
     <div className="flex h-panel flex-col">
       <ConversationSidePanelHeader onClose={onClosePanel}>
-        <div className="flex w-full items-center justify-between">
-          <Button
-            icon={showCode ? Eye : Terminal}
-            onClick={() => setShowCode(!showCode)}
-            tooltip={showCode ? "Switch to Rendering" : "Switch to Code"}
-            variant="ghost"
-          />
-          <div className="flex items-center">
-            <ExportContentDropdown
-              iframeRef={iframeRef}
-              owner={owner}
-              fileId={fileId}
-              fileContent={fileContent ?? null}
-              fileName={fileMetadata?.fileName}
+        {renderMode === "legacy" && (
+          <div className="flex w-full items-center justify-between">
+            <Button
+              icon={showCode ? Eye : Terminal}
+              onClick={() => setShowCode(!showCode)}
+              tooltip={showCode ? "Switch to Rendering" : "Switch to Code"}
+              variant="ghost"
             />
-            <ShareFrameSheet
-              key={contentHash ?? fileId}
-              fileId={fileId}
-              owner={owner}
-              contentHash={contentHash}
-            />
-            <PinPodBannerButton
-              owner={owner}
-              spaceId={projectId ?? ""}
-              pinnedFramePath={projectInfo?.pinnedFramePath ?? null}
-              isEditor={projectInfo?.isEditor ?? false}
-              framePath={framePath}
-              fileName={fileMetadata?.fileName}
-              hidden={!isFrameInPod}
-            />
-            {hasFrameTabs && (
-              <PodFrameTabButton
+            <div className="flex items-center">
+              <ExportContentDropdown
+                iframeRef={iframeRef}
+                owner={owner}
+                fileId={fileId}
+                fileContent={fileContent ?? null}
+                fileName={fileMetadata?.fileName}
+              />
+              <ShareFrameSheet
+                key={contentHash ?? fileId}
+                fileId={fileId}
+                owner={owner}
+                contentHash={contentHash}
+              />
+              <PinPodBannerButton
                 owner={owner}
                 spaceId={projectId ?? ""}
-                frameTabs={projectInfo?.frameTabs ?? []}
-                tabsOrder={projectInfo?.tabsOrder ?? []}
+                pinnedFramePath={projectInfo?.pinnedFramePath ?? null}
                 isEditor={projectInfo?.isEditor ?? false}
                 framePath={framePath}
                 fileName={fileMetadata?.fileName}
                 hidden={!isFrameInPod}
               />
-            )}
-            {projectSaveState === "saved" && (
-              <Button
-                icon={CheckCircle}
-                variant="ghost"
-                disabled={true}
-                label={isMobile ? undefined : "Saved"}
-                tooltip={`Saved in "${projectInfo?.name ?? "unknown Pod"}"`}
-              />
-            )}
-            {projectSaveState === "supported" && (
-              <Button
-                icon={UploadCloud02}
-                variant="ghost"
-                label={
-                  isMobile ? undefined : isSavingToProject ? "Saving…" : "Save"
-                }
-                isLoading={isSavingToProject}
-                tooltip={`Save to "${projectInfo?.name ?? "unknown Pod"}"`}
-                onClick={handleSaveToProject}
-              />
-            )}
+              {hasFrameTabs && (
+                <PodFrameTabButton
+                  owner={owner}
+                  spaceId={projectId ?? ""}
+                  frameTabs={projectInfo?.frameTabs ?? []}
+                  tabsOrder={projectInfo?.tabsOrder ?? []}
+                  isEditor={projectInfo?.isEditor ?? false}
+                  framePath={framePath}
+                  fileName={fileMetadata?.fileName}
+                  hidden={!isFrameInPod}
+                />
+              )}
+              {projectSaveState === "saved" && (
+                <Button
+                  icon={CheckCircle}
+                  variant="ghost"
+                  disabled={true}
+                  label={isMobile ? undefined : "Saved"}
+                  tooltip={`Saved in "${projectInfo?.name ?? "unknown Pod"}"`}
+                />
+              )}
+              {projectSaveState === "supported" && (
+                <Button
+                  icon={UploadCloud02}
+                  variant="ghost"
+                  label={
+                    isMobile
+                      ? undefined
+                      : isSavingToProject
+                        ? "Saving…"
+                        : "Save"
+                  }
+                  isLoading={isSavingToProject}
+                  tooltip={`Save to "${projectInfo?.name ?? "unknown Pod"}"`}
+                  onClick={handleSaveToProject}
+                />
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </ConversationSidePanelHeader>
 
       <div className="flex-1 overflow-hidden">
@@ -458,11 +466,11 @@ export function FrameRenderer({
               }}
               key={`viz-${fileId}`}
               conversationId={conversation?.sId ?? null}
-              isEditable={true}
               spaceId={frameSpaceId ?? undefined}
               framePath={framePath}
               isInDrawer={true}
-              onEditText={handleEditText}
+              isEditable={renderMode === "legacy"}
+              onEditText={renderMode === "legacy" ? handleEditText : undefined}
               ref={iframeRef}
             />
             {conversation && (

--- a/front/components/assistant/conversation/interactive_content/InteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/InteractiveContentContainer.tsx
@@ -3,9 +3,14 @@ import { ConversationSidePanelHeader } from "@app/components/assistant/conversat
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { FrameRenderer } from "@app/components/assistant/conversation/interactive_content/FrameRenderer";
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/interactive_content/UnsupportedContentRenderer";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useFileMetadata } from "@app/lib/swr/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
 import { useMemo } from "react";
@@ -20,6 +25,7 @@ export function InteractiveContentContainer({
   owner,
 }: InteractiveContentContainerProps) {
   const { data: contentHash, closePanel } = useConversationSidePanelContext();
+  const { hasFeature } = useFeatureFlags();
 
   const contentId = useMemo(() => {
     if (!contentHash) {
@@ -87,6 +93,28 @@ export function InteractiveContentContainer({
             }
             owner={owner}
             contentHash={contentHash}
+            renderMode="legacy"
+          />
+        );
+
+      case frameV2ContentType:
+        if (!hasFeature("frames_v2")) {
+          return (
+            <UnsupportedContentRenderer
+              fileName={fileMetadata.fileName}
+              contentType={fileMetadata.contentType}
+            />
+          );
+        }
+
+        return (
+          <FrameRenderer
+            conversation={conversation}
+            fileId={contentId}
+            projectId={fileMetadata.useCaseMetadata.spaceId ?? null}
+            owner={owner}
+            contentHash={contentHash}
+            renderMode="v2"
           />
         );
 

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2587,47 +2587,47 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
   },
   "workspace_analytics": {
     "get_agent_details": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_credit_timeseries": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_credit_usage": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_source_breakdown": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_top_agent_tags": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_top_agents": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_top_models": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_top_skills": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_top_tools": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_top_users": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
     "get_usage_timeseries": {
-      "freeUsage": false,
+      "freeUsage": true,
       "toolCostCategory": "basic",
     },
   },

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -299,6 +299,50 @@ export async function loadFramePublicationManifest(
   return manifest;
 }
 
+export async function loadActiveFrameUiBundle(
+  auth: Authenticator,
+  {
+    frame,
+  }: {
+    frame: FileResource;
+  }
+): Promise<Result<string, FramePublicationError>> {
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return frameIdentity;
+  }
+
+  const publicationId = frame.useCaseMetadata?.activePublicationId;
+  if (!publicationId) {
+    return new Err(
+      new FramePublicationError(
+        "publication_not_found",
+        "Frame has no active publication."
+      )
+    );
+  }
+
+  const uiBundlePath = getFramePublicationUiBundlePath({
+    ...frameIdentity.value,
+    publicationId,
+  });
+  try {
+    const uiBundle =
+      await getPrivateUploadBucket().fetchFileContent(uiBundlePath);
+    return new Ok(uiBundle);
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Err(
+        new FramePublicationError(
+          "publication_not_found",
+          `Frame publication not found: ${publicationId}`
+        )
+      );
+    }
+    throw error;
+  }
+}
+
 export async function activateFramePublication(
   auth: Authenticator,
   {


### PR DESCRIPTION
## Description

Serve the active Frames v2 UI publication from the file view endpoint behind the `frames_v2` feature flag, and render it read-only in the conversation side panel. Legacy Frames keep their existing behavior.

Also refresh the generated Swagger file and the stale workspace analytics billing snapshot inherited from `main`.

## Tests

- Added route coverage for active and unpublished Frames v2
- `npm test -- routes/w/[wId]/files/[fileId]/index.test.ts` from `front-api`
- `npm run tsgo` from `front`
- `npm run docs` from `front-api`
- Updated and ran `mcp_servers_metadata.test.ts`

## Risk

Low. The new path is feature-flagged and only applies to the Frames v2 MIME type. Rollback is a normal revert.

## Deploy Plan

Deploy normally. No migration or coordinated rollout is required.