### PR TITLE
[front] fix: stop blocked-action prompts from getting permanently stuck

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.test.ts
@@ -1,0 +1,64 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupAgentMessage() {
+  const { auth, workspace } = await createPrivateApiMockRequest({
+    role: "user",
+    method: "POST",
+  });
+
+  const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+    auth,
+    { name: "Retry endpoint" }
+  );
+
+  const createdConversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [],
+  });
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    createdConversation.sId
+  );
+  if (!conversation) {
+    throw new Error("Just-created conversation not found.");
+  }
+
+  const { messageRow: userMessage } =
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Search Slack for the release notes",
+    });
+
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig: agentConfiguration,
+    parentMessageModelId: userMessage.id,
+    rank: 1,
+  });
+
+  return { conversation, agentMessage, workspace };
+}
+
+describe("POST /api/w/:wId/assistant/conversations/:cId/messages/:mId/retry", () => {
+  it("succeeds when there are no blocked actions left to resume", async () => {
+    const { conversation, agentMessage, workspace } = await setupAgentMessage();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}` +
+        `/messages/${agentMessage.sId}/retry?blocked_only=true`,
+      { method: "POST", headers: { "Content-Type": "application/json" } }
+    );
+
+    // The prompt the caller acted on is already gone, which is the outcome they asked for.
+    // Reporting a failure here left the blocked-action banner on screen with no way to clear it.
+    expect(response.status).toBe(200);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,8 +1,12 @@
 import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
-import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import {
+  NOTHING_TO_RESUME_ERROR_CODES,
+  retryBlockedActions,
+} from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -144,18 +148,34 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     if (retryBlockedActionsRes.isErr()) {
       const { error } = retryBlockedActionsRes;
 
-      if (
-        error instanceof DustError &&
-        error.code === "agent_loop_already_running"
-      ) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
+      if (error instanceof DustError) {
+        // Nothing left to resume: the blocked actions the user acted on are already gone, and
+        // their stale events have just been purged. That is the outcome the caller asked for,
+        // so reporting a failure would leave the prompt on screen with no way to clear it.
+        if (NOTHING_TO_RESUME_ERROR_CODES.includes(error.code)) {
+          return ctx.json({ message });
+        }
+
+        if (error.code === "agent_loop_already_running") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        }
       }
+
+      logger.error(
+        {
+          conversationId: conversation.sId,
+          error,
+          messageId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Failed to retry blocked actions"
+      );
 
       return apiError(ctx, {
         status_code: 500,

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/assistant/conversation/retry_blocked_actions", () => ({
-  retryBlockedActions: vi.fn(),
-}));
+vi.mock(
+  "@app/lib/api/assistant/conversation/retry_blocked_actions",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/assistant/conversation/retry_blocked_actions")
+    >()),
+    retryBlockedActions: vi.fn(),
+  })
+);
 
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -1,6 +1,9 @@
 import { listAgenticAncestors } from "@app/lib/api/assistant/conversation/agentic_ancestors";
 import { MAX_CONVERSATION_DEPTH } from "@app/lib/api/assistant/conversation/constants";
-import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import {
+  NOTHING_TO_RESUME_ERROR_CODES,
+  retryBlockedActions,
+} from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustErrorCode } from "@app/lib/error";
 import { DustError } from "@app/lib/error";
@@ -12,8 +15,7 @@ import logger from "@app/logger/logger";
 // state. Higher ancestors may still be parked, so the walk continues.
 const NON_BLOCKING_RETRY_ERROR_CODES: DustErrorCode[] = [
   "agent_loop_already_running",
-  "agent_message_not_resumable",
-  "no_blocked_actions",
+  ...NOTHING_TO_RESUME_ERROR_CODES,
 ];
 
 /**

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -2,6 +2,7 @@ import { isBlockedActionEvent } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustErrorCode } from "@app/lib/error";
 import { DustError } from "@app/lib/error";
 // TODO(2026-07-31 QOS): move these message fetches behind a resource method instead of using
 // models directly in lib/api.
@@ -17,6 +18,25 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+// Outcomes that mean the message has nothing left to resume, rather than a resume that failed:
+// the blocked actions were already consumed, or the agent message reached a terminal state.
+export const NOTHING_TO_RESUME_ERROR_CODES: DustErrorCode[] = [
+  "agent_message_not_resumable",
+  "no_blocked_actions",
+];
+
+// Clients replay the whole message stream on load, so any blocked-action event left behind keeps
+// re-prompting the user forever. Purge them:
+// - remove tool_approve_execution events (watch out as those events are not republished).
+// - remove tool_personal_auth_required events.
+async function purgeBlockedActionEvents(messageId: string): Promise<void> {
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+
+    return isBlockedActionEvent(payload);
+  }, getMessageChannelId(messageId));
+}
 
 async function findUserMessageForRetry(
   auth: Authenticator,
@@ -78,6 +98,10 @@ async function findUserMessageForRetry(
       agentMessageId: agentMessage.agentMessageId,
     });
 
+  // Purge before the early returns below: a message with nothing left to resume is exactly the
+  // case where stale events would otherwise keep the prompt on screen with no way to clear it.
+  await purgeBlockedActionEvents(messageId);
+
   if (blockedActions.length === 0) {
     // Not a failure: the message simply has nothing waiting on user input (already resumed, or
     // reached here through a handover whose caller was never blocked).
@@ -97,15 +121,6 @@ async function findUserMessageForRetry(
       )
     );
   }
-
-  // Purge blocked actions event message from the stream:
-  // - remove tool_approve_execution events (watch out as those events are not republished).
-  // - remove tool_personal_auth_required events.
-  await getRedisHybridManager().removeEvent((event) => {
-    const payload = JSON.parse(event.message["payload"]);
-
-    return isBlockedActionEvent(payload);
-  }, getMessageChannelId(messageId));
 
   return new Ok({
     agentMessageId: agentMessage.sId,

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -19,9 +19,15 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
 }));
 
 // Mock the ancestor resume so we can assert on it without launching workflows
-vi.mock("@app/lib/api/assistant/conversation/retry_blocked_actions", () => ({
-  retryBlockedActions: vi.fn(),
-}));
+vi.mock(
+  "@app/lib/api/assistant/conversation/retry_blocked_actions",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/assistant/conversation/retry_blocked_actions")
+    >()),
+    retryBlockedActions: vi.fn(),
+  })
+);
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";


### PR DESCRIPTION
## Problem

`POST .../messages/:mId/retry?blocked_only=true` returns **500 whenever there is nothing left to resume**, and leaves the stale blocked-action events in Redis. The result is a prompt the user can never clear.

`findUserMessageForRetry` returns `DustError("no_blocked_actions")` when the blocked actions were already consumed, and `DustError("agent_message_not_resumable")` when the agent message reached a terminal state. Neither is a failure — the code says so itself (*"Not a failure: the message simply has nothing waiting on user input"*), and `resumeAncestorConversations` already lists both in `NON_BLOCKING_RETRY_ERROR_CODES`. But the handler special-cased only `agent_loop_already_running` and mapped everything else to a 500.

The purge of blocked-action events from the message stream sat *after* those two early returns, so it never ran for precisely the messages that needed it. Clients replay the whole stream from `"0-0"` on load, so:

1. User connects Slack / clicks retry → 500, no purge, no agent loop.
2. `useRetryMessage` swallows non-limit errors and returns `Ok`, so no error is surfaced — the button just does nothing.
3. The banner is only removed by an incoming stream event (`AgentMessage.tsx:428-443`); none arrives.
4. On reload the stale events replay and the prompt is back.

Forever. This is what 1Password reported as "3 (or more) manual actions are needed, only shows one" — the queue holds several, `getFirstBlockedActionForMessage` renders the head.

**Scale:** 103,609 of these 500s in 7 days across prod (~15k/day). 3,037 of them are the 1Password workspace, whose Slack integration is otherwise healthy (26,123 tool executions in the same window). So this is not a Slack problem and not a 1Password problem.

## Change

- **Purge blocked-action events before the early returns** in `retry_blocked_actions.ts`. A message with nothing left to resume is exactly the case where stale events keep re-prompting.
- **Treat both codes as success** in the handler and return the message. The prompt is gone, which is what the caller asked for. `agent_loop_already_running` still maps to 400.
- **Log the underlying error before any 500.** The handler discarded `retryBlockedActionsRes.error` entirely, which is why a five-figure daily error count went unnoticed and why I can't say from logs which of the two codes dominates.
- **One definition of "nothing to resume"**, shared with `resumeAncestorConversations` rather than each caller deciding for itself.

## Test

`retry.test.ts` covers the reported case: a blocked-only retry on a message with no blocked actions. Verified it fails on the old code with `expected 500 to be 200`, and passes here.

## Follow-ups (not in this PR)

- `useRetryMessage` swallowing non-limit errors is a landmine beyond this endpoint — it should return `Err` and notify.
- Clear the banner on a successful blocked-only retry, so the fix doesn't need a reload.
- A monitor on retry 5xx.
- Longer term, blocked-action prompts should derive from server state rather than a replayed event stream whose purge is on the success path only.
