### PR TITLE
fix(sandbox): Pod network scope-badge color and domain removal

### DIFF
--- a/front/components/sandbox/MultiPodNetworkSection.test.tsx
+++ b/front/components/sandbox/MultiPodNetworkSection.test.tsx
@@ -10,16 +10,26 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { bulkUpdateMock, mutatePodPoliciesMock, mutateWorkspaceMock } =
-  vi.hoisted(() => ({
+const {
+  bulkUpdateMock,
+  mutatePodPoliciesMock,
+  mutateWorkspaceMock,
+  podPoliciesState,
+} = vi.hoisted(() => {
+  const podPoliciesState: {
+    current: { podId: string; policy: EgressPolicy }[];
+  } = { current: [] };
+  return {
     bulkUpdateMock: vi.fn(),
     mutatePodPoliciesMock: vi.fn(),
     mutateWorkspaceMock: vi.fn(),
-  }));
+    podPoliciesState,
+  };
+});
 
 vi.mock("@app/lib/swr/sandbox", () => ({
   useBulkPodEgressPolicies: () => ({
-    podPolicies: [],
+    podPolicies: podPoliciesState.current,
     isPodPoliciesLoading: false,
     isPodPoliciesError: false,
     mutatePodPolicies: mutatePodPoliciesMock,
@@ -171,6 +181,37 @@ describe("buildPendingRequests", () => {
 describe("MultiPodNetworkSection mutation flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    podPoliciesState.current = [];
+  });
+
+  it("removes a Pod-only domain from just that Pod, not the workspace", async () => {
+    podPoliciesState.current = [
+      { podId: podA.sId, policy: policy(["*.example.com"]) },
+    ];
+    bulkUpdateMock.mockResolvedValue(true);
+
+    render(
+      <MultiPodNetworkSection
+        owner={{ sId: "wId" } as LightWorkspaceType}
+        includeWorkspace
+        selection={{ kind: "pods", podIds: [podA.sId] }}
+        selectedPods={[podA]}
+      />
+    );
+
+    // The row is Pod-owned (not a workspace domain), so removal is scoped and
+    // skips the workspace-confirm dialog — it must target only that Pod, never
+    // the workspace or other selected scopes.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Remove *.example.com" })
+    );
+
+    expect(bulkUpdateMock).toHaveBeenCalledWith({
+      includeWorkspace: false,
+      pods: [podA],
+      operation: "remove",
+      domain: "*.example.com",
+    });
   });
 
   it("revalidates after a partial-failure add so changed scopes are not left stale", async () => {

--- a/front/components/sandbox/MultiPodNetworkSection.tsx
+++ b/front/components/sandbox/MultiPodNetworkSection.tsx
@@ -284,12 +284,15 @@ export function MultiPodNetworkSection({
     return success;
   };
 
-  const handleRemoveDomain = async (domain: string) => {
+  // Remove only from the scopes that actually own this row: the workspace when
+  // it's a selected workspace domain, plus the specific Pods listing it — not
+  // every selected scope.
+  const handleRemoveDomain = async (row: DomainRow) => {
     await bulkUpdateEgressDomain({
-      includeWorkspace,
-      pods: selectedPods,
+      includeWorkspace: includeWorkspace && row.inWorkspace,
+      pods: row.ownedByPods,
       operation: "remove",
-      domain,
+      domain: row.domain,
     });
     await revalidate();
   };
@@ -323,16 +326,16 @@ export function MultiPodNetworkSection({
       setRemoveTarget(row);
       return;
     }
-    void handleRemoveDomain(row.domain);
+    void handleRemoveDomain(row);
   };
 
   const handleConfirmRemove = async () => {
     if (!removeTarget) {
       return;
     }
-    const domain = removeTarget.domain;
+    const row = removeTarget;
     setRemoveTarget(null);
-    await handleRemoveDomain(domain);
+    await handleRemoveDomain(row);
   };
 
   // Scope badges only disambiguate once Pods are in the mix. In the
@@ -384,14 +387,14 @@ export function MultiPodNetworkSection({
                 request.scopeKind === "workspace" ? (
                   <Chip
                     size="xs"
-                    color="info"
+                    color="highlight"
                     label="Workspace"
                     icon={Building04}
                   />
                 ) : (
                   <Chip
                     size="xs"
-                    color="info"
+                    color="highlight"
                     label={request.pod.name}
                     icon={podIcon(request.pod)}
                   />
@@ -428,7 +431,7 @@ export function MultiPodNetworkSection({
               {showScopeBadges && row.inWorkspace ? (
                 <Chip
                   size="xs"
-                  color="info"
+                  color="highlight"
                   label="Workspace"
                   icon={Building04}
                 />
@@ -437,7 +440,7 @@ export function MultiPodNetworkSection({
                 <Chip
                   key={pod.sId}
                   size="xs"
-                  color="info"
+                  color="highlight"
                   label={pod.name}
                   icon={podIcon(pod)}
                 />

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -52,6 +52,7 @@ import {
   parseExactEgressDomain,
   readOwnerPolicy,
   readWorkspacePolicy,
+  removeOwnerPolicyDomain,
   requestOwnerPolicyDomain,
   writeOwnerPolicy,
   writeWorkspacePolicy,
@@ -283,6 +284,29 @@ describe("owner egress policy storage", () => {
     expect(result.isErr()).toBe(true);
     expect(mockFetchFileContent).not.toHaveBeenCalled();
     expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("removes a stored wildcard domain from an owner policy", async () => {
+    setGcsObjects({
+      [OWNER_PATH]: { allowedDomains: ["*.example.com", "keep.example.org"] },
+    });
+
+    const result = await removeOwnerPolicyDomain(mockAuth, {
+      ownerId: "owner-sid",
+      domain: "*.example.com",
+    });
+
+    expect(result).toEqual(
+      new Ok({
+        policy: { allowedDomains: ["keep.example.org"] },
+        removedDomain: "*.example.com",
+      })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({ allowedDomains: ["keep.example.org"] }),
+      contentType: "application/json",
+      filePath: OWNER_PATH,
+    });
   });
 
   it("rejects owner policies over the domain cap", async () => {

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -338,25 +338,23 @@ export async function removeOwnerPolicyDomain(
 ): Promise<
   Result<{ policy: EgressPolicy; removedDomain: string | null }, Error>
 > {
-  const parsedDomain = parseExactEgressDomain(domain);
-  if (parsedDomain.isErr()) {
-    return new Err(parsedDomain.error);
-  }
-
   const currentPolicy = await readOwnerPolicy(auth, ownerId);
   if (currentPolicy.isErr()) {
     return new Err(currentPolicy.error);
   }
 
-  // Skip the write entirely when the domain is absent so a no-op remove never
-  // creates an owner policy file — which would make an unconfigured Pod look
+  // Match the stored entry as-is: the domain comes straight from the existing
+  // allowlist, so there's nothing to validate or normalize — and matching as-is
+  // is what lets wildcards (`*.example.com`) be removed, which the exact-domain
+  // add parser rejects. A domain that isn't present is a no-op: never create an
+  // owner policy file for it, which would make an unconfigured Pod look
   // configured to listPodIdsWithEgressPolicy (file-existence based).
-  if (!currentPolicy.value.allowedDomains.includes(parsedDomain.value)) {
+  if (!currentPolicy.value.allowedDomains.includes(domain)) {
     return new Ok({ policy: currentPolicy.value, removedDomain: null });
   }
 
   const allowedDomains = currentPolicy.value.allowedDomains.filter(
-    (allowed) => allowed !== parsedDomain.value
+    (allowed) => allowed !== domain
   );
 
   const written = await writeOwnerPolicy(auth, {
@@ -367,7 +365,7 @@ export async function removeOwnerPolicyDomain(
     return new Err(written.error);
   }
 
-  return new Ok({ policy: written.value, removedDomain: parsedDomain.value });
+  return new Ok({ policy: written.value, removedDomain: domain });
 }
 
 // Workspace-scoped counterpart of removeOwnerPolicyDomain.
@@ -377,24 +375,20 @@ export async function removeWorkspacePolicyDomain(
 ): Promise<
   Result<{ policy: EgressPolicy; removedDomain: string | null }, Error>
 > {
-  const parsedDomain = parseExactEgressDomain(domain);
-  if (parsedDomain.isErr()) {
-    return new Err(parsedDomain.error);
-  }
-
   const currentPolicy = await readWorkspacePolicy(auth);
   if (currentPolicy.isErr()) {
     return new Err(currentPolicy.error);
   }
 
-  // Skip the write when the domain is absent (no-op remove), mirroring
-  // removeOwnerPolicyDomain.
-  if (!currentPolicy.value.allowedDomains.includes(parsedDomain.value)) {
+  // Match the stored entry as-is (see removeOwnerPolicyDomain): the domain comes
+  // from the existing allowlist, so there's nothing to normalize, and matching
+  // as-is lets wildcards be removed. Absent domain is a no-op.
+  if (!currentPolicy.value.allowedDomains.includes(domain)) {
     return new Ok({ policy: currentPolicy.value, removedDomain: null });
   }
 
   const allowedDomains = currentPolicy.value.allowedDomains.filter(
-    (allowed) => allowed !== parsedDomain.value
+    (allowed) => allowed !== domain
   );
 
   const written = await writeWorkspacePolicy(auth, {
@@ -404,7 +398,7 @@ export async function removeWorkspacePolicyDomain(
     return new Err(written.error);
   }
 
-  return new Ok({ policy: written.value, removedDomain: parsedDomain.value });
+  return new Ok({ policy: written.value, removedDomain: domain });
 }
 
 // Caps the pending-request section: the proxy re-reads this file on every


### PR DESCRIPTION
## Description

Follow-ups from testing the merged Pod network editor (`30996`). Three fixes:

1. **Scope-badge color.** The Workspace/Pod badges used Chip `color="info"`, which in the sparkle palette aliases to `--color-golden-*` — so they rendered gold, not blue. Switched to `color="highlight"` (`--color-blue-*`), which is also the only option with real contrast against the rows (`bg-muted-background` = `stone-50`; a `primary` chip is also `stone-50`).

2. **Removal targeted the wrong scopes.** Pressing the trash on a Pod-owned domain removed it from *every selected scope* (e.g. Workspace **and** the Pod), not just the scopes that own the row. `handleRemoveDomain` now takes the `DomainRow` and targets only `includeWorkspace && row.inWorkspace` plus `row.ownedByPods` — matching what `removableScopeCount` already computes.

3. **Wildcards couldn't be removed.** `removeOwnerPolicyDomain` / `removeWorkspacePolicyDomain` ran the input through `parseExactEgressDomain`, which rejects wildcards — but the admin whole-list write can store wildcards (`*.example.com`), so a stored wildcard was impossible to remove. Removal now matches the stored entry as-is (the domain comes straight from the allowlist, so there's nothing to normalize); an absent domain stays a no-op.

## Tests

Added: backend unit test that a stored wildcard is removed from an owner policy; frontend render test that removing a Pod-owned row targets only that Pod (`includeWorkspace: false`, `pods: [pod]`). Existing `buildDomainRows` coverage already exercises the `ownedByPods` / `removableScopeCount` data the removal now relies on.

## Risk

Low. Cosmetic color change; removal now correctly scoped and no longer rejects wildcards on delete (the exact-domain add path is unchanged, so wildcards still can't be *added* via the bulk editor). Safe to roll back.

## Deploy Plan

Standard front deploy. No migration.