### PR TITLE
Persist Frame-owned SQLite runtime state

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -7,9 +7,9 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { podEnv } from "./context.ts";
 
 /**
- * Pod state databases.
+ * Frame and Pod state databases.
  *
- * `db(name)` returns a cached Drizzle instance over the pod's live SQLite
+ * `db(name)` returns a cached Drizzle instance over the sandbox owner's live SQLite
  * database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. Databases are
  * created by `dsbx db reconcile` (the db_reconcile tool), never here: the file
  * is opened must-exist so a typo'd name errors clearly instead of minting an
@@ -22,10 +22,10 @@ import { podEnv } from "./context.ts";
  * therefore resolves `db("chat")` to its own database. See
  * {@link resolveDatabasePath} for the resolution order.
  *
- * Disk guardrails — pod state must not fill the sandbox disk by accident:
+ * Disk guardrails — sandbox state must not fill the sandbox disk by accident:
  *
  * - `db()` cannot create database files (must-exist open), so the set of
- *   databases is fixed by what reconcile has created. Total pod-state
+ *   databases is fixed by what reconcile has created. Total sandbox-state
  *   footprint is the number of databases times the per-database cap;
  *   bounding the count is the reconcile path's job.
  * - Each database is capped via `PRAGMA max_page_count` at the byte quota
@@ -39,8 +39,8 @@ import { podEnv } from "./context.ts";
  * The cap turns runaway state growth into an actionable error well before the
  * disk is full, instead of unrecoverable ENOSPC everywhere. It is not a
  * security boundary — workload code can write to the filesystem directly; the
- * sandbox's own disk is the hard limit, and filling it breaks only this pod's
- * sandbox.
+ * sandbox's own disk is the hard limit, and filling it breaks only this
+ * owner's sandbox.
  */
 
 /**
@@ -52,11 +52,12 @@ import { podEnv } from "./context.ts";
 export const POD_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
 
 /**
- * Sandbox-global env var carrying the pod sId — set at sandbox creation for
- * pod-owned sandboxes only. Its absence means this is not a pod sandbox
- * (e.g. a conversation sandbox), where pod databases do not exist.
+ * Sandbox-global env var carrying the Pod sId for Pod-owned sandboxes.
  */
 export const POD_SPACE_ID_ENV = "SPACE_ID";
+
+/** Sandbox-global env var carrying the Frame sId for Frame-owned sandboxes. */
+export const FRAME_ID_ENV = "FRAME_ID";
 
 /**
  * Env var carrying the per-database size quota in bytes, required. Like the
@@ -113,10 +114,10 @@ export class PodDatabaseInvalidNameError extends PodDatabaseError {
 export class PodDatabasesUnavailableError extends PodDatabaseError {
   constructor() {
     super(
-      `Pod databases are not available in this sandbox: ${POD_SPACE_ID_ENV} ` +
-        `is not set, which means this sandbox does not belong to a pod ` +
-        `(conversation sandboxes have no pod databases). db() only works in ` +
-        `functions running in a pod sandbox.`
+      `Databases are not available in this sandbox: neither ${POD_SPACE_ID_ENV} ` +
+        `nor ${FRAME_ID_ENV} is set, which means this sandbox does not belong ` +
+        `to a Pod or Frame. db() only works in functions running in a Pod or ` +
+        `Frame sandbox.`
     );
     this.name = "PodDatabasesUnavailableError";
   }
@@ -369,13 +370,13 @@ function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
 const instances = new Map<string, PodDatabase>();
 
 /**
- * Get the pod's Drizzle handle for database `name`, where `name` is the app's
- * own name for it (`db("chat")`) and the app prefix is applied by
+ * Get the sandbox owner's Drizzle handle for database `name`, where `name` is
+ * the app's own name for it (`db("chat")`) and the app prefix is applied by
  * {@link resolveDatabasePath} from the environment.
  *
  * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
- * @throws PodDatabasesUnavailableError when SPACE_ID is absent — this sandbox
- *   is not pod-owned (conversation sandboxes have no pod databases).
+ * @throws PodDatabasesUnavailableError when both SPACE_ID and FRAME_ID are
+ *   absent — this sandbox is owned by neither a Pod nor a Frame.
  * @throws PodDatabaseError when DUST_POD_DATABASES_DIR or
  *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
  *   in functions launched by `dsbx function run`.
@@ -388,7 +389,11 @@ export function db(name: string): PodDatabase {
     throw new PodDatabaseInvalidNameError(name);
   }
   const spaceId = podEnv(POD_SPACE_ID_ENV);
-  if (spaceId === undefined || spaceId.length === 0) {
+  const frameId = podEnv(FRAME_ID_ENV);
+  if (
+    (spaceId === undefined || spaceId.length === 0) &&
+    (frameId === undefined || frameId.length === 0)
+  ) {
     throw new PodDatabasesUnavailableError();
   }
   const path = resolveDatabasePath(podDatabasesDir(), name);

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -45,7 +45,7 @@ import { podEnv } from "./context.ts";
 
 /**
  * Env var pointing at the live databases directory, required. The location is
- * hardcoded once, in front (`POD_SANDBOX_DATABASES_DIR`), passed per-exec to
+ * hardcoded once, in front (`SANDBOX_STATE_DATABASES_DIR`), passed per-exec to
  * `dsbx function run`, which forwards it here — no layer below front carries
  * its own copy of the path.
  */

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   db,
+  FRAME_ID_ENV,
   POD_DATABASE_BUSY_TIMEOUT_MS,
   POD_DATABASE_MAX_SIZE_BYTES_ENV,
   POD_DATABASE_PREFIX_ENV,
@@ -56,6 +57,7 @@ function uniqueName(prefix: string): string {
 }
 
 let originalSpaceId: string | undefined;
