### PR TITLE
Reconcile Frame databases before publication activation

### DIFF
--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -3,6 +3,7 @@
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
 import { FRAME_SOURCE_STAGING_ROOT } from "@app/lib/api/frames/source_staging";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { Authenticator } from "@app/lib/auth";
@@ -118,9 +119,17 @@ async function setup(): Promise<{
     version: "0.0.0-test",
   });
   vi.spyOn(sandbox, "writeFile").mockResolvedValue(new Ok(undefined));
-  vi.spyOn(sandbox, "exec").mockResolvedValue(
+  vi.spyOn(sandbox, "execRoot").mockResolvedValue(
     new Ok({ exitCode: 0, stdout: "", stderr: "" })
   );
+  vi.spyOn(sandbox, "readFile").mockImplementation(async (_auth, filePath) => {
+    const sourceFile = sourceFiles.find(({ relativePath }) =>
+      filePath.endsWith(`/${relativePath}`)
+    );
+    return sourceFile
+      ? new Ok(sourceFile.content)
+      : new Err(new Error(`Unexpected staged path: ${filePath}`));
+  });
   vi.mocked(ensureConversationSandboxReadyWithScope).mockResolvedValue(
     new Ok({ sandbox, freshlyCreated: false, scope: { spaceId: null } })
   );
@@ -219,12 +228,11 @@ describe("buildAndPublishFramePublication", () => {
         ),
       }
     );
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      auth,
-      expect.stringMatching(
-        new RegExp(`^rm -rf -- '${FRAME_SOURCE_STAGING_ROOT}/[^/]+'$`)
-      ),
-      { user: "agent-proxied" }
+    expect(sandbox.readFile).toHaveBeenCalledTimes(sourceFiles.length);
+    expect(
+      renderRootCommand(vi.mocked(sandbox.execRoot).mock.calls.at(-1)![1])
+    ).toMatch(
+      new RegExp(`^/usr/bin/rm -rf -- ${FRAME_SOURCE_STAGING_ROOT}/[^/]+$`)
     );
     expect(ensureConversationSandboxReadyWithScope).toHaveBeenCalledOnce();
     const publicationId = result.isOk() ? result.value.publicationId : "";

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import { FRAME_SOURCE_STAGING_ROOT } from "@app/lib/api/frames/source_staging";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -200,7 +201,9 @@ describe("buildAndPublishFramePublication", () => {
       {
         sandbox,
         srcSandboxPath: expect.stringMatching(
-          /^\/tmp\/dust-frame-publication-builds\/[^/]+\/functions\/add_task\.ts$/
+          new RegExp(
+            `^${FRAME_SOURCE_STAGING_ROOT}/[^/]+/functions/add_task\\.ts$`
+          )
         ),
       }
     );
@@ -210,14 +213,16 @@ describe("buildAndPublishFramePublication", () => {
       {
         sandbox,
         srcSandboxPath: expect.stringMatching(
-          /^\/tmp\/dust-frame-publication-builds\/[^/]+\/functions\/list_tasks\.ts$/
+          new RegExp(
+            `^${FRAME_SOURCE_STAGING_ROOT}/[^/]+/functions/list_tasks\\.ts$`
+          )
         ),
       }
     );
     expect(sandbox.exec).toHaveBeenCalledWith(
       auth,
       expect.stringMatching(
-        /^rm -rf -- '\/tmp\/dust-frame-publication-builds\/[^/]+'$/
+        new RegExp(`^rm -rf -- '${FRAME_SOURCE_STAGING_ROOT}/[^/]+'$`)
       ),
       { user: "agent-proxied" }
     );

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
-import { FRAME_SOURCE_STAGING_ROOT } from "@app/lib/api/frames/source_staging";
+import {
+  computeFrameSourcePathSetSha256,
+  FRAME_SOURCE_STAGING_ROOT,
+} from "@app/lib/api/frames/source_staging";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
@@ -119,9 +122,17 @@ async function setup(): Promise<{
     version: "0.0.0-test",
   });
   vi.spyOn(sandbox, "writeFile").mockResolvedValue(new Ok(undefined));
-  vi.spyOn(sandbox, "execRoot").mockResolvedValue(
-    new Ok({ exitCode: 0, stdout: "", stderr: "" })
-  );
+  vi.spyOn(sandbox, "execRoot").mockImplementation(async () => {
+    const call = vi.mocked(sandbox.execRoot).mock.calls.length;
+    const pathSetSha256 = computeFrameSourcePathSetSha256(
+      sourceFiles.map((sourceFile) => sourceFile.relativePath)
+    );
+    return new Ok({
+      exitCode: 0,
+      stdout: call === 2 ? `${pathSetSha256}  -\n` : "",
+      stderr: "",
+    });
+  });
   vi.spyOn(sandbox, "readFile").mockImplementation(async (_auth, filePath) => {
     const sourceFile = sourceFiles.find(({ relativePath }) =>
       filePath.endsWith(`/${relativePath}`)

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -270,6 +270,80 @@ describe("buildAndPublishFramePublication", () => {
     );
   });
 
+  it("publishes only after staged function source cleanup succeeds", async () => {
+    const { auth, conversation, frame, sandbox } = await setup();
+    vi.mocked(buildSandboxFunctionOnReadySandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "export const built = true;",
+        userIdentity: "optional",
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" },
+      })
+    );
+
+    const pathSetSha256 = computeFrameSourcePathSetSha256(
+      sourceFiles.map((sourceFile) => sourceFile.relativePath)
+    );
+    const execRoot = vi.mocked(sandbox.execRoot);
+    execRoot.mockImplementation(async () => {
+      const call = execRoot.mock.calls.length;
+      if (call === 3) {
+        return new Err(new Error("cleanup failed"));
+      }
+      return new Ok({
+        exitCode: 0,
+        stdout: call === 2 ? `${pathSetSha256}  -\n` : "",
+        stderr: "",
+      });
+    });
+
+    const failed = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(failed.isErr() && failed.error).toMatchObject({
+      code: "internal",
+      message: "cleanup failed",
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+    expect(
+      (await FileResource.fetchById(auth, frame.sId))?.useCaseMetadata
+        ?.activePublicationId
+    ).toBeUndefined();
+
+    execRoot.mockClear();
+    execRoot.mockImplementation(async () => {
+      const call = execRoot.mock.calls.length;
+      return new Ok({
+        exitCode: 0,
+        stdout: call === 2 ? `${pathSetSha256}  -\n` : "",
+        stderr: "",
+      });
+    });
+
+    const published = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(published.isOk()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(3);
+    expect(
+      fileStorageMock.saveFileCalls.filter(({ filePath }) =>
+        filePath.endsWith("/publication.json")
+      )
+    ).toHaveLength(1);
+    expect(
+      (await FileResource.fetchById(auth, frame.sId))?.useCaseMetadata
+        ?.activePublicationId
+    ).toBe(published.isOk() ? published.value.publicationId : undefined);
+  });
+
   it("does not write a publication when a function build fails", async () => {
     const { auth, conversation, frame } = await setup();
     vi.mocked(buildSandboxFunctionOnReadySandbox).mockResolvedValue(

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -122,7 +122,7 @@ export async function buildAndPublishFramePublication(
     );
   }
   const sandbox = ensureResult.value.sandbox;
-  return withStagedFrameSource(
+  const functionArtifactResult = await withStagedFrameSource(
     auth,
     { sandbox, sourceFiles },
     async (stagingDirectory) => {
@@ -144,13 +144,18 @@ export async function buildAndPublishFramePublication(
         functionArtifacts.push({ name: fn.name, ...buildResult.value });
       }
 
-      return publishFramePublication(auth, {
-        frame,
-        functionArtifacts,
-        manifest,
-        sourceFiles,
-        uiBundleCode: uiBundle.value,
-      });
+      return new Ok(functionArtifacts);
     }
   );
+  if (functionArtifactResult.isErr()) {
+    return functionArtifactResult;
+  }
+
+  return publishFramePublication(auth, {
+    frame,
+    functionArtifacts: functionArtifactResult.value,
+    manifest,
+    sourceFiles,
+    uiBundleCode: uiBundle.value,
+  });
 }

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type {
   FramePublicationFunctionArtifact,
@@ -8,22 +7,18 @@ import {
   FramePublicationError,
   publishFramePublication,
 } from "@app/lib/api/frames/publication_storage";
+import { withStagedFrameSource } from "@app/lib/api/frames/source_staging";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
-import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { buildFrameBundle } from "@app/lib/api/viz/build_frame_bundle";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-
-const FRAME_BUILD_STAGING_ROOT = "/tmp/dust-frame-publication-builds";
-const FRAME_BUILD_STAGING_CONCURRENCY = 8;
 
 async function buildFrameUiBundle({
   manifest,
@@ -127,57 +122,35 @@ export async function buildAndPublishFramePublication(
     );
   }
   const sandbox = ensureResult.value.sandbox;
-  const stagingDirectory = path.posix.join(
-    FRAME_BUILD_STAGING_ROOT,
-    randomUUID()
-  );
+  return withStagedFrameSource(
+    auth,
+    { sandbox, sourceFiles },
+    async (stagingDirectory) => {
+      const functionArtifacts: FramePublicationFunctionArtifact[] = [];
+      for (const fn of manifest.functions) {
+        const buildResult = await buildSandboxFunctionOnReadySandbox(auth, {
+          sandbox,
+          srcSandboxPath: path.posix.join(stagingDirectory, fn.entryPoint),
+        });
+        if (buildResult.isErr()) {
+          return new Err(
+            new SandboxFunctionError(
+              buildResult.error.code,
+              `Failed to build Frame function "${fn.name}": ${buildResult.error.message}`
+            )
+          );
+        }
 
-  try {
-    const stagingResults = await concurrentExecutor(
-      sourceFiles,
-      (sourceFile) =>
-        sandbox.writeFile(
-          auth,
-          path.posix.join(stagingDirectory, sourceFile.relativePath),
-          Uint8Array.from(sourceFile.content).buffer
-        ),
-      { concurrency: FRAME_BUILD_STAGING_CONCURRENCY }
-    );
-    const stagingError = stagingResults.find((result) => result.isErr());
-    if (stagingError?.isErr()) {
-      return new Err(
-        new SandboxFunctionError("internal", stagingError.error.message)
-      );
-    }
-
-    const functionArtifacts: FramePublicationFunctionArtifact[] = [];
-    for (const fn of manifest.functions) {
-      const buildResult = await buildSandboxFunctionOnReadySandbox(auth, {
-        sandbox,
-        srcSandboxPath: path.posix.join(stagingDirectory, fn.entryPoint),
-      });
-      if (buildResult.isErr()) {
-        return new Err(
-          new SandboxFunctionError(
-            buildResult.error.code,
-            `Failed to build Frame function "${fn.name}": ${buildResult.error.message}`
-          )
-        );
+        functionArtifacts.push({ name: fn.name, ...buildResult.value });
       }
 
-      functionArtifacts.push({ name: fn.name, ...buildResult.value });
+      return publishFramePublication(auth, {
+        frame,
+        functionArtifacts,
+        manifest,
+        sourceFiles,
+        uiBundleCode: uiBundle.value,
+      });
     }
-
-    return publishFramePublication(auth, {
-      frame,
-      functionArtifacts,
-      manifest,
-      sourceFiles,
-      uiBundleCode: uiBundle.value,
-    });
-  } finally {
-    await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {
-      user: "agent-proxied",
-    });
-  }
+  );
 }

--- a/front/lib/api/frames/database_reconciliation.test.ts
+++ b/front/lib/api/frames/database_reconciliation.test.ts
@@ -211,4 +211,35 @@ describe("reconcileFramePublicationDatabases", () => {
 
     expect(result.isErr() && result.error.message).toBe("cleanup failed");
   });
+
+  it.each([
+    { operation: "creation", failedCall: 1 },
+    { operation: "hardening", failedCall: 2 },
+    { operation: "cleanup", failedCall: 3 },
+  ])("rejects a nonzero root $operation command", async ({ failedCall }) => {
+    const { auth, frame, sandbox } = await setup();
+    vi.mocked(sandbox.execRoot).mockImplementation(async () => {
+      const call = vi.mocked(sandbox.execRoot).mock.calls.length;
+      return new Ok({
+        exitCode: call === failedCall ? 1 : 0,
+        stdout: "",
+        stderr: call === failedCall ? "root command failed" : "",
+      });
+    });
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.message).toContain(
+      "root command failed"
+    );
+    if (failedCall === 3) {
+      expect(reconcileDatabaseOnReadySandbox).toHaveBeenCalledOnce();
+    } else {
+      expect(reconcileDatabaseOnReadySandbox).not.toHaveBeenCalled();
+    }
+  });
 });

--- a/front/lib/api/frames/database_reconciliation.test.ts
+++ b/front/lib/api/frames/database_reconciliation.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+
+import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
+import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { reconcileDatabaseOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { FrameManifestSchema } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/lifecycle")>();
+  return { ...actual, ensureFrameSandboxReady: vi.fn() };
+});
+
+vi.mock("@app/lib/api/sandbox_functions/dsbx_db", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/dsbx_db")
+    >();
+  return { ...actual, reconcileDatabaseOnReadySandbox: vi.fn() };
+});
+
+const manifest = FrameManifestSchema.parse({
+  version: 1,
+  name: "Tasks",
+  description: "Track tasks.",
+  databases: [{ name: "tasks", schema: "databases/tasks.db.ts" }],
+});
+
+const sourceFiles = [
+  {
+    relativePath: "index.tsx",
+    content: Buffer.from("export default function App() {}"),
+    contentType: "text/typescript" as const,
+  },
+  {
+    relativePath: "databases/tasks.db.ts",
+    content: Buffer.from('import { columns } from "./columns";'),
+    contentType: "text/typescript" as const,
+  },
+  {
+    relativePath: "databases/columns.ts",
+    content: Buffer.from("export const columns = {};"),
+    contentType: "text/typescript" as const,
+  },
+];
+
+async function setup() {
+  const { authenticator } = await createResourceTest({ role: "admin" });
+  const frame = await FileFactory.create(authenticator, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 0,
+    status: "created",
+    useCase: "project_context",
+  });
+  const sandbox = await SandboxResource.makeNew(authenticator, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.spyOn(sandbox, "writeFile").mockResolvedValue(new Ok(undefined));
+  vi.spyOn(sandbox, "exec").mockResolvedValue(
+    new Ok({ exitCode: 0, stdout: "", stderr: "" })
+  );
+  vi.mocked(ensureFrameSandboxReady).mockResolvedValue(
+    new Ok({
+      sandbox,
+      freshlyCreated: false,
+      scope: { spaceId: null },
+    })
+  );
+  vi.mocked(reconcileDatabaseOnReadySandbox).mockResolvedValue(
+    new Ok({ database: "tasks", created: true, statements: [] })
+  );
+
+  return { auth: authenticator, frame, sandbox };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("reconcileFramePublicationDatabases", () => {
+  it("does not start a Frame sandbox when no database is declared", async () => {
+    const { auth, frame } = await setup();
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest: FrameManifestSchema.parse({
+        version: 1,
+        name: "Static",
+        description: "Static Frame.",
+      }),
+      sourceFiles: sourceFiles.slice(0, 1),
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(ensureFrameSandboxReady).not.toHaveBeenCalled();
+  });
+
+  it("stages the captured source tree and reconciles the Frame-owned database", async () => {
+    const { auth, frame, sandbox } = await setup();
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(sandbox.writeFile).toHaveBeenCalledTimes(sourceFiles.length);
+    expect(sandbox.writeFile).toHaveBeenCalledWith(
+      auth,
+      expect.stringMatching(
+        /^\/tmp\/dust-frame-database-schemas\/[^/]+\/databases\/columns\.ts$/
+      ),
+      expect.any(ArrayBuffer)
+    );
+    expect(reconcileDatabaseOnReadySandbox).toHaveBeenCalledWith(auth, {
+      sandbox,
+      database: "tasks",
+      schemaFileSandboxPath: expect.stringMatching(
+        /^\/tmp\/dust-frame-database-schemas\/[^/]+\/databases\/tasks\.db\.ts$/
+      ),
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      auth,
+      expect.stringMatching(
+        /^rm -rf -- '\/tmp\/dust-frame-database-schemas\/[^/]+'$/
+      ),
+      { user: "agent-proxied" }
+    );
+  });
+
+  it("returns a reconciliation error and still removes the staged source", async () => {
+    const { auth, frame, sandbox } = await setup();
+    vi.mocked(reconcileDatabaseOnReadySandbox).mockResolvedValueOnce(
+      new Err(
+        new SandboxFunctionError(
+          "reconcile_blocked",
+          'Database "tasks": destructive change.'
+        )
+      )
+    );
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("reconcile_blocked");
+    expect(sandbox.exec).toHaveBeenCalledOnce();
+  });
+});

--- a/front/lib/api/frames/database_reconciliation.test.ts
+++ b/front/lib/api/frames/database_reconciliation.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
+import { FRAME_SOURCE_STAGING_ROOT } from "@app/lib/api/frames/source_staging";
 import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { reconcileDatabaseOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -120,7 +121,9 @@ describe("reconcileFramePublicationDatabases", () => {
     expect(sandbox.writeFile).toHaveBeenCalledWith(
       auth,
       expect.stringMatching(
-        /^\/tmp\/dust-frame-database-schemas\/[^/]+\/databases\/columns\.ts$/
+        new RegExp(
+          `^${FRAME_SOURCE_STAGING_ROOT}/[^/]+/databases/columns\\.ts$`
+        )
       ),
       expect.any(ArrayBuffer)
     );
@@ -128,13 +131,15 @@ describe("reconcileFramePublicationDatabases", () => {
       sandbox,
       database: "tasks",
       schemaFileSandboxPath: expect.stringMatching(
-        /^\/tmp\/dust-frame-database-schemas\/[^/]+\/databases\/tasks\.db\.ts$/
+        new RegExp(
+          `^${FRAME_SOURCE_STAGING_ROOT}/[^/]+/databases/tasks\\.db\\.ts$`
+        )
       ),
     });
     expect(sandbox.exec).toHaveBeenCalledWith(
       auth,
       expect.stringMatching(
-        /^rm -rf -- '\/tmp\/dust-frame-database-schemas\/[^/]+'$/
+        new RegExp(`^rm -rf -- '${FRAME_SOURCE_STAGING_ROOT}/[^/]+'$`)
       ),
       { user: "agent-proxied" }
     );

--- a/front/lib/api/frames/database_reconciliation.test.ts
+++ b/front/lib/api/frames/database_reconciliation.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
-import { FRAME_SOURCE_STAGING_ROOT } from "@app/lib/api/frames/source_staging";
+import {
+  computeFrameSourcePathSetSha256,
+  FRAME_SOURCE_STAGING_ROOT,
+} from "@app/lib/api/frames/source_staging";
 import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { reconcileDatabaseOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
@@ -53,6 +56,10 @@ const sourceFiles = [
   },
 ];
 
+function pathSetHashStdout(relativePaths: ReadonlyArray<string>): string {
+  return `${computeFrameSourcePathSetSha256(relativePaths)}  -\n`;
+}
+
 async function setup() {
   const { authenticator } = await createResourceTest({ role: "admin" });
   const frame = await FileFactory.create(authenticator, null, {
@@ -69,9 +76,19 @@ async function setup() {
     version: "0.0.0-test",
   });
   vi.spyOn(sandbox, "writeFile").mockResolvedValue(new Ok(undefined));
-  vi.spyOn(sandbox, "execRoot").mockResolvedValue(
-    new Ok({ exitCode: 0, stdout: "", stderr: "" })
-  );
+  vi.spyOn(sandbox, "execRoot").mockImplementation(async () => {
+    const call = vi.mocked(sandbox.execRoot).mock.calls.length;
+    return new Ok({
+      exitCode: 0,
+      stdout:
+        call === 2
+          ? pathSetHashStdout(
+              sourceFiles.map((sourceFile) => sourceFile.relativePath)
+            )
+          : "",
+      stderr: "",
+    });
+  });
   vi.spyOn(sandbox, "readFile").mockImplementation(async (_auth, filePath) => {
     const sourceFile = sourceFiles.find(({ relativePath }) =>
       filePath.endsWith(`/${relativePath}`)
@@ -191,13 +208,50 @@ describe("reconcileFramePublicationDatabases", () => {
     expect(sandbox.execRoot).toHaveBeenCalledTimes(3);
   });
 
+  it("refuses to reconcile when staging contains an extra regular file", async () => {
+    const { auth, frame, sandbox } = await setup();
+    vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+    vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
+      new Ok({
+        exitCode: 0,
+        stdout: pathSetHashStdout([
+          ...sourceFiles.map((sourceFile) => sourceFile.relativePath),
+          "databases/injected.ts",
+        ]),
+        stderr: "",
+      })
+    );
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "internal",
+      message: "Staged Frame source file set differs from the captured source.",
+    });
+    expect(sandbox.readFile).not.toHaveBeenCalled();
+    expect(reconcileDatabaseOnReadySandbox).not.toHaveBeenCalled();
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(3);
+  });
+
   it("fails the operation when staged source cleanup fails", async () => {
     const { auth, frame, sandbox } = await setup();
     vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
       new Ok({ exitCode: 0, stdout: "", stderr: "" })
     );
     vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
-      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+      new Ok({
+        exitCode: 0,
+        stdout: pathSetHashStdout(
+          sourceFiles.map((sourceFile) => sourceFile.relativePath)
+        ),
+        stderr: "",
+      })
     );
     vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
       new Err(new Error("cleanup failed"))
@@ -222,7 +276,12 @@ describe("reconcileFramePublicationDatabases", () => {
       const call = vi.mocked(sandbox.execRoot).mock.calls.length;
       return new Ok({
         exitCode: call === failedCall ? 1 : 0,
-        stdout: "",
+        stdout:
+          call === 2 && failedCall !== 2
+            ? pathSetHashStdout(
+                sourceFiles.map((sourceFile) => sourceFile.relativePath)
+              )
+            : "",
         stderr: call === failedCall ? "root command failed" : "",
       });
     });

--- a/front/lib/api/frames/database_reconciliation.test.ts
+++ b/front/lib/api/frames/database_reconciliation.test.ts
@@ -3,6 +3,7 @@
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
 import { FRAME_SOURCE_STAGING_ROOT } from "@app/lib/api/frames/source_staging";
 import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { reconcileDatabaseOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -68,9 +69,17 @@ async function setup() {
     version: "0.0.0-test",
   });
   vi.spyOn(sandbox, "writeFile").mockResolvedValue(new Ok(undefined));
-  vi.spyOn(sandbox, "exec").mockResolvedValue(
+  vi.spyOn(sandbox, "execRoot").mockResolvedValue(
     new Ok({ exitCode: 0, stdout: "", stderr: "" })
   );
+  vi.spyOn(sandbox, "readFile").mockImplementation(async (_auth, filePath) => {
+    const sourceFile = sourceFiles.find(({ relativePath }) =>
+      filePath.endsWith(`/${relativePath}`)
+    );
+    return sourceFile
+      ? new Ok(sourceFile.content)
+      : new Err(new Error(`Unexpected staged path: ${filePath}`));
+  });
   vi.mocked(ensureFrameSandboxReady).mockResolvedValue(
     new Ok({
       sandbox,
@@ -136,12 +145,11 @@ describe("reconcileFramePublicationDatabases", () => {
         )
       ),
     });
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      auth,
-      expect.stringMatching(
-        new RegExp(`^rm -rf -- '${FRAME_SOURCE_STAGING_ROOT}/[^/]+'$`)
-      ),
-      { user: "agent-proxied" }
+    expect(sandbox.readFile).toHaveBeenCalledTimes(sourceFiles.length);
+    expect(
+      renderRootCommand(vi.mocked(sandbox.execRoot).mock.calls.at(-1)![1])
+    ).toMatch(
+      new RegExp(`^/usr/bin/rm -rf -- ${FRAME_SOURCE_STAGING_ROOT}/[^/]+$`)
     );
   });
 
@@ -163,6 +171,44 @@ describe("reconcileFramePublicationDatabases", () => {
     });
 
     expect(result.isErr() && result.error.code).toBe("reconcile_blocked");
-    expect(sandbox.exec).toHaveBeenCalledOnce();
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(3);
+  });
+
+  it("refuses to reconcile when staged source differs from the capture", async () => {
+    const { auth, frame, sandbox } = await setup();
+    vi.mocked(sandbox.readFile).mockResolvedValueOnce(
+      new Ok(Buffer.from("modified"))
+    );
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("internal");
+    expect(reconcileDatabaseOnReadySandbox).not.toHaveBeenCalled();
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails the operation when staged source cleanup fails", async () => {
+    const { auth, frame, sandbox } = await setup();
+    vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+    vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+    vi.mocked(sandbox.execRoot).mockResolvedValueOnce(
+      new Err(new Error("cleanup failed"))
+    );
+
+    const result = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error.message).toBe("cleanup failed");
   });
 });

--- a/front/lib/api/frames/database_reconciliation.ts
+++ b/front/lib/api/frames/database_reconciliation.ts
@@ -1,21 +1,15 @@
-import { randomUUID } from "node:crypto";
 import path from "node:path";
 
+import { withStagedFrameSource } from "@app/lib/api/frames/source_staging";
 import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
-import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { reconcileDatabaseOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
-import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-
-const FRAME_DATABASE_STAGING_ROOT = "/tmp/dust-frame-database-schemas";
-const FRAME_DATABASE_STAGING_CONCURRENCY = 8;
 
 /**
  * Reconcile every declared database against the Frame-owned SQLite state before publication
@@ -48,65 +42,37 @@ export async function reconcileFramePublicationDatabases(
     );
   }
   const { sandbox } = ensureResult.value;
-  const stagingDirectory = path.posix.join(
-    FRAME_DATABASE_STAGING_ROOT,
-    randomUUID()
-  );
-
-  try {
-    const stagingResults = await concurrentExecutor(
-      sourceFiles,
-      async (sourceFile) => {
-        if (!isSafeFrameRelativePath(sourceFile.relativePath)) {
-          return new Err(
-            new Error(`Invalid Frame source path: ${sourceFile.relativePath}`)
+  return withStagedFrameSource(
+    auth,
+    { sandbox, sourceFiles },
+    async (stagingDirectory) => {
+      for (const database of manifest.databases) {
+        const reconcileResult = await reconcileDatabaseOnReadySandbox(auth, {
+          sandbox,
+          database: database.name,
+          schemaFileSandboxPath: path.posix.join(
+            stagingDirectory,
+            database.schema
+          ),
+        });
+        if (reconcileResult.isErr()) {
+          return reconcileResult;
+        }
+        if (reconcileResult.value.statements.length > 0) {
+          logger.info(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              frameId: frame.sId,
+              database: database.name,
+              created: reconcileResult.value.created,
+              statements: reconcileResult.value.statements,
+            },
+            "Frame database reconciled: applied DDL"
           );
         }
-        return sandbox.writeFile(
-          auth,
-          path.posix.join(stagingDirectory, sourceFile.relativePath),
-          Uint8Array.from(sourceFile.content).buffer
-        );
-      },
-      { concurrency: FRAME_DATABASE_STAGING_CONCURRENCY }
-    );
-    const stagingError = stagingResults.find((result) => result.isErr());
-    if (stagingError?.isErr()) {
-      return new Err(
-        new SandboxFunctionError("internal", stagingError.error.message)
-      );
-    }
-
-    for (const database of manifest.databases) {
-      const reconcileResult = await reconcileDatabaseOnReadySandbox(auth, {
-        sandbox,
-        database: database.name,
-        schemaFileSandboxPath: path.posix.join(
-          stagingDirectory,
-          database.schema
-        ),
-      });
-      if (reconcileResult.isErr()) {
-        return reconcileResult;
       }
-      if (reconcileResult.value.statements.length > 0) {
-        logger.info(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            frameId: frame.sId,
-            database: database.name,
-            created: reconcileResult.value.created,
-            statements: reconcileResult.value.statements,
-          },
-          "Frame database reconciled: applied DDL"
-        );
-      }
-    }
 
-    return new Ok(undefined);
-  } finally {
-    await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {
-      user: "agent-proxied",
-    });
-  }
+      return new Ok(undefined);
+    }
+  );
 }

--- a/front/lib/api/frames/database_reconciliation.ts
+++ b/front/lib/api/frames/database_reconciliation.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { reconcileDatabaseOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { FrameManifest } from "@app/types/api/frame_manifest";
+import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const FRAME_DATABASE_STAGING_ROOT = "/tmp/dust-frame-database-schemas";
+const FRAME_DATABASE_STAGING_CONCURRENCY = 8;
+
+/**
+ * Reconcile every declared database against the Frame-owned SQLite state before publication
+ * activation. The full captured source tree is staged so schema files can use relative imports.
+ * Reconciliation is additive and retriable; a failure leaves the previous publication active.
+ */
+export async function reconcileFramePublicationDatabases(
+  auth: Authenticator,
+  {
+    frame,
+    manifest,
+    sourceFiles,
+  }: {
+    frame: FileResource;
+    manifest: FrameManifest;
+    sourceFiles: ReadonlyArray<{ relativePath: string; content: Buffer }>;
+  }
+): Promise<Result<void, SandboxFunctionError>> {
+  if (manifest.databases.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const ensureResult = await ensureFrameSandboxReady(auth, frame);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+  const { sandbox } = ensureResult.value;
+  const stagingDirectory = path.posix.join(
+    FRAME_DATABASE_STAGING_ROOT,
+    randomUUID()
+  );
+
+  try {
+    const stagingResults = await concurrentExecutor(
+      sourceFiles,
+      async (sourceFile) => {
+        if (!isSafeFrameRelativePath(sourceFile.relativePath)) {
+          return new Err(
+            new Error(`Invalid Frame source path: ${sourceFile.relativePath}`)
+          );
+        }
+        return sandbox.writeFile(
+          auth,
+          path.posix.join(stagingDirectory, sourceFile.relativePath),
+          Uint8Array.from(sourceFile.content).buffer
+        );
+      },
+      { concurrency: FRAME_DATABASE_STAGING_CONCURRENCY }
+    );
+    const stagingError = stagingResults.find((result) => result.isErr());
+    if (stagingError?.isErr()) {
+      return new Err(
+        new SandboxFunctionError("internal", stagingError.error.message)
+      );
+    }
+
+    for (const database of manifest.databases) {
+      const reconcileResult = await reconcileDatabaseOnReadySandbox(auth, {
+        sandbox,
+        database: database.name,
+        schemaFileSandboxPath: path.posix.join(
+          stagingDirectory,
+          database.schema
+        ),
+      });
+      if (reconcileResult.isErr()) {
+        return reconcileResult;
+      }
+      if (reconcileResult.value.statements.length > 0) {
+        logger.info(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            frameId: frame.sId,
+            database: database.name,
+            created: reconcileResult.value.created,
+            statements: reconcileResult.value.statements,
+          },
+          "Frame database reconciled: applied DDL"
+        );
+      }
+    }
+
+    return new Ok(undefined);
+  } finally {
+    await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {
+      user: "agent-proxied",
+    });
+  }
+}

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,4 +1,6 @@
-import { executeWithLock } from "@app/lib/lock";
+import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
+import { executeWithLockResult } from "@app/lib/lock";
+import type { Result } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
 
@@ -6,11 +8,14 @@ export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
 }
 
-export function withFramePublishLock<T>(
+export function withFramePublishLock<T, E>(
   frameId: string,
-  callback: () => Promise<T>
-): Promise<T> {
-  return executeWithLock(getFramePublishLockName(frameId), callback, 30_000, {
-    lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS,
-  });
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
+  return executeWithLockResult(
+    getFramePublishLockName(frameId),
+    callback,
+    30_000,
+    { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
+  );
 }

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -7,9 +7,11 @@ import {
   publishFramePublication,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
+import { getRedisStreamClient } from "@app/lib/api/redis";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
+import { LockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import {
   computeSandboxFunctionBundleSha256,
@@ -837,7 +839,8 @@ describe("publishFramePublication", () => {
   it("returns a typed conflict when another publication holds the lock", async () => {
     const { auth, frame } = await setupFrame();
     const lockKey = `lock:${getFramePublishLockName(frame.sId)}`;
-    await redisMock.streamClient.set(lockKey, "held-by-test", {
+    const redisClient = await getRedisStreamClient({ origin: "lock" });
+    await redisClient.set(lockKey, "held-by-test", {
       NX: true,
       PX: 60_000,
     });
@@ -859,8 +862,28 @@ describe("publishFramePublication", () => {
       );
     } finally {
       vi.useRealTimers();
-      await redisMock.streamClient.del(lockKey);
+      await redisClient.del(lockKey);
     }
+  });
+
+  it("does not relabel a nested lock timeout as a publication conflict", async () => {
+    const { auth, frame } = await setupFrame();
+    vi.mocked(reconcileFramePublicationDatabases).mockRejectedValueOnce(
+      new LockAcquisitionTimeoutError(`sandbox:lifecycle:frame:${frame.sId}`)
+    );
+
+    await expect(
+      publishFramePublication(auth, {
+        frame,
+        functionArtifacts: [],
+        manifest,
+        sourceFiles,
+        uiBundleCode,
+      })
+    ).rejects.toMatchObject({
+      name: "LockAcquisitionTimeoutError",
+      lockName: `sandbox:lifecycle:frame:${frame.sId}`,
+    });
   });
 
   it("stores and activates a publication", async () => {

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -10,7 +10,6 @@ import {
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
-import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import {
   computeSandboxFunctionBundleSha256,
@@ -40,15 +39,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@app/lib/api/frames/database_reconciliation", () => ({
   reconcileFramePublicationDatabases: vi.fn(),
 }));
-
-vi.mock("@app/lib/lock", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@app/lib/lock")>();
-  return {
-    ...actual,
-    distributedLock: vi.fn(),
-    distributedUnlock: vi.fn(),
-  };
-});
 
 async function setupFrame({
   ready = false,
@@ -152,8 +142,6 @@ function createDeferred() {
 }
 
 beforeEach(() => {
-  vi.mocked(distributedLock).mockResolvedValue("test-frame-publish-lock");
-  vi.mocked(distributedUnlock).mockResolvedValue(undefined);
   vi.mocked(reconcileFramePublicationDatabases).mockResolvedValue(
     new Ok(undefined)
   );
@@ -848,7 +836,11 @@ describe("activateFramePublication", () => {
 describe("publishFramePublication", () => {
   it("returns a typed conflict when another publication holds the lock", async () => {
     const { auth, frame } = await setupFrame();
-    vi.mocked(distributedLock).mockResolvedValue(undefined);
+    const lockKey = `lock:${getFramePublishLockName(frame.sId)}`;
+    await redisMock.streamClient.set(lockKey, "held-by-test", {
+      NX: true,
+      PX: 60_000,
+    });
     vi.useFakeTimers();
 
     try {
@@ -859,15 +851,15 @@ describe("publishFramePublication", () => {
         sourceFiles,
         uiBundleCode,
       });
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.runAllTimersAsync();
       const published = await publicationPromise;
 
       expect(published.isErr() && published.error.code).toBe(
         "publish_conflict"
       );
-      expect(distributedUnlock).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
+      await redisMock.streamClient.del(lockKey);
     }
   });
 

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1,3 +1,4 @@
+import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
 import { getFramePublishLockName } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationFunctionArtifact } from "@app/lib/api/frames/publication_storage";
 import {
@@ -6,6 +7,7 @@ import {
   publishFramePublication,
   storeFramePublication,
 } from "@app/lib/api/frames/publication_storage";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -31,7 +33,12 @@ import {
   frameV2ContentType,
   sandboxFunctionContentType,
 } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/frames/database_reconciliation", () => ({
+  reconcileFramePublicationDatabases: vi.fn(),
+}));
 
 async function setupFrame({
   ready = false,
@@ -135,6 +142,9 @@ function createDeferred() {
 }
 
 beforeEach(() => {
+  vi.mocked(reconcileFramePublicationDatabases).mockResolvedValue(
+    new Ok(undefined)
+  );
   fileStorageMock.reset();
 });
 
@@ -842,6 +852,65 @@ describe("publishFramePublication", () => {
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       published.value.publicationId
+    );
+  });
+
+  it("reconciles declared databases before activation", async () => {
+    const { auth, frame } = await setupFrame();
+    const databaseSchema = {
+      relativePath: "databases/tasks.db.ts",
+      content: Buffer.from("export const tasks = {};"),
+      contentType: "text/typescript" as const,
+    };
+
+    const published = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: manifestWithDatabase,
+      sourceFiles: [...sourceFiles, databaseSchema],
+      uiBundleCode,
+    });
+
+    expect(published.isOk()).toBe(true);
+    expect(reconcileFramePublicationDatabases).toHaveBeenCalledWith(auth, {
+      frame,
+      manifest: manifestWithDatabase,
+      sourceFiles: [...sourceFiles, databaseSchema],
+    });
+  });
+
+  it("keeps the previous publication active when database reconciliation fails", async () => {
+    const { auth, frame } = await setupFrame();
+    const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    await frame.setActiveFramePublication(activePublicationId);
+    vi.mocked(reconcileFramePublicationDatabases).mockResolvedValueOnce(
+      new Err(
+        new SandboxFunctionError(
+          "reconcile_blocked",
+          'Database "tasks": destructive change.'
+        )
+      )
+    );
+
+    const published = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: manifestWithDatabase,
+      sourceFiles: [
+        ...sourceFiles,
+        {
+          relativePath: "databases/tasks.db.ts",
+          content: Buffer.from("export const tasks = {};"),
+          contentType: "text/typescript",
+        },
+      ],
+      uiBundleCode,
+    });
+
+    expect(published.isErr() && published.error.code).toBe("reconcile_blocked");
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
+      activePublicationId
     );
   });
 

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -10,6 +10,7 @@ import {
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
+import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import {
   computeSandboxFunctionBundleSha256,
@@ -39,6 +40,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@app/lib/api/frames/database_reconciliation", () => ({
   reconcileFramePublicationDatabases: vi.fn(),
 }));
+
+vi.mock("@app/lib/lock", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    distributedLock: vi.fn(),
+    distributedUnlock: vi.fn(),
+  };
+});
 
 async function setupFrame({
   ready = false,
@@ -142,6 +152,8 @@ function createDeferred() {
 }
 
 beforeEach(() => {
+  vi.mocked(distributedLock).mockResolvedValue("test-frame-publish-lock");
+  vi.mocked(distributedUnlock).mockResolvedValue(undefined);
   vi.mocked(reconcileFramePublicationDatabases).mockResolvedValue(
     new Ok(undefined)
   );
@@ -834,6 +846,31 @@ describe("activateFramePublication", () => {
 });
 
 describe("publishFramePublication", () => {
+  it("returns a typed conflict when another publication holds the lock", async () => {
+    const { auth, frame } = await setupFrame();
+    vi.mocked(distributedLock).mockResolvedValue(undefined);
+    vi.useFakeTimers();
+
+    try {
+      const publicationPromise = publishFramePublication(auth, {
+        frame,
+        functionArtifacts: [],
+        manifest,
+        sourceFiles,
+        uiBundleCode,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      const published = await publicationPromise;
+
+      expect(published.isErr() && published.error.code).toBe(
+        "publish_conflict"
+      );
+      expect(distributedUnlock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stores and activates a publication", async () => {
     const { auth, frame } = await setupFrame();
 

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -4,7 +4,9 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
 import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import type { Authenticator } from "@app/lib/auth";
@@ -577,7 +579,12 @@ export async function publishFramePublication(
     sourceFiles: FramePublicationSourceFile[];
     uiBundleCode: string;
   }
-): Promise<Result<{ publicationId: string }, FramePublicationError>> {
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
   return withFramePublishLock(frame.sId, async () => {
     const publication = await storeFramePublication(auth, {
       frame,
@@ -588,6 +595,15 @@ export async function publishFramePublication(
     });
     if (publication.isErr()) {
       return publication;
+    }
+
+    const reconciliation = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    if (reconciliation.isErr()) {
+      return reconciliation;
     }
 
     const activation = await activateFramePublication(auth, {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -5,8 +5,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
-import { getFramePublishLockName } from "@app/lib/api/frames/operation_lock";
-import { getRedisStreamClient } from "@app/lib/api/redis";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
@@ -16,13 +15,12 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
-import { distributedLock, distributedUnlock } from "@app/lib/lock";
+import { LockAcquisitionTimeoutError } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import tracer from "@app/logger/tracer";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
@@ -49,9 +47,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
-const FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
-const FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS = 100;
-const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
 
 export type FramePublicationSourceFile = {
   relativePath: string;
@@ -591,69 +586,47 @@ export async function publishFramePublication(
     FramePublicationError | SandboxFunctionError
   >
 > {
-  const client = await getRedisStreamClient({ origin: "lock" });
-  const lockName = getFramePublishLockName(frame.sId);
-  const lockValue = await tracer.trace(
-    "lock.acquire",
-    { resource: "frame.publish" },
-    async () => {
-      const startMs = Date.now();
-      while (Date.now() - startMs < FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS) {
-        const acquired = await distributedLock(
-          client,
-          lockName,
-          FRAME_PUBLISH_LOCK_TTL_MS
-        );
-        if (acquired) {
-          return acquired;
-        }
-        await new Promise((resolve) =>
-          setTimeout(resolve, FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS)
-        );
-      }
-      return undefined;
-    }
-  );
-  if (!lockValue) {
-    return new Err(
-      new SandboxFunctionError(
-        "publish_conflict",
-        "Another publication is in progress for this Frame; retry shortly."
-      )
-    );
-  }
-
   try {
-    const publication = await storeFramePublication(auth, {
-      frame,
-      functionArtifacts,
-      manifest,
-      sourceFiles,
-      uiBundleCode,
-    });
-    if (publication.isErr()) {
+    return await withFramePublishLock(frame.sId, async () => {
+      const publication = await storeFramePublication(auth, {
+        frame,
+        functionArtifacts,
+        manifest,
+        sourceFiles,
+        uiBundleCode,
+      });
+      if (publication.isErr()) {
+        return publication;
+      }
+
+      const reconciliation = await reconcileFramePublicationDatabases(auth, {
+        frame,
+        manifest,
+        sourceFiles,
+      });
+      if (reconciliation.isErr()) {
+        return reconciliation;
+      }
+
+      const activation = await activateFramePublication(auth, {
+        frame,
+        publicationId: publication.value.publicationId,
+      });
+      if (activation.isErr()) {
+        return activation;
+      }
+
       return publication;
-    }
-
-    const reconciliation = await reconcileFramePublicationDatabases(auth, {
-      frame,
-      manifest,
-      sourceFiles,
     });
-    if (reconciliation.isErr()) {
-      return reconciliation;
+  } catch (error) {
+    if (error instanceof LockAcquisitionTimeoutError) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          "Another publication is in progress for this Frame; retry shortly."
+        )
+      );
     }
-
-    const activation = await activateFramePublication(auth, {
-      frame,
-      publicationId: publication.value.publicationId,
-    });
-    if (activation.isErr()) {
-      return activation;
-    }
-
-    return publication;
-  } finally {
-    await distributedUnlock(client, lockName, lockValue);
+    throw error;
   }
 }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -5,7 +5,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
-import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import {
+  getFramePublishLockName,
+  withFramePublishLock,
+} from "@app/lib/api/frames/operation_lock";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
@@ -619,7 +622,10 @@ export async function publishFramePublication(
       return publication;
     });
   } catch (error) {
-    if (error instanceof LockAcquisitionTimeoutError) {
+    if (
+      error instanceof LockAcquisitionTimeoutError &&
+      error.lockName === getFramePublishLockName(frame.sId)
+    ) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -15,7 +15,7 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
-import { LockAcquisitionTimeoutError } from "@app/lib/lock";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -622,7 +622,7 @@ export async function publishFramePublication(
   });
   if (publication.isErr()) {
     const error = publication.error;
-    if (error instanceof LockAcquisitionTimeoutError) {
+    if (isLockAcquisitionTimeoutError(error)) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -5,8 +5,9 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
-import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
-import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { getFramePublishLockName } from "@app/lib/api/frames/operation_lock";
+import { getRedisStreamClient } from "@app/lib/api/redis";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,11 +16,13 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import tracer from "@app/logger/tracer";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
@@ -46,6 +49,9 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
+const FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+const FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS = 100;
+const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
 
 export type FramePublicationSourceFile = {
   relativePath: string;
@@ -585,7 +591,39 @@ export async function publishFramePublication(
     FramePublicationError | SandboxFunctionError
   >
 > {
-  return withFramePublishLock(frame.sId, async () => {
+  const client = await getRedisStreamClient({ origin: "lock" });
+  const lockName = getFramePublishLockName(frame.sId);
+  const lockValue = await tracer.trace(
+    "lock.acquire",
+    { resource: "frame.publish" },
+    async () => {
+      const startMs = Date.now();
+      while (Date.now() - startMs < FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS) {
+        const acquired = await distributedLock(
+          client,
+          lockName,
+          FRAME_PUBLISH_LOCK_TTL_MS
+        );
+        if (acquired) {
+          return acquired;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS)
+        );
+      }
+      return undefined;
+    }
+  );
+  if (!lockValue) {
+    return new Err(
+      new SandboxFunctionError(
+        "publish_conflict",
+        "Another publication is in progress for this Frame; retry shortly."
+      )
+    );
+  }
+
+  try {
     const publication = await storeFramePublication(auth, {
       frame,
       functionArtifacts,
@@ -615,5 +653,7 @@ export async function publishFramePublication(
     }
 
     return publication;
-  });
+  } finally {
+    await distributedUnlock(client, lockName, lockValue);
+  }
 }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -5,10 +5,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
-import {
-  getFramePublishLockName,
-  withFramePublishLock,
-} from "@app/lib/api/frames/operation_lock";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
@@ -589,43 +586,43 @@ export async function publishFramePublication(
     FramePublicationError | SandboxFunctionError
   >
 > {
-  try {
-    return await withFramePublishLock(frame.sId, async () => {
-      const publication = await storeFramePublication(auth, {
-        frame,
-        functionArtifacts,
-        manifest,
-        sourceFiles,
-        uiBundleCode,
-      });
-      if (publication.isErr()) {
-        return publication;
-      }
-
-      const reconciliation = await reconcileFramePublicationDatabases(auth, {
-        frame,
-        manifest,
-        sourceFiles,
-      });
-      if (reconciliation.isErr()) {
-        return reconciliation;
-      }
-
-      const activation = await activateFramePublication(auth, {
-        frame,
-        publicationId: publication.value.publicationId,
-      });
-      if (activation.isErr()) {
-        return activation;
-      }
-
-      return publication;
+  const publication = await withFramePublishLock<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >(frame.sId, async () => {
+    const storedPublication = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest,
+      sourceFiles,
+      uiBundleCode,
     });
-  } catch (error) {
-    if (
-      error instanceof LockAcquisitionTimeoutError &&
-      error.lockName === getFramePublishLockName(frame.sId)
-    ) {
+    if (storedPublication.isErr()) {
+      return storedPublication;
+    }
+
+    const reconciliation = await reconcileFramePublicationDatabases(auth, {
+      frame,
+      manifest,
+      sourceFiles,
+    });
+    if (reconciliation.isErr()) {
+      return reconciliation;
+    }
+
+    const activation = await activateFramePublication(auth, {
+      frame,
+      publicationId: storedPublication.value.publicationId,
+    });
+    if (activation.isErr()) {
+      return activation;
+    }
+
+    return storedPublication;
+  });
+  if (publication.isErr()) {
+    const error = publication.error;
+    if (error instanceof LockAcquisitionTimeoutError) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",
@@ -633,6 +630,8 @@ export async function publishFramePublication(
         )
       );
     }
-    throw error;
+    return new Err(error);
   }
+
+  return publication;
 }

--- a/front/lib/api/frames/source_staging.ts
+++ b/front/lib/api/frames/source_staging.ts
@@ -16,6 +16,25 @@ const FRAME_SOURCE_STAGING_CONCURRENCY = 8;
 
 type FrameSourceFile = { relativePath: string; content: Buffer };
 
+type RootExecResult = Awaited<ReturnType<SandboxResource["execRoot"]>>;
+
+function rootCommandFailure(
+  result: RootExecResult,
+  operation: string
+): SandboxFunctionError | undefined {
+  if (result.isErr()) {
+    return new SandboxFunctionError("internal", result.error.message);
+  }
+  if (result.value.exitCode !== 0) {
+    const detail = result.value.stderr.trim() || result.value.stdout.trim();
+    return new SandboxFunctionError(
+      "internal",
+      `${operation} failed with exit code ${result.value.exitCode}${detail ? `: ${detail}` : "."}`
+    );
+  }
+  return undefined;
+}
+
 /** Stage one captured Frame source tree for a sandbox operation, then always remove it. */
 export async function withStagedFrameSource<T, E>(
   auth: Authenticator,
@@ -48,103 +67,107 @@ export async function withStagedFrameSource<T, E>(
     FRAME_SOURCE_STAGING_ROOT,
     randomUUID()
   );
-  const createResult = await sandbox.execRoot(
-    auth,
-    rootCommand.and([
-      rootCommand.exec("/usr/bin/install", [
-        "-d",
-        "-m",
-        "0711",
-        "-o",
-        "root",
-        "-g",
-        "root",
-        FRAME_SOURCE_STAGING_ROOT,
-      ]),
-      rootCommand.exec("/usr/bin/install", [
-        "-d",
-        "-m",
-        "0755",
-        "-o",
-        "root",
-        "-g",
-        "root",
-        stagingDirectory,
-      ]),
-    ])
-  );
-  if (createResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError("internal", createResult.error.message)
-    );
-  }
-
   let result: Result<T, E | SandboxFunctionError>;
-  let cleanupResult: Awaited<ReturnType<SandboxResource["execRoot"]>>;
+  let cleanupResult: RootExecResult;
   try {
-    const stagingResults = await concurrentExecutor(
-      sourceFiles,
-      (sourceFile) =>
-        sandbox.writeFile(
-          auth,
-          path.posix.join(stagingDirectory, sourceFile.relativePath),
-          Uint8Array.from(sourceFile.content).buffer
-        ),
-      { concurrency: FRAME_SOURCE_STAGING_CONCURRENCY }
+    const createResult = await sandbox.execRoot(
+      auth,
+      rootCommand.and([
+        rootCommand.exec("/usr/bin/install", [
+          "-d",
+          "-m",
+          "0711",
+          "-o",
+          "root",
+          "-g",
+          "root",
+          FRAME_SOURCE_STAGING_ROOT,
+        ]),
+        rootCommand.exec("/usr/bin/install", [
+          "-d",
+          "-m",
+          "0755",
+          "-o",
+          "root",
+          "-g",
+          "root",
+          stagingDirectory,
+        ]),
+      ])
     );
-    const stagingError = stagingResults.find((result) => result.isErr());
-    if (stagingError?.isErr()) {
-      result = new Err(
-        new SandboxFunctionError("internal", stagingError.error.message)
-      );
+    const createFailure = rootCommandFailure(
+      createResult,
+      "Frame source staging creation"
+    );
+    if (createFailure) {
+      result = new Err(createFailure);
     } else {
-      const hardenResult = await sandbox.execRoot(
-        auth,
-        rootCommand.unsafeShell(
-          [
-            `/usr/bin/chown -R root:root -- ${shellEscape(stagingDirectory)}`,
-            `/usr/bin/find ${shellEscape(stagingDirectory)} -type d -exec /usr/bin/chmod 0555 -- {} +`,
-            `/usr/bin/find ${shellEscape(stagingDirectory)} -type f -exec /usr/bin/chmod 0444 -- {} +`,
-            `test -z "$(/usr/bin/find ${shellEscape(stagingDirectory)} ! -type d ! -type f -print -quit)"`,
-          ].join(" && "),
-          "Harden and validate captured Frame source before workload execution."
-        )
+      const stagingResults = await concurrentExecutor(
+        sourceFiles,
+        (sourceFile) =>
+          sandbox.writeFile(
+            auth,
+            path.posix.join(stagingDirectory, sourceFile.relativePath),
+            Uint8Array.from(sourceFile.content).buffer
+          ),
+        { concurrency: FRAME_SOURCE_STAGING_CONCURRENCY }
       );
-      if (hardenResult.isErr()) {
+      const stagingError = stagingResults.find((item) => item.isErr());
+      if (stagingError?.isErr()) {
         result = new Err(
-          new SandboxFunctionError("internal", hardenResult.error.message)
+          new SandboxFunctionError("internal", stagingError.error.message)
         );
       } else {
-        const verificationResults = await concurrentExecutor(
-          sourceFiles,
-          async (sourceFile) => {
-            const stagedPath = path.posix.join(
-              stagingDirectory,
-              sourceFile.relativePath
-            );
-            const readResult = await sandbox.readFile(auth, stagedPath);
-            if (readResult.isErr()) {
-              return new Err(readResult.error);
-            }
-            return Buffer.compare(readResult.value, sourceFile.content) === 0
-              ? new Ok(undefined)
-              : new Err(
-                  new Error(`Staged Frame source changed: ${stagedPath}`)
-                );
-          },
-          { concurrency: FRAME_SOURCE_STAGING_CONCURRENCY }
+        const hardenResult = await sandbox.execRoot(
+          auth,
+          rootCommand.unsafeShell(
+            [
+              `/usr/bin/chown -R root:root -- ${shellEscape(stagingDirectory)}`,
+              `/usr/bin/find ${shellEscape(stagingDirectory)} -type d -exec /usr/bin/chmod 0555 -- {} +`,
+              `/usr/bin/find ${shellEscape(stagingDirectory)} -type f -exec /usr/bin/chmod 0444 -- {} +`,
+              `test -z "$(/usr/bin/find ${shellEscape(stagingDirectory)} ! -type d ! -type f -print -quit)"`,
+            ].join(" && "),
+            "Harden and validate captured Frame source before workload execution."
+          )
         );
-        const verificationError = verificationResults.find((item) =>
-          item.isErr()
+        const hardenFailure = rootCommandFailure(
+          hardenResult,
+          "Frame source staging hardening"
         );
-        result = verificationError?.isErr()
-          ? new Err(
-              new SandboxFunctionError(
-                "internal",
-                verificationError.error.message
+        if (hardenFailure) {
+          result = new Err(hardenFailure);
+        } else {
+          const verificationResults = await concurrentExecutor(
+            sourceFiles,
+            async (sourceFile) => {
+              const stagedPath = path.posix.join(
+                stagingDirectory,
+                sourceFile.relativePath
+              );
+              const readResult = await sandbox.readFile(auth, stagedPath);
+              if (readResult.isErr()) {
+                return new Err(readResult.error);
+              }
+              return Buffer.compare(readResult.value, sourceFile.content) === 0
+                ? new Ok(undefined)
+                : new Err(
+                    new Error(`Staged Frame source changed: ${stagedPath}`)
+                  );
+            },
+            { concurrency: FRAME_SOURCE_STAGING_CONCURRENCY }
+          );
+          const verificationError = verificationResults.find((item) =>
+            item.isErr()
+          );
+          result = verificationError?.isErr()
+            ? new Err(
+                new SandboxFunctionError(
+                  "internal",
+                  verificationError.error.message
+                )
               )
-            )
-          : await callback(stagingDirectory);
+            : await callback(stagingDirectory);
+        }
       }
     }
   } finally {
@@ -153,10 +176,12 @@ export async function withStagedFrameSource<T, E>(
       rootCommand.exec("/usr/bin/rm", ["-rf", "--", stagingDirectory])
     );
   }
-  if (cleanupResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError("internal", cleanupResult.error.message)
-    );
+  const cleanupFailure = rootCommandFailure(
+    cleanupResult,
+    "Frame source staging cleanup"
+  );
+  if (cleanupFailure) {
+    return new Err(cleanupFailure);
   }
   return result;
 }

--- a/front/lib/api/frames/source_staging.ts
+++ b/front/lib/api/frames/source_staging.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
@@ -18,6 +18,22 @@ type FrameSourceFile = { relativePath: string; content: Buffer };
 
 type RootExecResult = Awaited<ReturnType<SandboxResource["execRoot"]>>;
 
+export function computeFrameSourcePathSetSha256(
+  relativePaths: ReadonlyArray<string>
+): string {
+  const hash = createHash("sha256");
+  const encodedPaths = relativePaths
+    .map((relativePath) => Buffer.from(relativePath, "utf8"))
+    .sort((left, right) => Buffer.compare(left, right));
+
+  for (const encodedPath of encodedPaths) {
+    hash.update(encodedPath);
+    hash.update("\0");
+  }
+
+  return hash.digest("hex");
+}
+
 function rootCommandFailure(
   result: RootExecResult,
   operation: string
@@ -32,6 +48,31 @@ function rootCommandFailure(
       `${operation} failed with exit code ${result.value.exitCode}${detail ? `: ${detail}` : "."}`
     );
   }
+  return undefined;
+}
+
+function stagedSourcePathSetFailure(
+  result: RootExecResult,
+  expectedSha256: string
+): SandboxFunctionError | undefined {
+  if (result.isErr()) {
+    return new SandboxFunctionError("internal", result.error.message);
+  }
+
+  const match = /^([0-9a-f]{64}) {2}-$/.exec(result.value.stdout.trim());
+  if (!match) {
+    return new SandboxFunctionError(
+      "internal",
+      "Frame source staging did not produce a valid path-set hash."
+    );
+  }
+  if (match[1] !== expectedSha256) {
+    return new SandboxFunctionError(
+      "internal",
+      "Staged Frame source file set differs from the captured source."
+    );
+  }
+
   return undefined;
 }
 
@@ -66,6 +107,9 @@ export async function withStagedFrameSource<T, E>(
   const stagingDirectory = path.posix.join(
     FRAME_SOURCE_STAGING_ROOT,
     randomUUID()
+  );
+  const expectedPathSetSha256 = computeFrameSourcePathSetSha256(
+    sourceFiles.map((sourceFile) => sourceFile.relativePath)
   );
   let result: Result<T, E | SandboxFunctionError>;
   let cleanupResult: RootExecResult;
@@ -126,14 +170,14 @@ export async function withStagedFrameSource<T, E>(
               `/usr/bin/find ${shellEscape(stagingDirectory)} -type d -exec /usr/bin/chmod 0555 -- {} +`,
               `/usr/bin/find ${shellEscape(stagingDirectory)} -type f -exec /usr/bin/chmod 0444 -- {} +`,
               `test -z "$(/usr/bin/find ${shellEscape(stagingDirectory)} ! -type d ! -type f -print -quit)"`,
+              `/usr/bin/find ${shellEscape(stagingDirectory)} -type f -printf '%P\\0' | LC_ALL=C /usr/bin/sort -z | /usr/bin/sha256sum`,
             ].join(" && "),
             "Harden and validate captured Frame source before workload execution."
           )
         );
-        const hardenFailure = rootCommandFailure(
-          hardenResult,
-          "Frame source staging hardening"
-        );
+        const hardenFailure =
+          rootCommandFailure(hardenResult, "Frame source staging hardening") ??
+          stagedSourcePathSetFailure(hardenResult, expectedPathSetSha256);
         if (hardenFailure) {
           result = new Err(hardenFailure);
         } else {

--- a/front/lib/api/frames/source_staging.ts
+++ b/front/lib/api/frames/source_staging.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,9 +9,9 @@ import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
-export const FRAME_SOURCE_STAGING_ROOT = "/tmp/dust-frame-sources";
+export const FRAME_SOURCE_STAGING_ROOT = "/var/lib/dust/frame-sources";
 const FRAME_SOURCE_STAGING_CONCURRENCY = 8;
 
 type FrameSourceFile = { relativePath: string; content: Buffer };
@@ -47,6 +48,39 @@ export async function withStagedFrameSource<T, E>(
     FRAME_SOURCE_STAGING_ROOT,
     randomUUID()
   );
+  const createResult = await sandbox.execRoot(
+    auth,
+    rootCommand.and([
+      rootCommand.exec("/usr/bin/install", [
+        "-d",
+        "-m",
+        "0711",
+        "-o",
+        "root",
+        "-g",
+        "root",
+        FRAME_SOURCE_STAGING_ROOT,
+      ]),
+      rootCommand.exec("/usr/bin/install", [
+        "-d",
+        "-m",
+        "0755",
+        "-o",
+        "root",
+        "-g",
+        "root",
+        stagingDirectory,
+      ]),
+    ])
+  );
+  if (createResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", createResult.error.message)
+    );
+  }
+
+  let result: Result<T, E | SandboxFunctionError>;
+  let cleanupResult: Awaited<ReturnType<SandboxResource["execRoot"]>>;
   try {
     const stagingResults = await concurrentExecutor(
       sourceFiles,
@@ -60,15 +94,69 @@ export async function withStagedFrameSource<T, E>(
     );
     const stagingError = stagingResults.find((result) => result.isErr());
     if (stagingError?.isErr()) {
-      return new Err(
+      result = new Err(
         new SandboxFunctionError("internal", stagingError.error.message)
       );
+    } else {
+      const hardenResult = await sandbox.execRoot(
+        auth,
+        rootCommand.unsafeShell(
+          [
+            `/usr/bin/chown -R root:root -- ${shellEscape(stagingDirectory)}`,
+            `/usr/bin/find ${shellEscape(stagingDirectory)} -type d -exec /usr/bin/chmod 0555 -- {} +`,
+            `/usr/bin/find ${shellEscape(stagingDirectory)} -type f -exec /usr/bin/chmod 0444 -- {} +`,
+            `test -z "$(/usr/bin/find ${shellEscape(stagingDirectory)} ! -type d ! -type f -print -quit)"`,
+          ].join(" && "),
+          "Harden and validate captured Frame source before workload execution."
+        )
+      );
+      if (hardenResult.isErr()) {
+        result = new Err(
+          new SandboxFunctionError("internal", hardenResult.error.message)
+        );
+      } else {
+        const verificationResults = await concurrentExecutor(
+          sourceFiles,
+          async (sourceFile) => {
+            const stagedPath = path.posix.join(
+              stagingDirectory,
+              sourceFile.relativePath
+            );
+            const readResult = await sandbox.readFile(auth, stagedPath);
+            if (readResult.isErr()) {
+              return new Err(readResult.error);
+            }
+            return Buffer.compare(readResult.value, sourceFile.content) === 0
+              ? new Ok(undefined)
+              : new Err(
+                  new Error(`Staged Frame source changed: ${stagedPath}`)
+                );
+          },
+          { concurrency: FRAME_SOURCE_STAGING_CONCURRENCY }
+        );
+        const verificationError = verificationResults.find((item) =>
+          item.isErr()
+        );
+        result = verificationError?.isErr()
+          ? new Err(
+              new SandboxFunctionError(
+                "internal",
+                verificationError.error.message
+              )
+            )
+          : await callback(stagingDirectory);
+      }
     }
-
-    return await callback(stagingDirectory);
   } finally {
-    await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {
-      user: "agent-proxied",
-    });
+    cleanupResult = await sandbox.execRoot(
+      auth,
+      rootCommand.exec("/usr/bin/rm", ["-rf", "--", stagingDirectory])
+    );
   }
+  if (cleanupResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", cleanupResult.error.message)
+    );
+  }
+  return result;
 }

--- a/front/lib/api/frames/source_staging.ts
+++ b/front/lib/api/frames/source_staging.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+
+export const FRAME_SOURCE_STAGING_ROOT = "/tmp/dust-frame-sources";
+const FRAME_SOURCE_STAGING_CONCURRENCY = 8;
+
+type FrameSourceFile = { relativePath: string; content: Buffer };
+
+/** Stage one captured Frame source tree for a sandbox operation, then always remove it. */
+export async function withStagedFrameSource<T, E>(
+  auth: Authenticator,
+  {
+    sandbox,
+    sourceFiles,
+  }: {
+    sandbox: SandboxResource;
+    sourceFiles: ReadonlyArray<FrameSourceFile>;
+  },
+  callback: (stagingDirectory: string) => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  const seenPaths = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    if (
+      !isSafeFrameRelativePath(sourceFile.relativePath) ||
+      seenPaths.has(sourceFile.relativePath)
+    ) {
+      return new Err(
+        new SandboxFunctionError(
+          "internal",
+          `Invalid Frame source path: ${sourceFile.relativePath}`
+        )
+      );
+    }
+    seenPaths.add(sourceFile.relativePath);
+  }
+
+  const stagingDirectory = path.posix.join(
+    FRAME_SOURCE_STAGING_ROOT,
+    randomUUID()
+  );
+  try {
+    const stagingResults = await concurrentExecutor(
+      sourceFiles,
+      (sourceFile) =>
+        sandbox.writeFile(
+          auth,
+          path.posix.join(stagingDirectory, sourceFile.relativePath),
+          Uint8Array.from(sourceFile.content).buffer
+        ),
+      { concurrency: FRAME_SOURCE_STAGING_CONCURRENCY }
+    );
+    const stagingError = stagingResults.find((result) => result.isErr());
+    if (stagingError?.isErr()) {
+      return new Err(
+        new SandboxFunctionError("internal", stagingError.error.message)
+      );
+    }
+
+    return await callback(stagingDirectory);
+  } finally {
+    await sandbox.exec(auth, `rm -rf -- ${shellEscape(stagingDirectory)}`, {
+      user: "agent-proxied",
+    });
+  }
+}

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -4,6 +4,7 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import {
   getDatabaseSchemaOnSandbox,
   listDatabasesOnSandbox,
+  reconcileDatabaseOnReadySandbox,
 } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -159,5 +160,72 @@ describe("non-staging db commands", () => {
       return;
     }
     expect(result.value).toEqual([]);
+  });
+});
+
+describe("reconcileDatabaseOnReadySandbox", () => {
+  it("reconciles an unprefixed database on the supplied owner sandbox", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          ok: true,
+          created: true,
+          statements: ['CREATE TABLE "tasks" (...)'],
+        }),
+        stderr: "",
+      })
+    );
+
+    const result = await reconcileDatabaseOnReadySandbox(authenticator, {
+      sandbox,
+      database: "tasks",
+      schemaFileSandboxPath: "/tmp/frame/databases/tasks.db.ts",
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      database: "tasks",
+      created: true,
+      statements: ['CREATE TABLE "tasks" (...)'],
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      authenticator,
+      expect.stringContaining(
+        "db reconcile -- 'tasks' '/tmp/frame/databases/tasks.db.ts'"
+      ),
+      expect.objectContaining({
+        envVars: expect.objectContaining({ DUST_POD_DATABASE_PREFIX: "" }),
+        user: "agent-proxied",
+      })
+    );
+  });
+
+  it("returns a typed blocked error for destructive schema changes", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          ok: false,
+          error: {
+            kind: "destructive_change",
+            message: "Dropping columns is not allowed.",
+          },
+        }),
+        stderr: "",
+      })
+    );
+
+    const result = await reconcileDatabaseOnReadySandbox(authenticator, {
+      sandbox,
+      database: "tasks",
+      schemaFileSandboxPath: "/tmp/frame/databases/tasks.db.ts",
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "reconcile_blocked",
+      message: expect.stringContaining("Dropping columns is not allowed."),
+    });
   });
 });

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -186,9 +186,8 @@ const reconcileEnvelopeSchema = z.union([
 
 export interface ReconcileDatabaseResult {
   /**
-   * The on-disk database name that was reconciled: the app-relative name qualified with the app
-   * prefix (see resolvePodDatabaseName). Reported back because it is what `db_list`, `db_query` and
-   * `db_schema` address the database by, and it is not what the caller passed in.
+   * The on-disk database name that was reconciled. Pod callers qualify the app-relative name with
+   * their app prefix; Frame callers use the unprefixed Frame-owned name.
    */
   database: string;
   created: boolean;

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -91,11 +91,31 @@ function dbErrorToSandboxFunctionError(
   return new SandboxFunctionError(dsbxErrorCode, `${prefix}${envelope.error}`);
 }
 
-// Ensure the pod sandbox is up, run a `dsbx db` command as agent-proxied, and parse its one-line
-// JSON envelope. Returns the sandbox too, since `db schema` reads a file back afterwards.
-async function execDbCommand<S extends z.ZodTypeAny>(
+type DbCommandArgs<S extends z.ZodTypeAny> = {
+  command: string;
+  schema: S;
+  what: string;
+  envVars?: Record<string, string>;
+  stdin?: string;
+  // Set only when `command` appends stagingHashCaptureLines.
+  stagingCapture?: boolean;
+};
+
+type DbCommandResult<S extends z.ZodTypeAny> = Result<
+  {
+    sandbox: SandboxResource;
+    envelope: z.infer<S>;
+    stagingHashes: StagingHashes;
+    execStderr: string;
+  },
+  SandboxFunctionError
+>;
+
+// Run a `dsbx db` command as agent-proxied on an already-ready owner sandbox and parse its
+// one-line JSON envelope. Returns the sandbox too, since `db schema` reads a file back afterwards.
+async function execDbCommandOnReadySandbox<S extends z.ZodTypeAny>(
   auth: Authenticator,
-  space: SpaceResource,
+  sandbox: SandboxResource,
   {
     command,
     schema,
@@ -103,37 +123,8 @@ async function execDbCommand<S extends z.ZodTypeAny>(
     envVars,
     stdin,
     stagingCapture = false,
-  }: {
-    command: string;
-    schema: S;
-    what: string;
-    envVars?: Record<string, string>;
-    stdin?: string;
-    // Set only when `command` appends stagingHashCaptureLines.
-    stagingCapture?: boolean;
-  }
-): Promise<
-  Result<
-    {
-      sandbox: SandboxResource;
-      envelope: z.infer<S>;
-      stagingHashes: StagingHashes;
-      execStderr: string;
-    },
-    SandboxFunctionError
-  >
-> {
-  const ensureResult = await ensurePodSandboxReady(auth, space);
-  if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
-    );
-  }
-  const { sandbox } = ensureResult.value;
-
+  }: DbCommandArgs<S>
+): Promise<DbCommandResult<S>> {
   const execResult = await sandbox.exec(auth, command, {
     timeoutMs: DB_EXEC_TIMEOUT_MS,
     envVars: { ...sandboxDatabaseExecEnvVars(), ...envVars },
@@ -164,6 +155,25 @@ async function execDbCommand<S extends z.ZodTypeAny>(
   });
 }
 
+// Ensure the Pod sandbox is up before using the owner-neutral ready-sandbox primitive.
+async function execDbCommand<S extends z.ZodTypeAny>(
+  auth: Authenticator,
+  space: SpaceResource,
+  args: DbCommandArgs<S>
+): Promise<DbCommandResult<S>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+
+  return execDbCommandOnReadySandbox(auth, ensureResult.value.sandbox, args);
+}
+
 // Success mirrors the reconcile result in cli/dust-sandbox/functions-runner/db/reconcile.ts.
 const reconcileEnvelopeSchema = z.union([
   z.object({
@@ -190,6 +200,43 @@ export interface ReconcileDatabaseResult {
  * apply it when strictly additive, refuse anything destructive. Runs as `agent-proxied` (the
  * schema file is model-written code that gets imported).
  */
+export async function reconcileDatabaseOnReadySandbox(
+  auth: Authenticator,
+  {
+    sandbox,
+    database,
+    schemaFileSandboxPath,
+  }: {
+    sandbox: SandboxResource;
+    database: string;
+    schemaFileSandboxPath: string;
+  }
+): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
+  const result = await execDbCommandOnReadySandbox(auth, sandbox, {
+    // `--` stops the model-influenced name and path from being read as flags.
+    command: `set -euo pipefail\n${DSBX_BIN_PATH} db reconcile -- ${shellEscape(database)} ${shellEscape(schemaFileSandboxPath)}`,
+    schema: reconcileEnvelopeSchema,
+    what: `dsbx db reconcile ${database}`,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const { envelope } = result.value;
+
+  if ("ok" in envelope && envelope.ok) {
+    return new Ok({
+      database,
+      created: envelope.created,
+      statements: envelope.statements,
+    });
+  }
+
+  // A bare `{error}` here is a bad database name or missing schema file, both model-supplied.
+  return new Err(
+    dbErrorToSandboxFunctionError(database, envelope, "reconcile_blocked")
+  );
+}
+
 async function reconcileDatabaseOnSandbox(
   auth: Authenticator,
   {
@@ -202,41 +249,34 @@ async function reconcileDatabaseOnSandbox(
     schemaFileSandboxPath: string;
   }
 ): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
-  const result = await execDbCommand(auth, space, {
-    // `--` stops the model-influenced name and path from being read as flags.
-    command: `set -euo pipefail\n${DSBX_BIN_PATH} db reconcile -- ${shellEscape(database)} ${shellEscape(schemaFileSandboxPath)}`,
-    schema: reconcileEnvelopeSchema,
-    what: `dsbx db reconcile ${database}`,
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+
+  const result = await reconcileDatabaseOnReadySandbox(auth, {
+    sandbox: ensureResult.value.sandbox,
+    database,
+    schemaFileSandboxPath,
   });
-  if (result.isErr()) {
-    return result;
+  if (result.isOk() && result.value.statements.length > 0) {
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        podId: space.sId,
+        database,
+        created: result.value.created,
+        statements: result.value.statements,
+      },
+      "Pod database reconciled: applied DDL"
+    );
   }
-  const { envelope } = result.value;
-
-  if ("ok" in envelope && envelope.ok) {
-    if (envelope.statements.length > 0) {
-      logger.info(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          podId: space.sId,
-          database,
-          created: envelope.created,
-          statements: envelope.statements,
-        },
-        "Pod database reconciled: applied DDL"
-      );
-    }
-    return new Ok({
-      database,
-      created: envelope.created,
-      statements: envelope.statements,
-    });
-  }
-
-  // A bare `{error}` here is a bad database name or missing schema file, both model-supplied.
-  return new Err(
-    dbErrorToSandboxFunctionError(database, envelope, "reconcile_blocked")
-  );
+  return result;
 }
 
 const RECONCILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -52,7 +52,7 @@ export async function distributedUnlock(
 const DEFAULT_RETRY_INTERVAL_MS = 100;
 
 export class LockAcquisitionTimeoutError extends Error {
-  constructor(lockName: string) {
+  constructor(readonly lockName: string) {
     super(`Lock acquisition timed out for ${lockName}`);
     this.name = "LockAcquisitionTimeoutError";
   }

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -60,6 +60,12 @@ export class LockAcquisitionTimeoutError extends Error {
   }
 }
 
+export function isLockAcquisitionTimeoutError(
+  error: unknown
+): error is LockAcquisitionTimeoutError {
+  return error instanceof LockAcquisitionTimeoutError;
+}
+
 type ExecuteWithLockOptions = {
   lockTtlMs?: number;
   // How long a waiter sleeps between acquisition attempts. The wait is blind

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -51,6 +51,13 @@ export async function distributedUnlock(
 
 const DEFAULT_RETRY_INTERVAL_MS = 100;
 
+export class LockAcquisitionTimeoutError extends Error {
+  constructor(lockName: string) {
+    super(`Lock acquisition timed out for ${lockName}`);
+    this.name = "LockAcquisitionTimeoutError";
+  }
+}
+
 export const executeWithLock = async <T>(
   lockName: string,
   callback: () => Promise<T>,
@@ -102,7 +109,7 @@ export const executeWithLock = async <T>(
     : await acquire();
 
   if (!lockValue) {
-    throw new Error(`Lock acquisition timed out for ${lockName}`);
+    throw new LockAcquisitionTimeoutError(lockName);
   }
 
   try {

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,6 +1,8 @@
 import type { RedisClientType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import tracer from "@app/logger/tracer";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
 
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
@@ -58,10 +60,19 @@ export class LockAcquisitionTimeoutError extends Error {
   }
 }
 
-export const executeWithLock = async <T>(
+type ExecuteWithLockOptions = {
+  lockTtlMs?: number;
+  // How long a waiter sleeps between acquisition attempts. The wait is blind
+  // (no notification on release), so on a contended lock every waiter loses
+  // in quanta of this interval — locks with short hold times on
+  // latency-sensitive paths should pass something well under the default.
+  retryIntervalMs?: number;
+  traceAcquireResource?: string;
+};
+
+async function acquireLock(
   lockName: string,
-  callback: () => Promise<T>,
-  timeoutMs: number = 30_000,
+  timeoutMs: number,
   // Opt-in: when set, the acquisition wait (only) is wrapped in a
   // `lock.acquire` APM span with this resource, so contention/wait time is
   // visible separately from the time spent holding the lock. Off by default so
@@ -70,16 +81,8 @@ export const executeWithLock = async <T>(
     lockTtlMs = 5_000,
     retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS,
     traceAcquireResource,
-  }: {
-    lockTtlMs?: number;
-    // How long a waiter sleeps between acquisition attempts. The wait is blind
-    // (no notification on release), so on a contended lock every waiter loses
-    // in quanta of this interval — locks with short hold times on
-    // latency-sensitive paths should pass something well under the default.
-    retryIntervalMs?: number;
-    traceAcquireResource?: string;
-  } = {}
-): Promise<T> => {
+  }: ExecuteWithLockOptions
+): Promise<{ client: RedisClientType; lockValue: string | undefined }> {
   const client = await getRedisStreamClient({ origin: "lock" });
 
   const acquire = async (): Promise<string | undefined> => {
@@ -108,17 +111,48 @@ export const executeWithLock = async <T>(
       )
     : await acquire();
 
+  return { client, lockValue };
+}
+
+async function runWithAcquiredLock<T>(
+  client: RedisClientType,
+  lockName: string,
+  lockValue: string,
+  callback: () => Promise<T>
+): Promise<T> {
+  try {
+    return await callback();
+  } finally {
+    await distributedUnlock(client, lockName, lockValue);
+  }
+}
+
+export const executeWithLock = async <T>(
+  lockName: string,
+  callback: () => Promise<T>,
+  timeoutMs: number = 30_000,
+  options: ExecuteWithLockOptions = {}
+): Promise<T> => {
+  const { client, lockValue } = await acquireLock(lockName, timeoutMs, options);
+
   if (!lockValue) {
     throw new LockAcquisitionTimeoutError(lockName);
   }
 
-  try {
-    const result = await callback();
-    return result;
-  } finally {
-    // Release the lock if we have it
-    if (lockValue) {
-      await distributedUnlock(client, lockName, lockValue);
-    }
+  return runWithAcquiredLock(client, lockName, lockValue, callback);
+};
+
+export const executeWithLockResult = async <T, E>(
+  lockName: string,
+  callback: () => Promise<Result<T, E>>,
+  timeoutMs: number = 30_000,
+  options: ExecuteWithLockOptions = {}
+): Promise<Result<T, E | LockAcquisitionTimeoutError>> => {
+  const { client, lockValue } = await acquireLock(lockName, timeoutMs, options);
+
+  if (!lockValue) {
+    return new Err(new LockAcquisitionTimeoutError(lockName));
   }
+
+  return runWithAcquiredLock(client, lockName, lockValue, callback);
 };

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -718,15 +718,11 @@ export class FileResource extends BaseResource<FileModel> {
       return this.deleteAfterSandboxCleanup(auth);
     }
 
-    try {
-      return await withFramePublishLock(this.sId, () =>
-        FrameSandboxAdapter.deleteSandbox(auth, this, {
-          afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
-        })
-      );
-    } catch (error) {
-      return new Err(normalizeError(error));
-    }
+    return withFramePublishLock(this.sId, () =>
+      FrameSandboxAdapter.deleteSandbox(auth, this, {
+        afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
+      })
+    );
   }
 
   get sId(): string {

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -30,6 +30,7 @@ vi.mock("@app/lib/api/sandbox/image", () => ({
 
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
+  executeWithLockResult: mockExecuteWithLock,
 }));
 
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -1,4 +1,5 @@
 import { INTERACTIVE_CONTENT_AUTHORING_PROSE_V2 } from "@app/lib/api/actions/servers/interactive_content/instructions_v2";
+import { MAX_FRAME_DATABASE_COUNT } from "@app/types/api/frame_manifest";
 
 export const FRAMES_V2_INSTRUCTIONS = `\
 # Frames v2
@@ -97,7 +98,7 @@ The manifest declares the UI entry point, every server function, and every datab
   import them with relative paths.
 - Each database declaration names Frame-owned SQLite state and points to its Drizzle schema file.
   Database names start with a lower-case letter and contain only lower-case letters, digits, and
-  underscores.
+  underscores. A Frame can declare up to ${MAX_FRAME_DATABASE_COUNT} databases.
 - \`executionMode\` defaults to \`durable\`. Use \`fast\` when the function never calls a Dust tool;
   use \`durable\` when it calls \`dsbx tools\`.
 - \`defaultStake\` defaults to \`low\`. \`never_ask\` runs unattended, \`low\` asks once and can be

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -307,8 +307,8 @@ are validated, built or reconciled, stored, and activated atomically:
 dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
 
-If validation or any function build fails, no partial publication becomes active. Fix the reported
-error and rerun the command.
+If validation, a function build, or database reconciliation fails, no partial publication becomes
+active. Fix the reported error and rerun the command.
 
 For a legacy Frame, pass its entry source file instead:
 

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -3,6 +3,7 @@ import {
   FRAME_DEFAULT_UI_ENTRY_POINT,
   FrameManifestSchema,
   isSafeFrameRelativePath,
+  MAX_FRAME_DATABASE_COUNT,
   MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
@@ -158,6 +159,21 @@ describe("FrameManifestSchema", () => {
         { name: "tasks", schema: "databases/tasks.db.ts" },
         { name: "tasks", schema: "databases/tasks_v2.db.ts" },
       ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("bounds database reconciliation within the publication lease", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      databases: Array.from(
+        { length: MAX_FRAME_DATABASE_COUNT + 1 },
+        (_, index) => ({
+          name: `database_${index}`,
+          schema: `databases/database_${index}.db.ts`,
+        })
+      ),
     });
 
     expect(parsed.success).toBe(false);

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -18,6 +18,8 @@ export const FRAME_DEFAULT_UI_ENTRY_POINT = "index.tsx";
 export const MAX_FRAME_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH = 255;
+// Each schema reconcile can take 60 seconds and runs under the 10-minute publication lease.
+export const MAX_FRAME_DATABASE_COUNT = 4;
 export const FRAME_DATABASE_NAME_REGEX = SANDBOX_DATABASE_NAME_REGEX;
 
 /** Manifest paths are always relative to the Frame source folder. */
@@ -73,7 +75,10 @@ export const FrameSourceManifestSchema = z
     description: z.string(),
     uiEntryPoint: FrameRelativePathSchema.optional(),
     functions: z.array(FrameFunctionManifestSchema).default([]),
-    databases: z.array(FrameDatabaseManifestSchema).default([]),
+    databases: z
+      .array(FrameDatabaseManifestSchema)
+      .max(MAX_FRAME_DATABASE_COUNT)
+      .default([]),
   })
   .superRefine((manifest, context) => {
     const functionNames = new Set<string>();


### PR DESCRIPTION
## Description

- Reconcile every declared Frame database against Frame-owned SQLite state before activation.
- Stage the captured source tree so schema files can resolve relative imports.
- Bound manifests to four databases and return a typed conflict when another publish holds the Frame lock.
- Keep the previous publication active when reconciliation is blocked.
- Reuse the existing DSBX database runner and source staging path without changing Pod behavior.

Depends on merged #31397.

## Tests

Added 17 focused tests covering Frame schema staging, typed lock and reconcile failures, activation rollback, the database-count bound, UI-only Frames, legacy publish routing, and Pod reconciliation.

## Risk

Limited to feature-flagged Frames v2 publishing. Reconciliation is additive; failures leave the current publication active and are safe to retry. The database cap keeps the worst-case reconcile budget within the publication lease.

## Deploy Plan

- [x] Deploy #31397 first.
- [ ] Standard deploy. No migration.

