### PR TITLE
Support sharing Frames v2 publications

### DIFF
--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -6,7 +6,6 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { GetShareFrameMetadataResponseBody } from "@app/types/api/files/share";
-import { isInteractiveContentType } from "@app/types/files";
 import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -67,7 +66,7 @@ app.get(
     const { file, shareScope } = result.value;
 
     // Only allow Frame files.
-    if (!isInteractiveContentType(file.contentType)) {
+    if (!file.isShareableFrame) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -11,7 +11,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import {
-  isInteractiveContentType,
+  isFrameContentType,
   isWorkspaceVisibleShareScope,
 } from "@app/types/files";
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";
@@ -79,10 +79,7 @@ app.get(
     }
 
     // Only allow conversation Frame files.
-    if (
-      !file.isInteractiveContent ||
-      !isInteractiveContentType(file.contentType)
-    ) {
+    if (!isFrameContentType(file.contentType)) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -78,7 +78,7 @@ app.get(
       });
     }
 
-    // Only allow conversation Frame files.
+    // Only allow Frame files.
     if (!isFrameContentType(file.contentType)) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/v1/viz/content.test.ts
+++ b/front-api/routes/v1/viz/content.test.ts
@@ -3,7 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
@@ -88,6 +88,41 @@ describe("/api/v1/viz/content endpoint tests", () => {
       },
       isAuthenticatedMember: false,
     });
