### PR TITLE
[front] feat: add action_id to tool.executed audit event

### DIFF
--- a/front/admin/audit_log_schemas/tool.executed.json
+++ b/front/admin/audit_log_schemas/tool.executed.json
@@ -14,6 +14,7 @@
     "mcp_server_name": "string",
     "conversation_id": "string",
     "agent_message_id": "string",
+    "action_id": "string",
     "trigger_id": "string",
     "pod_id": "string",
     "pod_function_id": "string",

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -93,7 +93,7 @@
   "subscription.changed": 1,
   "tool.approval_requested": 3,
   "tool.approval_resolved": 3,
-  "tool.executed": 7,
+  "tool.executed": 8,
   "trigger.created": 1,
   "trigger.deleted": 1,
   "trigger.disabled": 2,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -508,6 +508,7 @@ async function executeToolStreaming(
             mcp_server_name: action.toolConfiguration.mcpServerName,
             conversation_id: conversation.sId,
             agent_message_id: agentMessage.sId,
+            action_id: action.sId,
             ...(conversation.triggerId
               ? { trigger_id: conversation.triggerId }
               : {}),

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_tool.ts
@@ -117,6 +117,7 @@ export async function runSandboxFunctionToolActivity(
                 ? "remote"
                 : "internal",
               mcp_server_name: action.toolConfiguration.mcpServerName,
+              action_id: action.sId,
               ...buildSandboxFunctionAuditMetadata(invocation),
               initiating_user_id: auth.user()?.sId ?? "unknown",
               initiating_user_email: auth.user()?.email ?? "unknown",


### PR DESCRIPTION
## Description

Adds `action_id` (the MCP action sId) to the `tool.executed` audit event so it can be joined to `tool.approval_requested` / `tool.approval_resolved`, which already emit that field.

- Schema: `front/admin/audit_log_schemas/tool.executed.json`
- Emit sites: agent-loop `run_tool.ts` and pod-function `run_sandbox_function_tool.ts`
- Version map: `tool.executed` v8 in `schema_versions.json` (bumped from main's v7 during rebase)

Approval fields stay on `tool.approval_resolved`; this is only the join key.

## Tests

- `npm -w front run test -- lib/api/audit/audit_log_schemas.test.ts`

## Risk

Low. Additive optional metadata on an existing event. Events emitted before deploy omit the field; WorkOS treats declared metadata as optional.

## Deploy Plan

Register the updated schema with WorkOS (expect v8), then deploy `front` workers that emit `tool.executed` so they send version 8. No DB migration. Rollback: revert the emit/schema PR; if workers already send v8, keep the version map or re-register as needed.