### PR TITLE
Document cloud login URL and disable Chrome password manager in the agent env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,28 @@ properties through documentation or example stories before using them.
 
 # Cursor Cloud specific instructions
 
+## Logging in
+
 You are provided with credentials to login to the app via email & password.
 They are available in the runtime secrets as DEV_WORKOS_USER_EMAIL & DEV_WORKOS_USER_PASSWORD.
-Note that in the login flow, you'll have to enter the email, continue and then you'll be able to enter the password.
+
+The app entry point is `http://localhost:3011` (front-spa). Open that URL with no path.
+There is no `/login` route. Unauthenticated visits to `/` call `useAuthContext`; a
+`not_authenticated` response redirects the browser to
+`http://localhost:3000/api/workos/login`, which then sends you to the WorkOS AuthKit
+sign-in page. Enter the email, continue, then enter the password.
+
+`front-spa` is a Vite SPA: every path returns HTTP 200 with the same HTML shell.
+`curl` status codes cannot tell you whether a client route exists. `/login` falls through
+to the React catch-all and renders a 404 page. Do not type `/login` in the address bar.
+
+Chrome's omnibox will autocomplete previously typed URLs (including `/login`) from history.
+Paste the full URL, or use a cookie-less check (incognito / Playwright) when verifying
+unauthenticated redirects. Do not trust an address-bar navigation that may have been
+completed from history.
+
+`dev/scripts/infra.sh` installs Chrome managed policies from
+`dev/config/chrome-policies.json` into `/etc/opt/chrome/policies/managed/` (password
+manager, autofill, search suggest, and saving browser history disabled). Those policies
+are read when Chrome starts, so they apply to new agent sessions after this start script
+is what the pod runs — not to a Chrome process that is already running.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,14 +41,3 @@ sign-in page. Enter the email, continue, then enter the password.
 `front-spa` is a Vite SPA: every path returns HTTP 200 with the same HTML shell.
 `curl` status codes cannot tell you whether a client route exists. `/login` falls through
 to the React catch-all and renders a 404 page. Do not type `/login` in the address bar.
-
-Chrome's omnibox will autocomplete previously typed URLs (including `/login`) from history.
-Paste the full URL, or use a cookie-less check (incognito / Playwright) when verifying
-unauthenticated redirects. Do not trust an address-bar navigation that may have been
-completed from history.
-
-`dev/scripts/infra.sh` installs Chrome managed policies from
-`dev/config/chrome-policies.json` into `/etc/opt/chrome/policies/managed/` (password
-manager, autofill, search suggest, and saving browser history disabled). Those policies
-are read when Chrome starts, so they apply to new agent sessions after this start script
-is what the pod runs — not to a Chrome process that is already running.

--- a/dev/README.md
+++ b/dev/README.md
@@ -22,7 +22,7 @@ bash dev/scripts/docker-run.sh --shell
 | Script | Role |
 |--------|------|
 | `install.sh` | `npm install` + lefthook |
-| `infra.sh` | Postgres/Redis/Qdrant/ES/Temporal + materialize 1Password + migrations |
+| `infra.sh` | Postgres/Redis/Qdrant/ES/Temporal + Chrome managed policies + materialize 1Password + migrations |
 | `apps.sh` | Wait for infra, optional WorkOS seed, mprocs |
 | `up.sh` | `install?` → `infra` → `apps` (serial entry for laptop / non-Cursor agents) |
 | `refresh-op-env.sh` | Re-fetch 1Password Environment into `/tmp` for all shells |

--- a/dev/config/chrome-policies.json
+++ b/dev/config/chrome-policies.json
@@ -1,0 +1,8 @@
+{
+  "PasswordManagerEnabled": false,
+  "PasswordLeakDetectionEnabled": false,
+  "AutofillAddressEnabled": false,
+  "AutofillCreditCardEnabled": false,
+  "SearchSuggestEnabled": false,
+  "SavingBrowserHistoryDisabled": true
+}

--- a/dev/scripts/common.sh
+++ b/dev/scripts/common.sh
@@ -20,6 +20,20 @@ install_mprocs_config() {
   fi
 }
 
+# Chrome in Cursor Cloud is launched by computer-use, not by our Dockerfile.
+# Managed policies are the supported Linux way to disable the password manager
+# and history-based omnibox suggestions (see AGENTS.md).
+install_chrome_policies() {
+  local src="${DUST_REPO_ROOT}/dev/config/chrome-policies.json"
+  local dest_dir="/etc/opt/chrome/policies/managed"
+  if [ ! -f "$src" ]; then
+    return 0
+  fi
+  mkdir -p "$dest_dir"
+  cp "$src" "${dest_dir}/dust-cloud.json"
+  chmod 644 "${dest_dir}/dust-cloud.json"
+}
+
 ensure_node_path() {
   if command -v node >/dev/null 2>&1; then
     return 0

--- a/dev/scripts/infra.sh
+++ b/dev/scripts/infra.sh
@@ -11,6 +11,7 @@ source "${SCRIPT_DIR}/common.sh"
 source "${SCRIPT_DIR}/env.sh"
 
 install_mprocs_config
+install_chrome_policies
 rm -f "${DUST_INFRA_LOG_DIR}/infra.ready"
 
 ensure_node_path


### PR DESCRIPTION
## Description

Documents the Cursor Cloud login entry point as `http://localhost:3011`, explains the `/` → WorkOS AuthKit redirect, and warns against `/login` history/autocomplete in `front-spa`. Adds `install_chrome_policies` to `dev/scripts/infra.sh` to install managed Chrome policies that disable password saving, autofill, search suggestions, and browser history for new agent sessions.

## Tests

- Ran `bash -n` on `dev/scripts/common.sh` and `dev/scripts/infra.sh`.
- Validated `dev/config/chrome-policies.json`.
- Verified the unauthenticated redirect with Playwright without cookies.
- Installed the policies and verified them as Mandatory / Machine / OK in `chrome://policy` with a fresh Chrome profile.

## Risk

Low. The change only affects Cursor Cloud guidance and development-agent startup. Chrome reads the policies when it starts, so existing processes and existing profile history remain unchanged.

## Deploy Plan

No production deploy. Rebuild or publish the cloud-agent environment so new pods run the updated `dev/scripts/infra.sh`; restart Chrome sessions to load the managed policies.