+  });
+
+  it("returns Frames v2 publication content", async () => {
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conversation-A" },
+    });
+    const frameShareInfo = await frameFile.getShareInfo();
+    const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+    if (!fileToken) {
+      throw new Error("No file token found");
+    }
+    const accessToken = generateVizAccessToken({
+      contentType: frameV2ContentType,
+      fileToken,
+      workspaceId: workspace.sId,
+      shareScope: "public",
+    });
+    mockFetchByShareToken(frameFile, { content: "active publication" });
+
+    const response = await request({
+      authorization: `Bearer ${accessToken}`,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        content: "active publication",
+        contentType: frameV2ContentType,
+      })
+    );
   });
 
   it("should reject requests without Authorization header", async () => {

--- a/front-api/routes/v1/viz/content.ts
+++ b/front-api/routes/v1/viz/content.ts
@@ -66,7 +66,7 @@ app.get("/", async (ctx): HandlerResult<PublicVizContentResponseBodyType> => {
     });
   }
 
-  // Only allow conversation interactive files.
+  // Only allow Frame files.
   if (!file.isShareableFrame) {
     return apiError(ctx, {
       status_code: 400,

--- a/front-api/routes/v1/viz/content.ts
+++ b/front-api/routes/v1/viz/content.ts
@@ -1,7 +1,6 @@
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { isInteractiveContentType } from "@app/types/files";
 import type { PublicVizContentResponseBodyType } from "@dust-tt/client";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -68,10 +67,7 @@ app.get("/", async (ctx): HandlerResult<PublicVizContentResponseBodyType> => {
   }
 
   // Only allow conversation interactive files.
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
+  if (!file.isShareableFrame) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {

--- a/front-api/routes/v1/viz/files/[...segments].ts
+++ b/front-api/routes/v1/viz/files/[...segments].ts
@@ -87,7 +87,7 @@ app.get("/:scope/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  if (!frameFile.isInteractiveContent) {
+  if (!frameFile.isShareableFrame) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {

--- a/front-api/routes/v1/viz/files/[fileId].ts
+++ b/front-api/routes/v1/viz/files/[fileId].ts
@@ -6,7 +6,6 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { isInteractiveContentType } from "@app/types/files";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -86,10 +85,7 @@ app.get("/:fileId", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  if (
-    !frameFile.isInteractiveContent ||
-    !isInteractiveContentType(frameFile.contentType)
-  ) {
+  if (!frameFile.isShareableFrame) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {

--- a/front-api/routes/w/[wId]/files/[fileId]/export/pdf.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/export/pdf.test.ts
@@ -1,7 +1,7 @@
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -178,6 +178,30 @@ describe("POST /api/w/:wId/files/:fileId/export/pdf", () => {
     expect(response.headers.get("content-disposition")).toContain(
       'attachment; filename="test.pdf"'
     );
+  });
+
+  it("exports a Frames v2 publication", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const response = await postPdf(workspace, file.sId);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/pdf");
   });
 
   it("should export PDF successfully with landscape orientation", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/export/pdf.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/export/pdf.test.ts
@@ -1,6 +1,9 @@
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -189,14 +192,31 @@ describe("POST /api/w/:wId/files/:fileId/export/pdf", () => {
       agentConfigurationId: "test-agent",
       messagesCreatedAt: [new Date()],
     });
+    const publicationId = "active-publication";
+    const uiBundleCode = "export default function App() {}";
     const file = await FileFactory.create(auth, user, {
       contentType: frameV2ContentType,
       fileName: "manifest.json",
       fileSize: 1024,
       status: "ready",
       useCase: "conversation",
-      useCaseMetadata: { conversationId: conversation.sId },
+      useCaseMetadata: {
+        activePublicationId: publicationId,
+        conversationId: conversation.sId,
+      },
     });
+    fileStorageMock.setObject(
+      getFramePublicationUiBundlePath({
+        workspaceId: workspace.sId,
+        frameId: file.sId,
+        publicationId,
+      }),
+      uiBundleCode
+    );
+
+    expect(
+      await file.getRenderableContent(renderLightWorkspaceType({ workspace }))
+    ).toBe(uiBundleCode);
 
     const response = await postPdf(workspace, file.sId);
 

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -1,11 +1,11 @@
 import { processAndStoreFile } from "@app/lib/api/files/processing";
-import { loadActiveFrameUiBundle } from "@app/lib/api/frames/publication_storage";
 import { addFileToProject } from "@app/lib/api/projects/context";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { frameContentType, isConversationFileUseCase } from "@app/types/files";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
@@ -223,8 +223,11 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const action = getSecureFileAction(ctx.req.query("action"), file);
   if (action === "view") {
     if (file.isFrameV2 && (await hasFeatureFlag(auth, "frames_v2"))) {
-      const uiBundle = await loadActiveFrameUiBundle(auth, { frame: file });
-      if (uiBundle.isErr()) {
+      const owner = renderLightWorkspaceType({
+        workspace: auth.getNonNullableWorkspace(),
+      });
+      const uiBundle = await file.getRenderableContent(owner);
+      if (!uiBundle) {
         return apiError(ctx, {
           status_code: 404,
           api_error: {
@@ -234,7 +237,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
         });
       }
 
-      return ctx.body(uiBundle.value, 200, {
+      return ctx.body(uiBundle, 200, {
         "Content-Type": frameContentType,
       });
     }

--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -237,6 +237,10 @@ async function fetchShareableFile(
     });
   }
 
+  if (file.isFrameV2) {
+    await file.ensureShareableFrame(auth);
+  }
+
   return file;
 }
 

--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -10,7 +10,6 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import {
   isConversationFileUseCase,
-  isInteractiveContentType,
   MAX_EMAILS_PER_INVITE,
 } from "@app/types/files";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -228,10 +227,7 @@ async function fetchShareableFile(
     }
   }
 
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
+  if (!file.isShareableFrame) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.test.ts
@@ -4,7 +4,7 @@ import { GroupPermissionResource } from "@app/lib/resources/group_permission_res
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceSharingPolicy } from "@app/types/user";
 import { honoApp } from "@front-api/app";
@@ -221,6 +221,27 @@ describe("share scope endpoint", () => {
       const file = await FileFactory.create(auth, user, {
         contentType: frameContentType,
         fileName: "test-frame.tsx",
+        fileSize: 1024,
+        status: "ready",
+        useCase: "conversation",
+      });
+
+      const response = await postShare(workspace, file.sId, {
+        shareScope: "workspace_and_emails",
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).scope).toBe("workspace_and_emails");
+    });
+
+    it("uses the existing sharing model for Frames v2", async () => {
+      const { auth, user, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
+      const file = await FileFactory.create(auth, user, {
+        contentType: frameV2ContentType,
+        fileName: "manifest.json",
         fileSize: 1024,
         status: "ready",
         useCase: "conversation",

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.test.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -234,7 +234,7 @@ describe("share scope endpoint", () => {
       expect((await response.json()).scope).toBe("workspace_and_emails");
     });
 
-    it("uses the existing sharing model for Frames v2", async () => {
+    it("lazily repairs a missing Frames v2 sharing record", async () => {
       const { auth, user, workspace } = await createPrivateApiMockRequest({
         method: "POST",
         role: "user",
@@ -246,6 +246,10 @@ describe("share scope endpoint", () => {
         status: "ready",
         useCase: "conversation",
       });
+      await FileResource.shareableFileModel.destroy({
+        where: { fileId: file.id, workspaceId: file.workspaceId },
+      });
+      expect(await file.getShareInfo()).toBeNull();
 
       const response = await postShare(workspace, file.sId, {
         shareScope: "workspace_and_emails",
@@ -253,6 +257,7 @@ describe("share scope endpoint", () => {
 
       expect(response.status).toBe(200);
       expect((await response.json()).scope).toBe("workspace_and_emails");
+      expect(await file.getShareInfo()).not.toBeNull();
     });
   });
 });

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -159,7 +159,7 @@ app.post(
   }
 );
 
-// Returns the file when it exists, is interactive, and (if linked to a
+// Returns the file when it exists, is a Frame, and (if linked to a
 // conversation) the caller can access it. Otherwise returns a `Response` for
 // the handler to short-circuit on.
 async function fetchShareableFile(

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -16,7 +16,6 @@ import type { APIErrorResponse } from "@app/types/error";
 import {
   fileShareScopeSchema,
   isConversationFileUseCase,
-  isInteractiveContentType,
   isUnverifiableFrameFileRefsShareError,
 } from "@app/types/files";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -192,10 +191,7 @@ async function fetchShareableFile(
     }
   }
 
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
+  if (!file.isShareableFrame) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -439,6 +439,23 @@ export function FrameRenderer({
             </div>
           </div>
         )}
+        {renderMode === "v2" && (
+          <div className="flex w-full justify-end">
+            <ExportContentDropdown
+              iframeRef={iframeRef}
+              owner={owner}
+              fileId={fileId}
+              fileContent={fileContent ?? null}
+              fileName={fileMetadata?.fileName}
+            />
+            <ShareFrameSheet
+              key={contentHash ?? fileId}
+              fileId={fileId}
+              owner={owner}
+              contentHash={contentHash}
+            />
+          </div>
+        )}
       </ConversationSidePanelHeader>
 
       <div className="flex-1 overflow-hidden">

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -3,7 +3,11 @@ import { PublicFrameRenderer } from "@app/components/assistant/conversation/inte
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/interactive_content/UnsupportedContentRenderer";
 import Custom404 from "@app/components/pages/Custom404";
 import { usePublicFrame } from "@app/lib/swr/frames";
-import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
 import { Spinner } from "@dust-tt/sparkle";
 
 interface PublicInteractiveContentContainerProps {
@@ -48,6 +52,7 @@ export function PublicInteractiveContentContainer({
     switch (frameMetadata.contentType) {
       case frameContentType:
       case frameSlideshowContentType:
+      case frameV2ContentType:
         return (
           <PublicFrameRenderer
             fileId={frameMetadata.sId}

--- a/front/lib/api/files/pdf_export.ts
+++ b/front/lib/api/files/pdf_export.ts
@@ -12,7 +12,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import {
   frameSlideshowContentType,
-  isInteractiveContentType,
+  isFrameContentType,
 } from "@app/types/files";
 import type {
   PdfOptions,
@@ -51,10 +51,7 @@ export async function exportInteractiveContentFileAsPdf(
     return new Err({ type: "file_not_found", message: "File not found." });
   }
 
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
+  if (!isFrameContentType(file.contentType)) {
     return new Err({
       type: "invalid_request",
       message: "Only Frame files can be exported as PDF.",

--- a/front/lib/api/files/pdf_export.ts
+++ b/front/lib/api/files/pdf_export.ts
@@ -68,6 +68,10 @@ export async function exportInteractiveContentFileAsPdf(
     }
   }
 
+  if (file.isFrameV2) {
+    await file.ensureShareableFrame(auth);
+  }
+
   const shareInfo = await file.getShareInfo();
   if (!shareInfo) {
     return new Err({

--- a/front/lib/api/files/screenshot.ts
+++ b/front/lib/api/files/screenshot.ts
@@ -52,6 +52,10 @@ export async function screenshotInteractiveContentFile(
     }
   }
 
+  if (file.isFrameV2) {
+    await file.ensureShareableFrame(auth);
+  }
+
   const shareInfo = await file.getShareInfo();
   if (!shareInfo) {
     return new Err({

--- a/front/lib/api/files/screenshot.ts
+++ b/front/lib/api/files/screenshot.ts
@@ -5,7 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-import { isInteractiveContentType } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import type { ScreenshotOptions } from "@app/types/shared/document_renderer";
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
@@ -34,10 +34,7 @@ export async function screenshotInteractiveContentFile(
     return new Err({ type: "file_not_found", message: "File not found." });
   }
 
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
+  if (!isFrameContentType(file.contentType)) {
     return new Err({
       type: "invalid_request",
       message: "Only Frame files can be exported as PNG.",

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -7,6 +7,7 @@ import {
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import type { Authenticator } from "@app/lib/auth";
+import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -25,7 +26,7 @@ import {
   sandboxFunctionContentType,
 } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 async function setupFrame(): Promise<{
   frame: FileResource;
@@ -516,6 +517,51 @@ describe("activateFramePublication", () => {
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
+    );
+  });
+
+  it("refreshes the sharing allowlist before activating a new bundle", async () => {
+    const { auth, frame } = await setupFrame();
+    vi.spyOn(frame, "computeAuthorizedFileAccess").mockImplementation(
+      async (_auth, { frameContent }) => ({
+        generatedByUserId: auth.getNonNullableUser().id,
+        frameContentHash: computeFrameContentHash(frameContent),
+        refs: [
+          {
+            kind: "file_id",
+            ref: "fil_ABCDEFGHIJ",
+          },
+        ],
+      })
+    );
+
+    const firstBundle = "export default function First() {}";
+    const first = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode: firstBundle,
+    });
+    expect(first.isOk()).toBe(true);
+    expect(
+      (await frame.getActiveAuthorizedFileAccessAllowlist())?.frameContentHash
+    ).toBe(computeFrameContentHash(firstBundle));
+
+    const secondBundle = "export default function Second() {}";
+    const second = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode: secondBundle,
+    });
+    expect(second.isOk()).toBe(true);
+    expect(
+      (await frame.getActiveAuthorizedFileAccessAllowlist())?.frameContentHash
+    ).toBe(computeFrameContentHash(secondBundle));
+    expect(frame.useCaseMetadata?.activePublicationId).toBe(
+      second.isOk() ? second.value.publicationId : undefined
     );
   });
 });

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -6,8 +6,8 @@ import {
   publishFramePublication,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
-import type { Authenticator } from "@app/lib/auth";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
+import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -548,6 +548,12 @@ describe("activateFramePublication", () => {
       (await frame.getActiveAuthorizedFileAccessAllowlist())?.frameContentHash
     ).toBe(computeFrameContentHash(firstBundle));
 
+    const setActivePublication = vi.spyOn(frame, "setActiveFramePublication");
+    const persistAuthorizedFileAccess = vi.spyOn(
+      frame,
+      "persistAuthorizedFileAccess"
+    );
+
     const secondBundle = "export default function Second() {}";
     const second = await publishFramePublication(auth, {
       frame,
@@ -562,6 +568,11 @@ describe("activateFramePublication", () => {
     ).toBe(computeFrameContentHash(secondBundle));
     expect(frame.useCaseMetadata?.activePublicationId).toBe(
       second.isOk() ? second.value.publicationId : undefined
+    );
+    const activationTransaction = setActivePublication.mock.calls[0]?.[1];
+    expect(activationTransaction).toBeDefined();
+    expect(persistAuthorizedFileAccess.mock.calls[0]?.[1]?.transaction).toBe(
+      activationTransaction
     );
   });
 });

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -299,50 +299,6 @@ export async function loadFramePublicationManifest(
   return manifest;
 }
 
-export async function loadActiveFrameUiBundle(
-  auth: Authenticator,
-  {
-    frame,
-  }: {
-    frame: FileResource;
-  }
-): Promise<Result<string, FramePublicationError>> {
-  const frameIdentity = getFrameIdentity(auth, frame);
-  if (frameIdentity.isErr()) {
-    return frameIdentity;
-  }
-
-  const publicationId = frame.useCaseMetadata?.activePublicationId;
-  if (!publicationId) {
-    return new Err(
-      new FramePublicationError(
-        "publication_not_found",
-        "Frame has no active publication."
-      )
-    );
-  }
-
-  const uiBundlePath = getFramePublicationUiBundlePath({
-    ...frameIdentity.value,
-    publicationId,
-  });
-  try {
-    const uiBundle =
-      await getPrivateUploadBucket().fetchFileContent(uiBundlePath);
-    return new Ok(uiBundle);
-  } catch (error) {
-    if (isGCSNotFoundError(error)) {
-      return new Err(
-        new FramePublicationError(
-          "publication_not_found",
-          `Frame publication not found: ${publicationId}`
-        )
-      );
-    }
-    throw error;
-  }
-}
-
 export async function activateFramePublication(
   auth: Authenticator,
   {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -4,7 +4,8 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import type { Authenticator } from "@app/lib/auth";
 import {
   GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
@@ -13,6 +14,7 @@ import {
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import {
   isSafeFrameRelativePath,
@@ -345,7 +347,7 @@ export async function activateFramePublication(
   }
 
   await frame.ensureShareableFrame(auth);
-  const allowlist = await ensureAuthorizedFileAccessForShare(auth, frame, {
+  const allowlist = await computeAuthorizedFileAccessForShare(auth, frame, {
     frameContent: uiBundleCode,
   });
   if (allowlist.isErr()) {
@@ -353,8 +355,21 @@ export async function activateFramePublication(
       new FramePublicationError("allowlist_failed", allowlist.error.message)
     );
   }
+  const shareScope = await frame.getShareScope();
 
-  await frame.setActiveFramePublication(publicationId);
+  await withTransaction(async (transaction) => {
+    // Updating the Frame first serializes concurrent activations. Neither the new
+    // pointer nor its allowlist becomes visible until the transaction commits.
+    await frame.setActiveFramePublication(publicationId, transaction);
+    await frame.persistAuthorizedFileAccess(allowlist.value, { transaction });
+  });
+
+  emitFrameAuthorizedFilesUpdatedAuditLog(
+    auth,
+    frame,
+    allowlist.value,
+    shareScope
+  );
 
   void emitAuditLogEvent({
     auth,

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -4,6 +4,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { Authenticator } from "@app/lib/auth";
 import {
   GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
@@ -58,6 +59,7 @@ export class FramePublicationError extends Error {
       | "invalid_function_artifact"
       | "invalid_manifest"
       | "invalid_source"
+      | "allowlist_failed"
       | "publication_not_found"
       | "source_not_found"
       | "ui_build_failed"
@@ -315,6 +317,41 @@ export async function activateFramePublication(
   });
   if (manifest.isErr()) {
     return manifest;
+  }
+
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return frameIdentity;
+  }
+
+  let uiBundleCode: string;
+  try {
+    uiBundleCode = await getPrivateUploadBucket().fetchFileContent(
+      getFramePublicationUiBundlePath({
+        ...frameIdentity.value,
+        publicationId,
+      })
+    );
+  } catch (error) {
+    if (!isGCSNotFoundError(error)) {
+      throw error;
+    }
+    return new Err(
+      new FramePublicationError(
+        "publication_not_found",
+        `Frame publication UI bundle not found: ${publicationId}`
+      )
+    );
+  }
+
+  await frame.ensureShareableFrame(auth);
+  const allowlist = await ensureAuthorizedFileAccessForShare(auth, frame, {
+    frameContent: uiBundleCode,
+  });
+  if (allowlist.isErr()) {
+    return new Err(
+      new FramePublicationError("allowlist_failed", allowlist.error.message)
+    );
   }
 
   await frame.setActiveFramePublication(publicationId);

--- a/front/lib/api/frames/register_from_source.test.ts
+++ b/front/lib/api/frames/register_from_source.test.ts
@@ -52,6 +52,7 @@ describe("registerFrameV2FromSource", () => {
     expect(first.value.created).toBe(true);
     expect(first.value.frame.mountFilePath).toBe(mountFilePath);
     expect(first.value.frame.isReady).toBe(true);
+    expect(await first.value.frame.getShareInfo()).not.toBeNull();
 
     const second = await registerFrameV2FromSource(auth, {
       conversation,
@@ -60,6 +61,9 @@ describe("registerFrameV2FromSource", () => {
     assert(second.isOk());
     expect(second.value.created).toBe(false);
     expect(second.value.frame.sId).toBe(first.value.frame.sId);
+    expect(await second.value.frame.getShareInfo()).toEqual(
+      await first.value.frame.getShareInfo()
+    );
 
     const files = await FileResource.fetchByMountFilePaths(auth, [
       mountFilePath,

--- a/front/lib/api/frames/register_from_source.ts
+++ b/front/lib/api/frames/register_from_source.ts
@@ -37,7 +37,7 @@ async function existingFrameAtMountPath(
     );
   }
 
-  await existing.markFrameV2AsReadyFromMount();
+  await existing.markFrameV2AsReadyFromMount(auth);
   return new Ok(existing);
 }
 
@@ -146,7 +146,7 @@ export async function registerFrameV2FromSource(
       mountFilePath,
       fileSystemNodeId: null,
     });
-    await frame.markFrameV2AsReadyFromMount();
+    await frame.markFrameV2AsReadyFromMount(auth);
     return new Ok({ frame, created: true });
   } catch (error) {
     if (!(error instanceof UniqueConstraintError)) {

--- a/front/lib/api/viz/access_tokens.ts
+++ b/front/lib/api/viz/access_tokens.ts
@@ -1,13 +1,11 @@
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
-import type {
-  FileShareScope,
-  InteractiveContentFileContentType,
-} from "@app/types/files";
+import type { FileShareScope, FrameFileContentType } from "@app/types/files";
 import {
   fileShareScopeSchema,
   frameContentType,
   frameSlideshowContentType,
+  frameV2ContentType,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -17,7 +15,11 @@ import { z } from "zod";
 
 // Zod schema for VizAccessTokenPayload.
 const VizAccessTokenPayloadSchema = z.object({
-  contentType: z.enum([frameContentType, frameSlideshowContentType]),
+  contentType: z.enum([
+    frameContentType,
+    frameSlideshowContentType,
+    frameV2ContentType,
+  ]),
   fileToken: z.string(),
   shareScope: fileShareScopeSchema,
   userId: z.string().optional(),
@@ -33,7 +35,7 @@ export function generateVizAccessToken({
   shareScope,
   workspaceId,
 }: {
-  contentType: InteractiveContentFileContentType;
+  contentType: FrameFileContentType;
   fileToken: string;
   userId?: string;
   shareScope: FileShareScope;

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -8,7 +8,6 @@ import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type {
   AuthorizedFileAccessAllowlist,
@@ -101,17 +100,7 @@ export async function readFrameFileContent(
   const workspace = renderLightWorkspaceType({
     workspace: auth.getNonNullableWorkspace(),
   });
-  // Read what actually renders: a published frame's bundle (processed), else the source.
-  const readStream = frameFile.getSharedReadStream(
-    workspace,
-    frameFile.getRenderableVersion()
-  );
-  const bufferResult = await streamToBuffer(readStream);
-  if (bufferResult.isErr()) {
-    return null;
-  }
-
-  return bufferResult.value.toString("utf-8") || null;
+  return frameFile.getRenderableContent(workspace);
 }
 
 /**

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -103,6 +103,26 @@ export async function readFrameFileContent(
   return frameFile.getRenderableContent(workspace);
 }
 
+export async function computeAuthorizedFileAccessForShare(
+  auth: Authenticator,
+  frameFile: FileResource,
+  { frameContent }: { frameContent: string }
+): Promise<
+  Result<ComputedAuthorizedFileAccess, AuthorizedFileAccessShareError>
+> {
+  const authorized = await frameFile.computeAuthorizedFileAccess(auth, {
+    frameContent,
+  });
+
+  if (authorized.unverifiableRefs && authorized.unverifiableRefs.length > 0) {
+    return new Err(
+      unverifiableFrameFileRefsShareError(authorized.unverifiableRefs)
+    );
+  }
+
+  return new Ok(authorized);
+}
+
 /**
  * Recomputes the allowlist when missing or stale on frame save.
  * Blocks when any static file ref cannot be verified under the author's auth.
@@ -138,26 +158,27 @@ export async function ensureAuthorizedFileAccessForShare(
     return new Ok(active);
   }
 
-  const authorized = await frameFile.computeAuthorizedFileAccess(auth, {
-    frameContent,
-  });
-
-  if (authorized.unverifiableRefs && authorized.unverifiableRefs.length > 0) {
-    return new Err(
-      unverifiableFrameFileRefsShareError(authorized.unverifiableRefs)
-    );
+  const authorized = await computeAuthorizedFileAccessForShare(
+    auth,
+    frameFile,
+    {
+      frameContent,
+    }
+  );
+  if (authorized.isErr()) {
+    return authorized;
   }
 
-  await frameFile.persistAuthorizedFileAccess(authorized);
+  await frameFile.persistAuthorizedFileAccess(authorized.value);
 
   emitFrameAuthorizedFilesUpdatedAuditLog(
     auth,
     frameFile,
-    authorized,
+    authorized.value,
     currentShareScope
   );
 
-  return new Ok(authorized);
+  return authorized;
 }
 
 type VizFileAuthorizationMode = "authorized" | "denied";

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -109,11 +109,13 @@ export async function readFrameFileContent(
  */
 export async function ensureAuthorizedFileAccessForShare(
   auth: Authenticator,
-  frameFile: FileResource
+  frameFile: FileResource,
+  { frameContent: suppliedFrameContent }: { frameContent?: string } = {}
 ): Promise<
   Result<ComputedAuthorizedFileAccess, AuthorizedFileAccessShareError>
 > {
-  const frameContent = await readFrameFileContent(auth, frameFile);
+  const frameContent =
+    suppliedFrameContent ?? (await readFrameFileContent(auth, frameFile));
   if (frameContent === null) {
     return new Err({
       name: "dust_error",

--- a/front/lib/api/viz/share_frame_viewer_files.ts
+++ b/front/lib/api/viz/share_frame_viewer_files.ts
@@ -229,6 +229,10 @@ export async function buildShareFileResponse(
   auth: Authenticator,
   file: FileResource
 ): Promise<ShareFileResponseBody | null> {
+  if (file.isFrameV2) {
+    await file.ensureShareableFrame(auth);
+  }
+
   const shareInfo = await file.getShareInfo();
   if (!shareInfo) {
     return null;

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -17,6 +17,7 @@ import type { MockFileVersion } from "@app/tests/utils/mocks/file_storage";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type {
   AllSupportedFileContentType,
@@ -24,6 +25,7 @@ import type {
 } from "@app/types/files";
 import {
   frameContentType,
+  frameV2ContentType,
   isUnverifiableFrameFileRefsShareError,
   sandboxFunctionContentType,
 } from "@app/types/files";
@@ -94,6 +96,44 @@ describe("FileResource", () => {
       expect(result).not.toBeNull();
       expect(result?.file.id).toBe(frameFile.id);
       expect(result?.content).toEqual(expectedContent);
+    });
+
+    it("returns the active Frames v2 publication", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+      const publicationId = "active-publication";
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameV2ContentType,
+        fileName: "manifest.json",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: {
+          activePublicationId: publicationId,
+          conversationId: conversation.sId,
+        },
+      });
+      fileStorageMock.setObject(
+        getFramePublicationUiBundlePath({
+          workspaceId: workspace.sId,
+          frameId: frameFile.sId,
+          publicationId,
+        }),
+        expectedContent
+      );
+      const shareInfo = await frameFile.getShareInfo();
+      const token = shareInfo?.shareUrl.split("/").at(-1);
+      assert(token, "Share token should be defined");
+
+      const result = await FileResource.fetchByShareTokenWithContent(token);
+
+      expect(result?.file.id).toBe(frameFile.id);
+      expect(result?.content).toBe(expectedContent);
     });
 
     it("should return null for soft-deleted conversation", async () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -33,6 +33,7 @@ import {
   getPublicUploadBucket,
   getUpsertQueueBucket,
 } from "@app/lib/file_storage";
+import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -675,7 +676,7 @@ export class FileResource extends BaseResource<FileModel> {
     return isFrameContentType(this.contentType);
   }
 
-  private async ensureShareableFrame(auth: Authenticator): Promise<void> {
+  async ensureShareableFrame(auth: Authenticator): Promise<void> {
     if (!this.isShareableFrame) {
       return;
     }
@@ -778,6 +779,9 @@ export class FileResource extends BaseResource<FileModel> {
         })
       );
     } catch (error) {
+      if (!isGCSNotFoundError(error)) {
+        throw error;
+      }
       logger.error(
         {
           err: normalizeError(error),

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -53,6 +53,7 @@ import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import { CoreAPI } from "@app/types/core/core_api";
 import type {
   AuthorizedFileAccessAllowlist,
@@ -72,6 +73,7 @@ import {
   frameSlideshowContentType,
   frameV2ContentType,
   isConversationFileUseCase,
+  isFrameContentType,
   isInteractiveContentType,
   isSandboxFunctionContentType,
 } from "@app/types/files";
@@ -242,11 +244,7 @@ export class FileResource extends BaseResource<FileModel> {
       return null;
     }
 
-    // Serve what renders: a published frame's bundle (processed), else the source.
-    const content = await r.value.file.getFileContent(
-      r.value.workspace,
-      r.value.file.getRenderableVersion()
-    );
+    const content = await r.value.file.getRenderableContent(r.value.workspace);
     if (!content) {
       return null;
     }
@@ -629,22 +627,7 @@ export class FileResource extends BaseResource<FileModel> {
 
     const updateResult = await this.update({ status: "ready" });
 
-    // For Interactive Content conversation files, automatically create a ShareableFileModel with
-    // a default scope based on the workspace sharing policy.
-    if (this.isInteractiveContent) {
-      const defaultScope = getDefaultFrameShareScope(
-        auth.getNonNullableWorkspace().sharingPolicy
-      );
-
-      await FileResource.shareableFileModel.upsert({
-        fileId: this.id,
-        shareScope: defaultScope,
-        sharedBy: this.userId ?? null,
-        workspaceId: this.workspaceId,
-        sharedAt: new Date(),
-        token: crypto.randomUUID(),
-      });
-    }
+    await this.ensureShareableFrame(auth);
 
     await this.resolveAndSetMountFilePath(auth);
 
@@ -655,9 +638,11 @@ export class FileResource extends BaseResource<FileModel> {
    * Mark a Frames v2 manifest that already exists at its mount path as ready.
    * Unlike markAsReady(), this must not copy from the canonical upload path.
    */
-  async markFrameV2AsReadyFromMount() {
+  async markFrameV2AsReadyFromMount(auth: Authenticator) {
     assert(this.isFrameV2, "Only Frames v2 can be adopted from a mount path");
     assert(this.mountFilePath, "A mounted Frames v2 manifest requires a path");
+
+    await this.ensureShareableFrame(auth);
 
     if (this.status === "ready") {
       return;
@@ -684,6 +669,35 @@ export class FileResource extends BaseResource<FileModel> {
 
   get isFrameV2(): boolean {
     return this.contentType === frameV2ContentType;
+  }
+
+  get isShareableFrame(): boolean {
+    return isFrameContentType(this.contentType);
+  }
+
+  private async ensureShareableFrame(auth: Authenticator): Promise<void> {
+    if (!this.isShareableFrame) {
+      return;
+    }
+
+    const defaultScope = getDefaultFrameShareScope(
+      auth.getNonNullableWorkspace().sharingPolicy
+    );
+
+    await FileResource.shareableFileModel.findOrCreate({
+      where: {
+        fileId: this.id,
+        workspaceId: this.workspaceId,
+      },
+      defaults: {
+        fileId: this.id,
+        shareScope: defaultScope,
+        sharedBy: this.userId ?? null,
+        workspaceId: this.workspaceId,
+        sharedAt: new Date(),
+        token: crypto.randomUUID(),
+      },
+    });
   }
 
   async setActiveFramePublication(publicationId: string) {
@@ -741,6 +755,40 @@ export class FileResource extends BaseResource<FileModel> {
       return "processed";
     }
     return "original";
+  }
+
+  async getRenderableContent(
+    owner: LightWorkspaceType
+  ): Promise<string | null> {
+    if (!this.isFrameV2) {
+      return this.getFileContent(owner, this.getRenderableVersion());
+    }
+
+    const publicationId = this.useCaseMetadata?.activePublicationId;
+    if (!publicationId || owner.id !== this.workspaceId) {
+      return null;
+    }
+
+    try {
+      return await getPrivateUploadBucket().fetchFileContent(
+        getFramePublicationUiBundlePath({
+          workspaceId: owner.sId,
+          frameId: this.sId,
+          publicationId,
+        })
+      );
+    } catch (error) {
+      logger.error(
+        {
+          err: normalizeError(error),
+          fileId: this.sId,
+          publicationId,
+          workspaceId: owner.sId,
+        },
+        "getRenderableContent failed"
+      );
+      return null;
+    }
   }
 
   /**
@@ -1526,24 +1574,19 @@ export class FileResource extends BaseResource<FileModel> {
     shareableFileToken: string;
   }): string {
     assert(
-      this.isInteractiveContent,
-      "getShareUrlForShareableFile called on non-interactive content file"
+      this.isShareableFrame,
+      "getShareUrlForShareableFile called on a non-Frame file"
     );
 
-    if (isInteractiveContentType(this.contentType)) {
-      return `${config.getAppUrl()}/share/frame/${shareableFileToken}`;
-    }
-
-    return `${config.getAppUrl()}/share/file/${shareableFileToken}`;
+    return `${config.getAppUrl()}/share/frame/${shareableFileToken}`;
   }
 
   async setShareScope(
     auth: Authenticator,
     scope: FileShareScope
   ): Promise<void> {
-    // Only Interactive Content files can be shared.
-    if (!this.isInteractiveContent) {
-      throw new Error("Only Interactive Content files can be shared");
+    if (!this.isShareableFrame) {
+      throw new Error("Only Frame files can be shared");
     }
 
     const user = auth.getNonNullableUser();
@@ -1570,7 +1613,7 @@ export class FileResource extends BaseResource<FileModel> {
     sharedAt: number;
     shareUrl: string;
   } | null> {
-    if (!this.isInteractiveContent) {
+    if (!this.isShareableFrame) {
       return null;
     }
 
@@ -1965,8 +2008,8 @@ export class FileResource extends BaseResource<FileModel> {
 
   private async getShareableFile(): Promise<ShareableFileModel> {
     assert(
-      this.isInteractiveContent,
-      `Shareable file access requires interactive content (file: ${this.sId})`
+      this.isShareableFrame,
+      `Shareable file access requires a Frame (file: ${this.sId})`
     );
 
     const shareableFile = await FileResource.shareableFileModel.findOne({
@@ -2099,10 +2142,7 @@ export class FileResource extends BaseResource<FileModel> {
     auth: Authenticator,
     { emails }: { emails: string[] }
   ): Promise<SharingGrantType[]> {
-    assert(
-      this.isInteractiveContent,
-      "addSharingGrants requires interactive content file"
-    );
+    assert(this.isShareableFrame, "addSharingGrants requires a Frame file");
     const user = auth.getNonNullableUser();
     const shareableFileId = await this.getShareableFileId();
 
@@ -2173,10 +2213,7 @@ export class FileResource extends BaseResource<FileModel> {
   }: {
     grantId: ModelId;
   }): Promise<Result<{ email: string }, DustError>> {
-    assert(
-      this.isInteractiveContent,
-      "revokeSharingGrant requires interactive content file"
-    );
+    assert(this.isShareableFrame, "revokeSharingGrant requires a Frame file");
     const shareableFileId = await this.getShareableFileId();
 
     const grant = await SharingGrantModel.findOne({
@@ -2224,8 +2261,8 @@ export class FileResource extends BaseResource<FileModel> {
 
   async listActiveSharingGrants(): Promise<SharingGrantType[]> {
     assert(
-      this.isInteractiveContent,
-      "listActiveSharingGrants requires interactive content file"
+      this.isShareableFrame,
+      "listActiveSharingGrants requires a Frame file"
     );
     const shareableFileId = await this.getShareableFileId();
 
@@ -2246,10 +2283,7 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   async listAllSharingGrants(): Promise<SharingGrantType[]> {
-    assert(
-      this.isInteractiveContent,
-      "listAllSharingGrants requires interactive content file"
-    );
+    assert(this.isShareableFrame, "listAllSharingGrants requires a Frame file");
     const shareableFileId = await this.getShareableFileId();
 
     const grants = await SharingGrantModel.findAll({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -701,13 +701,19 @@ export class FileResource extends BaseResource<FileModel> {
     });
   }
 
-  async setActiveFramePublication(publicationId: string) {
-    return this.update({
-      useCaseMetadata: {
-        ...this.useCaseMetadata,
-        activePublicationId: publicationId,
+  async setActiveFramePublication(
+    publicationId: string,
+    transaction?: Transaction
+  ) {
+    return this.update(
+      {
+        useCaseMetadata: {
+          ...this.useCaseMetadata,
+          activePublicationId: publicationId,
+        },
       },
-    });
+      transaction
+    );
   }
 
   // Content access logic.
@@ -1593,6 +1599,8 @@ export class FileResource extends BaseResource<FileModel> {
       throw new Error("Only Frame files can be shared");
     }
 
+    await this.ensureShareableFrame(auth);
+
     const user = auth.getNonNullableUser();
 
     // Always update the existing ShareableFileModel record (never delete).
@@ -2010,7 +2018,9 @@ export class FileResource extends BaseResource<FileModel> {
     };
   }
 
-  private async getShareableFile(): Promise<ShareableFileModel> {
+  private async getShareableFile(
+    transaction?: Transaction
+  ): Promise<ShareableFileModel> {
     assert(
       this.isShareableFrame,
       `Shareable file access requires a Frame (file: ${this.sId})`
@@ -2018,6 +2028,7 @@ export class FileResource extends BaseResource<FileModel> {
 
     const shareableFile = await FileResource.shareableFileModel.findOne({
       where: { fileId: this.id, workspaceId: this.workspaceId },
+      transaction,
     });
 
     assert(
@@ -2060,9 +2071,12 @@ export class FileResource extends BaseResource<FileModel> {
 
   async persistAuthorizedFileAccess(
     computed: ComputedAuthorizedFileAccess,
-    allowedAt: Date = new Date()
+    {
+      allowedAt = new Date(),
+      transaction,
+    }: { allowedAt?: Date; transaction?: Transaction } = {}
   ): Promise<void> {
-    const shareableFile = await this.getShareableFile();
+    const shareableFile = await this.getShareableFile(transaction);
 
     const baseRow = {
       workspaceId: this.workspaceId,
@@ -2096,10 +2110,13 @@ export class FileResource extends BaseResource<FileModel> {
         shareableFileId: shareableFile.id,
         workspaceId: this.workspaceId,
       },
+      transaction,
     });
 
     if (rows.length > 0) {
-      await FileResource.authorizedFileAccessModel.bulkCreate(rows);
+      await FileResource.authorizedFileAccessModel.bulkCreate(rows, {
+        transaction,
+      });
     }
   }
 
@@ -2147,6 +2164,7 @@ export class FileResource extends BaseResource<FileModel> {
     { emails }: { emails: string[] }
   ): Promise<SharingGrantType[]> {
     assert(this.isShareableFrame, "addSharingGrants requires a Frame file");
+    await this.ensureShareableFrame(auth);
     const user = auth.getNonNullableUser();
     const shareableFileId = await this.getShareableFileId();
 

--- a/front/lib/resources/frame_file_resource.test.ts
+++ b/front/lib/resources/frame_file_resource.test.ts
@@ -16,5 +16,6 @@ describe("Frames v2 FileResource", () => {
 
     expect(frame.isFrameV2).toBe(true);
     expect(frame.isInteractiveContent).toBe(false);
+    expect(frame.isShareableFrame).toBe(true);
   });
 });

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -751,6 +751,10 @@ const FRAME_V2_FILE_FORMATS = {
 
 type FrameV2FileContentType = keyof typeof FRAME_V2_FILE_FORMATS;
 
+export type FrameFileContentType =
+  | InteractiveContentFileContentType
+  | FrameV2FileContentType;
+
 const SANDBOX_FUNCTION_FILE_FORMATS = {
   [sandboxFunctionContentType]: {
     cat: "code",
@@ -845,6 +849,14 @@ export function isFrameV2ContentType(
   contentType: string
 ): contentType is FrameV2FileContentType {
   return contentType === frameV2ContentType;
+}
+
+export function isFrameContentType(
+  contentType: string
+): contentType is FrameFileContentType {
+  return (
+    isInteractiveContentType(contentType) || isFrameV2ContentType(contentType)
+  );
 }
 
 export function isAllSupportedFileContentType(


### PR DESCRIPTION
## Description

Frames v2 now uses the existing Frame sharing and export capabilities against its active publication. Registering or activating a Frame creates its shareable record without resetting existing sharing settings. Activation refreshes the authorized-file allowlist against the new bundle before switching the active publication. Public and authenticated reads serve the active UI bundle, and the v2 renderer exposes Share and Export while keeping v1-only authoring controls hidden. Legacy Frames behavior is unchanged.

Stacked on #31379.

## Tests

- `npm run tsgo` in `front`
- `npm run tsgo` in `front-api`
- 76 focused `front` tests for registration, publication allowlist refresh, and FileResource behavior
- 96 focused `front-api` tests for authenticated/public rendering, sharing, grants, viz access, and PDF export

## Risk

The new paths apply only to Frames v2 files. Existing v1 Frame rendering and sharing paths remain unchanged. Activation computes the sharing allowlist before switching publications, so validation failures keep the previous publication active. Safe to roll back.

## Deploy Plan

Normal deployment after #31379.