### PR TITLE
Add Frame-owned sandbox lifecycle

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -370,6 +370,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "credits. Rows may overlap, so don't sum them for a workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top consumers",
       done: "Retrieved top consumers",

--- a/front/lib/api/sandbox/env_manifest.test.ts
+++ b/front/lib/api/sandbox/env_manifest.test.ts
@@ -149,6 +149,31 @@ describe("sandbox environment manifest", () => {
     ]);
   });
 
+  it("identifies Frame sandbox manifests with FRAME_ID", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const manifestResult = await buildSandboxEnvManifest(authenticator, {
+      kind: "frame",
+      frameId: "frame-id",
+      spaceId: null,
+    });
+
+    expect(manifestResult.isOk()).toBe(true);
+    if (manifestResult.isErr()) {
+      throw manifestResult.error;
+    }
+    expect(manifestResult.value.system).toEqual([
+      {
+        name: "FRAME_ID",
+        description: "current Frame sId",
+      },
+      {
+        name: "WORKSPACE_ID",
+        description: "current workspace sId",
+      },
+    ]);
+  });
+
   it("lists pod vars (pod wins on collision) for sandboxes running in a pod", async () => {
     const { authenticator, workspace, user } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/sandbox/owner.ts
+++ b/front/lib/api/sandbox/owner.ts
@@ -23,6 +23,9 @@ export async function resolvePodForRuntimeOwner(
   auth: Authenticator,
   owner: SandboxRuntimeOwner
 ): Promise<Result<SpaceResource | null, Error>> {
+  // SpaceResource.fetchById is workspace-scoped but intentionally does not
+  // permission-filter. Runtime configuration belongs to the owner and must
+  // not vary with the caller who triggered execution.
   switch (owner.kind) {
     case "conversation": {
       if (!owner.spaceId) {

--- a/front/lib/api/sandbox/owner.ts
+++ b/front/lib/api/sandbox/owner.ts
@@ -10,6 +10,7 @@ export type SandboxRuntimeOwner =
   // HTTPS secrets — applies to every Computer running in the Pod, so
   // conversation-owned sandboxes carry their pod alongside pod-owned ones.
   | { kind: "conversation"; conversationId: string; spaceId: string | null }
+  | { kind: "frame"; frameId: string; spaceId: string | null }
   | { kind: "pod"; spaceId: string };
 
 // Resolves the pod a sandbox runs in, if any. Pod-level config (env vars,
@@ -24,6 +25,14 @@ export async function resolvePodForRuntimeOwner(
 ): Promise<Result<SpaceResource | null, Error>> {
   switch (owner.kind) {
     case "conversation": {
+      if (!owner.spaceId) {
+        return new Ok(null);
+      }
+      const pod = await SpaceResource.fetchById(auth, owner.spaceId);
+      return new Ok(pod?.isProject() ? pod : null);
+    }
+
+    case "frame": {
       if (!owner.spaceId) {
         return new Ok(null);
       }
@@ -53,6 +62,9 @@ export function getSandboxOwnerEnvVars(
     case "conversation":
       return { CONVERSATION_ID: owner.conversationId };
 
+    case "frame":
+      return { FRAME_ID: owner.frameId };
+
     case "pod":
       return { SPACE_ID: owner.spaceId };
 
@@ -67,6 +79,9 @@ export function getSandboxOwnerLogContext(
   switch (owner.kind) {
     case "conversation":
       return { conversationId: owner.conversationId };
+
+    case "frame":
+      return { frameId: owner.frameId };
 
     case "pod":
       return { spaceId: owner.spaceId };
@@ -85,6 +100,14 @@ export function getSandboxOwnerEnvManifestEntries(
         {
           name: "CONVERSATION_ID",
           description: "current conversation sId",
+        },
+      ];
+
+    case "frame":
+      return [
+        {
+          name: "FRAME_ID",
+          description: "current Frame sId",
         },
       ];
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -38,6 +38,7 @@ import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
@@ -195,6 +196,25 @@ export class FileResource extends BaseResource<FileModel> {
     });
 
     return blobs.map((blob) => new this(this.model, blob.get()));
+  }
+
+  /** Cross-workspace lookup for the sandbox reaper only. */
+  static async dangerouslyFetchFrameV2ByModelIds(
+    ids: ModelId[]
+  ): Promise<FileResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const frames = await this.model.findAll({
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified: the sandbox reaper operates across workspaces and the ids come from workspace-scoped owner links.
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      where: {
+        contentType: frameV2ContentType,
+        id: { [Op.in]: ids },
+      },
+    });
+    return frames.map((frame) => new this(this.model, frame.get()));
   }
 
   static override async fetchByModelId(
@@ -440,6 +460,7 @@ export class FileResource extends BaseResource<FileModel> {
   static async deleteAllForWorkspace(auth: Authenticator) {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
+    await FrameSandboxAdapter.deleteAllForWorkspace(auth);
     await this.deleteAllFrameFunctionsForWorkspace(workspaceId);
 
     await AuthorizedFileAccessModel.destroy({
@@ -608,6 +629,13 @@ export class FileResource extends BaseResource<FileModel> {
   ): Promise<Result<undefined, Error>> {
     try {
       if (this.isFrameV2) {
+        const sandboxResult = await FrameSandboxAdapter.deleteSandbox(
+          auth,
+          this
+        );
+        if (sandboxResult.isErr()) {
+          throw sandboxResult.error;
+        }
         await this.deleteFrameFunctions(auth);
       }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -256,6 +256,12 @@ export class FileResource extends BaseResource<FileModel> {
     return file ?? null;
   }
 
+  /** Re-fetch this stable identity and keep only a Frames v2 resource. */
+  async fetchFreshFrameV2(auth: Authenticator): Promise<FileResource | null> {
+    const fresh = await FileResource.fetchByModelIdWithAuth(auth, this.id);
+    return fresh?.isFrameV2 ? fresh : null;
+  }
+
   static async fetchByShareTokenWithContent(token: string): Promise<{
     file: FileResource;
     content: string;

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -630,18 +630,11 @@ export class FileResource extends BaseResource<FileModel> {
     );
   }
 
-  private async deleteWithoutLock(
+  private async deleteAfterSandboxCleanup(
     auth: Authenticator
   ): Promise<Result<undefined, Error>> {
     try {
       if (this.isFrameV2) {
-        const sandboxResult = await FrameSandboxAdapter.deleteSandbox(
-          auth,
-          this
-        );
-        if (sandboxResult.isErr()) {
-          throw sandboxResult.error;
-        }
         await this.deleteFrameFunctions(auth);
       }
 
@@ -707,12 +700,14 @@ export class FileResource extends BaseResource<FileModel> {
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     if (!this.isFrameV2) {
-      return this.deleteWithoutLock(auth);
+      return this.deleteAfterSandboxCleanup(auth);
     }
 
     try {
       return await withFramePublishLock(this.sId, () =>
-        this.deleteWithoutLock(auth)
+        FrameSandboxAdapter.deleteSandbox(auth, this, {
+          afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
+        })
       );
     } catch (error) {
       return new Err(normalizeError(error));

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -35,14 +35,12 @@ vi.mock("@app/lib/lock", () => ({
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
-import {
-  SandboxModel,
-  SandboxOwnerModel,
-} from "@app/lib/resources/storage/models/sandbox";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { frameV2ContentType } from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 
 describe("FrameSandboxAdapter", () => {
@@ -118,14 +116,7 @@ describe("FrameSandboxAdapter", () => {
     expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
       "SPACE_ID"
     );
-    expect(
-      await SandboxOwnerModel.count({
-        where: {
-          frameFileModelId: frame.id,
-          workspaceId: workspace.id,
-        },
-      })
-    ).toBe(1);
+    expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).not.toBeNull();
   });
 
   it("deletes the owned sandbox before deleting the Frame", async () => {
@@ -148,6 +139,7 @@ describe("FrameSandboxAdapter", () => {
     if (sandboxResult.isErr()) {
       throw sandboxResult.error;
     }
+    const sandboxModelId = sandboxResult.value.sandbox.id;
 
     const deleteResult = await frame.delete(auth);
 
@@ -158,14 +150,10 @@ describe("FrameSandboxAdapter", () => {
     expect(mockProviderDestroy).toHaveBeenCalledWith("frame-provider", {
       workspaceId: workspace.sId,
     });
+    expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
     expect(
-      await SandboxOwnerModel.count({
-        where: { workspaceId: workspace.id },
-      })
-    ).toBe(0);
-    expect(
-      await SandboxModel.count({ where: { workspaceId: workspace.id } })
-    ).toBe(0);
+      await SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)
+    ).toBeNull();
   });
 
   it("deletes Frame sandboxes during a workspace scrub", async () => {
@@ -173,34 +161,40 @@ describe("FrameSandboxAdapter", () => {
       role: "admin",
     });
     const pod = await SpaceFactory.project(workspace);
-    const frame = await FileFactory.create(auth, null, {
-      contentType: frameV2ContentType,
-      fileName: "manifest.json",
-      fileSize: 1,
-      status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: pod.sId },
-    });
-    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
-      auth,
-      frame
+    const frames = await Promise.all(
+      ["first", "second"].map((name) =>
+        FileFactory.create(auth, null, {
+          contentType: frameV2ContentType,
+          fileName: `${name}/manifest.json`,
+          fileSize: 1,
+          status: "created",
+          useCase: "project_context",
+          useCaseMetadata: { spaceId: pod.sId },
+        })
+      )
     );
-    if (sandboxResult.isErr()) {
-      throw sandboxResult.error;
+    const sandboxModelIds: ModelId[] = [];
+    for (const frame of frames) {
+      const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+        auth,
+        frame
+      );
+      if (sandboxResult.isErr()) {
+        throw sandboxResult.error;
+      }
+      sandboxModelIds.push(sandboxResult.value.sandbox.id);
     }
 
     await FileResource.deleteAllForWorkspace(auth);
 
-    expect(mockProviderDestroy).toHaveBeenCalledWith("frame-provider", {
-      workspaceId: workspace.sId,
-    });
-    expect(
-      await SandboxOwnerModel.count({
-        where: { workspaceId: workspace.id },
-      })
-    ).toBe(0);
-    expect(
-      await SandboxModel.count({ where: { workspaceId: workspace.id } })
-    ).toBe(0);
+    expect(mockProviderDestroy).toHaveBeenCalledTimes(2);
+    for (const frame of frames) {
+      expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
+    }
+    for (const sandboxModelId of sandboxModelIds) {
+      expect(
+        await SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)
+      ).toBeNull();
+    }
   });
 });

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockExecuteWithLock,
+  mockGetSandboxImage,
+  mockGetSandboxProvider,
+  mockProviderCreate,
+  mockProviderDestroy,
+  mockRevokeAllExecTokensForSandbox,
+} = vi.hoisted(() => ({
+  mockExecuteWithLock: vi.fn(),
+  mockGetSandboxImage: vi.fn(),
+  mockGetSandboxProvider: vi.fn(),
+  mockProviderCreate: vi.fn(),
+  mockProviderDestroy: vi.fn(),
+  mockRevokeAllExecTokensForSandbox: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/sandbox", () => ({
+  getSandboxProvider: mockGetSandboxProvider,
+}));
+
+vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
+  revokeAllExecTokensForSandbox: mockRevokeAllExecTokensForSandbox,
+}));
+
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: mockExecuteWithLock,
+}));
+
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import {
+  SandboxModel,
+  SandboxOwnerModel,
+} from "@app/lib/resources/storage/models/sandbox";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+
+describe("FrameSandboxAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { imageName: "test-image", tag: "0.0.1" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockProviderCreate.mockResolvedValue(
+      new Ok({ providerId: "frame-provider" })
+    );
+    mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockGetSandboxProvider.mockReturnValue({
+      create: mockProviderCreate,
+      destroy: mockProviderDestroy,
+    });
+    mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+  });
+
+  it("owns one sandbox per stable Frame identity", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const podEnvResult = await SandboxEnvVarResource.makeNew(
+      auth,
+      { kind: "pod", pod },
+      { name: "RUNTIME_TOKEN", value: "pod-value" }
+    );
+    expect(podEnvResult.isOk()).toBe(true);
+
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+
+    const first = await FrameSandboxAdapter.ensureSandboxActive(auth, frame);
+    const second = await FrameSandboxAdapter.ensureSandboxActive(auth, frame);
+    if (first.isErr()) {
+      throw first.error;
+    }
+    if (second.isErr()) {
+      throw second.error;
+    }
+
+    expect(first.value.scope).toEqual({ spaceId: pod.sId });
+    expect(second.value.sandbox.id).toBe(first.value.sandbox.id);
+    expect(mockProviderCreate).toHaveBeenCalledTimes(1);
+    expect(mockProviderCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          DST_RUNTIME_TOKEN: "pod-value",
+          FRAME_ID: frame.sId,
+          WORKSPACE_ID: workspace.sId,
+        }),
+      }),
+      { workspaceId: workspace.sId }
+    );
+    expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
+      "SPACE_ID"
+    );
+    expect(
+      await SandboxOwnerModel.count({
+        where: {
+          frameFileModelId: frame.id,
+          workspaceId: workspace.id,
+        },
+      })
+    ).toBe(1);
+  });
+
+  it("deletes the owned sandbox before deleting the Frame", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+
+    const deleteResult = await frame.delete(auth);
+
+    expect(
+      deleteResult.isOk(),
+      deleteResult.isErr() ? deleteResult.error.message : ""
+    ).toBe(true);
+    expect(mockProviderDestroy).toHaveBeenCalledWith("frame-provider", {
+      workspaceId: workspace.sId,
+    });
+    expect(
+      await SandboxOwnerModel.count({
+        where: { workspaceId: workspace.id },
+      })
+    ).toBe(0);
+    expect(
+      await SandboxModel.count({ where: { workspaceId: workspace.id } })
+    ).toBe(0);
+  });
+
+  it("deletes Frame sandboxes during a workspace scrub", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+
+    await FileResource.deleteAllForWorkspace(auth);
+
+    expect(mockProviderDestroy).toHaveBeenCalledWith("frame-provider", {
+      workspaceId: workspace.sId,
+    });
+    expect(
+      await SandboxOwnerModel.count({
+        where: { workspaceId: workspace.id },
+      })
+    ).toBe(0);
+    expect(
+      await SandboxModel.count({ where: { workspaceId: workspace.id } })
+    ).toBe(0);
+  });
+});

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -33,9 +33,15 @@ vi.mock("@app/lib/lock", () => ({
 }));
 
 import { FileResource } from "@app/lib/resources/file_resource";
-import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import {
+  FrameGoneError,
+  FrameSandboxAdapter,
+} from "@app/lib/resources/frame_sandbox_adapter";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -43,11 +49,44 @@ import { frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 
+function createDeferred() {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) {
+    throw new Error("Deferred promise resolver was not initialized.");
+  }
+
+  return { promise, resolve: resolvePromise };
+}
+
 describe("FrameSandboxAdapter", () => {
+  const lockTails = new Map<string, Promise<void>>();
+
   beforeEach(() => {
     vi.clearAllMocks();
+    lockTails.clear();
     mockExecuteWithLock.mockImplementation(
-      async (_key: string, fn: () => Promise<unknown>) => fn()
+      async (key: string, fn: () => Promise<unknown>) => {
+        const previous = lockTails.get(key) ?? Promise.resolve();
+        let release: (() => void) | undefined;
+        const current = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const tail = previous.then(() => current);
+        lockTails.set(key, tail);
+
+        await previous;
+        try {
+          return await fn();
+        } finally {
+          release?.();
+          if (lockTails.get(key) === tail) {
+            lockTails.delete(key);
+          }
+        }
+      }
     );
     mockGetSandboxImage.mockReturnValue(
       new Ok({
@@ -154,6 +193,109 @@ describe("FrameSandboxAdapter", () => {
     expect(
       await SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)
     ).toBeNull();
+  });
+
+  it("keeps sandbox creation blocked until Frame deletion completes", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+    await withTransaction((transaction) =>
+      SandboxFunctionResource.createForFramePublication(
+        auth,
+        {
+          frame,
+          publicationId: "frame-delete-race",
+          functions: [
+            {
+              name: "delete-task",
+              description: "Delete a task.",
+              userIdentity: "workspace_user_required",
+              executionMode: "durable",
+              defaultStake: "low",
+              bundleCode: "export default async function run() {}",
+              inputSchema: { type: "object" },
+              outputSchema: { type: "object" },
+            },
+          ],
+        },
+        transaction
+      )
+    );
+
+    const deletionReachedFunctionCleanup = createDeferred();
+    const releaseFunctionCleanup = createDeferred();
+    const deleteInvocations =
+      SandboxFunctionInvocationResource.deleteAllForSandboxFunctionModelIds.bind(
+        SandboxFunctionInvocationResource
+      );
+    const deleteInvocationsSpy = vi
+      .spyOn(
+        SandboxFunctionInvocationResource,
+        "deleteAllForSandboxFunctionModelIds"
+      )
+      .mockImplementation(async (...args) => {
+        deletionReachedFunctionCleanup.resolve();
+        await releaseFunctionCleanup.promise;
+        return deleteInvocations(...args);
+      });
+
+    try {
+      mockExecuteWithLock.mockClear();
+      const deletionPromise = frame.delete(auth);
+      await deletionReachedFunctionCleanup.promise;
+      expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
+
+      const ensurePromise = FrameSandboxAdapter.ensureSandboxActive(
+        auth,
+        frame
+      );
+      const lifecycleLockKey = `sandbox:lifecycle:${frame.sId}`;
+      await vi.waitFor(() => {
+        expect(
+          mockExecuteWithLock.mock.calls.filter(
+            ([key]) => key === lifecycleLockKey
+          )
+        ).toHaveLength(2);
+      });
+      expect(mockProviderCreate).toHaveBeenCalledTimes(1);
+
+      releaseFunctionCleanup.resolve();
+      const [deletionResult, ensureResult] = await Promise.all([
+        deletionPromise,
+        ensurePromise,
+      ]);
+
+      expect(
+        deletionResult.isOk(),
+        deletionResult.isErr() ? deletionResult.error.message : ""
+      ).toBe(true);
+      expect(ensureResult.isErr()).toBe(true);
+      if (ensureResult.isErr()) {
+        expect(ensureResult.error).toBeInstanceOf(FrameGoneError);
+      }
+      expect(await FileResource.fetchById(auth, frame.sId)).toBeNull();
+      expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
+      expect(mockProviderCreate).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseFunctionCleanup.resolve();
+      deleteInvocationsSpy.mockRestore();
+    }
   });
 
   it("deletes Frame sandboxes during a workspace scrub", async () => {

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -221,11 +221,17 @@ export class FrameSandboxAdapter {
 
   static async deleteSandbox(
     auth: Authenticator,
-    frame: FrameSandboxOwner
-  ): Promise<Result<void, Error>> {
+    frame: FrameSandboxOwner,
+    {
+      afterSandboxCleanup,
+    }: {
+      afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+    } = {}
+  ): Promise<Result<undefined, Error>> {
     return SandboxResource.deleteByOwner(
       auth,
-      this.toSandboxDeleteOwner(auth, frame)
+      this.toSandboxDeleteOwner(auth, frame),
+      { afterSandboxCleanup }
     );
   }
 

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -10,12 +10,9 @@ import type {
   SandboxLifecycleOwner,
 } from "@app/lib/resources/sandbox_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import { FileModel } from "@app/lib/resources/storage/models/files";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
-import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -24,12 +21,15 @@ import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 const SANDBOX_OWNER_LOOKUP_CONCURRENCY = 4;
-const SANDBOX_OWNER_DELETE_CONCURRENCY = 4;
+const FRAME_SANDBOX_WORKSPACE_DELETE_BATCH_SIZE = 1024;
 
 export type FrameSandboxOwner = Pick<
   FileResource,
   "id" | "sId" | "workspaceId"
 >;
+
+type FrameSandboxScopeOwner = FrameSandboxOwner &
+  Pick<FileResource, "fetchFreshFrameV2">;
 
 export type FrameSandboxScope = {
   spaceId: string | null;
@@ -98,17 +98,11 @@ export class FrameSandboxAdapter {
 
   private static async resolveScope(
     auth: Authenticator,
-    frame: FrameSandboxOwner
+    frame: FrameSandboxScopeOwner
   ): Promise<Result<FrameSandboxScope, Error>> {
     this.assertWorkspace(auth, frame);
 
-    const freshFrame = await FileModel.findOne({
-      where: {
-        contentType: frameV2ContentType,
-        id: frame.id,
-        workspaceId: frame.workspaceId,
-      },
-    });
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
     if (!freshFrame) {
       return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
     }
@@ -212,7 +206,7 @@ export class FrameSandboxAdapter {
 
   static async ensureSandboxActive(
     auth: Authenticator,
-    frame: FrameSandboxOwner
+    frame: FrameSandboxScopeOwner
   ): Promise<Result<EnsureSandboxResult<FrameSandboxScope>, Error>> {
     return SandboxResource.ensureActive(auth, {
       lockKey: this.lockKey(frame),
@@ -239,36 +233,38 @@ export class FrameSandboxAdapter {
     const workspaceModelId = auth.getNonNullableWorkspace().id;
     for (;;) {
       const links = await SandboxOwnerModel.findAll({
-        attributes: ["frameFileModelId"],
+        attributes: ["sandboxId"],
         where: {
           frameFileModelId: { [Op.ne]: null },
           workspaceId: workspaceModelId,
         },
-        limit: 1000,
+        limit: FRAME_SANDBOX_WORKSPACE_DELETE_BATCH_SIZE,
       });
       if (links.length === 0) {
         return;
       }
 
-      await concurrentExecutor(
-        links,
-        async (link) => {
-          assert(link.frameFileModelId !== null);
-          const frame: FrameSandboxOwner = {
-            id: link.frameFileModelId,
-            sId: makeSId("file", {
-              id: link.frameFileModelId,
-              workspaceId: workspaceModelId,
-            }),
-            workspaceId: workspaceModelId,
-          };
-          const result = await this.deleteSandbox(auth, frame);
-          if (result.isErr()) {
-            throw result.error;
-          }
-        },
-        { concurrency: SANDBOX_OWNER_DELETE_CONCURRENCY }
+      const sandboxModelIds = links.map((link) => link.sandboxId);
+      const sandboxes = await SandboxResource.fetchByModelIdsForWorkspace(
+        auth,
+        sandboxModelIds
       );
+      const result = await SandboxResource.deleteBatchForWorkspaceScrub(auth, {
+        sandboxes,
+        deleteOwnerLinks: async (transaction) => {
+          await SandboxOwnerModel.destroy({
+            where: {
+              frameFileModelId: { [Op.ne]: null },
+              sandboxId: { [Op.in]: sandboxModelIds },
+              workspaceId: workspaceModelId,
+            },
+            transaction,
+          });
+        },
+      });
+      if (result.isErr()) {
+        throw result.error;
+      }
     }
   }
 

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -1,0 +1,357 @@
+import { resolvePodForRuntimeOwner } from "@app/lib/api/sandbox/owner";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import type {
+  EnsureSandboxResult,
+  SandboxCreateBlob,
+  SandboxDeleteOwner,
+  SandboxLifecycleOwner,
+} from "@app/lib/resources/sandbox_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { frameV2ContentType } from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+const SANDBOX_OWNER_LOOKUP_CONCURRENCY = 4;
+const SANDBOX_OWNER_DELETE_CONCURRENCY = 4;
+
+export type FrameSandboxOwner = Pick<
+  FileResource,
+  "id" | "sId" | "workspaceId"
+>;
+
+export type FrameSandboxScope = {
+  spaceId: string | null;
+};
+
+export class FrameGoneError extends Error {}
+
+export class FrameSandboxAdapter {
+  private static assertWorkspace(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): void {
+    assert(
+      frame.workspaceId === auth.getNonNullableWorkspace().id,
+      "The Frame must belong to the authenticated workspace."
+    );
+  }
+
+  private static lockKey(frame: Pick<FrameSandboxOwner, "sId">): string {
+    return frame.sId;
+  }
+
+  private static async fetchSandboxByFrame(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<SandboxResource | null> {
+    this.assertWorkspace(auth, frame);
+
+    const link = await SandboxOwnerModel.findOne({
+      where: {
+        frameFileModelId: frame.id,
+        workspaceId: frame.workspaceId,
+      },
+    });
+    if (!link) {
+      return null;
+    }
+
+    return SandboxResource.fetchByModelIdForWorkspace(auth, link.sandboxId);
+  }
+
+  private static async createSandboxRecordForFrame(
+    auth: Authenticator,
+    frame: FrameSandboxOwner,
+    blob: SandboxCreateBlob
+  ): Promise<SandboxResource> {
+    this.assertWorkspace(auth, frame);
+
+    return withTransaction(async (transaction) => {
+      const sandbox = await SandboxResource.makeNew(auth, blob, {
+        transaction,
+      });
+
+      await SandboxOwnerModel.create(
+        {
+          workspaceId: frame.workspaceId,
+          frameFileModelId: frame.id,
+          sandboxId: sandbox.id,
+        },
+        { transaction }
+      );
+
+      return sandbox;
+    });
+  }
+
+  private static async resolveScope(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<FrameSandboxScope, Error>> {
+    this.assertWorkspace(auth, frame);
+
+    const freshFrame = await FileModel.findOne({
+      where: {
+        contentType: frameV2ContentType,
+        id: frame.id,
+        workspaceId: frame.workspaceId,
+      },
+    });
+    if (!freshFrame) {
+      return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
+    }
+
+    const { conversationId, spaceId } = freshFrame.useCaseMetadata ?? {};
+    if (spaceId) {
+      return new Ok({ spaceId });
+    }
+    if (!conversationId) {
+      return new Err(
+        new Error(`Frame ${frame.sId} has no conversation or Pod scope.`)
+      );
+    }
+
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId,
+      { dangerouslySkipPermissionFiltering: true }
+    );
+    if (!conversation) {
+      return new Err(
+        new Error(`Frame source conversation ${conversationId} not found.`)
+      );
+    }
+
+    return new Ok({ spaceId: conversation.spaceSId });
+  }
+
+  private static async buildFrameEnvVars(
+    auth: Authenticator,
+    frame: FrameSandboxOwner,
+    scope: FrameSandboxScope
+  ): Promise<Result<Record<string, string>, Error>> {
+    const baseEnv = { FRAME_ID: frame.sId };
+    const runtimeOwner = {
+      kind: "frame" as const,
+      frameId: frame.sId,
+      spaceId: scope.spaceId,
+    };
+    const podResult = await resolvePodForRuntimeOwner(auth, runtimeOwner);
+    if (podResult.isErr()) {
+      return podResult;
+    }
+    if (!podResult.value) {
+      return new Ok(baseEnv);
+    }
+
+    const podScopedResult = await PodSandboxAdapter.buildPodScopedEnvVars(
+      auth,
+      podResult.value,
+      runtimeOwner
+    );
+    if (podScopedResult.isErr()) {
+      return podScopedResult;
+    }
+
+    return new Ok({
+      ...podScopedResult.value,
+      ...baseEnv,
+    });
+  }
+
+  private static toSandboxLifecycleOwner(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): SandboxLifecycleOwner {
+    return {
+      lockKey: this.lockKey(frame),
+      fetchSandbox: () => this.fetchSandboxByFrame(auth, frame),
+    };
+  }
+
+  private static toSandboxDeleteOwner(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): SandboxDeleteOwner {
+    return {
+      ...this.toSandboxLifecycleOwner(auth, frame),
+      deleteSandbox: async (
+        sandbox: SandboxResource,
+        transaction: Transaction
+      ) => {
+        await SandboxOwnerModel.destroy({
+          where: {
+            frameFileModelId: frame.id,
+            sandboxId: sandbox.id,
+            workspaceId: frame.workspaceId,
+          },
+          transaction,
+        });
+      },
+    };
+  }
+
+  static async fetchSandbox(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<SandboxResource | null> {
+    return this.fetchSandboxByFrame(auth, frame);
+  }
+
+  static async ensureSandboxActive(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<EnsureSandboxResult<FrameSandboxScope>, Error>> {
+    return SandboxResource.ensureActive(auth, {
+      lockKey: this.lockKey(frame),
+      resolveScope: () => this.resolveScope(auth, frame),
+      envVars: (scope) => this.buildFrameEnvVars(auth, frame, scope),
+      logLabel: "frame",
+      fetchSandbox: () => this.fetchSandboxByFrame(auth, frame),
+      createSandbox: (blob) =>
+        this.createSandboxRecordForFrame(auth, frame, blob),
+    });
+  }
+
+  static async deleteSandbox(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.deleteByOwner(
+      auth,
+      this.toSandboxDeleteOwner(auth, frame)
+    );
+  }
+
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    for (;;) {
+      const links = await SandboxOwnerModel.findAll({
+        attributes: ["frameFileModelId"],
+        where: {
+          frameFileModelId: { [Op.ne]: null },
+          workspaceId: workspaceModelId,
+        },
+        limit: 1000,
+      });
+      if (links.length === 0) {
+        return;
+      }
+
+      await concurrentExecutor(
+        links,
+        async (link) => {
+          assert(link.frameFileModelId !== null);
+          const frame: FrameSandboxOwner = {
+            id: link.frameFileModelId,
+            sId: makeSId("file", {
+              id: link.frameFileModelId,
+              workspaceId: workspaceModelId,
+            }),
+            workspaceId: workspaceModelId,
+          };
+          const result = await this.deleteSandbox(auth, frame);
+          if (result.isErr()) {
+            throw result.error;
+          }
+        },
+        { concurrency: SANDBOX_OWNER_DELETE_CONCURRENCY }
+      );
+    }
+  }
+
+  static async dangerouslySleepSandboxIfRunning(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfRunning(
+      auth,
+      this.toSandboxLifecycleOwner(auth, frame)
+    );
+  }
+
+  static async dangerouslySleepSandboxIfPendingApproval(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslySleepIfPendingApproval(
+      auth,
+      this.toSandboxLifecycleOwner(auth, frame)
+    );
+  }
+
+  static async dangerouslyDestroySandboxIfSleeping(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfSleeping(
+      auth,
+      this.toSandboxLifecycleOwner(auth, frame)
+    );
+  }
+
+  static async dangerouslyDestroySandboxIfKillRequested(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): Promise<Result<void, Error>> {
+    return SandboxResource.dangerouslyDestroyIfKillRequested(
+      auth,
+      this.toSandboxLifecycleOwner(auth, frame)
+    );
+  }
+
+  static async dangerouslyFetchFrameModelIdsBySandboxes(
+    sandboxes: Pick<SandboxResource, "id" | "workspaceId">[]
+  ): Promise<Map<ModelId, ModelId>> {
+    if (sandboxes.length === 0) {
+      return new Map();
+    }
+
+    const sandboxModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
+    for (const sandbox of sandboxes) {
+      const sandboxModelIds =
+        sandboxModelIdsByWorkspaceModelId.get(sandbox.workspaceId) ?? [];
+      sandboxModelIds.push(sandbox.id);
+      sandboxModelIdsByWorkspaceModelId.set(
+        sandbox.workspaceId,
+        sandboxModelIds
+      );
+    }
+
+    const rows = (
+      await concurrentExecutor(
+        [...sandboxModelIdsByWorkspaceModelId.entries()],
+        async ([workspaceModelId, sandboxModelIds]) =>
+          SandboxOwnerModel.findAll({
+            where: {
+              workspaceId: workspaceModelId,
+              frameFileModelId: { [Op.ne]: null },
+              sandboxId: { [Op.in]: sandboxModelIds },
+            },
+            attributes: ["sandboxId", "frameFileModelId"],
+          }),
+        { concurrency: SANDBOX_OWNER_LOOKUP_CONCURRENCY }
+      )
+    ).flat();
+
+    const frameModelIdsBySandboxModelId = new Map<ModelId, ModelId>();
+    for (const row of rows) {
+      if (row.frameFileModelId !== null) {
+        frameModelIdsBySandboxModelId.set(row.sandboxId, row.frameFileModelId);
+      }
+    }
+    return frameModelIdsBySandboxModelId;
+  }
+}

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1111,6 +1111,7 @@ describe("SandboxResource.ensureActive", () => {
           imageId: { imageName: "test-image", tag: "0.0.1" },
           envVars: {
             DST_API_TOKEN: "image-token",
+            FRAME_ID: "image-frame-id",
             SPACE_ID: "image-space-id",
             WORKSPACE_ID: "image-workspace-id",
           },
@@ -1230,6 +1231,9 @@ describe("SandboxResource.ensureActive", () => {
     );
     expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
       "SPACE_ID"
+    );
+    expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
+      "FRAME_ID"
     );
     expect(mockProviderExec).not.toHaveBeenCalled();
   });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -29,6 +29,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { PokeSandboxType } from "@app/types/poke";
@@ -141,6 +142,7 @@ const LAST_ACTIVITY_WRITE_INTERVAL_MS = 30_000;
 // rollout forever. Generous enough that a transient GCS or daemon hiccup still
 // resolves on a later sweep — the reaper sweeps every 5 minutes.
 const KILL_REQUESTED_FLUSH_GRACE_MS = 60 * 60 * 1000;
+const WORKSPACE_SCRUB_PROVIDER_CONCURRENCY = 16;
 
 // Owner identity env vars are reserved for owner adapters. SandboxResource
 // only enforces the env contract and does not interpret owner types.
@@ -210,6 +212,23 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       sandboxModelId,
       workspaceModelId: auth.getNonNullableWorkspace().id,
     });
+  }
+
+  static async fetchByModelIdsForWorkspace(
+    auth: Authenticator,
+    sandboxModelIds: ModelId[]
+  ): Promise<SandboxResource[]> {
+    if (sandboxModelIds.length === 0) {
+      return [];
+    }
+
+    const sandboxes = await this.model.findAll({
+      where: {
+        id: { [Op.in]: sandboxModelIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    return sandboxes.map((sandbox) => new this(this.model, sandbox.get()));
   }
 
   static async dangerouslyFetchByModelIdForWorkspace({
@@ -550,6 +569,64 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
     );
+  }
+
+  /**
+   * Batch cleanup for a workspace scrub, which already owns the workspace
+   * deletion boundary. Provider calls stay concurrent; owner links and
+   * sandbox rows are removed in two set-based statements.
+   */
+  static async deleteBatchForWorkspaceScrub(
+    auth: Authenticator,
+    {
+      deleteOwnerLinks,
+      sandboxes,
+    }: {
+      deleteOwnerLinks: (transaction: Transaction) => Promise<void>;
+      sandboxes: SandboxResource[];
+    }
+  ): Promise<Result<void, Error>> {
+    const liveSandboxes = sandboxes.filter(
+      (sandbox) => sandbox.status !== "deleted"
+    );
+    const provider = getSandboxProvider();
+    if (!provider && liveSandboxes.length > 0) {
+      return new Err(new Error("Sandbox provider not configured."));
+    }
+
+    if (provider) {
+      await concurrentExecutor(
+        liveSandboxes,
+        async (sandbox) => {
+          const result = await provider.destroy(sandbox.providerId, {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          });
+          if (
+            result.isErr() &&
+            !(result.error instanceof SandboxNotFoundError)
+          ) {
+            logger.error(
+              { sandbox: sandbox.toLogJSON(), error: result.error.message },
+              "Failed to destroy sandbox at provider during workspace scrub; proceeding with DB cleanup."
+            );
+          }
+        },
+        { concurrency: WORKSPACE_SCRUB_PROVIDER_CONCURRENCY }
+      );
+    }
+
+    await withTransaction(async (transaction) => {
+      await deleteOwnerLinks(transaction);
+      await SandboxModel.destroy({
+        where: {
+          id: sandboxes.map((sandbox) => sandbox.id),
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      });
+    });
+
+    return new Ok(undefined);
   }
 
   // ---------------------------------------------------------------------------

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -146,6 +146,7 @@ const KILL_REQUESTED_FLUSH_GRACE_MS = 60 * 60 * 1000;
 // only enforces the env contract and does not interpret owner types.
 const SANDBOX_OWNER_ENV_VAR_CONTRACT_NAMES = new Set([
   "CONVERSATION_ID",
+  "FRAME_ID",
   "SPACE_ID",
 ]);
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -421,10 +421,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return new Ok(deletedCount);
   }
 
-  /**
-   * Full cleanup under the lifecycle lock: best-effort destroy at the provider,
-   * then delete the owner link and DB row.
-   */
   // Runs an owner scope transition (e.g. a conversation move) under the
   // lifecycle lock, in three phases without releasing it:
   //
@@ -521,16 +517,26 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
   }
 
+  /**
+   * Full cleanup under the lifecycle lock: best-effort destroy at the provider,
+   * then delete the owner link and DB row. The optional callback extends that
+   * lock through owner deletion, including when no sandbox exists.
+   */
   static async deleteByOwner(
     auth: Authenticator,
-    owner: SandboxDeleteOwner
-  ): Promise<Result<void, Error>> {
+    owner: SandboxDeleteOwner,
+    {
+      afterSandboxCleanup,
+    }: {
+      afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+    } = {}
+  ): Promise<Result<undefined, Error>> {
     return this.withLifecycleLockWithOptionalProvider(
       owner.lockKey,
       async (provider) => {
         const sandbox = await owner.fetchSandbox();
         if (!sandbox) {
-          return new Ok(undefined);
+          return afterSandboxCleanup?.() ?? new Ok(undefined);
         }
         if (!provider) {
           return new Err(new Error("Sandbox provider not configured."));
@@ -566,7 +572,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           });
         });
 
-        return new Ok(undefined);
+        return afterSandboxCleanup?.() ?? new Ok(undefined);
       }
     );
   }

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -505,38 +505,50 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     auth: Authenticator,
     owner: SandboxDeleteOwner
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(owner.lockKey, async (provider) => {
-      const sandbox = await owner.fetchSandbox();
-      if (!sandbox) {
+    return this.withLifecycleLockWithOptionalProvider(
+      owner.lockKey,
+      async (provider) => {
+        const sandbox = await owner.fetchSandbox();
+        if (!sandbox) {
+          return new Ok(undefined);
+        }
+        if (!provider) {
+          return new Err(new Error("Sandbox provider not configured."));
+        }
+
+        if (sandbox.status !== "deleted") {
+          const tracingOpts = {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          };
+          const result = await provider.destroy(
+            sandbox.providerId,
+            tracingOpts
+          );
+          if (
+            result.isErr() &&
+            !(result.error instanceof SandboxNotFoundError)
+          ) {
+            logger.error(
+              { sandbox: sandbox.toLogJSON(), error: result.error.message },
+              "Failed to destroy sandbox at provider — proceeding with DB cleanup."
+            );
+          }
+        }
+
+        await withTransaction(async (transaction) => {
+          await owner.deleteSandbox(sandbox, transaction);
+          await SandboxModel.destroy({
+            where: {
+              id: sandbox.id,
+              workspaceId: auth.getNonNullableWorkspace().id,
+            },
+            transaction,
+          });
+        });
+
         return new Ok(undefined);
       }
-
-      if (sandbox.status !== "deleted") {
-        const tracingOpts = {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-        };
-        const result = await provider.destroy(sandbox.providerId, tracingOpts);
-        if (result.isErr() && !(result.error instanceof SandboxNotFoundError)) {
-          logger.error(
-            { sandbox: sandbox.toLogJSON(), error: result.error.message },
-            "Failed to destroy sandbox at provider — proceeding with DB cleanup."
-          );
-        }
-      }
-
-      await withTransaction(async (transaction) => {
-        await owner.deleteSandbox(sandbox, transaction);
-        await SandboxModel.destroy({
-          where: {
-            id: sandbox.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction,
-        });
-      });
-
-      return new Ok(undefined);
-    });
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -547,14 +559,24 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     lockKey: string,
     fn: (provider: SandboxProvider) => Promise<Result<T, Error>>
   ): Promise<Result<T, Error>> {
-    const provider = getSandboxProvider();
-    if (!provider) {
-      return new Err(new Error("Sandbox provider not configured."));
-    }
+    return this.withLifecycleLockWithOptionalProvider(
+      lockKey,
+      async (provider) => {
+        if (!provider) {
+          return new Err(new Error("Sandbox provider not configured."));
+        }
+        return fn(provider);
+      }
+    );
+  }
 
+  private static async withLifecycleLockWithOptionalProvider<T>(
+    lockKey: string,
+    fn: (provider: SandboxProvider | null) => Promise<Result<T, Error>>
+  ): Promise<Result<T, Error>> {
     return executeWithLock(
       `sandbox:lifecycle:${lockKey}`,
-      () => fn(provider),
+      () => fn(getSandboxProvider() ?? null),
       undefined,
       {
         traceAcquireResource: "sandbox:lifecycle",

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -1,13 +1,16 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { ensurePodStateHealthOnSleep } from "@app/lib/api/sandbox/db";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { reapSandboxPhaseActivity } from "@app/temporal/sandbox_reaper/activities";
 import { SLEEP_THRESHOLD_MS } from "@app/temporal/sandbox_reaper/config";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameV2ContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -208,6 +211,61 @@ describe("reapSandboxPhaseActivity", () => {
     );
     const sandbox = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
     expect(sandbox?.status).toBe("deleted");
+  });
+
+  it("sleeps a stale Frame sandbox", async () => {
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { imageName: "test-image", tag: "0.0.1" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: vi
+        .fn()
+        .mockResolvedValue(new Ok({ providerId: "frame-provider" })),
+      sleep: mockProviderSleep.mockResolvedValue(new Ok(undefined)),
+    });
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(authenticator, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+    vi.advanceTimersByTime(SLEEP_THRESHOLD_MS + 1);
+
+    const result = await reapSandboxPhaseActivity({
+      cursor: null,
+      phase: "running",
+    });
+
+    expect(result).toEqual({
+      failedCount: 0,
+      nextCursor: null,
+      processedCount: 1,
+      skippedCount: 0,
+      succeededCount: 1,
+    });
+    expect(mockProviderSleep).toHaveBeenCalledWith("frame-provider", {
+      workspaceId: workspace.sId,
+    });
   });
 
   it("skips kill-requested sleeping sandboxes in the awake kill phase", async () => {

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -1,6 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import type { SandboxTimestampCursor } from "@app/lib/resources/sandbox_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -48,7 +50,7 @@ export interface ReapSandboxPhaseActivityResult {
 }
 
 type ReaperSandboxLifecycleOwner = {
-  kind: "conversation" | "pod";
+  kind: "conversation" | "frame" | "pod";
   modelId: ModelId;
   workspaceModelId: ModelId;
   dangerouslyDestroySandboxIfKillRequested(
@@ -77,6 +79,7 @@ type SandboxOwnerMaps = {
 
 type ReaperAuthMaps = {
   conversation: Map<ModelId, Authenticator>;
+  frame: Map<ModelId, Authenticator>;
   pod: Map<ModelId, Authenticator>;
 };
 
@@ -92,6 +95,7 @@ async function fetchAuthMaps(
 ): Promise<ReaperAuthMaps> {
   const workspaceModelIdsByOwnerKind = {
     conversation: new Set<ModelId>(),
+    frame: new Set<ModelId>(),
     pod: new Set<ModelId>(),
   };
 
@@ -105,6 +109,7 @@ async function fetchAuthMaps(
   const uniqueWorkspaceModelIds = [
     ...new Set([
       ...workspaceModelIdsByOwnerKind.conversation,
+      ...workspaceModelIdsByOwnerKind.frame,
       ...workspaceModelIdsByOwnerKind.pod,
     ]),
   ];
@@ -113,7 +118,7 @@ async function fetchAuthMaps(
     uniqueWorkspaceModelIds
   );
 
-  const [conversationEntries, podEntries] = await Promise.all([
+  const [conversationEntries, frameEntries, podEntries] = await Promise.all([
     concurrentExecutor(
       workspaces.filter((workspace) =>
         workspaceModelIdsByOwnerKind.conversation.has(workspace.id)
@@ -121,6 +126,21 @@ async function fetchAuthMaps(
       async (workspace) => {
         const authenticator = await Authenticator.internalUserForWorkspace(
           workspace.sId
+        );
+        return [workspace.id, authenticator] as const;
+      },
+      { concurrency: REAPER_CONCURRENCY }
+    ),
+    concurrentExecutor(
+      workspaces.filter((workspace) =>
+        workspaceModelIdsByOwnerKind.frame.has(workspace.id)
+      ),
+      async (workspace) => {
+        const authenticator = await Authenticator.internalAdminForWorkspace(
+          workspace.sId,
+          {
+            dangerouslyRequestAllGroups: true,
+          }
         );
         return [workspace.id, authenticator] as const;
       },
@@ -145,6 +165,7 @@ async function fetchAuthMaps(
 
   return {
     conversation: new Map(conversationEntries),
+    frame: new Map(frameEntries),
     pod: new Map(podEntries),
   };
 }
@@ -163,20 +184,28 @@ async function fetchSandboxOwnerMaps(
     );
   const podModelIdsBySandboxModelId =
     await PodSandboxAdapter.dangerouslyFetchPodModelIdsBySandboxes(sandboxes);
+  const frameModelIdsBySandboxModelId =
+    await FrameSandboxAdapter.dangerouslyFetchFrameModelIdsBySandboxes(
+      sandboxes
+    );
 
   const conversationModelIds = [
     ...new Set(conversationModelIdsBySandboxModelId.values()),
   ];
   const podModelIds = [...new Set(podModelIdsBySandboxModelId.values())];
+  const frameModelIds = [...new Set(frameModelIdsBySandboxModelId.values())];
 
   const conversations =
     await ConversationResource.dangerouslyFetchByModelIds(conversationModelIds);
   const pods = await SpaceResource.dangerouslyFetchByModelIds(podModelIds);
+  const frames =
+    await FileResource.dangerouslyFetchFrameV2ByModelIds(frameModelIds);
 
   const conversationsById = new Map(conversations.map((c) => [c.id, c]));
   const podsById = new Map(
     pods.filter((p) => p.isProject()).map((p) => [p.id, p])
   );
+  const framesById = new Map(frames.map((frame) => [frame.id, frame]));
 
   const ownerRefsBySandboxModelId = new Map<ModelId, SandboxOwnerRef>();
   const ownersBySandboxModelId = new Map<
@@ -220,6 +249,41 @@ async function fetchSandboxOwnerMaps(
               auth,
               conversation
             ),
+        });
+      }
+      continue;
+    }
+
+    const frameModelId = frameModelIdsBySandboxModelId.get(sandbox.id);
+    if (frameModelId) {
+      ownerRefsBySandboxModelId.set(sandbox.id, {
+        kind: "frame",
+        modelId: frameModelId,
+      });
+
+      const frame = framesById.get(frameModelId);
+      if (frame) {
+        ownersBySandboxModelId.set(sandbox.id, {
+          kind: "frame",
+          modelId: frame.id,
+          workspaceModelId: frame.workspaceId,
+          dangerouslyDestroySandboxIfKillRequested: (auth) =>
+            FrameSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+              auth,
+              frame
+            ),
+          dangerouslyDestroySandboxIfSleeping: (auth) =>
+            FrameSandboxAdapter.dangerouslyDestroySandboxIfSleeping(
+              auth,
+              frame
+            ),
+          dangerouslySleepSandboxIfPendingApproval: (auth) =>
+            FrameSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
+              auth,
+              frame
+            ),
+          dangerouslySleepSandboxIfRunning: (auth) =>
+            FrameSandboxAdapter.dangerouslySleepSandboxIfRunning(auth, frame),
         });
       }
       continue;


### PR DESCRIPTION
## Description

- Add a Frame sandbox adapter keyed by the stable Frames v2 FileResource identity.
- Re-resolve the Frame source scope under the lifecycle lock and inherit Pod-scoped runtime configuration when applicable.
- Add FRAME_ID runtime metadata while preserving existing conversation and Pod behavior.
- Delete Frame sandboxes before Frame or workspace deletion, with batched workspace cleanup, and include them in the sandbox reaper.
- Keep the slice internal: publication mounts and invocation routes follow in stacked PRs.

Stacked on #31388.

## Tests

- Added Frame sandbox identity, Pod configuration, direct deletion, batched workspace scrub, environment manifest, and reaper coverage.
- Ran 123 focused tests across Frame, FileResource, sandbox lifecycle, egress, environment manifest, and reaper suites.
- Ran npm run tsgo.
- Ran Biome on all changed files and git diff --check.

## Risk

The adapter is not reachable from a user invocation path yet. Existing Frames v1 and Pod Functions paths are unchanged. Runtime Pod lookup is workspace-scoped and intentionally independent of caller visibility, so a shared invocation cannot silently lose inherited configuration. The shared lifecycle adjustment only allows an absent owner link to resolve under lock before requiring a configured provider; deleting an existing sandbox still fails closed when no provider is configured.

## Deploy Plan

Merge #31388 first, then merge this PR. No migration or configuration change is required.