### PR TITLE
Declare Frames v2 SQLite databases

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -64,6 +64,13 @@ const manifestWithFunction = FrameManifestSchema.parse({
   ],
 });
 
+const manifestWithDatabase = FrameManifestSchema.parse({
+  version: 1,
+  name: "Task List",
+  description: "Track tasks.",
+  databases: [{ name: "tasks", schema: "databases/tasks.db.ts" }],
+});
+
 const sourceFiles = [
   {
     relativePath: "index.tsx",
@@ -219,6 +226,49 @@ describe("storeFramePublication", () => {
     ).toBe("application/json");
   });
 
+  it("stores declared database schemas in the immutable source snapshot", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+    const databaseSchema = {
+      relativePath: "databases/tasks.db.ts",
+      content: Buffer.from("export const tasks = {};"),
+      contentType: "text/typescript" as const,
+    };
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: manifestWithDatabase,
+      sourceFiles: [...sourceFiles, databaseSchema],
+      uiBundleCode,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    const identity = {
+      workspaceId,
+      frameId: frame.sId,
+      publicationId: result.value.publicationId,
+    };
+    expect(
+      fileStorageMock.getObject(
+        getFramePublicationSourcePath({
+          ...identity,
+          relativePath: databaseSchema.relativePath,
+        })
+      )
+    ).toBe(databaseSchema.content.toString());
+    const loadedManifest = await loadFramePublicationManifest(auth, {
+      frame,
+      publicationId: identity.publicationId,
+    });
+    expect(loadedManifest.isOk() && loadedManifest.value.databases).toEqual(
+      manifestWithDatabase.databases
+    );
+  });
+
   it("rejects a publication whose UI entry point is missing", async () => {
     const { auth, frame } = await setupFrame();
 
@@ -248,6 +298,24 @@ describe("storeFramePublication", () => {
     expect(result.isErr() && result.error.code).toBe("invalid_source");
     expect(result.isErr() && result.error.message).toContain(
       "add-task (functions/add_task.ts)"
+    );
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("rejects a publication whose database schema is missing", async () => {
+    const { auth, frame } = await setupFrame();
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: manifestWithDatabase,
+      sourceFiles,
+      uiBundleCode,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_source");
+    expect(result.isErr() && result.error.message).toContain(
+      "Frame database schema not found: tasks"
     );
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -155,6 +155,16 @@ export async function storeFramePublication(
       );
     }
   }
+  for (const database of manifest.databases) {
+    if (!sourcePaths.has(database.schema)) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_source",
+          `Frame database schema not found: ${database.name} (${database.schema})`
+        )
+      );
+    }
+  }
 
   const declaredFunctionNames = new Set(
     manifest.functions.map((fn) => fn.name)

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -1,6 +1,6 @@
 import {
-  FRAME_DEFAULT_UI_ENTRY_POINT,
   FRAME_DATABASE_NAME_REGEX,
+  FRAME_DEFAULT_UI_ENTRY_POINT,
   FrameManifestSchema,
   isSafeFrameRelativePath,
   MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
@@ -129,9 +129,7 @@ describe("FrameManifestSchema", () => {
   it("parses database declarations", () => {
     const parsed = FrameManifestSchema.safeParse({
       ...MANIFEST,
-      databases: [
-        { name: "task_store", schema: "databases/task_store.db.ts" },
-      ],
+      databases: [{ name: "task_store", schema: "databases/task_store.db.ts" }],
     });
 
     expect(parsed.success).toBe(true);

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -1,5 +1,6 @@
 import {
   FRAME_DEFAULT_UI_ENTRY_POINT,
+  FRAME_DATABASE_NAME_REGEX,
   FrameManifestSchema,
   isSafeFrameRelativePath,
   MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
@@ -31,6 +32,7 @@ describe("FrameManifestSchema", () => {
     if (parsed.success) {
       expect(parsed.data.uiEntryPoint).toBe(FRAME_DEFAULT_UI_ENTRY_POINT);
       expect(parsed.data.functions).toEqual([]);
+      expect(parsed.data.databases).toEqual([]);
     }
   });
 
@@ -118,6 +120,45 @@ describe("FrameManifestSchema", () => {
           ...FUNCTION,
           description: "a".repeat(MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH + 1),
         },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("parses database declarations", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      databases: [
+        { name: "task_store", schema: "databases/task_store.db.ts" },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects invalid database names and schema paths", () => {
+    expect(FRAME_DATABASE_NAME_REGEX.test("task_store")).toBe(true);
+    expect(
+      FrameManifestSchema.safeParse({
+        ...MANIFEST,
+        databases: [{ name: "Task Store", schema: "databases/tasks.db.ts" }],
+      }).success
+    ).toBe(false);
+    expect(
+      FrameManifestSchema.safeParse({
+        ...MANIFEST,
+        databases: [{ name: "tasks", schema: "../tasks.db.ts" }],
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects duplicate database names", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      databases: [
+        { name: "tasks", schema: "databases/tasks.db.ts" },
+        { name: "tasks", schema: "databases/tasks_v2.db.ts" },
       ],
     });
 

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
   DEFAULT_SANDBOX_FUNCTION_STAKE,
+  SANDBOX_DATABASE_NAME_REGEX,
   SANDBOX_FUNCTION_EXECUTION_MODES,
   SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
   SANDBOX_FUNCTION_STAKES,
@@ -17,6 +18,7 @@ export const FRAME_DEFAULT_UI_ENTRY_POINT = "index.tsx";
 export const MAX_FRAME_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH = 255;
+export const FRAME_DATABASE_NAME_REGEX = SANDBOX_DATABASE_NAME_REGEX;
 
 /** Manifest paths are always relative to the Frame source folder. */
 export function isSafeFrameRelativePath(path: string): boolean {
@@ -56,6 +58,14 @@ export const FrameFunctionManifestSchema = z.object({
     .default(DEFAULT_SANDBOX_FUNCTION_STAKE),
 });
 
+export const FrameDatabaseManifestSchema = z.object({
+  name: z.string().regex(FRAME_DATABASE_NAME_REGEX, {
+    message:
+      "Database name must start with a lowercase letter and contain only lowercase letters, digits, and underscores.",
+  }),
+  schema: FrameRelativePathSchema,
+});
+
 export const FrameSourceManifestSchema = z
   .object({
     version: z.literal(FRAME_MANIFEST_VERSION),
@@ -63,19 +73,32 @@ export const FrameSourceManifestSchema = z
     description: z.string(),
     uiEntryPoint: FrameRelativePathSchema.optional(),
     functions: z.array(FrameFunctionManifestSchema).default([]),
+    databases: z.array(FrameDatabaseManifestSchema).default([]),
   })
   .superRefine((manifest, context) => {
-    const names = new Set<string>();
+    const functionNames = new Set<string>();
 
     manifest.functions.forEach((fn, index) => {
-      if (names.has(fn.name)) {
+      if (functionNames.has(fn.name)) {
         context.addIssue({
           code: "custom",
           message: `Function name '${fn.name}' must be unique.`,
           path: ["functions", index, "name"],
         });
       }
-      names.add(fn.name);
+      functionNames.add(fn.name);
+    });
+
+    const databaseNames = new Set<string>();
+    manifest.databases.forEach((database, index) => {
+      if (databaseNames.has(database.name)) {
+        context.addIssue({
+          code: "custom",
+          message: `Database name '${database.name}' must be unique.`,
+          path: ["databases", index, "name"],
+        });
+      }
+      databaseNames.add(database.name);
     });
   });
 

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -1,5 +1,6 @@
 import {
   getFrameBasePath,
+  getFrameDatabaseReplicaBasePath,
   getFramePublicationFunctionBundlePath,
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
@@ -49,6 +50,16 @@ describe("Frames v2 GCS paths", () => {
     );
   });
 
+  it("keeps SQLite replica state outside publications", () => {
+    expect(
+      getFrameDatabaseReplicaBasePath({
+        workspaceId: IDS.workspaceId,
+        frameId: IDS.frameId,
+        databaseName: "task_store",
+      })
+    ).toBe("w/w_123/frames/fil_456/state/databases/task_store.db/");
+  });
+
   it("rejects path traversal and unsafe identity segments", () => {
     expect(() =>
       getFramePublicationSourcePath({
@@ -65,5 +76,12 @@ describe("Frames v2 GCS paths", () => {
         functionName: "../other",
       })
     ).toThrow("Invalid functionName");
+    expect(() =>
+      getFrameDatabaseReplicaBasePath({
+        workspaceId: IDS.workspaceId,
+        frameId: IDS.frameId,
+        databaseName: "../other",
+      })
+    ).toThrow("Invalid databaseName");
   });
 });

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -1,4 +1,7 @@
-import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
+import {
+  FRAME_DATABASE_NAME_REGEX,
+  isSafeFrameRelativePath,
+} from "@app/types/api/frame_manifest";
 
 const SAFE_FRAME_STORAGE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
@@ -25,6 +28,21 @@ export function getFramePublicationsBasePath(args: {
   frameId: string;
 }): string {
   return `${getFrameBasePath(args)}publications/`;
+}
+
+export function getFrameDatabaseReplicaBasePath({
+  databaseName,
+  ...args
+}: {
+  workspaceId: string;
+  frameId: string;
+  databaseName: string;
+}): string {
+  if (!FRAME_DATABASE_NAME_REGEX.test(databaseName)) {
+    throw new Error("Invalid databaseName for Frame storage.");
+  }
+
+  return `${getFrameBasePath(args)}state/databases/${databaseName}.db/`;
 }
 
 export function getFramePublicationBasePath({

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -126,7 +126,10 @@ export const SANDBOX_FUNCTION_SLUG_REGEX = new RegExp(
 // Mirrors DB_NAME_REGEX in cli/dust-sandbox/functions-runner/types/db.ts. Regex values cannot
 // be type-checked and front cannot runtime-import cli code; equality is asserted in
 // build_on_sandbox.test.ts.
-export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+export const SANDBOX_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+
+// Pod databases and Frame databases share the dsbx runtime naming contract.
+export const POD_DATABASE_NAME_REGEX = SANDBOX_DATABASE_NAME_REGEX;
 
 export function isValidSandboxFunctionSlug(value: unknown): value is string {
   return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);


### PR DESCRIPTION
## Description

Adds the foundational Frames v2 SQLite contract. Frame manifests can declare uniquely named databases and their schema source paths. Publication rejects missing schema files and preserves declared schemas in the immutable source snapshot. Stable database replica prefixes are keyed by workspace, Frame identity, and database name outside publication storage.

This slice does not yet mount, reconcile, or replicate live SQLite databases; those runtime lifecycle changes follow separately.

Stacked on #31380.

## Tests

- 43 focused manifest, GCS path, and publication storage tests
- `npm run tsgo` in `front`

## Risk

Existing manifests default to an empty database list. No runtime or existing Pod database behavior changes. Safe to roll back.

## Deploy Plan

Normal deployment after #31380.