### PR TITLE
Version Frame publication descriptors

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -2,7 +2,7 @@ import { getFramePublishLockName } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationFunctionArtifact } from "@app/lib/api/frames/publication_storage";
 import {
   activateFramePublication,
-  loadFramePublicationManifest,
+  loadFramePublicationDescriptor,
   publishFramePublication,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
@@ -20,10 +20,10 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { redisMock } from "@app/tests/utils/mocks/redis";
 import { getNamespace } from "@app/tests/utils/test_cls";
 import { FrameManifestSchema } from "@app/types/api/frame_manifest";
+import { FramePublicationDescriptorSchema } from "@app/types/api/frame_publication";
 import {
+  getFramePublicationDescriptorPath,
   getFramePublicationFunctionBundlePath,
-  getFramePublicationFunctionSchemaPath,
-  getFramePublicationManifestPath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import {
@@ -31,7 +31,6 @@ import {
   frameV2ContentType,
   sandboxFunctionContentType,
 } from "@app/types/files";
-import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 async function setupFrame({
@@ -139,6 +138,14 @@ beforeEach(() => {
   fileStorageMock.reset();
 });
 
+function getStoredDescriptor(path: string) {
+  const storedDescriptor = fileStorageMock.getObject(path);
+  if (!storedDescriptor) {
+    throw new Error(`Missing stored Frame publication descriptor: ${path}`);
+  }
+  return FramePublicationDescriptorSchema.parse(JSON.parse(storedDescriptor));
+}
+
 describe("storeFramePublication", () => {
   it("stores runtime artifacts without source before the publication commit marker", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
@@ -163,7 +170,7 @@ describe("storeFramePublication", () => {
     expect(new Set(savedPaths.slice(0, -1))).toEqual(
       new Set([getFramePublicationUiBundlePath(identity)])
     );
-    expect(savedPaths.at(-1)).toBe(getFramePublicationManifestPath(identity));
+    expect(savedPaths.at(-1)).toBe(getFramePublicationDescriptorPath(identity));
     expect(fileStorageMock.saveFileCalls.at(-1)?.contentType).toBe(
       frameV2ContentType
     );
@@ -205,37 +212,35 @@ describe("storeFramePublication", () => {
       ...identity,
       functionName: "add-task",
     });
-    const schemaPath = getFramePublicationFunctionSchemaPath({
-      ...identity,
-      functionName: "add-task",
-    });
     const savedPaths = fileStorageMock.saveFileCalls.map(
       ({ filePath }) => filePath
     );
 
     expect(savedPaths).toContain(bundlePath);
-    expect(savedPaths).toContain(schemaPath);
-    expect(savedPaths.at(-1)).toBe(getFramePublicationManifestPath(identity));
+    expect(savedPaths.at(-1)).toBe(getFramePublicationDescriptorPath(identity));
     expect(fileStorageMock.getObject(bundlePath)).toBe(
       functionArtifacts[0].bundleCode
-    );
-    expect(fileStorageMock.getObject(schemaPath)).toBe(
-      JSON.stringify({
-        userIdentity: functionArtifacts[0].userIdentity,
-        inputSchema: functionArtifacts[0].inputSchema,
-        outputSchema: functionArtifacts[0].outputSchema,
-      })
     );
     expect(
       fileStorageMock.saveFileCalls.find(
         ({ filePath }) => filePath === bundlePath
       )?.contentType
     ).toBe(sandboxFunctionContentType);
-    expect(
-      fileStorageMock.saveFileCalls.find(
-        ({ filePath }) => filePath === schemaPath
-      )?.contentType
-    ).toBe("application/json");
+    const descriptor = await loadFramePublicationDescriptor(auth, {
+      frame,
+      publicationId: result.value.publicationId,
+    });
+    expect(descriptor.isOk() && descriptor.value.functions).toEqual([
+      {
+        name: "add-task",
+        bundleSha256: computeSandboxFunctionBundleSha256(
+          functionArtifacts[0].bundleCode
+        ),
+        userIdentity: functionArtifacts[0].userIdentity,
+        inputSchema: functionArtifacts[0].inputSchema,
+        outputSchema: functionArtifacts[0].outputSchema,
+      },
+    ]);
   });
 
   it("retains declared database schemas in publication metadata", async () => {
@@ -259,13 +264,19 @@ describe("storeFramePublication", () => {
       return;
     }
 
-    const loadedManifest = await loadFramePublicationManifest(auth, {
+    const descriptor = await loadFramePublicationDescriptor(auth, {
       frame,
       publicationId: result.value.publicationId,
     });
-    expect(loadedManifest.isOk() && loadedManifest.value.databases).toEqual(
-      manifestWithDatabase.databases
-    );
+    expect(descriptor.isOk() && descriptor.value.databases).toEqual([
+      {
+        name: "tasks",
+        schemaSource: databaseSchema.content.toString("utf8"),
+        schemaSha256: computeSandboxFunctionBundleSha256(
+          databaseSchema.content.toString("utf8")
+        ),
+      },
+    ]);
   });
 
   it("rejects a publication whose UI entry point is missing", async () => {
@@ -316,6 +327,28 @@ describe("storeFramePublication", () => {
     expect(result.isErr() && result.error.message).toContain(
       "Frame database schema not found: tasks"
     );
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("rejects a database schema that is not valid UTF-8", async () => {
+    const { auth, frame } = await setupFrame();
+
+    const result = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: manifestWithDatabase,
+      sourceFiles: [
+        ...sourceFiles,
+        {
+          relativePath: "databases/tasks.db.ts",
+          content: Buffer.from([0xff]),
+          contentType: "text/typescript" as const,
+        },
+      ],
+      uiBundleCode,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_source");
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
@@ -417,7 +450,7 @@ describe("storeFramePublication", () => {
 });
 
 describe("Frame publication reads", () => {
-  it("loads the manifest of a committed publication", async () => {
+  it("loads the descriptor of a committed publication", async () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
       frame,
@@ -431,18 +464,33 @@ describe("Frame publication reads", () => {
       return;
     }
 
-    const loadedManifest = await loadFramePublicationManifest(auth, {
+    const descriptor = await loadFramePublicationDescriptor(auth, {
       frame,
       publicationId: stored.value.publicationId,
     });
-    expect(loadedManifest).toEqual(new Ok(manifest));
+    expect(descriptor.isOk()).toBe(true);
+    if (descriptor.isErr()) {
+      return;
+    }
+    expect(descriptor.value).toMatchObject({
+      schemaVersion: 1,
+      manifest,
+      publisherId: auth.getNonNullableUser().sId,
+      ui: {
+        bundleSha256: computeSandboxFunctionBundleSha256(uiBundleCode),
+      },
+      functions: [],
+      databases: [],
+    });
+    expect(descriptor.value.publishedAt).toEqual(expect.any(String));
+    expect(descriptor.value.sourceFiles).toHaveLength(sourceFiles.length);
   });
 
-  it("rejects an invalid stored manifest", async () => {
+  it("rejects an invalid stored descriptor", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
     const publicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
     fileStorageMock.setObject(
-      getFramePublicationManifestPath({
+      getFramePublicationDescriptorPath({
         workspaceId,
         frameId: frame.sId,
         publicationId,
@@ -450,12 +498,57 @@ describe("Frame publication reads", () => {
       "not json"
     );
 
-    const result = await loadFramePublicationManifest(auth, {
+    const result = await loadFramePublicationDescriptor(auth, {
       frame,
       publicationId,
     });
 
-    expect(result.isErr() && result.error.code).toBe("invalid_manifest");
+    expect(result.isErr() && result.error.code).toBe("invalid_publication");
+  });
+
+  it("rejects a modified database schema contract", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: manifestWithDatabase,
+      sourceFiles: [
+        ...sourceFiles,
+        {
+          relativePath: "databases/tasks.db.ts",
+          content: Buffer.from("export const tasks = {};"),
+          contentType: "text/typescript" as const,
+        },
+      ],
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    const descriptorPath = getFramePublicationDescriptorPath({
+      workspaceId,
+      frameId: frame.sId,
+      publicationId: stored.value.publicationId,
+    });
+    const descriptor = getStoredDescriptor(descriptorPath);
+    fileStorageMock.setObject(
+      descriptorPath,
+      JSON.stringify({
+        ...descriptor,
+        databases: descriptor.databases.map((database) => ({
+          ...database,
+          schemaSource: "export const tampered = {};",
+        })),
+      })
+    );
+
+    const result = await loadFramePublicationDescriptor(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_publication");
   });
 });
 
@@ -566,6 +659,40 @@ describe("activateFramePublication", () => {
     );
   });
 
+  it("rejects a modified function bundle before activation", async () => {
+    const { auth, frame, workspaceId } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    fileStorageMock.setObject(
+      getFramePublicationFunctionBundlePath({
+        workspaceId,
+        frameId: frame.sId,
+        publicationId: stored.value.publicationId,
+        functionName: "add-task",
+      }),
+      "export const tampered = true;"
+    );
+
+    const result = await activateFramePublication(auth, {
+      frame,
+      publicationId: stored.value.publicationId,
+    });
+
+    expect(result.isErr() && result.error.code).toBe(
+      "invalid_function_artifact"
+    );
+    expect(frame.useCaseMetadata?.activePublicationId).toBeUndefined();
+  });
+
   it("rolls back the allowlist and function rows when activation fails", async () => {
     const { auth, frame, workspaceId } = await setupFrame();
     vi.spyOn(frame, "computeAuthorizedFileAccess").mockImplementation(
@@ -590,13 +717,26 @@ describe("activateFramePublication", () => {
     }
 
     const stagedBundle = "export default function Staged() {}";
+    const identity = {
+      workspaceId,
+      frameId: frame.sId,
+      publicationId: active.value.publicationId,
+    };
     fileStorageMock.setObject(
-      getFramePublicationUiBundlePath({
-        workspaceId,
-        frameId: frame.sId,
-        publicationId: active.value.publicationId,
-      }),
+      getFramePublicationUiBundlePath(identity),
       stagedBundle
+    );
+    const descriptor = getStoredDescriptor(
+      getFramePublicationDescriptorPath(identity)
+    );
+    fileStorageMock.setObject(
+      getFramePublicationDescriptorPath(identity),
+      JSON.stringify({
+        ...descriptor,
+        ui: {
+          bundleSha256: computeSandboxFunctionBundleSha256(stagedBundle),
+        },
+      })
     );
 
     const parentTransaction =
@@ -710,7 +850,7 @@ describe("publishFramePublication", () => {
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
     await frame.setActiveFramePublication(activePublicationId);
     fileStorageMock.setFileSaveFails((filePath) =>
-      filePath.endsWith(".schema.json")
+      filePath.endsWith("/functions/add-task.ts")
     );
 
     await expect(

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -17,21 +17,21 @@ import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
+import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
+import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
 import {
-  isSafeFrameRelativePath,
-  parseFrameManifest,
-} from "@app/types/api/frame_manifest";
+  FRAME_PUBLICATION_SCHEMA_VERSION,
+  FramePublicationDescriptorSchema,
+  parseFramePublicationDescriptor,
+} from "@app/types/api/frame_publication";
 import {
+  getFramePublicationDescriptorPath,
   getFramePublicationFunctionBundlePath,
-  getFramePublicationFunctionSchemaPath,
-  getFramePublicationManifestPath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
-import { SANDBOX_FUNCTION_USER_IDENTITY_POLICIES } from "@app/types/api/sandbox_functions";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import {
   frameContentType,
@@ -40,25 +40,10 @@ import {
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
-
-const jsonSchemaValue = z.custom<JSONSchema>(
-  (value) =>
-    typeof value === "object" &&
-    value !== null &&
-    validateJsonSchema(value).isValid
-);
-
-const FramePublicationFunctionSchemaArtifactSchema = z.object({
-  userIdentity: z.enum(SANDBOX_FUNCTION_USER_IDENTITY_POLICIES),
-  inputSchema: jsonSchemaValue,
-  outputSchema: jsonSchemaValue,
-});
 
 export type FramePublicationSourceFile = {
   relativePath: string;
@@ -80,6 +65,7 @@ export class FramePublicationError extends Error {
       | "invalid_frame"
       | "invalid_function_artifact"
       | "invalid_manifest"
+      | "invalid_publication"
       | "invalid_source"
       | "allowlist_failed"
       | "publication_not_found"
@@ -92,6 +78,9 @@ export class FramePublicationError extends Error {
   }
 }
 
+function sha256(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
 export function isFramePublicationError(
   error: unknown
 ): error is FramePublicationError {
@@ -136,7 +125,7 @@ export async function storeFramePublication(
     return frameIdentity;
   }
 
-  const sourcePaths = new Set<string>();
+  const sourceFilesByPath = new Map<string, FramePublicationSourceFile>();
   for (const sourceFile of sourceFiles) {
     if (!isSafeFrameRelativePath(sourceFile.relativePath)) {
       return new Err(
@@ -146,7 +135,7 @@ export async function storeFramePublication(
         )
       );
     }
-    if (sourcePaths.has(sourceFile.relativePath)) {
+    if (sourceFilesByPath.has(sourceFile.relativePath)) {
       return new Err(
         new FramePublicationError(
           "invalid_source",
@@ -154,9 +143,9 @@ export async function storeFramePublication(
         )
       );
     }
-    sourcePaths.add(sourceFile.relativePath);
+    sourceFilesByPath.set(sourceFile.relativePath, sourceFile);
   }
-  if (!sourcePaths.has(manifest.uiEntryPoint)) {
+  if (!sourceFilesByPath.has(manifest.uiEntryPoint)) {
     return new Err(
       new FramePublicationError(
         "invalid_source",
@@ -165,7 +154,7 @@ export async function storeFramePublication(
     );
   }
   for (const fn of manifest.functions) {
-    if (!sourcePaths.has(fn.entryPoint)) {
+    if (!sourceFilesByPath.has(fn.entryPoint)) {
       return new Err(
         new FramePublicationError(
           "invalid_source",
@@ -174,8 +163,10 @@ export async function storeFramePublication(
       );
     }
   }
+  const databaseContracts: FramePublicationDescriptor["databases"] = [];
   for (const database of manifest.databases) {
-    if (!sourcePaths.has(database.schema)) {
+    const schemaFile = sourceFilesByPath.get(database.schema);
+    if (!schemaFile) {
       return new Err(
         new FramePublicationError(
           "invalid_source",
@@ -183,14 +174,31 @@ export async function storeFramePublication(
         )
       );
     }
+    const schemaSource = schemaFile.content.toString("utf8");
+    if (!Buffer.from(schemaSource, "utf8").equals(schemaFile.content)) {
+      return new Err(
+        new FramePublicationError(
+          "invalid_source",
+          `Frame database schema is not valid UTF-8: ${database.name} (${database.schema})`
+        )
+      );
+    }
+    databaseContracts.push({
+      name: database.name,
+      schemaSource,
+      schemaSha256: sha256(schemaSource),
+    });
   }
 
   const declaredFunctionNames = new Set(
     manifest.functions.map((fn) => fn.name)
   );
-  const artifactNames = new Set<string>();
+  const functionArtifactsByName = new Map<
+    string,
+    FramePublicationFunctionArtifact
+  >();
   for (const artifact of functionArtifacts) {
-    if (artifactNames.has(artifact.name)) {
+    if (functionArtifactsByName.has(artifact.name)) {
       return new Err(
         new FramePublicationError(
           "invalid_function_artifact",
@@ -206,10 +214,12 @@ export async function storeFramePublication(
         )
       );
     }
-    artifactNames.add(artifact.name);
+    functionArtifactsByName.set(artifact.name, artifact);
   }
+  const functionContracts: FramePublicationDescriptor["functions"] = [];
   for (const fn of manifest.functions) {
-    if (!artifactNames.has(fn.name)) {
+    const artifact = functionArtifactsByName.get(fn.name);
+    if (!artifact) {
       return new Err(
         new FramePublicationError(
           "invalid_function_artifact",
@@ -217,6 +227,13 @@ export async function storeFramePublication(
         )
       );
     }
+    functionContracts.push({
+      name: fn.name,
+      bundleSha256: sha256(artifact.bundleCode),
+      userIdentity: artifact.userIdentity,
+      inputSchema: artifact.inputSchema,
+      outputSchema: artifact.outputSchema,
+    });
   }
 
   const identity = {
@@ -225,34 +242,45 @@ export async function storeFramePublication(
   };
   const storage = getPrivateUploadBucket();
 
+  const descriptorResult = FramePublicationDescriptorSchema.safeParse({
+    schemaVersion: FRAME_PUBLICATION_SCHEMA_VERSION,
+    manifest,
+    publishedAt: new Date().toISOString(),
+    publisherId: auth.user()?.sId ?? null,
+    sourceFiles: sourceFiles
+      .map((sourceFile) => ({
+        path: sourceFile.relativePath,
+        contentSha256: sha256(sourceFile.content),
+      }))
+      .sort((left, right) => left.path.localeCompare(right.path)),
+    ui: { bundleSha256: sha256(uiBundleCode) },
+    functions: functionContracts,
+    databases: databaseContracts,
+  } satisfies FramePublicationDescriptor);
+  if (!descriptorResult.success) {
+    return new Err(
+      new FramePublicationError(
+        "invalid_publication",
+        `Invalid Frame publication descriptor: ${descriptorResult.error.message}`
+      )
+    );
+  }
+  const descriptor = descriptorResult.data;
+
   const publicationFiles = [
     {
       filePath: getFramePublicationUiBundlePath(identity),
       content: uiBundleCode,
       contentType: frameContentType,
     },
-    ...functionArtifacts.flatMap((artifact) => [
-      {
-        filePath: getFramePublicationFunctionBundlePath({
-          ...identity,
-          functionName: artifact.name,
-        }),
-        content: artifact.bundleCode,
-        contentType: sandboxFunctionContentType,
-      },
-      {
-        filePath: getFramePublicationFunctionSchemaPath({
-          ...identity,
-          functionName: artifact.name,
-        }),
-        content: JSON.stringify({
-          userIdentity: artifact.userIdentity,
-          inputSchema: artifact.inputSchema,
-          outputSchema: artifact.outputSchema,
-        }),
-        contentType: "application/json",
-      },
-    ]),
+    ...functionArtifacts.map((artifact) => ({
+      filePath: getFramePublicationFunctionBundlePath({
+        ...identity,
+        functionName: artifact.name,
+      }),
+      content: artifact.bundleCode,
+      contentType: sandboxFunctionContentType,
+    })),
   ];
 
   await concurrentExecutor(
@@ -268,18 +296,20 @@ export async function storeFramePublication(
   );
 
   // publication.json is the commit marker. Readers never observe partial publication data.
-  const manifestPath = getFramePublicationManifestPath(identity);
-  await storage.file(manifestPath).save(Buffer.from(JSON.stringify(manifest)), {
-    contentType: frameV2ContentType,
-    preconditionOpts: {
-      ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-    },
-  });
+  const descriptorPath = getFramePublicationDescriptorPath(identity);
+  await storage
+    .file(descriptorPath)
+    .save(Buffer.from(JSON.stringify(descriptor)), {
+      contentType: frameV2ContentType,
+      preconditionOpts: {
+        ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+      },
+    });
 
   return new Ok({ publicationId: identity.publicationId });
 }
 
-export async function loadFramePublicationManifest(
+export async function loadFramePublicationDescriptor(
   auth: Authenticator,
   {
     frame,
@@ -288,20 +318,20 @@ export async function loadFramePublicationManifest(
     frame: FileResource;
     publicationId: string;
   }
-): Promise<Result<FrameManifest, FramePublicationError>> {
+): Promise<Result<FramePublicationDescriptor, FramePublicationError>> {
   const frameIdentity = getFrameIdentity(auth, frame);
   if (frameIdentity.isErr()) {
     return frameIdentity;
   }
 
-  const manifestPath = getFramePublicationManifestPath({
+  const descriptorPath = getFramePublicationDescriptorPath({
     ...frameIdentity.value,
     publicationId,
   });
-  let manifestBuffer: Uint8Array<ArrayBuffer>;
+  let descriptorBuffer: Uint8Array<ArrayBuffer>;
   try {
-    manifestBuffer =
-      await getPrivateUploadBucket().fetchFileBuffer(manifestPath);
+    descriptorBuffer =
+      await getPrivateUploadBucket().fetchFileBuffer(descriptorPath);
   } catch (error) {
     if (isGCSNotFoundError(error)) {
       return new Err(
@@ -314,25 +344,39 @@ export async function loadFramePublicationManifest(
     throw error;
   }
 
-  const manifest = parseFrameManifest(Buffer.from(manifestBuffer));
-  if (manifest.isErr()) {
+  const descriptor = parseFramePublicationDescriptor(
+    Buffer.from(descriptorBuffer)
+  );
+  if (descriptor.isErr()) {
     return new Err(
-      new FramePublicationError("invalid_manifest", manifest.error)
+      new FramePublicationError("invalid_publication", descriptor.error)
     );
   }
 
-  return manifest;
+  const invalidDatabaseContract = descriptor.value.databases.find(
+    (database) => sha256(database.schemaSource) !== database.schemaSha256
+  );
+  if (invalidDatabaseContract) {
+    return new Err(
+      new FramePublicationError(
+        "invalid_publication",
+        `Frame publication database schema hash mismatch: ${invalidDatabaseContract.name}`
+      )
+    );
+  }
+
+  return descriptor;
 }
 
 async function loadFramePublicationFunctionDefinitions(
   auth: Authenticator,
   {
     frame,
-    manifest,
+    descriptor,
     publicationId,
   }: {
     frame: FileResource;
-    manifest: FrameManifest;
+    descriptor: FramePublicationDescriptor;
     publicationId: string;
   }
 ): Promise<
@@ -345,24 +389,18 @@ async function loadFramePublicationFunctionDefinitions(
 
   const storage = getPrivateUploadBucket();
   const definitions = await concurrentExecutor(
-    manifest.functions,
-    async (fn) => {
+    descriptor.manifest.functions,
+    async (fn, index) => {
       const identity = {
         ...frameIdentity.value,
         publicationId,
         functionName: fn.name,
       };
       let bundleCode: string;
-      let schemaContent: string;
       try {
-        [bundleCode, schemaContent] = await Promise.all([
-          storage.fetchFileContent(
-            getFramePublicationFunctionBundlePath(identity)
-          ),
-          storage.fetchFileContent(
-            getFramePublicationFunctionSchemaPath(identity)
-          ),
-        ]);
+        bundleCode = await storage.fetchFileContent(
+          getFramePublicationFunctionBundlePath(identity)
+        );
       } catch (error) {
         if (!isGCSNotFoundError(error)) {
           throw error;
@@ -375,24 +413,12 @@ async function loadFramePublicationFunctionDefinitions(
         );
       }
 
-      let schemaJson: unknown;
-      try {
-        schemaJson = JSON.parse(schemaContent);
-      } catch (error) {
+      const contract = descriptor.functions[index];
+      if (!contract || sha256(bundleCode) !== contract.bundleSha256) {
         return new Err(
           new FramePublicationError(
             "invalid_function_artifact",
-            `Invalid Frame publication function schema for ${fn.name}: ${normalizeError(error).message}`
-          )
-        );
-      }
-      const schema =
-        FramePublicationFunctionSchemaArtifactSchema.safeParse(schemaJson);
-      if (!schema.success) {
-        return new Err(
-          new FramePublicationError(
-            "invalid_function_artifact",
-            `Invalid Frame publication function schema for ${fn.name}: ${schema.error.message}`
+            `Frame publication function bundle hash mismatch: ${fn.name}`
           )
         );
       }
@@ -403,7 +429,9 @@ async function loadFramePublicationFunctionDefinitions(
         executionMode: fn.executionMode,
         defaultStake: fn.defaultStake,
         bundleCode,
-        ...schema.data,
+        userIdentity: contract.userIdentity,
+        inputSchema: contract.inputSchema,
+        outputSchema: contract.outputSchema,
       });
     },
     { concurrency: FRAME_PUBLICATION_READ_CONCURRENCY }
@@ -431,12 +459,12 @@ export async function activateFramePublication(
     publicationId: string;
   }
 ): Promise<Result<void, FramePublicationError>> {
-  const manifest = await loadFramePublicationManifest(auth, {
+  const descriptor = await loadFramePublicationDescriptor(auth, {
     frame,
     publicationId,
   });
-  if (manifest.isErr()) {
-    return manifest;
+  if (descriptor.isErr()) {
+    return descriptor;
   }
 
   const frameIdentity = getFrameIdentity(auth, frame);
@@ -446,7 +474,7 @@ export async function activateFramePublication(
 
   const functionDefinitions = await loadFramePublicationFunctionDefinitions(
     auth,
-    { frame, manifest: manifest.value, publicationId }
+    { frame, descriptor: descriptor.value, publicationId }
   );
   if (functionDefinitions.isErr()) {
     return functionDefinitions;
@@ -468,6 +496,14 @@ export async function activateFramePublication(
       new FramePublicationError(
         "publication_not_found",
         `Frame publication UI bundle not found: ${publicationId}`
+      )
+    );
+  }
+  if (sha256(uiBundleCode) !== descriptor.value.ui.bundleSha256) {
+    return new Err(
+      new FramePublicationError(
+        "invalid_publication",
+        `Frame publication UI bundle hash mismatch: ${publicationId}`
       )
     );
   }

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -15,7 +15,8 @@ import {
   FRAME_MANIFEST_FILE,
   FrameManifestSchema,
 } from "@app/types/api/frame_manifest";
-import { getFramePublicationManifestPath } from "@app/types/api/frame_storage";
+import { FramePublicationDescriptorSchema } from "@app/types/api/frame_publication";
+import { getFramePublicationDescriptorPath } from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
 import {
   getConversationFilesBasePath,
@@ -203,9 +204,16 @@ describe("publishFrameV2FromSource", () => {
       frameId: frame.sId,
       publicationId: result.value.publicationId,
     };
-    expect(
-      fileStorageMock.getObject(getFramePublicationManifestPath(identity))
-    ).toBe(JSON.stringify(FrameManifestSchema.parse(JSON.parse(manifest))));
+    const storedPublication = fileStorageMock.getObject(
+      getFramePublicationDescriptorPath(identity)
+    );
+    assert(storedPublication);
+    const publication = FramePublicationDescriptorSchema.parse(
+      JSON.parse(storedPublication)
+    );
+    expect(publication.manifest).toEqual(
+      FrameManifestSchema.parse(JSON.parse(manifest))
+    );
     expect(
       fileStorageMock.saveFileCalls.some(({ filePath }) =>
         filePath.startsWith(`${gcsSourceDirectoryPath}/`)

--- a/front/types/api/frame_publication.test.ts
+++ b/front/types/api/frame_publication.test.ts
@@ -1,0 +1,85 @@
+import {
+  FramePublicationDescriptorSchema,
+  parseFramePublicationDescriptor,
+} from "@app/types/api/frame_publication";
+import { describe, expect, it } from "vitest";
+
+const SHA256 = "a".repeat(64);
+
+const publication = {
+  schemaVersion: 1,
+  manifest: {
+    version: 1,
+    name: "Tasks",
+    description: "Track tasks.",
+    uiEntryPoint: "index.tsx",
+    functions: [
+      {
+        name: "add-task",
+        description: "Add a task.",
+        entryPoint: "functions/add_task.ts",
+        executionMode: "durable",
+        defaultStake: "low",
+      },
+    ],
+    databases: [{ name: "tasks", schema: "databases/tasks.db.ts" }],
+  },
+  publishedAt: "2026-08-28T12:00:00.000Z",
+  publisherId: "usr_publisher",
+  sourceFiles: [{ path: "index.tsx", contentSha256: SHA256 }],
+  ui: { bundleSha256: SHA256 },
+  functions: [
+    {
+      name: "add-task",
+      bundleSha256: SHA256,
+      userIdentity: "workspace_user_required",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+    },
+  ],
+  databases: [
+    {
+      name: "tasks",
+      schemaSource: "export const tasks = {};",
+      schemaSha256: SHA256,
+    },
+  ],
+} as const;
+
+describe("FramePublicationDescriptorSchema", () => {
+  it("parses a complete immutable publication contract", () => {
+    expect(FramePublicationDescriptorSchema.parse(publication)).toEqual(
+      publication
+    );
+  });
+
+  it("requires function and database contracts to match the manifest", () => {
+    const result = FramePublicationDescriptorSchema.safeParse({
+      ...publication,
+      functions: [],
+      databases: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate source hashes", () => {
+    const result = FramePublicationDescriptorSchema.safeParse({
+      ...publication,
+      sourceFiles: [publication.sourceFiles[0], publication.sourceFiles[0]],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("parseFramePublicationDescriptor", () => {
+  it("returns a typed error for invalid JSON", () => {
+    const result = parseFramePublicationDescriptor(Buffer.from("not json"));
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error).toContain(
+      "publication.json is not valid JSON"
+    );
+  });
+});

--- a/front/types/api/frame_publication.test.ts
+++ b/front/types/api/frame_publication.test.ts
@@ -26,7 +26,11 @@ const publication = {
   },
   publishedAt: "2026-08-28T12:00:00.000Z",
   publisherId: "usr_publisher",
-  sourceFiles: [{ path: "index.tsx", contentSha256: SHA256 }],
+  sourceFiles: [
+    { path: "index.tsx", contentSha256: SHA256 },
+    { path: "functions/add_task.ts", contentSha256: SHA256 },
+    { path: "databases/tasks.db.ts", contentSha256: SHA256 },
+  ],
   ui: { bundleSha256: SHA256 },
   functions: [
     {
@@ -67,6 +71,29 @@ describe("FramePublicationDescriptorSchema", () => {
     const result = FramePublicationDescriptorSchema.safeParse({
       ...publication,
       sourceFiles: [publication.sourceFiles[0], publication.sourceFiles[0]],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("requires hashes for every manifest-referenced source path", () => {
+    const result = FramePublicationDescriptorSchema.safeParse({
+      ...publication,
+      sourceFiles: publication.sourceFiles.slice(0, 1),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("ties each database contract to its schema source hash", () => {
+    const result = FramePublicationDescriptorSchema.safeParse({
+      ...publication,
+      databases: [
+        {
+          ...publication.databases[0],
+          schemaSha256: "b".repeat(64),
+        },
+      ],
     });
 
     expect(result.success).toBe(false);

--- a/front/types/api/frame_publication.ts
+++ b/front/types/api/frame_publication.ts
@@ -1,0 +1,133 @@
+import { validateJsonSchema } from "@app/lib/utils/json_schemas";
+import {
+  FrameDatabaseManifestSchema,
+  FrameFunctionManifestSchema,
+  FrameManifestSchema,
+  isSafeFrameRelativePath,
+} from "@app/types/api/frame_manifest";
+import { SANDBOX_FUNCTION_USER_IDENTITY_POLICIES } from "@app/types/api/sandbox_functions";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export const FRAME_PUBLICATION_FILE = "publication.json";
+export const FRAME_PUBLICATION_SCHEMA_VERSION = 1;
+
+const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+const RelativePathSchema = z.string().refine(isSafeFrameRelativePath);
+const JsonSchemaSchema = z.custom<JSONSchema>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    validateJsonSchema(value).isValid,
+  { message: "Invalid JSON schema" }
+);
+
+export const FramePublicationDescriptorSchema = z
+  .object({
+    schemaVersion: z.literal(FRAME_PUBLICATION_SCHEMA_VERSION),
+    manifest: FrameManifestSchema,
+    publishedAt: z.string().datetime({ offset: true }),
+    publisherId: z.string().nullable(),
+    sourceFiles: z.array(
+      z.object({
+        path: RelativePathSchema,
+        contentSha256: Sha256Schema,
+      })
+    ),
+    ui: z.object({ bundleSha256: Sha256Schema }),
+    functions: z.array(
+      z.object({
+        name: FrameFunctionManifestSchema.shape.name,
+        bundleSha256: Sha256Schema,
+        userIdentity: z.enum(SANDBOX_FUNCTION_USER_IDENTITY_POLICIES),
+        inputSchema: JsonSchemaSchema,
+        outputSchema: JsonSchemaSchema,
+      })
+    ),
+    databases: z.array(
+      z.object({
+        name: FrameDatabaseManifestSchema.shape.name,
+        schemaSource: z.string(),
+        schemaSha256: Sha256Schema,
+      })
+    ),
+  })
+  .superRefine((publication, context) => {
+    publication.manifest.functions.forEach((fn, index) => {
+      if (publication.functions[index]?.name !== fn.name) {
+        context.addIssue({
+          code: "custom",
+          message: `Missing publication contract for function '${fn.name}'.`,
+          path: ["functions", index],
+        });
+      }
+    });
+    if (
+      publication.functions.length !== publication.manifest.functions.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Publication function contracts must match the manifest.",
+        path: ["functions"],
+      });
+    }
+
+    publication.manifest.databases.forEach((database, index) => {
+      if (publication.databases[index]?.name !== database.name) {
+        context.addIssue({
+          code: "custom",
+          message: `Missing publication contract for database '${database.name}'.`,
+          path: ["databases", index],
+        });
+      }
+    });
+    if (
+      publication.databases.length !== publication.manifest.databases.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Publication database contracts must match the manifest.",
+        path: ["databases"],
+      });
+    }
+
+    const sourcePaths = new Set<string>();
+    publication.sourceFiles.forEach((sourceFile, index) => {
+      if (sourcePaths.has(sourceFile.path)) {
+        context.addIssue({
+          code: "custom",
+          message: `Duplicate source hash for '${sourceFile.path}'.`,
+          path: ["sourceFiles", index, "path"],
+        });
+      }
+      sourcePaths.add(sourceFile.path);
+    });
+  });
+
+export type FramePublicationDescriptor = z.infer<
+  typeof FramePublicationDescriptorSchema
+>;
+
+export function parseFramePublicationDescriptor(
+  buffer: Buffer
+): Result<FramePublicationDescriptor, string> {
+  let json: unknown;
+  try {
+    json = JSON.parse(buffer.toString("utf-8"));
+  } catch (error) {
+    return new Err(
+      `${FRAME_PUBLICATION_FILE} is not valid JSON: ${normalizeError(error).message}`
+    );
+  }
+
+  const validation = FramePublicationDescriptorSchema.safeParse(json);
+  if (!validation.success) {
+    return new Err(fromError(validation.error).toString());
+  }
+
+  return new Ok(validation.data);
+}

--- a/front/types/api/frame_publication.ts
+++ b/front/types/api/frame_publication.ts
@@ -95,16 +95,45 @@ export const FramePublicationDescriptorSchema = z
       });
     }
 
-    const sourcePaths = new Set<string>();
+    const sourceHashesByPath = new Map<string, string>();
     publication.sourceFiles.forEach((sourceFile, index) => {
-      if (sourcePaths.has(sourceFile.path)) {
+      if (sourceHashesByPath.has(sourceFile.path)) {
         context.addIssue({
           code: "custom",
           message: `Duplicate source hash for '${sourceFile.path}'.`,
           path: ["sourceFiles", index, "path"],
         });
       }
-      sourcePaths.add(sourceFile.path);
+      sourceHashesByPath.set(sourceFile.path, sourceFile.contentSha256);
+    });
+
+    const referencedPaths = [
+      publication.manifest.uiEntryPoint,
+      ...publication.manifest.functions.map((fn) => fn.entryPoint),
+      ...publication.manifest.databases.map((database) => database.schema),
+    ];
+    referencedPaths.forEach((referencedPath) => {
+      if (!sourceHashesByPath.has(referencedPath)) {
+        context.addIssue({
+          code: "custom",
+          message: `Missing source hash for '${referencedPath}'.`,
+          path: ["sourceFiles"],
+        });
+      }
+    });
+
+    publication.manifest.databases.forEach((database, index) => {
+      const contract = publication.databases[index];
+      if (
+        contract &&
+        contract.schemaSha256 !== sourceHashesByPath.get(database.schema)
+      ) {
+        context.addIssue({
+          code: "custom",
+          message: `Database contract hash does not match source '${database.schema}'.`,
+          path: ["databases", index, "schemaSha256"],
+        });
+      }
     });
   });
 

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -1,9 +1,8 @@
 import {
   getFrameBasePath,
   getFrameDatabaseReplicaBasePath,
+  getFramePublicationDescriptorPath,
   getFramePublicationFunctionBundlePath,
-  getFramePublicationFunctionSchemaPath,
-  getFramePublicationManifestPath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import { describe, expect, it } from "vitest";
@@ -17,7 +16,7 @@ const IDS = {
 describe("Frames v2 GCS paths", () => {
   it("keeps publications under the Frame identity", () => {
     expect(getFrameBasePath(IDS)).toBe("w/w_123/frames/fil_456/");
-    expect(getFramePublicationManifestPath(IDS)).toBe(
+    expect(getFramePublicationDescriptorPath(IDS)).toBe(
       "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/publication.json"
     );
     expect(getFramePublicationUiBundlePath(IDS)).toBe(
@@ -30,14 +29,6 @@ describe("Frames v2 GCS paths", () => {
       })
     ).toBe(
       "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task.ts"
-    );
-    expect(
-      getFramePublicationFunctionSchemaPath({
-        ...IDS,
-        functionName: "add-task",
-      })
-    ).toBe(
-      "w/w_123/frames/fil_456/publications/b8c2b796-534a-4ad2-a5ad-071da692ca0b/functions/add-task.schema.json"
     );
   });
 

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -54,7 +54,7 @@ export function getFramePublicationBasePath({
   return `${getFramePublicationsBasePath({ workspaceId, frameId })}${safeSegment(publicationId, "publicationId")}/`;
 }
 
-export function getFramePublicationManifestPath(args: {
+export function getFramePublicationDescriptorPath(args: {
   workspaceId: string;
   frameId: string;
   publicationId: string;
@@ -77,13 +77,4 @@ export function getFramePublicationFunctionBundlePath(args: {
   functionName: string;
 }): string {
   return `${getFramePublicationBasePath(args)}functions/${safeSegment(args.functionName, "functionName")}.ts`;
-}
-
-export function getFramePublicationFunctionSchemaPath(args: {
-  workspaceId: string;
-  frameId: string;
-  publicationId: string;
-  functionName: string;
-}): string {
-  return `${getFramePublicationBasePath(args)}functions/${safeSegment(args.functionName, "functionName")}.schema.json`;
 }


### PR DESCRIPTION
## Description

- Replace the raw manifest commit marker with a versioned `publication.json` descriptor.
- Record publisher/time, normalized manifest, source hashes, UI/function hashes, build-derived function contracts, and exact database schema source.
- Verify database, UI, and function hashes before activation. Remove function schema sidecars now covered by the descriptor.
- Stack on #31392.

## Tests

Added descriptor validation, manifest-to-source integrity checks, immutable database-schema capture, corruption rejection, artifact ordering, and activation regression coverage. Tested the focused 45-test suite locally.

## Risk

Low. Frames v2 remains feature-flagged and invocation is not user-reachable yet. Draft publications from earlier slices must be republished. Frames v1 and Pod Functions are unchanged.

## Deploy Plan

Merge #31392 first, then standard deploy. No migration.