### PR TITLE
Activate published Frame functions atomically

### DIFF
--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,0 +1,16 @@
+import { executeWithLock } from "@app/lib/lock";
+
+const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
+
+export function getFramePublishLockName(frameId: string): string {
+  return `frame:publish:${frameId}`;
+}
+
+export function withFramePublishLock<T>(
+  frameId: string,
+  callback: () => Promise<T>
+): Promise<T> {
+  return executeWithLock(getFramePublishLockName(frameId), callback, 30_000, {
+    lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS,
+  });
+}

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -654,9 +654,9 @@ describe("activateFramePublication", () => {
     const activeBundle = "export default function Active() {}";
     const active = await publishFramePublication(auth, {
       frame,
-      functionArtifacts: [],
-      manifest,
-      sourceFiles,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
       uiBundleCode: activeBundle,
     });
     expect(active.isOk()).toBe(true);
@@ -664,55 +664,27 @@ describe("activateFramePublication", () => {
       return;
     }
 
-    const staged = await storeFramePublication(auth, {
-      frame,
-      functionArtifacts,
-      manifest: manifestWithFunction,
-      sourceFiles: sourceFilesWithFunction,
-      uiBundleCode: "export default function Staged() {}",
-    });
-    expect(staged.isOk()).toBe(true);
-    if (staged.isErr()) {
-      return;
-    }
+    const stagedBundle = "export default function Staged() {}";
     fileStorageMock.setObject(
-      getFramePublicationFunctionSchemaPath({
+      getFramePublicationUiBundlePath({
         workspaceId,
         frameId: frame.sId,
-        publicationId: staged.value.publicationId,
-        functionName: "add-task",
+        publicationId: active.value.publicationId,
       }),
-      JSON.stringify({
-        userIdentity: "workspace_user_required",
-        inputSchema: { type: "not-a-json-schema-type" },
-        outputSchema: functionArtifacts[0].outputSchema,
-      })
+      stagedBundle
     );
 
     const parentTransaction =
       getNamespace("test-namespace")?.get("transaction");
     expect(parentTransaction).toBeDefined();
     await expect(
-      frontSequelize.transaction(
-        { transaction: parentTransaction },
-        async (transaction) => {
-          const activation = await activateFramePublication(
-            auth,
-            {
-              frame,
-              publicationId: staged.value.publicationId,
-            },
-            { transaction }
-          );
-          expect(activation.isErr() && activation.error.code).toBe(
-            "activation_failed"
-          );
-          throw activation.isErr()
-            ? activation.error
-            : new Error("Expected Frame publication activation to fail.");
-        }
+      frontSequelize.transaction({ transaction: parentTransaction }, async () =>
+        activateFramePublication(auth, {
+          frame,
+          publicationId: active.value.publicationId,
+        })
       )
-    ).rejects.toThrow("Failed to activate Frame publication");
+    ).rejects.toThrow();
 
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
@@ -724,9 +696,9 @@ describe("activateFramePublication", () => {
     expect(
       await SandboxFunctionResource.listByFramePublication(auth, {
         frame,
-        publicationId: staged.value.publicationId,
+        publicationId: active.value.publicationId,
       })
-    ).toHaveLength(0);
+    ).toHaveLength(1);
   });
 
   it("refreshes the sharing allowlist before activating a new bundle", async () => {

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1,3 +1,4 @@
+import { getFramePublishLockName } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationFunctionArtifact } from "@app/lib/api/frames/publication_storage";
 import {
   activateFramePublication,
@@ -17,6 +18,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { redisMock } from "@app/tests/utils/mocks/redis";
 import { getNamespace } from "@app/tests/utils/test_cls";
 import { FrameManifestSchema } from "@app/types/api/frame_manifest";
 import {
@@ -34,7 +36,11 @@ import {
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-async function setupFrame(): Promise<{
+async function setupFrame({
+  ready = false,
+}: {
+  ready?: boolean;
+} = {}): Promise<{
   frame: FileResource;
   workspaceId: string;
   auth: Authenticator;
@@ -44,7 +50,7 @@ async function setupFrame(): Promise<{
     contentType: frameV2ContentType,
     fileName: "manifest.json",
     fileSize: 0,
-    status: "created",
+    status: ready ? "ready" : "created",
     useCase: "project_context",
   });
 
@@ -118,6 +124,18 @@ const functionArtifacts = [
     },
   },
 ] satisfies FramePublicationFunctionArtifact[];
+
+function createDeferred() {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) {
+    throw new Error("Deferred promise resolver was not initialized.");
+  }
+
+  return { promise, resolve: resolvePromise };
+}
 
 beforeEach(() => {
   fileStorageMock.reset();
@@ -806,5 +824,65 @@ describe("publishFramePublication", () => {
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       activePublicationId
     );
+  });
+
+  it("finishes an in-flight publication before deleting its Frame", async () => {
+    const { auth, frame } = await setupFrame({ ready: true });
+    const activationStarted = createDeferred();
+    const releaseActivation = createDeferred();
+    vi.spyOn(frame, "computeAuthorizedFileAccess").mockImplementation(
+      async (_auth, { frameContent }) => {
+        activationStarted.resolve();
+        await releaseActivation.promise;
+        return {
+          generatedByUserId: auth.getNonNullableUser().id,
+          frameContentHash: computeFrameContentHash(frameContent),
+          refs: [],
+        };
+      }
+    );
+
+    const publicationPromise = publishFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      uiBundleCode,
+    });
+    await activationStarted.promise;
+
+    const deletionPromise = frame.delete(auth);
+    const redisSet = vi.mocked(
+      redisMock.streamClient.set as (
+        key: string,
+        value: string,
+        options: { NX?: boolean; PX?: number }
+      ) => Promise<string | null>
+    );
+    const lockKey = `lock:${getFramePublishLockName(frame.sId)}`;
+    try {
+      await vi.waitFor(() => {
+        expect(
+          redisSet.mock.calls.filter(([key]) => key === lockKey).length
+        ).toBeGreaterThanOrEqual(2);
+      });
+      await expect(
+        FileResource.fetchById(auth, frame.sId)
+      ).resolves.not.toBeNull();
+    } finally {
+      releaseActivation.resolve();
+    }
+
+    const publication = await publicationPromise;
+    expect(
+      publication.isOk(),
+      publication.isErr() ? publication.error.message : undefined
+    ).toBe(true);
+    const deletion = await deletionPromise;
+    expect(
+      deletion.isOk(),
+      deletion.isErr() ? deletion.error.message : undefined
+    ).toBe(true);
+    await expect(FileResource.fetchById(auth, frame.sId)).resolves.toBeNull();
   });
 });

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -9,9 +9,15 @@ import {
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import {
+  computeSandboxFunctionBundleSha256,
+  SandboxFunctionResource,
+} from "@app/lib/resources/sandbox_function_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import { FrameManifestSchema } from "@app/types/api/frame_manifest";
 import {
   getFramePublicationFunctionBundlePath,
@@ -548,7 +554,10 @@ describe("activateFramePublication", () => {
       publicationId: stored.value.publicationId,
     });
 
-    expect(activated.isOk()).toBe(true);
+    expect(
+      activated.isOk(),
+      activated.isErr() ? activated.error.message : undefined
+    ).toBe(true);
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
@@ -586,6 +595,138 @@ describe("activateFramePublication", () => {
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
     );
+  });
+
+  it("materializes immutable function rows for the activated publication", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+
+    const activated = await activateFramePublication(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+    });
+
+    expect(activated.isOk()).toBe(true);
+    const functions = await SandboxFunctionResource.listByFramePublication(
+      auth,
+      { frame, publicationId: stored.value.publicationId }
+    );
+    expect(functions).toHaveLength(1);
+    expect(functions[0]).toMatchObject({
+      publicationId: stored.value.publicationId,
+      slug: "add-task",
+      description: "Add a task.",
+      userIdentity: "workspace_user_required",
+      executionMode: "durable",
+      defaultStake: "low",
+      bundleSha256: computeSandboxFunctionBundleSha256(
+        functionArtifacts[0].bundleCode
+      ),
+      inputSchema: functionArtifacts[0].inputSchema,
+      outputSchema: functionArtifacts[0].outputSchema,
+    });
+    expect(functions[0]?.frame?.sId).toBe(frame.sId);
+    expect(() => functions[0]?.space).toThrow(
+      "Frame functions do not belong to a Pod space."
+    );
+  });
+
+  it("rolls back the allowlist and function rows when activation fails", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+    vi.spyOn(frame, "computeAuthorizedFileAccess").mockImplementation(
+      async (_auth, { frameContent }) => ({
+        generatedByUserId: auth.getNonNullableUser().id,
+        frameContentHash: computeFrameContentHash(frameContent),
+        refs: [{ kind: "file_id", ref: "fil_ABCDEFGHIJ" }],
+      })
+    );
+
+    const activeBundle = "export default function Active() {}";
+    const active = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode: activeBundle,
+    });
+    expect(active.isOk()).toBe(true);
+    if (active.isErr()) {
+      return;
+    }
+
+    const staged = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      uiBundleCode: "export default function Staged() {}",
+    });
+    expect(staged.isOk()).toBe(true);
+    if (staged.isErr()) {
+      return;
+    }
+    fileStorageMock.setObject(
+      getFramePublicationFunctionSchemaPath({
+        workspaceId,
+        frameId: frame.sId,
+        publicationId: staged.value.publicationId,
+        functionName: "add-task",
+      }),
+      JSON.stringify({
+        userIdentity: "workspace_user_required",
+        inputSchema: { type: "not-a-json-schema-type" },
+        outputSchema: functionArtifacts[0].outputSchema,
+      })
+    );
+
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+    await expect(
+      frontSequelize.transaction(
+        { transaction: parentTransaction },
+        async (transaction) => {
+          const activation = await activateFramePublication(
+            auth,
+            {
+              frame,
+              publicationId: staged.value.publicationId,
+            },
+            { transaction }
+          );
+          expect(activation.isErr() && activation.error.code).toBe(
+            "activation_failed"
+          );
+          throw activation.isErr()
+            ? activation.error
+            : new Error("Expected Frame publication activation to fail.");
+        }
+      )
+    ).rejects.toThrow("Failed to activate Frame publication");
+
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      active.value.publicationId
+    );
+    expect(
+      (await frame.getActiveAuthorizedFileAccessAllowlist())?.frameContentHash
+    ).toBe(computeFrameContentHash(activeBundle));
+    expect(
+      await SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: staged.value.publicationId,
+      })
+    ).toHaveLength(0);
   });
 
   it("refreshes the sharing allowlist before activating a new bundle", async () => {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -4,6 +4,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,7 +13,6 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
-import { executeWithLock } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -47,7 +47,6 @@ import { z } from "zod";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
-const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
 
 const jsonSchemaValue = z.custom<JSONSchema>(
   (value) =>
@@ -93,10 +92,6 @@ export class FramePublicationError extends Error {
     super(message);
     this.name = "FramePublicationError";
   }
-}
-
-export function getFramePublishLockName(frameId: string): string {
-  return `frame:publish:${frameId}`;
 }
 
 export function isFramePublicationError(
@@ -557,33 +552,28 @@ export async function publishFramePublication(
     uiBundleCode: string;
   }
 ): Promise<Result<{ publicationId: string }, FramePublicationError>> {
-  return executeWithLock(
-    getFramePublishLockName(frame.sId),
-    async () => {
-      const publication = await storeFramePublication(auth, {
-        frame,
-        functionArtifacts,
-        manifest,
-        sourceFiles,
-        uiBundleCode,
-      });
-      if (publication.isErr()) {
-        return publication;
-      }
-
-      const activation = await activateFramePublication(auth, {
-        frame,
-        publicationId: publication.value.publicationId,
-      });
-      if (activation.isErr()) {
-        return activation;
-      }
-
+  return withFramePublishLock(frame.sId, async () => {
+    const publication = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+    if (publication.isErr()) {
       return publication;
-    },
-    30_000,
-    { lockTtlMs: FRAME_PUBLISH_LOCK_TTL_MS }
-  );
+    }
+
+    const activation = await activateFramePublication(auth, {
+      frame,
+      publicationId: publication.value.publicationId,
+    });
+    if (activation.isErr()) {
+      return activation;
+    }
+
+    return publication;
+  });
 }
 
 export async function loadFramePublicationSourceFile(

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -17,6 +17,7 @@ import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import {
@@ -42,7 +43,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import type { Transaction } from "sequelize";
 import { z } from "zod";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
@@ -50,7 +50,10 @@ const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
 const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
 
 const jsonSchemaValue = z.custom<JSONSchema>(
-  (value) => typeof value === "object" && value !== null
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    validateJsonSchema(value).isValid
 );
 
 const FramePublicationFunctionSchemaArtifactSchema = z.object({
@@ -81,7 +84,6 @@ export class FramePublicationError extends Error {
       | "invalid_manifest"
       | "invalid_source"
       | "allowlist_failed"
-      | "activation_failed"
       | "publication_not_found"
       | "source_not_found"
       | "ui_build_failed"
@@ -442,8 +444,7 @@ export async function activateFramePublication(
   }: {
     frame: FileResource;
     publicationId: string;
-  },
-  { transaction }: { transaction?: Transaction } = {}
+  }
 ): Promise<Result<void, FramePublicationError>> {
   const manifest = await loadFramePublicationManifest(auth, {
     frame,
@@ -497,35 +498,21 @@ export async function activateFramePublication(
   }
   const shareScope = await frame.getShareScope();
 
-  try {
-    await withTransaction(async (activationTransaction) => {
-      // Updating the Frame first serializes concurrent activations. None of the
-      // new publication state becomes visible until the transaction commits.
-      await frame.setActiveFramePublication(
+  await withTransaction(async (transaction) => {
+    // Updating the Frame first serializes concurrent activations. None of the
+    // new publication state becomes visible until the transaction commits.
+    await frame.setActiveFramePublication(publicationId, transaction);
+    await frame.persistAuthorizedFileAccess(allowlist.value, { transaction });
+    await SandboxFunctionResource.createForFramePublication(
+      auth,
+      {
+        frame,
+        functions: functionDefinitions.value,
         publicationId,
-        activationTransaction
-      );
-      await frame.persistAuthorizedFileAccess(allowlist.value, {
-        transaction: activationTransaction,
-      });
-      await SandboxFunctionResource.createForFramePublication(
-        auth,
-        {
-          frame,
-          functions: functionDefinitions.value,
-          publicationId,
-        },
-        activationTransaction
-      );
-    }, transaction);
-  } catch (error) {
-    return new Err(
-      new FramePublicationError(
-        "activation_failed",
-        `Failed to activate Frame publication ${publicationId}: ${normalizeError(error).message}`
-      )
+      },
+      transaction
     );
-  }
+  });
 
   emitFrameAuthorizedFilesUpdatedAuditLog(
     auth,

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -12,7 +12,10 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import { executeWithLock } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
@@ -28,6 +31,7 @@ import {
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import { SANDBOX_FUNCTION_USER_IDENTITY_POLICIES } from "@app/types/api/sandbox_functions";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import {
   frameContentType,
@@ -36,9 +40,24 @@ import {
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type { Transaction } from "sequelize";
+import { z } from "zod";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
+const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
+const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
+
+const jsonSchemaValue = z.custom<JSONSchema>(
+  (value) => typeof value === "object" && value !== null
+);
+
+const FramePublicationFunctionSchemaArtifactSchema = z.object({
+  userIdentity: z.enum(SANDBOX_FUNCTION_USER_IDENTITY_POLICIES),
+  inputSchema: jsonSchemaValue,
+  outputSchema: jsonSchemaValue,
+});
 
 export type FramePublicationSourceFile = {
   relativePath: string;
@@ -62,6 +81,7 @@ export class FramePublicationError extends Error {
       | "invalid_manifest"
       | "invalid_source"
       | "allowlist_failed"
+      | "activation_failed"
       | "publication_not_found"
       | "source_not_found"
       | "ui_build_failed"
@@ -71,6 +91,10 @@ export class FramePublicationError extends Error {
     super(message);
     this.name = "FramePublicationError";
   }
+}
+
+export function getFramePublishLockName(frameId: string): string {
+  return `frame:publish:${frameId}`;
 }
 
 export function isFramePublicationError(
@@ -313,6 +337,103 @@ export async function loadFramePublicationManifest(
   return manifest;
 }
 
+async function loadFramePublicationFunctionDefinitions(
+  auth: Authenticator,
+  {
+    frame,
+    manifest,
+    publicationId,
+  }: {
+    frame: FileResource;
+    manifest: FrameManifest;
+    publicationId: string;
+  }
+): Promise<
+  Result<FramePublicationFunctionDefinition[], FramePublicationError>
+> {
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return frameIdentity;
+  }
+
+  const storage = getPrivateUploadBucket();
+  const definitions = await concurrentExecutor(
+    manifest.functions,
+    async (fn) => {
+      const identity = {
+        ...frameIdentity.value,
+        publicationId,
+        functionName: fn.name,
+      };
+      let bundleCode: string;
+      let schemaContent: string;
+      try {
+        [bundleCode, schemaContent] = await Promise.all([
+          storage.fetchFileContent(
+            getFramePublicationFunctionBundlePath(identity)
+          ),
+          storage.fetchFileContent(
+            getFramePublicationFunctionSchemaPath(identity)
+          ),
+        ]);
+      } catch (error) {
+        if (!isGCSNotFoundError(error)) {
+          throw error;
+        }
+        return new Err(
+          new FramePublicationError(
+            "publication_not_found",
+            `Frame publication function artifact not found: ${fn.name}`
+          )
+        );
+      }
+
+      let schemaJson: unknown;
+      try {
+        schemaJson = JSON.parse(schemaContent);
+      } catch (error) {
+        return new Err(
+          new FramePublicationError(
+            "invalid_function_artifact",
+            `Invalid Frame publication function schema for ${fn.name}: ${normalizeError(error).message}`
+          )
+        );
+      }
+      const schema =
+        FramePublicationFunctionSchemaArtifactSchema.safeParse(schemaJson);
+      if (!schema.success) {
+        return new Err(
+          new FramePublicationError(
+            "invalid_function_artifact",
+            `Invalid Frame publication function schema for ${fn.name}: ${schema.error.message}`
+          )
+        );
+      }
+
+      return new Ok({
+        name: fn.name,
+        description: fn.description,
+        executionMode: fn.executionMode,
+        defaultStake: fn.defaultStake,
+        bundleCode,
+        ...schema.data,
+      });
+    },
+    { concurrency: FRAME_PUBLICATION_READ_CONCURRENCY }
+  );
+
+  const definitionError = definitions.find((definition) => definition.isErr());
+  if (definitionError?.isErr()) {
+    return definitionError;
+  }
+
+  return new Ok(
+    definitions.flatMap((definition) =>
+      definition.isOk() ? [definition.value] : []
+    )
+  );
+}
+
 export async function activateFramePublication(
   auth: Authenticator,
   {
@@ -321,7 +442,8 @@ export async function activateFramePublication(
   }: {
     frame: FileResource;
     publicationId: string;
-  }
+  },
+  { transaction }: { transaction?: Transaction } = {}
 ): Promise<Result<void, FramePublicationError>> {
   const manifest = await loadFramePublicationManifest(auth, {
     frame,
@@ -334,6 +456,14 @@ export async function activateFramePublication(
   const frameIdentity = getFrameIdentity(auth, frame);
   if (frameIdentity.isErr()) {
     return frameIdentity;
+  }
+
+  const functionDefinitions = await loadFramePublicationFunctionDefinitions(
+    auth,
+    { frame, manifest: manifest.value, publicationId }
+  );
+  if (functionDefinitions.isErr()) {
+    return functionDefinitions;
   }
 
   let uiBundleCode: string;
@@ -367,12 +497,35 @@ export async function activateFramePublication(
   }
   const shareScope = await frame.getShareScope();
 
-  await withTransaction(async (transaction) => {
-    // Updating the Frame first serializes concurrent activations. Neither the new
-    // pointer nor its allowlist becomes visible until the transaction commits.
-    await frame.setActiveFramePublication(publicationId, transaction);
-    await frame.persistAuthorizedFileAccess(allowlist.value, { transaction });
-  });
+  try {
+    await withTransaction(async (activationTransaction) => {
+      // Updating the Frame first serializes concurrent activations. None of the
+      // new publication state becomes visible until the transaction commits.
+      await frame.setActiveFramePublication(
+        publicationId,
+        activationTransaction
+      );
+      await frame.persistAuthorizedFileAccess(allowlist.value, {
+        transaction: activationTransaction,
+      });
+      await SandboxFunctionResource.createForFramePublication(
+        auth,
+        {
+          frame,
+          functions: functionDefinitions.value,
+          publicationId,
+        },
+        activationTransaction
+      );
+    }, transaction);
+  } catch (error) {
+    return new Err(
+      new FramePublicationError(
+        "activation_failed",
+        `Failed to activate Frame publication ${publicationId}: ${normalizeError(error).message}`
+      )
+    );
+  }
 
   emitFrameAuthorizedFilesUpdatedAuditLog(
     auth,
@@ -417,26 +570,33 @@ export async function publishFramePublication(
     uiBundleCode: string;
   }
 ): Promise<Result<{ publicationId: string }, FramePublicationError>> {
-  const publication = await storeFramePublication(auth, {
-    frame,
-    functionArtifacts,
-    manifest,
-    sourceFiles,
-    uiBundleCode,
-  });
-  if (publication.isErr()) {
-    return publication;
-  }
+  return executeWithLock(
+    getFramePublishLockName(frame.sId),
+    async () => {
+      const publication = await storeFramePublication(auth, {
+        frame,
+        functionArtifacts,
+        manifest,
+        sourceFiles,
+        uiBundleCode,
+      });
+      if (publication.isErr()) {
+        return publication;
+      }
 
-  const activation = await activateFramePublication(auth, {
-    frame,
-    publicationId: publication.value.publicationId,
-  });
-  if (activation.isErr()) {
-    return activation;
-  }
+      const activation = await activateFramePublication(auth, {
+        frame,
+        publicationId: publication.value.publicationId,
+      });
+      if (activation.isErr()) {
+        return activation;
+      }
 
-  return publication;
+      return publication;
+    },
+    30_000,
+    { lockTtlMs: FRAME_PUBLISH_LOCK_TTL_MS }
+  );
 }
 
 export async function loadFramePublicationSourceFile(

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -4,11 +4,13 @@ import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import {
   AuthorizedFileAccessModel,
   FileModel,
 } from "@app/lib/resources/storage/models/files";
 import { copyContent } from "@app/lib/utils/files";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -31,6 +33,44 @@ import {
 } from "@app/types/files";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function createFrameWithFunction(
+  auth: Authenticator,
+  publicationId: string
+): Promise<FileResource> {
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 100,
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: { conversationId: "conv-frame-delete" },
+  });
+  await withTransaction((transaction) =>
+    SandboxFunctionResource.createForFramePublication(
+      auth,
+      {
+        frame,
+        publicationId,
+        functions: [
+          {
+            name: "delete-task",
+            description: "Delete a task.",
+            userIdentity: "workspace_user_required",
+            executionMode: "durable",
+            defaultStake: "low",
+            bundleCode: "export default async function run() {}",
+            inputSchema: { type: "object" },
+            outputSchema: { type: "object" },
+          },
+        ],
+      },
+      transaction
+    )
+  );
+
+  return frame;
+}
 
 // Mock copyContent from utils/files.ts
 vi.mock("@app/lib/utils/files", () => ({
@@ -1708,5 +1748,43 @@ describe("FileResource", () => {
         await FileModel.count({ where: { workspaceId: otherWorkspace.id } })
       ).toBe(1);
     });
+
+    it("deletes Frames v2 function rows before workspace files", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const frame = await createFrameWithFunction(auth, "workspace-delete");
+      expect(
+        await SandboxFunctionResource.listByFramePublication(auth, {
+          frame,
+          publicationId: "workspace-delete",
+        })
+      ).toHaveLength(1);
+
+      const deletedCount = await FileResource.deleteAllForWorkspace(auth);
+
+      expect(deletedCount).toBe(1);
+      expect(await FileResource.fetchById(auth, frame.sId)).toBeNull();
+    });
+  });
+
+  it("deletes Frames v2 function rows before the Frame file", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+    const frame = await createFrameWithFunction(auth, "frame-delete");
+    expect(
+      await SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: "frame-delete",
+      })
+    ).toHaveLength(1);
+
+    const result = await frame.delete(auth);
+
+    expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
+      true
+    );
+    expect(await FileResource.fetchById(auth, frame.sId)).toBeNull();
   });
 });

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -37,6 +37,7 @@ import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   AuthorizedFileAccessModel,
@@ -45,6 +46,7 @@ import {
   ShareableFileModel,
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
+import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -121,6 +123,7 @@ const FRAME_CONTENT_TYPES = new Set([
 ]);
 
 const BATCH_DESTROY_SIZE = 10_000;
+const FRAME_FUNCTION_DELETE_BATCH_SIZE = 1_000;
 
 export interface FileUploadedRequestResponseBody {
   file: FileType & {
@@ -436,6 +439,8 @@ export class FileResource extends BaseResource<FileModel> {
   static async deleteAllForWorkspace(auth: Authenticator) {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
+    await this.deleteAllFrameFunctionsForWorkspace(workspaceId);
+
     await AuthorizedFileAccessModel.destroy({
       where: { workspaceId },
     });
@@ -500,6 +505,71 @@ export class FileResource extends BaseResource<FileModel> {
     return deletedCount;
   }
 
+  private static async deleteFrameFunctionModelIds(
+    workspaceModelId: ModelId,
+    sandboxFunctionModelIds: ModelId[]
+  ): Promise<number> {
+    if (sandboxFunctionModelIds.length === 0) {
+      return 0;
+    }
+
+    await SandboxFunctionInvocationResource.deleteAllForSandboxFunctionModelIds(
+      { workspaceModelId, sandboxFunctionModelIds }
+    );
+
+    return SandboxFunctionModel.destroy({
+      where: {
+        id: sandboxFunctionModelIds,
+        workspaceId: workspaceModelId,
+      },
+    });
+  }
+
+  private static async deleteAllFrameFunctionsForWorkspace(
+    workspaceModelId: ModelId
+  ): Promise<void> {
+    for (;;) {
+      const sandboxFunctions = await SandboxFunctionModel.findAll({
+        attributes: ["id"],
+        where: {
+          workspaceId: workspaceModelId,
+          publicationId: { [Op.ne]: null },
+        },
+        limit: FRAME_FUNCTION_DELETE_BATCH_SIZE,
+      });
+      if (sandboxFunctions.length === 0) {
+        return;
+      }
+
+      await this.deleteFrameFunctionModelIds(
+        workspaceModelId,
+        sandboxFunctions.map(({ id }) => id)
+      );
+    }
+  }
+
+  private async deleteFrameFunctions(auth: Authenticator): Promise<void> {
+    assert(this.isFrameV2, "Frame function cleanup requires a Frames v2 file.");
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    assert(
+      this.workspaceId === workspaceModelId,
+      "The Frame must belong to the authenticated workspace."
+    );
+
+    const sandboxFunctions = await SandboxFunctionModel.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: workspaceModelId,
+        fileId: this.id,
+        publicationId: { [Op.ne]: null },
+      },
+    });
+    await FileResource.deleteFrameFunctionModelIds(
+      workspaceModelId,
+      sandboxFunctions.map(({ id }) => id)
+    );
+  }
+
   static async deleteAllForUser(
     auth: Authenticator,
     user: UserType,
@@ -534,6 +604,10 @@ export class FileResource extends BaseResource<FileModel> {
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
+      if (this.isFrameV2) {
+        await this.deleteFrameFunctions(auth);
+      }
+
       if (this.isReady) {
         await maybeDeleteCoreArtifactsForIndexedFile(auth, this);
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -12,6 +12,7 @@ import {
   getProcessedContentType,
   hasProcessedVersion,
 } from "@app/lib/api/files/processing";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
 import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import {
   getDefaultFrameShareScope,
@@ -602,7 +603,9 @@ export class FileResource extends BaseResource<FileModel> {
     );
   }
 
-  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+  private async deleteWithoutLock(
+    auth: Authenticator
+  ): Promise<Result<undefined, Error>> {
     try {
       if (this.isFrameV2) {
         await this.deleteFrameFunctions(auth);
@@ -663,6 +666,20 @@ export class FileResource extends BaseResource<FileModel> {
       });
 
       return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+    if (!this.isFrameV2) {
+      return this.deleteWithoutLock(auth);
+    }
+
+    try {
+      return await withFramePublishLock(this.sId, () =>
+        this.deleteWithoutLock(auth)
+      );
     } catch (error) {
       return new Err(normalizeError(error));
     }

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -1335,20 +1335,46 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     sandboxFunction: SandboxFunctionResource,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<number> {
+    return this.deleteAllForSandboxFunctionModelIds(
+      {
+        workspaceModelId: sandboxFunction.workspaceId,
+        sandboxFunctionModelIds: [sandboxFunction.id],
+      },
+      { transaction }
+    );
+  }
+
+  static async deleteAllForSandboxFunctionModelIds(
+    {
+      workspaceModelId,
+      sandboxFunctionModelIds,
+    }: {
+      workspaceModelId: ModelId;
+      sandboxFunctionModelIds: ModelId[];
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<number> {
+    if (sandboxFunctionModelIds.length === 0) {
+      return 0;
+    }
+
     const where = {
-      sandboxFunctionId: sandboxFunction.id,
-      workspaceId: sandboxFunction.workspaceId,
+      sandboxFunctionId: sandboxFunctionModelIds,
+      workspaceId: workspaceModelId,
     };
     const invocations = await this.model.findAll({
-      attributes: ["gcsPath"],
+      attributes: ["id", "gcsPath"],
       where,
       transaction,
     });
     const gcsPaths = invocations.map(({ gcsPath }) => gcsPath);
 
     // MCP actions FK invocations with RESTRICT: delete them (rows + output GCS objects) first.
-    await SandboxFunctionMCPActionResource.deleteAllForSandboxFunction(
-      sandboxFunction,
+    await SandboxFunctionMCPActionResource.deleteAllForInvocationModelIds(
+      {
+        workspaceModelId,
+        invocationModelIds: invocations.map(({ id }) => id),
+      },
       { transaction }
     );
 

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -11,8 +11,6 @@ import {
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
-import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { SandboxFunctionMCPActionModel } from "@app/lib/resources/storage/models/sandbox_function_mcp_action";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -483,29 +481,24 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
     );
   }
 
-  static async deleteAllForSandboxFunction(
-    sandboxFunction: SandboxFunctionResource,
+  static async deleteAllForInvocationModelIds(
+    {
+      workspaceModelId,
+      invocationModelIds,
+    }: {
+      workspaceModelId: ModelId;
+      invocationModelIds: ModelId[];
+    },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<number> {
-    const invocationIds = (
-      await SandboxFunctionInvocationModel.findAll({
-        attributes: ["id"],
-        where: {
-          sandboxFunctionId: sandboxFunction.id,
-          workspaceId: sandboxFunction.workspaceId,
-        },
-        transaction,
-      })
-    ).map((invocation) => invocation.id);
-
-    if (invocationIds.length === 0) {
+    if (invocationModelIds.length === 0) {
       return 0;
     }
 
     return this.deleteAllWithOutputs(
       {
-        workspaceId: sandboxFunction.workspaceId,
-        sandboxFunctionInvocationId: invocationIds,
+        workspaceId: workspaceModelId,
+        sandboxFunctionInvocationId: invocationModelIds,
       },
       { transaction }
     );

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -56,6 +56,17 @@ import type { Attributes, Transaction } from "sequelize";
 export interface SandboxFunctionResource
   extends ReadonlyAttributesType<SandboxFunctionModel> {}
 
+export interface FramePublicationFunctionDefinition {
+  name: string;
+  description: string;
+  userIdentity: SandboxFunctionUserIdentityPolicy;
+  executionMode: SandboxFunctionExecutionMode;
+  defaultStake: SandboxFunctionStake;
+  bundleCode: string;
+  inputSchema: JSONSchema;
+  outputSchema: JSONSchema;
+}
+
 export const SANDBOX_FUNCTION_PUBLISH_LOCK_TTL_MS = 5 * 60_000;
 
 /**
@@ -112,18 +123,29 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static model: ModelStaticWorkspaceAware<SandboxFunctionModel> =
     SandboxFunctionModel;
 
-  readonly space: SpaceResource;
+  private readonly ownerSpace: SpaceResource | null;
   file: FileResource;
 
   constructor(
     model: ModelStaticWorkspaceAware<SandboxFunctionModel>,
     blob: Attributes<SandboxFunctionModel>,
-    space: SpaceResource,
+    space: SpaceResource | null,
     file: FileResource
   ) {
     super(model, blob);
-    this.space = space;
+    this.ownerSpace = space;
     this.file = file;
+  }
+
+  get space(): SpaceResource {
+    assert(this.ownerSpace, "Frame functions do not belong to a Pod space.");
+    return this.ownerSpace;
+  }
+
+  get frame(): FileResource | null {
+    return this.publicationId !== null && this.file.isFrameV2
+      ? this.file
+      : null;
   }
 
   get sId(): string {
@@ -214,6 +236,45 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
 
     return new this(this.model, sandboxFunction.get(), space, file);
+  }
+
+  static async createForFramePublication(
+    auth: Authenticator,
+    {
+      frame,
+      functions,
+      publicationId,
+    }: {
+      frame: FileResource;
+      functions: FramePublicationFunctionDefinition[];
+      publicationId: string;
+    },
+    transaction: Transaction
+  ): Promise<void> {
+    const owner = auth.getNonNullableWorkspace();
+    assert(frame.isFrameV2, "Frame functions require a Frames v2 file.");
+    assert(
+      frame.workspaceId === owner.id,
+      "The Frame must belong to the authenticated workspace."
+    );
+
+    await this.model.bulkCreate(
+      functions.map((fn) => ({
+        workspaceId: owner.id,
+        spaceId: null,
+        fileId: frame.id,
+        publicationId,
+        slug: fn.name,
+        description: fn.description,
+        userIdentity: fn.userIdentity,
+        executionMode: fn.executionMode,
+        defaultStake: fn.defaultStake,
+        bundleSha256: computeSandboxFunctionBundleSha256(fn.bundleCode),
+        inputSchema: fn.inputSchema,
+        outputSchema: fn.outputSchema,
+      })),
+      { transaction, validate: true }
+    );
   }
 
   /**
@@ -324,10 +385,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     {
       includeDeletedSpace,
+      includeFrameFunctions = false,
       dangerouslyBypassSpacePermissionFilter = false,
       ...options
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
+      includeFrameFunctions?: boolean;
       // Reserved for resolution paths whose authorization is established before the fetch:
       // fetchByIdForExecution and the tool workflow (an invocation row), and fetchInAppFolder
       // (a validated frame share capability, enforced by its own query constraints).
@@ -382,7 +445,16 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
       if (blob.spaceId === null) {
-        return [];
+        const file = filesById.get(blob.fileId);
+        if (
+          !includeFrameFunctions ||
+          blob.publicationId === null ||
+          !file?.isFrameV2
+        ) {
+          return [];
+        }
+
+        return [new this(this.model, blob, null, file)];
       }
 
       const space =
@@ -501,6 +573,40 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
 
     return this.baseFetch(auth, { where: { spaceId: space.id } });
+  }
+
+  static async listByFramePublication(
+    auth: Authenticator,
+    { frame, publicationId }: { frame: FileResource; publicationId: string }
+  ): Promise<SandboxFunctionResource[]> {
+    if (!frame.isFrameV2) {
+      return [];
+    }
+
+    return this.baseFetch(auth, {
+      where: { fileId: frame.id, publicationId },
+      includeFrameFunctions: true,
+    });
+  }
+
+  static async fetchByFramePublicationAndSlug(
+    auth: Authenticator,
+    {
+      frame,
+      publicationId,
+      slug,
+    }: { frame: FileResource; publicationId: string; slug: string }
+  ): Promise<SandboxFunctionResource | null> {
+    if (!frame.isFrameV2 || !isValidSandboxFunctionSlug(slug)) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { fileId: frame.id, publicationId, slug },
+      includeFrameFunctions: true,
+    });
+
+    return sandboxFunction ?? null;
   }
 
   static async fetchBySpaceAndSlug(

--- a/front/tests/utils/mocks/redis.ts
+++ b/front/tests/utils/mocks/redis.ts
@@ -100,14 +100,16 @@ class RedisMock {
         async (
           key: string,
           value: string,
-          opts?: { EX?: number; PX?: number }
+          opts?: { EX?: number; NX?: boolean; PX?: number }
         ) => {
-          // The "OK" return matters: distributedLock treats anything else as acquisition failure,
-          // and a mock that returns undefined spins executeWithLock's acquire loop until its 30s
-          // timeout in every suite that takes a lock. NX is deliberately NOT enforced: tests run
-          // sequentially, so mutual exclusion never needs to hold, and enforcing it would break
-          // consumers that legitimately re-set a live key (and require the unlock Lua script to
-          // really delete).
+          const existing = this.stringStore.get(key);
+          if (
+            opts?.NX &&
+            existing &&
+            (existing.expiresAtMs === 0 || existing.expiresAtMs > Date.now())
+          ) {
+            return null;
+          }
           const expiresAtMs = opts?.EX
             ? Date.now() + opts.EX * 1000
             : opts?.PX
@@ -152,7 +154,23 @@ class RedisMock {
       subscribe: vi.fn().mockResolvedValue(undefined),
       unsubscribe: vi.fn().mockResolvedValue(undefined),
       ping: vi.fn().mockResolvedValue("PONG"),
-      eval: vi.fn().mockResolvedValue(1),
+      eval: vi.fn(
+        async (
+          script: string,
+          { keys, arguments: args }: { keys: string[]; arguments: string[] }
+        ) => {
+          if (!script.includes('redis.call("del", KEYS[1])')) {
+            return 1;
+          }
+          const [key] = keys;
+          const [expectedValue] = args;
+          if (key && this.stringStore.get(key)?.value === expectedValue) {
+            this.stringStore.delete(key);
+            return 1;
+          }
+          return 0;
+        }
+      ),
       exists: vi.fn(async (key: string) => {
         const entry = this.stringStore.get(key);
         if (!entry) {


### PR DESCRIPTION
## Description

Materialize one immutable sandbox function row per Frames v2 publication function. Activation updates the function set, authorized-file snapshot, and active publication pointer in one transaction under the Frame publish lock.

Frame deletion and workspace scrub now remove Frame-owned function invocations, actions, and rows before deleting the owning file.

Stacked on #31382.

## Tests

Added coverage for function materialization, transactional rollback, direct Frame deletion, and workspace scrub. Ran the focused publication, sharing allowlist, FileResource, Sandbox Function, invocation, action, and build/publish suites locally.

## Risk

Activation depends on valid stored function contracts. A failed activation leaves the prior publication and allowlist active. Frame-owned cleanup is batched for workspace scrub.

## Deploy Plan

Merge after #31382, then standard deploy.