### PR TITLE
Mount canonical Frame publication artifacts

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -711,6 +711,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
   private sandboxOnlyMountGCSPrefix(mount: SandboxOnlyMount): string {
     switch (mount.kind) {
+      case "frame_publications":
+        return `w/${this.workspaceId}/frames/${mount.id}/publications`;
+
       case "pod_sandbox_functions":
         return `w/${this.workspaceId}/pods/${mount.id}/sandbox-functions`;
 
@@ -726,6 +729,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     mount: SandboxOnlyMount
   ): GCSMountTarget["mountProfile"] {
     switch (mount.kind) {
+      case "frame_publications":
+        return "frame_publications";
+
       case "pod_sandbox_functions":
         return "pod_sandbox_functions";
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -712,16 +712,16 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   private sandboxOnlyMountGCSPrefix(mount: SandboxOnlyMount): string {
     switch (mount.kind) {
       case "frame_publications":
-        return `w/${this.workspaceId}/frames/${mount.id}/publications`;
+        return `w/${this.workspaceId}/frames/${mount.frameId}/publications`;
 
       case "pod_sandbox_functions":
-        return `w/${this.workspaceId}/pods/${mount.id}/sandbox-functions`;
+        return `w/${this.workspaceId}/pods/${mount.podId}/sandbox-functions`;
 
       case "pod_state":
-        return `w/${this.workspaceId}/pods/${mount.id}/state`;
+        return `w/${this.workspaceId}/pods/${mount.podId}/state`;
 
       default:
-        assertNever(mount.kind);
+        assertNever(mount);
     }
   }
 
@@ -739,7 +739,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
         return "pod_state_replica";
 
       default:
-        assertNever(mount.kind);
+        assertNever(mount);
     }
   }
 }

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -12,11 +12,13 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { frameV2ContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
@@ -252,6 +254,66 @@ describe("DustFileSystem.forPodSandboxProvisioning", () => {
       otherWorkspaceAuth,
       projectSpace
     );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("unauthorized");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forFrameSandboxProvisioning
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.forFrameSandboxProvisioning", () => {
+  it("builds a GCS filesystem without agent-visible source mounts", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: "spc_source" },
+    });
+    const sandboxOnlyMounts = [
+      {
+        kind: "frame_publications" as const,
+        id: frame.sId,
+        sandboxMountPoint: `/frames/${frame.sId}/publications`,
+        readOnly: true,
+      },
+    ];
+
+    const result = await DustFileSystem.forFrameSandboxProvisioning(
+      auth,
+      frame,
+      { sandboxOnlyMounts }
+    );
+
+    assert(result.isOk());
+    expect(result.value.getMounts()).toEqual([]);
+  });
+
+  it("rejects Frames from another workspace", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const { authenticator: otherAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const otherFrame = await FileFactory.create(otherAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: "spc_source" },
+    });
+
+    const result = await DustFileSystem.forFrameSandboxProvisioning(
+      auth,
+      otherFrame
+    );
+
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.code).toBe("unauthorized");

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -279,7 +279,7 @@ describe("DustFileSystem.forFrameSandboxProvisioning", () => {
     const sandboxOnlyMounts = [
       {
         kind: "frame_publications" as const,
-        id: frame.sId,
+        frameId: frame.sId,
         sandboxMountPoint: `/frames/${frame.sId}/publications`,
         readOnly: true,
       },

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -32,6 +32,7 @@ import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
@@ -412,6 +413,38 @@ export class DustFileSystem {
 
     return new Ok(
       new DustFileSystem(auth, [mount], backend, storageMode, sandboxOnlyMounts)
+    );
+  }
+
+  /**
+   * Build the publication-only filesystem mounted into a Frame-owned sandbox. Frame artifacts
+   * always live in GCS, independently of the storage mode used by the source conversation or Pod.
+   * No agent-visible source mount is included.
+   */
+  static async forFrameSandboxProvisioning(
+    auth: Authenticator,
+    frame: Pick<FileResource, "sId" | "workspaceId" | "isFrameV2">,
+    { sandboxOnlyMounts = [] }: { sandboxOnlyMounts?: SandboxOnlyMount[] } = {}
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    const owner = auth.getNonNullableWorkspace();
+    if (frame.workspaceId !== owner.id || !frame.isFrameV2) {
+      return new Err(
+        new DustFileSystemError(
+          "unauthorized",
+          "Frame sandbox provisioning requires a Frames v2 resource in this workspace."
+        )
+      );
+    }
+
+    const backend = DustFileSystem.createBackend(
+      auth,
+      [],
+      "gcs",
+      sandboxOnlyMounts
+    );
+
+    return new Ok(
+      new DustFileSystem(auth, [], backend, "gcs", sandboxOnlyMounts)
     );
   }
 

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
@@ -51,7 +51,7 @@ const mounts: FileSystemMount[] = [
 const sandboxOnlyMounts: SandboxOnlyMount[] = [
   {
     kind: "pod_state",
-    id: "pod1",
+    podId: "pod1",
     sandboxMountPoint: "/pod-state/replica",
     readOnly: false,
   },

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -5,6 +5,7 @@ import {
   buildMountCommand,
   GCSSandboxMountAdapter,
 } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
+import { frameSandboxOnlyMounts } from "@app/lib/api/sandbox/frame_mounts";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import type { RootCommand } from "@app/lib/api/sandbox/root_command";
@@ -91,6 +92,20 @@ function createPodSandboxAdapter(): GCSSandboxMountAdapter {
   return adapter;
 }
 
+function createFrameSandboxAdapter(): GCSSandboxMountAdapter {
+  const backend = new GCSFileSystemBackend("ws1", "test-private-uploads");
+  const adapter = backend.createSandboxAdapter(
+    [],
+    frameSandboxOnlyMounts({ sId: "fil_frame" })
+  );
+
+  if (!(adapter instanceof GCSSandboxMountAdapter)) {
+    throw new Error("expected a GCSSandboxMountAdapter");
+  }
+
+  return adapter;
+}
+
 describe("buildMountCommand", () => {
   test("workload profile disables caches for shared mutable files", () => {
     const command = renderRootCommand(
@@ -131,6 +146,28 @@ describe("buildMountCommand", () => {
     expect(command).toContain("--metadata-cache-ttl-secs=0");
     expect(command).toContain("--metadata-cache-negative-ttl-secs=0");
     expect(command).toContain("--token-url http://127.0.0.1:987/token/mount-1");
+  });
+
+  test("Frame publication profile is read-only and uncached", () => {
+    const command = renderRootCommand(
+      buildMountCommand({
+        bucket: "bucket-x",
+        target: workloadTarget({
+          gcsPrefix: "w/ws1/frames/fil_frame/publications",
+          sandboxMountPoint: "/frames/fil_frame/publications",
+          legacySandboxMountPoint: null,
+          readOnly: true,
+          mountProfile: "frame_publications",
+        }),
+      })
+    );
+
+    expect(command).toContain("-o allow_other,ro");
+    expect(command).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-negative-ttl-secs=0");
+    expect(command).toContain("--only-dir w/ws1/frames/fil_frame/publications");
+    expect(command).toContain("bucket-x /frames/fil_frame/publications");
   });
 
   test("pod_state_replica profile mounts as dust-state without allow_other or list caching", () => {
@@ -232,6 +269,24 @@ describe("pod sandbox mount wiring", () => {
     expect(podFunctionsCommand).toContain(
       "--metadata-cache-negative-ttl-secs=0"
     );
+  });
+});
+
+describe("Frame sandbox mount wiring", () => {
+  beforeAll(() => {
+    process.env.GOOGLE_CLOUD_PROJECT_ID ??= "test-project";
+    process.env.DUST_PRIVATE_UPLOADS_BUCKET ??= "test-private-uploads";
+  });
+
+  test("grants only the stable Frame publication prefix", () => {
+    const rules = createFrameSandboxAdapter().getAccessBoundaryRules();
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toHaveLength(3);
+    const serializedRules = JSON.stringify(rules);
+    expect(serializedRules).toContain("w/ws1/frames/fil_frame/publications/");
+    expect(serializedRules).not.toContain("/conversations/");
+    expect(serializedRules).not.toContain("/pods/");
   });
 });
 

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -72,7 +72,7 @@ function tokenUrl(index: number): string {
  *   users can access it; permissive file/dir modes. All agent-facing mounts
  *   are shared mutable filesystems, so namespace and metadata caching are
  *   disabled: writes from another sandbox or Front must be visible immediately.
- * - "pod_sandbox_functions": same access model as "workload", but without
+ * - "frame_publications" / "pod_sandbox_functions": same access model as "workload", but without
  *   caching so newly published or replaced functions are visible immediately.
  * - "pod_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
  *   default — only the mounting user can access the fs — makes it invisible to
@@ -83,6 +83,7 @@ function tokenUrl(index: number): string {
  *   constructed when a pod sandbox (the sandbox-functions computer) boots.
  */
 export type GCSMountProfile =
+  | "frame_publications"
   | "workload"
   | "pod_sandbox_functions"
   | "pod_state_replica";
@@ -424,6 +425,7 @@ export function buildMountCommand({
   ];
 
   switch (target.mountProfile) {
+    case "frame_publications":
     case "workload":
     case "pod_sandbox_functions": {
       // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -14,7 +14,10 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FrameManifestSchema } from "@app/types/api/frame_manifest";
-import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
+import {
+  getFramePublicationFunctionBundlePath,
+  getFramePublicationUiBundlePath,
+} from "@app/types/api/frame_storage";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { frameV2ContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
@@ -219,11 +222,23 @@ describe("buildAndPublishFramePublication", () => {
       { user: "agent-proxied" }
     );
     expect(ensureConversationSandboxReadyWithScope).toHaveBeenCalledOnce();
-    expect(
-      fileStorageMock.saveFileCalls.filter(({ filePath }) =>
-        filePath.endsWith("/bundle.js")
-      )
-    ).toHaveLength(3);
+    const publicationId = result.isOk() ? result.value.publicationId : "";
+    const savedPaths = fileStorageMock.saveFileCalls.map(
+      ({ filePath }) => filePath
+    );
+    for (const functionName of ["add-task", "list-tasks"]) {
+      expect(savedPaths).toContain(
+        getFramePublicationFunctionBundlePath({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          frameId: frame.sId,
+          publicationId,
+          functionName,
+        })
+      );
+    }
+    expect(savedPaths.some((filePath) => filePath.includes("/source/"))).toBe(
+      false
+    );
 
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -61,8 +61,8 @@ async function buildFrameUiBundle({
 
 /**
  * Build the UI and every declared function from one captured source snapshot, then atomically
- * publish the source and artifacts. Function builds stage the snapshot in the invoking
- * conversation's DSBX. No publication storage is touched until every build has succeeded.
+ * publish its artifacts. Function builds stage the snapshot in the invoking conversation's DSBX;
+ * source stays in its authoring scope. No publication storage is touched until every build succeeds.
  */
 export async function buildAndPublishFramePublication(
   auth: Authenticator,

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -3,7 +3,6 @@ import type { FramePublicationFunctionArtifact } from "@app/lib/api/frames/publi
 import {
   activateFramePublication,
   loadFramePublicationManifest,
-  loadFramePublicationSourceFile,
   publishFramePublication,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
@@ -25,7 +24,6 @@ import {
   getFramePublicationFunctionBundlePath,
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
-  getFramePublicationSourcePath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import {
@@ -142,7 +140,7 @@ beforeEach(() => {
 });
 
 describe("storeFramePublication", () => {
-  it("stores the UI bundle and immutable source before the manifest commit marker", async () => {
+  it("stores runtime artifacts without source before the publication commit marker", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
 
     const result = await storeFramePublication(auth, {
@@ -163,17 +161,7 @@ describe("storeFramePublication", () => {
       ({ filePath }) => filePath
     );
     expect(new Set(savedPaths.slice(0, -1))).toEqual(
-      new Set([
-        getFramePublicationUiBundlePath(identity),
-        getFramePublicationSourcePath({
-          ...identity,
-          relativePath: "index.tsx",
-        }),
-        getFramePublicationSourcePath({
-          ...identity,
-          relativePath: "data.json",
-        }),
-      ])
+      new Set([getFramePublicationUiBundlePath(identity)])
     );
     expect(savedPaths.at(-1)).toBe(getFramePublicationManifestPath(identity));
     expect(fileStorageMock.saveFileCalls.at(-1)?.contentType).toBe(
@@ -193,7 +181,7 @@ describe("storeFramePublication", () => {
     ).toBe(false);
   });
 
-  it("stores function artifacts before the manifest commit marker", async () => {
+  it("stores function artifacts before the publication commit marker", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
 
     const result = await storeFramePublication(auth, {
@@ -250,8 +238,8 @@ describe("storeFramePublication", () => {
     ).toBe("application/json");
   });
 
-  it("stores declared database schemas in the immutable source snapshot", async () => {
-    const { auth, frame, workspaceId } = await setupFrame();
+  it("retains declared database schemas in publication metadata", async () => {
+    const { auth, frame } = await setupFrame();
     const databaseSchema = {
       relativePath: "databases/tasks.db.ts",
       content: Buffer.from("export const tasks = {};"),
@@ -271,22 +259,9 @@ describe("storeFramePublication", () => {
       return;
     }
 
-    const identity = {
-      workspaceId,
-      frameId: frame.sId,
-      publicationId: result.value.publicationId,
-    };
-    expect(
-      fileStorageMock.getObject(
-        getFramePublicationSourcePath({
-          ...identity,
-          relativePath: databaseSchema.relativePath,
-        })
-      )
-    ).toBe(databaseSchema.content.toString());
     const loadedManifest = await loadFramePublicationManifest(auth, {
       frame,
-      publicationId: identity.publicationId,
+      publicationId: result.value.publicationId,
     });
     expect(loadedManifest.isOk() && loadedManifest.value.databases).toEqual(
       manifestWithDatabase.databases
@@ -418,10 +393,10 @@ describe("storeFramePublication", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
-  it("does not write the manifest after a partial source failure", async () => {
+  it("does not write publication.json after an artifact failure", async () => {
     const { auth, frame } = await setupFrame();
     fileStorageMock.setFileSaveFails((filePath) =>
-      filePath.endsWith("/source/data.json")
+      filePath.endsWith("/ui/bundle.js")
     );
 
     await expect(
@@ -435,14 +410,14 @@ describe("storeFramePublication", () => {
     ).rejects.toThrow("Simulated GCS write failure");
     expect(
       fileStorageMock.saveFileCalls.some(({ filePath }) =>
-        filePath.endsWith("/manifest.json")
+        filePath.endsWith("/publication.json")
       )
     ).toBe(false);
   });
 });
 
 describe("Frame publication reads", () => {
-  it("loads the manifest and source of a committed publication", async () => {
+  it("loads the manifest of a committed publication", async () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
       frame,
@@ -461,38 +436,6 @@ describe("Frame publication reads", () => {
       publicationId: stored.value.publicationId,
     });
     expect(loadedManifest).toEqual(new Ok(manifest));
-
-    const loadedSource = await loadFramePublicationSourceFile(auth, {
-      frame,
-      publicationId: stored.value.publicationId,
-      relativePath: "index.tsx",
-    });
-    expect(loadedSource.isOk() && loadedSource.value.toString("utf8")).toBe(
-      "export default function App() {}"
-    );
-  });
-
-  it("does not expose source without the manifest commit marker", async () => {
-    const { auth, frame, workspaceId } = await setupFrame();
-    const publicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
-    fileStorageMock.setObject(
-      getFramePublicationSourcePath({
-        workspaceId,
-        frameId: frame.sId,
-        publicationId,
-        relativePath: "index.tsx",
-      }),
-      "partial source"
-    );
-    fileStorageMock.setFetchFileContentNotFound(() => true);
-
-    const result = await loadFramePublicationSourceFile(auth, {
-      frame,
-      publicationId,
-      relativePath: "index.tsx",
-    });
-
-    expect(result.isErr() && result.error.code).toBe("publication_not_found");
   });
 
   it("rejects an invalid stored manifest", async () => {
@@ -513,42 +456,6 @@ describe("Frame publication reads", () => {
     });
 
     expect(result.isErr() && result.error.code).toBe("invalid_manifest");
-  });
-
-  it("returns a typed error for a missing source file", async () => {
-    const { auth, frame } = await setupFrame();
-    const stored = await storeFramePublication(auth, {
-      frame,
-      functionArtifacts: [],
-      manifest,
-      sourceFiles,
-      uiBundleCode,
-    });
-    expect(stored.isOk()).toBe(true);
-    if (stored.isErr()) {
-      return;
-    }
-    fileStorageMock.setFetchFileContentNotFound(() => true);
-
-    const result = await loadFramePublicationSourceFile(auth, {
-      frame,
-      publicationId: stored.value.publicationId,
-      relativePath: "missing.ts",
-    });
-
-    expect(result.isErr() && result.error.code).toBe("source_not_found");
-  });
-
-  it("rejects unsafe source paths before reading", async () => {
-    const { auth, frame } = await setupFrame();
-
-    const result = await loadFramePublicationSourceFile(auth, {
-      frame,
-      publicationId: "b8c2b796-534a-4ad2-a5ad-071da692ca0b",
-      relativePath: "../index.tsx",
-    });
-
-    expect(result.isErr() && result.error.code).toBe("invalid_source");
   });
 });
 
@@ -803,7 +710,7 @@ describe("publishFramePublication", () => {
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
     await frame.setActiveFramePublication(activePublicationId);
     fileStorageMock.setFileSaveFails((filePath) =>
-      filePath.endsWith("/schema.json")
+      filePath.endsWith(".schema.json")
     );
 
     await expect(
@@ -817,7 +724,7 @@ describe("publishFramePublication", () => {
     ).rejects.toThrow("Simulated GCS write failure");
     expect(
       fileStorageMock.saveFileCalls.some(({ filePath }) =>
-        filePath.endsWith("/manifest.json")
+        filePath.endsWith("/publication.json")
       )
     ).toBe(false);
     const reloaded = await FileResource.fetchById(auth, frame.sId);

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -28,7 +28,6 @@ import {
   getFramePublicationFunctionBundlePath,
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
-  getFramePublicationSourcePath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
@@ -84,7 +83,6 @@ export class FramePublicationError extends Error {
       | "invalid_source"
       | "allowlist_failed"
       | "publication_not_found"
-      | "source_not_found"
       | "ui_build_failed"
       | "unauthorized",
     message: string
@@ -233,14 +231,6 @@ export async function storeFramePublication(
       content: uiBundleCode,
       contentType: frameContentType,
     },
-    ...sourceFiles.map((sourceFile) => ({
-      filePath: getFramePublicationSourcePath({
-        ...identity,
-        relativePath: sourceFile.relativePath,
-      }),
-      content: sourceFile.content,
-      contentType: sourceFile.contentType,
-    })),
     ...functionArtifacts.flatMap((artifact) => [
       {
         filePath: getFramePublicationFunctionBundlePath({
@@ -277,7 +267,7 @@ export async function storeFramePublication(
     { concurrency: FRAME_PUBLICATION_UPLOAD_CONCURRENCY }
   );
 
-  // The manifest is the publication commit marker. Readers never observe partial publication data.
+  // publication.json is the commit marker. Readers never observe partial publication data.
   const manifestPath = getFramePublicationManifestPath(identity);
   await storage.file(manifestPath).save(Buffer.from(JSON.stringify(manifest)), {
     contentType: frameV2ContentType,
@@ -574,57 +564,4 @@ export async function publishFramePublication(
 
     return publication;
   });
-}
-
-export async function loadFramePublicationSourceFile(
-  auth: Authenticator,
-  {
-    frame,
-    publicationId,
-    relativePath,
-  }: {
-    frame: FileResource;
-    publicationId: string;
-    relativePath: string;
-  }
-): Promise<Result<Buffer, FramePublicationError>> {
-  if (!isSafeFrameRelativePath(relativePath)) {
-    return new Err(
-      new FramePublicationError(
-        "invalid_source",
-        `Invalid Frame source path: ${relativePath}`
-      )
-    );
-  }
-
-  const manifest = await loadFramePublicationManifest(auth, {
-    frame,
-    publicationId,
-  });
-  if (manifest.isErr()) {
-    return manifest;
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-  const sourcePath = getFramePublicationSourcePath({
-    workspaceId: owner.sId,
-    frameId: frame.sId,
-    publicationId,
-    relativePath,
-  });
-  try {
-    const sourceBuffer =
-      await getPrivateUploadBucket().fetchFileBuffer(sourcePath);
-    return new Ok(Buffer.from(sourceBuffer));
-  } catch (error) {
-    if (isGCSNotFoundError(error)) {
-      return new Err(
-        new FramePublicationError(
-          "source_not_found",
-          `Frame publication source file not found: ${relativePath}`
-        )
-      );
-    }
-    throw error;
-  }
 }

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -11,8 +11,11 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
-import { getFramePublicationSourcePath } from "@app/types/api/frame_storage";
+import {
+  FRAME_MANIFEST_FILE,
+  FrameManifestSchema,
+} from "@app/types/api/frame_manifest";
+import { getFramePublicationManifestPath } from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
 import {
   getConversationFilesBasePath,
@@ -178,9 +181,15 @@ describe("publishFrameFromSource", () => {
 });
 
 describe("publishFrameV2FromSource", () => {
-  it("snapshots the source folder and activates one publication", async () => {
-    const { auth, conversation, frame, manifestPath, workspace } =
-      await setup();
+  it("publishes artifacts without copying source and activates one publication", async () => {
+    const {
+      auth,
+      conversation,
+      frame,
+      gcsSourceDirectoryPath,
+      manifestPath,
+      workspace,
+    } = await setup();
 
     const result = await publishFrameV2FromSource(auth, {
       conversation,
@@ -195,21 +204,13 @@ describe("publishFrameV2FromSource", () => {
       publicationId: result.value.publicationId,
     };
     expect(
-      fileStorageMock.getObject(
-        getFramePublicationSourcePath({
-          ...identity,
-          relativePath: FRAME_MANIFEST_FILE,
-        })
-      )
-    ).toBe(manifest);
+      fileStorageMock.getObject(getFramePublicationManifestPath(identity))
+    ).toBe(JSON.stringify(FrameManifestSchema.parse(JSON.parse(manifest))));
     expect(
-      fileStorageMock.getObject(
-        getFramePublicationSourcePath({
-          ...identity,
-          relativePath: "index.tsx",
-        })
+      fileStorageMock.saveFileCalls.some(({ filePath }) =>
+        filePath.startsWith(`${gcsSourceDirectoryPath}/`)
       )
-    ).toBe(uiSource);
+    ).toBe(false);
 
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(

--- a/front/lib/api/sandbox/frame_mounts.test.ts
+++ b/front/lib/api/sandbox/frame_mounts.test.ts
@@ -1,0 +1,15 @@
+import { frameSandboxOnlyMounts } from "@app/lib/api/sandbox/frame_mounts";
+import { describe, expect, it } from "vitest";
+
+describe("frameSandboxOnlyMounts", () => {
+  it("mounts only the stable Frame publication root read-only", () => {
+    expect(frameSandboxOnlyMounts({ sId: "fil_frame" })).toEqual([
+      {
+        kind: "frame_publications",
+        id: "fil_frame",
+        sandboxMountPoint: "/frames/fil_frame/publications",
+        readOnly: true,
+      },
+    ]);
+  });
+});

--- a/front/lib/api/sandbox/frame_mounts.test.ts
+++ b/front/lib/api/sandbox/frame_mounts.test.ts
@@ -6,7 +6,7 @@ describe("frameSandboxOnlyMounts", () => {
     expect(frameSandboxOnlyMounts({ sId: "fil_frame" })).toEqual([
       {
         kind: "frame_publications",
-        id: "fil_frame",
+        frameId: "fil_frame",
         sandboxMountPoint: "/frames/fil_frame/publications",
         readOnly: true,
       },

--- a/front/lib/api/sandbox/frame_mounts.ts
+++ b/front/lib/api/sandbox/frame_mounts.ts
@@ -1,0 +1,16 @@
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { SandboxOnlyMount } from "@app/types/file_system";
+import { getFramePublicationsMountPoint } from "@app/types/mount_path";
+
+type FrameRef = Pick<FileResource, "sId">;
+
+export function frameSandboxOnlyMounts(frame: FrameRef): SandboxOnlyMount[] {
+  return [
+    {
+      kind: "frame_publications",
+      id: frame.sId,
+      sandboxMountPoint: getFramePublicationsMountPoint(frame.sId),
+      readOnly: true,
+    },
+  ];
+}

--- a/front/lib/api/sandbox/frame_mounts.ts
+++ b/front/lib/api/sandbox/frame_mounts.ts
@@ -8,7 +8,7 @@ export function frameSandboxOnlyMounts(frame: FrameRef): SandboxOnlyMount[] {
   return [
     {
       kind: "frame_publications",
-      id: frame.sId,
+      frameId: frame.sId,
       sandboxMountPoint: getFramePublicationsMountPoint(frame.sId),
       readOnly: true,
     },

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockEnsureSandboxActive,
   mockEnsurePodSandboxActive,
+  mockEnsureFrameSandboxActive,
   mockEnsureSandboxEgressOnExec,
   mockGetSandboxImage,
   mockLoggerError,
@@ -13,6 +14,7 @@ const {
   mockLoggerChild,
   mockForConversation,
   mockForPodSandboxProvisioning,
+  mockForFrameSandboxProvisioning,
   mockSetupSandboxMount,
   mockRefreshSandboxMount,
   mockPrepareSandboxEgressBeforeMount,
@@ -24,6 +26,7 @@ const {
   return {
     mockEnsureSandboxActive: vi.fn(),
     mockEnsurePodSandboxActive: vi.fn(),
+    mockEnsureFrameSandboxActive: vi.fn(),
     mockEnsureSandboxEgressOnExec: vi.fn(),
     mockGetSandboxImage: vi.fn(),
     mockLoggerError: vi.fn(),
@@ -32,6 +35,7 @@ const {
     mockLoggerChild: vi.fn(),
     mockForConversation: vi.fn(),
     mockForPodSandboxProvisioning: vi.fn(),
+    mockForFrameSandboxProvisioning: vi.fn(),
     mockSetupSandboxMount,
     mockRefreshSandboxMount,
     mockPrepareSandboxEgressBeforeMount: vi.fn(),
@@ -60,6 +64,7 @@ vi.mock("@app/lib/api/file_system/dust_file_system", () => ({
   DustFileSystem: {
     forConversation: mockForConversation,
     forPodSandboxProvisioning: mockForPodSandboxProvisioning,
+    forFrameSandboxProvisioning: mockForFrameSandboxProvisioning,
   },
 }));
 
@@ -95,6 +100,12 @@ vi.mock("@app/lib/resources/pod_sandbox_adapter", () => ({
   },
 }));
 
+vi.mock("@app/lib/resources/frame_sandbox_adapter", () => ({
+  FrameSandboxAdapter: {
+    ensureSandboxActive: mockEnsureFrameSandboxActive,
+  },
+}));
+
 vi.mock("@app/logger/logger", () => {
   const logger = {
     error: mockLoggerError,
@@ -115,6 +126,7 @@ import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import {
   ensureConversationSandboxReady,
+  ensureFrameSandboxReady,
   ensurePodSandboxReady,
 } from "./lifecycle";
 
@@ -184,12 +196,21 @@ describe("ensureConversationSandboxReady", () => {
         scope: undefined,
       })
     );
+    mockEnsureFrameSandboxActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
+    );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Ok(undefined));
     mockEnsureSandboxEgressOnExec.mockResolvedValue(new Ok(undefined));
     mockGetSandboxImage.mockReturnValue(new Ok(image));
     mockStartTelemetry.mockResolvedValue(new Ok(undefined));
     mockForConversation.mockResolvedValue(new Ok(mockFs));
     mockForPodSandboxProvisioning.mockResolvedValue(new Ok(mockFs));
+    mockForFrameSandboxProvisioning.mockResolvedValue(new Ok(mockFs));
     mockSetupSandboxMount.mockResolvedValue(new Ok(undefined));
     mockRefreshSandboxMount.mockResolvedValue(new Ok(undefined));
     mockSetupPodStateOnColdStart.mockResolvedValue(new Ok(undefined));
@@ -477,6 +498,54 @@ describe("ensureConversationSandboxReady", () => {
       egressPolicyOwnerId: pod.sId,
       wokeFromSleep: false,
     });
+  });
+
+  it("mounts only Frame publications with Frame-owned egress", async () => {
+    const frame = { sId: "fil_frame" };
+    mockEnsureFrameSandboxActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: pod.sId },
+      })
+    );
+
+    const result = await ensureFrameSandboxReady(auth, frame as never);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEnsureFrameSandboxActive).toHaveBeenCalledWith(auth, frame);
+    expect(mockForFrameSandboxProvisioning).toHaveBeenCalledWith(auth, frame, {
+      sandboxOnlyMounts: [
+        {
+          kind: "frame_publications",
+          id: frame.sId,
+          sandboxMountPoint: `/frames/${frame.sId}/publications`,
+          readOnly: true,
+        },
+      ],
+    });
+    const frameOwner = {
+      kind: "frame",
+      frameId: frame.sId,
+      spaceId: pod.sId,
+    };
+    expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      {
+        runtimeOwner: frameOwner,
+        egressPolicyOwnerId: frame.sId,
+        egressPolicyPodId: pod.sId,
+      }
+    );
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      runtimeOwner: frameOwner,
+      egressPolicyOwnerId: frame.sId,
+      egressPolicyPodId: pod.sId,
+      wokeFromSleep: false,
+    });
+    expect(mockSetupPodStateOnColdStart).not.toHaveBeenCalled();
   });
 
   it("does not run pod state bring-up for conversation sandboxes", async () => {

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -60,13 +60,20 @@ vi.mock("@app/lib/api/sandbox/egress", () => ({
   prepareSandboxEgressBeforeMount: mockPrepareSandboxEgressBeforeMount,
 }));
 
-vi.mock("@app/lib/api/file_system/dust_file_system", () => ({
-  DustFileSystem: {
-    forConversation: mockForConversation,
-    forPodSandboxProvisioning: mockForPodSandboxProvisioning,
-    forFrameSandboxProvisioning: mockForFrameSandboxProvisioning,
-  },
-}));
+vi.mock("@app/lib/api/file_system/dust_file_system", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/file_system/dust_file_system")
+    >();
+  return {
+    ...actual,
+    DustFileSystem: {
+      forConversation: mockForConversation,
+      forPodSandboxProvisioning: mockForPodSandboxProvisioning,
+      forFrameSandboxProvisioning: mockForFrameSandboxProvisioning,
+    },
+  };
+});
 
 vi.mock("@app/lib/api/sandbox/image", () => ({
   getSandboxImage: mockGetSandboxImage,
@@ -121,9 +128,11 @@ import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import { frameV2ContentType } from "@app/types/files";
 import {
   ensureConversationSandboxReady,
   ensureFrameSandboxReady,
@@ -465,13 +474,13 @@ describe("ensureConversationSandboxReady", () => {
       sandboxOnlyMounts: [
         {
           kind: "pod_sandbox_functions",
-          id: pod.sId,
+          podId: pod.sId,
           sandboxMountPoint: `/sandbox-functions/pods/${pod.sId}`,
           readOnly: true,
         },
         {
           kind: "pod_state",
-          id: pod.sId,
+          podId: pod.sId,
           sandboxMountPoint: "/pod-state/replica",
           readOnly: false,
         },
@@ -501,7 +510,14 @@ describe("ensureConversationSandboxReady", () => {
   });
 
   it("mounts only Frame publications with Frame-owned egress", async () => {
-    const frame = { sId: "fil_frame" };
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
     mockEnsureFrameSandboxActive.mockResolvedValue(
       new Ok({
         freshlyCreated: true,
@@ -511,7 +527,7 @@ describe("ensureConversationSandboxReady", () => {
       })
     );
 
-    const result = await ensureFrameSandboxReady(auth, frame as never);
+    const result = await ensureFrameSandboxReady(auth, frame);
 
     expect(result.isOk()).toBe(true);
     expect(mockEnsureFrameSandboxActive).toHaveBeenCalledWith(auth, frame);
@@ -519,7 +535,7 @@ describe("ensureConversationSandboxReady", () => {
       sandboxOnlyMounts: [
         {
           kind: "frame_publications",
-          id: frame.sId,
+          frameId: frame.sId,
           sandboxMountPoint: `/frames/${frame.sId}/publications`,
           readOnly: true,
         },

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -4,6 +4,7 @@ import {
   ensureSandboxEgressOnExec,
   prepareSandboxEgressBeforeMount,
 } from "@app/lib/api/sandbox/egress";
+import { frameSandboxOnlyMounts } from "@app/lib/api/sandbox/frame_mounts";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
   recordSandboxStartupTotal,
@@ -15,6 +16,8 @@ import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import type { ConversationSandboxScope } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import type {
   EnsureSandboxResult,
@@ -286,6 +289,28 @@ export async function ensurePodSandboxReady(
         spaceId: pod.sId,
       },
       egressPolicyOwnerId: pod.sId,
+    }),
+  });
+}
+
+export async function ensureFrameSandboxReady(
+  auth: Authenticator,
+  frame: FileResource
+): Promise<Result<EnsureSandboxReadyResult, Error>> {
+  return ensureOwnerSandboxReady(auth, {
+    ensureActive: () => FrameSandboxAdapter.ensureSandboxActive(auth, frame),
+    deriveConfig: (scope) => ({
+      getFileSystem: () =>
+        DustFileSystem.forFrameSandboxProvisioning(auth, frame, {
+          sandboxOnlyMounts: frameSandboxOnlyMounts(frame),
+        }),
+      runtimeOwner: {
+        kind: "frame",
+        frameId: frame.sId,
+        spaceId: scope.spaceId,
+      },
+      egressPolicyOwnerId: frame.sId,
+      egressPolicyPodId: scope.spaceId ?? undefined,
     }),
   });
 }

--- a/front/lib/api/sandbox/pod_mounts.ts
+++ b/front/lib/api/sandbox/pod_mounts.ts
@@ -19,7 +19,7 @@ type PodRef = Pick<SpaceResource, "sId">;
 function podSandboxFunctionsMount(pod: PodRef): SandboxOnlyMount {
   return {
     kind: "pod_sandbox_functions",
-    id: pod.sId,
+    podId: pod.sId,
     sandboxMountPoint: getPodSandboxFunctionsMountPoint(pod.sId),
     readOnly: true,
   };
@@ -31,7 +31,7 @@ function podSandboxFunctionsMount(pod: PodRef): SandboxOnlyMount {
 function podStateReplicaMount(pod: PodRef): SandboxOnlyMount {
   return {
     kind: "pod_state",
-    id: pod.sId,
+    podId: pod.sId,
     sandboxMountPoint: POD_STATE_REPLICA_MOUNT_POINT,
     readOnly: false,
   };

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -4,7 +4,6 @@ import {
   getFramePublicationFunctionBundlePath,
   getFramePublicationFunctionSchemaPath,
   getFramePublicationManifestPath,
-  getFramePublicationSourcePath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import { describe, expect, it } from "vitest";
@@ -19,15 +18,7 @@ describe("Frames v2 GCS paths", () => {
   it("keeps publications under the Frame identity", () => {
     expect(getFrameBasePath(IDS)).toBe("w/w_123/frames/fil_456/");
     expect(getFramePublicationManifestPath(IDS)).toBe(
-      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/manifest.json"
-    );
-    expect(
-      getFramePublicationSourcePath({
-        ...IDS,
-        relativePath: "src/index.tsx",
-      })
-    ).toBe(
-      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/source/src/index.tsx"
+      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/publication.json"
     );
     expect(getFramePublicationUiBundlePath(IDS)).toBe(
       "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/ui/bundle.js"
@@ -38,7 +29,7 @@ describe("Frames v2 GCS paths", () => {
         functionName: "add-task",
       })
     ).toBe(
-      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task/bundle.js"
+      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task.ts"
     );
     expect(
       getFramePublicationFunctionSchemaPath({
@@ -46,7 +37,7 @@ describe("Frames v2 GCS paths", () => {
         functionName: "add-task",
       })
     ).toBe(
-      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task/schema.json"
+      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task.schema.json"
     );
   });
 
@@ -61,12 +52,6 @@ describe("Frames v2 GCS paths", () => {
   });
 
   it("rejects path traversal and unsafe identity segments", () => {
-    expect(() =>
-      getFramePublicationSourcePath({
-        ...IDS,
-        relativePath: "../secret",
-      })
-    ).toThrow("Invalid relative source path");
     expect(() =>
       getFrameBasePath({ workspaceId: "../other", frameId: IDS.frameId })
     ).toThrow("Invalid workspaceId");

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -1,7 +1,4 @@
-import {
-  FRAME_DATABASE_NAME_REGEX,
-  isSafeFrameRelativePath,
-} from "@app/types/api/frame_manifest";
+import { FRAME_DATABASE_NAME_REGEX } from "@app/types/api/frame_manifest";
 
 const SAFE_FRAME_STORAGE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
@@ -62,31 +59,7 @@ export function getFramePublicationManifestPath(args: {
   frameId: string;
   publicationId: string;
 }): string {
-  return `${getFramePublicationBasePath(args)}manifest.json`;
-}
-
-export function getFramePublicationSourceBasePath(args: {
-  workspaceId: string;
-  frameId: string;
-  publicationId: string;
-}): string {
-  return `${getFramePublicationBasePath(args)}source/`;
-}
-
-export function getFramePublicationSourcePath({
-  relativePath,
-  ...args
-}: {
-  workspaceId: string;
-  frameId: string;
-  publicationId: string;
-  relativePath: string;
-}): string {
-  if (!isSafeFrameRelativePath(relativePath)) {
-    throw new Error("Invalid relative source path for Frame storage.");
-  }
-
-  return `${getFramePublicationSourceBasePath(args)}${relativePath}`;
+  return `${getFramePublicationBasePath(args)}publication.json`;
 }
 
 export function getFramePublicationUiBundlePath(args: {
@@ -97,25 +70,13 @@ export function getFramePublicationUiBundlePath(args: {
   return `${getFramePublicationBasePath(args)}ui/bundle.js`;
 }
 
-export function getFramePublicationFunctionBasePath({
-  functionName,
-  ...args
-}: {
-  workspaceId: string;
-  frameId: string;
-  publicationId: string;
-  functionName: string;
-}): string {
-  return `${getFramePublicationBasePath(args)}functions/${safeSegment(functionName, "functionName")}/`;
-}
-
 export function getFramePublicationFunctionBundlePath(args: {
   workspaceId: string;
   frameId: string;
   publicationId: string;
   functionName: string;
 }): string {
-  return `${getFramePublicationFunctionBasePath(args)}bundle.js`;
+  return `${getFramePublicationBasePath(args)}functions/${safeSegment(args.functionName, "functionName")}.ts`;
 }
 
 export function getFramePublicationFunctionSchemaPath(args: {
@@ -124,5 +85,5 @@ export function getFramePublicationFunctionSchemaPath(args: {
   publicationId: string;
   functionName: string;
 }): string {
-  return `${getFramePublicationFunctionBasePath(args)}schema.json`;
+  return `${getFramePublicationBasePath(args)}functions/${safeSegment(args.functionName, "functionName")}.schema.json`;
 }

--- a/front/types/file_system.ts
+++ b/front/types/file_system.ts
@@ -61,21 +61,17 @@ export type FileSystemMount = {
  * but that are not an agent-visible namespace, e.g. published sandbox-function bundles or the
  * pod-state litestream replica.
  */
-export type SandboxOnlyMountKind =
-  | "frame_publications"
-  | "pod_sandbox_functions"
-  | "pod_state";
-
-export type SandboxOnlyMount = {
-  kind: SandboxOnlyMountKind;
-
-  /** Stable sId of the resource this mount belongs to. */
-  id: string;
-
+type SandboxOnlyMountConfig = {
   sandboxMountPoint: string;
-
   readOnly: boolean;
 };
+
+export type SandboxOnlyMount = SandboxOnlyMountConfig &
+  (
+    | { kind: "frame_publications"; frameId: string }
+    | { kind: "pod_sandbox_functions"; podId: string }
+    | { kind: "pod_state"; podId: string }
+  );
 
 export type DustFileSystemErrorCode =
   | "unauthorized"

--- a/front/types/file_system.ts
+++ b/front/types/file_system.ts
@@ -61,12 +61,15 @@ export type FileSystemMount = {
  * but that are not an agent-visible namespace, e.g. published sandbox-function bundles or the
  * pod-state litestream replica.
  */
-export type SandboxOnlyMountKind = "pod_sandbox_functions" | "pod_state";
+export type SandboxOnlyMountKind =
+  | "frame_publications"
+  | "pod_sandbox_functions"
+  | "pod_state";
 
 export type SandboxOnlyMount = {
   kind: SandboxOnlyMountKind;
 
-  /** sId of the pod this mount belongs to. */
+  /** Stable sId of the resource this mount belongs to. */
   id: string;
 
   sandboxMountPoint: string;

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -98,6 +98,15 @@ export function getPodSandboxFunctionsMountPoint(podId: string): string {
 }
 
 /**
+ * Read-only root containing every immutable publication of one Frame. The stable Frame identity
+ * keeps the mount unchanged when a new publication activates; each invocation selects its exact
+ * publication below this root.
+ */
+export function getFramePublicationsMountPoint(frameId: string): string {
+  return `/frames/${frameId}/publications`;
+}
+
+/**
  * Absolute in-sandbox path of the pod's live SQLite databases (`{name}.db` files opened by
  * `@dust/pod`'s `db()`). Local disk, not a gcsfuse mount — Litestream replicates it to GCS.
  * Front is the only layer that hardcodes this location (the paths-env.v1 contract): it is


### PR DESCRIPTION
## Description

- Store immutable Frame artifacts under the canonical publication keys and keep authoring source out of publication storage.
- Mount the stable Frame publication root read-only in its Frame-owned sandbox, with no agent-visible source mounts.
- Stack on #31391.

Follow-up before SQLite reconciliation: replace the raw manifest payload in `publication.json` with the versioned publication descriptor, including immutable database schema sources and hashes.

## Tests

Added coverage for publication keys, source exclusion, Frame filesystem scoping, mount configuration, and lifecycle setup. Tested the focused 142-test suite locally.

## Risk

Low. The path changes are behind Frames v2 and are not user-reachable until invocation wiring lands. Existing draft publications need republishing. Frames v1 and Pod Functions are unchanged.

## Deploy Plan

Merge #31391 first, then standard deploy. No migration.