### PR TITLE
Move Frames without changing identity

### DIFF
--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -5,6 +5,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   emitGCSMountFileMovedAuditLogMock,
   lockLeaseCheckMock,
+  sandboxProviderDestroyMock,
+  sandboxProviderMock,
+  sandboxStateHealthOnSleepMock,
   sandboxLifecycleAfterCallbackMock,
   sandboxLifecycleBeforeCallbackMock,
   sandboxLifecycleLockTails,
@@ -13,11 +16,26 @@ const {
   return {
     emitGCSMountFileMovedAuditLogMock: vi.fn(),
     lockLeaseCheckMock: vi.fn(),
+    sandboxProviderDestroyMock: vi.fn(),
+    sandboxProviderMock: vi.fn(),
+    sandboxStateHealthOnSleepMock: vi.fn(),
     sandboxLifecycleAfterCallbackMock: vi.fn(),
     sandboxLifecycleBeforeCallbackMock: vi.fn(),
     sandboxLifecycleLockTails,
   };
 });
+
+vi.mock("@app/lib/api/sandbox/db", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/api/sandbox/db")>();
+  return {
+    ...actual,
+    ensureSandboxStateHealthOnSleep: sandboxStateHealthOnSleepMock,
+  };
+});
+
+vi.mock("@app/lib/api/sandbox", () => ({
+  getSandboxProvider: sandboxProviderMock,
+}));
 
 vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => {
   const actual =
@@ -82,6 +100,9 @@ import { Authenticator } from "@app/lib/auth";
 import { LockLeaseLostError } from "@app/lib/lock";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -222,6 +243,12 @@ beforeEach(() => {
   sandboxLifecycleAfterCallbackMock.mockReset();
   sandboxLifecycleAfterCallbackMock.mockResolvedValue(undefined);
   emitGCSMountFileMovedAuditLogMock.mockClear();
+  sandboxProviderDestroyMock.mockReset();
+  sandboxProviderDestroyMock.mockResolvedValue(new Ok(undefined));
+  sandboxProviderMock.mockReset();
+  sandboxProviderMock.mockReturnValue({ destroy: sandboxProviderDestroyMock });
+  sandboxStateHealthOnSleepMock.mockReset();
+  sandboxStateHealthOnSleepMock.mockResolvedValue(new Ok(undefined));
   vi.restoreAllMocks();
   leaseCheckCount = 0;
   loseLeaseAtCheck = Number.POSITIVE_INFINITY;
@@ -423,7 +450,7 @@ describe("moveFrameV2Source", () => {
     );
   });
 
-  it("serializes conversation scope changes with final eligibility and update", async () => {
+  it("recycles a running sandbox when runtime scopes converge under the lifecycle lock", async () => {
     const context = await setup({ withRuntimePod: true });
     assert(context.runtimeSpace);
     const nextRuntimeSpace = await SpaceFactory.project(
@@ -435,12 +462,27 @@ describe("moveFrameV2Source", () => {
       context.workspace.sId
     );
     assert(auth);
-    const destinationDirectoryPath = `pod-${context.runtimeSpace.sId}/Status`;
+    const destinationDirectoryPath = `pod-${nextRuntimeSpace.sId}/Status`;
     const destinationGcsDirectoryPath = `${getPodFilesBasePath({
       workspaceId: context.workspace.sId,
-      podId: context.runtimeSpace.sId,
+      podId: nextRuntimeSpace.sId,
     })}Status`;
     const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const scopeTransition = vi.spyOn(
+      FrameSandboxAdapter,
+      "withScopeTransition"
+    );
+    const sandbox = await SandboxResource.makeNew(auth, {
+      providerId: "frame-sandbox",
+      status: "running",
+      baseImage: "dust-base",
+      version: "1",
+    });
+    await SandboxOwnerModel.create({
+      frameFileModelId: context.frame.id,
+      sandboxId: sandbox.id,
+      workspaceId: context.workspace.id,
+    });
 
     let releaseTransition: () => void = () => undefined;
     const allowTransition = new Promise<void>((resolve) => {
@@ -491,33 +533,34 @@ describe("moveFrameV2Source", () => {
     );
 
     const moved = await move;
-    expect(moved.isErr() && moved.error).toMatchObject({
-      code: "conflict",
-      message:
-        "The Frame runtime scope changed while its source was being moved.",
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value.frameId).toBe(context.frame.sId);
+    expect(scopeTransition).toHaveBeenCalledTimes(1);
+    expect(sandboxStateHealthOnSleepMock).toHaveBeenCalledTimes(1);
+    expect(sandboxProviderDestroyMock).toHaveBeenCalledWith("frame-sandbox", {
+      workspaceId: context.workspace.sId,
     });
+    await expect(
+      FrameSandboxAdapter.fetchSandbox(auth, context.frame)
+    ).resolves.toMatchObject({ id: sandbox.id, status: "deleted" });
     const reloaded = await FileResource.fetchById(auth, context.frame.sId);
-    expect(reloaded?.mountFilePath).toBe(
-      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
-    );
+    expect(reloaded?.mountFilePath).toBe(destinationManifestPath);
     expect(reloaded?.useCaseMetadata).toEqual({
       activePublicationId: "publication-1",
-      conversationId: context.conversation.sId,
+      spaceId: nextRuntimeSpace.sId,
     });
-    expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
     expect(
       fileStorageMock.getObject(`${destinationGcsDirectoryPath}/index.tsx`)
+    ).toBe("ui source");
+    expect(
+      fileStorageMock.getObject(
+        `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+      )
     ).toBeUndefined();
-    expect(fileStorageMock.deleteCalls).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          filePath: destinationManifestPath,
-          options: expect.objectContaining({
-            ifGenerationMatch: expect.any(String),
-          }),
-        }),
-      ])
-    );
+    expect(
+      fileStorageMock.getObject(`${context.sourceGcsDirectoryPath}/index.tsx`)
+    ).toBeUndefined();
   });
 
   it("moves from a Pod mount to a conversation in that runtime", async () => {
@@ -588,7 +631,7 @@ describe("moveFrameV2Source", () => {
     );
   });
 
-  it("rejects moves to a different runtime before any mutation", async () => {
+  it("recycles the runtime when moving to a different runtime", async () => {
     const context = await setup();
     const destinationPod = await SpaceFactory.project(
       context.workspace,
@@ -599,33 +642,51 @@ describe("moveFrameV2Source", () => {
       context.workspace.sId
     );
     assert(auth);
-    const fetchFrames = vi.spyOn(FileResource, "fetchByMountFilePaths");
-    const updateMount = vi.spyOn(FileResource.prototype, "updateMount");
-    const copyFile = vi.fn();
-    fileStorageMock.setAfterCopyFile(copyFile);
+    const beforeShare = await context.frame.getShareInfo();
+    const sandbox = await SandboxResource.makeNew(context.auth, {
+      providerId: "frame-sandbox",
+      status: "sleeping",
+      baseImage: "dust-base",
+      version: "1",
+    });
+    await SandboxOwnerModel.create({
+      frameFileModelId: context.frame.id,
+      sandboxId: sandbox.id,
+      workspaceId: context.workspace.id,
+    });
+    const destinationDirectoryPath = `pod-${destinationPod.sId}/Status`;
 
     const moved = await moveFrameV2Source(auth, {
       conversation: context.conversation,
-      destinationDirectoryPath: `pod-${destinationPod.sId}/Status`,
+      destinationDirectoryPath,
       sourceDirectoryPath: context.sourceDirectoryPath,
     });
 
-    expect(moved.isErr() && moved.error).toMatchObject({
-      code: "invalid_source",
-      message:
-        "Frame source and destination must resolve to the same runtime space.",
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value).toEqual({
+      destinationDirectoryPath,
+      frameId: context.frame.sId,
+      sourceDeletionFailed: false,
     });
-    expect(fetchFrames).not.toHaveBeenCalled();
-    expect(updateMount).not.toHaveBeenCalled();
-    expect(copyFile).not.toHaveBeenCalled();
-    expect(fileStorageMock.deleteCalls).toEqual([]);
-    const reloaded = await FileResource.fetchById(
-      context.auth,
-      context.frame.sId
-    );
+    const reloaded = await FileResource.fetchById(auth, context.frame.sId);
+    expect(reloaded).toMatchObject({
+      sId: context.frame.sId,
+      useCase: "project_context",
+    });
     expect(reloaded?.mountFilePath).toBe(
-      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+      `${getPodFilesBasePath({
+        workspaceId: context.workspace.sId,
+        podId: destinationPod.sId,
+      })}Status/${FRAME_MANIFEST_FILE}`
     );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      spaceId: destinationPod.sId,
+    });
+    await expect(reloaded?.getShareInfo()).resolves.toEqual(beforeShare);
+    await expect(
+      FrameSandboxAdapter.fetchSandbox(auth, context.frame)
+    ).resolves.toMatchObject({ id: sandbox.id, status: "deleted" });
   });
 
   it("moves within another conversation when the caller can access its mount", async () => {

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -24,7 +24,12 @@ import { isLockLeaseLostError } from "@app/lib/lock";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { FrameGoneError } from "@app/lib/resources/frame_sandbox_adapter";
+import type { FrameScopeTransitionStateError } from "@app/lib/resources/frame_sandbox_adapter";
+import {
+  FrameGoneError,
+  FrameSandboxAdapter,
+} from "@app/lib/resources/frame_sandbox_adapter";
+import type { ScopeTransitionDestroyError } from "@app/lib/resources/sandbox_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
@@ -65,11 +70,29 @@ export function isFrameSourceMoveError(
   return error instanceof FrameSourceMoveError;
 }
 
+type FrameDestinationUpdateCause =
+  | FrameGoneError
+  | FrameScopeTransitionStateError
+  | FrameSourceMoveError
+  | ScopeTransitionDestroyError;
+
+class FrameDestinationUpdateError extends Error {
+  constructor(
+    readonly error: FrameDestinationUpdateCause,
+    readonly preserveDestinationObjects: boolean
+  ) {
+    super(error.message);
+    this.name = "FrameDestinationUpdateError";
+  }
+}
+
 export type MoveFrameV2SourceError =
   | DustFileSystemError
   | FrameGoneError
+  | FrameScopeTransitionStateError
   | FrameSourceMoveError
-  | SandboxFunctionError;
+  | SandboxFunctionError
+  | ScopeTransitionDestroyError;
 
 function invalidSource(message: string) {
   return new Err(new FrameSourceMoveError("invalid_source", message));
@@ -753,11 +776,6 @@ export async function moveFrameV2Source(
   if (destinationRuntimeSpace.isErr()) {
     return destinationRuntimeSpace;
   }
-  if (sourceRuntimeSpace.value !== destinationRuntimeSpace.value) {
-    return invalidSource(
-      "Frame source and destination must resolve to the same runtime space."
-    );
-  }
 
   const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
   const destinationManifestPath = path.posix.join(
@@ -961,25 +979,23 @@ export async function moveFrameV2Source(
           );
     }
 
-    type DestinationUpdateError = {
-      error: FrameSourceMoveError;
-      preserveDestinationObjects: boolean;
-    };
     const updateFrame = async (
       currentFrame: FileResource
-    ): Promise<Result<void, DestinationUpdateError>> => {
+    ): Promise<Result<void, FrameDestinationUpdateError>> => {
       const currentReservation = getMatchingPendingMove(currentFrame, {
         destinationMountFilePath: destinationMountPath,
         sourceMountFilePath: sourceMountPath,
       });
       if (currentReservation?.operationId !== operationId) {
-        return new Err({
-          error: new FrameSourceMoveError(
-            "internal",
-            "The Frame source changed while its destination update was being committed."
-          ),
-          preserveDestinationObjects: true,
-        });
+        return new Err(
+          new FrameDestinationUpdateError(
+            new FrameSourceMoveError(
+              "internal",
+              "The Frame source changed while its destination update was being committed."
+            ),
+            true
+          )
+        );
       }
       try {
         await currentFrame.updateMount({
@@ -1004,7 +1020,7 @@ export async function moveFrameV2Source(
 
     const reconcileDestinationUpdate = async (
       updateError: FrameSourceMoveError
-    ): Promise<Result<void, DestinationUpdateError>> => {
+    ): Promise<Result<void, FrameDestinationUpdateError>> => {
       let reconciledFrame: FileResource | null = null;
       try {
         reconciledFrame = await freshFrame.fetchFreshFrameV2(auth);
@@ -1030,21 +1046,23 @@ export async function moveFrameV2Source(
           })
         : null;
       if (reconciledReservation?.operationId === operationId) {
-        return new Err({
-          error: updateError,
-          preserveDestinationObjects: false,
-        });
+        return new Err(new FrameDestinationUpdateError(updateError, false));
       }
-      return new Err({
-        error: new FrameSourceMoveError(
-          "internal",
-          "The Frame destination update could not be reconciled; retry the move."
-        ),
-        preserveDestinationObjects: true,
-      });
+      return new Err(
+        new FrameDestinationUpdateError(
+          new FrameSourceMoveError(
+            "internal",
+            "The Frame destination update could not be reconciled; retry the move."
+          ),
+          true
+        )
+      );
     };
 
-    let updateResult: Result<void, DestinationUpdateError | LockLeaseLostError>;
+    let updateResult: Result<
+      void,
+      FrameDestinationUpdateError | LockLeaseLostError
+    >;
     try {
       updateResult = await withConversationOwnerLifecycleLocks(
         [sourceOwner, destinationOwner],
@@ -1055,34 +1073,86 @@ export async function moveFrameV2Source(
               resolveRuntimeSpaceId(auth, destinationOwner),
             ]);
           if (freshSourceRuntimeSpace.isErr()) {
-            return new Err({
-              error: freshSourceRuntimeSpace.error,
-              preserveDestinationObjects: false,
-            });
+            return new Err(
+              new FrameDestinationUpdateError(
+                freshSourceRuntimeSpace.error,
+                false
+              )
+            );
           }
           if (freshDestinationRuntimeSpace.isErr()) {
-            return new Err({
-              error: freshDestinationRuntimeSpace.error,
-              preserveDestinationObjects: false,
-            });
-          }
-          if (
-            freshSourceRuntimeSpace.value !== freshDestinationRuntimeSpace.value
-          ) {
-            return new Err({
-              error: new FrameSourceMoveError(
-                "conflict",
-                "The Frame runtime scope changed while its source was being moved."
-              ),
-              preserveDestinationObjects: false,
-            });
+            return new Err(
+              new FrameDestinationUpdateError(
+                freshDestinationRuntimeSpace.error,
+                false
+              )
+            );
           }
 
           const heldBeforeUpdate = lease.check();
           if (heldBeforeUpdate.isErr()) {
             return heldBeforeUpdate;
           }
-          return updateFrame(freshFrame);
+          const canUpdateWithoutScopeTransition =
+            sourceRuntimeSpace.value === destinationRuntimeSpace.value &&
+            freshSourceRuntimeSpace.value === sourceRuntimeSpace.value &&
+            freshDestinationRuntimeSpace.value ===
+              destinationRuntimeSpace.value;
+          if (canUpdateWithoutScopeTransition) {
+            return updateFrame(freshFrame);
+          }
+
+          const transitionResult =
+            await FrameSandboxAdapter.withScopeTransition<
+              undefined,
+              void,
+              FrameDestinationUpdateError | LockLeaseLostError
+            >(auth, freshFrame, {
+              prepare: async (currentFrame) => {
+                const heldBeforeDestroy = lease.check();
+                if (heldBeforeDestroy.isErr()) {
+                  return heldBeforeDestroy;
+                }
+                const currentReservation = getMatchingPendingMove(
+                  currentFrame,
+                  {
+                    destinationMountFilePath: destinationMountPath,
+                    sourceMountFilePath: sourceMountPath,
+                  }
+                );
+                return currentReservation?.operationId === operationId
+                  ? new Ok(undefined)
+                  : new Err(
+                      new FrameDestinationUpdateError(
+                        new FrameSourceMoveError(
+                          "internal",
+                          "The Frame source changed before its runtime could be recycled."
+                        ),
+                        true
+                      )
+                    );
+              },
+              commit: async (currentFrame) => {
+                const heldAfterDestroy = lease.check();
+                return heldAfterDestroy.isErr()
+                  ? heldAfterDestroy
+                  : updateFrame(currentFrame);
+              },
+            });
+          if (transitionResult.isOk()) {
+            return transitionResult;
+          }
+          if (isLockLeaseLostError(transitionResult.error)) {
+            return new Err(transitionResult.error);
+          }
+          return new Err(
+            transitionResult.error instanceof FrameDestinationUpdateError
+              ? transitionResult.error
+              : new FrameDestinationUpdateError(
+                  transitionResult.error,
+                  transitionResult.error instanceof FrameGoneError
+                )
+          );
         }
       );
     } catch (error) {

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  mockEnsureSandboxStateHealthOnSleep,
   mockExecuteWithLock,
   mockExecuteWithRenewingLockResult,
   mockGetSandboxImage,
@@ -9,6 +10,7 @@ const {
   mockProviderDestroy,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
+  mockEnsureSandboxStateHealthOnSleep: vi.fn(),
   mockExecuteWithLock: vi.fn(),
   mockExecuteWithRenewingLockResult: vi.fn(),
   mockGetSandboxImage: vi.fn(),
@@ -17,6 +19,14 @@ const {
   mockProviderDestroy: vi.fn(),
   mockRevokeAllExecTokensForSandbox: vi.fn(),
 }));
+
+vi.mock("@app/lib/api/sandbox/db", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/api/sandbox/db")>();
+  return {
+    ...actual,
+    ensureSandboxStateHealthOnSleep: mockEnsureSandboxStateHealthOnSleep,
+  };
+});
 
 vi.mock("@app/lib/api/sandbox", () => ({
   getSandboxProvider: mockGetSandboxProvider,
@@ -40,6 +50,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import {
   FrameGoneError,
   FrameSandboxAdapter,
+  FrameScopeTransitionStateError,
 } from "@app/lib/resources/frame_sandbox_adapter";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -52,7 +63,7 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 function createDeferred() {
   let resolvePromise: (() => void) | undefined;
@@ -116,6 +127,7 @@ describe("FrameSandboxAdapter", () => {
       destroy: mockProviderDestroy,
     });
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+    mockEnsureSandboxStateHealthOnSleep.mockResolvedValue(new Ok(undefined));
   });
 
   it("owns one sandbox per stable Frame identity", async () => {
@@ -312,6 +324,109 @@ describe("FrameSandboxAdapter", () => {
       releaseFunctionCleanup.resolve();
       deleteInvocationsSpy.mockRestore();
     }
+  });
+
+  it("flushes state, destroys the runtime, then commits with a reloaded Frame", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+    const fetchFreshFrame = vi.spyOn(frame, "fetchFreshFrameV2");
+    const prepare = vi.fn(
+      async (_freshFrame: FileResource) => new Ok("prepared")
+    );
+    const commit = vi.fn(
+      async (_freshFrame: FileResource, _prep: string) => new Ok(undefined)
+    );
+
+    const transition = await FrameSandboxAdapter.withScopeTransition(
+      auth,
+      frame,
+      { prepare, commit }
+    );
+
+    expect(transition.isOk()).toBe(true);
+    expect(fetchFreshFrame).toHaveBeenCalledTimes(2);
+    expect(prepare.mock.calls[0]?.[0]).not.toBe(frame);
+    expect(commit.mock.calls[0]?.[0]).not.toBe(prepare.mock.calls[0]?.[0]);
+    expect(commit).toHaveBeenCalledWith(expect.any(FileResource), "prepared");
+    expect(mockEnsureSandboxStateHealthOnSleep).toHaveBeenCalledWith(
+      auth,
+      sandboxResult.value.sandbox,
+      expect.objectContaining({ refreshMountCredential: expect.any(Function) })
+    );
+    expect(
+      mockEnsureSandboxStateHealthOnSleep.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockProviderDestroy.mock.invocationCallOrder[0]);
+    expect(mockProviderDestroy.mock.invocationCallOrder[0]).toBeLessThan(
+      commit.mock.invocationCallOrder[0]
+    );
+    await expect(
+      FrameSandboxAdapter.fetchSandbox(auth, frame)
+    ).resolves.toMatchObject({ status: "deleted" });
+  });
+
+  it("keeps the current runtime when state cannot be flushed", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+    mockEnsureSandboxStateHealthOnSleep.mockResolvedValue(
+      new Err(new Error("sync failed"))
+    );
+    mockProviderDestroy.mockClear();
+    const commit = vi.fn(async () => new Ok(undefined));
+
+    const transition = await FrameSandboxAdapter.withScopeTransition(
+      auth,
+      frame,
+      { prepare: async () => new Ok(undefined), commit }
+    );
+
+    expect(transition.isErr() && transition.error).toBeInstanceOf(
+      FrameScopeTransitionStateError
+    );
+    expect(transition.isErr() && transition.error.message).toContain(
+      "sync failed"
+    );
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+    await expect(
+      FrameSandboxAdapter.fetchSandbox(auth, frame)
+    ).resolves.toMatchObject({
+      id: sandboxResult.value.sandbox.id,
+      status: "running",
+    });
   });
 
   it("deletes Frame sandboxes during a workspace scrub", async () => {

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -13,6 +13,7 @@ import type {
   SandboxDeleteOwner,
   SandboxLifecycleOwner,
   SandboxPreSleepCheck,
+  ScopeTransitionDestroyError,
 } from "@app/lib/resources/sandbox_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
@@ -41,6 +42,8 @@ export type FrameSandboxScope = {
 };
 
 export class FrameGoneError extends Error {}
+
+export class FrameScopeTransitionStateError extends Error {}
 
 export class FrameSandboxAdapter {
   private static assertWorkspace(
@@ -272,6 +275,67 @@ export class FrameSandboxAdapter {
       this.toSandboxDeleteOwner(auth, frame),
       { afterSandboxCleanup, beforeSandboxCleanup }
     );
+  }
+
+  static async withScopeTransition<TPrep, T, E extends Error>(
+    auth: Authenticator,
+    frame: FrameSandboxScopeOwner,
+    {
+      prepare,
+      commit,
+    }: {
+      prepare: (freshFrame: FileResource) => Promise<Result<TPrep, E>>;
+      commit: (freshFrame: FileResource, prep: TPrep) => Promise<Result<T, E>>;
+    }
+  ): Promise<
+    Result<
+      T,
+      | E
+      | FrameGoneError
+      | FrameScopeTransitionStateError
+      | ScopeTransitionDestroyError
+    >
+  > {
+    return SandboxResource.runScopeTransition<
+      TPrep,
+      T,
+      E | FrameGoneError | FrameScopeTransitionStateError
+    >(auth, this.toSandboxLifecycleOwner(auth, frame), {
+      prepare: async () => {
+        const freshFrame = await frame.fetchFreshFrameV2(auth);
+        if (!freshFrame) {
+          return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
+        }
+        const prepResult = await prepare(freshFrame);
+        if (prepResult.isErr()) {
+          return prepResult;
+        }
+
+        const sandbox = await this.fetchSandboxByFrame(auth, frame);
+        if (sandbox?.status === "running") {
+          const stateResult = await this.sqliteStatePreSleepCheck(
+            auth,
+            frame
+          )(sandbox);
+          if (stateResult.isErr()) {
+            return new Err(
+              new FrameScopeTransitionStateError(
+                `Failed to flush Frame state for scope transition: ${stateResult.error.message}`
+              )
+            );
+          }
+        }
+
+        return new Ok(prepResult.value);
+      },
+      commit: async (prep) => {
+        const freshFrame = await frame.fetchFreshFrameV2(auth);
+        if (!freshFrame) {
+          return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
+        }
+        return commit(freshFrame, prep);
+      },
+    });
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {


### PR DESCRIPTION
## Description

- enable registered Frames v2 to move between owners that resolve to different runtime spaces
- flush SQLite state for a running Frame sandbox, destroy that sandbox, reload the Frame, and commit the destination mount without changing the Frame identity
- keep the final runtime resolution and Frame transition inside the conversation owner lifecycle locks introduced by the base PR
- use the direct destination update only when the initial runtime scopes match and both remain unchanged under the final locks; recycle the Frame sandbox for every other transition, including scopes that converge while the move is in flight
- recheck the durable move reservation before sandbox destruction and again before the destination update

Stacked on #31486.

## Tests

- focused Front tests for Frame scope transition ordering, post-destroy reload, SQLite flush failure, stable identity, publication and sharing preservation, and concurrent conversation runtime changes
- deterministic regression for initially different runtime scopes that converge while a running Frame sandbox still has its original configuration
- 35 focused Front tests across `frame_sandbox_adapter.test.ts` and `move_source.test.ts`
- Front `tsgo`
- Biome and `git diff --check`

## Risk

Frames v2 is feature flagged. A direct destination update is used only when the initially equal runtime assignments are still unchanged under the final lifecycle locks. Any assignment change takes the conservative sandbox recycle path. Cross-runtime failures use typed cleanup state so destination objects are removed only when ownership is still unambiguous; ambiguous post-transition failures preserve them for retry. Existing Frame identity, publication, sharing, and sandbox ownership remain attached to the same resource.

## Deploy Plan

Deploy after #31486. No migration or manual step is required.
