### PR TITLE
Delete Frames v2 packages

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9199,7 +9199,7 @@
       },
       "delete": {
         "summary": "Delete a file",
-        "description": "Delete a file from the workspace. Files referenced by a skill or its version history cannot be deleted.",
+        "description": "Delete a file from the workspace. Frames v2 are deleted with their source package and owned runtime data. Files referenced by a skill or its version history cannot be deleted.",
         "tags": [
           "Private Files"
         ],

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -8,8 +9,13 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import {
+  getFrameBasePath,
+  getFramePublicationUiBundlePath,
+} from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -340,6 +346,99 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     });
 
     expect(response.status).toBe(204);
+  });
+
+  it("deletes a Frames v2 package and keeps the generic 204 response", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "manager",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+    })}Status`;
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 128,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    await frame.markFrameV2AsReadyFromMount(auth);
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setFileExists((path) => path.endsWith("/"));
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    const response = await honoApp.request(fileUrl(workspace, frame.sId), {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(204);
+    await expect(FileResource.fetchById(auth, frame.sId)).resolves.toBeNull();
+    expect(deletedPrefixes).toContain(`${sourceGcsDirectoryPath}/`);
+    expect(deletedPrefixes).toContain(
+      getFrameBasePath({ workspaceId: workspace.sId, frameId: frame.sId })
+    );
+  });
+
+  it("rejects deleting a Frame package that contains another registered Frame", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "manager",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+    })}Parent`;
+    const parent = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 128,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    await parent.markFrameV2AsReadyFromMount(auth);
+    const child = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 128,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${sourceGcsDirectoryPath}/Child/${FRAME_MANIFEST_FILE}`,
+    });
+    await child.markFrameV2AsReadyFromMount(auth);
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    const response = await honoApp.request(fileUrl(workspace, parent.sId), {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(
+      FileResource.fetchById(auth, parent.sId)
+    ).resolves.not.toBeNull();
+    await expect(
+      FileResource.fetchById(auth, child.sId)
+    ).resolves.not.toBeNull();
+    expect(deletedPrefixes).toEqual([]);
   });
 
   it("should allow file author with admin role to delete upload files", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -1,4 +1,5 @@
 import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { deleteFrameV2FromFile } from "@app/lib/api/frames/delete_from_source";
 import { addFileToProject } from "@app/lib/api/projects/context";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -164,7 +165,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  *         description: File not found
  *   delete:
  *     summary: Delete a file
- *     description: Delete a file from the workspace. Files referenced by a skill or its version history cannot be deleted.
+ *     description: Delete a file from the workspace. Frames v2 are deleted with their source package and owned runtime data. Files referenced by a skill or its version history cannot be deleted.
  *     tags:
  *       - Private Files
  *     parameters:
@@ -327,7 +328,9 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const deleteRes = await file.delete(auth);
+  const deleteRes = file.isFrameV2
+    ? await deleteFrameV2FromFile(auth, { frame: file })
+    : await file.delete(auth);
   if (deleteRes.isErr()) {
     return apiError(ctx, {
       status_code: 400,

--- a/front/admin/audit_log_schemas/frame.deleted.json
+++ b/front/admin/audit_log_schemas/frame.deleted.json
@@ -1,0 +1,14 @@
+{
+  "action": "frame.deleted",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "frame_id": "string",
+    "source_path": "string",
+    "active_publication_id": "string",
+    "source": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.deleted": 1,
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -176,6 +176,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.deleted",
   "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",

--- a/front/lib/api/frames/delete_from_source.ts
+++ b/front/lib/api/frames/delete_from_source.ts
@@ -1,0 +1,206 @@
+import path from "node:path";
+
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { removeFileFromProject } from "@app/lib/api/projects/context";
+import type { Authenticator } from "@app/lib/auth";
+import type { FrameV2SourceDeletion } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+function deletionError(message: string): Err<Error> {
+  return new Err(new Error(message));
+}
+
+async function deleteFrameResource(
+  auth: Authenticator,
+  {
+    deleteFrameSource,
+    frame,
+    manifestPath,
+  }: {
+    deleteFrameSource: FrameV2SourceDeletion;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<Result<void, Error>> {
+  if (frame.useCase !== "project_context") {
+    return frame.delete(auth, { deleteFrameSource });
+  }
+
+  const podId = frame.useCaseMetadata?.spaceId;
+  const pod = podId ? await SpaceResource.fetchById(auth, podId) : null;
+  if (!pod?.isProject()) {
+    return deletionError("Frame source Pod not found.");
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  const result = await removeFileFromProject(auth, {
+    deleteFrameSource: async () => {
+      const sourceResult = await deleteFrameSource();
+      if (sourceResult.isErr()) {
+        return sourceResult;
+      }
+      try {
+        if (metadata) {
+          await metadata.removeFramePath(manifestPath);
+        }
+      } catch (error) {
+        return new Err(normalizeError(error));
+      }
+      return new Ok(undefined);
+    },
+    space: pod,
+    fileId: frame.sId,
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+
+  return new Ok(undefined);
+}
+
+async function deleteFrameV2(
+  auth: Authenticator,
+  {
+    dustFileSystem,
+    frame,
+    sourceDirectoryPath,
+  }: {
+    dustFileSystem: DustFileSystem;
+    frame: FileResource;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<void, Error>> {
+  const sourceDirectory =
+    DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  if (
+    !sourceDirectory ||
+    !sourceDirectory.includes("/") ||
+    path.posix.basename(sourceDirectory) === FRAME_MANIFEST_FILE
+  ) {
+    return deletionError(
+      "Frame deletion requires its source folder under /files."
+    );
+  }
+  const manifestPath = path.posix.join(sourceDirectory, FRAME_MANIFEST_FILE);
+
+  if (!dustFileSystem.isGCSBacked()) {
+    return deletionError(
+      "Frames v2 deletion does not yet support the database-backed filesystem."
+    );
+  }
+  const writeAccess = dustFileSystem.checkWriteAccess(sourceDirectory);
+  if (writeAccess.isErr()) {
+    return new Err(writeAccess.error);
+  }
+  if (!frame.isFrameV2 || frame.toScopedPath(auth) !== manifestPath) {
+    return deletionError(
+      `No registered Frames v2 package found at ${sourceDirectory}.`
+    );
+  }
+
+  const descendantFrames = await FileResource.fetchFrameV2Descendants(
+    auth,
+    frame
+  );
+  if (descendantFrames.length > 0) {
+    return deletionError(
+      "Delete nested Frames before deleting their parent package."
+    );
+  }
+
+  let deletedFrame = frame;
+  const resourceResult = await deleteFrameResource(auth, {
+    frame,
+    manifestPath,
+    deleteFrameSource: async () => {
+      const freshFrame = await FileResource.fetchById(auth, frame.sId);
+      if (
+        !freshFrame?.isFrameV2 ||
+        freshFrame.toScopedPath(auth) !== manifestPath
+      ) {
+        return deletionError(
+          "The Frame source changed while it was being deleted; retry from its current path."
+        );
+      }
+      deletedFrame = freshFrame;
+      return dustFileSystem.delete(sourceDirectory, { ignoreNotFound: true });
+    },
+  });
+  if (resourceResult.isErr()) {
+    return resourceResult;
+  }
+
+  const activePublicationId =
+    deletedFrame.useCaseMetadata?.activePublicationId ?? "";
+  const frameName = path.posix.basename(sourceDirectory);
+  void emitAuditLogEvent({
+    auth,
+    action: "frame.deleted",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("frame", {
+        sId: deletedFrame.sId,
+        name: frameName,
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      active_publication_id: activePublicationId,
+      frame_id: deletedFrame.sId,
+      source: "api",
+      source_path: sourceDirectory,
+    },
+  });
+
+  logger.info(
+    {
+      activePublicationId,
+      frameId: deletedFrame.sId,
+      source: "api",
+      sourceDirectoryPath: sourceDirectory,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    "Deleted Frame v2"
+  );
+
+  return new Ok(undefined);
+}
+
+/** Delete the package owned by a known Frames v2 FileResource. */
+export async function deleteFrameV2FromFile(
+  auth: Authenticator,
+  {
+    frame,
+  }: {
+    frame: FileResource;
+  }
+): Promise<Result<void, Error>> {
+  const manifestPath = frame.toScopedPath(auth);
+  if (!manifestPath) {
+    return deletionError("Frame source path not found.");
+  }
+  const fileSystemResult = await DustFileSystem.fromScopedPath(
+    auth,
+    manifestPath
+  );
+  if (fileSystemResult.isErr()) {
+    return new Err(fileSystemResult.error);
+  }
+  return deleteFrameV2(auth, {
+    dustFileSystem: fileSystemResult.value,
+    frame,
+    sourceDirectoryPath: path.posix.dirname(manifestPath),
+  });
+}

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1019,7 +1019,9 @@ describe("publishFramePublication", () => {
     });
     await activationStarted.promise;
 
-    const deletionPromise = frame.delete(auth);
+    const deletionPromise = frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
     const redisSet = vi.mocked(
       redisMock.streamClient.set as (
         key: string,

--- a/front/lib/api/poke/plugins/files/delete_frame.test.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.test.ts
@@ -5,7 +5,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -81,5 +81,31 @@ describe("deleteFramePlugin", () => {
         },
       })
     );
+  });
+
+  it("leaves Frames v2 deletion to the package-aware flow", async () => {
+    const {
+      authenticator: auth,
+      user,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const frame = await ProjectFileFactory.create(auth, user, pod, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "ready",
+    });
+
+    expect(deleteFramePlugin.isApplicableTo(auth, frame)).toBe(false);
+    const result = await deleteFramePlugin.execute(auth, frame, {
+      confirmation: "DELETE",
+    });
+
+    expect(result.isErr()).toBe(true);
+    await expect(
+      FileResource.fetchById(auth, frame.sId)
+    ).resolves.not.toBeNull();
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/poke/plugins/files/delete_frame.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.ts
@@ -82,7 +82,7 @@ export const deleteFramePlugin = createPlugin({
     requiredRoles: ["engineering", "support"],
   },
   execute: async (auth, file, args) => {
-    if (!file?.isInteractiveContent) {
+    if (!file?.isInteractiveContent || file.isFrameV2) {
       return new Err(new Error("Frame not found."));
     }
     if (args.confirmation !== "DELETE") {
@@ -117,5 +117,6 @@ export const deleteFramePlugin = createPlugin({
       value: `Frame "${frameName}" was permanently deleted.`,
     });
   },
-  isApplicableTo: (auth, file) => file?.isInteractiveContent === true,
+  isApplicableTo: (_auth, file) =>
+    file?.isInteractiveContent === true && !file.isFrameV2,
 });

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -12,6 +12,8 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("removeFileFromProject", () => {
@@ -115,6 +117,138 @@ describe("removeFileFromProject", () => {
     expect(frAfter).toBeTruthy();
     expect(frAfter!.spaceId).toBeNull();
     expect(frAfter!.expiredReason).toBe("file_deleted");
+  });
+
+  it("preserves orphaned and referenced Frame fragments on source failure and cleans them on retry", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 123,
+      status: "ready",
+    });
+    const referenced = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(referenced).toBeTruthy();
+    const orphan = await ContentFragmentModel.create({
+      workspaceId: workspace.id,
+      spaceId: project.id,
+      fileId: file.id,
+      title: "Old Frame fragment",
+      contentType: "text/plain",
+      sourceUrl: null,
+      textBytes: null,
+      userId: user.id,
+      userContextUsername: null,
+      userContextFullName: null,
+      userContextEmail: null,
+      userContextProfilePictureUrl: null,
+      nodeId: null,
+      nodeDataSourceViewId: null,
+      nodeType: null,
+      version: "superseded",
+      expiredReason: null,
+      sId: generateRandomModelSId(),
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 999,
+      conversationId: conversation.id,
+      parentId: null,
+      contentFragmentId: referenced!.id,
+      workspaceId: workspace.id,
+    });
+
+    const failed = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+      deleteFrameSource: async () => new Err(new Error("source unavailable")),
+    });
+    expect(failed.isErr()).toBe(true);
+    await expect(
+      FileModel.findOne({ where: { id: file.id, workspaceId: workspace.id } })
+    ).resolves.not.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: orphan.id, workspaceId: workspace.id },
+      })
+    ).resolves.not.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: referenced!.id, workspaceId: workspace.id },
+      })
+    ).resolves.not.toBeNull();
+
+    const retried = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+      deleteFrameSource: async () => new Ok(undefined),
+    });
+    expect(retried.isOk()).toBe(true);
+    await expect(
+      FileModel.findOne({ where: { id: file.id, workspaceId: workspace.id } })
+    ).resolves.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: orphan.id, workspaceId: workspace.id },
+      })
+    ).resolves.toBeNull();
+    const referencedAfter = await ContentFragmentModel.findOne({
+      where: { id: referenced!.id, workspaceId: workspace.id },
+    });
+    expect(referencedAfter?.spaceId).toBeNull();
+    expect(referencedAfter?.expiredReason).toBe("file_deleted");
+  });
+
+  it("rejects Frames v2 before mutating project fragments without package deletion", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 123,
+      status: "ready",
+    });
+    const fragment = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(fragment).toBeTruthy();
+
+    const result = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    await expect(
+      FileModel.findOne({ where: { id: file.id, workspaceId: workspace.id } })
+    ).resolves.not.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: fragment!.id, workspaceId: workspace.id },
+      })
+    ).resolves.not.toBeNull();
   });
 });
 

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -20,6 +20,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { FrameV2SourceDeletion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -43,6 +44,7 @@ import {
 } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Op } from "sequelize";
 import { z } from "zod";
@@ -513,12 +515,70 @@ export async function addContentNodeToProject(
  * - If some fragments are referenced by messages, we keep them but detach them from the space
  *   and mark them expired so conversation rendering can display an appropriate placeholder.
  */
+async function cleanupProjectFileFragments(
+  auth: Authenticator,
+  {
+    file,
+    space,
+  }: {
+    file: FileResource;
+    space: SpaceResource;
+  }
+): Promise<void> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const projectFragmentModelIds = await ContentFragmentModel.findAll({
+    attributes: ["id"],
+    where: {
+      workspaceId,
+      spaceId: space.id,
+      fileId: file.id,
+    },
+  }).then((rows) => rows.map((r) => r.id));
+  if (projectFragmentModelIds.length === 0) {
+    return;
+  }
+
+  const messagesReferencing = await MessageModel.findAll({
+    attributes: ["contentFragmentId"],
+    where: {
+      workspaceId,
+      contentFragmentId: { [Op.in]: projectFragmentModelIds },
+    },
+  });
+  const referencedModelIds = new Set(
+    removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
+  );
+  const orphanModelIds = projectFragmentModelIds.filter(
+    (id) => !referencedModelIds.has(id)
+  );
+
+  if (orphanModelIds.length > 0) {
+    await ContentFragmentModel.destroy({
+      where: { workspaceId, id: { [Op.in]: orphanModelIds } },
+    });
+  }
+
+  if (referencedModelIds.size > 0) {
+    await ContentFragmentModel.update(
+      { spaceId: null, expiredReason: "file_deleted" },
+      {
+        where: {
+          workspaceId,
+          id: { [Op.in]: Array.from(referencedModelIds) },
+        },
+      }
+    );
+  }
+}
+
 export async function removeFileFromProject(
   auth: Authenticator,
   {
+    deleteFrameSource,
     space,
     fileId,
   }: {
+    deleteFrameSource?: FrameV2SourceDeletion;
     space: SpaceResource;
     fileId: string; // file sId
   }
@@ -528,56 +588,42 @@ export async function removeFileFromProject(
     return new Err(new Error("File not found."));
   }
 
-  // Best-effort cleanup of the project content fragments for this file.
-  const workspaceId = auth.getNonNullableWorkspace().id;
-  const projectFragmentIds = await ContentFragmentModel.findAll({
-    attributes: ["id"],
-    where: {
-      workspaceId,
-      spaceId: space.id,
-      fileId: file.id,
-    },
-  }).then((rows) => rows.map((r) => r.id));
-
-  if (projectFragmentIds.length > 0) {
-    const messagesReferencing = await MessageModel.findAll({
-      attributes: ["contentFragmentId"],
-      where: {
-        workspaceId,
-        contentFragmentId: {
-          [Op.in]: projectFragmentIds,
-        },
-      },
-    });
-
-    const referencedIds = new Set(
-      removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
+  if (file.isFrameV2 && !deleteFrameSource) {
+    return new Err(
+      new Error(
+        "Frames v2 must be deleted through the package-aware Frame deletion flow."
+      )
     );
-    const orphanIds = projectFragmentIds.filter((id) => !referencedIds.has(id));
-
-    if (orphanIds.length > 0) {
-      await ContentFragmentModel.destroy({
-        where: {
-          workspaceId,
-          id: { [Op.in]: orphanIds },
-        },
-      });
-    }
-
-    if (referencedIds.size > 0) {
-      await ContentFragmentModel.update(
-        { spaceId: null, expiredReason: "file_deleted" },
-        {
-          where: {
-            workspaceId,
-            id: { [Op.in]: Array.from(referencedIds) },
-          },
-        }
-      );
-    }
   }
 
-  const deleteRes = await file.delete(auth);
+  const deleteSourceAndFragments: FrameV2SourceDeletion | undefined =
+    deleteFrameSource
+      ? async () => {
+          const sourceResult = await deleteFrameSource();
+          if (sourceResult.isErr()) {
+            return sourceResult;
+          }
+          try {
+            await cleanupProjectFileFragments(auth, {
+              file,
+              space,
+            });
+            return new Ok(undefined);
+          } catch (error) {
+            return new Err(normalizeError(error));
+          }
+        }
+      : undefined;
+
+  // Legacy project files have no separately-owned source package, so preserve their existing
+  // cleanup order. Frames v2 run this only after their retryable source deletion succeeds.
+  if (!deleteFrameSource) {
+    await cleanupProjectFileFragments(auth, { file, space });
+  }
+
+  const deleteRes = await file.delete(auth, {
+    deleteFrameSource: deleteSourceAndFragments,
+  });
   if (deleteRes.isErr()) {
     return new Err(deleteRes.error);
   }

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -31,6 +31,7 @@ import {
   isUnverifiableFrameFileRefsShareError,
   sandboxFunctionContentType,
 } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1780,7 +1781,15 @@ describe("FileResource", () => {
       })
     ).toHaveLength(1);
 
-    const result = await frame.delete(auth);
+    const direct = await frame.delete(auth);
+    expect(direct.isErr() && direct.error.message).toBe(
+      "Frames v2 must be deleted through the package-aware Frame deletion flow."
+    );
+    expect(await FileResource.fetchById(auth, frame.sId)).not.toBeNull();
+
+    const result = await frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
 
     expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
       true

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -124,6 +124,8 @@ import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_mod
 
 export type FileVersion = "processed" | "original" | "public";
 
+export type FrameV2SourceDeletion = () => Promise<Result<void, Error>>;
+
 const FRAME_CONTENT_TYPES = new Set([
   frameContentType,
   frameSlideshowContentType,
@@ -468,6 +470,35 @@ export class FileResource extends BaseResource<FileModel> {
     return files.map((f) => new this(this.model, f.get()));
   }
 
+  static async fetchFrameV2Descendants(
+    auth: Authenticator,
+    parent: FileResource
+  ): Promise<FileResource[]> {
+    if (!parent.mountFilePath) {
+      return [];
+    }
+    const owner = auth.getNonNullableWorkspace();
+    const files = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        contentType: frameV2ContentType,
+        status: "ready",
+      },
+    });
+    const directoryPrefix = parent.mountFilePath.slice(
+      0,
+      parent.mountFilePath.lastIndexOf("/") + 1
+    );
+
+    return files
+      .map((file) => new this(this.model, file.get()))
+      .filter(
+        (file) =>
+          file.id !== parent.id &&
+          file.mountFilePath?.startsWith(directoryPrefix) === true
+      );
+  }
+
   static async deleteAllForWorkspace(auth: Authenticator) {
     const owner = auth.getNonNullableWorkspace();
     const workspaceModelId = owner.id;
@@ -659,18 +690,23 @@ export class FileResource extends BaseResource<FileModel> {
         // Delete mount file copies if set.
         await this.deleteMountFileCopies();
 
-        await this.getBucketForVersion("original")
-          .file(this.getCloudStoragePath(auth, "original"))
-          .delete();
+        // Frames v2 are contentless identities: their source lives at mountFilePath and their
+        // published/runtime data lives under the Frame prefix deleted above. They never own the
+        // canonical original/processed/public FileResource objects.
+        if (!this.isFrameV2) {
+          await this.getBucketForVersion("original")
+            .file(this.getCloudStoragePath(auth, "original"))
+            .delete();
 
-        // Delete the processed file if it exists.
-        await this.getBucketForVersion("processed")
-          .file(this.getCloudStoragePath(auth, "processed"))
-          .delete({ ignoreNotFound: true });
-        // Delete the public file if it exists.
-        await this.getBucketForVersion("public")
-          .file(this.getCloudStoragePath(auth, "public"))
-          .delete({ ignoreNotFound: true });
+          // Delete the processed file if it exists.
+          await this.getBucketForVersion("processed")
+            .file(this.getCloudStoragePath(auth, "processed"))
+            .delete({ ignoreNotFound: true });
+          // Delete the public file if it exists.
+          await this.getBucketForVersion("public")
+            .file(this.getCloudStoragePath(auth, "public"))
+            .delete({ ignoreNotFound: true });
+        }
 
         // Delete sharing grants and access snapshots before shareable file (FK constraint).
         const shareableFile = await FileResource.shareableFileModel.findOne({
@@ -713,16 +749,36 @@ export class FileResource extends BaseResource<FileModel> {
     }
   }
 
-  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+  async delete(
+    auth: Authenticator,
+    {
+      deleteFrameSource,
+    }: {
+      transaction?: Transaction;
+      deleteFrameSource?: FrameV2SourceDeletion;
+    } = {}
+  ): Promise<Result<undefined, Error>> {
     if (!this.isFrameV2) {
       return this.deleteAfterSandboxCleanup(auth);
     }
 
-    return withFramePublishLock(this.sId, () =>
-      FrameSandboxAdapter.deleteSandbox(auth, this, {
+    if (!deleteFrameSource) {
+      return new Err(
+        new Error(
+          "Frames v2 must be deleted through the package-aware Frame deletion flow."
+        )
+      );
+    }
+
+    return withFramePublishLock(this.sId, async () => {
+      const sourceResult = await deleteFrameSource();
+      if (sourceResult.isErr()) {
+        return sourceResult;
+      }
+      return FrameSandboxAdapter.deleteSandbox(auth, this, {
         afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
-      })
-    );
+      });
+    });
   }
 
   get sId(): string {

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -186,7 +186,9 @@ describe("FrameSandboxAdapter", () => {
       deletedPrefixes.push(prefix)
     );
 
-    const deleteResult = await frame.delete(auth);
+    const deleteResult = await frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
 
     expect(
       deleteResult.isOk(),
@@ -266,7 +268,9 @@ describe("FrameSandboxAdapter", () => {
 
     try {
       mockExecuteWithLock.mockClear();
-      const deletionPromise = frame.delete(auth);
+      const deletionPromise = frame.delete(auth, {
+        deleteFrameSource: async () => new Ok(undefined),
+      });
       await deletionReachedFunctionCleanup.promise;
       expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
 


### PR DESCRIPTION
## Description

- Preserve the generic private file DELETE contract: Frames v2 delete their source package, runtime data, sharing records, and identity, then return 204.
- For Pod Frames, delete the source first, then clean project metadata and content fragments before deleting runtime state and identity. Missing source folders are treated as an idempotent retry.
- Reject direct or legacy project deletion before any mutation, and keep the Poke action legacy-only.
- Reject deleting a package that contains another registered Frame, preventing orphaned nested identities.
- Emit `frame.deleted` after successful package deletion.

Scope: 15 files, +671/-69. No dsbx CLI or sandbox endpoint changes.

## Tests

- Generic DELETE coverage for the 204 response and full source/runtime/identity cleanup.
- Pod source-failure and retry coverage for orphaned and referenced fragments.
- Direct-delete, legacy project-delete, nested-package, and Poke guards.
- Existing publication and sandbox deletion regressions.
- Locally: 76 focused Front tests and 90 file-route Front API tests; both typechecks, Biome, Swagger checks, and commit hooks pass.

## Risk

Deletion is irreversible. The flow holds the existing bounded Frame publication lock across source and owned-resource cleanup, and retains the Frame identity when a required cleanup step fails. Large-installation batching and renewable lease checks are intentionally deferred to a separate hardening change.

## Deploy Plan

Register the WorkOS `frame.deleted` schema before deploy. Standard application deploy.