+let originalFrameId: string | undefined;
 
 beforeEach(() => {
   databasesDir = mkdtempSync(join(tmpdir(), "dust-pod-test-"));
@@ -65,6 +67,8 @@ beforeEach(() => {
   // Pod sandboxes carry SPACE_ID as a sandbox-global env var.
   originalSpaceId = process.env[POD_SPACE_ID_ENV];
   process.env[POD_SPACE_ID_ENV] = "spc_test_pod";
+  originalFrameId = process.env[FRAME_ID_ENV];
+  delete process.env[FRAME_ID_ENV];
 });
 
 afterEach(() => {
@@ -76,27 +80,43 @@ afterEach(() => {
   } else {
     process.env[POD_SPACE_ID_ENV] = originalSpaceId;
   }
+  if (originalFrameId === undefined) {
+    delete process.env[FRAME_ID_ENV];
+  } else {
+    process.env[FRAME_ID_ENV] = originalFrameId;
+  }
   rmSync(databasesDir, { recursive: true, force: true });
 });
 
-describe("pod sandbox guard", () => {
-  test("SPACE_ID absent throws PodDatabasesUnavailableError even when the file exists", () => {
+describe("sandbox database owner guard", () => {
+  test("both owner ids absent throws even when the file exists", () => {
     const name = uniqueName("guard");
     createDatabaseFile(name);
     delete process.env[POD_SPACE_ID_ENV];
     expect(() => db(name)).toThrow(PodDatabasesUnavailableError);
-    expect(() => db(name)).toThrow(/does not belong to a pod/);
+    expect(() => db(name)).toThrow(/does not belong to a Pod or Frame/);
   });
 
-  test("empty SPACE_ID is treated as absent", () => {
+  test("empty owner ids are treated as absent", () => {
     const name = uniqueName("guard");
     createDatabaseFile(name);
     process.env[POD_SPACE_ID_ENV] = "";
+    process.env[FRAME_ID_ENV] = "";
     expect(() => db(name)).toThrow(PodDatabasesUnavailableError);
+  });
+
+  test("FRAME_ID makes databases available without SPACE_ID", () => {
+    const name = uniqueName("frame_guard");
+    createDatabaseFile(name);
+    delete process.env[POD_SPACE_ID_ENV];
+    process.env[FRAME_ID_ENV] = "fil_test_frame";
+
+    expect(() => db(name)).not.toThrow();
   });
 
   test("the guard runs before the missing-file check", () => {
     delete process.env[POD_SPACE_ID_ENV];
+    delete process.env[FRAME_ID_ENV];
     expect(() => db(uniqueName("guard"))).toThrow(PodDatabasesUnavailableError);
   });
 });
@@ -276,6 +296,23 @@ describe("app prefix resolution", () => {
       expect(
         runWithInvocationEnv(contextEnv("myapp__"), () => ownerOf(name))
       ).toBe("myapp");
+    });
+
+    test("accepts a Frame-only invocation context", () => {
+      const name = uniqueName("frame_context");
+      createDatabaseOwnedBy(name, "frame");
+
+      expect(
+        runWithInvocationEnv(
+          {
+            [POD_DATABASES_DIR_ENV]: databasesDir,
+            [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+            [FRAME_ID_ENV]: "fil_test_frame",
+            [POD_DATABASE_PREFIX_ENV]: "",
+          },
+          () => ownerOf(name)
+        )
+      ).toBe("frame");
     });
 
     test("the context's prefix wins over the one in process.env", () => {

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -9,6 +9,7 @@ import type {
   FileSystemDirectoryEntry,
   FileSystemEntry,
 } from "@app/types/api/file_system/types";
+import { getFrameDatabaseReplicasBasePath } from "@app/types/api/frame_storage";
 import type { FileSystemMount, SandboxOnlyMount } from "@app/types/file_system";
 import {
   DustFileSystemError,
@@ -715,7 +716,10 @@ export class GCSFileSystemBackend implements FileSystemBackend {
         return `w/${this.workspaceId}/frames/${mount.frameId}/publications`;
 
       case "frame_state":
-        return `w/${this.workspaceId}/frames/${mount.frameId}/state`;
+        return getFrameDatabaseReplicasBasePath({
+          workspaceId: this.workspaceId,
+          frameId: mount.frameId,
+        }).replace(/\/$/, "");
 
       case "pod_sandbox_functions":
         return `w/${this.workspaceId}/pods/${mount.podId}/sandbox-functions`;

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -714,6 +714,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       case "frame_publications":
         return `w/${this.workspaceId}/frames/${mount.frameId}/publications`;
 
+      case "frame_state":
+        return `w/${this.workspaceId}/frames/${mount.frameId}/state`;
+
       case "pod_sandbox_functions":
         return `w/${this.workspaceId}/pods/${mount.podId}/sandbox-functions`;
 
@@ -732,11 +735,14 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       case "frame_publications":
         return "frame_publications";
 
+      case "frame_state":
+        return "sandbox_state_replica";
+
       case "pod_sandbox_functions":
         return "pod_sandbox_functions";
 
       case "pod_state":
-        return "pod_state_replica";
+        return "sandbox_state_replica";
 
       default:
         assertNever(mount);

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
@@ -52,7 +52,7 @@ const sandboxOnlyMounts: SandboxOnlyMount[] = [
   {
     kind: "pod_state",
     podId: "pod1",
-    sandboxMountPoint: "/pod-state/replica",
+    sandboxMountPoint: "/sandbox-state/replica",
     readOnly: false,
   },
 ];

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -176,7 +176,7 @@ describe("buildMountCommand", () => {
         bucket: "bucket-x",
         target: {
           gcsPrefix: "w/ws1/pods/spc1/state",
-          sandboxMountPoint: "/pod-state/replica",
+          sandboxMountPoint: "/sandbox-state/replica",
           legacySandboxMountPoint: null,
           readOnly: false,
           mountProfile: "sandbox_state_replica",
@@ -198,7 +198,7 @@ describe("buildMountCommand", () => {
     expect(command).toContain("--dir-mode=700");
     expect(command).toContain("--only-dir w/ws1/pods/spc1/state");
     expect(command).toContain("--enable-hns=false");
-    expect(command).toContain("bucket-x /pod-state/replica");
+    expect(command).toContain("bucket-x /sandbox-state/replica");
   });
 });
 

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -170,7 +170,7 @@ describe("buildMountCommand", () => {
     expect(command).toContain("bucket-x /frames/fil_frame/publications");
   });
 
-  test("pod_state_replica profile mounts as dust-state without allow_other or list caching", () => {
+  test("sandbox state replica mounts as dust-state without allow_other or list caching", () => {
     const command = renderRootCommand(
       buildMountCommand({
         bucket: "bucket-x",
@@ -179,7 +179,7 @@ describe("buildMountCommand", () => {
           sandboxMountPoint: "/pod-state/replica",
           legacySandboxMountPoint: null,
           readOnly: false,
-          mountProfile: "pod_state_replica",
+          mountProfile: "sandbox_state_replica",
         },
       })
     );
@@ -278,13 +278,14 @@ describe("Frame sandbox mount wiring", () => {
     process.env.DUST_PRIVATE_UPLOADS_BUCKET ??= "test-private-uploads";
   });
 
-  test("grants only the stable Frame publication prefix", () => {
+  test("grants only stable Frame publication and state prefixes", () => {
     const rules = createFrameSandboxAdapter().getAccessBoundaryRules();
 
-    expect(rules).toHaveLength(1);
-    expect(rules[0]).toHaveLength(3);
+    expect(rules).toHaveLength(2);
+    expect(rules.every((tokenRules) => tokenRules.length === 3)).toBe(true);
     const serializedRules = JSON.stringify(rules);
     expect(serializedRules).toContain("w/ws1/frames/fil_frame/publications/");
+    expect(serializedRules).toContain("w/ws1/frames/fil_frame/state/");
     expect(serializedRules).not.toContain("/conversations/");
     expect(serializedRules).not.toContain("/pods/");
   });

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -285,7 +285,9 @@ describe("Frame sandbox mount wiring", () => {
     expect(rules.every((tokenRules) => tokenRules.length === 3)).toBe(true);
     const serializedRules = JSON.stringify(rules);
     expect(serializedRules).toContain("w/ws1/frames/fil_frame/publications/");
-    expect(serializedRules).toContain("w/ws1/frames/fil_frame/state/");
+    expect(serializedRules).toContain(
+      "w/ws1/frames/fil_frame/state/databases/"
+    );
     expect(serializedRules).not.toContain("/conversations/");
     expect(serializedRules).not.toContain("/pods/");
   });

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -74,7 +74,7 @@ function tokenUrl(index: number): string {
  *   disabled: writes from another sandbox or Front must be visible immediately.
  * - "frame_publications" / "pod_sandbox_functions": same access model as "workload", but without
  *   caching so newly published or replaced functions are visible immediately.
- * - "pod_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
+ * - "sandbox_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
  *   default — only the mounting user can access the fs — makes it invisible to
  *   every other uid, including the untrusted workload uid 1003 and root. No
  *   `allow_other`, restrictive modes, and NO kernel list caching: litestream
@@ -86,7 +86,7 @@ export type GCSMountProfile =
   | "frame_publications"
   | "workload"
   | "pod_sandbox_functions"
-  | "pod_state_replica";
+  | "sandbox_state_replica";
 
 export type GCSMountTarget = {
   /**
@@ -458,7 +458,7 @@ export function buildMountCommand({
       );
     }
 
-    case "pod_state_replica": {
+    case "sandbox_state_replica": {
       // Mounted AS dust-state (runuser): with no allow_other, the FUSE layer
       // denies every uid but the mounting one — the kernel-enforced version of
       // "invisible to uid 1003". List caching is OFF: litestream restore reads

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -80,7 +80,7 @@ function tokenUrl(index: number): string {
  *   `allow_other`, restrictive modes, and NO kernel list caching: litestream
  *   restore must never see a stale LTX listing. Needs the dust-state user and
  *   /pod-state layout in the image; targets with this profile are only ever
- *   constructed when a pod sandbox (the sandbox-functions computer) boots.
+ *   constructed for stateful Pod or Frame sandboxes.
  */
 export type GCSMountProfile =
   | "frame_publications"

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -79,7 +79,7 @@ function tokenUrl(index: number): string {
  *   every other uid, including the untrusted workload uid 1003 and root. No
  *   `allow_other`, restrictive modes, and NO kernel list caching: litestream
  *   restore must never see a stale LTX listing. Needs the dust-state user and
- *   /pod-state layout in the image; targets with this profile are only ever
+ *   sandbox state layout in the image; targets with this profile are only ever
  *   constructed for stateful Pod or Frame sandboxes.
  */
 export type GCSMountProfile =

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -1,10 +1,14 @@
 import {
+  checkReplicaMountLiveness,
   isFuseStatfsMagic,
   isValidPodDatabaseName,
   parseLiveDatabaseNames,
   parseReplicaDatabaseNames,
 } from "@app/lib/api/sandbox/db";
-import { describe, expect, test } from "vitest";
+import type { RootCommand } from "@app/lib/api/sandbox/root_command";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, test, vi } from "vitest";
 
 describe("pod state helpers", () => {
   test("validates database names against the contract shape", () => {
@@ -27,14 +31,14 @@ describe("pod state helpers", () => {
   test("parses replica enumeration output (watcher {db}.db layout), dropping non-conforming entries", () => {
     const findOutput = [
       // The directory watcher names replica subdirs by database FILENAME.
-      "/pod-state/replica/chat.db",
-      "/pod-state/replica/tasks.db",
+      "/sandbox-state/replica/chat.db",
+      "/sandbox-state/replica/tasks.db",
       // Hostile or accidental entries a workload could plant elsewhere or a
       // partial write could leave behind: all dropped by the name allowlist.
-      "/pod-state/replica/.hidden.db",
-      "/pod-state/replica/Invalid-Name.db",
-      "/pod-state/replica/-o.db",
-      "/pod-state/replica/no-db-suffix",
+      "/sandbox-state/replica/.hidden.db",
+      "/sandbox-state/replica/Invalid-Name.db",
+      "/sandbox-state/replica/-o.db",
+      "/sandbox-state/replica/no-db-suffix",
       "",
       "  ",
     ].join("\n");
@@ -65,5 +69,78 @@ describe("pod state helpers", () => {
     expect(isFuseStatfsMagic("ef53")).toBe(false);
     expect(isFuseStatfsMagic("794c7630")).toBe(false);
     expect(isFuseStatfsMagic("")).toBe(false);
+  });
+
+  test("checks the canonical sandbox-state replica mount", async () => {
+    const execRoot = vi
+      .fn()
+      .mockResolvedValue(
+        new Ok({ exitCode: 0, stdout: "65735546\n", stderr: "" })
+      );
+
+    const result = await checkReplicaMountLiveness(
+      {} as never,
+      { execRoot } as never
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      renderRootCommand(execRoot.mock.calls[0][1] as RootCommand)
+    ).toContain("/sandbox-state/replica");
+    expect(execRoot).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the legacy replica mount for old images", async () => {
+    const execRoot = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 1, stdout: "", stderr: "No such file" })
+      )
+      .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 0, stdout: "65735546\n", stderr: "" })
+      );
+
+    const result = await checkReplicaMountLiveness(
+      {} as never,
+      { execRoot } as never
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      renderRootCommand(execRoot.mock.calls[2][1] as RootCommand)
+    ).toContain("/pod-state/replica");
+    expect(execRoot).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not fall back when the canonical path is present but not FUSE", async () => {
+    const execRoot = vi
+      .fn()
+      .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ef53\n", stderr: "" }));
+
+    const result = await checkReplicaMountLiveness(
+      {} as never,
+      { execRoot } as never
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fall back when the canonical root exists but its mount is missing", async () => {
+    const execRoot = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 1, stdout: "", stderr: "No such file" })
+      )
+      .mockResolvedValueOnce(new Ok({ exitCode: 1, stdout: "", stderr: "" }));
+
+    const result = await checkReplicaMountLiveness(
+      {} as never,
+      { execRoot } as never
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(2);
   });
 });

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -26,13 +26,13 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 /**
  * Pod state runtime plumbing: SQLite databases under /pod-state/databases,
  * continuously replicated by a litestream daemon (running as dust-state) to a
- * gcsfuse-mounted GCS prefix at /pod-state/replica.
+ * gcsfuse-mounted GCS prefix at /sandbox-state/replica.
  *
  * The daemon runs litestream's directory watcher over /pod-state/databases
  * (static /etc/litestream.yml baked at image build): databases created at any
  * point — including publish-time `dsbx db reconcile` — are discovered and
  * replicated automatically within seconds. Replica subdirectories are named
- * by database FILENAME: /pod-state/replica/{db}.db/ltx/...
+ * by database FILENAME: /sandbox-state/replica/{db}.db/ltx/...
  *
  * Lifecycle:
  *  - Cold start (`setupPodStateOnColdStart`, after the gcsfuse mounts): restore
@@ -69,6 +69,12 @@ const RM_BIN = "/usr/bin/rm";
 const CHMOD_BIN = "/usr/bin/chmod";
 const HEAD_BIN = "/usr/bin/head";
 const TEST_BIN = "/usr/bin/test";
+
+// Old sandboxes keep their original image and mount layout until they are
+// recycled after deployment. Only the pre-sleep liveness probe needs this
+// bridge; new cold starts, restores, and mounts always use the canonical path.
+const LEGACY_POD_STATE_REPLICA_MOUNT_POINT = "/pod-state/replica";
+const SANDBOX_STATE_ROOT_DIR = "/sandbox-state";
 
 // Database name shape. Doubles as an allowlist: enumeration outputs are
 // workload-influenced, so anything not matching (dotfiles, litestream sidecar
@@ -603,22 +609,57 @@ export async function ensurePodStateHealthOnSleep(
 
 export const ensureSandboxStateHealthOnSleep = ensurePodStateHealthOnSleep;
 
-async function checkReplicaMountLiveness(
+export async function checkReplicaMountLiveness(
   auth: Authenticator,
   sandbox: SandboxResource
 ): Promise<Result<void, Error>> {
   // As dust-state: without allow_other the FUSE layer denies every other uid,
   // including root. `stat -f -c %t` prints the statfs filesystem magic.
-  const result = await sandbox.execRoot(
+  const result = await statReplicaMount(
     auth,
-    asPodStateUser(STAT_BIN, [
-      "-f",
-      "-c",
-      "%t",
-      SANDBOX_STATE_REPLICA_MOUNT_POINT,
-    ]),
+    sandbox,
+    SANDBOX_STATE_REPLICA_MOUNT_POINT
+  );
+  if (result.isErr() || result.value.exitCode === 0) {
+    return validateReplicaMountStat(result);
+  }
+
+  // Sandboxes booted from the previous image do not have /sandbox-state at
+  // all. They keep running during the deployment drain, so allow their old
+  // replica mount to flush before sleep. If the new root exists, fail closed:
+  // the canonical mount is broken rather than legacy.
+  const rootMissingResult = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(TEST_BIN, ["!", "-d", SANDBOX_STATE_ROOT_DIR]),
     { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
   );
+  if (rootMissingResult.isErr()) {
+    return rootMissingResult;
+  }
+  if (rootMissingResult.value.exitCode !== 0) {
+    return validateReplicaMountStat(result);
+  }
+
+  return validateReplicaMountStat(
+    await statReplicaMount(auth, sandbox, LEGACY_POD_STATE_REPLICA_MOUNT_POINT)
+  );
+}
+
+async function statReplicaMount(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  mountPoint: string
+) {
+  return sandbox.execRoot(
+    auth,
+    asPodStateUser(STAT_BIN, ["-f", "-c", "%t", mountPoint]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+}
+
+function validateReplicaMountStat(
+  result: Awaited<ReturnType<typeof statReplicaMount>>
+): Result<void, Error> {
   if (result.isErr()) {
     return result;
   }

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -256,6 +256,10 @@ export async function setupPodStateOnColdStart(
   });
 }
 
+// Pods and Frames use the same isolated SQLite/Litestream runtime. Keep the Pod-named export for
+// existing callers while owner-neutral lifecycle code uses this name.
+export const setupSandboxStateOnColdStart = setupPodStateOnColdStart;
+
 async function listReplicaDatabases(
   auth: Authenticator,
   sandbox: SandboxResource
@@ -596,6 +600,8 @@ export async function ensurePodStateHealthOnSleep(
 
   return new Ok(undefined);
 }
+
+export const ensureSandboxStateHealthOnSleep = ensurePodStateHealthOnSleep;
 
 async function checkReplicaMountLiveness(
   auth: Authenticator,

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -14,7 +14,11 @@ import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
-import { getPodStateBasePath } from "@app/types/mount_path";
+import {
+  getPodStateBasePath,
+  SANDBOX_STATE_DATABASES_DIR,
+  SANDBOX_STATE_REPLICA_MOUNT_POINT,
+} from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -45,10 +49,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  *    daemon, its control socket, the mounts and the database files.
  */
 
-export const POD_STATE_DATABASES_DIR = "/pod-state/databases";
-const POD_STATE_REPLICA_DIR = "/pod-state/replica";
-/** In-sandbox mount point of the state replica gcsfuse mount. */
-export const POD_STATE_REPLICA_MOUNT_POINT = POD_STATE_REPLICA_DIR;
 /** System user running the litestream daemon and owning the replica mount. */
 const POD_STATE_USER = "dust-state";
 
@@ -267,7 +267,7 @@ async function listReplicaDatabases(
   const result = await sandbox.execRoot(
     auth,
     asPodStateUser(FIND_BIN, [
-      POD_STATE_REPLICA_DIR,
+      SANDBOX_STATE_REPLICA_MOUNT_POINT,
       "-mindepth",
       "1",
       "-maxdepth",
@@ -291,10 +291,10 @@ async function restorePodDatabase(
   sandbox: SandboxResource,
   name: string
 ): Promise<Result<void, Error>> {
-  const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
-  const tmpPath = `${POD_STATE_DATABASES_DIR}/.restore-${name}.db`;
+  const dbPath = `${SANDBOX_STATE_DATABASES_DIR}/${name}.db`;
+  const tmpPath = `${SANDBOX_STATE_DATABASES_DIR}/.restore-${name}.db`;
   // Replica subdir named by database FILENAME (directory watcher layout).
-  const replicaUrl = `file://${POD_STATE_REPLICA_DIR}/${name}.db`;
+  const replicaUrl = `file://${SANDBOX_STATE_REPLICA_MOUNT_POINT}/${name}.db`;
 
   const failAndCleanup = async (err: Error): Promise<Result<void, Error>> => {
     // Best effort: a leftover temp file is invisible to enumeration (dotfile)
@@ -555,7 +555,7 @@ export async function ensurePodStateHealthOnSleep(
 
   // 4. Sync each database through the daemon control socket.
   for (const name of names) {
-    const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
+    const dbPath = `${SANDBOX_STATE_DATABASES_DIR}/${name}.db`;
     const syncResult = await sandbox.execRoot(
       auth,
       rootCommand.exec(LITESTREAM_BIN, [
@@ -611,7 +611,12 @@ async function checkReplicaMountLiveness(
   // including root. `stat -f -c %t` prints the statfs filesystem magic.
   const result = await sandbox.execRoot(
     auth,
-    asPodStateUser(STAT_BIN, ["-f", "-c", "%t", POD_STATE_REPLICA_MOUNT_POINT]),
+    asPodStateUser(STAT_BIN, [
+      "-f",
+      "-c",
+      "%t",
+      SANDBOX_STATE_REPLICA_MOUNT_POINT,
+    ]),
     { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
   );
   if (result.isErr()) {
@@ -637,7 +642,7 @@ async function listLiveDatabases(
   const result = await sandbox.execRoot(
     auth,
     rootCommand.exec(FIND_BIN, [
-      POD_STATE_DATABASES_DIR,
+      SANDBOX_STATE_DATABASES_DIR,
       "-mindepth",
       "1",
       "-maxdepth",
@@ -679,7 +684,7 @@ async function listValidLiveDatabases(
 
   const valid: string[] = [];
   for (const name of namesResult.value) {
-    const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
+    const dbPath = `${SANDBOX_STATE_DATABASES_DIR}/${name}.db`;
     const headResult = await sandbox.execRoot(
       auth,
       rootCommand.exec(HEAD_BIN, ["-c", "15", "--", dbPath]),

--- a/front/lib/api/sandbox/frame_mounts.test.ts
+++ b/front/lib/api/sandbox/frame_mounts.test.ts
@@ -13,7 +13,7 @@ describe("frameSandboxOnlyMounts", () => {
       {
         kind: "frame_state",
         frameId: "fil_frame",
-        sandboxMountPoint: "/pod-state/replica",
+        sandboxMountPoint: "/sandbox-state/replica",
         readOnly: false,
       },
     ]);

--- a/front/lib/api/sandbox/frame_mounts.test.ts
+++ b/front/lib/api/sandbox/frame_mounts.test.ts
@@ -2,13 +2,19 @@ import { frameSandboxOnlyMounts } from "@app/lib/api/sandbox/frame_mounts";
 import { describe, expect, it } from "vitest";
 
 describe("frameSandboxOnlyMounts", () => {
-  it("mounts only the stable Frame publication root read-only", () => {
+  it("mounts stable Frame publications and durable state", () => {
     expect(frameSandboxOnlyMounts({ sId: "fil_frame" })).toEqual([
       {
         kind: "frame_publications",
         frameId: "fil_frame",
         sandboxMountPoint: "/frames/fil_frame/publications",
         readOnly: true,
+      },
+      {
+        kind: "frame_state",
+        frameId: "fil_frame",
+        sandboxMountPoint: "/pod-state/replica",
+        readOnly: false,
       },
     ]);
   });

--- a/front/lib/api/sandbox/frame_mounts.ts
+++ b/front/lib/api/sandbox/frame_mounts.ts
@@ -1,6 +1,9 @@
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { SandboxOnlyMount } from "@app/types/file_system";
-import { getFramePublicationsMountPoint } from "@app/types/mount_path";
+import {
+  getFramePublicationsMountPoint,
+  SANDBOX_STATE_REPLICA_MOUNT_POINT,
+} from "@app/types/mount_path";
 
 type FrameRef = Pick<FileResource, "sId">;
 
@@ -11,6 +14,12 @@ export function frameSandboxOnlyMounts(frame: FrameRef): SandboxOnlyMount[] {
       frameId: frame.sId,
       sandboxMountPoint: getFramePublicationsMountPoint(frame.sId),
       readOnly: true,
+    },
+    {
+      kind: "frame_state",
+      frameId: frame.sId,
+      sandboxMountPoint: SANDBOX_STATE_REPLICA_MOUNT_POINT,
+      readOnly: false,
     },
   ];
 }

--- a/front/lib/api/sandbox/image/litestream/litestream.service
+++ b/front/lib/api/sandbox/image/litestream/litestream.service
@@ -20,12 +20,13 @@ RuntimeDirectory=litestream
 RuntimeDirectoryMode=0755
 
 # Defense in depth, modeled on dust-egress-resolver.service. The daemon only
-# needs rw under /pod-state (live databases + replica gcsfuse mount); the
+# needs rw under /pod-state (live databases) and /sandbox-state (replica
+# gcsfuse mount); the
 # control socket is AF_UNIX and the file replica needs no network.
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
-ReadWritePaths=/pod-state
+ReadWritePaths=/pod-state /sandbox-state
 ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes

--- a/front/lib/api/sandbox/image/litestream/litestream.yml
+++ b/front/lib/api/sandbox/image/litestream/litestream.yml
@@ -19,11 +19,11 @@ socket:
 # start — e.g. by a publish-time `dsbx db reconcile` — are discovered and
 # replicated within seconds. Non-SQLite files matching the pattern are
 # ignored by the watcher (header validation). Replica subdirectories are
-# named by database FILENAME: /pod-state/replica/{db}.db/ltx/...
+# named by database FILENAME: /sandbox-state/replica/{db}.db/ltx/...
 dbs:
   - dir: /pod-state/databases
     pattern: "*.db"
     watch: true
     replica:
       type: file
-      path: /pod-state/replica
+      path: /sandbox-state/replica

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -2,14 +2,14 @@ import { runCachedBunBuild } from "@app/lib/api/sandbox/image/bun_build";
 import fs from "fs";
 import path from "path";
 
-// @dust/pod is the pod-state runtime package exposed to sandbox function
-// code: db(name) returns a handle on one of the pod's SQLite databases
+// @dust/pod is the sandbox-state runtime package exposed to sandbox function
+// code: db(name) returns a handle on one of the owner's SQLite databases
 // (bun:sqlite). The @dust scope is never published to npm, so the package is
 // vendored at image build time: bun-bundle the entrypoint (dependencies stay
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
 export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.3.0";
+export const POD_PACKAGE_VERSION = "0.3.1";
 export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
 
 let podPackageSrcDir: string | undefined;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.99",
+      tag: "0.8.100",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -673,7 +673,7 @@ describe("sandbox image registry", () => {
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.3.0" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.3.1" }),
       ])
     );
   });

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -570,7 +570,10 @@ describe("sandbox image registry", () => {
         expect.stringContaining("setfacl -R -d -m g::rwx /pod-state/databases"),
         expect.stringContaining("setfacl -R -m g::rwx /pod-state/databases"),
         expect.stringContaining(
-          "install -d -o dust-state -g dust-state -m 700 /pod-state/replica"
+          "install -d -o root -g root -m 755 /sandbox-state"
+        ),
+        expect.stringContaining(
+          "install -d -o dust-state -g dust-state -m 700 /sandbox-state/replica"
         ),
       ])
     );
@@ -599,7 +602,9 @@ describe("sandbox image registry", () => {
     expect(litestreamUnit).toContain("RuntimeDirectory=litestream");
     expect(litestreamUnit).toContain("NoNewPrivileges=yes");
     expect(litestreamUnit).toContain("ProtectSystem=strict");
-    expect(litestreamUnit).toContain("ReadWritePaths=/pod-state");
+    expect(litestreamUnit).toContain(
+      "ReadWritePaths=/pod-state /sandbox-state"
+    );
     expect(litestreamUnit).toContain("RestrictAddressFamilies=AF_UNIX");
     expect(litestreamUnit).toContain("MemoryDenyWriteExecute=yes");
 
@@ -638,7 +643,7 @@ describe("sandbox image registry", () => {
     expect(litestreamConfig).toContain('pattern: "*.db"');
     expect(litestreamConfig).toContain("watch: true");
     expect(litestreamConfig).toContain("type: file");
-    expect(litestreamConfig).toContain("path: /pod-state/replica");
+    expect(litestreamConfig).toContain("path: /sandbox-state/replica");
   });
 
   test("pins drizzle packages and vendors @dust/pod", () => {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -237,7 +237,7 @@ function getPodStateSetupCommand(): string {
   // /pod-state/databases holds the live SQLite files: both agent-proxied
   // function code (group agent) and the litestream daemon (user dust-state)
   // need rw, so it gets the same setgid + default-ACL treatment as /files.
-  // /pod-state/replica is the gcsfuse mount point for the litestream replica
+  // /sandbox-state/replica is the gcsfuse mount point for the litestream replica
   // — the durable copy of pod state. Untrusted workload code must never read
   // or tamper with it, so the directory is dust-state-only: 0700 here, no
   // allow_other on the runtime mount.
@@ -246,7 +246,8 @@ function getPodStateSetupCommand(): string {
     "install -d -o dust-state -g agent -m 2770 /pod-state/databases",
     "setfacl -R -d -m g::rwx /pod-state/databases",
     "setfacl -R -m g::rwx /pod-state/databases",
-    "install -d -o dust-state -g dust-state -m 700 /pod-state/replica",
+    "install -d -o root -g root -m 755 /sandbox-state",
+    "install -d -o dust-state -g dust-state -m 700 /sandbox-state/replica",
   ].join(" && ");
 }
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.99";
+const DUST_BASE_IMAGE_VERSION = "0.8.100";
 const DSBX_CLI_VERSION = "0.1.52";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
@@ -53,7 +53,7 @@ const SNOWFLAKE_CLI_DEB_SHA256 =
 // machine and not another. This assumes an Ubuntu base and build-time egress to
 // launchpad.net; if PPAs are blocked, install the TDF .deb bundle instead.
 const LIBREOFFICE_PPA = "ppa:libreoffice/ppa";
-// Litestream (Apache-2.0) replicates the pod-state SQLite databases to the
+// Litestream (Apache-2.0) replicates the sandbox-state SQLite databases to the
 // GCS replica mount.
 const LITESTREAM_VERSION = "0.5.13";
 const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
@@ -557,7 +557,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
       "chown root:root /opt/bin/litestream && chmod 755 /opt/bin/litestream",
     { user: "root" }
   )
-  // Litestream unit + STATIC config (all paths are pod-state contract
+  // Litestream unit + STATIC config (all paths are sandbox-state contract
   // constants), both baked at build. The unit is deliberately NOT enabled:
   // front starts it at runtime AFTER the replica gcsfuse mount and the
   // cold-start restore — at boot the daemon would write to the unmounted
@@ -583,7 +583,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     name: POD_PACKAGE_NAME,
     version: POD_PACKAGE_VERSION,
     description:
-      "Pod database access: db(name) returns a drizzle instance over the pod's SQLite database",
+      "Frame and Pod database access: db(name) returns a Drizzle instance over the sandbox owner's SQLite database",
     runtime: "node",
   })
   .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -480,7 +480,7 @@ describe("ensureConversationSandboxReady", () => {
         {
           kind: "pod_state",
           podId: pod.sId,
-          sandboxMountPoint: "/pod-state/replica",
+          sandboxMountPoint: "/sandbox-state/replica",
           readOnly: false,
         },
       ],
@@ -546,7 +546,7 @@ describe("ensureConversationSandboxReady", () => {
         {
           kind: "frame_state",
           frameId: frame.sId,
-          sandboxMountPoint: "/pod-state/replica",
+          sandboxMountPoint: "/sandbox-state/replica",
           readOnly: false,
         },
       ],

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -19,7 +19,7 @@ const {
   mockRefreshSandboxMount,
   mockPrepareSandboxEgressBeforeMount,
   mockStartTelemetry,
-  mockSetupPodStateOnColdStart,
+  mockSetupSandboxStateOnColdStart,
 } = vi.hoisted(() => {
   const mockSetupSandboxMount = vi.fn();
   const mockRefreshSandboxMount = vi.fn();
@@ -40,7 +40,7 @@ const {
     mockRefreshSandboxMount,
     mockPrepareSandboxEgressBeforeMount: vi.fn(),
     mockStartTelemetry: vi.fn(),
-    mockSetupPodStateOnColdStart: vi.fn(),
+    mockSetupSandboxStateOnColdStart: vi.fn(),
   };
 });
 
@@ -51,7 +51,7 @@ vi.mock("@app/lib/api/sandbox/db", async (importOriginal) => {
     await importOriginal<typeof import("@app/lib/api/sandbox/db")>();
   return {
     ...actual,
-    setupPodStateOnColdStart: mockSetupPodStateOnColdStart,
+    setupSandboxStateOnColdStart: mockSetupSandboxStateOnColdStart,
   };
 });
 
@@ -222,7 +222,7 @@ describe("ensureConversationSandboxReady", () => {
     mockForFrameSandboxProvisioning.mockResolvedValue(new Ok(mockFs));
     mockSetupSandboxMount.mockResolvedValue(new Ok(undefined));
     mockRefreshSandboxMount.mockResolvedValue(new Ok(undefined));
-    mockSetupPodStateOnColdStart.mockResolvedValue(new Ok(undefined));
+    mockSetupSandboxStateOnColdStart.mockResolvedValue(new Ok(undefined));
   });
 
   it("preps egress, mounts files, and ensures egress on exec for freshly-created sandboxes", async () => {
@@ -495,12 +495,15 @@ describe("ensureConversationSandboxReady", () => {
     expect(mockStartTelemetry).toHaveBeenCalledWith(auth, sandbox, podOwner);
     expect(mockSetupSandboxMount).toHaveBeenCalledWith(sandbox, image);
     // Pod state bring-up runs after the mounts and before egress-on-exec.
-    expect(mockSetupPodStateOnColdStart).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockSetupSandboxStateOnColdStart).toHaveBeenCalledWith(
+      auth,
+      sandbox
+    );
     expect(mockSetupSandboxMount.mock.invocationCallOrder[0]).toBeLessThan(
-      mockSetupPodStateOnColdStart.mock.invocationCallOrder[0]
+      mockSetupSandboxStateOnColdStart.mock.invocationCallOrder[0]
     );
     expect(
-      mockSetupPodStateOnColdStart.mock.invocationCallOrder[0]
+      mockSetupSandboxStateOnColdStart.mock.invocationCallOrder[0]
     ).toBeLessThan(mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]);
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
       runtimeOwner: podOwner,
@@ -509,7 +512,7 @@ describe("ensureConversationSandboxReady", () => {
     });
   });
 
-  it("mounts only Frame publications with Frame-owned egress", async () => {
+  it("mounts Frame publications and durable state with Frame-owned egress", async () => {
     const frame = await FileFactory.create(auth, null, {
       contentType: frameV2ContentType,
       fileName: "manifest.json",
@@ -541,6 +544,12 @@ describe("ensureConversationSandboxReady", () => {
           sandboxMountPoint: `/frames/${frame.sId}/publications`,
           readOnly: true,
         },
+        {
+          kind: "frame_state",
+          frameId: frame.sId,
+          sandboxMountPoint: "/pod-state/replica",
+          readOnly: false,
+        },
       ],
     });
     const frameOwner = {
@@ -563,7 +572,10 @@ describe("ensureConversationSandboxReady", () => {
       egressPolicyPodId: pod.sId,
       wokeFromSleep: false,
     });
-    expect(mockSetupPodStateOnColdStart).not.toHaveBeenCalled();
+    expect(mockSetupSandboxStateOnColdStart).toHaveBeenCalledWith(
+      auth,
+      sandbox
+    );
   });
 
   it("does not run pod state bring-up for conversation sandboxes", async () => {
@@ -582,7 +594,7 @@ describe("ensureConversationSandboxReady", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockSetupPodStateOnColdStart).not.toHaveBeenCalled();
+    expect(mockSetupSandboxStateOnColdStart).not.toHaveBeenCalled();
   });
 
   it("requests a sandbox kill when pod state cold start fails", async () => {
@@ -595,7 +607,7 @@ describe("ensureConversationSandboxReady", () => {
       })
     );
     const podStateError = new Error("restore failed");
-    mockSetupPodStateOnColdStart.mockResolvedValue(new Err(podStateError));
+    mockSetupSandboxStateOnColdStart.mockResolvedValue(new Err(podStateError));
 
     const result = await ensurePodSandboxReady(auth as never, pod as never);
 

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -44,8 +44,7 @@ const {
   };
 });
 
-// Partial mock: pod_mounts.ts imports POD_STATE_REPLICA_MOUNT_POINT from the
-// same module, so the real constants must be preserved.
+// Partial mock: lifecycle tests replace state startup but preserve the remaining helpers.
 vi.mock("@app/lib/api/sandbox/db", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@app/lib/api/sandbox/db")>();

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -29,6 +29,7 @@ import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const SANDBOX_RUNTIME_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -59,6 +60,18 @@ type SandboxReadyConfig<TScope> = {
     egressPolicyPodId?: string;
   };
 };
+
+function sandboxOwnerHasPersistentState(owner: SandboxRuntimeOwner): boolean {
+  switch (owner.kind) {
+    case "conversation":
+      return false;
+    case "frame":
+    case "pod":
+      return true;
+    default:
+      assertNever(owner);
+  }
+}
 
 // /!\ All sandbox-touching tools must use the owner-specific ready helper rather than calling
 // the owner adapter directly, otherwise the GCS FUSE mount and egress forwarder bring-up will be
@@ -181,7 +194,7 @@ async function ensureOwnerSandboxReady<TScope>(
       // through the replica mount) and is awaited: `invoke` awaits
       // the owner-specific ready helper, which guarantees no function runs
       // before restore and daemon startup complete. Conversation sandboxes do not own state.
-      if (freshlyCreated && runtimeOwner.kind !== "conversation") {
+      if (freshlyCreated && sandboxOwnerHasPersistentState(runtimeOwner)) {
         const stateResult = await setupSandboxStateOnColdStart(auth, sandbox);
         if (stateResult.isErr()) {
           // status=running was already committed by ensureActive, and this

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -1,5 +1,5 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { setupPodStateOnColdStart } from "@app/lib/api/sandbox/db";
+import { setupSandboxStateOnColdStart } from "@app/lib/api/sandbox/db";
 import {
   ensureSandboxEgressOnExec,
   prepareSandboxEgressBeforeMount,
@@ -177,14 +177,13 @@ async function ensureOwnerSandboxReady<TScope>(
         }
       }
 
-      // Pod state bring-up must run strictly AFTER the mounts (restore reads
+      // Durable SQLite bring-up must run strictly AFTER the mounts (restore reads
       // through the replica mount) and is awaited: `invoke` awaits
-      // ensurePodSandboxReady, which is what guarantees no function runs
-      // before the restore + daemon start completed. Only runs for pod
-      // owners.
-      if (freshlyCreated && runtimeOwner.kind === "pod") {
-        const podStateResult = await setupPodStateOnColdStart(auth, sandbox);
-        if (podStateResult.isErr()) {
+      // the owner-specific ready helper, which guarantees no function runs
+      // before restore and daemon startup complete. Conversation sandboxes do not own state.
+      if (freshlyCreated && runtimeOwner.kind !== "conversation") {
+        const stateResult = await setupSandboxStateOnColdStart(auth, sandbox);
+        if (stateResult.isErr()) {
           // status=running was already committed by ensureActive, and this
           // block only runs when freshlyCreated — a plain Err would make the
           // NEXT call take the warm path and happily serve a half-initialized
@@ -192,12 +191,12 @@ async function ensureOwnerSandboxReady<TScope>(
           // kill instead: ensureActive's kill-requested branch destroys and
           // recreates on the next access, re-running this setup from scratch.
           logger.error(
-            { err: podStateResult.error, sandboxId: sandbox.sId },
-            "Pod state cold start failed — requesting sandbox kill so the next access recreates it."
+            { err: stateResult.error, sandboxId: sandbox.sId },
+            "Sandbox SQLite state cold start failed — requesting sandbox kill so the next access recreates it."
           );
           await sandbox.requestKill();
           status = "error";
-          return podStateResult;
+          return stateResult;
         }
       }
 

--- a/front/lib/api/sandbox/pod_mounts.ts
+++ b/front/lib/api/sandbox/pod_mounts.ts
@@ -28,7 +28,7 @@ function podSandboxFunctionsMount(pod: PodRef): SandboxOnlyMount {
 }
 
 // The pod's litestream replica prefix, mounted dust-state-only (no
-// allow_other) at /pod-state/replica. rw: the in-sandbox litestream daemon is
+// allow_other) at /sandbox-state/replica. rw: the in-sandbox litestream daemon is
 // the writer.
 function podStateReplicaMount(pod: PodRef): SandboxOnlyMount {
   return {

--- a/front/lib/api/sandbox/pod_mounts.ts
+++ b/front/lib/api/sandbox/pod_mounts.ts
@@ -1,7 +1,9 @@
-import { POD_STATE_REPLICA_MOUNT_POINT } from "@app/lib/api/sandbox/db";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxOnlyMount } from "@app/types/file_system";
-import { getPodSandboxFunctionsMountPoint } from "@app/types/mount_path";
+import {
+  getPodSandboxFunctionsMountPoint,
+  SANDBOX_STATE_REPLICA_MOUNT_POINT,
+} from "@app/types/mount_path";
 
 /**
  * The pod sandbox's sandbox-only mounts, shared by the bring-up path
@@ -32,7 +34,7 @@ function podStateReplicaMount(pod: PodRef): SandboxOnlyMount {
   return {
     kind: "pod_state",
     podId: pod.sId,
-    sandboxMountPoint: POD_STATE_REPLICA_MOUNT_POINT,
+    sandboxMountPoint: SANDBOX_STATE_REPLICA_MOUNT_POINT,
     readOnly: false,
   };
 }

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -26,7 +26,7 @@ import tracer from "@app/logger/tracer";
 import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import {
   POD_SANDBOX_DATABASES_DIR,
-  podDatabaseExecEnvVars,
+  sandboxDatabaseExecEnvVars,
   TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
@@ -136,7 +136,7 @@ async function execDbCommand<S extends z.ZodTypeAny>(
 
   const execResult = await sandbox.exec(auth, command, {
     timeoutMs: DB_EXEC_TIMEOUT_MS,
-    envVars: { ...podDatabaseExecEnvVars(), ...envVars },
+    envVars: { ...sandboxDatabaseExecEnvVars(), ...envVars },
     user: "agent-proxied",
     stdin,
   });

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -25,7 +25,7 @@ import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import {
-  POD_SANDBOX_DATABASES_DIR,
+  SANDBOX_STATE_DATABASES_DIR,
   sandboxDatabaseExecEnvVars,
   TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/types/mount_path";
@@ -380,7 +380,7 @@ export async function deleteDatabaseOnSandbox(
     );
   }
 
-  const dbPath = `${POD_SANDBOX_DATABASES_DIR}/${database}.db`;
+  const dbPath = `${SANDBOX_STATE_DATABASES_DIR}/${database}.db`;
   // `rm` unlinks a symlink itself rather than following it, so a link planted in the
   // workload-writable databases dir cannot make this reach a foreign file.
   const paths = [

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -470,36 +470,36 @@ export class FileResource extends BaseResource<FileModel> {
 
   static async deleteAllForWorkspace(auth: Authenticator) {
     const owner = auth.getNonNullableWorkspace();
-    const workspaceId = owner.id;
+    const workspaceModelId = owner.id;
 
     await FrameSandboxAdapter.deleteAllForWorkspace(auth);
-    await this.deleteAllFrameFunctionsForWorkspace(workspaceId);
+    await this.deleteAllFrameFunctionsForWorkspace(workspaceModelId);
     await getPrivateUploadBucket().deleteByPrefix(
       getFramesBasePath({ workspaceId: owner.sId })
     );
 
     await AuthorizedFileAccessModel.destroy({
-      where: { workspaceId },
+      where: { workspaceId: workspaceModelId },
     });
 
     // Delete external viewer sessions before shareable files (FK constraint).
     await ExternalViewerSessionModel.destroy({
-      where: { workspaceId },
+      where: { workspaceId: workspaceModelId },
     });
 
     // Delete sharing grants before shareable files (FK constraint).
     await SharingGrantModel.destroy({
-      where: { workspaceId },
+      where: { workspaceId: workspaceModelId },
     });
 
     // Delete authorized file accesses before shareable files (FK constraint).
     await this.authorizedFileAccessModel.destroy({
-      where: { workspaceId },
+      where: { workspaceId: workspaceModelId },
     });
 
     // Delete all shareable file records.
     await this.shareableFileModel.destroy({
-      where: { workspaceId },
+      where: { workspaceId: workspaceModelId },
     });
 
     return this.batchDestroyAllForWorkspace(auth);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -58,7 +58,11 @@ import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
+import {
+  getFrameBasePath,
+  getFramePublicationUiBundlePath,
+  getFramesBasePath,
+} from "@app/types/api/frame_storage";
 import { CoreAPI } from "@app/types/core/core_api";
 import type {
   AuthorizedFileAccessAllowlist,
@@ -465,10 +469,14 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   static async deleteAllForWorkspace(auth: Authenticator) {
-    const workspaceId = auth.getNonNullableWorkspace().id;
+    const owner = auth.getNonNullableWorkspace();
+    const workspaceId = owner.id;
 
     await FrameSandboxAdapter.deleteAllForWorkspace(auth);
     await this.deleteAllFrameFunctionsForWorkspace(workspaceId);
+    await getPrivateUploadBucket().deleteByPrefix(
+      getFramesBasePath({ workspaceId: owner.sId })
+    );
 
     await AuthorizedFileAccessModel.destroy({
       where: { workspaceId },
@@ -637,6 +645,12 @@ export class FileResource extends BaseResource<FileModel> {
     try {
       if (this.isFrameV2) {
         await this.deleteFrameFunctions(auth);
+        await getPrivateUploadBucket().deleteByPrefix(
+          getFrameBasePath({
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            frameId: this.sId,
+          })
+        );
       }
 
       if (this.isReady) {

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -44,6 +44,7 @@ import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -179,6 +180,10 @@ describe("FrameSandboxAdapter", () => {
       throw sandboxResult.error;
     }
     const sandboxModelId = sandboxResult.value.sandbox.id;
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
 
     const deleteResult = await frame.delete(auth);
 
@@ -193,6 +198,9 @@ describe("FrameSandboxAdapter", () => {
     expect(
       await SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)
     ).toBeNull();
+    expect(deletedPrefixes).toContain(
+      `w/${workspace.sId}/frames/${frame.sId}/`
+    );
   });
 
   it("keeps sandbox creation blocked until Frame deletion completes", async () => {
@@ -316,6 +324,10 @@ describe("FrameSandboxAdapter", () => {
       )
     );
     const sandboxModelIds: ModelId[] = [];
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
     for (const frame of frames) {
       const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
         auth,
@@ -338,5 +350,6 @@ describe("FrameSandboxAdapter", () => {
         await SandboxResource.fetchByModelIdForWorkspace(auth, sandboxModelId)
       ).toBeNull();
     }
+    expect(deletedPrefixes).toContain(`w/${workspace.sId}/frames/`);
   });
 });

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -1,3 +1,7 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { ensureSandboxStateHealthOnSleep } from "@app/lib/api/sandbox/db";
+import { frameSandboxOnlyMounts } from "@app/lib/api/sandbox/frame_mounts";
+import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import { resolvePodForRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -8,6 +12,7 @@ import type {
   SandboxCreateBlob,
   SandboxDeleteOwner,
   SandboxLifecycleOwner,
+  SandboxPreSleepCheck,
 } from "@app/lib/resources/sandbox_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
@@ -25,7 +30,7 @@ const FRAME_SANDBOX_WORKSPACE_DELETE_BATCH_SIZE = 1024;
 
 export type FrameSandboxOwner = Pick<
   FileResource,
-  "id" | "sId" | "workspaceId"
+  "id" | "sId" | "workspaceId" | "isFrameV2"
 >;
 
 type FrameSandboxScopeOwner = FrameSandboxOwner &
@@ -197,6 +202,30 @@ export class FrameSandboxAdapter {
     };
   }
 
+  private static sqliteStatePreSleepCheck(
+    auth: Authenticator,
+    frame: FrameSandboxOwner
+  ): SandboxPreSleepCheck {
+    return (sandbox) =>
+      ensureSandboxStateHealthOnSleep(auth, sandbox, {
+        refreshMountCredential: async () => {
+          const imageResult = getSandboxImage(auth);
+          if (imageResult.isErr()) {
+            return imageResult;
+          }
+          const fsResult = await DustFileSystem.forFrameSandboxProvisioning(
+            auth,
+            frame,
+            { sandboxOnlyMounts: frameSandboxOnlyMounts(frame) }
+          );
+          if (fsResult.isErr()) {
+            return fsResult;
+          }
+          return fsResult.value.refreshSandboxMount(sandbox, imageResult.value);
+        },
+      });
+  }
+
   static async fetchSandbox(
     auth: Authenticator,
     frame: FrameSandboxOwner
@@ -220,7 +249,10 @@ export class FrameSandboxAdapter {
         createSandbox: (blob) =>
           this.createSandboxRecordForFrame(auth, frame, blob),
       },
-      { requireRunning }
+      {
+        beforeSleep: this.sqliteStatePreSleepCheck(auth, frame),
+        requireRunning,
+      }
     );
   }
 
@@ -285,7 +317,8 @@ export class FrameSandboxAdapter {
   ): Promise<Result<void, Error>> {
     return SandboxResource.dangerouslySleepIfRunning(
       auth,
-      this.toSandboxLifecycleOwner(auth, frame)
+      this.toSandboxLifecycleOwner(auth, frame),
+      { beforeSleep: this.sqliteStatePreSleepCheck(auth, frame) }
     );
   }
 
@@ -315,7 +348,8 @@ export class FrameSandboxAdapter {
   ): Promise<Result<void, Error>> {
     return SandboxResource.dangerouslyDestroyIfKillRequested(
       auth,
-      this.toSandboxLifecycleOwner(auth, frame)
+      this.toSandboxLifecycleOwner(auth, frame),
+      { beforeSleep: this.sqliteStatePreSleepCheck(auth, frame) }
     );
   }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -906,10 +906,12 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     const execOptions = execSpy.mock.calls[0]?.[2];
     expect(execOptions?.envVars).toMatchObject({
+      DUST_POD_DATABASES_DIR: "/pod-state/databases",
+      DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
+      DUST_POD_DATABASE_PREFIX: "",
       DUST_FUNCTIONS_DIR: `/frames/${frame.sId}/publications/${publicationId}/functions`,
       DUST_SANDBOX_TOKEN: "sbt-frame-function-token",
     });
-    expect(execOptions?.envVars).not.toHaveProperty("DUST_POD_DATABASES_DIR");
     expect(invocation.gcsPath).toBe(
       `w/${authenticator.getNonNullableWorkspace().sId}/frames/${frame.sId}/invocations/${invocation.sId}`
     );

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -64,7 +64,7 @@ import type {
 import {
   getFramePublicationFunctionsMountPoint,
   getPodSandboxFunctionsMountPoint,
-  podDatabaseExecEnvVars,
+  sandboxDatabaseExecEnvVars,
 } from "@app/types/mount_path";
 import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -811,8 +811,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         );
       }
       const databaseEnvVars = frame
-        ? {}
-        : podDatabaseExecEnvVars({
+        ? sandboxDatabaseExecEnvVars()
+        : sandboxDatabaseExecEnvVars({
             databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
           });
 

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -208,18 +208,19 @@ describe("sandbox security check assertions", () => {
     const safeOutput = [
       "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x",
       "POD_STATE_DIR=/pod-state/databases dust-state:agent 2770 drwxrws---",
-      "POD_STATE_DIR=/pod-state/replica dust-state:dust-state 700 drwx------",
+      "POD_STATE_DIR=/sandbox-state root:root 755 drwxr-xr-x",
+      "POD_STATE_DIR=/sandbox-state/replica dust-state:dust-state 700 drwx------",
     ].join("\n");
 
     expect(() => assertPodStateDirsSafe(safeOutput)).not.toThrow();
     expect(() =>
       assertPodStateDirsSafe(
         safeOutput.replace(
-          "/pod-state/replica dust-state:dust-state 700",
-          "/pod-state/replica dust-state:dust-state 755"
+          "/sandbox-state/replica dust-state:dust-state 700",
+          "/sandbox-state/replica dust-state:dust-state 755"
         )
       )
-    ).toThrow("pod-state directory /pod-state/replica");
+    ).toThrow("pod-state directory /sandbox-state/replica");
     expect(() =>
       assertPodStateDirsSafe(
         safeOutput.replace(

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -826,7 +826,12 @@ export function assertRootInvokedHelpersSafe(output: string): void {
 const POD_STATE_DIR_EXPECTATIONS = [
   { path: "/pod-state", owner: "root:root", mode: "755" },
   { path: "/pod-state/databases", owner: "dust-state:agent", mode: "2770" },
-  { path: "/pod-state/replica", owner: "dust-state:dust-state", mode: "700" },
+  { path: "/sandbox-state", owner: "root:root", mode: "755" },
+  {
+    path: "/sandbox-state/replica",
+    owner: "dust-state:dust-state",
+    mode: "700",
+  },
 ] as const;
 
 export function assertPodStateDirsSafe(output: string): void {
@@ -1184,12 +1189,12 @@ rm -f "$proof"
     providerId,
     `
 set -euo pipefail
-if ls /pod-state/replica >/dev/null 2>&1; then
-  echo "CRITICAL: workload user can list /pod-state/replica"
+if ls /sandbox-state/replica >/dev/null 2>&1; then
+  echo "CRITICAL: workload user can list /sandbox-state/replica"
   exit 1
 fi
-if touch /pod-state/replica/dust-security-proof 2>/dev/null; then
-  echo "CRITICAL: workload user can write /pod-state/replica"
+if touch /sandbox-state/replica/dust-security-proof 2>/dev/null; then
+  echo "CRITICAL: workload user can write /sandbox-state/replica"
   exit 1
 fi
 if [ -w /opt/bin/litestream ]; then

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -1,5 +1,5 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type { ensurePodStateHealthOnSleep } from "@app/lib/api/sandbox/db";
+import type { ensureSandboxStateHealthOnSleep } from "@app/lib/api/sandbox/db";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
@@ -15,7 +15,7 @@ import { Ok } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockEnsurePodStateHealthOnSleep,
+  mockEnsureSandboxStateHealthOnSleep,
   mockExecuteWithLock,
   mockGetSandboxImage,
   mockGetSandboxProvider,
@@ -23,7 +23,7 @@ const {
   mockProviderDestroy,
   mockProviderSleep,
 } = vi.hoisted(() => ({
-  mockEnsurePodStateHealthOnSleep: vi.fn(),
+  mockEnsureSandboxStateHealthOnSleep: vi.fn(),
   mockExecuteWithLock: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
@@ -52,7 +52,8 @@ vi.mock("@app/lib/api/sandbox/db", async (importOriginal) => {
     await importOriginal<typeof import("@app/lib/api/sandbox/db")>();
   return {
     ...actual,
-    ensurePodStateHealthOnSleep: mockEnsurePodStateHealthOnSleep,
+    ensurePodStateHealthOnSleep: mockEnsureSandboxStateHealthOnSleep,
+    ensureSandboxStateHealthOnSleep: mockEnsureSandboxStateHealthOnSleep,
   };
 });
 
@@ -68,8 +69,8 @@ describe("reapSandboxPhaseActivity", () => {
     mockExecuteWithLock.mockImplementation(
       async (_key: string, fn: () => Promise<unknown>) => fn()
     );
-    mockEnsurePodStateHealthOnSleep.mockImplementation(
-      async (...args: Parameters<typeof ensurePodStateHealthOnSleep>) => {
+    mockEnsureSandboxStateHealthOnSleep.mockImplementation(
+      async (...args: Parameters<typeof ensureSandboxStateHealthOnSleep>) => {
         const refreshMountCredential = args[2]?.refreshMountCredential;
         if (!refreshMountCredential) {
           throw new Error("Expected a mount credential refresh callback.");
@@ -150,7 +151,7 @@ describe("reapSandboxPhaseActivity", () => {
       workspaceId: workspace.sId,
     });
     // Pod sleeps run the pre-sleep state health check; conversations don't.
-    expect(mockEnsurePodStateHealthOnSleep).toHaveBeenCalledTimes(1);
+    expect(mockEnsureSandboxStateHealthOnSleep).toHaveBeenCalledTimes(1);
     expect(DustFileSystem.prototype.refreshSandboxMount).toHaveBeenCalledTimes(
       1
     );
@@ -266,6 +267,10 @@ describe("reapSandboxPhaseActivity", () => {
     expect(mockProviderSleep).toHaveBeenCalledWith("frame-provider", {
       workspaceId: workspace.sId,
     });
+    expect(mockEnsureSandboxStateHealthOnSleep).toHaveBeenCalledTimes(1);
+    expect(DustFileSystem.prototype.refreshSandboxMount).toHaveBeenCalledTimes(
+      1
+    );
   });
 
   it("skips kill-requested sleeping sandboxes in the awake kill phase", async () => {

--- a/front/types/api/frame_storage.test.ts
+++ b/front/types/api/frame_storage.test.ts
@@ -1,6 +1,7 @@
 import {
   getFrameBasePath,
   getFrameDatabaseReplicaBasePath,
+  getFrameDatabaseReplicasBasePath,
   getFramePublicationDescriptorPath,
   getFramePublicationFunctionBundlePath,
   getFramePublicationUiBundlePath,
@@ -33,6 +34,9 @@ describe("Frames v2 GCS paths", () => {
   });
 
   it("keeps SQLite replica state outside publications", () => {
+    expect(getFrameDatabaseReplicasBasePath(IDS)).toBe(
+      "w/w_123/frames/fil_456/state/databases/"
+    );
     expect(
       getFrameDatabaseReplicaBasePath({
         workspaceId: IDS.workspaceId,

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -10,14 +10,29 @@ function safeSegment(value: string, label: string): string {
   return value;
 }
 
-export function getFrameBasePath({
+export function getFramesBasePath({
   workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `w/${safeSegment(workspaceId, "workspaceId")}/frames/`;
+}
+
+export function getFrameBasePath({
   frameId,
+  ...args
 }: {
   workspaceId: string;
   frameId: string;
 }): string {
-  return `w/${safeSegment(workspaceId, "workspaceId")}/frames/${safeSegment(frameId, "frameId")}/`;
+  return `${getFramesBasePath(args)}${safeSegment(frameId, "frameId")}/`;
+}
+
+export function getFrameDatabaseReplicasBasePath(args: {
+  workspaceId: string;
+  frameId: string;
+}): string {
+  return `${getFrameBasePath(args)}state/databases/`;
 }
 
 export function getFramePublicationsBasePath(args: {
@@ -39,7 +54,7 @@ export function getFrameDatabaseReplicaBasePath({
     throw new Error("Invalid databaseName for Frame storage.");
   }
 
-  return `${getFrameBasePath(args)}state/databases/${databaseName}.db/`;
+  return `${getFrameDatabaseReplicasBasePath(args)}${databaseName}.db/`;
 }
 
 export function getFramePublicationBasePath({

--- a/front/types/file_system.ts
+++ b/front/types/file_system.ts
@@ -69,6 +69,7 @@ type SandboxOnlyMountConfig = {
 export type SandboxOnlyMount = SandboxOnlyMountConfig &
   (
     | { kind: "frame_publications"; frameId: string }
+    | { kind: "frame_state"; frameId: string }
     | { kind: "pod_sandbox_functions"; podId: string }
     | { kind: "pod_state"; podId: string }
   );

--- a/front/types/file_system.ts
+++ b/front/types/file_system.ts
@@ -59,7 +59,7 @@ export type FileSystemMount = {
  * A mount that exists only inside the sandbox filesystem and is never exposed through the
  * scoped-path API (the agent's file tools never see it). Used for prefixes the sandbox must read
  * but that are not an agent-visible namespace, e.g. published sandbox-function bundles or the
- * pod-state litestream replica.
+ * sandbox-state Litestream replica.
  */
 type SandboxOnlyMountConfig = {
   sandboxMountPoint: string;

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -123,6 +123,7 @@ export function getFramePublicationFunctionsMountPoint({
  * replica is durable, under the stable Frame identity in GCS.
  */
 export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/pod-state/replica";
+export const SANDBOX_STATE_DATABASES_DIR = "/pod-state/databases";
 
 /**
  * Absolute in-sandbox path of the owner's live SQLite databases (`{name}.db` files opened by
@@ -130,12 +131,7 @@ export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/pod-state/replica";
  * Front is the only layer that hardcodes this location (the paths-env.v1 contract): it is
  * passed per exec to `dsbx function run` as `DUST_POD_DATABASES_DIR`, dsbx forwards it to
  * the bun child, and `@dust/pod` reads the env var — neither carries a fallback copy.
- *
- * TODO(pod-state): Track 1's parallel stack defines the same contract value as
- * `POD_STATE_DATABASES_DIR` in `front/lib/api/sandbox/db.ts` (litestream config /
- * restore side). Dedup into a single constant once both stacks are merged.
  */
-export const POD_SANDBOX_DATABASES_DIR = "/pod-state/databases";
 
 /**
  * Per-database size quota in bytes (1 GiB). The other half of the paths-env.v1 contract: like
@@ -144,7 +140,7 @@ export const POD_SANDBOX_DATABASES_DIR = "/pod-state/databases";
  * require it and carry no fallback (see `cli/dust-sandbox/pod/db.ts`). A single source here
  * keeps the quota the workload writes against identical to the one `db_query` enforces.
  */
-const POD_SANDBOX_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
+const SANDBOX_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
 
 /**
  * The env vars every sandbox-database exec (`dsbx function run` and every `dsbx db` subcommand)
@@ -167,9 +163,9 @@ export function sandboxDatabaseExecEnvVars({
   DUST_POD_DATABASE_PREFIX: string;
 } {
   return {
-    DUST_POD_DATABASES_DIR: POD_SANDBOX_DATABASES_DIR,
+    DUST_POD_DATABASES_DIR: SANDBOX_STATE_DATABASES_DIR,
     DUST_POD_DATABASE_MAX_SIZE_BYTES: String(
-      POD_SANDBOX_DATABASE_MAX_SIZE_BYTES
+      SANDBOX_DATABASE_MAX_SIZE_BYTES
     ),
     // Empty means unprefixed, which is what the shim reads an absent value as.
     DUST_POD_DATABASE_PREFIX: databasePrefix ?? "",

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -118,7 +118,14 @@ export function getFramePublicationFunctionsMountPoint({
 }
 
 /**
- * Absolute in-sandbox path of the pod's live SQLite databases (`{name}.db` files opened by
+ * Frame-owned SQLite uses the same isolated local runtime directories as Pod SQLite. A Frame has
+ * its own sandbox, so the live files cannot overlap another Frame or a Pod; only its Litestream
+ * replica is durable, under the stable Frame identity in GCS.
+ */
+export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/pod-state/replica";
+
+/**
+ * Absolute in-sandbox path of the owner's live SQLite databases (`{name}.db` files opened by
  * `@dust/pod`'s `db()`). Local disk, not a gcsfuse mount — Litestream replicates it to GCS.
  * Front is the only layer that hardcodes this location (the paths-env.v1 contract): it is
  * passed per exec to `dsbx function run` as `DUST_POD_DATABASES_DIR`, dsbx forwards it to
@@ -140,16 +147,17 @@ export const POD_SANDBOX_DATABASES_DIR = "/pod-state/databases";
 const POD_SANDBOX_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
 
 /**
- * The env vars every pod-database exec (`dsbx function run` and every `dsbx db` subcommand)
+ * The env vars every sandbox-database exec (`dsbx function run` and every `dsbx db` subcommand)
  * must carry so the bun child resolves the databases dir and the size quota. Returned as a
  * fresh object so callers can spread it into their own env without sharing a reference.
  *
- * `databasePrefix` is the app prefix that namespaces the databases the exec resolves by their
+ * The `DUST_POD_*` names are the existing DSBX/@dust/pod ABI and also apply to Frame-owned state.
+ * `databasePrefix` is the Pod app prefix that namespaces the databases the exec resolves by their
  * app-relative name, i.e. `@dust/pod`'s `db("chat")` inside a published function (see
  * `podDatabasePrefixFromSlug`). Omit it for execs that address databases by their on-disk name —
  * every `dsbx db` subcommand does, since front resolves the name before running them.
  */
-export function podDatabaseExecEnvVars({
+export function sandboxDatabaseExecEnvVars({
   databasePrefix,
 }: {
   databasePrefix?: string | null;

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -122,7 +122,7 @@ export function getFramePublicationFunctionsMountPoint({
  * its own sandbox, so the live files cannot overlap another Frame or a Pod; only its Litestream
  * replica is durable, under the stable Frame identity in GCS.
  */
-export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/pod-state/replica";
+export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/sandbox-state/replica";
 
 /**
  * Absolute in-sandbox path of the owner's live SQLite databases (`{name}.db` files opened by
@@ -173,7 +173,7 @@ export function sandboxDatabaseExecEnvVars({
 /**
  * Prefix for the pod's Litestream state replica (LTX chains for the pod's SQLite databases). The
  * sandbox's litestream daemon is the only writer, through the dust-state-only gcsfuse mount at
- * /pod-state/replica. Never mounted under /files, never a FileResource: cleanup is a wholesale
+ * /sandbox-state/replica. Never mounted under /files, never a FileResource: cleanup is a wholesale
  * prefix delete at pod deletion (see deletePodStatePrefix).
  */
 export function getPodStateBasePath({

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -164,9 +164,7 @@ export function sandboxDatabaseExecEnvVars({
 } {
   return {
     DUST_POD_DATABASES_DIR: SANDBOX_STATE_DATABASES_DIR,
-    DUST_POD_DATABASE_MAX_SIZE_BYTES: String(
-      SANDBOX_DATABASE_MAX_SIZE_BYTES
-    ),
+    DUST_POD_DATABASE_MAX_SIZE_BYTES: String(SANDBOX_DATABASE_MAX_SIZE_BYTES),
     // Empty means unprefixed, which is what the shim reads an absent value as.
     DUST_POD_DATABASE_PREFIX: databasePrefix ?? "",
   };

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -123,7 +123,6 @@ export function getFramePublicationFunctionsMountPoint({
  * replica is durable, under the stable Frame identity in GCS.
  */
 export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/pod-state/replica";
-export const SANDBOX_STATE_DATABASES_DIR = "/pod-state/databases";
 
 /**
  * Absolute in-sandbox path of the owner's live SQLite databases (`{name}.db` files opened by
@@ -132,6 +131,7 @@ export const SANDBOX_STATE_DATABASES_DIR = "/pod-state/databases";
  * passed per exec to `dsbx function run` as `DUST_POD_DATABASES_DIR`, dsbx forwards it to
  * the bun child, and `@dust/pod` reads the env var — neither carries a fallback copy.
  */
+export const SANDBOX_STATE_DATABASES_DIR = "/pod-state/databases";
 
 /**
  * Per-database size quota in bytes (1 GiB). The other half of the paths-env.v1 contract: like


### PR DESCRIPTION
## Description

- mount a private writable Litestream replica at `w/{workspaceId}/frames/{frameId}/state/databases`
- restore Frame SQLite state before a fresh sandbox can execute functions
- flush Frame databases before sandbox sleep or kill, including credential refresh
- expose the existing DSBX database runtime ABI to Frame functions without mounting source files
- delete all canonical publication and state objects on Frame deletion or workspace scrub
- stack on #31396

## Tests

- 143 focused Front tests covering Frame paths, mounts, cold start, reaper sleep, invocation, individual deletion, and workspace scrub
- Front `tsgo`
- Biome on all touched files
- `git diff --check`

## Risk

Low and feature-gated by `frames_v2`. The Pod path keeps the same mount prefix, runtime env, and lifecycle behavior. Rollback removes the Frame state mount and runtime wiring; explicit deletion remains safe.

## Deploy Plan

Merge #31396 first, then deploy normally. No migration or manual production step.
