### PR TITLE
Expose Frames v2 function invocation APIs

### DIFF
--- a/front-api/lib/api/sse/sandbox_function_invocation_events.ts
+++ b/front-api/lib/api/sse/sandbox_function_invocation_events.ts
@@ -31,7 +31,8 @@ export async function streamSandboxFunctionInvocationEventsForRoute(
   const sandboxFunction = await resolveSandboxFunctionWithCapability(
     auth,
     functionId,
-    ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
+    ctx.req.header(FRAME_SHARE_TOKEN_HEADER),
+    { allowInactiveFramePublication: true }
   );
   if (!sandboxFunction) {
     return ctx.notFound();

--- a/front-api/middlewares/with_sandbox_functions_feature.ts
+++ b/front-api/middlewares/with_sandbox_functions_feature.ts
@@ -34,3 +34,25 @@ export function withSandboxFunctionsFeature({
     }
   );
 }
+
+/** Invocation routes are shared while Frames v2 progressively replaces Pod Functions. */
+export function withSandboxFunctionInvocationFeature() {
+  return createMiddleware<PublicApiCtx | WorkspaceAwareCtx>(
+    async (ctx, next) => {
+      const featureFlags = await getFeatureFlags(ctx.get("auth"));
+      if (
+        !featureFlags.includes("sandbox_functions") &&
+        !featureFlags.includes("frames_v2")
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "feature_flag_not_found",
+            message: "Sandbox Functions are not enabled for this workspace.",
+          },
+        });
+      }
+      await next();
+    }
+  );
+}

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9338,7 +9338,7 @@
     "/api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events": {
       "get": {
         "summary": "Stream sandbox function invocation events",
-        "description": "Stream real-time events for a sandbox function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.",
+        "description": "Stream real-time events for a Pod or Frame function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.",
         "tags": [
           "Private Events"
         ],
@@ -9356,7 +9356,7 @@
             "in": "path",
             "name": "functionId",
             "required": true,
-            "description": "ID of the sandbox function",
+            "description": "ID of the Pod or Frame function",
             "schema": {
               "type": "string"
             }

--- a/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.ts
@@ -6,18 +6,13 @@ import { SseQuerySchema } from "@front-api/lib/api/sse/stream_events";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { streamingTag } from "@front-api/middlewares/streaming";
 import { validate } from "@front-api/middlewares/validator";
-import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { withSandboxFunctionInvocationFeature } from "@front-api/middlewares/with_sandbox_functions_feature";
 
 // Mounted at /api/sse/w/:wId/sandbox-functions/:functionId/invocations/:invocationId/events.
 const app = workspaceApp();
 
 app.use("*", streamingTag);
-app.use(
-  "*",
-  withFeatureFlag("sandbox_functions", {
-    message: "Sandbox Functions are not enabled for this workspace.",
-  })
-);
+app.use("*", withSandboxFunctionInvocationFeature());
 
 /** @ignoreswagger */
 app.get(

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -242,16 +242,11 @@ async function setupFrameV2Function({
     role: "user",
     workspace,
   });
-  const callerAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
   return {
     adminAuth,
-    callerAuth,
     frame,
-    publicationId,
     sandboxFunction,
+    space,
     user,
     workspace,
   };
@@ -299,11 +294,25 @@ async function createSharedAppFrame(
 
 // Builds a blocked action awaiting validation, the state spolu's creation gate produces for
 // approval-requiring tools (created without a workflow launch).
+async function setupFunctionForBlockedAction(functionOwner: "pod" | "frame") {
+  if (functionOwner === "frame") {
+    const setup = await setupFrameV2Function();
+    const callerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      setup.user.sId,
+      setup.workspace.sId
+    );
+    return { ...setup, callerAuth };
+  }
+
+  return { ...(await setupSandboxFunction()), frame: null };
+}
+
 async function setupBlockedAction({
   permission = "high",
   blockedStatus = "blocked_validation_required",
   invocationOwnedByOtherMember = false,
   invocationOwnerless = false,
+  functionOwner = "pod",
 }: {
   permission?: MCPToolStakeLevelType;
   blockedStatus?:
@@ -311,9 +320,10 @@ async function setupBlockedAction({
     | "blocked_authentication_required";
   invocationOwnedByOtherMember?: boolean;
   invocationOwnerless?: boolean;
+  functionOwner?: "pod" | "frame";
 } = {}) {
-  const { workspace, sandboxFunction, adminAuth, callerAuth, space } =
-    await setupSandboxFunction();
+  const { workspace, sandboxFunction, adminAuth, callerAuth, space, frame } =
+    await setupFunctionForBlockedAction(functionOwner);
 
   const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
   await SpaceResource.makeDefaultsForWorkspace(adminAuth, {
@@ -358,7 +368,15 @@ async function setupBlockedAction({
   });
   expect(blockedCount).toBe(1);
 
-  return { workspace, sandboxFunction, invocation, action, view, adminAuth };
+  return {
+    workspace,
+    sandboxFunction,
+    invocation,
+    action,
+    view,
+    adminAuth,
+    frame,
+  };
 }
 
 function postValidate({
@@ -558,16 +576,21 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
   });
 
   it("does not expose Frame functions through the Pod Functions flag", async () => {
-    const { workspace, frame } = await setupFrameV2Function({
+    const { workspace, frame, sandboxFunction } = await setupFrameV2Function({
       featureFlag: "sandbox_functions",
     });
 
-    const response = await postInvocation({
+    const byReference = await postInvocation({
       workspaceId: workspace.sId,
       functionIdOrSlug: `${frame.sId}/run-function`,
     });
+    const byId = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
 
-    expect(response.status).toBe(404);
+    expect(byReference.status).toBe(404);
+    expect(byId.status).toBe(404);
   });
 
   it("does not expose Pod Functions through the Frames v2 flag", async () => {
@@ -1207,6 +1230,34 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
     );
   });
 
+  it("approves an in-flight Frame action after a new publication activates", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth, frame } =
+      await setupBlockedAction({ functionOwner: "frame" });
+    if (!frame) {
+      throw new Error("Expected a Frame-owned function.");
+    }
+    await createFramePublicationFunction({
+      adminAuth,
+      frame,
+      publicationId: "publication-2",
+    });
+    await frame.setActiveFramePublication("publication-2");
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "approved" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledOnce();
+  });
+
   it("rejects a blocked action without launching its workflow", async () => {
     const { workspace, sandboxFunction, invocation, action, adminAuth } =
       await setupBlockedAction();
@@ -1437,6 +1488,37 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       expect.any(Function),
       `sandbox-function-invocation-${invocation.sId}`
     );
+  });
+
+  it("resolves an in-flight Frame authentication after a new publication activates", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth, frame } =
+      await setupBlockedAction({
+        blockedStatus: "blocked_authentication_required",
+        functionOwner: "frame",
+      });
+    if (!frame) {
+      throw new Error("Expected a Frame-owned function.");
+    }
+    await createFramePublicationFunction({
+      adminAuth,
+      frame,
+      publicationId: "publication-2",
+    });
+    await frame.setActiveFramePublication("publication-2");
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const response = await postResolveAuthentication({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { outcome: "completed" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledOnce();
   });
 
   it("denies authentication without relaunching the workflow", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -9,6 +9,7 @@ import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_fun
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -24,7 +25,11 @@ import type {
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import type { FileShareScope } from "@app/types/files";
-import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import {
+  frameContentType,
+  frameV2ContentType,
+  sandboxFunctionContentType,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -156,6 +161,100 @@ async function setupSandboxFunction({
   );
 
   return { workspace, sandboxFunction, adminAuth, callerAuth, space, user };
+}
+
+async function createFramePublicationFunction({
+  adminAuth,
+  frame,
+  publicationId,
+}: {
+  adminAuth: Authenticator;
+  frame: Awaited<ReturnType<typeof FileFactory.create>>;
+  publicationId: string;
+}) {
+  await withTransaction((transaction) =>
+    SandboxFunctionResource.createForFramePublication(
+      adminAuth,
+      {
+        frame,
+        publicationId,
+        functions: [
+          {
+            name: "run-function",
+            description: "Run the Frame function.",
+            userIdentity: "optional",
+            executionMode: "durable",
+            defaultStake: "low",
+            bundleCode: "export default () => ({ ok: true });",
+            inputSchema,
+            outputSchema,
+          },
+        ],
+      },
+      transaction
+    )
+  );
+  const sandboxFunction =
+    await SandboxFunctionResource.fetchByFramePublicationAndSlug(adminAuth, {
+      frame,
+      publicationId,
+      slug: "run-function",
+    });
+  if (!sandboxFunction) {
+    throw new Error("Expected the Frame function to exist.");
+  }
+  return sandboxFunction;
+}
+
+async function setupFrameV2Function({
+  shareScope = "workspace_and_emails",
+  featureFlag = "frames_v2",
+}: {
+  shareScope?: FileShareScope;
+  featureFlag?: "frames_v2" | "sandbox_functions";
+} = {}) {
+  const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  await FeatureFlagFactory.basic(adminAuth, featureFlag);
+  const space = await SpaceFactory.project(workspace);
+  const publicationId = "publication-1";
+  const frame = await FileFactory.create(adminAuth, null, {
+    contentType: frameV2ContentType,
+    fileName: "app.frame.json",
+    fileSize: 100,
+    status: "ready",
+    useCase: "conversation",
+    useCaseMetadata: {
+      spaceId: space.sId,
+      activePublicationId: publicationId,
+    },
+  });
+  await frame.setShareScope(adminAuth, shareScope);
+  const sandboxFunction = await createFramePublicationFunction({
+    adminAuth,
+    frame,
+    publicationId,
+  });
+
+  // The last mock request owns the route session.
+  const { user } = await createPrivateApiMockRequest({
+    role: "user",
+    workspace,
+  });
+  const callerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  return {
+    adminAuth,
+    callerAuth,
+    frame,
+    publicationId,
+    sandboxFunction,
+    user,
+    workspace,
+  };
 }
 
 // Creates a Pod app frame in `folderName` shared with the given scope, returning its share token —
@@ -369,6 +468,121 @@ function toolApprovalEvent({
 }
 
 describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () => {
+  it("invokes the active Frame publication with only frames_v2 enabled", async () => {
+    const { workspace, frame, sandboxFunction } = await setupFrameV2Function();
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+      body: { input: { message: "hello" } },
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.invocation).toMatchObject({
+      functionId: sandboxFunction.sId,
+      status: "created",
+    });
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        sandboxFunction: expect.objectContaining({
+          sId: sandboxFunction.sId,
+          publicationId: "publication-1",
+        }),
+        invocation: expect.objectContaining({
+          sId: body.invocation.sId,
+          origin: "interactive_session",
+        }),
+      }
+    );
+  });
+
+  it("keeps an in-flight Frame invocation streamable after a new publication activates", async () => {
+    const { adminAuth, workspace, frame, sandboxFunction } =
+      await setupFrameV2Function();
+    const invocationResponse = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+    expect(invocationResponse.status).toBe(201);
+    const { invocation } = await invocationResponse.json();
+
+    const nextPublicationId = "publication-2";
+    await createFramePublicationFunction({
+      adminAuth,
+      frame,
+      publicationId: nextPublicationId,
+    });
+    await frame.setActiveFramePublication(nextPublicationId);
+    const staleInvocation = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+    expect(staleInvocation.status).toBe(404);
+    mockInvocationEventStream([
+      {
+        type: "sandbox_function_invocation_result",
+        created: Date.now(),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        result: { ok: true },
+      },
+    ]);
+
+    const response = await honoApp.request(
+      `/api/sse/w/${workspace.sId}/sandbox-functions/${sandboxFunction.sId}/invocations/${invocation.sId}/events`
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"result":{"ok":true}');
+  });
+
+  it("enforces Frame use rights independently from source access", async () => {
+    const { adminAuth, workspace, frame, user } = await setupFrameV2Function({
+      shareScope: "emails_only",
+    });
+
+    const denied = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+    expect(denied.status).toBe(404);
+
+    await frame.addSharingGrants(adminAuth, { emails: [user.email] });
+    const allowed = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+    expect(allowed.status).toBe(201);
+  });
+
+  it("does not expose Frame functions through the Pod Functions flag", async () => {
+    const { workspace, frame } = await setupFrameV2Function({
+      featureFlag: "sandbox_functions",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("does not expose Pod Functions through the Frames v2 flag", async () => {
+    const { workspace, sandboxFunction, adminAuth } =
+      await setupSandboxFunction({ withSandboxFunctionsFeatureFlag: false });
+    await FeatureFlagFactory.basic(adminAuth, "frames_v2");
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(404);
+  });
+
   it("creates an invocation and starts its workflow", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
 

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -58,7 +58,7 @@ const app = workspaceApp();
  * /api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events:
  *   get:
  *     summary: Stream sandbox function invocation events
- *     description: Stream real-time events for a sandbox function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.
+ *     description: Stream real-time events for a Pod or Frame function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.
  *     tags:
  *       - Private Events
  *     parameters:
@@ -71,7 +71,7 @@ const app = workspaceApp();
  *       - in: path
  *         name: functionId
  *         required: true
- *         description: ID of the sandbox function
+ *         description: ID of the Pod or Frame function
  *         schema:
  *           type: string
  *       - in: path
@@ -182,7 +182,8 @@ app.post(
     const sandboxFunction = await resolveSandboxFunctionWithCapability(
       auth,
       functionIdOrSlug,
-      ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
+      ctx.req.header(FRAME_SHARE_TOKEN_HEADER),
+      { allowInactiveFramePublication: true }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {
@@ -250,7 +251,8 @@ app.post(
     const sandboxFunction = await resolveSandboxFunctionWithCapability(
       auth,
       functionIdOrSlug,
-      ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
+      ctx.req.header(FRAME_SHARE_TOKEN_HEADER),
+      { allowInactiveFramePublication: true }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/sandbox-functions/index.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/index.ts
@@ -1,16 +1,11 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { withSandboxFunctionInvocationFeature } from "@front-api/middlewares/with_sandbox_functions_feature";
 
 import functionId from "./[functionId]";
 
 const app = workspaceApp();
 
-app.use(
-  "*",
-  withFeatureFlag("sandbox_functions", {
-    message: "Sandbox Functions are not enabled for this workspace.",
-  })
-);
+app.use("*", withSandboxFunctionInvocationFeature());
 
 app.route("/:functionIdOrSlug", functionId);
 

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -31,26 +31,53 @@ export async function resolveSandboxFunctionWithCapability(
   }: { allowInactiveFramePublication?: boolean } = {}
 ): Promise<SandboxFunctionResource | null> {
   const featureFlags = await getFeatureFlags(auth);
-  if (featureFlags.includes("sandbox_functions")) {
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
-      auth,
-      functionIdOrSlug
-    );
-    if (sandboxFunction) {
+  const isSandboxFunctionsEnabled = featureFlags.includes("sandbox_functions");
+  const isFramesV2Enabled = featureFlags.includes("frames_v2");
+
+  if (isResourceSId("sandbox_function", functionIdOrSlug)) {
+    const sandboxFunction =
+      await SandboxFunctionResource.fetchByIdForInvocationResolution(
+        auth,
+        functionIdOrSlug
+      );
+    if (sandboxFunction?.frame) {
+      if (isFramesV2Enabled) {
+        const frameFunction = await resolveFrameV2FunctionAccess(
+          auth,
+          sandboxFunction,
+          { allowInactivePublication: allowInactiveFramePublication }
+        );
+        if (frameFunction) {
+          return frameFunction;
+        }
+      }
+    } else if (sandboxFunction && isSandboxFunctionsEnabled) {
       return sandboxFunction;
     }
-  }
+  } else {
+    if (isSandboxFunctionsEnabled) {
+      const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+        auth,
+        functionIdOrSlug
+      );
+      if (sandboxFunction) {
+        return sandboxFunction;
+      }
+    }
 
-  if (featureFlags.includes("frames_v2")) {
-    const frameFunction = await resolveFrameV2Function(auth, functionIdOrSlug, {
-      allowInactivePublication: allowInactiveFramePublication,
-    });
-    if (frameFunction) {
-      return frameFunction;
+    if (isFramesV2Enabled) {
+      const frameFunction = await resolveFrameV2FunctionReference(
+        auth,
+        functionIdOrSlug,
+        { allowInactivePublication: allowInactiveFramePublication }
+      );
+      if (frameFunction) {
+        return frameFunction;
+      }
     }
   }
 
-  if (!featureFlags.includes("sandbox_functions") || !frameShareToken) {
+  if (!isSandboxFunctionsEnabled || !frameShareToken) {
     return null;
   }
 
@@ -66,42 +93,43 @@ export async function resolveSandboxFunctionWithCapability(
   });
 }
 
-async function resolveFrameV2Function(
+async function resolveFrameV2FunctionReference(
   auth: Authenticator,
   functionIdOrReference: string,
   { allowInactivePublication }: { allowInactivePublication: boolean }
 ): Promise<SandboxFunctionResource | null> {
-  let sandboxFunction: SandboxFunctionResource | null = null;
-  if (isResourceSId("sandbox_function", functionIdOrReference)) {
-    sandboxFunction =
-      await SandboxFunctionResource.fetchByIdForInvocationResolution(
-        auth,
-        functionIdOrReference
-      );
-  } else {
-    const [frameId, slug, ...rest] = functionIdOrReference.split("/");
-    if (
-      !frameId ||
-      !slug ||
-      rest.length > 0 ||
-      !isResourceSId("file", frameId) ||
-      !isValidSandboxFunctionSlug(slug)
-    ) {
-      return null;
-    }
-    const frame = await FileResource.fetchById(auth, frameId);
-    const publicationId = frame?.useCaseMetadata?.activePublicationId;
-    if (!frame?.isFrameV2 || !publicationId) {
-      return null;
-    }
-    sandboxFunction =
-      await SandboxFunctionResource.fetchByFramePublicationAndSlug(auth, {
-        frame,
-        publicationId,
-        slug,
-      });
+  const [frameId, slug, ...rest] = functionIdOrReference.split("/");
+  if (
+    !frameId ||
+    !slug ||
+    rest.length > 0 ||
+    !isResourceSId("file", frameId) ||
+    !isValidSandboxFunctionSlug(slug)
+  ) {
+    return null;
   }
+  const frame = await FileResource.fetchById(auth, frameId);
+  const publicationId = frame?.useCaseMetadata?.activePublicationId;
+  if (!frame?.isFrameV2 || !publicationId) {
+    return null;
+  }
+  const sandboxFunction =
+    await SandboxFunctionResource.fetchByFramePublicationAndSlug(auth, {
+      frame,
+      publicationId,
+      slug,
+    });
 
+  return resolveFrameV2FunctionAccess(auth, sandboxFunction, {
+    allowInactivePublication,
+  });
+}
+
+async function resolveFrameV2FunctionAccess(
+  auth: Authenticator,
+  sandboxFunction: SandboxFunctionResource | null,
+  { allowInactivePublication }: { allowInactivePublication: boolean }
+): Promise<SandboxFunctionResource | null> {
   const frame = sandboxFunction?.frame;
   if (
     !sandboxFunction ||

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -1,8 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
 import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
 import type { FrameShareCapability } from "@app/types/api/sandbox_functions";
+import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { isWorkspaceVisibleShareScope } from "@app/types/files";
 
 /**
@@ -14,21 +17,41 @@ import { isWorkspaceVisibleShareScope } from "@app/types/files";
  */
 
 /**
- * Resolve a function the way invocation-facing routes need it: by the caller's own access first,
- * and only when that misses, by the frame share token they presented. Members thus never pay the
- * token lookup, and an invalid token behaves exactly like an absent one.
+ * Resolve a caller-facing function without crossing feature or ownership boundaries. Pod
+ * Functions use their existing space/share capability. Frames v2 accepts `<frameId>/<slug>` for
+ * new invocations and function ids for an active publication (or an explicitly allowed in-flight
+ * publication), with use rights read from the Frame's sharing record.
  */
 export async function resolveSandboxFunctionWithCapability(
   auth: Authenticator,
   functionIdOrSlug: string,
-  frameShareToken: string | undefined
+  frameShareToken: string | undefined,
+  {
+    allowInactiveFramePublication = false,
+  }: { allowInactiveFramePublication?: boolean } = {}
 ): Promise<SandboxFunctionResource | null> {
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
-    auth,
-    functionIdOrSlug
-  );
-  if (sandboxFunction || !frameShareToken) {
-    return sandboxFunction;
+  const featureFlags = await getFeatureFlags(auth);
+  if (featureFlags.includes("sandbox_functions")) {
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+      auth,
+      functionIdOrSlug
+    );
+    if (sandboxFunction) {
+      return sandboxFunction;
+    }
+  }
+
+  if (featureFlags.includes("frames_v2")) {
+    const frameFunction = await resolveFrameV2Function(auth, functionIdOrSlug, {
+      allowInactivePublication: allowInactiveFramePublication,
+    });
+    if (frameFunction) {
+      return frameFunction;
+    }
+  }
+
+  if (!featureFlags.includes("sandbox_functions") || !frameShareToken) {
+    return null;
   }
 
   const capability = await resolveFrameShareCapability(auth, frameShareToken);
@@ -41,6 +64,59 @@ export async function resolveSandboxFunctionWithCapability(
     appPrefix: capability.appPrefix,
     idOrSlug: functionIdOrSlug,
   });
+}
+
+async function resolveFrameV2Function(
+  auth: Authenticator,
+  functionIdOrReference: string,
+  { allowInactivePublication }: { allowInactivePublication: boolean }
+): Promise<SandboxFunctionResource | null> {
+  let sandboxFunction: SandboxFunctionResource | null = null;
+  if (isResourceSId("sandbox_function", functionIdOrReference)) {
+    sandboxFunction =
+      await SandboxFunctionResource.fetchByIdForInvocationResolution(
+        auth,
+        functionIdOrReference
+      );
+  } else {
+    const [frameId, slug, ...rest] = functionIdOrReference.split("/");
+    if (
+      !frameId ||
+      !slug ||
+      rest.length > 0 ||
+      !isResourceSId("file", frameId) ||
+      !isValidSandboxFunctionSlug(slug)
+    ) {
+      return null;
+    }
+    const frame = await FileResource.fetchById(auth, frameId);
+    const publicationId = frame?.useCaseMetadata?.activePublicationId;
+    if (!frame?.isFrameV2 || !publicationId) {
+      return null;
+    }
+    sandboxFunction =
+      await SandboxFunctionResource.fetchByFramePublicationAndSlug(auth, {
+        frame,
+        publicationId,
+        slug,
+      });
+  }
+
+  const frame = sandboxFunction?.frame;
+  if (
+    !sandboxFunction ||
+    !frame ||
+    !(await frame.canCurrentUserUseFrame(auth))
+  ) {
+    return null;
+  }
+  if (
+    !allowInactivePublication &&
+    sandboxFunction.publicationId !== frame.useCaseMetadata?.activePublicationId
+  ) {
+    return null;
+  }
+  return sandboxFunction;
 }
 
 /**

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -81,6 +81,7 @@ import {
   isFrameContentType,
   isInteractiveContentType,
   isSandboxFunctionContentType,
+  isWorkspaceVisibleShareScope,
 } from "@app/types/files";
 import type { FrameScopedPathContext } from "@app/types/mount_path";
 import {
@@ -1764,6 +1765,49 @@ export class FileResource extends BaseResource<FileModel> {
     }
 
     return null;
+  }
+
+  /**
+   * Whether the current workspace member holds the Frame's use right. Source-path access is an
+   * authoring concern and deliberately does not participate here.
+   */
+  async canCurrentUserUseFrame(auth: Authenticator): Promise<boolean> {
+    if (
+      !this.isFrameV2 ||
+      this.workspaceId !== auth.getNonNullableWorkspace().id ||
+      !auth.isUser()
+    ) {
+      return false;
+    }
+
+    const user = auth.user();
+    if (!user) {
+      return false;
+    }
+    const shareableFile = await FileResource.shareableFileModel.findOne({
+      where: { fileId: this.id, workspaceId: this.workspaceId },
+    });
+    if (!shareableFile) {
+      return false;
+    }
+
+    if (
+      shareableFile.shareScope === "public" ||
+      isWorkspaceVisibleShareScope(shareableFile.shareScope) ||
+      this.userId === user.id
+    ) {
+      return true;
+    }
+
+    return (
+      (await FileResource.getActiveGrantForEmail(
+        auth.getNonNullableWorkspace(),
+        {
+          email: user.email,
+          shareableFileId: shareableFile.id,
+        }
+      )) !== null
+    );
   }
 
   static async revokePublicSharingInWorkspace(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -489,6 +489,30 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   }
 
   /**
+   * Resolve either owner kind for caller-facing invocation routes. Pod space access is still
+   * filtered here; Frame use rights and active-publication checks are applied by the route
+   * resolver once the owning Frame is known.
+   */
+  static async fetchByIdForInvocationResolution(
+    auth: Authenticator,
+    sandboxFunctionId: string
+  ): Promise<SandboxFunctionResource | null> {
+    if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
+      return null;
+    }
+    const sandboxFunctionModelId = getResourceIdFromSId(sandboxFunctionId);
+    if (sandboxFunctionModelId === null) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { id: sandboxFunctionModelId },
+      includeFrameFunctions: true,
+    });
+    return sandboxFunction ?? null;
+  }
+
+  /**
    * Gets the function if a matching invocation exists.
    * In the context of a temporal activity or a sandbox callback, we don't have the original
    * caller's grant (e.g. a frame share token) in the auth, so the space permission filter is


### PR DESCRIPTION
## Description

- Resolve Frames v2 functions as `<frameId>/<functionName>` from the active immutable publication.
- Reuse the existing invocation, approval, authentication, and SSE routes while gating each owner kind independently: `frames_v2` never exposes Pod Functions, and `sandbox_functions` never exposes Frame functions.
- Read Frame use rights from the existing sharing record, independently from source-folder access.
- Keep already-created invocations streamable after a newer publication becomes active.
- Update the generated Swagger description for the shared event endpoint.
- Stack on #31395.

## Tests

Added active/inactive publication, SSE continuity, use-right, and feature-isolation coverage. Ran 119 focused tests, Front and Front API typechecks, Biome, Swagger annotation lint and generation, and `git diff --check`.

## Risk

Low. The new resolution path is feature-flagged by `frames_v2`; Pod Function behavior remains gated by `sandbox_functions` and has explicit regression coverage. Rollback removes the Frame resolver without changing stored data.

## Deploy Plan

Merge #31395 first, then deploy normally. No migration or backfill.
