### PR TITLE
[sparkle] fix: prevent SliderSteps tooltip jitter

### DIFF
--- a/sparkle/src/components/SliderSteps.tsx
+++ b/sparkle/src/components/SliderSteps.tsx
@@ -122,7 +122,7 @@ export function SliderSteps({
       ? (stepTooltips?.[hoveredIndex] ?? null)
       : null;
 
-  const root = (
+  const slider = (
     <SliderPrimitive.Root
       className={cn(
         "relative flex h-5 w-full touch-none select-none items-center",
@@ -197,31 +197,18 @@ export function SliderSteps({
       >
         <span className="block h-4 w-4 rounded-full bg-white drop-shadow" />
       </SliderPrimitive.Thumb>
-      {stepTooltips ? (
-        <TooltipTrigger asChild>
-          <span
-            aria-hidden
-            className="pointer-events-none absolute top-1/2 h-0 w-0 -translate-y-1/2"
-            style={{
-              left:
-                hoveredIndex !== null
-                  ? stepCenter(hoveredIndex, lastIndex)
-                  : "50%",
-            }}
-          />
-        </TooltipTrigger>
-      ) : null}
     </SliderPrimitive.Root>
   );
 
   if (!stepTooltips) {
-    return root;
+    return slider;
   }
 
   return (
     <TooltipProvider delayDuration={0}>
       <TooltipRoot open={activeTooltip !== null}>
-        {root}
+        {/* Keep the trigger geometry stable while the hovered step changes. */}
+        <TooltipTrigger asChild>{slider}</TooltipTrigger>
         {activeTooltip !== null ? (
           <TooltipContent>{activeTooltip}</TooltipContent>
         ) : null}

--- a/sparkle/src/stories/SliderSteps.stories.tsx
+++ b/sparkle/src/stories/SliderSteps.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import { useArgs } from "storybook/preview-api";
-import { fn } from "storybook/test";
+import { expect, fireEvent, fn, waitFor, within } from "storybook/test";
 
 import { SliderSteps } from "../index_with_tw_base";
 
@@ -27,6 +27,9 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const THIRD_STEP_TOOLTIP = "This step requires a higher plan.";
+const FOURTH_STEP_TOOLTIP = "This step requires the highest plan.";
 
 // SliderSteps is fully controlled; this shared render wires changes back into
 // the `value` arg (on top of the `onChange` spy) so every story is interactive
@@ -72,10 +75,39 @@ export const WithLockedSteps: Story = {
     stepCount: 4,
     value: 1,
     lockedSteps: [2, 3],
+    stepTooltips: [null, null, THIRD_STEP_TOOLTIP, FOURTH_STEP_TOOLTIP],
     ariaLabel: "Level",
     onChange: fn(),
   },
   render: ControlledSliderSteps,
+  play: async ({ canvasElement }) => {
+    const slider = within(canvasElement).getByRole("slider");
+    const root = slider.parentElement?.parentElement;
+    if (!root) {
+      throw new Error("Slider root not found.");
+    }
+
+    const rootRect = root.getBoundingClientRect();
+    fireEvent.pointerMove(root, {
+      clientX: rootRect.left + (rootRect.width * 2) / 3,
+      clientY: rootRect.top + rootRect.height / 2,
+    });
+
+    const tooltip = await within(canvasElement.ownerDocument.body).findByRole(
+      "tooltip",
+    );
+    await waitFor(() => expect(tooltip).toBeVisible());
+    expect(tooltip).toHaveTextContent(THIRD_STEP_TOOLTIP);
+    // The slider itself remains the trigger while the hovered step changes.
+    expect(root).toHaveAttribute("aria-describedby");
+
+    fireEvent.pointerMove(root, {
+      clientX: rootRect.right - 1,
+      clientY: rootRect.top + rootRect.height / 2,
+    });
+
+    await waitFor(() => expect(tooltip).toHaveTextContent(FOURTH_STEP_TOOLTIP));
+  },
 };
 
 /**

--- a/sparkle/src/stories/SliderSteps.stories.tsx
+++ b/sparkle/src/stories/SliderSteps.stories.tsx
@@ -94,7 +94,7 @@ export const WithLockedSteps: Story = {
     });
 
     const tooltip = await within(canvasElement.ownerDocument.body).findByRole(
-      "tooltip",
+      "tooltip"
     );
     await waitFor(() => expect(tooltip).toBeVisible());
     expect(tooltip).toHaveTextContent(THIRD_STEP_TOOLTIP);


### PR DESCRIPTION
## Description

SliderSteps tooltips were anchored to a zero-size element that moved between hovered steps, which made the reasoning-effort tooltip jump near step boundaries.

This PR uses the slider root as the tooltip trigger so its geometry stays stable while the per-step copy still updates.

## Tests

- Updated the story.
- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
