### PR TITLE
Route Frames v2 calls through Frame identity

### DIFF
--- a/front-api/middlewares/cors.test.ts
+++ b/front-api/middlewares/cors.test.ts
@@ -1,5 +1,8 @@
 import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+} from "@app/types/files";
 import { cors } from "@front-api/middlewares/cors";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
@@ -20,16 +23,19 @@ function getExposedHeaders(response: Response): string[] {
 }
 
 describe("cors middleware", () => {
-  it("exposes the linked file id header on cross-origin responses", async () => {
+  it("exposes linked file metadata headers on cross-origin responses", async () => {
     const response = await createApp().request("/", {
       headers: { Origin: APP_ORIGIN },
     });
 
     expect(response.status).toBe(200);
     expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+    expect(getExposedHeaders(response)).toContain(
+      DUST_FILE_CONTENT_TYPE_HEADER
+    );
   });
 
-  it("exposes the linked file id header on preflight responses", async () => {
+  it("exposes linked file metadata headers on preflight responses", async () => {
     const response = await createApp().request("/", {
       method: "OPTIONS",
       headers: { Origin: APP_ORIGIN },
@@ -37,6 +43,9 @@ describe("cors middleware", () => {
 
     expect(response.status).toBe(200);
     expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+    expect(getExposedHeaders(response)).toContain(
+      DUST_FILE_CONTENT_TYPE_HEADER
+    );
   });
 
   it("allows the frame share token header on preflight requests", async () => {

--- a/front-api/middlewares/cors.ts
+++ b/front-api/middlewares/cors.ts
@@ -4,7 +4,10 @@ import {
   isAllowedOrigin,
 } from "@app/config/cors";
 import logger from "@app/logger/logger";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+} from "@app/types/files";
 import { isDevelopment } from "@app/types/shared/env";
 import type { MiddlewareHandler } from "hono";
 
@@ -14,6 +17,7 @@ const EXPOSE_HEADERS = [
   "WWW-Authenticate",
   "mcp-session-id",
   "mcp-protocol-version",
+  DUST_FILE_CONTENT_TYPE_HEADER,
   DUST_FILE_ID_HEADER,
 ].join(", ");
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -4,7 +4,11 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { DUST_FILE_ID_HEADER, frameContentType } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+  frameV2ContentType,
+} from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -259,16 +263,16 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
     expect(fileStorageMock.readStreamCalls).toHaveLength(0);
   });
 
-  it("returns the linked file id header when a FileResource exists", async () => {
+  it("returns linked FileResource metadata without replacing raw metadata", async () => {
     const { workspace, auth, conversation } = await setup();
 
     setExistingFiles(["/files/frame.tsx"], {
-      contentType: frameContentType,
+      contentType: "text/plain",
       size: "2048",
     });
 
     const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
-      contentType: frameContentType,
+      contentType: frameV2ContentType,
       fileName: "frame.tsx",
       fileSize: 2048,
       status: "ready",
@@ -290,8 +294,11 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe(frameContentType);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
     expect(response.headers.get(DUST_FILE_ID_HEADER)).toBe(file.sId);
+    expect(response.headers.get(DUST_FILE_CONTENT_TYPE_HEADER)).toBe(
+      frameV2ContentType
+    );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -14,6 +14,7 @@ import {
 import { requestDustProjectIncrementalSyncForScopedPath } from "@app/lib/api/projects/request_incremental_sync";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
   DUST_FILE_ID_HEADER,
   getFileFormat,
   normalizeMimeType,
@@ -161,6 +162,7 @@ async function handleHeadRequest(
   };
   if (linkedFileResource) {
     headers[DUST_FILE_ID_HEADER] = linkedFileResource.sId;
+    headers[DUST_FILE_CONTENT_TYPE_HEADER] = linkedFileResource.contentType;
   }
 
   return new Response(null, {

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,6 +1,30 @@
-import { getFrameRuntimeAccess } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import {
+  getFrameRuntimeAccess,
+  VisualizationActionIframe,
+} from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clientFetch: vi.fn(),
+}));
+
+vi.mock("@app/hooks/conversations", () => ({
+  useVisualizationRetry: () => ({
+    canRetry: false,
+    handleVisualizationRetry: vi.fn(),
+  }),
+}));
+
+vi.mock("@app/hooks/useNotification", () => ({
+  useSendNotification: () => vi.fn(),
+}));
+
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: mocks.clientFetch,
+}));
 
 const user = {
   sId: "usr_123",
@@ -14,6 +38,11 @@ const scopedUserIdentity: ScopedWorkspaceUserIdentity = {
   workspaceId: "w_current",
   user,
 };
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe("getFrameRuntimeAccess", () => {
   it("enables access with an identity scoped to the Frame workspace", () => {
@@ -97,6 +126,62 @@ describe("getFrameRuntimeAccess", () => {
         isPodMember: false,
         user,
       },
+    });
+  });
+});
+
+describe("VisualizationActionIframe", () => {
+  it("routes a Frames v2 call through the rendered Frame identity", async () => {
+    mocks.clientFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          invocation: { functionId: "sfn_function", sId: "sfi_invocation" },
+          outcome: { status: "succeeded", result: { ok: true } },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const { container } = render(
+      createElement(VisualizationActionIframe, {
+        agentConfigurationId: null,
+        canInvokeFunctions: true,
+        conversationId: null,
+        frameId: "fil_frame",
+        scopedUserIdentity,
+        viewer: null,
+        visualization: {
+          code: "export default function Frame() {}",
+          complete: true,
+          identifier: "viz-fil_frame",
+        },
+        vizUrl: "https://viz.dust.tt",
+        workspaceId: "w_current",
+      })
+    );
+    const iframe = container.querySelector("iframe");
+    if (!iframe?.contentWindow) {
+      throw new Error("Expected the visualization iframe to be mounted.");
+    }
+    vi.spyOn(iframe.contentWindow, "postMessage").mockImplementation(() => {});
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframe.contentWindow,
+        data: {
+          command: "callFunction",
+          identifier: "viz-fil_frame",
+          messageUniqueId: "message-1",
+          params: { functionIdOrSlug: "list-comments" },
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(mocks.clientFetch).toHaveBeenCalledWith(
+        "/api/w/w_current/sandbox-functions/fil_frame%2Flist-comments/invocations",
+        expect.objectContaining({ method: "POST" })
+      );
     });
   });
 });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -10,11 +10,9 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
-import {
-  podFunctionScopeFromFramePath,
-  resolvePodFunctionReference,
-} from "@app/types/api/pod_function_reference";
+import type { FrameFunctionReferenceScope } from "@app/types/api/frame_function_reference";
+import { resolveFrameFunctionReference } from "@app/types/api/frame_function_reference";
+import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
@@ -398,7 +396,7 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
-  podFunctionScope,
+  functionReferenceScope,
   setCodeDrawerOpened,
   setContentHeight,
   setErrorMessage,
@@ -416,7 +414,7 @@ function useVisualizationDataHandler({
     Result<PostSandboxFunctionInvocationResponseBody, SandboxFunctionCallError>
   >;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
-  podFunctionScope: PodFunctionScope | null;
+  functionReferenceScope: FrameFunctionReferenceScope;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
   setContentHeight: (v: SetStateAction<number>) => void;
@@ -486,11 +484,11 @@ function useVisualizationDataHandler({
 
       switch (data.command) {
         case "callFunction": {
-          // A Frame in an app folder may name its own functions by bare slug; qualify it here, the
-          // only layer that both knows which Frame is calling and is trusted about it.
-          const referenceRes = resolvePodFunctionReference(
+          // Qualify bare function names in the trusted host. Frames v2 bind to stable identity;
+          // legacy Frames keep their existing Pod app-folder resolution.
+          const referenceRes = resolveFrameFunctionReference(
             data.params.functionIdOrSlug,
-            podFunctionScope
+            functionReferenceScope
           );
           if (referenceRes.isErr()) {
             sendErrorToIframe(
@@ -613,7 +611,7 @@ function useVisualizationDataHandler({
     downloadFileFromBlob,
     getFileBlob,
     onEditText,
-    podFunctionScope,
+    functionReferenceScope,
     setContentHeight,
     setErrorMessage,
     setCodeDrawerOpened,
@@ -666,6 +664,8 @@ export interface VisualizationActionIframeProps {
    * bare name; without it, relative references are refused.
    */
   framePath?: string | null;
+  /** Stable identity of a Frames v2 resource. Omit for legacy Frames and raw visualizations. */
+  frameId?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
@@ -695,6 +695,13 @@ export const VisualizationActionIframe = forwardRef<
   const podFunctionScope = useMemo(
     () => podFunctionScopeFromFramePath(props.framePath),
     [props.framePath]
+  );
+  const functionReferenceScope = useMemo<FrameFunctionReferenceScope>(
+    () =>
+      props.frameId
+        ? { kind: "v2", frameId: props.frameId }
+        : { kind: "legacy", podFunctionScope },
+    [podFunctionScope, props.frameId]
   );
 
   // In-flight sandbox function invocations. Each entry mounts a
@@ -937,7 +944,7 @@ export const VisualizationActionIframe = forwardRef<
     createSandboxFunctionInvocation,
     getFileBlob,
     onEditText,
-    podFunctionScope,
+    functionReferenceScope,
     setCodeDrawerOpened,
     setContentHeight,
     setErrorMessage,

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -485,6 +485,7 @@ export function FrameRenderer({
               conversationId={conversation?.sId ?? null}
               spaceId={frameSpaceId ?? undefined}
               framePath={framePath}
+              frameId={renderMode === "v2" ? fileId : undefined}
               isInDrawer={true}
               isEditable={renderMode === "legacy"}
               onEditText={renderMode === "legacy" ? handleEditText : undefined}

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   iframeProps: null as {
     canInvokeFunctions: boolean;
+    frameId?: string;
     scopedUserIdentity?: ScopedWorkspaceUserIdentity;
     viewer: unknown;
   } | null,
@@ -25,6 +26,7 @@ vi.mock(
   () => ({
     VisualizationActionIframe: (props: {
       canInvokeFunctions: boolean;
+      frameId?: string;
       scopedUserIdentity?: ScopedWorkspaceUserIdentity;
       viewer: unknown;
     }) => {
@@ -144,7 +146,8 @@ describe("PublicFrameRenderer", () => {
 
     render(
       createElement(PublicFrameRenderer, {
-        fileId: "file_123",
+        fileId: "fil_frame",
+        frameId: "fil_frame",
         hideHeader: true,
         shareToken: "share-token",
         workspaceId: "w_current",
@@ -154,6 +157,7 @@ describe("PublicFrameRenderer", () => {
 
     expect(mocks.iframeProps).toMatchObject({
       canInvokeFunctions: true,
+      frameId: "fil_frame",
       scopedUserIdentity: {
         workspaceId: "w_current",
         isPodMember: true,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -16,6 +16,7 @@ import { useCookies } from "react-cookie";
 
 interface PublicFrameRendererProps {
   fileId: string;
+  frameId?: string;
   fileName?: string;
   hideHeader?: boolean;
   logoUrl?: string | null;
@@ -62,6 +63,7 @@ export function getPublicFrameUserIdentity(
 
 export function PublicFrameRenderer({
   fileId,
+  frameId,
   fileName,
   hideHeader = false,
   logoUrl,
@@ -161,6 +163,7 @@ export function PublicFrameRenderer({
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
             framePath={framePath}
+            frameId={frameId}
             isInDrawer
           />
         </div>

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.test.ts
@@ -1,0 +1,81 @@
+import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  frameMetadata: {
+    contentType: string;
+    fileName: string;
+    sId: string;
+  };
+  rendererProps: { fileId: string; frameId?: string } | null;
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  frameMetadata: {
+    contentType: "application/vnd.dust.frame.v2+json",
+    fileName: "app.frame.json",
+    sId: "fil_frame",
+  },
+  rendererProps: null,
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/PublicFrameRenderer",
+  () => ({
+    PublicFrameRenderer: (props: { fileId: string; frameId?: string }) => {
+      mocks.rendererProps = props;
+      return "public-frame-renderer";
+    },
+  })
+);
+
+vi.mock("@app/lib/swr/frames", () => ({
+  usePublicFrame: () => ({
+    error: null,
+    frameMetadata: mocks.frameMetadata,
+    isFrameLoading: false,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.frameMetadata = {
+    contentType: frameV2ContentType,
+    fileName: "app.frame.json",
+    sId: "fil_frame",
+  };
+  mocks.rendererProps = null;
+});
+
+describe("PublicInteractiveContentContainer", () => {
+  it("passes the stable identity only for Frames v2", () => {
+    const props = {
+      shareToken: "share-token",
+      workspaceId: "w_current",
+      vizUrl: "https://viz.dust.tt",
+    };
+    const { rerender } = render(
+      createElement(PublicInteractiveContentContainer, props)
+    );
+
+    expect(mocks.rendererProps).toMatchObject({
+      fileId: "fil_frame",
+      frameId: "fil_frame",
+    });
+
+    mocks.frameMetadata = {
+      contentType: frameContentType,
+      fileName: "legacy.tsx",
+      sId: "fil_legacy",
+    };
+    rerender(createElement(PublicInteractiveContentContainer, props));
+
+    expect(mocks.rendererProps).toEqual(
+      expect.objectContaining({ fileId: "fil_legacy" })
+    );
+    expect(mocks.rendererProps?.frameId).toBeUndefined();
+  });
+});

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -56,6 +56,11 @@ export function PublicInteractiveContentContainer({
         return (
           <PublicFrameRenderer
             fileId={frameMetadata.sId}
+            frameId={
+              frameMetadata.contentType === frameV2ContentType
+                ? frameMetadata.sId
+                : undefined
+            }
             fileName={frameMetadata.fileName}
             shareToken={shareToken}
             workspaceId={workspaceId}

--- a/front/components/pod/PodFrameTabContent.test.ts
+++ b/front/components/pod/PodFrameTabContent.test.ts
@@ -1,0 +1,99 @@
+import { PodFrameTabContent } from "@app/components/pod/PodFrameTabContent";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import type { RichSpaceType } from "@app/types/api/spaces";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
+import { cleanup, render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  functionReferenceKind: "legacy" | "v2" | null;
+  visualizationProps: { frameId?: string } | null;
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  functionReferenceKind: "v2",
+  visualizationProps: null,
+}));
+
+vi.mock("@app/components/pod/PodFrameVisualization", () => ({
+  PodFrameVisualization: (props: { frameId?: string }) => {
+    mocks.visualizationProps = props;
+    return "pod-frame-visualization";
+  },
+}));
+
+vi.mock("@app/hooks/usePodFrameRenderableContent", () => ({
+  usePodFrameRenderableContent: () => ({
+    fileContent: "frame bundle",
+    fileId: "fil_frame",
+    functionReferenceKind: mocks.functionReferenceKind,
+    isLoading: false,
+    isNotFound: false,
+  }),
+}));
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({ vizUrl: "https://viz.dust.tt" }),
+}));
+
+const owner = LightWorkspaceFactory.build();
+const podInfo = {
+  archivedAt: null,
+  canRead: true,
+  canWrite: true,
+  categories: {},
+  createdAt: 0,
+  description: null,
+  frameTabs: [],
+  groupIds: [],
+  isAdminControlled: false,
+  isEditor: true,
+  isMember: true,
+  isRestricted: false,
+  kind: "project",
+  lastTodoAnalysisAt: null,
+  managementMode: "manual",
+  members: [],
+  name: "Project",
+  pinnedFramePath: null,
+  sId: "vlt_project",
+  tabsOrder: [],
+  todoGenerationEnabled: false,
+  updatedAt: 0,
+} satisfies RichSpaceType;
+const tab = {
+  icon: DEFAULT_POD_FRAME_TAB_ICON,
+  path: "pod-vlt_project/App/App.tsx",
+  title: "App",
+} satisfies PodFrameTab;
+
+afterEach(() => {
+  cleanup();
+  mocks.functionReferenceKind = "v2";
+  mocks.visualizationProps = null;
+});
+
+describe("PodFrameTabContent", () => {
+  it("passes the stable identity only for a Frames v2 tab", () => {
+    const props = { owner, podInfo, tab };
+    const { rerender } = render(createElement(PodFrameTabContent, props));
+
+    expect(mocks.visualizationProps?.frameId).toBe("fil_frame");
+
+    mocks.functionReferenceKind = "legacy";
+    rerender(createElement(PodFrameTabContent, props));
+
+    expect(mocks.visualizationProps?.frameId).toBeUndefined();
+  });
+
+  it("fails closed when the path metadata is not a known Frame", () => {
+    mocks.functionReferenceKind = null;
+
+    render(createElement(PodFrameTabContent, { owner, podInfo, tab }));
+
+    expect(screen.getByText(/no longer available/i)).not.toBeNull();
+    expect(mocks.visualizationProps).toBeNull();
+  });
+});

--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -18,7 +18,7 @@ export function PodFrameTabContent({
   tab,
 }: PodFrameTabContentProps) {
   const { vizUrl } = useAuth();
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, functionReferenceKind, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: tab.path,
@@ -32,7 +32,13 @@ export function PodFrameTabContent({
     );
   }
 
-  if (isNotFound || !fileId || !fileContent || !vizUrl) {
+  if (
+    isNotFound ||
+    !fileId ||
+    !fileContent ||
+    !functionReferenceKind ||
+    !vizUrl
+  ) {
     return (
       <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
         This frame is no longer available in the Pod files.
@@ -49,6 +55,7 @@ export function PodFrameTabContent({
           fileContent={fileContent}
           vizUrl={vizUrl}
           identifier={`viz-frame-tab-${fileId}`}
+          frameId={functionReferenceKind === "v2" ? fileId : undefined}
           isPodEditor={podInfo.isEditor}
           isPodMember={podInfo.isMember}
           framePath={tab.path}

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -8,6 +8,7 @@ interface PodFrameVisualizationProps {
   fileContent: string;
   vizUrl: string;
   identifier: string;
+  frameId?: string;
   isPodEditor?: boolean;
   isPodMember?: boolean;
   /** Scoped path of the Frame, so one inside an app folder can call its functions by bare name. */
@@ -24,6 +25,7 @@ export function PodFrameVisualization({
   fileContent,
   vizUrl,
   identifier,
+  frameId,
   isPodEditor,
   isPodMember,
   framePath,
@@ -43,6 +45,7 @@ export function PodFrameVisualization({
       conversationId={null}
       spaceId={spaceId}
       framePath={framePath}
+      frameId={frameId}
       isInDrawer={true}
       isPodEditor={isPodEditor}
       isPodMember={isPodMember}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -143,7 +143,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     isEditor: podInfo.isEditor,
   });
 
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, functionReferenceKind, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: pinnedFramePath,
@@ -192,7 +192,13 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     );
   }
 
-  if (isNotFound || !fileId || !fileContent || !vizUrl) {
+  if (
+    isNotFound ||
+    !fileId ||
+    !fileContent ||
+    !functionReferenceKind ||
+    !vizUrl
+  ) {
     return null;
   }
 
@@ -202,6 +208,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     fileContent,
     vizUrl,
     identifier: `viz-banner-${fileId}`,
+    frameId: functionReferenceKind === "v2" ? fileId : undefined,
     isPodEditor: podInfo.isEditor,
     isPodMember: podInfo.isMember,
     framePath: pinnedFramePath,

--- a/front/components/pod/files/PodFrameSheet.test.ts
+++ b/front/components/pod/files/PodFrameSheet.test.ts
@@ -1,0 +1,131 @@
+import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { cleanup, render } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  iframeProps: { frameId?: string } | null;
+  metadataCalls: { disabled?: boolean; fileId: string | null }[];
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  iframeProps: null,
+  metadataCalls: [],
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe",
+  async () => {
+    const { forwardRef } = await import("react");
+    return {
+      AuthenticatedVisualizationActionIframe: forwardRef<
+        HTMLIFrameElement,
+        { frameId?: string }
+      >(function AuthenticatedVisualizationActionIframe(props, _ref) {
+        mocks.iframeProps = props;
+        return "frame-iframe";
+      }),
+    };
+  }
+);
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/ExportContentDropdown",
+  () => ({ ExportContentDropdown: () => null })
+);
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet",
+  () => ({ ShareFrameSheet: () => null })
+);
+
+vi.mock("@app/components/pod/files/PinPodBannerButton", () => ({
+  PinPodBannerButton: () => null,
+}));
+
+vi.mock("@app/components/pod/files/PodFrameTabButton", () => ({
+  PodFrameTabButton: () => null,
+}));
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({ vizUrl: "https://viz.dust.tt" }),
+  useFeatureFlags: () => ({ hasFeature: () => false }),
+}));
+
+vi.mock("@app/lib/swr/files", () => ({
+  useFileContent: () => ({ fileContent: "frame bundle" }),
+  useFileMetadata: (args: { disabled?: boolean; fileId: string | null }) => {
+    mocks.metadataCalls.push(args);
+    return {
+      fileMetadata: {
+        contentType: "application/vnd.dust.frame.v2+json",
+        fileName: "app.frame.json",
+        useCaseMetadata: { spaceId: "vlt_project" },
+      },
+      isFileMetadataError: null,
+      isFileMetadataLoading: false,
+    };
+  },
+}));
+
+vi.mock("@dust-tt/sparkle", async () => {
+  const { createElement } = await import("react");
+  const Container = ({ children }: PropsWithChildren) =>
+    createElement("div", null, children);
+  const Sheet = ({ children, open }: PropsWithChildren<{ open?: boolean }>) =>
+    open ? createElement("div", null, children) : null;
+  const Empty = () => null;
+
+  return {
+    Button: Empty,
+    Maximize01: Empty,
+    Minimize01: Empty,
+    Sheet,
+    SheetClose: Container,
+    SheetContent: Container,
+    SheetHeader: Container,
+    SheetTitle: Container,
+    Spinner: Empty,
+    XClose: Empty,
+    cn: (...classes: Array<string | false | null | undefined>) =>
+      classes.filter(Boolean).join(" "),
+  };
+});
+
+const owner = LightWorkspaceFactory.build();
+
+afterEach(() => {
+  cleanup();
+  mocks.iframeProps = null;
+  mocks.metadataCalls = [];
+});
+
+describe("PodFrameSheet", () => {
+  it("loads metadata only while open and forwards the Frames v2 identity", () => {
+    const props = {
+      fileId: "fil_frame",
+      fileName: "app.frame.json",
+      framePath: "pod-vlt_project/App/app.frame.json",
+      frameTabs: [],
+      isArchived: false,
+      isEditor: true,
+      isMember: true,
+      isOpen: false,
+      onClose: vi.fn(),
+      owner,
+      pinnedFramePath: null,
+      podId: "vlt_project",
+    };
+    const { rerender } = render(createElement(PodFrameSheet, props));
+
+    expect(mocks.metadataCalls.at(-1)).toMatchObject({ disabled: true });
+    expect(mocks.iframeProps).toBeNull();
+
+    rerender(createElement(PodFrameSheet, { ...props, isOpen: true }));
+
+    expect(mocks.metadataCalls.at(-1)).toMatchObject({ disabled: false });
+    expect(mocks.iframeProps?.frameId).toBe("fil_frame");
+  });
+});

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -5,6 +5,7 @@ import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton
 import { PodFrameTabButton } from "@app/components/pod/files/PodFrameTabButton";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -65,10 +66,15 @@ export function PodFrameSheet({
     config: { disabled: !isOpen || !fileId },
   });
 
-  const { fileMetadata, isFileMetadataLoading } = useFileMetadata({
-    fileId,
-    owner,
-  });
+  const { fileMetadata, isFileMetadataLoading, isFileMetadataError } =
+    useFileMetadata({
+      fileId,
+      owner,
+      disabled: !isOpen || !fileId,
+    });
+  const functionReferenceKind = getFrameFunctionReferenceKind(
+    fileMetadata?.contentType
+  );
 
   useEffect(() => {
     if (!isOpen) {
@@ -141,7 +147,15 @@ export function PodFrameSheet({
           </div>
         </SheetHeader>
         <div className="flex-1 overflow-hidden">
-          {isFileMetadataLoading || !fileContent ? (
+          {isFileMetadataLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : isFileMetadataError || !fileMetadata || !functionReferenceKind ? (
+            <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+              This frame is no longer available in the Pod files.
+            </div>
+          ) : !fileContent ? (
             <div className="flex h-full items-center justify-center">
               <Spinner />
             </div>
@@ -164,6 +178,7 @@ export function PodFrameSheet({
                 conversationId={null}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 framePath={framePath}
+                frameId={functionReferenceKind === "v2" ? fileId : undefined}
                 isInDrawer={true}
                 isPodEditor={isEditor}
                 isPodMember={isMember}

--- a/front/hooks/usePodFrameRenderableContent.test.ts
+++ b/front/hooks/usePodFrameRenderableContent.test.ts
@@ -1,0 +1,53 @@
+import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  fileContentType: string | null;
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  fileContentType: "application/vnd.dust.frame.v2+json",
+}));
+
+vi.mock("@app/lib/swr/files", () => ({
+  useFileContent: () => ({
+    error: null,
+    fileContent: "frame bundle",
+    isFileContentLoading: false,
+  }),
+  useFileIdFromPath: () => ({
+    fileContentType: mocks.fileContentType,
+    fileId: "fil_frame",
+    fileIdError: null,
+    isFileIdLoading: false,
+    isFileIdNotFound: false,
+  }),
+}));
+
+const owner = LightWorkspaceFactory.build();
+
+afterEach(() => {
+  mocks.fileContentType = frameV2ContentType;
+});
+
+describe("usePodFrameRenderableContent", () => {
+  it.each([
+    [frameV2ContentType, "v2"],
+    [frameContentType, "legacy"],
+    ["text/plain", null],
+  ])("classifies %s from the linked FileResource header", (contentType, kind) => {
+    mocks.fileContentType = contentType;
+
+    const { result } = renderHook(() =>
+      usePodFrameRenderableContent({
+        owner,
+        framePath: "pod-vlt_project/App/App.tsx",
+      })
+    );
+
+    expect(result.current.functionReferenceKind).toBe(kind);
+  });
+});

--- a/front/hooks/usePodFrameRenderableContent.ts
+++ b/front/hooks/usePodFrameRenderableContent.ts
@@ -1,4 +1,5 @@
 import { useFileContent, useFileIdFromPath } from "@app/lib/swr/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -20,12 +21,17 @@ export function usePodFrameRenderableContent({
 }) {
   const isDisabled = disabled || !framePath;
 
-  const { fileId, isFileIdLoading, isFileIdNotFound, fileIdError } =
-    useFileIdFromPath({
-      owner,
-      filePath: framePath,
-      disabled: isDisabled,
-    });
+  const {
+    fileId,
+    fileContentType,
+    isFileIdLoading,
+    isFileIdNotFound,
+    fileIdError,
+  } = useFileIdFromPath({
+    owner,
+    filePath: framePath,
+    disabled: isDisabled,
+  });
 
   const {
     fileContent,
@@ -36,10 +42,10 @@ export function usePodFrameRenderableContent({
     owner,
     config: { disabled: isDisabled || !fileId },
   });
-
   return {
     fileId,
     fileContent: fileContent ?? null,
+    functionReferenceKind: getFrameFunctionReferenceKind(fileContentType),
     isLoading:
       !isDisabled && (isFileIdLoading || (!!fileId && isFileContentLoading)),
     isNotFound: isFileIdNotFound,

--- a/front/lib/swr/files.test.ts
+++ b/front/lib/swr/files.test.ts
@@ -1,9 +1,14 @@
 import {
+  fetchFileHeadMetadataFromPath,
   fetchFileIdFromPath,
   getFilePathContentApiPath,
 } from "@app/lib/swr/files";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+  frameV2ContentType,
+} from "@app/types/files";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClientFetch = vi.fn();
@@ -27,13 +32,42 @@ describe("file path API", () => {
   });
 });
 
-describe("fetchFileIdFromPath", () => {
-  it("fetches the linked file id with HEAD", async () => {
+describe("file path HEAD metadata", () => {
+  it("fetches linked file metadata with HEAD", async () => {
     mockClientFetch.mockResolvedValue(
       new Response(null, {
         status: 200,
         headers: {
+          [DUST_FILE_CONTENT_TYPE_HEADER]: frameV2ContentType,
           [DUST_FILE_ID_HEADER]: "fil_frame",
+          "Content-Type": "text/plain",
+        },
+      })
+    );
+
+    await expect(
+      fetchFileHeadMetadataFromPath({
+        owner,
+        filePath: "conversation-c1/frame.tsx",
+      })
+    ).resolves.toEqual({
+      fileId: "fil_frame",
+      contentType: frameV2ContentType,
+    });
+    expect(mockClientFetch).toHaveBeenCalledWith(
+      "/api/w/w_test_ws/files/path/conversation-c1/frame.tsx?metadata=1",
+      { method: "HEAD" }
+    );
+  });
+
+  it("keeps the file-id-only helper backward compatible", async () => {
+    mockClientFetch.mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: {
+          [DUST_FILE_CONTENT_TYPE_HEADER]: frameV2ContentType,
+          [DUST_FILE_ID_HEADER]: "fil_frame",
+          "Content-Type": "text/plain",
         },
       })
     );
@@ -44,10 +78,6 @@ describe("fetchFileIdFromPath", () => {
         filePath: "conversation-c1/frame.tsx",
       })
     ).resolves.toBe("fil_frame");
-    expect(mockClientFetch).toHaveBeenCalledWith(
-      "/api/w/w_test_ws/files/path/conversation-c1/frame.tsx?metadata=1",
-      { method: "HEAD" }
-    );
   });
 
   it("returns null for a missing path", async () => {

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -20,7 +20,10 @@ import type {
   FileTypeWithMetadata,
   SharingGrantType,
 } from "@app/types/files";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+} from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -72,13 +75,18 @@ function getFilePathMetadataApiPath(
   return `${getFilePathContentApiPath(owner, canonicalPath)}?metadata=1`;
 }
 
-export async function fetchFileIdFromPath({
+export interface FilePathHeadMetadata {
+  fileId: string | null;
+  contentType: string | null;
+}
+
+export async function fetchFileHeadMetadataFromPath({
   owner,
   filePath,
 }: {
   owner: LightWorkspaceType;
   filePath: string;
-}): Promise<string | null> {
+}): Promise<FilePathHeadMetadata | null> {
   const response = await clientFetch(
     getFilePathMetadataApiPath(owner, filePath),
     { method: "HEAD" }
@@ -90,13 +98,27 @@ export async function fetchFileIdFromPath({
     throw new Error(`Failed to fetch file metadata (HTTP ${response.status}).`);
   }
 
-  return response.headers.get(DUST_FILE_ID_HEADER);
+  return {
+    fileId: response.headers.get(DUST_FILE_ID_HEADER),
+    contentType: response.headers.get(DUST_FILE_CONTENT_TYPE_HEADER),
+  };
+}
+
+export async function fetchFileIdFromPath({
+  owner,
+  filePath,
+}: {
+  owner: LightWorkspaceType;
+  filePath: string;
+}): Promise<string | null> {
+  const metadata = await fetchFileHeadMetadataFromPath({ owner, filePath });
+  return metadata?.fileId ?? null;
 }
 
 /**
- * Resolve the FileResource sId linked to a canonical scoped path.
- * Returns null when the path exists but has no linked FileResource, or when
- * the path is not found.
+ * Resolve the FileResource sId and content type linked to a canonical scoped path.
+ * The id is null when the path exists but has no linked FileResource, or when
+ * the path is not found; callers can use `isFileIdNotFound` to distinguish loading.
  */
 export function useFileIdFromPath({
   owner,
@@ -111,15 +133,15 @@ export function useFileIdFromPath({
   const swrKey =
     disabled || path === null
       ? null
-      : (`file-id-from-path:${owner.sId}:${path}` as const);
+      : (`file-head-metadata-from-path:${owner.sId}:${path}` as const);
 
   const { data, error } = useSWRWithDefaults(
     swrKey,
-    async (): Promise<string | null> => {
+    async (): Promise<FilePathHeadMetadata | null> => {
       if (path === null) {
         return null;
       }
-      return fetchFileIdFromPath({ owner, filePath: path });
+      return fetchFileHeadMetadataFromPath({ owner, filePath: path });
     },
     { disabled: swrKey === null }
   );
@@ -127,9 +149,11 @@ export function useFileIdFromPath({
   const isLoading = swrKey !== null && !error && data === undefined;
 
   return {
-    fileId: data ?? null,
+    fileId: data?.fileId ?? null,
+    fileContentType: data?.contentType ?? null,
     isFileIdLoading: isLoading,
-    isFileIdNotFound: swrKey !== null && !isLoading && data === null,
+    isFileIdNotFound:
+      swrKey !== null && !isLoading && (data === null || data?.fileId === null),
     fileIdError: error ? normalizeError(error) : null,
   };
 }
@@ -380,29 +404,33 @@ export function useFileMetadata({
   fileId,
   owner,
   cacheKey,
+  disabled = false,
 }: {
   fileId: string | null;
   owner: LightWorkspaceType;
   cacheKey?: string | null;
+  disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const fileMetadataFetcher: Fetcher<FileTypeWithMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
-  const swrKey = fileId
-    ? cacheKey
-      ? `/api/w/${owner.sId}/files/${fileId}/metadata?v=${cacheKey}`
-      : `/api/w/${owner.sId}/files/${fileId}/metadata`
-    : null;
+  const swrKey =
+    !disabled && fileId
+      ? cacheKey
+        ? `/api/w/${owner.sId}/files/${fileId}/metadata?v=${cacheKey}`
+        : `/api/w/${owner.sId}/files/${fileId}/metadata`
+      : null;
 
   const { data, error, mutateRegardlessOfQueryParams } = useSWRWithDefaults(
     swrKey,
-    fileMetadataFetcher
+    fileMetadataFetcher,
+    { disabled: swrKey === null }
   );
 
   return {
     fileMetadata: data,
-    isFileMetadataLoading: !error && !data,
+    isFileMetadataLoading: swrKey !== null && !error && !data,
     isFileMetadataError: error,
     mutateFileMetadata: mutateRegardlessOfQueryParams,
   };

--- a/front/types/api/frame_function_reference.test.ts
+++ b/front/types/api/frame_function_reference.test.ts
@@ -1,0 +1,59 @@
+import {
+  getFrameFunctionReferenceKind,
+  resolveFrameFunctionReference,
+} from "@app/types/api/frame_function_reference";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+describe("resolveFrameFunctionReference", () => {
+  it("qualifies a Frames v2 function with the stable Frame identity", () => {
+    const result = resolveFrameFunctionReference("list-comments", {
+      kind: "v2",
+      frameId: "file_123",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe("file_123/list-comments");
+  });
+
+  it("rejects cross-Frame references from Frames v2", () => {
+    const result = resolveFrameFunctionReference("file_other/list-comments", {
+      kind: "v2",
+      frameId: "file_123",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("keeps legacy Pod-relative resolution unchanged", () => {
+    const result = resolveFrameFunctionReference("list-comments", {
+      kind: "legacy",
+      podFunctionScope: { podId: "pod_123", appPrefix: "comments" },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe(
+      "pod_123/comments__list-comments"
+    );
+  });
+});
+
+describe("getFrameFunctionReferenceKind", () => {
+  it("classifies only known Frame MIME types", () => {
+    expect(getFrameFunctionReferenceKind(frameV2ContentType)).toBe("v2");
+    expect(getFrameFunctionReferenceKind(frameContentType)).toBe("legacy");
+    expect(getFrameFunctionReferenceKind(frameSlideshowContentType)).toBe(
+      "legacy"
+    );
+  });
+
+  it("does not treat absent or unknown metadata as legacy", () => {
+    expect(getFrameFunctionReferenceKind(null)).toBeNull();
+    expect(getFrameFunctionReferenceKind(undefined)).toBeNull();
+    expect(getFrameFunctionReferenceKind("text/plain")).toBeNull();
+  });
+});

--- a/front/types/api/frame_function_reference.ts
+++ b/front/types/api/frame_function_reference.ts
@@ -1,0 +1,50 @@
+import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
+import {
+  isRelativePodFunctionReference,
+  resolvePodFunctionReference,
+} from "@app/types/api/pod_function_reference";
+import { frameV2ContentType, isInteractiveContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type FrameFunctionReferenceScope =
+  | { kind: "v2"; frameId: string }
+  | { kind: "legacy"; podFunctionScope: PodFunctionScope | null };
+
+export type FrameFunctionReferenceKind = FrameFunctionReferenceScope["kind"];
+
+/** Classify only known Frame MIME types. Missing metadata must never imply a legacy Frame. */
+export function getFrameFunctionReferenceKind(
+  contentType: string | null | undefined
+): FrameFunctionReferenceKind | null {
+  if (contentType === frameV2ContentType) {
+    return "v2";
+  }
+  if (contentType && isInteractiveContentType(contentType)) {
+    return "legacy";
+  }
+  return null;
+}
+
+/** Resolve the function reference emitted by a Frame against that Frame's trusted host identity. */
+export function resolveFrameFunctionReference(
+  reference: string,
+  scope: FrameFunctionReferenceScope
+): Result<string, Error> {
+  switch (scope.kind) {
+    case "v2":
+      if (!isRelativePodFunctionReference(reference)) {
+        return new Err(
+          new Error(
+            `'${reference}' is not a Frames v2 function name: expected a bare manifest function name.`
+          )
+        );
+      }
+      return new Ok(`${scope.frameId}/${reference}`);
+    case "legacy":
+      return resolvePodFunctionReference(reference, scope.podFunctionScope);
+    default:
+      return assertNever(scope);
+  }
+}

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -10,6 +10,7 @@ const uniq = <T>(arr: T[]): T[] => Array.from(new Set(arr));
 
 export const TABLE_PREFIX = "TABLE:";
 export const DUST_FILE_ID_HEADER = "X-Dust-File-Id";
+export const DUST_FILE_CONTENT_TYPE_HEADER = "X-Dust-File-Content-Type";
 
 export type FileStatus = "created" | "failed" | "ready";
 


### PR DESCRIPTION
## Description

Route Frames v2 `callFunction` messages through the stable Frame identity and active publication. Keep the existing Pod-relative resolver for legacy Frames and Pod Functions, and fail closed when a Pod-hosted Frame cannot be classified from trusted metadata.

Reuse the existing path HEAD response for the linked FileResource id and MIME type, avoiding a second metadata request for Pod tabs and pinned banners. The raw mounted object keeps its standard `Content-Type`; the linked FileResource MIME is returned through an explicit CORS-exposed Dust header. Metadata loading stays disabled while the Pod Frame sheet is closed.

Based directly on `main`.

No visual changes.

## Tests

- focused Front Vitest: 9 files / 36 tests passed
- focused Front API Vitest: 2 files / 29 tests passed
- `npx tsgo --noEmit` in `front`
- `npx tsgo --noEmit` in `front-api`
- `npm run format:changed`
- `git diff --check`
- Storybook MCP was unavailable in this session; no Sparkle properties changed

## Risk

Low and feature-gated. Frames v2 receive an identity-qualified reference; legacy Frames, raw visualizations, and Pod Functions retain their existing reference resolution. Unknown Pod Frame metadata fails closed. The new response header is additive and raw `Content-Type` behavior is preserved. Rollback is reverting this PR.

## Deploy Plan

Deploy normally. No migration or backfill.
