### PR TITLE
Drop the SSO and SCIM feature flags

### DIFF
--- a/front-api/routes/w/[wId]/dsync.ts
+++ b/front-api/routes/w/[wId]/dsync.ts
@@ -8,7 +8,6 @@ import {
   generateWorkOSAdminPortalUrl,
   getWorkOSOrganizationDSyncDirectories,
 } from "@app/lib/api/workos/organization";
-import { getFeatureFlags } from "@app/lib/auth";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
@@ -46,8 +45,7 @@ async function checkAccess(ctx: Context) {
   }
 
   const plan = auth.getNonNullablePlan();
-  const featureFlags = await getFeatureFlags(auth);
-  if (!isSCIMEnabled(plan, featureFlags)) {
+  if (!isSCIMEnabled(plan)) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front-api/routes/w/[wId]/sso.ts
+++ b/front-api/routes/w/[wId]/sso.ts
@@ -9,7 +9,6 @@ import {
   getWorkOSOrganizationSSOConnections,
 } from "@app/lib/api/workos/organization";
 import type { GetWorkspaceResponseBody } from "@app/lib/api/workspace";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
@@ -56,8 +55,7 @@ async function checkAccess(ctx: Context) {
   }
 
   const plan = auth.getNonNullablePlan();
-  const hasSSOFeatureFlag = await hasFeatureFlag(auth, "allow_sso");
-  if (!plan.limits.users.isSSOAllowed && !hasSSOFeatureFlag) {
+  if (!plan.limits.users.isSSOAllowed) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -3,7 +3,7 @@ import { GroupDialog } from "@app/components/groups/GroupDialog";
 import { getGroupKindChip } from "@app/components/groups/GroupKinds";
 import { ProvisionedGroupDialog } from "@app/components/groups/ProvisionedGroupDialog";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
 import { useAppRouter } from "@app/lib/platform";
 import { useDeleteGroup, useGroups } from "@app/lib/swr/groups";
@@ -129,8 +129,7 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
 
   const router = useAppRouter();
   const { subscription } = useAuth();
-  const { featureFlags } = useFeatureFlags();
-  const isScimAllowed = isSCIMEnabled(subscription.plan, featureFlags);
+  const isScimAllowed = isSCIMEnabled(subscription.plan);
   const [searchTerm, setSearchTerm] = useState("");
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -1,11 +1,7 @@
 import { WorkspaceGroupsList } from "@app/components/groups/WorkspaceGroupsList";
 import { WorkspaceMembersSection } from "@app/components/members/WorkspaceMembersSection";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
 import {
   usePerSeatPricing,
@@ -22,8 +18,6 @@ import {
 } from "@dust-tt/sparkle";
 
 export function MembersPage() {
-  const { featureFlags } = useFeatureFlags();
-
   const owner = useWorkspace();
   const { subscription, user } = useAuth();
   const plan = subscription.plan;
@@ -40,8 +34,7 @@ export function MembersPage() {
   });
 
   const hasVerifiedDomains = verifiedDomains.length > 0;
-  const isProvisioningEnabled =
-    isSCIMEnabled(plan, featureFlags) && hasVerifiedDomains;
+  const isProvisioningEnabled = isSCIMEnabled(plan) && hasVerifiedDomains;
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
 

--- a/front/components/poke/plans/NewPlanWarningDialog.tsx
+++ b/front/components/poke/plans/NewPlanWarningDialog.tsx
@@ -57,10 +57,9 @@ export function NewPlanWarningDialog({
             </p>
             <ul className="flex flex-col gap-2 pl-5">
               <li className="list-disc">
-                <span className="font-semibold">SSO / SCIM</span> — enable the{" "}
-                <span className="font-mono">allow_sso</span> /{" "}
-                <span className="font-mono">allow_scim</span> feature flags on
-                the workspace.
+                <span className="font-semibold">SSO / SCIM</span> — use the{" "}
+                <span className="font-semibold">Override Plan Limits</span> poke
+                plugin on the workspace.
               </li>
               <li className="list-disc">
                 <span className="font-semibold">

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -2,7 +2,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
@@ -72,8 +72,7 @@ export function CreateOrEditSpaceModal({
     useState<MembersManagementType>("manual");
   const [isDirty, setIsDirty] = useState(false);
 
-  const { featureFlags } = useFeatureFlags();
-  const scimEnabled = isSCIMEnabled(plan, featureFlags);
+  const scimEnabled = isSCIMEnabled(plan);
   const { user } = useAuth();
 
   useEffect(() => {

--- a/front/components/workspace/SSOConnection.tsx
+++ b/front/components/workspace/SSOConnection.tsx
@@ -1,5 +1,4 @@
 import WorkOSSSOConnection from "@app/components/workspace/sso/WorkOSSSOConnection";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { PlanType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import type { Organization } from "@workos-inc/node";
@@ -15,9 +14,7 @@ export default function SSOConnection({
   owner,
   plan,
 }: SSOConnectionProps) {
-  const { hasFeature } = useFeatureFlags();
-
-  if (!plan.limits.users.isSSOAllowed && !hasFeature("allow_sso")) {
+  if (!plan.limits.users.isSSOAllowed) {
     return null;
   }
 

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -45,9 +45,9 @@ export default function WorkspaceAccessPanel({
   const { addDomainLink, domains, isDomainsLoading } = useWorkspaceDomains({
     owner,
   });
-  const { featureFlags, hasFeature } = useFeatureFlags();
+  const { hasFeature } = useFeatureFlags();
   const workspace = useWorkspace();
-  const scimEnabled = isSCIMEnabled(plan, featureFlags);
+  const scimEnabled = isSCIMEnabled(plan);
   const hasAuditLogsAccess =
     plan.isAuditLogsAllowed || hasFeature("audit_logs");
   const showAuditLogs =

--- a/front/lib/plans/scim.ts
+++ b/front/lib/plans/scim.ts
@@ -1,9 +1,5 @@
 import type { PlanType } from "@app/types/plan";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
-export function isSCIMEnabled(
-  plan: PlanType,
-  featureFlags: WhitelistableFeature[]
-): boolean {
-  return plan.limits.users.isSCIMAllowed || featureFlags.includes("allow_scim");
+export function isSCIMEnabled(plan: PlanType): boolean {
+  return plan.limits.users.isSCIMAllowed;
 }

--- a/front/migrations/20260901_backfill_sso_scim_plan_limit_overrides.ts
+++ b/front/migrations/20260901_backfill_sso_scim_plan_limit_overrides.ts
@@ -1,0 +1,179 @@
+import {
+  getWorkspacePlanLimitOverrides,
+  setWorkspacePlanLimitOverrides,
+} from "@app/lib/api/plan_limit_overrides";
+import { Authenticator } from "@app/lib/auth";
+import type {
+  OverridablePlanFlag,
+  PlanLimitOverride,
+} from "@app/lib/plans/plan_limit_overrides";
+import { EMPTY_PLAN_LIMIT_OVERRIDE } from "@app/lib/plans/plan_limit_overrides";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Backfills the `isSSOAllowed` / `isSCIMAllowed` plan-limit overrides from the legacy
+// `allow_sso` / `allow_scim` feature flags, so the workspaces that relied on a flag keep their
+// entitlement once the flags are gone from the code.
+//
+// Run this BEFORE merging the PR that drops the flags: while the old code is still live both
+// mechanisms grant the feature, so there is no window where a workspace loses SSO or SCIM.
+// Merging then removes the flag path and the override carries the entitlement.
+//
+// The flag names are already out of `WHITELISTABLE_FEATURES`, so this reads the rows by name
+// rather than through `FeatureFlagResource.listForWorkspace` (which filters unknown names out).
+// It only reads the flag rows — deleting them is a separate step, see
+// `scripts/delete_legacy_feature_flag.ts`.
+//
+// Dry run by default:
+//   npx tsx migrations/20260901_backfill_sso_scim_plan_limit_overrides.ts [--execute]
+
+// Legacy flag name -> the plan-limit override that replaces it.
+const FLAG_MIGRATIONS: {
+  flagName: string;
+  overrideKey: OverridablePlanFlag;
+}[] = [
+  { flagName: "allow_sso", overrideKey: "isSSOAllowed" },
+  { flagName: "allow_scim", overrideKey: "isSCIMAllowed" },
+];
+
+/**
+ * The full override row to write. The row holds every overridable limit at once and
+ * `setWorkspacePlanLimitOverrides` replaces it wholesale, so the existing values have to
+ * be carried over — writing only the flags would clear any negotiated seat, space or
+ * data-source override this workspace already has.
+ */
+function buildBackfilledOverride(
+  existingOverride: PlanLimitOverride | null,
+  overrideKeys: OverridablePlanFlag[]
+): PlanLimitOverride {
+  return {
+    ...(existingOverride ?? EMPTY_PLAN_LIMIT_OVERRIDE),
+    ...Object.fromEntries(overrideKeys.map((key) => [key, true])),
+  };
+}
+
+/**
+ * Lists the workspaces holding a legacy flag, and which override each one needs. A
+ * workspace with both flags gets a single entry so it is written once.
+ */
+async function listOverrideKeysByWorkspaceModelId(
+  logger: Logger
+): Promise<Map<ModelId, OverridablePlanFlag[]>> {
+  const overrideKeysByWorkspaceModelId = new Map<
+    ModelId,
+    OverridablePlanFlag[]
+  >();
+
+  for (const { flagName, overrideKey } of FLAG_MIGRATIONS) {
+    const rowCount = await FeatureFlagResource.countLegacyByName(flagName);
+    if (rowCount === 0) {
+      logger.info({ flagName }, "No workspace holds this flag.");
+      continue;
+    }
+
+    const flags =
+      await FeatureFlagResource.dangerouslyListForAllWorkspacesByName(
+        flagName,
+        { limit: rowCount }
+      );
+    if (flags.length !== rowCount) {
+      logger.warn(
+        { flagName, rowCount, listed: flags.length },
+        "Listed fewer rows than counted; re-run to pick up the remainder."
+      );
+    }
+
+    logger.info(
+      { flagName, overrideKey, workspaceCount: flags.length },
+      "Found workspaces holding the flag."
+    );
+
+    for (const flag of flags) {
+      const keys = overrideKeysByWorkspaceModelId.get(flag.workspaceId) ?? [];
+      overrideKeysByWorkspaceModelId.set(flag.workspaceId, [
+        ...keys,
+        overrideKey,
+      ]);
+    }
+  }
+
+  return overrideKeysByWorkspaceModelId;
+}
+
+async function processWorkspace(
+  workspaceId: string,
+  overrideKeys: OverridablePlanFlag[],
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const existingOverride = await getWorkspacePlanLimitOverrides(auth);
+
+  logger.info(
+    { workspaceId, overrideKeys },
+    execute ? "Setting overrides." : "Would set overrides."
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  const res = await setWorkspacePlanLimitOverrides(
+    auth,
+    buildBackfilledOverride(existingOverride, overrideKeys)
+  );
+  if (res.isErr()) {
+    logger.error(
+      { workspaceId, overrideKeys, error: res.error.message },
+      "Failed to set overrides."
+    );
+    return;
+  }
+
+  logger.info({ workspaceId, overrideKeys }, "Overrides set.");
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const overrideKeysByWorkspaceModelId =
+    await listOverrideKeysByWorkspaceModelId(logger);
+
+  const workspaceModelIds = [...overrideKeysByWorkspaceModelId.keys()];
+  if (workspaceModelIds.length === 0) {
+    logger.info("Nothing to backfill.");
+    return;
+  }
+
+  const workspaces = await WorkspaceResource.fetchByModelIds(workspaceModelIds);
+
+  const missingCount = workspaceModelIds.length - workspaces.length;
+  if (missingCount > 0) {
+    // Flag rows outliving their workspace: nothing to backfill for them.
+    logger.warn(
+      { missingCount },
+      "Some flagged workspaces no longer exist, skipping them."
+    );
+  }
+
+  logger.info(
+    { candidates: workspaces.length },
+    `${execute ? "Executing" : "[DRY RUN]"} over ${workspaces.length} workspace(s)`
+  );
+
+  // Sequential on purpose: only a handful of workspaces ever held these flags, and each one
+  // costs a few queries.
+  for (const workspace of workspaces) {
+    const overrideKeys = overrideKeysByWorkspaceModelId.get(workspace.id) ?? [];
+    try {
+      await processWorkspace(workspace.sId, overrideKeys, execute, logger);
+    } catch (err) {
+      logger.error(
+        { workspaceId: workspace.sId, error: normalizeError(err).message },
+        "Unexpected error while processing workspace."
+      );
+    }
+  }
+});

--- a/front/scripts/enable_allow_sso_for_pro_plan_seat_39.ts
+++ b/front/scripts/enable_allow_sso_for_pro_plan_seat_39.ts
@@ -1,17 +1,24 @@
 /**
  * For every active subscription on the legacy PRO_PLAN_SEAT_39 plan, check whether the
- * workspace has an active WorkOS SSO connection configured. If it does, enable the
- * `allow_sso` feature flag so the workspace keeps access to its SSO settings even though
- * the plan itself does not grant `isSSOAllowed`.
+ * workspace has an active WorkOS SSO connection configured. If it does, set the
+ * `isSSOAllowed` plan-limit override so the workspace keeps access to its SSO settings
+ * even though the plan itself does not grant `isSSOAllowed`.
+ *
+ * A workspace that already has an explicit `isSSOAllowed` override is left alone, in
+ * either direction: `false` is a deliberate deny, not a missing value.
  *
  * Dry run by default. Run with:
  *   npx tsx scripts/enable_allow_sso_for_pro_plan_seat_39.ts [--concurrency 4] [--execute]
  */
 
+import {
+  getWorkspacePlanLimitOverrides,
+  setWorkspacePlanLimitOverrides,
+} from "@app/lib/api/plan_limit_overrides";
 import { getWorkOSOrganizationSSOConnections } from "@app/lib/api/workos/organization";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { PRO_PLAN_SEAT_39_CODE } from "@app/lib/plans/plan_codes";
-import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import { EMPTY_PLAN_LIMIT_OVERRIDE } from "@app/lib/plans/plan_limit_overrides";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -37,11 +44,14 @@ async function processWorkspace(
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  const hasFlagEnabled = await hasFeatureFlag(auth, "allow_sso");
-  if (hasFlagEnabled) {
+  const existingOverride = await getWorkspacePlanLimitOverrides(auth);
+  if (existingOverride?.isSSOAllowed != null) {
     logger.info(
-      { workspaceId: workspace.sId },
-      "allow_sso already enabled, skipping."
+      {
+        workspaceId: workspace.sId,
+        isSSOAllowed: existingOverride.isSSOAllowed,
+      },
+      "isSSOAllowed override already set, skipping."
     );
     return;
   }
@@ -70,11 +80,25 @@ async function processWorkspace(
 
   logger.info(
     { workspaceId: workspace.sId },
-    execute ? "Enabling allow_sso." : "Would enable allow_sso."
+    execute
+      ? "Setting isSSOAllowed override."
+      : "Would set isSSOAllowed override."
   );
 
   if (execute) {
-    await FeatureFlagResource.enable(workspace, "allow_sso");
+    // The override row holds every overridable limit at once, so the existing
+    // values have to be carried over — a bare `isSSOAllowed` would clear any
+    // negotiated seat or space override this workspace already has.
+    const res = await setWorkspacePlanLimitOverrides(auth, {
+      ...(existingOverride ?? EMPTY_PLAN_LIMIT_OVERRIDE),
+      isSSOAllowed: true,
+    });
+    if (res.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: res.error.message },
+        "Failed to set isSSOAllowed override."
+      );
+    }
   }
 }
 

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -23,7 +23,7 @@ import {
   getWorkspaceInfos,
   isWorkspaceRelocationDone,
 } from "@app/lib/api/workspace";
-import { Authenticator, getFeatureFlagsForWorkspace } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import type { ExternalUser } from "@app/lib/iam/provider";
 import type { CustomAttributeKey } from "@app/lib/iam/users";
 import {
@@ -127,9 +127,8 @@ async function verifyWorkOSWorkspace<E extends Event, R>(
   ) {
     const subscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-    const featureFlags = await getFeatureFlagsForWorkspace(workspace);
     const plan = subscription?.getPlan();
-    if (!plan || !isSCIMEnabled(plan, featureFlags)) {
+    if (!plan || !isSCIMEnabled(plan)) {
       logger.warn(
         { workspaceId: workspace.sId, organizationId },
         "SCIM event received but neither the workspace plan nor a feature flag allows SCIM, skipping"

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -16,18 +16,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "fontanierh",
   },
-  allow_sso: {
-    description:
-      "Allow this workspace to configure SSO, independently of the plan's isSSOAllowed flag. Enable on demand for Business plan workspaces.",
-    stage: "self_serve",
-    owner: "tdraier",
-  },
-  allow_scim: {
-    description:
-      "Allow this workspace to configure SCIM user provisioning, independently of the plan's isSCIMAllowed flag. Enable on demand.",
-    stage: "self_serve",
-    owner: "tdraier",
-  },
   live_speech_to_text: {
     description:
       "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",
@@ -420,7 +408,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   enforce_user_spend_limit_rate_cap: {
     description:
       "Enable the Redis fixed-window spend-cap backups (per-user, per-API-key, programmatic, and workspace usage cap): record AWU usage into the counters and enforce them at message send. When off, usage is neither recorded nor enforced.",
-    stage: "ask_owner",
+    stage: "dust_only",
     owner: "tdraier",
   },
   enforce_premium_model_message_limit: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -742,8 +742,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "activation_force_nudge"
   | "admin_controlled_pods"
   | "advanced_notion_management"
-  | "allow_scim"
-  | "allow_sso"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
   | "archive_inactive_agents"


### PR DESCRIPTION
## Description

follow up of https://github.com/dust-tt/dust/pull/31377
drop the feature flags now that we have the fields in DB for that.
Flags deleted:
 - "allow_scim"
 - "allow_sso"


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

easy to revert

## Deploy Plan

Run the backfill first
```
npx tsx migrations/20260901_backfill_sso_scim_plan_limit_overrides.ts --execute
```

deploy front after migrating all the workspaces using the feature flag
