### PR TITLE
Configure Frame use rights through dsbx

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,8 +9,9 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FramePublishRequest, FramePublishResponse,
-    FrameRegisterRequest, FrameRegisterResponse, MCPServerView, SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FrameMoveRequest, FrameMoveResponse, FramePublishRequest,
+    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, MCPServerView,
+    SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -151,6 +152,22 @@ impl DustApiClient {
         self.post(
             "sandbox/frames/register",
             &FrameRegisterRequest { manifest_path },
+        )
+        .await
+    }
+
+    pub async fn move_frame(
+        &self,
+        source_directory_path: &str,
+        destination_directory_path: &str,
+    ) -> anyhow::Result<FrameMoveResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/move",
+            &FrameMoveRequest {
+                source_directory_path,
+                destination_directory_path,
+            },
+            POLL_MAX_DURATION,
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,9 +9,9 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FrameMoveRequest, FrameMoveResponse, FramePublishRequest,
-    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, MCPServerView,
-    SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FrameDeleteRequest, FrameDeleteResponse, FrameMoveRequest,
+    FrameMoveResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
+    FrameRegisterResponse, MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -166,6 +166,20 @@ impl DustApiClient {
             &FrameMoveRequest {
                 source_directory_path,
                 destination_directory_path,
+            },
+            POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn delete_frame(
+        &self,
+        source_directory_path: &str,
+    ) -> anyhow::Result<FrameDeleteResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/delete",
+            &FrameDeleteRequest {
+                source_directory_path,
             },
             POLL_MAX_DURATION,
         )

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -11,7 +11,8 @@ use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, FrameDeleteRequest, FrameDeleteResponse, FrameMoveRequest,
     FrameMoveResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
-    FrameRegisterResponse, MCPServerView, SandboxServerViewsResponse,
+    FrameRegisterResponse, FrameShareRequest, FrameShareResponse, MCPServerView,
+    SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -182,6 +183,23 @@ impl DustApiClient {
                 source_directory_path,
             },
             POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn share_frame(
+        &self,
+        source_directory_path: &str,
+        share_scope: &str,
+        emails: &[String],
+    ) -> anyhow::Result<FrameShareResponse> {
+        self.post(
+            "sandbox/frames/share",
+            &FrameShareRequest {
+                emails,
+                share_scope,
+                source_directory_path,
+            },
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -28,6 +28,14 @@ pub struct FrameDeleteRequest<'a> {
     pub source_directory_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameShareRequest<'a> {
+    pub emails: &'a [String],
+    pub share_scope: &'a str,
+    pub source_directory_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -59,6 +67,16 @@ pub struct FrameMoveResponse {
 #[serde(rename_all = "camelCase")]
 pub struct FrameDeleteResponse {
     pub frame_id: String,
+    pub source_directory_path: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameShareResponse {
+    pub emails: Vec<String>,
+    pub frame_id: String,
+    pub share_scope: String,
+    pub share_url: String,
     pub source_directory_path: String,
 }
 

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -15,6 +15,13 @@ pub struct FrameRegisterRequest<'a> {
     pub manifest_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMoveRequest<'a> {
+    pub source_directory_path: &'a str,
+    pub destination_directory_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -32,6 +39,14 @@ pub struct FrameRegisterResponse {
     pub frame_id: String,
     pub manifest_path: String,
     pub created: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMoveResponse {
+    pub frame_id: String,
+    pub destination_directory_path: String,
+    pub source_deletion_failed: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -22,6 +22,12 @@ pub struct FrameMoveRequest<'a> {
     pub destination_directory_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameDeleteRequest<'a> {
+    pub source_directory_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -47,6 +53,13 @@ pub struct FrameMoveResponse {
     pub frame_id: String,
     pub destination_directory_path: String,
     pub source_deletion_failed: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameDeleteResponse {
+    pub frame_id: String,
+    pub source_directory_path: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/dust-sandbox/src/commands/frame/delete.rs
+++ b/cli/dust-sandbox/src/commands/frame/delete.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_path};
+
+pub async fn run(directory: &Path) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(directory)?;
+    let client = DustApiClient::from_env()?;
+    let response = client.delete_frame(&source_directory_path).await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -3,19 +3,38 @@ mod delete;
 mod move_frame;
 mod publish;
 mod register;
+mod share;
 
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{bail, Context};
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 
 pub use create::run as cmd_frame_create;
 pub use delete::run as cmd_frame_delete;
 pub use move_frame::run as cmd_frame_move;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
+pub use share::run as cmd_frame_share;
 
 const FRAME_MANIFEST_FILE: &str = "manifest.json";
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum FrameShareScope {
+    EmailsOnly,
+    Public,
+    WorkspaceAndEmails,
+}
+
+impl FrameShareScope {
+    fn as_api_value(self) -> &'static str {
+        match self {
+            Self::EmailsOnly => "emails_only",
+            Self::Public => "public",
+            Self::WorkspaceAndEmails => "workspace_and_emails",
+        }
+    }
+}
 
 #[derive(Subcommand)]
 pub enum FrameCommand {
@@ -46,6 +65,17 @@ pub enum FrameCommand {
         source: PathBuf,
         /// New Frame folder path under /files
         destination: PathBuf,
+    },
+    /// Configure who can use a registered Frame
+    Share {
+        /// Existing Frame folder under /files
+        directory: PathBuf,
+        /// Use-rights scope
+        #[arg(long, value_enum)]
+        scope: FrameShareScope,
+        /// Email to grant access to; repeat for multiple recipients
+        #[arg(long = "email")]
+        emails: Vec<String>,
     },
     /// Build and publish a Frame from its current source
     Publish {

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,4 +1,5 @@
 mod create;
+mod move_frame;
 mod publish;
 mod register;
 
@@ -8,6 +9,7 @@ use anyhow::{bail, Context};
 use clap::Subcommand;
 
 pub use create::run as cmd_frame_create;
+pub use move_frame::run as cmd_frame_move;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
 
@@ -30,6 +32,13 @@ pub enum FrameCommand {
     Register {
         /// Absolute /files/.../manifest.json path
         manifest: PathBuf,
+    },
+    /// Move a registered Frame folder while preserving its identity and state
+    Move {
+        /// Existing Frame folder under /files
+        source: PathBuf,
+        /// New Frame folder path under /files
+        destination: PathBuf,
     },
     /// Build and publish a Frame from its current source
     Publish {

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,4 +1,5 @@
 mod create;
+mod delete;
 mod move_frame;
 mod publish;
 mod register;
@@ -9,6 +10,7 @@ use anyhow::{bail, Context};
 use clap::Subcommand;
 
 pub use create::run as cmd_frame_create;
+pub use delete::run as cmd_frame_delete;
 pub use move_frame::run as cmd_frame_move;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
@@ -27,6 +29,11 @@ pub enum FrameCommand {
         /// Frame description
         #[arg(long, default_value = "")]
         description: String,
+    },
+    /// Permanently delete a registered Frame, its source folder, and owned runtime data
+    Delete {
+        /// Existing Frame folder under /files
+        directory: PathBuf,
     },
     /// Register an existing Frame manifest and assign its stable identity
     Register {

--- a/cli/dust-sandbox/src/commands/frame/move_frame.rs
+++ b/cli/dust-sandbox/src/commands/frame/move_frame.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_path};
+
+pub async fn run(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(source)?;
+    let destination_directory_path = scoped_path(destination)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .move_frame(&source_directory_path, &destination_directory_path)
+        .await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/frame/share.rs
+++ b/cli/dust-sandbox/src/commands/frame/share.rs
@@ -1,0 +1,18 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_path, FrameShareScope};
+
+pub async fn run(
+    directory: &Path,
+    scope: FrameShareScope,
+    emails: &[String],
+) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(directory)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .share_frame(&source_directory_path, scope.as_api_value(), emails)
+        .await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
-pub use frame::{cmd_frame_create, cmd_frame_publish, cmd_frame_register};
+pub use frame::{cmd_frame_create, cmd_frame_move, cmd_frame_publish, cmd_frame_register};
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -13,7 +13,9 @@ pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
-pub use frame::{cmd_frame_create, cmd_frame_move, cmd_frame_publish, cmd_frame_register};
+pub use frame::{
+    cmd_frame_create, cmd_frame_delete, cmd_frame_move, cmd_frame_publish, cmd_frame_register,
+};
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
 pub use frame::{
     cmd_frame_create, cmd_frame_delete, cmd_frame_move, cmd_frame_publish, cmd_frame_register,
+    cmd_frame_share,
 };
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -34,7 +34,7 @@ enum Commands {
         #[command(subcommand)]
         command: commands::db::DbCommand,
     },
-    /// Create, register, and publish Frames
+    /// Manage Frames
     Frame {
         #[command(subcommand)]
         command: commands::frame::FrameCommand,
@@ -136,6 +136,9 @@ async fn run() -> anyhow::Result<()> {
                 name,
                 description,
             } => commands::cmd_frame_create(&directory, name.as_deref(), &description).await?,
+            commands::frame::FrameCommand::Delete { directory } => {
+                commands::cmd_frame_delete(&directory).await?
+            }
             commands::frame::FrameCommand::Register { manifest } => {
                 commands::cmd_frame_register(&manifest).await?
             }
@@ -526,6 +529,29 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected move"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_delete_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "delete",
+            "/files/conversation-conv_123/Status",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command: commands::frame::FrameCommand::Delete { directory },
+            } => {
+                assert_eq!(
+                    directory,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected delete"),
             _ => panic!("expected frame"),
         }
     }

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -139,6 +139,10 @@ async fn run() -> anyhow::Result<()> {
             commands::frame::FrameCommand::Register { manifest } => {
                 commands::cmd_frame_register(&manifest).await?
             }
+            commands::frame::FrameCommand::Move {
+                source,
+                destination,
+            } => commands::cmd_frame_move(&source, &destination).await?,
             commands::frame::FrameCommand::Publish { source } => {
                 commands::cmd_frame_publish(&source).await?
             }
@@ -490,6 +494,38 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected publish"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_move_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "move",
+            "/files/conversation-conv_123/Status",
+            "/files/pod-vlt_123/Status",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Move {
+                        source,
+                        destination,
+                    },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+                assert_eq!(
+                    destination,
+                    std::path::PathBuf::from("/files/pod-vlt_123/Status")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected move"),
             _ => panic!("expected frame"),
         }
     }

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -142,6 +142,11 @@ async fn run() -> anyhow::Result<()> {
             commands::frame::FrameCommand::Register { manifest } => {
                 commands::cmd_frame_register(&manifest).await?
             }
+            commands::frame::FrameCommand::Share {
+                directory,
+                scope,
+                emails,
+            } => commands::cmd_frame_share(&directory, scope, &emails).await?,
             commands::frame::FrameCommand::Move {
                 source,
                 destination,
@@ -552,6 +557,43 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected delete"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_share_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "share",
+            "/files/conversation-conv_123/Status",
+            "--scope",
+            "emails-only",
+            "--email",
+            "alice@example.com",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Share {
+                        directory,
+                        scope,
+                        emails,
+                    },
+            } => {
+                assert_eq!(
+                    directory,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+                assert!(matches!(
+                    scope,
+                    commands::frame::FrameShareScope::EmailsOnly
+                ));
+                assert_eq!(emails, vec!["alice@example.com"]);
+            }
+            Commands::Frame { .. } => panic!("expected share"),
             _ => panic!("expected frame"),
         }
     }

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/delete.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/delete.ts
@@ -4,7 +4,7 @@ import {
   isFrameDeletionError,
 } from "@app/lib/api/frames/delete_from_source";
 import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
-import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { isSandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isDustFileSystemError } from "@app/types/file_system";
@@ -35,7 +35,7 @@ function frameDeleteErrorStatus(
   if (isFrameDeletionError(error)) {
     return error.code === "internal" ? 500 : 400;
   }
-  if (error instanceof SandboxFunctionError) {
+  if (isSandboxFunctionError(error)) {
     return error.code === "internal" ? 500 : 400;
   }
   return 500;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/delete.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/delete.ts
@@ -1,0 +1,113 @@
+import {
+  type DeleteFrameV2FromSourceError,
+  deleteFrameV2FromSource,
+  isFrameDeletionError,
+} from "@app/lib/api/frames/delete_from_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameDeleteRequestSchema = z.object({
+  sourceDirectoryPath: z.string().min(1),
+});
+
+type FrameDeleteResponse = {
+  frameId: string;
+  sourceDirectoryPath: string;
+};
+
+function frameDeleteErrorStatus(
+  error: DeleteFrameV2FromSourceError
+): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFrameDeletionError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (error instanceof SandboxFunctionError) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  return 500;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameDeleteRequestSchema),
+  async (ctx): HandlerResult<FrameDeleteResponse> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot delete Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { sourceDirectoryPath } = ctx.req.valid("json");
+    const deleted = await deleteFrameV2FromSource(auth, {
+      conversation: conversation.toJSON(),
+      sourceDirectoryPath,
+    });
+    if (deleted.isErr()) {
+      const status = frameDeleteErrorStatus(deleted.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: deleted.error.message,
+          },
+        },
+        deleted.error
+      );
+    }
+
+    return ctx.json(deleted.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -58,6 +58,22 @@ function requestFrameRegister(
   });
 }
 
+function requestFrameMove(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string,
+  destinationDirectoryPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/move`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourceDirectoryPath, destinationDirectoryPath }),
+  });
+}
+
 async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -182,6 +198,39 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     const frame = await FileResource.fetchById(context.auth, published.frameId);
     expect(frame?.useCaseMetadata?.activePublicationId).toBe(
       published.publicationId
+    );
+  });
+
+  it("moves a registered Frame folder while preserving its identity", async () => {
+    const context = await setup();
+    assert(context.frame);
+    fileStorageMock.setFileExists(() => false);
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const destinationDirectoryPath = sourceDirectoryPath.replace(
+      "/Status",
+      "/Renamed"
+    );
+
+    const response = await requestFrameMove(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      destinationDirectoryPath
+    );
+
+    const moved = await response.json();
+    expect(response.status, JSON.stringify(moved)).toBe(200);
+    expect(moved).toEqual({
+      destinationDirectoryPath,
+      frameId: context.frame.sId,
+      sourceDeletionFailed: false,
+    });
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.toScopedPath(context.auth)).toBe(
+      `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
     );
   });
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -89,6 +89,26 @@ function requestFrameDelete(
   });
 }
 
+function requestFrameShare(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string,
+  emails: string[] = []
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/share`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      emails,
+      shareScope: "workspace_and_emails",
+      sourceDirectoryPath,
+    }),
+  });
+}
+
 async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -280,6 +300,39 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     await expect(
       FileResource.fetchById(context.auth, context.frame.sId)
     ).resolves.toBeNull();
+  });
+
+  it("configures Frame use rights through the sandbox token", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const user = context.auth.getNonNullableUser();
+    const publishResponse = await requestFramePublish(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(publishResponse.status).toBe(200);
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+
+    const response = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      [user.email]
+    );
+
+    const shared = await response.json();
+    expect(response.status, JSON.stringify(shared)).toBe(200);
+    expect(shared).toMatchObject({
+      emails: [user.email],
+      frameId: context.frame.sId,
+      shareScope: "workspace_and_emails",
+      sourceDirectoryPath,
+    });
+    expect(shared.shareUrl).toContain("/share/frame/");
   });
 
   it("publishes a legacy Frame through its existing publication flow", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -98,18 +98,24 @@ async function setup({ registered = true }: { registered?: boolean } = {}) {
     [`${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifest],
     [`${mountDirectoryPath}/index.tsx`, uiSource],
   ]);
+  for (const [filePath, content] of sourceByPath) {
+    fileStorageMock.setObject(filePath, content);
+  }
   fileStorageMock.setFileContent((path) => sourceByPath.get(path) ?? null);
   fileStorageMock.setFilesByPrefix((prefix) =>
     prefix === `${mountDirectoryPath}/`
-      ? [...sourceByPath.entries()].map(([name, content]) => ({
-          name,
-          metadata: {
-            contentType: name.endsWith(".tsx")
-              ? "text/typescript"
-              : "application/json",
-            size: String(Buffer.byteLength(content)),
-          },
-        }))
+      ? [...sourceByPath.entries()]
+          .filter(([name]) => fileStorageMock.getObject(name) !== undefined)
+          .map(([name, content], index) => ({
+            name,
+            metadata: {
+              contentType: name.endsWith(".tsx")
+                ? "text/typescript"
+                : "application/json",
+              generation: String(index + 1),
+              size: String(Buffer.byteLength(content)),
+            },
+          }))
       : null
   );
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -7,11 +7,22 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
 
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
@@ -93,7 +104,11 @@ function requestFrameShare(
   workspaceId: string,
   token: string,
   sourceDirectoryPath: string,
-  emails: string[] = []
+  emails: string[] = [],
+  shareScope:
+    | "emails_only"
+    | "public"
+    | "workspace_and_emails" = "workspace_and_emails"
 ) {
   return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/share`, {
     method: "POST",
@@ -103,7 +118,7 @@ function requestFrameShare(
     },
     body: JSON.stringify({
       emails,
-      shareScope: "workspace_and_emails",
+      shareScope,
       sourceDirectoryPath,
     }),
   });
@@ -197,6 +212,7 @@ async function setupLegacyFrame() {
 
 beforeEach(() => {
   fileStorageMock.reset();
+  mockEmitAuditLogEvent.mockClear();
 });
 
 describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
@@ -333,6 +349,69 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
       sourceDirectoryPath,
     });
     expect(shared.shareUrl).toContain("/share/frame/");
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.email_grant_added",
+        metadata: expect.objectContaining({ emails: user.email }),
+      })
+    );
+
+    mockEmitAuditLogEvent.mockClear();
+    const repeatedResponse = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      [user.email]
+    );
+    expect(repeatedResponse.status).toBe(200);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "frame.email_grant_added" })
+    );
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "frame.share_scope_updated" })
+    );
+  });
+
+  it("preserves existing rights when authorized-file validation fails", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const publishResponse = await requestFramePublish(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(publishResponse.status).toBe(200);
+    const published = await publishResponse.json();
+    await context.frame.setShareScope(context.auth, "emails_only");
+    fileStorageMock.setObject(
+      getFramePublicationUiBundlePath({
+        workspaceId: context.workspace.sId,
+        frameId: context.frame.sId,
+        publicationId: published.publicationId,
+      }),
+      'useFile("fil_ZZZZZZZZZZ");'
+    );
+
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const response = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      [context.auth.getNonNullableUser().email],
+      "workspace_and_emails"
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: expect.stringContaining("cannot be verified"),
+      },
+    });
+    expect(await context.frame.getShareScope()).toBe("emails_only");
+    expect(await context.frame.listActiveSharingGrants()).toEqual([]);
   });
 
   it("publishes a legacy Frame through its existing publication flow", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -74,6 +74,21 @@ function requestFrameMove(
   });
 }
 
+function requestFrameDelete(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/delete`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourceDirectoryPath }),
+  });
+}
+
 async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -238,6 +253,33 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.toScopedPath(context.auth)).toBe(
       `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
     );
+  });
+
+  it("deletes a registered Frames v2 package through the sandbox token", async () => {
+    const context = await setup();
+    assert(context.frame);
+    await context.frame.markFrameV2AsReadyFromMount(context.auth);
+    fileStorageMock.setFileExists((filePath) => filePath.endsWith("/"));
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+
+    const response = await requestFrameDelete(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath
+    );
+
+    const deleted = await response.json();
+    expect(response.status, JSON.stringify(deleted)).toBe(200);
+    expect(deleted).toEqual({
+      frameId: context.frame.sId,
+      sourceDirectoryPath,
+    });
+    await expect(
+      FileResource.fetchById(context.auth, context.frame.sId)
+    ).resolves.toBeNull();
   });
 
   it("publishes a legacy Frame through its existing publication flow", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -16,7 +16,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
+import move from "./move";
 import register from "./register";
 
 const FramePublishRequestSchema = z.object({
@@ -69,6 +69,7 @@ function frameErrorStatus(error: PublishFrameFromSourceError): 400 | 403 | 500 {
 const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
+app.route("/move", move);
 app.route("/register", register);
 
 /**

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 import deleteFrame from "./delete";
 import move from "./move";
 import register from "./register";
+import share from "./share";
 
 const FramePublishRequestSchema = z.object({
   manifestPath: z.string().min(1),
@@ -73,6 +74,7 @@ app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
 app.route("/delete", deleteFrame);
 app.route("/move", move);
 app.route("/register", register);
+app.route("/share", share);
 
 /**
  * @ignoreswagger

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -16,6 +16,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
+import deleteFrame from "./delete";
 import move from "./move";
 import register from "./register";
 
@@ -69,6 +70,7 @@ function frameErrorStatus(error: PublishFrameFromSourceError): 400 | 403 | 500 {
 const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
+app.route("/delete", deleteFrame);
 app.route("/move", move);
 app.route("/register", register);
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
@@ -4,7 +4,7 @@ import {
   moveFrameV2Source,
 } from "@app/lib/api/frames/move_source";
 import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
-import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { isSandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isDustFileSystemError } from "@app/types/file_system";
@@ -35,7 +35,7 @@ function frameMoveErrorStatus(error: MoveFrameV2SourceError): 400 | 403 | 500 {
   if (isFrameSourceMoveError(error)) {
     return error.code === "internal" ? 500 : 400;
   }
-  if (error instanceof SandboxFunctionError) {
+  if (isSandboxFunctionError(error)) {
     return error.code === "internal" ? 500 : 400;
   }
   return 500;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
@@ -1,0 +1,109 @@
+import {
+  isFrameSourceMoveError,
+  type MoveFrameV2SourceError,
+  moveFrameV2Source,
+} from "@app/lib/api/frames/move_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameMoveRequestSchema = z.object({
+  destinationDirectoryPath: z.string().min(1),
+  sourceDirectoryPath: z.string().min(1),
+});
+
+type FrameMoveResponse = {
+  destinationDirectoryPath: string;
+  frameId: string;
+  sourceDeletionFailed: boolean;
+};
+
+function frameMoveErrorStatus(error: MoveFrameV2SourceError): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFrameSourceMoveError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (error instanceof SandboxFunctionError) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  return 500;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameMoveRequestSchema),
+  async (ctx): HandlerResult<FrameMoveResponse> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot move Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { destinationDirectoryPath, sourceDirectoryPath } =
+      ctx.req.valid("json");
+    const moved = await moveFrameV2Source(auth, {
+      conversation: conversation.toJSON(),
+      destinationDirectoryPath,
+      sourceDirectoryPath,
+    });
+    if (moved.isErr()) {
+      const status = frameMoveErrorStatus(moved.error);
+      return apiError(ctx, {
+        status_code: status,
+        api_error: {
+          type:
+            status === 500 ? "internal_server_error" : "invalid_request_error",
+          message: moved.error.message,
+        },
+      });
+    }
+
+    return ctx.json(moved.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
@@ -92,14 +92,20 @@ app.post(
     });
     if (moved.isErr()) {
       const status = frameMoveErrorStatus(moved.error);
-      return apiError(ctx, {
-        status_code: status,
-        api_error: {
-          type:
-            status === 500 ? "internal_server_error" : "invalid_request_error",
-          message: moved.error.message,
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: moved.error.message,
+          },
         },
-      });
+        moved.error
+      );
     }
 
     return ctx.json(moved.value, 200);

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/share.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/share.ts
@@ -1,0 +1,117 @@
+import {
+  isFrameSharingError,
+  type ShareFrameV2FromSourceError,
+  type ShareFrameV2FromSourceResult,
+  shareFrameV2FromSource,
+} from "@app/lib/api/frames/share_from_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { isSandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { fileShareScopeSchema, MAX_EMAILS_PER_INVITE } from "@app/types/files";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameShareRequestSchema = z.object({
+  emails: z.array(z.string().email()).max(MAX_EMAILS_PER_INVITE).default([]),
+  shareScope: fileShareScopeSchema.exclude(["workspace"]),
+  sourceDirectoryPath: z.string().min(1),
+});
+
+function frameShareErrorStatus(
+  error: ShareFrameV2FromSourceError
+): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFrameSharingError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isSandboxFunctionError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  return 500;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameShareRequestSchema),
+  async (ctx): HandlerResult<ShareFrameV2FromSourceResult> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot share Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { emails, shareScope, sourceDirectoryPath } = ctx.req.valid("json");
+    const shared = await shareFrameV2FromSource(auth, {
+      conversation: conversation.toJSON(),
+      emails,
+      shareScope,
+      sourceDirectoryPath,
+    });
+    if (shared.isErr()) {
+      const status = frameShareErrorStatus(shared.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: shared.error.message,
+          },
+        },
+        shared.error
+      );
+    }
+
+    return ctx.json(shared.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -340,6 +341,35 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     });
 
     expect(response.status).toBe(204);
+  });
+
+  it("should reject generic deletion of a Frames v2 file", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "manager",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 128,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        activePublicationId: "active-publication",
+        conversationId: conversation.sId,
+      },
+    });
+
+    const response = await honoApp.request(fileUrl(workspace, frame.sId), {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await FileResource.fetchById(auth, frame.sId)).not.toBeNull();
   });
 
   it("should allow file author with admin role to delete upload files", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { checkFrameEmailGrantPermission } from "@app/lib/api/share/frame_sharing";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -89,43 +90,15 @@ app.post(
 
     const { emails: rawEmails } = ctx.req.valid("json");
 
-    const workspace = auth.getNonNullableWorkspace();
-
-    const externalSharingDisabledByPolicy =
-      workspace.sharingPolicy === "workspace_only";
-    const canInviteExternal =
-      !externalSharingDisabledByPolicy &&
-      (await auth.hasWorkspacePermission("invite", "frame"));
-
-    if (!canInviteExternal) {
-      const emails = rawEmails.map((e) => e.toLowerCase());
-      const users = await UserResource.fetchByEmails(emails);
-
-      const userIdToEmail = new Map(
-        users.map((u) => [u.id, u.email.toLowerCase()])
-      );
-
-      const { memberships } = await MembershipResource.getActiveMemberships({
-        users,
-        workspace,
+    const permission = await checkFrameEmailGrantPermission(auth, rawEmails);
+    if (permission.isErr()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: permission.error.message,
+        },
       });
-
-      const memberEmails = new Set(
-        memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
-      );
-
-      const hasNonMemberEmails = emails.some((e) => !memberEmails.has(e));
-      if (hasNonMemberEmails) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: externalSharingDisabledByPolicy
-              ? "Only workspace members can be invited when external sharing is disabled."
-              : "You do not have permission to invite people outside the workspace. Only workspace members can be invited.",
-          },
-        });
-      }
     }
 
     const grants = await file.addSharingGrants(auth, { emails: rawEmails });

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { checkFrameShareScopePermission } from "@app/lib/api/share/frame_sharing";
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import {
   buildShareFileResponse,
@@ -85,25 +86,15 @@ app.post(
 
     const { shareScope } = ctx.req.valid("json");
 
-    if (shareScope === "public") {
-      const workspace = auth.getNonNullableWorkspace();
-      const publicSharingAllowedByPolicy =
-        workspace.sharingPolicy === "all_scopes";
-      const canPublish =
-        publicSharingAllowedByPolicy &&
-        (await auth.hasWorkspacePermission("publish", "frame"));
-
-      if (!canPublish) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: publicSharingAllowedByPolicy
-              ? "You do not have permission to share this frame publicly."
-              : "Public sharing is disabled for this workspace.",
-          },
-        });
-      }
+    const permission = await checkFrameShareScopePermission(auth, shareScope);
+    if (permission.isErr()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: permission.error.message,
+        },
+      });
     }
 
     await file.setShareScope(auth, shareScope);

--- a/front/admin/audit_log_schemas/frame.deleted.json
+++ b/front/admin/audit_log_schemas/frame.deleted.json
@@ -1,0 +1,14 @@
+{
+  "action": "frame.deleted",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "frame_id": "string",
+    "source_path": "string",
+    "active_publication_id": "string",
+    "source": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -10,11 +10,9 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
-import {
-  podFunctionScopeFromFramePath,
-  resolvePodFunctionReference,
-} from "@app/types/api/pod_function_reference";
+import type { FrameFunctionReferenceScope } from "@app/types/api/frame_function_reference";
+import { resolveFrameFunctionReference } from "@app/types/api/frame_function_reference";
+import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
@@ -398,7 +396,7 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
-  podFunctionScope,
+  functionReferenceScope,
   setCodeDrawerOpened,
   setContentHeight,
   setErrorMessage,
@@ -416,7 +414,7 @@ function useVisualizationDataHandler({
     Result<PostSandboxFunctionInvocationResponseBody, SandboxFunctionCallError>
   >;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
-  podFunctionScope: PodFunctionScope | null;
+  functionReferenceScope: FrameFunctionReferenceScope;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
   setContentHeight: (v: SetStateAction<number>) => void;
@@ -486,11 +484,11 @@ function useVisualizationDataHandler({
 
       switch (data.command) {
         case "callFunction": {
-          // A Frame in an app folder may name its own functions by bare slug; qualify it here, the
-          // only layer that both knows which Frame is calling and is trusted about it.
-          const referenceRes = resolvePodFunctionReference(
+          // Qualify bare function names in the trusted host. Frames v2 bind to stable identity;
+          // legacy Frames keep their existing Pod app-folder resolution.
+          const referenceRes = resolveFrameFunctionReference(
             data.params.functionIdOrSlug,
-            podFunctionScope
+            functionReferenceScope
           );
           if (referenceRes.isErr()) {
             sendErrorToIframe(
@@ -613,7 +611,7 @@ function useVisualizationDataHandler({
     downloadFileFromBlob,
     getFileBlob,
     onEditText,
-    podFunctionScope,
+    functionReferenceScope,
     setContentHeight,
     setErrorMessage,
     setCodeDrawerOpened,
@@ -666,6 +664,8 @@ export interface VisualizationActionIframeProps {
    * bare name; without it, relative references are refused.
    */
   framePath?: string | null;
+  /** Stable identity of a Frames v2 resource. Omit for legacy Frames and raw visualizations. */
+  frameId?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
@@ -695,6 +695,13 @@ export const VisualizationActionIframe = forwardRef<
   const podFunctionScope = useMemo(
     () => podFunctionScopeFromFramePath(props.framePath),
     [props.framePath]
+  );
+  const functionReferenceScope = useMemo<FrameFunctionReferenceScope>(
+    () =>
+      props.frameId
+        ? { kind: "v2", frameId: props.frameId }
+        : { kind: "legacy", podFunctionScope },
+    [podFunctionScope, props.frameId]
   );
 
   // In-flight sandbox function invocations. Each entry mounts a
@@ -937,7 +944,7 @@ export const VisualizationActionIframe = forwardRef<
     createSandboxFunctionInvocation,
     getFileBlob,
     onEditText,
-    podFunctionScope,
+    functionReferenceScope,
     setCodeDrawerOpened,
     setContentHeight,
     setErrorMessage,

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -485,6 +485,7 @@ export function FrameRenderer({
               conversationId={conversation?.sId ?? null}
               spaceId={frameSpaceId ?? undefined}
               framePath={framePath}
+              frameId={renderMode === "v2" ? fileId : undefined}
               isInDrawer={true}
               isEditable={renderMode === "legacy"}
               onEditText={renderMode === "legacy" ? handleEditText : undefined}

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -16,6 +16,7 @@ import { useCookies } from "react-cookie";
 
 interface PublicFrameRendererProps {
   fileId: string;
+  frameId?: string;
   fileName?: string;
   hideHeader?: boolean;
   logoUrl?: string | null;
@@ -62,6 +63,7 @@ export function getPublicFrameUserIdentity(
 
 export function PublicFrameRenderer({
   fileId,
+  frameId,
   fileName,
   hideHeader = false,
   logoUrl,
@@ -161,6 +163,7 @@ export function PublicFrameRenderer({
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
             framePath={framePath}
+            frameId={frameId}
             isInDrawer
           />
         </div>

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -56,6 +56,11 @@ export function PublicInteractiveContentContainer({
         return (
           <PublicFrameRenderer
             fileId={frameMetadata.sId}
+            frameId={
+              frameMetadata.contentType === frameV2ContentType
+                ? frameMetadata.sId
+                : undefined
+            }
             fileName={frameMetadata.fileName}
             shareToken={shareToken}
             workspaceId={workspaceId}

--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -2,7 +2,6 @@ import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization
 import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { RichSpaceType } from "@app/types/api/spaces";
-import { frameV2ContentType } from "@app/types/files";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
@@ -19,7 +18,7 @@ export function PodFrameTabContent({
   tab,
 }: PodFrameTabContentProps) {
   const { vizUrl } = useAuth();
-  const { fileId, fileContent, contentType, isLoading, isNotFound } =
+  const { fileId, fileContent, functionReferenceKind, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: tab.path,
@@ -33,7 +32,13 @@ export function PodFrameTabContent({
     );
   }
 
-  if (isNotFound || !fileId || !fileContent || !vizUrl) {
+  if (
+    isNotFound ||
+    !fileId ||
+    !fileContent ||
+    !functionReferenceKind ||
+    !vizUrl
+  ) {
     return (
       <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
         This frame is no longer available in the Pod files.
@@ -50,7 +55,7 @@ export function PodFrameTabContent({
           fileContent={fileContent}
           vizUrl={vizUrl}
           identifier={`viz-frame-tab-${fileId}`}
-          frameId={contentType === frameV2ContentType ? fileId : undefined}
+          frameId={functionReferenceKind === "v2" ? fileId : undefined}
           isPodEditor={podInfo.isEditor}
           isPodMember={podInfo.isMember}
           framePath={tab.path}

--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -2,6 +2,7 @@ import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization
 import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { RichSpaceType } from "@app/types/api/spaces";
+import { frameV2ContentType } from "@app/types/files";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
@@ -18,7 +19,7 @@ export function PodFrameTabContent({
   tab,
 }: PodFrameTabContentProps) {
   const { vizUrl } = useAuth();
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, contentType, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: tab.path,
@@ -49,6 +50,7 @@ export function PodFrameTabContent({
           fileContent={fileContent}
           vizUrl={vizUrl}
           identifier={`viz-frame-tab-${fileId}`}
+          frameId={contentType === frameV2ContentType ? fileId : undefined}
           isPodEditor={podInfo.isEditor}
           isPodMember={podInfo.isMember}
           framePath={tab.path}

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -8,6 +8,7 @@ interface PodFrameVisualizationProps {
   fileContent: string;
   vizUrl: string;
   identifier: string;
+  frameId?: string;
   isPodEditor?: boolean;
   isPodMember?: boolean;
   /** Scoped path of the Frame, so one inside an app folder can call its functions by bare name. */
@@ -24,6 +25,7 @@ export function PodFrameVisualization({
   fileContent,
   vizUrl,
   identifier,
+  frameId,
   isPodEditor,
   isPodMember,
   framePath,
@@ -43,6 +45,7 @@ export function PodFrameVisualization({
       conversationId={null}
       spaceId={spaceId}
       framePath={framePath}
+      frameId={frameId}
       isInDrawer={true}
       isPodEditor={isPodEditor}
       isPodMember={isPodMember}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -5,6 +5,7 @@ import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import logger from "@app/logger/logger";
 import type { RichSpaceType } from "@app/types/api/spaces";
+import { frameV2ContentType } from "@app/types/files";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -143,7 +144,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     isEditor: podInfo.isEditor,
   });
 
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, contentType, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: pinnedFramePath,
@@ -202,6 +203,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     fileContent,
     vizUrl,
     identifier: `viz-banner-${fileId}`,
+    frameId: contentType === frameV2ContentType ? fileId : undefined,
     isPodEditor: podInfo.isEditor,
     isPodMember: podInfo.isMember,
     framePath: pinnedFramePath,

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -5,7 +5,6 @@ import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import logger from "@app/logger/logger";
 import type { RichSpaceType } from "@app/types/api/spaces";
-import { frameV2ContentType } from "@app/types/files";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -144,7 +143,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     isEditor: podInfo.isEditor,
   });
 
-  const { fileId, fileContent, contentType, isLoading, isNotFound } =
+  const { fileId, fileContent, functionReferenceKind, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: pinnedFramePath,
@@ -193,7 +192,13 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     );
   }
 
-  if (isNotFound || !fileId || !fileContent || !vizUrl) {
+  if (
+    isNotFound ||
+    !fileId ||
+    !fileContent ||
+    !functionReferenceKind ||
+    !vizUrl
+  ) {
     return null;
   }
 
@@ -203,7 +208,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     fileContent,
     vizUrl,
     identifier: `viz-banner-${fileId}`,
-    frameId: contentType === frameV2ContentType ? fileId : undefined,
+    frameId: functionReferenceKind === "v2" ? fileId : undefined,
     isPodEditor: podInfo.isEditor,
     isPodMember: podInfo.isMember,
     framePath: pinnedFramePath,

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -5,7 +5,7 @@ import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton
 import { PodFrameTabButton } from "@app/components/pod/files/PodFrameTabButton";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
-import { frameV2ContentType } from "@app/types/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -66,10 +66,14 @@ export function PodFrameSheet({
     config: { disabled: !isOpen || !fileId },
   });
 
-  const { fileMetadata, isFileMetadataLoading } = useFileMetadata({
-    fileId,
-    owner,
-  });
+  const { fileMetadata, isFileMetadataLoading, isFileMetadataError } =
+    useFileMetadata({
+      fileId,
+      owner,
+    });
+  const functionReferenceKind = getFrameFunctionReferenceKind(
+    fileMetadata?.contentType
+  );
 
   useEffect(() => {
     if (!isOpen) {
@@ -142,7 +146,15 @@ export function PodFrameSheet({
           </div>
         </SheetHeader>
         <div className="flex-1 overflow-hidden">
-          {isFileMetadataLoading || !fileContent ? (
+          {isFileMetadataLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : isFileMetadataError || !fileMetadata || !functionReferenceKind ? (
+            <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+              This frame is no longer available in the Pod files.
+            </div>
+          ) : !fileContent ? (
             <div className="flex h-full items-center justify-center">
               <Spinner />
             </div>
@@ -165,11 +177,7 @@ export function PodFrameSheet({
                 conversationId={null}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 framePath={framePath}
-                frameId={
-                  fileMetadata?.contentType === frameV2ContentType
-                    ? fileId
-                    : undefined
-                }
+                frameId={functionReferenceKind === "v2" ? fileId : undefined}
                 isInDrawer={true}
                 isPodEditor={isEditor}
                 isPodMember={isMember}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -5,6 +5,7 @@ import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton
 import { PodFrameTabButton } from "@app/components/pod/files/PodFrameTabButton";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import { frameV2ContentType } from "@app/types/files";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -164,6 +165,11 @@ export function PodFrameSheet({
                 conversationId={null}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 framePath={framePath}
+                frameId={
+                  fileMetadata?.contentType === frameV2ContentType
+                    ? fileId
+                    : undefined
+                }
                 isInDrawer={true}
                 isPodEditor={isEditor}
                 isPodMember={isMember}

--- a/front/hooks/usePodFrameRenderableContent.ts
+++ b/front/hooks/usePodFrameRenderableContent.ts
@@ -1,4 +1,9 @@
-import { useFileContent, useFileIdFromPath } from "@app/lib/swr/files";
+import {
+  useFileContent,
+  useFileIdFromPath,
+  useFileMetadata,
+} from "@app/lib/swr/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -36,13 +41,24 @@ export function usePodFrameRenderableContent({
     owner,
     config: { disabled: isDisabled || !fileId },
   });
+  const { fileMetadata, isFileMetadataLoading, isFileMetadataError } =
+    useFileMetadata({
+      fileId: isDisabled ? null : fileId,
+      owner,
+    });
 
   return {
     fileId,
     fileContent: fileContent ?? null,
+    contentType: fileMetadata?.contentType ?? null,
     isLoading:
-      !isDisabled && (isFileIdLoading || (!!fileId && isFileContentLoading)),
+      !isDisabled &&
+      (isFileIdLoading ||
+        (!!fileId && (isFileContentLoading || isFileMetadataLoading))),
     isNotFound: isFileIdNotFound,
-    error: fileIdError ?? fileContentError,
+    error:
+      fileIdError ??
+      fileContentError ??
+      (isFileMetadataError ? normalizeError(isFileMetadataError) : null),
   };
 }

--- a/front/hooks/usePodFrameRenderableContent.ts
+++ b/front/hooks/usePodFrameRenderableContent.ts
@@ -3,6 +3,7 @@ import {
   useFileIdFromPath,
   useFileMetadata,
 } from "@app/lib/swr/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -50,7 +51,9 @@ export function usePodFrameRenderableContent({
   return {
     fileId,
     fileContent: fileContent ?? null,
-    contentType: fileMetadata?.contentType ?? null,
+    functionReferenceKind: getFrameFunctionReferenceKind(
+      fileMetadata?.contentType
+    ),
     isLoading:
       !isDisabled &&
       (isFileIdLoading ||

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.deleted": 1,
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -176,6 +176,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.deleted",
   "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -422,7 +422,7 @@ async function moveGCSMountFile({
   return new Ok(undefined);
 }
 
-async function emitGCSMountFileMovedAuditLog(
+export async function emitGCSMountFileMovedAuditLog(
   auth: Authenticator,
   scope: GCSMountPoint,
   {

--- a/front/lib/api/frames/delete_from_source.test.ts
+++ b/front/lib/api/frames/delete_from_source.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
+vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("@app/lib/api/frames/publication_storage")
+    >();
+  return {
+    ...actual,
+    withFrameSourceAndPublishLock: async (
+      _frameId: string,
+      callback: () => Promise<unknown>
+    ) => callback(),
+  };
+});
+
+import { deleteFrameV2FromSource } from "@app/lib/api/frames/delete_from_source";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { getFrameBasePath } from "@app/types/api/frame_storage";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import assert from "assert";
+
+async function setup() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: 100,
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: {
+      activePublicationId: "publication-1",
+      conversationId: conversation.sId,
+    },
+    mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+
+  return {
+    auth,
+    conversation,
+    frame,
+    sourceDirectoryPath,
+    sourceGcsDirectoryPath,
+    workspace,
+  };
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  mockEmitAuditLogEvent.mockReset();
+  mockEmitAuditLogEvent.mockResolvedValue(undefined);
+});
+
+describe("deleteFrameV2FromSource", () => {
+  it("deletes source, identity, runtime data, and sharing without a canonical original", async () => {
+    const context = await setup();
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setFileExists((filePath) => filePath.endsWith("/"));
+    fileStorageMock.setDeleteFails((filePath) =>
+      filePath.endsWith("/original")
+    );
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    const result = await deleteFrameV2FromSource(context.auth, {
+      conversation: context.conversation,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(result.isOk());
+    expect(result.value).toEqual({
+      frameId: context.frame.sId,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+    await expect(
+      FileResource.fetchById(context.auth, context.frame.sId)
+    ).resolves.toBeNull();
+    expect(deletedPrefixes).toContain(`${context.sourceGcsDirectoryPath}/`);
+    expect(deletedPrefixes).toContain(
+      getFrameBasePath({
+        workspaceId: context.workspace.sId,
+        frameId: context.frame.sId,
+      })
+    );
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.deleted",
+        metadata: expect.objectContaining({
+          active_publication_id: "publication-1",
+          frame_id: context.frame.sId,
+          source_path: context.sourceDirectoryPath,
+        }),
+      })
+    );
+  });
+
+  it("keeps the Frame identity when source deletion fails", async () => {
+    const context = await setup();
+    fileStorageMock.setFileExists(
+      (filePath) => filePath === context.sourceGcsDirectoryPath
+    );
+    fileStorageMock.setDeleteFails(
+      (filePath) => filePath === context.sourceGcsDirectoryPath
+    );
+
+    const result = await deleteFrameV2FromSource(context.auth, {
+      conversation: context.conversation,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(result.isErr());
+    await expect(
+      FileResource.fetchById(context.auth, context.frame.sId)
+    ).resolves.not.toBeNull();
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/frames/delete_from_source.test.ts
+++ b/front/lib/api/frames/delete_from_source.test.ts
@@ -2,8 +2,14 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+const {
+  mockEmitAuditLogEvent,
+  mockWithFramePublishLock,
+  mockWithFrameSourceLock,
+} = vi.hoisted(() => ({
   mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+  mockWithFramePublishLock: vi.fn(),
+  mockWithFrameSourceLock: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
@@ -12,55 +18,80 @@ vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
   return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
 });
 
-vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
+vi.mock("@app/lib/api/frames/operation_lock", async (importActual) => {
   const actual =
-    await importActual<
-      typeof import("@app/lib/api/frames/publication_storage")
-    >();
+    await importActual<typeof import("@app/lib/api/frames/operation_lock")>();
   return {
     ...actual,
-    withFrameSourceAndPublishLock: async (
-      _frameId: string,
-      callback: () => Promise<unknown>
-    ) => callback(),
+    withFramePublishLock: mockWithFramePublishLock,
+    withFrameSourceLock: mockWithFrameSourceLock,
   };
 });
 
 import { deleteFrameV2FromSource } from "@app/lib/api/frames/delete_from_source";
+import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { getFrameBasePath } from "@app/types/api/frame_storage";
 import { frameV2ContentType } from "@app/types/files";
-import { getConversationFilesBasePath } from "@app/types/mount_path";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
+import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import assert from "assert";
 
-async function setup() {
-  const { authenticator: auth, workspace } = await createResourceTest({
+async function setup({ inPod = false }: { inPod?: boolean } = {}) {
+  const {
+    authenticator: initialAuth,
+    globalGroup,
+    user,
+    workspace,
+  } = await createResourceTest({
     role: "admin",
   });
+  const pod = inPod ? await SpaceFactory.project(workspace, user.id) : null;
+  if (pod) {
+    await SpaceFactory.attachGroup(pod, globalGroup, "project_editor");
+  }
+  const auth = pod
+    ? await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId)
+    : initialAuth;
   const conversation = await ConversationFactory.create(auth, {
     agentConfigurationId: "test-agent",
     messagesCreatedAt: [],
+    spaceId: pod?.id,
   });
-  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
-  const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
-    workspaceId: workspace.sId,
-    conversationId: conversation.sId,
-  })}Status`;
+  const sourceDirectoryPath = pod
+    ? `pod-${pod.sId}/Status`
+    : `conversation-${conversation.sId}/Status`;
+  const sourceGcsDirectoryPath = pod
+    ? `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: pod.sId,
+      })}Status`
+    : `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}Status`;
   const frame = await FileFactory.create(auth, null, {
     contentType: frameV2ContentType,
     fileName: FRAME_MANIFEST_FILE,
     fileSize: 100,
     status: "created",
-    useCase: "conversation",
-    useCaseMetadata: {
-      activePublicationId: "publication-1",
-      conversationId: conversation.sId,
-    },
+    useCase: pod ? "project_context" : "conversation",
+    useCaseMetadata: pod
+      ? { activePublicationId: "publication-1", spaceId: pod.sId }
+      : {
+          activePublicationId: "publication-1",
+          conversationId: conversation.sId,
+        },
     mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
   });
   await frame.markFrameV2AsReadyFromMount(auth);
@@ -69,6 +100,7 @@ async function setup() {
     auth,
     conversation,
     frame,
+    pod,
     sourceDirectoryPath,
     sourceGcsDirectoryPath,
     workspace,
@@ -79,6 +111,14 @@ beforeEach(() => {
   fileStorageMock.reset();
   mockEmitAuditLogEvent.mockReset();
   mockEmitAuditLogEvent.mockResolvedValue(undefined);
+  mockWithFramePublishLock.mockReset();
+  mockWithFramePublishLock.mockImplementation(
+    async (_frameId: string, callback: () => Promise<unknown>) => callback()
+  );
+  mockWithFrameSourceLock.mockReset();
+  mockWithFrameSourceLock.mockImplementation(
+    async (_frameId: string, callback: () => Promise<unknown>) => callback()
+  );
 });
 
 describe("deleteFrameV2FromSource", () => {
@@ -123,6 +163,8 @@ describe("deleteFrameV2FromSource", () => {
         }),
       })
     );
+    expect(mockWithFrameSourceLock).toHaveBeenCalledTimes(1);
+    expect(mockWithFramePublishLock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the Frame identity when source deletion fails", async () => {
@@ -144,5 +186,52 @@ describe("deleteFrameV2FromSource", () => {
       FileResource.fetchById(context.auth, context.frame.sId)
     ).resolves.not.toBeNull();
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("removes Pod UI references through the package-aware deletion flow", async () => {
+    const context = await setup({ inPod: true });
+    assert(context.pod);
+    const manifestPath = `${context.sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    await ProjectMetadataResource.makeNew(context.auth, context.pod, {
+      description: null,
+      pinnedFramePath: manifestPath,
+      frameTabs: [
+        {
+          path: manifestPath,
+          title: "Status",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ],
+      tabsOrder: [manifestPath],
+    });
+    fileStorageMock.setFileExists((filePath) => filePath.endsWith("/"));
+
+    const result = await deleteFrameV2FromSource(context.auth, {
+      conversation: context.conversation,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : undefined);
+    const metadata = await ProjectMetadataResource.fetchBySpace(
+      context.auth,
+      context.pod
+    );
+    expect(metadata?.pinnedFramePath).toBeNull();
+    expect(metadata?.frameTabs).toEqual([]);
+    expect(metadata?.tabsOrder).not.toContain(manifestPath);
+  });
+
+  it("rejects direct Frames v2 resource deletion", async () => {
+    const context = await setup();
+
+    const result = await context.frame.delete(context.auth);
+
+    expect(result.isErr() && result.error.message).toBe(
+      "Frames v2 must be deleted through the package-aware Frame deletion flow."
+    );
+    await expect(
+      FileResource.fetchById(context.auth, context.frame.sId)
+    ).resolves.not.toBeNull();
+    expect(mockWithFramePublishLock).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/frames/delete_from_source.ts
+++ b/front/lib/api/frames/delete_from_source.ts
@@ -1,0 +1,230 @@
+import path from "node:path";
+
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { removeFileFromProject } from "@app/lib/api/projects/context";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export class FrameDeletionError extends Error {
+  constructor(
+    readonly code: "conflict" | "internal" | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameDeletionError";
+  }
+}
+
+export function isFrameDeletionError(
+  error: unknown
+): error is FrameDeletionError {
+  return error instanceof FrameDeletionError;
+}
+
+export type DeleteFrameV2FromSourceError =
+  | DustFileSystemError
+  | FrameDeletionError
+  | SandboxFunctionError;
+
+function deletionError(
+  code: FrameDeletionError["code"],
+  message: string
+): Err<FrameDeletionError> {
+  return new Err(new FrameDeletionError(code, message));
+}
+
+async function deleteFrameResource(
+  auth: Authenticator,
+  frame: FileResource,
+  manifestPath: string
+): Promise<Result<void, FrameDeletionError>> {
+  if (frame.useCase !== "project_context") {
+    const result = await frame.delete(auth);
+    return result.isErr()
+      ? deletionError("internal", result.error.message)
+      : new Ok(undefined);
+  }
+
+  const podId = frame.useCaseMetadata?.spaceId;
+  const pod = podId ? await SpaceResource.fetchById(auth, podId) : null;
+  if (!pod?.isProject()) {
+    return deletionError("invalid_source", "Frame source Pod not found.");
+  }
+
+  const result = await removeFileFromProject(auth, {
+    space: pod,
+    fileId: frame.sId,
+  });
+  if (result.isErr()) {
+    return deletionError("internal", result.error.message);
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  if (metadata) {
+    try {
+      await metadata.removeFramePath(manifestPath);
+    } catch (error) {
+      logger.warn(
+        {
+          error: normalizeError(error),
+          frameId: frame.sId,
+          manifestPath,
+          spaceId: pod.sId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Deleted Frame but failed to remove its Pod UI references"
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+/** Delete a registered Frame package and every resource owned by its stable identity. */
+export async function deleteFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    sourceDirectoryPath: string;
+  }
+): Promise<
+  Result<
+    { frameId: string; sourceDirectoryPath: string },
+    DeleteFrameV2FromSourceError
+  >
+> {
+  const sourceDirectory =
+    DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  if (
+    !sourceDirectory ||
+    !sourceDirectory.includes("/") ||
+    path.posix.basename(sourceDirectory) === FRAME_MANIFEST_FILE
+  ) {
+    return deletionError(
+      "invalid_source",
+      "Frame deletion requires its source folder under /files."
+    );
+  }
+  const manifestPath = path.posix.join(sourceDirectory, FRAME_MANIFEST_FILE);
+
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return deletionError(
+      "invalid_source",
+      "Frames v2 deletion does not yet support the database-backed filesystem."
+    );
+  }
+
+  const writeAccess = dustFs.checkWriteAccess(sourceDirectory);
+  if (writeAccess.isErr()) {
+    return new Err(writeAccess.error);
+  }
+  const mountFilePath = dustFs.toMountFilePath(manifestPath);
+  if (!mountFilePath) {
+    return deletionError("invalid_source", "Invalid Frame source folder.");
+  }
+
+  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+    mountFilePath,
+  ]);
+  if (!frame?.isFrameV2) {
+    return deletionError(
+      "invalid_source",
+      `No registered Frames v2 package found at ${sourceDirectory}.`
+    );
+  }
+
+  return withFrameSourceAndPublishLock<
+    { frameId: string; sourceDirectoryPath: string },
+    DustFileSystemError | FrameDeletionError
+  >(frame.sId, async () => {
+    const freshFrame = await FileResource.fetchById(auth, frame.sId);
+    if (
+      !freshFrame?.isFrameV2 ||
+      freshFrame.toScopedPath(auth) !== manifestPath
+    ) {
+      return deletionError(
+        "conflict",
+        "The Frame source changed while it was being deleted; retry from its current path."
+      );
+    }
+
+    // Delete source first. If resource cleanup fails, the identity remains and this operation can
+    // be retried; deleting the identity first would leave an unregistered folder with no retry key.
+    const sourceResult = await dustFs.delete(sourceDirectory, {
+      ignoreNotFound: true,
+    });
+    if (sourceResult.isErr()) {
+      return new Err(sourceResult.error);
+    }
+
+    const activePublicationId =
+      freshFrame.useCaseMetadata?.activePublicationId ?? "";
+    const resourceResult = await deleteFrameResource(
+      auth,
+      freshFrame,
+      manifestPath
+    );
+    if (resourceResult.isErr()) {
+      return resourceResult;
+    }
+
+    const frameName = path.posix.basename(sourceDirectory);
+    void emitAuditLogEvent({
+      auth,
+      action: "frame.deleted",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("frame", {
+          sId: freshFrame.sId,
+          name: frameName,
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        active_publication_id: activePublicationId,
+        frame_id: freshFrame.sId,
+        source: "dsbx",
+        source_path: sourceDirectory,
+      },
+    });
+
+    logger.info(
+      {
+        activePublicationId,
+        frameId: freshFrame.sId,
+        sourceDirectoryPath: sourceDirectory,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Deleted Frame v2"
+    );
+
+    return new Ok({
+      frameId: freshFrame.sId,
+      sourceDirectoryPath: sourceDirectory,
+    });
+  });
+}

--- a/front/lib/api/frames/delete_from_source.ts
+++ b/front/lib/api/frames/delete_from_source.ts
@@ -6,10 +6,12 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import { removeFileFromProject } from "@app/lib/api/projects/context";
-import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
+import type { FrameV2SourceDeletion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -17,6 +19,7 @@ import logger from "@app/logger/logger";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { DustFileSystemError } from "@app/types/file_system";
+import { isDustFileSystemError } from "@app/types/file_system";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -52,13 +55,15 @@ function deletionError(
 async function deleteFrameResource(
   auth: Authenticator,
   frame: FileResource,
-  manifestPath: string
-): Promise<Result<void, FrameDeletionError>> {
+  manifestPath: string,
+  deleteFrameSource: FrameV2SourceDeletion
+): Promise<Result<void, DeleteFrameV2FromSourceError>> {
   if (frame.useCase !== "project_context") {
-    const result = await frame.delete(auth);
-    return result.isErr()
-      ? deletionError("internal", result.error.message)
-      : new Ok(undefined);
+    const result = await frame.delete(auth, { deleteFrameSource });
+    if (result.isErr()) {
+      return frameResourceDeletionError(result.error);
+    }
+    return new Ok(undefined);
   }
 
   const podId = frame.useCaseMetadata?.spaceId;
@@ -67,15 +72,18 @@ async function deleteFrameResource(
     return deletionError("invalid_source", "Frame source Pod not found.");
   }
 
+  // Load Pod metadata before deleting the Frame identity. A failed fetch must leave the operation
+  // retryable; the update itself remains best-effort after deletion, as in the legacy flow.
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
   const result = await removeFileFromProject(auth, {
+    deleteFrameSource,
     space: pod,
     fileId: frame.sId,
   });
   if (result.isErr()) {
-    return deletionError("internal", result.error.message);
+    return frameResourceDeletionError(result.error);
   }
 
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
   if (metadata) {
     try {
       await metadata.removeFramePath(manifestPath);
@@ -94,6 +102,23 @@ async function deleteFrameResource(
   }
 
   return new Ok(undefined);
+}
+
+function frameResourceDeletionError(
+  error: Error
+): Err<DeleteFrameV2FromSourceError> {
+  if (isDustFileSystemError(error)) {
+    return new Err(error);
+  }
+  if (isLockAcquisitionTimeoutError(error)) {
+    return new Err(
+      new SandboxFunctionError(
+        "publish_conflict",
+        "Another publication or source operation is in progress for this Frame; retry shortly."
+      )
+    );
+  }
+  return deletionError("internal", error.message);
 }
 
 /** Delete a registered Frame package and every resource owned by its stable identity. */
@@ -157,9 +182,9 @@ export async function deleteFrameV2FromSource(
     );
   }
 
-  return withFrameSourceAndPublishLock<
+  return withFrameSourceLock<
     { frameId: string; sourceDirectoryPath: string },
-    DustFileSystemError | FrameDeletionError
+    DeleteFrameV2FromSourceError
   >(frame.sId, async () => {
     const freshFrame = await FileResource.fetchById(auth, frame.sId);
     if (
@@ -172,21 +197,16 @@ export async function deleteFrameV2FromSource(
       );
     }
 
-    // Delete source first. If resource cleanup fails, the identity remains and this operation can
-    // be retried; deleting the identity first would leave an unregistered folder with no retry key.
-    const sourceResult = await dustFs.delete(sourceDirectory, {
-      ignoreNotFound: true,
-    });
-    if (sourceResult.isErr()) {
-      return new Err(sourceResult.error);
-    }
-
     const activePublicationId =
       freshFrame.useCaseMetadata?.activePublicationId ?? "";
     const resourceResult = await deleteFrameResource(
       auth,
       freshFrame,
-      manifestPath
+      manifestPath,
+      () =>
+        dustFs.delete(sourceDirectory, {
+          ignoreNotFound: true,
+        })
     );
     if (resourceResult.isErr()) {
       return resourceResult;

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -337,6 +337,39 @@ describe("moveFrameV2Source", () => {
     );
   });
 
+  it("does not adopt a matching destination object created during the move", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/MatchingCollision`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}MatchingCollision`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setObject(destinationManifestPath, manifest);
+    fileStorageMock.setFileMetadata((filePath) =>
+      filePath === destinationManifestPath
+        ? {
+            contentType: frameV2ContentType,
+            generation: "3",
+            md5Hash: "manifest",
+            size: String(Buffer.byteLength(manifest)),
+          }
+        : null
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
+    );
+  });
+
   it("copies pinned source generations and preserves concurrent edits", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/Edited`;
@@ -399,6 +432,56 @@ describe("moveFrameV2Source", () => {
     expect(fileStorageMock.getObject(sourceManifestPath)).toBeUndefined();
   });
 
+  it("does not delete a destination generation overwritten after copy", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Overwritten`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Overwritten`;
+    const destinationUiPath = `${destinationGcsDirectoryPath}/index.tsx`;
+    fileStorageMock.setAfterCopyFile((_sourcePath, destinationPath) => {
+      if (destinationPath === destinationUiPath) {
+        fileStorageMock.setObject(
+          destinationPath,
+          "concurrent destination edit"
+        );
+      }
+    });
+    const updateMount = FileResource.prototype.updateMount;
+    let updateMountCalls = 0;
+    vi.spyOn(FileResource.prototype, "updateMount").mockImplementation(
+      function (this: FileResource, args) {
+        updateMountCalls++;
+        if (updateMountCalls === 2) {
+          return Promise.reject(
+            new Error("Simulated final Frame update failure")
+          );
+        }
+        return updateMount.call(this, args);
+      }
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    expect(fileStorageMock.getObject(destinationUiPath)).toBe(
+      "concurrent destination edit"
+    );
+    expect(fileStorageMock.deleteCalls).toContainEqual(
+      expect.objectContaining({
+        filePath: destinationUiPath,
+        options: expect.objectContaining({
+          ifGenerationMatch: expect.any(String),
+        }),
+      })
+    );
+  });
+
   it("keeps the recovery reservation when exact-generation cleanup fails", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/Retry`;
@@ -439,6 +522,95 @@ describe("moveFrameV2Source", () => {
           }),
         }),
       ])
+    );
+  });
+
+  it("does not delete a matching recovery object that this attempt did not copy", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/RecoveryRollback`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}RecoveryRollback`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const destinationMountFilePath = destinationManifestPath;
+    const sourceMountFilePath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    await context.frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: destinationMountFilePath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: {
+        activePublicationId: "publication-1",
+        conversationId: context.conversation.sId,
+        pendingFrameSourceMove: {
+          destinationMountFilePath,
+          sourceMountFilePath,
+        },
+      },
+    });
+    fileStorageMock.setObject(destinationManifestPath, manifest);
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix === `${context.sourceGcsDirectoryPath}/`) {
+        return [
+          {
+            name: sourceMountFilePath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: `${context.sourceGcsDirectoryPath}/index.tsx`,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ];
+      }
+      if (prefix === `${destinationGcsDirectoryPath}/`) {
+        return [
+          {
+            name: destinationManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "3",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+        ];
+      }
+      return null;
+    });
+    const updateMount = FileResource.prototype.updateMount;
+    let updateMountCalls = 0;
+    vi.spyOn(FileResource.prototype, "updateMount").mockImplementation(
+      function (this: FileResource, args) {
+        updateMountCalls++;
+        if (updateMountCalls === 1) {
+          return Promise.reject(
+            new Error("Simulated final Frame update failure")
+          );
+        }
+        return updateMount.call(this, args);
+      }
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
     );
   });
 

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -158,6 +158,43 @@ describe("moveFrameV2Source", () => {
     await expect(reloaded?.getShareInfo()).resolves.toEqual(beforeShare);
   });
 
+  it("does not move a registered Frame whose source manifest is missing", async () => {
+    const context = await setup();
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix === `${context.sourceGcsDirectoryPath}/`
+        ? [
+            {
+              name: sourceUiPath,
+              metadata: {
+                contentType: "text/typescript",
+                generation: "2",
+                md5Hash: "ui",
+                size: "1",
+              },
+            },
+          ]
+        : null
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `conversation-${context.conversation.sId}/MissingManifest`,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+  });
+
   it("requires write access to the destination scope", async () => {
     const context = await setup();
     const destinationPod = await SpaceFactory.project(context.workspace);
@@ -367,6 +404,78 @@ describe("moveFrameV2Source", () => {
     expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
     expect(fileStorageMock.deleteCalls).not.toContainEqual(
       expect.objectContaining({ filePath: destinationManifestPath })
+    );
+  });
+
+  it("does not move over a destination-only object created during the move", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/UnexpectedCollision`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}UnexpectedCollision`;
+    const destinationExtraPath = `${destinationGcsDirectoryPath}/extra.ts`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    let destinationListings = 0;
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix === `${context.sourceGcsDirectoryPath}/`) {
+        return [
+          {
+            name: sourceManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: sourceUiPath,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ];
+      }
+      if (prefix === `${destinationGcsDirectoryPath}/`) {
+        destinationListings++;
+        return destinationListings === 1
+          ? []
+          : [
+              {
+                name: destinationExtraPath,
+                metadata: {
+                  contentType: "text/typescript",
+                  generation: "3",
+                  md5Hash: "extra",
+                  size: "1",
+                },
+              },
+            ];
+      }
+      return null;
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationExtraPath })
     );
   });
 

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -525,7 +525,7 @@ describe("moveFrameV2Source", () => {
     );
   });
 
-  it("does not delete a matching recovery object that this attempt did not copy", async () => {
+  it("keeps matching recovery objects reserved until a retry succeeds", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/RecoveryRollback`;
     const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
@@ -570,7 +570,7 @@ describe("moveFrameV2Source", () => {
               size: "1",
             },
           },
-        ];
+        ].filter(({ name }) => fileStorageMock.getObject(name) !== undefined);
       }
       if (prefix === `${destinationGcsDirectoryPath}/`) {
         return [
@@ -612,6 +612,31 @@ describe("moveFrameV2Source", () => {
     expect(fileStorageMock.deleteCalls).not.toContainEqual(
       expect.objectContaining({ filePath: destinationManifestPath })
     );
+
+    const reserved = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reserved?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reserved?.useCaseMetadata?.pendingFrameSourceMove).toEqual({
+      destinationMountFilePath,
+      sourceMountFilePath,
+    });
+
+    const retried = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(retried.isOk(), retried.isErr() ? retried.error.message : undefined);
+    expect(retried.value.sourceDeletionFailed).toBe(false);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
   });
 
   it("resumes an interrupted move from its destination reservation", async () => {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -221,62 +221,98 @@ describe("moveFrameV2Source", () => {
     ).toMatchObject({ id: sandbox.id, status: "deleted" });
   });
 
-  it("atomically reserves one destination across concurrent Frame moves", async () => {
+  it("does not overwrite a destination object created during the move", async () => {
     const context = await setup();
-    const otherDirectoryPath = `conversation-${context.conversation.sId}/Other`;
-    const otherGcsDirectoryPath = `${getConversationFilesBasePath({
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Collision`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
       workspaceId: context.workspace.sId,
       conversationId: context.conversation.sId,
-    })}Other`;
-    const otherFrame = await FileFactory.create(context.auth, null, {
-      contentType: frameV2ContentType,
-      fileName: FRAME_MANIFEST_FILE,
-      fileSize: Buffer.byteLength(manifest),
-      status: "created",
-      useCase: "conversation",
-      useCaseMetadata: { conversationId: context.conversation.sId },
-      mountFilePath: `${otherGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
-    });
-    await otherFrame.markFrameV2AsReadyFromMount(context.auth);
-    fileStorageMock.setFilesByPrefix((prefix) => {
-      const sourcePrefix = [
-        `${context.sourceGcsDirectoryPath}/`,
-        `${otherGcsDirectoryPath}/`,
-      ].find((candidate) => candidate === prefix);
-      return sourcePrefix
-        ? [
-            {
-              name: `${sourcePrefix}${FRAME_MANIFEST_FILE}`,
-              metadata: {
-                contentType: frameV2ContentType,
-                generation: "1",
-                md5Hash: "manifest",
-                size: String(Buffer.byteLength(manifest)),
-              },
-            },
-          ]
-        : null;
-    });
-    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Destination`;
+    })}Collision`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setObject(destinationManifestPath, "raw destination");
+    fileStorageMock.setFileMetadata((filePath) =>
+      filePath === destinationManifestPath
+        ? {
+            contentType: frameV2ContentType,
+            generation: "1",
+            md5Hash: "raw",
+            size: "15",
+          }
+        : null
+    );
 
-    const results = await Promise.all([
-      moveFrameV2Source(context.auth, {
-        conversation: context.conversation,
-        destinationDirectoryPath,
-        sourceDirectoryPath: context.sourceDirectoryPath,
-      }),
-      moveFrameV2Source(context.auth, {
-        conversation: context.conversation,
-        destinationDirectoryPath,
-        sourceDirectoryPath: otherDirectoryPath,
-      }),
-    ]);
-
-    expect(results.filter((result) => result.isOk())).toHaveLength(1);
-    expect(results.filter((result) => result.isErr())).toHaveLength(1);
-    expect(results.find((result) => result.isErr())?.error).toMatchObject({
-      code: "conflict",
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
     });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(
+      "raw destination"
+    );
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
+    );
+    expect(fileStorageMock.deleteCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          options: expect.objectContaining({
+            ifGenerationMatch: expect.any(String),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("keeps the recovery reservation when exact-generation cleanup fails", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Retry`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Retry`;
+    const destinationMountFilePath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setCopyFileFails((sourcePath) =>
+      sourcePath.endsWith(`/${FRAME_MANIFEST_FILE}`)
+    );
+    fileStorageMock.setDeleteFails((filePath) =>
+      filePath.endsWith("/index.tsx")
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toEqual({
+      destinationMountFilePath,
+      sourceMountFilePath: `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    expect(fileStorageMock.deleteCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filePath: `${destinationGcsDirectoryPath}/index.tsx`,
+          options: expect.objectContaining({
+            ifGenerationMatch: expect.any(String),
+          }),
+        }),
+      ])
+    );
   });
 
   it("resumes an interrupted move from its destination reservation", async () => {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -66,12 +66,16 @@ async function setup() {
   });
   await frame.markFrameV2AsReadyFromMount(auth);
 
+  const sourceManifestPath = `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+  const sourceUiPath = `${sourceGcsDirectoryPath}/index.tsx`;
+  fileStorageMock.setObject(sourceManifestPath, manifest);
+  fileStorageMock.setObject(sourceUiPath, "ui source");
   fileStorageMock.setFileExists(() => false);
   fileStorageMock.setFilesByPrefix((prefix) =>
     prefix === `${sourceGcsDirectoryPath}/`
       ? [
           {
-            name: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+            name: sourceManifestPath,
             metadata: {
               contentType: frameV2ContentType,
               generation: "1",
@@ -80,15 +84,15 @@ async function setup() {
             },
           },
           {
-            name: `${sourceGcsDirectoryPath}/index.tsx`,
+            name: sourceUiPath,
             metadata: {
               contentType: "text/typescript",
-              generation: "1",
+              generation: "2",
               md5Hash: "ui",
               size: "1",
             },
           },
-        ]
+        ].filter(({ name }) => fileStorageMock.getObject(name) !== undefined)
       : null
   );
 
@@ -152,6 +156,85 @@ describe("moveFrameV2Source", () => {
       conversationId: context.conversation.sId,
     });
     await expect(reloaded?.getShareInfo()).resolves.toEqual(beforeShare);
+  });
+
+  it("requires write access to the destination scope", async () => {
+    const context = await setup();
+    const destinationPod = await SpaceFactory.project(context.workspace);
+    await SpaceFactory.attachGroup(
+      destinationPod,
+      context.globalGroup,
+      "project_viewer"
+    );
+    const viewerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      context.user.sId,
+      context.workspace.sId
+    );
+    assert(viewerAuth);
+
+    const moved = await moveFrameV2Source(viewerAuth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `pod-${destinationPod.sId}/Status`,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "unauthorized",
+    });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+  });
+
+  it("requires write access to the source scope", async () => {
+    const context = await setup();
+    const sourcePod = await SpaceFactory.project(context.workspace);
+    await SpaceFactory.attachGroup(
+      sourcePod,
+      context.globalGroup,
+      "project_viewer"
+    );
+    const viewerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      context.user.sId,
+      context.workspace.sId
+    );
+    assert(viewerAuth);
+    const sourceDirectoryPath = `pod-${sourcePod.sId}/Status`;
+    const sourceGcsDirectoryPath = `${getPodFilesBasePath({
+      workspaceId: context.workspace.sId,
+      podId: sourcePod.sId,
+    })}Status`;
+    const sourceManifestPath = `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setObject(sourceManifestPath, manifest);
+    fileStorageMock.setObject(
+      `${sourceGcsDirectoryPath}/index.tsx`,
+      "ui source"
+    );
+    await context.frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: sourceManifestPath,
+      destUseCase: "project_context",
+      destUseCaseMetadata: { spaceId: sourcePod.sId },
+    });
+
+    const moved = await moveFrameV2Source(viewerAuth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `conversation-${context.conversation.sId}/Moved`,
+      sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "unauthorized",
+    });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(sourceManifestPath);
   });
 
   it("recycles the runtime when moving to another scope while keeping state ownership", async () => {
@@ -254,6 +337,68 @@ describe("moveFrameV2Source", () => {
     );
   });
 
+  it("copies pinned source generations and preserves concurrent edits", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Edited`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Edited`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    const newSourcePath = `${context.sourceGcsDirectoryPath}/new.ts`;
+    let sourceListings = 0;
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix !== `${context.sourceGcsDirectoryPath}/`) {
+        return null;
+      }
+      sourceListings++;
+      if (sourceListings === 1) {
+        const snapshot = [
+          {
+            name: sourceManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: sourceUiPath,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ];
+        fileStorageMock.setObject(sourceUiPath, "edited ui");
+        fileStorageMock.setObject(newSourcePath, "new source");
+        return snapshot;
+      }
+      return [sourceManifestPath, sourceUiPath, newSourcePath]
+        .filter((filePath) => fileStorageMock.getObject(filePath) !== undefined)
+        .map((filePath) => ({ name: filePath, metadata: {} }));
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value.sourceDeletionFailed).toBe(true);
+    expect(
+      fileStorageMock.getObject(`${destinationGcsDirectoryPath}/index.tsx`)
+    ).toBe("ui source");
+    expect(fileStorageMock.getObject(sourceUiPath)).toBe("edited ui");
+    expect(fileStorageMock.getObject(newSourcePath)).toBe("new source");
+    expect(fileStorageMock.getObject(sourceManifestPath)).toBeUndefined();
+  });
+
   it("keeps the recovery reservation when exact-generation cleanup fails", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/Retry`;
@@ -342,12 +487,14 @@ describe("moveFrameV2Source", () => {
           name: `${directoryPath}/index.tsx`,
           metadata: {
             contentType: "text/typescript",
-            generation: isSource ? "1" : "2",
+            generation: "2",
             md5Hash: "ui",
             size: "1",
           },
         },
-      ];
+      ].filter(
+        ({ name }) => !isSource || fileStorageMock.getObject(name) !== undefined
+      );
     });
 
     const moved = await moveFrameV2Source(context.auth, {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -2,24 +2,6 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
-  const actual =
-    await importActual<
-      typeof import("@app/lib/api/frames/publication_storage")
-    >();
-  return {
-    ...actual,
-    withFramePublishLock: async (
-      _frameId: string,
-      callback: () => Promise<unknown>
-    ) => callback(),
-    withFrameSourceAndPublishLock: async (
-      _frameId: string,
-      callback: () => Promise<unknown>
-    ) => callback(),
-  };
-});
-
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
   return {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -13,6 +13,10 @@ vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
       _frameId: string,
       callback: () => Promise<unknown>
     ) => callback(),
+    withFrameSourceAndPublishLock: async (
+      _frameId: string,
+      callback: () => Promise<unknown>
+    ) => callback(),
   };
 });
 
@@ -88,12 +92,19 @@ async function setup() {
             name: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
             metadata: {
               contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
               size: String(Buffer.byteLength(manifest)),
             },
           },
           {
             name: `${sourceGcsDirectoryPath}/index.tsx`,
-            metadata: { contentType: "text/typescript", size: "1" },
+            metadata: {
+              contentType: "text/typescript",
+              generation: "1",
+              md5Hash: "ui",
+              size: "1",
+            },
           },
         ]
       : null
@@ -208,6 +219,135 @@ describe("moveFrameV2Source", () => {
     expect(
       await FrameSandboxAdapter.fetchSandbox(auth, context.frame)
     ).toMatchObject({ id: sandbox.id, status: "deleted" });
+  });
+
+  it("atomically reserves one destination across concurrent Frame moves", async () => {
+    const context = await setup();
+    const otherDirectoryPath = `conversation-${context.conversation.sId}/Other`;
+    const otherGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Other`;
+    const otherFrame = await FileFactory.create(context.auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(manifest),
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: context.conversation.sId },
+      mountFilePath: `${otherGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    await otherFrame.markFrameV2AsReadyFromMount(context.auth);
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      const sourcePrefix = [
+        `${context.sourceGcsDirectoryPath}/`,
+        `${otherGcsDirectoryPath}/`,
+      ].find((candidate) => candidate === prefix);
+      return sourcePrefix
+        ? [
+            {
+              name: `${sourcePrefix}${FRAME_MANIFEST_FILE}`,
+              metadata: {
+                contentType: frameV2ContentType,
+                generation: "1",
+                md5Hash: "manifest",
+                size: String(Buffer.byteLength(manifest)),
+              },
+            },
+          ]
+        : null;
+    });
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Destination`;
+
+    const results = await Promise.all([
+      moveFrameV2Source(context.auth, {
+        conversation: context.conversation,
+        destinationDirectoryPath,
+        sourceDirectoryPath: context.sourceDirectoryPath,
+      }),
+      moveFrameV2Source(context.auth, {
+        conversation: context.conversation,
+        destinationDirectoryPath,
+        sourceDirectoryPath: otherDirectoryPath,
+      }),
+    ]);
+
+    expect(results.filter((result) => result.isOk())).toHaveLength(1);
+    expect(results.filter((result) => result.isErr())).toHaveLength(1);
+    expect(results.find((result) => result.isErr())?.error).toMatchObject({
+      code: "conflict",
+    });
+  });
+
+  it("resumes an interrupted move from its destination reservation", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Recovered`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Recovered`;
+    const destinationMountFilePath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceMountFilePath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    await context.frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: destinationMountFilePath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: {
+        activePublicationId: "publication-1",
+        conversationId: context.conversation.sId,
+        pendingFrameSourceMove: {
+          destinationMountFilePath,
+          sourceMountFilePath,
+        },
+      },
+    });
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      const isSource = prefix === `${context.sourceGcsDirectoryPath}/`;
+      const isDestination = prefix === `${destinationGcsDirectoryPath}/`;
+      if (!isSource && !isDestination) {
+        return null;
+      }
+      const directoryPath = isSource
+        ? context.sourceGcsDirectoryPath
+        : destinationGcsDirectoryPath;
+      return [
+        {
+          name: `${directoryPath}/${FRAME_MANIFEST_FILE}`,
+          metadata: {
+            contentType: frameV2ContentType,
+            generation: isSource ? "1" : "2",
+            md5Hash: "manifest",
+            size: String(Buffer.byteLength(manifest)),
+          },
+        },
+        {
+          name: `${directoryPath}/index.tsx`,
+          metadata: {
+            contentType: "text/typescript",
+            generation: isSource ? "1" : "2",
+            md5Hash: "ui",
+            size: "1",
+          },
+        },
+      ];
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: context.conversation.sId,
+    });
   });
 
   it("rejects moving a Frame inside its own source folder", async () => {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("@app/lib/api/frames/publication_storage")
+    >();
+  return {
+    ...actual,
+    withFramePublishLock: async (
+      _frameId: string,
+      callback: () => Promise<unknown>
+    ) => callback(),
+  };
+});
+
+vi.mock("@app/lib/lock", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    executeWithLock: async <T>(_key: string, callback: () => Promise<T>) =>
+      callback(),
+  };
+});
+
+import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
+import assert from "assert";
+
+const manifest = JSON.stringify({
+  version: 1,
+  name: "Status",
+  description: "Show the current status.",
+});
+
+async function setup() {
+  const {
+    authenticator: auth,
+    globalGroup,
+    user,
+    workspace,
+  } = await createResourceTest({ role: "admin" });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(manifest),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: {
+      activePublicationId: "publication-1",
+      conversationId: conversation.sId,
+    },
+    mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+
+  fileStorageMock.setFileExists(() => false);
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    prefix === `${sourceGcsDirectoryPath}/`
+      ? [
+          {
+            name: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+            metadata: {
+              contentType: frameV2ContentType,
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: `${sourceGcsDirectoryPath}/index.tsx`,
+            metadata: { contentType: "text/typescript", size: "1" },
+          },
+        ]
+      : null
+  );
+
+  return {
+    auth,
+    conversation,
+    frame,
+    globalGroup,
+    sourceDirectoryPath,
+    sourceGcsDirectoryPath,
+    user,
+    workspace,
+  };
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  vi.restoreAllMocks();
+});
+
+describe("moveFrameV2Source", () => {
+  it("moves within one scope without replacing identity, publication, or sharing", async () => {
+    const context = await setup();
+    const beforeShare = await context.frame.getShareInfo();
+    const scopeTransition = vi.spyOn(
+      FrameSandboxAdapter,
+      "withScopeTransition"
+    );
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Renamed`;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value).toEqual({
+      destinationDirectoryPath,
+      frameId: context.frame.sId,
+      sourceDeletionFailed: false,
+    });
+    expect(scopeTransition).not.toHaveBeenCalled();
+
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded).toMatchObject({
+      sId: context.frame.sId,
+      useCase: "conversation",
+    });
+    expect(reloaded?.mountFilePath).toBe(
+      `${getConversationFilesBasePath({
+        workspaceId: context.workspace.sId,
+        conversationId: context.conversation.sId,
+      })}Renamed/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: context.conversation.sId,
+    });
+    await expect(reloaded?.getShareInfo()).resolves.toEqual(beforeShare);
+  });
+
+  it("recycles the runtime when moving to another scope while keeping state ownership", async () => {
+    const context = await setup();
+    const destinationPod = await SpaceFactory.project(context.workspace);
+    await SpaceFactory.attachGroup(
+      destinationPod,
+      context.globalGroup,
+      "project_editor"
+    );
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      context.user.sId,
+      context.workspace.sId
+    );
+    assert(auth);
+    const sandbox = await SandboxResource.makeNew(context.auth, {
+      providerId: "frame-sandbox",
+      status: "sleeping",
+      baseImage: "dust-base",
+      version: "1",
+    });
+    await SandboxOwnerModel.create({
+      frameFileModelId: context.frame.id,
+      sandboxId: sandbox.id,
+      workspaceId: context.workspace.id,
+    });
+    const destinationDirectoryPath = `pod-${destinationPod.sId}/Status`;
+
+    const moved = await moveFrameV2Source(auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(auth, context.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${getPodFilesBasePath({
+        workspaceId: context.workspace.sId,
+        podId: destinationPod.sId,
+      })}Status/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      spaceId: destinationPod.sId,
+    });
+    expect(
+      await FrameSandboxAdapter.fetchSandbox(auth, context.frame)
+    ).toMatchObject({ id: sandbox.id, status: "deleted" });
+  });
+
+  it("rejects moving a Frame inside its own source folder", async () => {
+    const context = await setup();
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `${context.sourceDirectoryPath}/Nested`,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+});

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -347,30 +347,45 @@ async function copyFrameSourceAsNew({
           );
         }
         let destinationFile = destinationByRelativePath.get(relativePath);
-        const destinationWasListed = Boolean(destinationFile);
-        let copied = false;
+        let ownedDestinationObject: GCSObjectGeneration | null = null;
 
         if (!destinationFile) {
           try {
-            await bucket.copyFile(sourceFile.name, destinationPath, undefined, {
-              destinationGenerationMatch:
-                GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-              sourceGeneration,
-            });
-            copied = true;
+            const copied = await bucket.copyFile(
+              sourceFile.name,
+              destinationPath,
+              undefined,
+              {
+                destinationGenerationMatch:
+                  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+                sourceGeneration,
+              }
+            );
+            destinationFile = copied.destinationFile;
+            ownedDestinationObject = {
+              filePath: destinationPath,
+              generation: copied.destinationGeneration,
+            };
           } catch (error) {
             if (!isGCSPreconditionFailedError(error)) {
               throw error;
             }
+            if (!allowMatchingDestinationObjects) {
+              throw new FrameSourceMoveError(
+                "conflict",
+                `Destination file already exists: ${relativePath}`
+              );
+            }
+            destinationFile = bucket.file(destinationPath);
+            const [metadata] = await destinationFile.getMetadata();
+            destinationFile.metadata = metadata;
           }
-          destinationFile = bucket.file(destinationPath);
-          const [metadata] = await destinationFile.getMetadata();
-          destinationFile.metadata = metadata;
         }
 
         if (
-          (!copied && !isSameGCSObject(sourceFile, destinationFile)) ||
-          (!allowMatchingDestinationObjects && destinationWasListed)
+          !ownedDestinationObject &&
+          (!allowMatchingDestinationObjects ||
+            !isSameGCSObject(sourceFile, destinationFile))
         ) {
           throw new FrameSourceMoveError(
             "conflict",
@@ -378,21 +393,11 @@ async function copyFrameSourceAsNew({
           );
         }
 
-        const generation = metadataValue(
-          destinationFile.metadata,
-          "generation"
-        );
-        if (!generation) {
-          throw new FrameSourceMoveError(
-            "internal",
-            `Destination generation is missing: ${relativePath}`
-          );
-        }
         return new Ok<{
-          destination: GCSObjectGeneration;
+          destination: GCSObjectGeneration | null;
           source: GCSObjectGeneration;
         }>({
-          destination: { filePath: destinationPath, generation },
+          destination: ownedDestinationObject,
           source: {
             filePath: sourceFile.name,
             generation: sourceGeneration,
@@ -414,8 +419,8 @@ async function copyFrameSourceAsNew({
   const copiedObjects = copyResults
     .filter((result) => result.isOk())
     .map((result) => result.value);
-  const destinationObjects = copiedObjects.map(
-    ({ destination }) => destination
+  const destinationObjects = copiedObjects.flatMap(({ destination }) =>
+    destination ? [destination] : []
   );
   const failedCopy = copyResults.find((result) => result.isErr());
   if (failedCopy?.isErr()) {

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -1,0 +1,393 @@
+import path from "node:path";
+
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import { withFramePublishLock } from "@app/lib/api/frames/publication_storage";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { FrameScopeTransitionStateError } from "@app/lib/resources/frame_sandbox_adapter";
+import {
+  FrameGoneError,
+  FrameSandboxAdapter,
+} from "@app/lib/resources/frame_sandbox_adapter";
+import type { ScopeTransitionDestroyError } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+type FrameSourceOwner = {
+  useCase: FileUseCase;
+  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
+};
+
+export class FrameSourceMoveError extends Error {
+  constructor(
+    readonly code: "conflict" | "internal" | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceMoveError";
+  }
+}
+
+export function isFrameSourceMoveError(
+  error: unknown
+): error is FrameSourceMoveError {
+  return error instanceof FrameSourceMoveError;
+}
+
+export type MoveFrameV2SourceError =
+  | DustFileSystemError
+  | FrameGoneError
+  | FrameScopeTransitionStateError
+  | FrameSourceMoveError
+  | SandboxFunctionError
+  | ScopeTransitionDestroyError;
+
+function invalidSource(message: string) {
+  return new Err(new FrameSourceMoveError("invalid_source", message));
+}
+
+function sourceOwnerFromPath(
+  scopedDirectoryPath: string
+): FrameSourceOwner | null {
+  const parsed = parseScopedPrefix(scopedDirectoryPath);
+  const slash = scopedDirectoryPath.indexOf("/");
+  if (
+    !parsed ||
+    slash < 0 ||
+    scopedDirectoryPath.slice(slash + 1).length === 0
+  ) {
+    return null;
+  }
+
+  switch (parsed.kind) {
+    case "conversation":
+      return {
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parsed.id },
+      };
+    case "pod":
+      return {
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: parsed.id },
+      };
+    case "user":
+      return null;
+  }
+}
+
+async function resolveRuntimeSpaceId(
+  auth: Authenticator,
+  sourceOwner: FrameSourceOwner
+): Promise<Result<string | null, FrameSourceMoveError>> {
+  const { conversationId, spaceId } = sourceOwner.useCaseMetadata;
+  if (spaceId) {
+    return new Ok(spaceId);
+  }
+  if (!conversationId) {
+    return invalidSource("Frame source has no conversation or Pod scope.");
+  }
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return invalidSource(`Conversation ${conversationId} not found.`);
+  }
+  return new Ok(conversation.spaceSId);
+}
+
+function frameMetadataAtDestination(
+  frame: FileResource,
+  destinationOwner: FrameSourceOwner
+): FileUseCaseMetadata {
+  const {
+    conversationId: _conversationId,
+    spaceId: _spaceId,
+    ...stableMetadata
+  } = frame.useCaseMetadata ?? {};
+  return {
+    ...stableMetadata,
+    ...destinationOwner.useCaseMetadata,
+  };
+}
+
+function assertFrameAtSource(
+  auth: Authenticator,
+  frame: FileResource,
+  sourceManifestPath: string
+): Result<void, FrameSourceMoveError> {
+  if (!frame.isFrameV2 || frame.toScopedPath(auth) !== sourceManifestPath) {
+    return new Err(
+      new FrameSourceMoveError(
+        "conflict",
+        "The Frame source changed while it was being moved; retry from its current path."
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
+async function rollbackSourceMove(
+  dustFs: DustFileSystem,
+  {
+    destinationDirectoryPath,
+    sourceDeletionFailed,
+    sourceDirectoryPath,
+  }: {
+    destinationDirectoryPath: string;
+    sourceDeletionFailed: boolean;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<void, DustFileSystemError>> {
+  if (sourceDeletionFailed) {
+    return dustFs.delete(destinationDirectoryPath, { ignoreNotFound: true });
+  }
+
+  const rollback = await dustFs.move({
+    src: destinationDirectoryPath,
+    dest: sourceDirectoryPath,
+  });
+  return rollback.isErr() ? rollback : new Ok(undefined);
+}
+
+/** Move a registered Frame folder while retaining its stable FileResource identity. */
+export async function moveFrameV2Source(
+  auth: Authenticator,
+  {
+    conversation,
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    destinationDirectoryPath: string;
+    sourceDirectoryPath: string;
+  }
+): Promise<
+  Result<
+    {
+      destinationDirectoryPath: string;
+      frameId: string;
+      sourceDeletionFailed: boolean;
+    },
+    MoveFrameV2SourceError
+  >
+> {
+  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  const destination = DustFileSystem.normalizeScopedPath(
+    destinationDirectoryPath
+  );
+  if (!source || !destination) {
+    return invalidSource("Frame source and destination must be scoped paths.");
+  }
+  if (source === destination) {
+    return invalidSource("Frame source and destination must be different.");
+  }
+  if (destination.startsWith(`${source}/`)) {
+    return invalidSource(
+      "A Frame cannot be moved inside its own source folder."
+    );
+  }
+
+  const sourceOwner = sourceOwnerFromPath(source);
+  const destinationOwner = sourceOwnerFromPath(destination);
+  if (!sourceOwner || !destinationOwner) {
+    return invalidSource(
+      "Frame source and destination must be folders in a conversation or Pod mount."
+    );
+  }
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [source, destination],
+  });
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return invalidSource(
+      "Frames v2 source moves do not yet support the database-backed filesystem."
+    );
+  }
+
+  const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
+  const destinationManifestPath = path.posix.join(
+    destination,
+    FRAME_MANIFEST_FILE
+  );
+  const sourceMountPath = dustFs.toMountFilePath(sourceManifestPath);
+  const destinationMountPath = dustFs.toMountFilePath(destinationManifestPath);
+  if (!sourceMountPath || !destinationMountPath) {
+    return invalidSource("Invalid Frame source or destination path.");
+  }
+
+  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+    sourceMountPath,
+  ]);
+  if (!frame?.isFrameV2) {
+    return invalidSource(`No registered Frame found at ${sourceManifestPath}.`);
+  }
+
+  return withFramePublishLock(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame) {
+      return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
+    }
+    const sourceCheck = assertFrameAtSource(
+      auth,
+      freshFrame,
+      sourceManifestPath
+    );
+    if (sourceCheck.isErr()) {
+      return sourceCheck;
+    }
+
+    const [destinationFrame] = await FileResource.fetchByMountFilePaths(auth, [
+      destinationMountPath,
+    ]);
+    if (destinationFrame) {
+      return new Err(
+        new FrameSourceMoveError(
+          "conflict",
+          "A registered file already uses the destination path."
+        )
+      );
+    }
+
+    const destinationContents = await dustFs.list(destination, { maxFiles: 1 });
+    if (destinationContents.isErr()) {
+      return destinationContents;
+    }
+    const destinationFileExists = await dustFs.exists(destination);
+    if (destinationFileExists.isErr()) {
+      return destinationFileExists;
+    }
+    if (destinationFileExists.value || destinationContents.value.length > 0) {
+      return new Err(
+        new FrameSourceMoveError(
+          "conflict",
+          "A file or folder already exists at the destination."
+        )
+      );
+    }
+
+    const [sourceRuntimeSpace, destinationRuntimeSpace] = await Promise.all([
+      resolveRuntimeSpaceId(auth, sourceOwner),
+      resolveRuntimeSpaceId(auth, destinationOwner),
+    ]);
+    if (sourceRuntimeSpace.isErr()) {
+      return sourceRuntimeSpace;
+    }
+    if (destinationRuntimeSpace.isErr()) {
+      return destinationRuntimeSpace;
+    }
+
+    const moveResult = await dustFs.move({
+      src: source,
+      dest: destination,
+    });
+    if (moveResult.isErr()) {
+      return moveResult;
+    }
+
+    const updateFrame = async (
+      currentFrame: FileResource
+    ): Promise<Result<void, FrameSourceMoveError>> => {
+      const currentSourceCheck = assertFrameAtSource(
+        auth,
+        currentFrame,
+        sourceManifestPath
+      );
+      if (currentSourceCheck.isErr()) {
+        return currentSourceCheck;
+      }
+      try {
+        await currentFrame.updateMount({
+          destFileName: FRAME_MANIFEST_FILE,
+          destMountFilePath: destinationMountPath,
+          destUseCase: destinationOwner.useCase,
+          destUseCaseMetadata: frameMetadataAtDestination(
+            currentFrame,
+            destinationOwner
+          ),
+        });
+        return new Ok(undefined);
+      } catch (error) {
+        return new Err(
+          new FrameSourceMoveError(
+            "internal",
+            `Failed to update the Frame source location: ${normalizeError(error).message}`
+          )
+        );
+      }
+    };
+
+    const updateResult =
+      sourceRuntimeSpace.value === destinationRuntimeSpace.value
+        ? await updateFrame(freshFrame)
+        : await FrameSandboxAdapter.withScopeTransition(auth, freshFrame, {
+            prepare: async (currentFrame) => {
+              const check = assertFrameAtSource(
+                auth,
+                currentFrame,
+                sourceManifestPath
+              );
+              return check.isErr() ? check : new Ok<FileResource>(currentFrame);
+            },
+            commit: (currentFrame) => updateFrame(currentFrame),
+          });
+
+    if (updateResult.isErr()) {
+      const rollbackResult = await rollbackSourceMove(dustFs, {
+        destinationDirectoryPath: destination,
+        sourceDeletionFailed: moveResult.value.sourceDeletionFailed,
+        sourceDirectoryPath: source,
+      });
+      if (rollbackResult.isErr()) {
+        logger.error(
+          {
+            destinationDirectoryPath: destination,
+            err: updateResult.error,
+            frameId: frame.sId,
+            rollbackErr: rollbackResult.error,
+            sourceDirectoryPath: source,
+          },
+          "Frame source move failed and could not be rolled back"
+        );
+        return new Err(
+          new FrameSourceMoveError(
+            "internal",
+            "The Frame source move failed and could not be rolled back."
+          )
+        );
+      }
+      return updateResult;
+    }
+
+    if (moveResult.value.sourceDeletionFailed) {
+      logger.warn(
+        {
+          destinationDirectoryPath: destination,
+          frameId: frame.sId,
+          sourceDirectoryPath: source,
+        },
+        "Frame source moved but the old folder could not be removed"
+      );
+    }
+
+    return new Ok({
+      destinationDirectoryPath: destination,
+      frameId: frame.sId,
+      sourceDeletionFailed: moveResult.value.sourceDeletionFailed,
+    });
+  });
+}

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import {
   MAX_FRAME_SOURCE_BYTES,
   MAX_FRAME_SOURCE_FILE_COUNT,

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -274,10 +274,12 @@ async function deleteCopiedSourceObjects(
 async function copyFrameSourceAsNew({
   allowMatchingDestinationObjects,
   destinationMountPrefix,
+  sourceManifestPath,
   sourceMountPrefix,
 }: {
   allowMatchingDestinationObjects: boolean;
   destinationMountPrefix: string;
+  sourceManifestPath: string;
   sourceMountPrefix: string;
 }): Promise<Result<FrameSourceCopy, FrameSourceCopyFailure>> {
   const bucket = getPrivateUploadBucket();
@@ -297,6 +299,16 @@ async function copyFrameSourceAsNew({
       error: new FrameSourceMoveError(
         "invalid_source",
         "Frame source folder is empty or no longer exists."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  if (!sourceFiles.some((file) => file.name === sourceManifestPath)) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source manifest is missing."
       ),
       hasPreexistingDestinationObjects: destinationFiles.length > 0,
     });
@@ -324,6 +336,24 @@ async function copyFrameSourceAsNew({
       error: new FrameSourceMoveError(
         "conflict",
         "Frame destination exceeds the move file count limit."
+      ),
+      hasPreexistingDestinationObjects: true,
+    });
+  }
+
+  const sourceRelativePaths = new Set(
+    sourceFiles.map((file) => file.name.slice(sourceMountPrefix.length))
+  );
+  const unexpectedDestination = destinationFiles.find(
+    (file) =>
+      !sourceRelativePaths.has(file.name.slice(destinationMountPrefix.length))
+  );
+  if (unexpectedDestination) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "conflict",
+        `Destination file already exists: ${unexpectedDestination.name.slice(destinationMountPrefix.length)}`
       ),
       hasPreexistingDestinationObjects: true,
     });
@@ -683,6 +713,7 @@ export async function moveFrameV2Source(
     const copyResult = await copyFrameSourceAsNew({
       allowMatchingDestinationObjects: isRecovery,
       destinationMountPrefix,
+      sourceManifestPath: sourceMountPath,
       sourceMountPrefix,
     });
     if (copyResult.isErr()) {

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -1,9 +1,16 @@
 import path from "node:path";
 
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
-import { withFramePublishLock } from "@app/lib/api/frames/publication_storage";
+import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
+import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
+import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { FrameScopeTransitionStateError } from "@app/lib/resources/frame_sandbox_adapter";
@@ -12,6 +19,7 @@ import {
   FrameSandboxAdapter,
 } from "@app/lib/resources/frame_sandbox_adapter";
 import type { ScopeTransitionDestroyError } from "@app/lib/resources/sandbox_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -21,6 +29,10 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { File, FileMetadata } from "@google-cloud/storage";
+import { UniqueConstraintError } from "sequelize";
+
+const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
 
 type FrameSourceOwner = {
   useCase: FileUseCase;
@@ -114,6 +126,7 @@ function frameMetadataAtDestination(
 ): FileUseCaseMetadata {
   const {
     conversationId: _conversationId,
+    pendingFrameSourceMove: _pendingFrameSourceMove,
     spaceId: _spaceId,
     ...stableMetadata
   } = frame.useCaseMetadata ?? {};
@@ -121,6 +134,33 @@ function frameMetadataAtDestination(
     ...stableMetadata,
     ...destinationOwner.useCaseMetadata,
   };
+}
+
+function metadataWithoutPendingMove(
+  metadata: FileUseCaseMetadata | null
+): FileUseCaseMetadata {
+  const { pendingFrameSourceMove: _pendingFrameSourceMove, ...stableMetadata } =
+    metadata ?? {};
+  return stableMetadata;
+}
+
+function hasMatchingPendingMove(
+  frame: FileResource,
+  {
+    destinationMountFilePath,
+    sourceMountFilePath,
+  }: {
+    destinationMountFilePath: string;
+    sourceMountFilePath: string;
+  }
+): boolean {
+  const pending = frame.useCaseMetadata?.pendingFrameSourceMove;
+  return (
+    frame.isFrameV2 &&
+    frame.mountFilePath === destinationMountFilePath &&
+    pending?.sourceMountFilePath === sourceMountFilePath &&
+    pending.destinationMountFilePath === destinationMountFilePath
+  );
 }
 
 function assertFrameAtSource(
@@ -139,27 +179,160 @@ function assertFrameAtSource(
   return new Ok(undefined);
 }
 
-async function rollbackSourceMove(
-  dustFs: DustFileSystem,
-  {
-    destinationDirectoryPath,
-    sourceDeletionFailed,
-    sourceDirectoryPath,
-  }: {
-    destinationDirectoryPath: string;
-    sourceDeletionFailed: boolean;
-    sourceDirectoryPath: string;
-  }
-): Promise<Result<void, DustFileSystemError>> {
-  if (sourceDeletionFailed) {
-    return dustFs.delete(destinationDirectoryPath, { ignoreNotFound: true });
+function metadataValue(metadata: FileMetadata, key: keyof FileMetadata) {
+  const value = metadata[key];
+  return value === undefined || value === null ? null : String(value);
+}
+
+function isSameGCSObject(source: File, destination: File): boolean {
+  const sourceMd5 = metadataValue(source.metadata, "md5Hash");
+  const destinationMd5 = metadataValue(destination.metadata, "md5Hash");
+  if (sourceMd5 && destinationMd5) {
+    return sourceMd5 === destinationMd5;
   }
 
-  const rollback = await dustFs.move({
-    src: destinationDirectoryPath,
-    dest: sourceDirectoryPath,
-  });
-  return rollback.isErr() ? rollback : new Ok(undefined);
+  const sourceCrc32c = metadataValue(source.metadata, "crc32c");
+  const destinationCrc32c = metadataValue(destination.metadata, "crc32c");
+  return Boolean(
+    sourceCrc32c &&
+      destinationCrc32c &&
+      sourceCrc32c === destinationCrc32c &&
+      metadataValue(source.metadata, "size") ===
+        metadataValue(destination.metadata, "size")
+  );
+}
+
+type DestinationObject = { filePath: string; generation: string };
+
+async function cleanupDestinationObjects(
+  objects: DestinationObject[]
+): Promise<boolean> {
+  const bucket = getPrivateUploadBucket();
+  try {
+    await concurrentExecutor(
+      objects,
+      ({ filePath, generation }) =>
+        bucket.delete(filePath, {
+          ignoreNotFound: true,
+          ifGenerationMatch: generation,
+        }),
+      { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+    );
+    return true;
+  } catch (error) {
+    logger.error(
+      { error: normalizeError(error) },
+      "Failed to clean up a Frame move destination"
+    );
+    return false;
+  }
+}
+
+async function copyFrameSourceAsNew({
+  allowMatchingDestinationObjects,
+  destinationMountPrefix,
+  sourceMountPrefix,
+}: {
+  allowMatchingDestinationObjects: boolean;
+  destinationMountPrefix: string;
+  sourceMountPrefix: string;
+}): Promise<Result<DestinationObject[], FrameSourceMoveError>> {
+  const bucket = getPrivateUploadBucket();
+  const [{ files: sourceFiles }, { files: destinationFiles }] =
+    await Promise.all([
+      bucket.getAllFilesByPrefix({ prefix: sourceMountPrefix }),
+      bucket.getAllFilesByPrefix({ prefix: destinationMountPrefix }),
+    ]);
+  if (sourceFiles.length === 0) {
+    return invalidSource("Frame source folder is empty or no longer exists.");
+  }
+
+  const destinationByRelativePath = new Map(
+    destinationFiles.map((file) => [
+      file.name.slice(destinationMountPrefix.length),
+      file,
+    ])
+  );
+  const copyResults = await concurrentExecutor(
+    sourceFiles,
+    async (sourceFile) => {
+      try {
+        const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
+        const destinationPath = `${destinationMountPrefix}${relativePath}`;
+        let destinationFile = destinationByRelativePath.get(relativePath);
+        const destinationWasListed = Boolean(destinationFile);
+        let copied = false;
+
+        if (!destinationFile) {
+          try {
+            await bucket.copyFile(sourceFile.name, destinationPath, undefined, {
+              destinationGenerationMatch:
+                GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+            });
+            copied = true;
+          } catch (error) {
+            if (!isGCSPreconditionFailedError(error)) {
+              throw error;
+            }
+          }
+          destinationFile = bucket.file(destinationPath);
+          const [metadata] = await destinationFile.getMetadata();
+          destinationFile.metadata = metadata;
+        }
+
+        if (
+          (!copied && !isSameGCSObject(sourceFile, destinationFile)) ||
+          (!allowMatchingDestinationObjects && destinationWasListed)
+        ) {
+          throw new FrameSourceMoveError(
+            "conflict",
+            `Destination file already exists: ${relativePath}`
+          );
+        }
+
+        const generation = metadataValue(
+          destinationFile.metadata,
+          "generation"
+        );
+        if (!generation) {
+          throw new FrameSourceMoveError(
+            "internal",
+            `Destination generation is missing: ${relativePath}`
+          );
+        }
+        return new Ok<DestinationObject>({
+          filePath: destinationPath,
+          generation,
+        });
+      } catch (error) {
+        return new Err(
+          error instanceof FrameSourceMoveError
+            ? error
+            : new FrameSourceMoveError(
+                "internal",
+                `Failed to copy the Frame source: ${normalizeError(error).message}`
+              )
+        );
+      }
+    },
+    { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+  );
+  const destinationObjects = copyResults
+    .filter((result) => result.isOk())
+    .map((result) => result.value);
+  const failedCopy = copyResults.find((result) => result.isErr());
+  if (failedCopy?.isErr()) {
+    const cleaned = await cleanupDestinationObjects(destinationObjects);
+    return cleaned
+      ? failedCopy
+      : new Err(
+          new FrameSourceMoveError(
+            "internal",
+            "The Frame source copy failed and its destination objects could not be cleaned up."
+          )
+        );
+  }
+  return new Ok(destinationObjects);
 }
 
 /** Move a registered Frame folder while retaining its stable FileResource identity. */
@@ -233,31 +406,55 @@ export async function moveFrameV2Source(
     return invalidSource("Invalid Frame source or destination path.");
   }
 
-  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+  const candidateFrames = await FileResource.fetchByMountFilePaths(auth, [
     sourceMountPath,
+    destinationMountPath,
   ]);
-  if (!frame?.isFrameV2) {
+  const sourceFrame = candidateFrames.find(
+    (candidate) => candidate.mountFilePath === sourceMountPath
+  );
+  const destinationFrame = candidateFrames.find(
+    (candidate) => candidate.mountFilePath === destinationMountPath
+  );
+  const frame =
+    sourceFrame?.isFrameV2 === true
+      ? sourceFrame
+      : destinationFrame &&
+          hasMatchingPendingMove(destinationFrame, {
+            destinationMountFilePath: destinationMountPath,
+            sourceMountFilePath: sourceMountPath,
+          })
+        ? destinationFrame
+        : null;
+  if (!frame) {
     return invalidSource(`No registered Frame found at ${sourceManifestPath}.`);
   }
 
-  return withFramePublishLock(frame.sId, async () => {
+  return withFrameSourceAndPublishLock(frame.sId, async () => {
     const freshFrame = await frame.fetchFreshFrameV2(auth);
     if (!freshFrame) {
       return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
     }
-    const sourceCheck = assertFrameAtSource(
-      auth,
-      freshFrame,
-      sourceManifestPath
-    );
-    if (sourceCheck.isErr()) {
-      return sourceCheck;
+    const isRecovery = hasMatchingPendingMove(freshFrame, {
+      destinationMountFilePath: destinationMountPath,
+      sourceMountFilePath: sourceMountPath,
+    });
+    if (!isRecovery) {
+      const sourceCheck = assertFrameAtSource(
+        auth,
+        freshFrame,
+        sourceManifestPath
+      );
+      if (sourceCheck.isErr()) {
+        return sourceCheck;
+      }
     }
 
-    const [destinationFrame] = await FileResource.fetchByMountFilePaths(auth, [
-      destinationMountPath,
-    ]);
-    if (destinationFrame) {
+    const [registeredDestination] = await FileResource.fetchByMountFilePaths(
+      auth,
+      [destinationMountPath]
+    );
+    if (registeredDestination && registeredDestination.sId !== freshFrame.sId) {
       return new Err(
         new FrameSourceMoveError(
           "conflict",
@@ -266,21 +463,25 @@ export async function moveFrameV2Source(
       );
     }
 
-    const destinationContents = await dustFs.list(destination, { maxFiles: 1 });
-    if (destinationContents.isErr()) {
-      return destinationContents;
-    }
-    const destinationFileExists = await dustFs.exists(destination);
-    if (destinationFileExists.isErr()) {
-      return destinationFileExists;
-    }
-    if (destinationFileExists.value || destinationContents.value.length > 0) {
-      return new Err(
-        new FrameSourceMoveError(
-          "conflict",
-          "A file or folder already exists at the destination."
-        )
-      );
+    if (!isRecovery) {
+      const destinationContents = await dustFs.list(destination, {
+        maxFiles: 1,
+      });
+      if (destinationContents.isErr()) {
+        return destinationContents;
+      }
+      const destinationFileExists = await dustFs.exists(destination);
+      if (destinationFileExists.isErr()) {
+        return destinationFileExists;
+      }
+      if (destinationFileExists.value || destinationContents.value.length > 0) {
+        return new Err(
+          new FrameSourceMoveError(
+            "conflict",
+            "A file or folder already exists at the destination."
+          )
+        );
+      }
     }
 
     const [sourceRuntimeSpace, destinationRuntimeSpace] = await Promise.all([
@@ -294,24 +495,94 @@ export async function moveFrameV2Source(
       return destinationRuntimeSpace;
     }
 
-    const moveResult = await dustFs.move({
-      src: source,
-      dest: destination,
+    const originalUseCase = freshFrame.useCase;
+    const originalMetadata = metadataWithoutPendingMove(
+      freshFrame.useCaseMetadata
+    );
+    const restoreSourceReservation = async (): Promise<boolean> => {
+      try {
+        await freshFrame.updateMount({
+          destFileName: FRAME_MANIFEST_FILE,
+          destMountFilePath: sourceMountPath,
+          destUseCase: originalUseCase,
+          destUseCaseMetadata: originalMetadata,
+        });
+        return true;
+      } catch (error) {
+        logger.error(
+          {
+            error: normalizeError(error),
+            frameId: frame.sId,
+            sourceMountPath,
+          },
+          "Failed to restore a Frame source reservation"
+        );
+        return false;
+      }
+    };
+
+    if (!isRecovery) {
+      try {
+        await freshFrame.updateMount({
+          destFileName: FRAME_MANIFEST_FILE,
+          destMountFilePath: destinationMountPath,
+          destUseCase: originalUseCase,
+          destUseCaseMetadata: {
+            ...originalMetadata,
+            pendingFrameSourceMove: {
+              destinationMountFilePath: destinationMountPath,
+              sourceMountFilePath: sourceMountPath,
+            },
+          },
+        });
+      } catch (error) {
+        return new Err(
+          new FrameSourceMoveError(
+            error instanceof UniqueConstraintError ? "conflict" : "internal",
+            error instanceof UniqueConstraintError
+              ? "A registered file already uses the destination path."
+              : `Failed to reserve the Frame destination: ${normalizeError(error).message}`
+          )
+        );
+      }
+    }
+
+    const sourceMountPrefix = `${path.posix.dirname(sourceMountPath)}/`;
+    const destinationMountPrefix = `${path.posix.dirname(
+      destinationMountPath
+    )}/`;
+    const copyResult = await copyFrameSourceAsNew({
+      allowMatchingDestinationObjects: isRecovery,
+      destinationMountPrefix,
+      sourceMountPrefix,
     });
-    if (moveResult.isErr()) {
-      return moveResult;
+    if (copyResult.isErr()) {
+      const restored = await restoreSourceReservation();
+      return restored
+        ? copyResult
+        : new Err(
+            new FrameSourceMoveError(
+              "internal",
+              "The Frame source copy failed and its destination reservation could not be released."
+            )
+          );
     }
 
     const updateFrame = async (
       currentFrame: FileResource
     ): Promise<Result<void, FrameSourceMoveError>> => {
-      const currentSourceCheck = assertFrameAtSource(
-        auth,
-        currentFrame,
-        sourceManifestPath
-      );
-      if (currentSourceCheck.isErr()) {
-        return currentSourceCheck;
+      if (
+        !hasMatchingPendingMove(currentFrame, {
+          destinationMountFilePath: destinationMountPath,
+          sourceMountFilePath: sourceMountPath,
+        })
+      ) {
+        return new Err(
+          new FrameSourceMoveError(
+            "conflict",
+            "The Frame source changed while it was being moved; retry from its current path."
+          )
+        );
       }
       try {
         await currentFrame.updateMount({
@@ -339,29 +610,32 @@ export async function moveFrameV2Source(
         ? await updateFrame(freshFrame)
         : await FrameSandboxAdapter.withScopeTransition(auth, freshFrame, {
             prepare: async (currentFrame) => {
-              const check = assertFrameAtSource(
-                auth,
-                currentFrame,
-                sourceManifestPath
-              );
-              return check.isErr() ? check : new Ok<FileResource>(currentFrame);
+              return hasMatchingPendingMove(currentFrame, {
+                destinationMountFilePath: destinationMountPath,
+                sourceMountFilePath: sourceMountPath,
+              })
+                ? new Ok(undefined)
+                : new Err(
+                    new FrameSourceMoveError(
+                      "conflict",
+                      "The Frame source changed while it was being moved; retry from its current path."
+                    )
+                  );
             },
             commit: (currentFrame) => updateFrame(currentFrame),
           });
 
     if (updateResult.isErr()) {
-      const rollbackResult = await rollbackSourceMove(dustFs, {
-        destinationDirectoryPath: destination,
-        sourceDeletionFailed: moveResult.value.sourceDeletionFailed,
-        sourceDirectoryPath: source,
-      });
-      if (rollbackResult.isErr()) {
+      const [cleaned, restored] = await Promise.all([
+        cleanupDestinationObjects(copyResult.value),
+        restoreSourceReservation(),
+      ]);
+      if (!cleaned || !restored) {
         logger.error(
           {
             destinationDirectoryPath: destination,
             err: updateResult.error,
             frameId: frame.sId,
-            rollbackErr: rollbackResult.error,
             sourceDirectoryPath: source,
           },
           "Frame source move failed and could not be rolled back"
@@ -376,10 +650,15 @@ export async function moveFrameV2Source(
       return updateResult;
     }
 
-    if (moveResult.value.sourceDeletionFailed) {
+    const sourceDeletion = await dustFs.delete(source, {
+      ignoreNotFound: true,
+    });
+    const sourceDeletionFailed = sourceDeletion.isErr();
+    if (sourceDeletionFailed) {
       logger.warn(
         {
           destinationDirectoryPath: destination,
+          error: sourceDeletion.error,
           frameId: frame.sId,
           sourceDirectoryPath: source,
         },
@@ -387,10 +666,30 @@ export async function moveFrameV2Source(
       );
     }
 
+    const destinationScope: GCSMountPoint =
+      destinationOwner.useCase === "conversation"
+        ? {
+            useCase: "conversation",
+            conversationId:
+              destinationOwner.useCaseMetadata.conversationId ?? "",
+          }
+        : {
+            useCase: "pod",
+            podId: destinationOwner.useCaseMetadata.spaceId ?? "",
+          };
+    const destinationRelativePath = destination.slice(
+      destination.indexOf("/") + 1
+    );
+    const parentRelativePath = path.posix.dirname(destinationRelativePath);
+    void emitGCSMountFileMovedAuditLog(auth, destinationScope, {
+      relativeFilePath: destinationRelativePath,
+      parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
+    });
+
     return new Ok({
       destinationDirectoryPath: destination,
       frameId: frame.sId,
-      sourceDeletionFailed: moveResult.value.sourceDeletionFailed,
+      sourceDeletionFailed,
     });
   });
 }

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -19,6 +19,7 @@ import type { DustFileSystemError } from "@app/types/file_system";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 type FrameSourceOwner = {
@@ -80,6 +81,8 @@ function sourceOwnerFromPath(
       };
     case "user":
       return null;
+    default:
+      return assertNever(parsed);
   }
 }
 

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -209,11 +209,13 @@ function isSameGCSObject(source: File, destination: File): boolean {
 type GCSObjectGeneration = { filePath: string; generation: string };
 type FrameSourceCopy = {
   destinationObjects: GCSObjectGeneration[];
+  hasPreexistingDestinationObjects: boolean;
   sourceObjects: GCSObjectGeneration[];
 };
 type FrameSourceCopyFailure = {
   destinationObjects: GCSObjectGeneration[];
   error: FrameSourceMoveError;
+  hasPreexistingDestinationObjects: boolean;
 };
 
 async function cleanupDestinationObjects(
@@ -296,6 +298,7 @@ async function copyFrameSourceAsNew({
         "invalid_source",
         "Frame source folder is empty or no longer exists."
       ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
     });
   }
   const totalSourceSize = sourceFiles.reduce(
@@ -312,6 +315,7 @@ async function copyFrameSourceAsNew({
         "invalid_source",
         "Frame source exceeds the move size limit."
       ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
     });
   }
   if (destinationFiles.length > MAX_FRAME_SOURCE_FILE_COUNT) {
@@ -321,6 +325,7 @@ async function copyFrameSourceAsNew({
         "conflict",
         "Frame destination exceeds the move file count limit."
       ),
+      hasPreexistingDestinationObjects: true,
     });
   }
 
@@ -333,6 +338,7 @@ async function copyFrameSourceAsNew({
   const copyResults = await concurrentExecutor(
     sourceFiles,
     async (sourceFile) => {
+      let hasPreexistingDestinationObject = false;
       try {
         const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
         const destinationPath = `${destinationMountPrefix}${relativePath}`;
@@ -348,6 +354,7 @@ async function copyFrameSourceAsNew({
         }
         let destinationFile = destinationByRelativePath.get(relativePath);
         let ownedDestinationObject: GCSObjectGeneration | null = null;
+        hasPreexistingDestinationObject = Boolean(destinationFile);
 
         if (!destinationFile) {
           try {
@@ -376,6 +383,7 @@ async function copyFrameSourceAsNew({
                 `Destination file already exists: ${relativePath}`
               );
             }
+            hasPreexistingDestinationObject = true;
             destinationFile = bucket.file(destinationPath);
             const [metadata] = await destinationFile.getMetadata();
             destinationFile.metadata = metadata;
@@ -395,23 +403,27 @@ async function copyFrameSourceAsNew({
 
         return new Ok<{
           destination: GCSObjectGeneration | null;
+          hasPreexistingDestinationObject: boolean;
           source: GCSObjectGeneration;
         }>({
           destination: ownedDestinationObject,
+          hasPreexistingDestinationObject,
           source: {
             filePath: sourceFile.name,
             generation: sourceGeneration,
           },
         });
       } catch (error) {
-        return new Err(
-          error instanceof FrameSourceMoveError
-            ? error
-            : new FrameSourceMoveError(
-                "internal",
-                `Failed to copy the Frame source: ${normalizeError(error).message}`
-              )
-        );
+        return new Err({
+          error:
+            error instanceof FrameSourceMoveError
+              ? error
+              : new FrameSourceMoveError(
+                  "internal",
+                  `Failed to copy the Frame source: ${normalizeError(error).message}`
+                ),
+          hasPreexistingDestinationObject,
+        });
       }
     },
     { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
@@ -422,15 +434,24 @@ async function copyFrameSourceAsNew({
   const destinationObjects = copiedObjects.flatMap(({ destination }) =>
     destination ? [destination] : []
   );
+  const hasPreexistingDestinationObjects =
+    destinationFiles.length > 0 ||
+    copyResults.some((result) =>
+      result.isOk()
+        ? result.value.hasPreexistingDestinationObject
+        : result.error.hasPreexistingDestinationObject
+    );
   const failedCopy = copyResults.find((result) => result.isErr());
   if (failedCopy?.isErr()) {
     return new Err({
       destinationObjects,
-      error: failedCopy.error,
+      error: failedCopy.error.error,
+      hasPreexistingDestinationObjects,
     });
   }
   return new Ok({
     destinationObjects,
+    hasPreexistingDestinationObjects,
     sourceObjects: copiedObjects.map(({ source }) => source),
   });
 }
@@ -676,6 +697,9 @@ export async function moveFrameV2Source(
           )
         );
       }
+      if (isRecovery && copyResult.error.hasPreexistingDestinationObjects) {
+        return new Err(copyResult.error.error);
+      }
       const restored = await restoreSourceReservation();
       return restored
         ? new Err(copyResult.error.error)
@@ -748,7 +772,11 @@ export async function moveFrameV2Source(
       const cleaned = await cleanupDestinationObjects(
         copyResult.value.destinationObjects
       );
-      const restored = cleaned ? await restoreSourceReservation() : false;
+      const restored =
+        cleaned &&
+        (!isRecovery || !copyResult.value.hasPreexistingDestinationObjects)
+          ? await restoreSourceReservation()
+          : false;
       if (!restored) {
         logger.error(
           {

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -206,14 +206,18 @@ function isSameGCSObject(source: File, destination: File): boolean {
   );
 }
 
-type DestinationObject = { filePath: string; generation: string };
+type GCSObjectGeneration = { filePath: string; generation: string };
+type FrameSourceCopy = {
+  destinationObjects: GCSObjectGeneration[];
+  sourceObjects: GCSObjectGeneration[];
+};
 type FrameSourceCopyFailure = {
-  destinationObjects: DestinationObject[];
+  destinationObjects: GCSObjectGeneration[];
   error: FrameSourceMoveError;
 };
 
 async function cleanupDestinationObjects(
-  objects: DestinationObject[]
+  objects: GCSObjectGeneration[]
 ): Promise<boolean> {
   const bucket = getPrivateUploadBucket();
   try {
@@ -236,6 +240,35 @@ async function cleanupDestinationObjects(
   }
 }
 
+async function deleteCopiedSourceObjects(
+  objects: GCSObjectGeneration[],
+  sourceMountPrefix: string
+): Promise<boolean> {
+  const bucket = getPrivateUploadBucket();
+  try {
+    await concurrentExecutor(
+      objects,
+      ({ filePath, generation }) =>
+        bucket.delete(filePath, {
+          ignoreNotFound: true,
+          ifGenerationMatch: generation,
+        }),
+      { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+    );
+    const remaining = await bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: 1,
+    });
+    return remaining.length === 0;
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), sourceMountPrefix },
+      "Failed to delete copied Frame source object generations"
+    );
+    return false;
+  }
+}
+
 async function copyFrameSourceAsNew({
   allowMatchingDestinationObjects,
   destinationMountPrefix,
@@ -244,7 +277,7 @@ async function copyFrameSourceAsNew({
   allowMatchingDestinationObjects: boolean;
   destinationMountPrefix: string;
   sourceMountPrefix: string;
-}): Promise<Result<DestinationObject[], FrameSourceCopyFailure>> {
+}): Promise<Result<FrameSourceCopy, FrameSourceCopyFailure>> {
   const bucket = getPrivateUploadBucket();
   const [sourceFiles, destinationFiles] = await Promise.all([
     bucket.getFiles({
@@ -303,6 +336,16 @@ async function copyFrameSourceAsNew({
       try {
         const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
         const destinationPath = `${destinationMountPrefix}${relativePath}`;
+        const sourceGeneration = metadataValue(
+          sourceFile.metadata,
+          "generation"
+        );
+        if (!sourceGeneration) {
+          throw new FrameSourceMoveError(
+            "internal",
+            `Source generation is missing: ${relativePath}`
+          );
+        }
         let destinationFile = destinationByRelativePath.get(relativePath);
         const destinationWasListed = Boolean(destinationFile);
         let copied = false;
@@ -312,6 +355,7 @@ async function copyFrameSourceAsNew({
             await bucket.copyFile(sourceFile.name, destinationPath, undefined, {
               destinationGenerationMatch:
                 GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+              sourceGeneration,
             });
             copied = true;
           } catch (error) {
@@ -344,9 +388,15 @@ async function copyFrameSourceAsNew({
             `Destination generation is missing: ${relativePath}`
           );
         }
-        return new Ok<DestinationObject>({
-          filePath: destinationPath,
-          generation,
+        return new Ok<{
+          destination: GCSObjectGeneration;
+          source: GCSObjectGeneration;
+        }>({
+          destination: { filePath: destinationPath, generation },
+          source: {
+            filePath: sourceFile.name,
+            generation: sourceGeneration,
+          },
         });
       } catch (error) {
         return new Err(
@@ -361,9 +411,12 @@ async function copyFrameSourceAsNew({
     },
     { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
   );
-  const destinationObjects = copyResults
+  const copiedObjects = copyResults
     .filter((result) => result.isOk())
     .map((result) => result.value);
+  const destinationObjects = copiedObjects.map(
+    ({ destination }) => destination
+  );
   const failedCopy = copyResults.find((result) => result.isErr());
   if (failedCopy?.isErr()) {
     return new Err({
@@ -371,7 +424,10 @@ async function copyFrameSourceAsNew({
       error: failedCopy.error,
     });
   }
-  return new Ok(destinationObjects);
+  return new Ok({
+    destinationObjects,
+    sourceObjects: copiedObjects.map(({ source }) => source),
+  });
 }
 
 /** Move a registered Frame folder while retaining its stable FileResource identity. */
@@ -432,6 +488,14 @@ export async function moveFrameV2Source(
     return invalidSource(
       "Frames v2 source moves do not yet support the database-backed filesystem."
     );
+  }
+  const sourceWriteAccess = dustFs.checkWriteAccess(source);
+  if (sourceWriteAccess.isErr()) {
+    return sourceWriteAccess;
+  }
+  const destinationWriteAccess = dustFs.checkWriteAccess(destination);
+  if (destinationWriteAccess.isErr()) {
+    return destinationWriteAccess;
   }
 
   const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
@@ -676,7 +740,9 @@ export async function moveFrameV2Source(
           });
 
     if (updateResult.isErr()) {
-      const cleaned = await cleanupDestinationObjects(copyResult.value);
+      const cleaned = await cleanupDestinationObjects(
+        copyResult.value.destinationObjects
+      );
       const restored = cleaned ? await restoreSourceReservation() : false;
       if (!restored) {
         logger.error(
@@ -698,15 +764,15 @@ export async function moveFrameV2Source(
       return updateResult;
     }
 
-    const sourceDeletion = await dustFs.delete(source, {
-      ignoreNotFound: true,
-    });
-    const sourceDeletionFailed = sourceDeletion.isErr();
+    const sourceDeleted = await deleteCopiedSourceObjects(
+      copyResult.value.sourceObjects,
+      sourceMountPrefix
+    );
+    const sourceDeletionFailed = !sourceDeleted;
     if (sourceDeletionFailed) {
       logger.warn(
         {
           destinationDirectoryPath: destination,
-          error: sourceDeletion.error,
           frameId: frame.sId,
           sourceDirectoryPath: source,
         },

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -4,6 +4,10 @@ import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
 import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import {
+  MAX_FRAME_SOURCE_BYTES,
+  MAX_FRAME_SOURCE_FILE_COUNT,
+} from "@app/lib/api/frames/source_limits";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -203,6 +207,10 @@ function isSameGCSObject(source: File, destination: File): boolean {
 }
 
 type DestinationObject = { filePath: string; generation: string };
+type FrameSourceCopyFailure = {
+  destinationObjects: DestinationObject[];
+  error: FrameSourceMoveError;
+};
 
 async function cleanupDestinationObjects(
   objects: DestinationObject[]
@@ -236,15 +244,51 @@ async function copyFrameSourceAsNew({
   allowMatchingDestinationObjects: boolean;
   destinationMountPrefix: string;
   sourceMountPrefix: string;
-}): Promise<Result<DestinationObject[], FrameSourceMoveError>> {
+}): Promise<Result<DestinationObject[], FrameSourceCopyFailure>> {
   const bucket = getPrivateUploadBucket();
-  const [{ files: sourceFiles }, { files: destinationFiles }] =
-    await Promise.all([
-      bucket.getAllFilesByPrefix({ prefix: sourceMountPrefix }),
-      bucket.getAllFilesByPrefix({ prefix: destinationMountPrefix }),
-    ]);
+  const [sourceFiles, destinationFiles] = await Promise.all([
+    bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    }),
+    bucket.getFiles({
+      prefix: destinationMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    }),
+  ]);
   if (sourceFiles.length === 0) {
-    return invalidSource("Frame source folder is empty or no longer exists.");
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source folder is empty or no longer exists."
+      ),
+    });
+  }
+  const totalSourceSize = sourceFiles.reduce(
+    (total, file) => total + Number(file.metadata.size ?? 0),
+    0
+  );
+  if (
+    sourceFiles.length > MAX_FRAME_SOURCE_FILE_COUNT ||
+    totalSourceSize > MAX_FRAME_SOURCE_BYTES
+  ) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source exceeds the move size limit."
+      ),
+    });
+  }
+  if (destinationFiles.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "conflict",
+        "Frame destination exceeds the move file count limit."
+      ),
+    });
   }
 
   const destinationByRelativePath = new Map(
@@ -322,15 +366,10 @@ async function copyFrameSourceAsNew({
     .map((result) => result.value);
   const failedCopy = copyResults.find((result) => result.isErr());
   if (failedCopy?.isErr()) {
-    const cleaned = await cleanupDestinationObjects(destinationObjects);
-    return cleaned
-      ? failedCopy
-      : new Err(
-          new FrameSourceMoveError(
-            "internal",
-            "The Frame source copy failed and its destination objects could not be cleaned up."
-          )
-        );
+    return new Err({
+      destinationObjects,
+      error: failedCopy.error,
+    });
   }
   return new Ok(destinationObjects);
 }
@@ -557,9 +596,20 @@ export async function moveFrameV2Source(
       sourceMountPrefix,
     });
     if (copyResult.isErr()) {
+      const cleaned = await cleanupDestinationObjects(
+        copyResult.error.destinationObjects
+      );
+      if (!cleaned) {
+        return new Err(
+          new FrameSourceMoveError(
+            "internal",
+            "The Frame source copy failed and its destination objects could not be cleaned up; retry the move."
+          )
+        );
+      }
       const restored = await restoreSourceReservation();
       return restored
-        ? copyResult
+        ? new Err(copyResult.error.error)
         : new Err(
             new FrameSourceMoveError(
               "internal",
@@ -626,11 +676,9 @@ export async function moveFrameV2Source(
           });
 
     if (updateResult.isErr()) {
-      const [cleaned, restored] = await Promise.all([
-        cleanupDestinationObjects(copyResult.value),
-        restoreSourceReservation(),
-      ]);
-      if (!cleaned || !restored) {
+      const cleaned = await cleanupDestinationObjects(copyResult.value);
+      const restored = cleaned ? await restoreSourceReservation() : false;
+      if (!restored) {
         logger.error(
           {
             destinationDirectoryPath: destination,

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,7 +1,8 @@
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
 import {
   executeWithLockResult,
-  LockAcquisitionTimeoutError,
+  isLockAcquisitionTimeoutError,
 } from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
@@ -38,7 +39,7 @@ async function withTypedFrameOperationLock<T, E>(
   });
   if (result.isErr()) {
     const error = result.error;
-    if (error instanceof LockAcquisitionTimeoutError) {
+    if (isLockAcquisitionTimeoutError(error)) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,11 +1,19 @@
-import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
-import { executeWithLockResult } from "@app/lib/lock";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import {
+  executeWithLockResult,
+  LockAcquisitionTimeoutError,
+} from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
 
 export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
+}
+
+export function getFrameSourceLockName(frameId: string): string {
+  return `frame:source:${frameId}`;
 }
 
 export function withFramePublishLock<T, E>(
@@ -17,5 +25,44 @@ export function withFramePublishLock<T, E>(
     callback,
     30_000,
     { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
+  );
+}
+
+async function withTypedFrameOperationLock<T, E>(
+  lockName: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  const result = await executeWithLockResult(lockName, callback, 30_000, {
+    lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS,
+    traceAcquireResource: "frame.source",
+  });
+  if (result.isErr()) {
+    const error = result.error;
+    if (error instanceof LockAcquisitionTimeoutError) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          "Another publication or source operation is in progress for this Frame; retry shortly."
+        )
+      );
+    }
+    return new Err(error);
+  }
+  return result;
+}
+
+export function withFrameSourceLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withTypedFrameOperationLock(getFrameSourceLockName(frameId), callback);
+}
+
+export function withFrameSourceAndPublishLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withFrameSourceLock(frameId, () =>
+    withTypedFrameOperationLock(getFramePublishLockName(frameId), callback)
   );
 }

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1019,7 +1019,9 @@ describe("publishFramePublication", () => {
     });
     await activationStarted.promise;
 
-    const deletionPromise = frame.delete(auth);
+    const deletionPromise = frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
     const redisSet = vi.mocked(
       redisMock.streamClient.set as (
         key: string,

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -241,6 +241,34 @@ describe("publishFrameV2FromSource", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
+  it("revalidates the Frame source path after acquiring the source lock", async () => {
+    const { auth, conversation, frame, manifestPath, workspace } =
+      await setup();
+    const staleFrame = await FileResource.fetchById(auth, frame.sId);
+    assert(staleFrame);
+    const movedManifestPath = `${getConversationFilesBasePath({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+    })}Moved/${FRAME_MANIFEST_FILE}`;
+    await frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: movedManifestPath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame: staleFrame,
+      manifestPath,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
   it("rejects publication from a read-only Pod", async () => {
     const {
       authenticator: auth,

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -8,6 +8,10 @@ import {
   FramePublicationError,
   withFrameSourceLock,
 } from "@app/lib/api/frames/publication_storage";
+import {
+  MAX_FRAME_SOURCE_BYTES,
+  MAX_FRAME_SOURCE_FILE_COUNT,
+} from "@app/lib/api/frames/source_limits";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import type { PublishFrameError } from "@app/lib/api/viz/publish_frame";
@@ -31,8 +35,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 const FRAME_SOURCE_READ_CONCURRENCY = 8;
-const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
-const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
 
 function frameError(code: FramePublicationError["code"], message: string) {
   return new Err(new FramePublicationError(code, message));

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -3,11 +3,9 @@ import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
-import {
-  FramePublicationError,
-  withFrameSourceLock,
-} from "@app/lib/api/frames/publication_storage";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import {
   MAX_FRAME_SOURCE_BYTES,
   MAX_FRAME_SOURCE_FILE_COUNT,

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -4,7 +4,10 @@ import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
-import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import {
+  FramePublicationError,
+  withFrameSourceLock,
+} from "@app/lib/api/frames/publication_storage";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import type { PublishFrameError } from "@app/lib/api/viz/publish_frame";
@@ -148,7 +151,7 @@ export async function publishFrameFromSource(
  * Publish a Frames v2 FileResource from its current source folder. The FileResource path is the
  * authority: callers cannot point a Frame identity at a different manifest or source tree.
  */
-export async function publishFrameV2FromSource(
+async function publishFrameV2FromSourceWithLockHeld(
   auth: Authenticator,
   {
     conversation,
@@ -323,4 +326,30 @@ export async function publishFrameV2FromSource(
     manifest: manifestResult.value,
     sourceFiles,
   });
+}
+
+export async function publishFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  return withFrameSourceLock(frame.sId, () =>
+    publishFrameV2FromSourceWithLockHeld(auth, {
+      conversation,
+      frame,
+      manifestPath,
+    })
+  );
 }

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -345,11 +345,19 @@ export async function publishFrameV2FromSource(
     FramePublicationError | SandboxFunctionError
   >
 > {
-  return withFrameSourceLock(frame.sId, () =>
-    publishFrameV2FromSourceWithLockHeld(auth, {
+  return withFrameSourceLock(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame) {
+      return frameError(
+        "invalid_frame",
+        `Frame '${frame.sId}' no longer exists.`
+      );
+    }
+
+    return publishFrameV2FromSourceWithLockHeld(auth, {
       conversation,
-      frame,
+      frame: freshFrame,
       manifestPath,
-    })
-  );
+    });
+  });
 }

--- a/front/lib/api/frames/share_from_source.ts
+++ b/front/lib/api/frames/share_from_source.ts
@@ -1,0 +1,221 @@
+import path from "node:path";
+
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import {
+  checkFrameEmailGrantPermission,
+  checkFrameShareScopePermission,
+} from "@app/lib/api/share/frame_sharing";
+import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { FileShareScope } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export class FrameSharingError extends Error {
+  constructor(
+    readonly code: "conflict" | "internal" | "invalid_source" | "unauthorized",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSharingError";
+  }
+}
+
+export function isFrameSharingError(
+  error: unknown
+): error is FrameSharingError {
+  return error instanceof FrameSharingError;
+}
+
+export type ShareFrameV2FromSourceError =
+  | DustFileSystemError
+  | FrameSharingError
+  | SandboxFunctionError;
+
+function sharingError(
+  code: FrameSharingError["code"],
+  message: string
+): Err<FrameSharingError> {
+  return new Err(new FrameSharingError(code, message));
+}
+
+export type ShareFrameV2FromSourceResult = {
+  emails: string[];
+  frameId: string;
+  shareScope: FileShareScope;
+  shareUrl: string;
+  sourceDirectoryPath: string;
+};
+
+/** Configure the use rights of the registered Frame package at a writable source path. */
+export async function shareFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    emails,
+    shareScope,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    emails: string[];
+    shareScope: FileShareScope;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<ShareFrameV2FromSourceResult, ShareFrameV2FromSourceError>> {
+  const sourceDirectory =
+    DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  if (
+    !sourceDirectory ||
+    !sourceDirectory.includes("/") ||
+    path.posix.basename(sourceDirectory) === FRAME_MANIFEST_FILE
+  ) {
+    return sharingError(
+      "invalid_source",
+      "Frame sharing requires its source folder under /files."
+    );
+  }
+  const manifestPath = path.posix.join(sourceDirectory, FRAME_MANIFEST_FILE);
+
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return sharingError(
+      "invalid_source",
+      "Frames v2 sharing does not yet support the database-backed filesystem."
+    );
+  }
+
+  const writeAccess = dustFs.checkWriteAccess(sourceDirectory);
+  if (writeAccess.isErr()) {
+    return new Err(writeAccess.error);
+  }
+  const mountFilePath = dustFs.toMountFilePath(manifestPath);
+  if (!mountFilePath) {
+    return sharingError("invalid_source", "Invalid Frame source folder.");
+  }
+
+  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+    mountFilePath,
+  ]);
+  if (!frame?.isFrameV2) {
+    return sharingError(
+      "invalid_source",
+      `No registered Frames v2 package found at ${sourceDirectory}.`
+    );
+  }
+
+  return withFrameSourceAndPublishLock<
+    ShareFrameV2FromSourceResult,
+    FrameSharingError
+  >(frame.sId, async () => {
+    const freshFrame = await FileResource.fetchById(auth, frame.sId);
+    if (
+      !freshFrame?.isFrameV2 ||
+      freshFrame.toScopedPath(auth) !== manifestPath
+    ) {
+      return sharingError(
+        "conflict",
+        "The Frame source changed while sharing was being configured; retry from its current path."
+      );
+    }
+
+    const scopePermission = await checkFrameShareScopePermission(
+      auth,
+      shareScope
+    );
+    if (scopePermission.isErr()) {
+      return sharingError("unauthorized", scopePermission.error.message);
+    }
+    const emailPermission = await checkFrameEmailGrantPermission(auth, emails);
+    if (emailPermission.isErr()) {
+      return sharingError("unauthorized", emailPermission.error.message);
+    }
+
+    try {
+      await freshFrame.setShareScope(auth, shareScope);
+
+      const allowlist = await ensureAuthorizedFileAccessForShare(
+        auth,
+        freshFrame
+      );
+      if (allowlist.isErr()) {
+        return sharingError(
+          allowlist.error.code === "invalid_request_error"
+            ? "invalid_source"
+            : "internal",
+          allowlist.error.message
+        );
+      }
+
+      const grants =
+        emails.length > 0
+          ? await freshFrame.addSharingGrants(auth, { emails })
+          : await freshFrame.listActiveSharingGrants();
+      const shareInfo = await freshFrame.getShareInfo();
+      if (!shareInfo) {
+        return sharingError("internal", "Frame sharing record not found.");
+      }
+
+      const frameName = path.posix.basename(sourceDirectory);
+      void emitAuditLogEvent({
+        auth,
+        action: "frame.share_scope_updated",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("frame", {
+            sId: freshFrame.sId,
+            name: frameName,
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          frame_name: frameName,
+          share_scope: shareScope,
+        },
+      });
+      if (emails.length > 0) {
+        void emitAuditLogEvent({
+          auth,
+          action: "frame.email_grant_added",
+          targets: [
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("frame", {
+              sId: freshFrame.sId,
+              name: frameName,
+            }),
+          ],
+          context: getAuditLogContext(auth),
+          metadata: {
+            emails: emails.join(","),
+            frame_name: frameName,
+          },
+        });
+      }
+
+      return new Ok({
+        emails: grants.map((grant) => grant.email),
+        frameId: freshFrame.sId,
+        shareScope: shareInfo.scope,
+        shareUrl: shareInfo.shareUrl,
+        sourceDirectoryPath: sourceDirectory,
+      });
+    } catch (error) {
+      return sharingError("internal", normalizeError(error).message);
+    }
+  });
+}

--- a/front/lib/api/frames/share_from_source.ts
+++ b/front/lib/api/frames/share_from_source.ts
@@ -6,22 +6,33 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import {
   checkFrameEmailGrantPermission,
   checkFrameShareScopePermission,
 } from "@app/lib/api/share/frame_sharing";
-import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import {
+  computeAuthorizedFileAccessForShare,
+  readFrameFileContent,
+} from "@app/lib/api/viz/authorized_file_access";
+import {
+  isAllowlistShareScopeStale,
+  isAllowlistStale,
+} from "@app/lib/api/viz/authorized_file_access_policy";
+import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { DustFileSystemError } from "@app/types/file_system";
-import type { FileShareScope } from "@app/types/files";
+import type {
+  ComputedAuthorizedFileAccess,
+  FileShareScope,
+} from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export class FrameSharingError extends Error {
   constructor(
@@ -133,6 +144,12 @@ export async function shareFrameV2FromSource(
         "The Frame source changed while sharing was being configured; retry from its current path."
       );
     }
+    if (!auth.user()) {
+      return sharingError(
+        "unauthorized",
+        "Frame sharing requires a workspace member."
+      );
+    }
 
     const scopePermission = await checkFrameShareScopePermission(
       auth,
@@ -146,32 +163,70 @@ export async function shareFrameV2FromSource(
       return sharingError("unauthorized", emailPermission.error.message);
     }
 
-    try {
-      await freshFrame.setShareScope(auth, shareScope);
-
-      const allowlist = await ensureAuthorizedFileAccessForShare(
-        auth,
-        freshFrame
+    const frameContent = await readFrameFileContent(auth, freshFrame);
+    if (frameContent === null) {
+      return sharingError(
+        "internal",
+        `Failed to read Frame content for authorized file access (Frame: ${freshFrame.sId}).`
       );
-      if (allowlist.isErr()) {
+    }
+
+    const [previousShareScope, activeAllowlist, activeAllowlistShareScope] =
+      await Promise.all([
+        freshFrame.getShareScope(),
+        freshFrame.getActiveAuthorizedFileAccessAllowlist(),
+        freshFrame.getActiveAuthorizedFileAccessShareScope(),
+      ]);
+    const shouldPersistAllowlist =
+      !activeAllowlist ||
+      isAllowlistStale(activeAllowlist, frameContent) ||
+      activeAllowlistShareScope === null ||
+      isAllowlistShareScopeStale(activeAllowlistShareScope, shareScope);
+
+    let authorizedFileAccess: ComputedAuthorizedFileAccess | null = null;
+    if (shouldPersistAllowlist) {
+      const computed = await computeAuthorizedFileAccessForShare(
+        auth,
+        freshFrame,
+        { frameContent }
+      );
+      if (computed.isErr()) {
         return sharingError(
-          allowlist.error.code === "invalid_request_error"
+          computed.error.code === "invalid_request_error"
             ? "invalid_source"
             : "internal",
-          allowlist.error.message
+          computed.error.message
         );
       }
+      authorizedFileAccess = computed.value;
+    }
 
-      const grants =
-        emails.length > 0
-          ? await freshFrame.addSharingGrants(auth, { emails })
-          : await freshFrame.listActiveSharingGrants();
-      const shareInfo = await freshFrame.getShareInfo();
-      if (!shareInfo) {
-        return sharingError("internal", "Frame sharing record not found.");
+    const createdEmails = await withTransaction(async (transaction) => {
+      if (previousShareScope !== shareScope) {
+        await freshFrame.setShareScope(auth, shareScope, transaction);
       }
+      if (authorizedFileAccess) {
+        await freshFrame.persistAuthorizedFileAccess(authorizedFileAccess, {
+          transaction,
+        });
+      }
+      return freshFrame.addSharingGrantsAndGetCreatedEmails(
+        auth,
+        { emails },
+        { transaction }
+      );
+    });
 
-      const frameName = path.posix.basename(sourceDirectory);
+    const [grants, shareInfo] = await Promise.all([
+      freshFrame.listActiveSharingGrants(),
+      freshFrame.getShareInfo(),
+    ]);
+    if (!shareInfo) {
+      throw new Error(`Frame sharing record not found for ${freshFrame.sId}.`);
+    }
+
+    const frameName = path.posix.basename(sourceDirectory);
+    if (previousShareScope !== shareScope) {
       void emitAuditLogEvent({
         auth,
         action: "frame.share_scope_updated",
@@ -188,34 +243,40 @@ export async function shareFrameV2FromSource(
           share_scope: shareScope,
         },
       });
-      if (emails.length > 0) {
-        void emitAuditLogEvent({
-          auth,
-          action: "frame.email_grant_added",
-          targets: [
-            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-            buildAuditLogTarget("frame", {
-              sId: freshFrame.sId,
-              name: frameName,
-            }),
-          ],
-          context: getAuditLogContext(auth),
-          metadata: {
-            emails: emails.join(","),
-            frame_name: frameName,
-          },
-        });
-      }
-
-      return new Ok({
-        emails: grants.map((grant) => grant.email),
-        frameId: freshFrame.sId,
-        shareScope: shareInfo.scope,
-        shareUrl: shareInfo.shareUrl,
-        sourceDirectoryPath: sourceDirectory,
-      });
-    } catch (error) {
-      return sharingError("internal", normalizeError(error).message);
     }
+    if (authorizedFileAccess) {
+      emitFrameAuthorizedFilesUpdatedAuditLog(
+        auth,
+        freshFrame,
+        authorizedFileAccess,
+        shareScope
+      );
+    }
+    if (createdEmails.length > 0) {
+      void emitAuditLogEvent({
+        auth,
+        action: "frame.email_grant_added",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("frame", {
+            sId: freshFrame.sId,
+            name: frameName,
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          emails: createdEmails.join(","),
+          frame_name: frameName,
+        },
+      });
+    }
+
+    return new Ok({
+      emails: grants.map((grant) => grant.email),
+      frameId: freshFrame.sId,
+      shareScope: shareInfo.scope,
+      shareUrl: shareInfo.shareUrl,
+      sourceDirectoryPath: sourceDirectory,
+    });
   });
 }

--- a/front/lib/api/frames/source_limits.ts
+++ b/front/lib/api/frames/source_limits.ts
@@ -1,0 +1,2 @@
+export const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
+export const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;

--- a/front/lib/api/poke/plugins/files/delete_frame.test.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.test.ts
@@ -5,7 +5,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -81,5 +81,31 @@ describe("deleteFramePlugin", () => {
         },
       })
     );
+  });
+
+  it("leaves Frames v2 deletion to the package-aware dsbx flow", async () => {
+    const {
+      authenticator: auth,
+      user,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const frame = await ProjectFileFactory.create(auth, user, pod, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "ready",
+    });
+
+    expect(deleteFramePlugin.isApplicableTo(auth, frame)).toBe(false);
+    const result = await deleteFramePlugin.execute(auth, frame, {
+      confirmation: "DELETE",
+    });
+
+    expect(result.isErr()).toBe(true);
+    await expect(
+      FileResource.fetchById(auth, frame.sId)
+    ).resolves.not.toBeNull();
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/poke/plugins/files/delete_frame.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.ts
@@ -82,7 +82,7 @@ export const deleteFramePlugin = createPlugin({
     requiredRoles: ["engineering", "support"],
   },
   execute: async (auth, file, args) => {
-    if (!file?.isInteractiveContent) {
+    if (!file?.isInteractiveContent || file.isFrameV2) {
       return new Err(new Error("Frame not found."));
     }
     if (args.confirmation !== "DELETE") {
@@ -117,5 +117,6 @@ export const deleteFramePlugin = createPlugin({
       value: `Frame "${frameName}" was permanently deleted.`,
     });
   },
-  isApplicableTo: (auth, file) => file?.isInteractiveContent === true,
+  isApplicableTo: (_auth, file) =>
+    file?.isInteractiveContent === true && !file.isFrameV2,
 });

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -20,6 +20,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { FrameV2SourceDeletion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -516,9 +517,11 @@ export async function addContentNodeToProject(
 export async function removeFileFromProject(
   auth: Authenticator,
   {
+    deleteFrameSource,
     space,
     fileId,
   }: {
+    deleteFrameSource?: FrameV2SourceDeletion;
     space: SpaceResource;
     fileId: string; // file sId
   }
@@ -577,7 +580,7 @@ export async function removeFileFromProject(
     }
   }
 
-  const deleteRes = await file.delete(auth);
+  const deleteRes = await file.delete(auth, { deleteFrameSource });
   if (deleteRes.isErr()) {
     return new Err(deleteRes.error);
   }

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -20,6 +20,12 @@ export class SandboxFunctionError extends Error {
   }
 }
 
+export function isSandboxFunctionError(
+  error: unknown
+): error is SandboxFunctionError {
+  return error instanceof SandboxFunctionError;
+}
+
 export class SandboxFunctionInvocationError extends Error {
   readonly code = "user_authentication_required";
 

--- a/front/lib/api/share/frame_sharing.ts
+++ b/front/lib/api/share/frame_sharing.ts
@@ -1,6 +1,10 @@
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import { runOnRedis } from "@app/lib/api/redis";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { FileShareScope } from "@app/types/files";
@@ -24,6 +28,82 @@ export function getDefaultFrameShareScope(
     default:
       assertNever(sharingPolicy);
   }
+}
+
+export async function checkFrameShareScopePermission(
+  auth: Authenticator,
+  shareScope: FileShareScope
+): Promise<Result<void, DustError<"unauthorized">>> {
+  if (shareScope !== "public") {
+    return new Ok(undefined);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  if (workspace.sharingPolicy !== "all_scopes") {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        "Public sharing is disabled for this workspace."
+      )
+    );
+  }
+  if (!(await auth.hasWorkspacePermission("publish", "frame"))) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        "You do not have permission to share this frame publicly."
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+export async function checkFrameEmailGrantPermission(
+  auth: Authenticator,
+  rawEmails: string[]
+): Promise<Result<void, DustError<"unauthorized">>> {
+  if (rawEmails.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const externalSharingDisabledByPolicy =
+    workspace.sharingPolicy === "workspace_only";
+  const canInviteExternal =
+    !externalSharingDisabledByPolicy &&
+    (await auth.hasWorkspacePermission("invite", "frame"));
+  if (canInviteExternal) {
+    return new Ok(undefined);
+  }
+
+  const emails = rawEmails.map((email) => email.toLowerCase());
+  const users = await UserResource.fetchByEmails(emails);
+  const userIdToEmail = new Map(
+    users.map((user) => [user.id, user.email.toLowerCase()])
+  );
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace,
+  });
+  const memberEmails = new Set(
+    memberships
+      .map((membership) => userIdToEmail.get(membership.userId))
+      .filter((email): email is string => email !== undefined)
+  );
+
+  if (emails.some((email) => !memberEmails.has(email))) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        externalSharingDisabledByPolicy
+          ? "Only workspace members can be invited when external sharing is disabled."
+          : "You do not have permission to invite people outside the workspace. Only workspace members can be invited."
+      )
+    );
+  }
+
+  return new Ok(undefined);
 }
 
 const OTP_TTL_SECONDS = 15 * 60; // 15 minutes.

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -1,6 +1,9 @@
 import config from "@app/lib/file_storage/config";
 import type { GCSAPIError } from "@app/lib/file_storage/types";
-import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import {
+  isGCSNotFoundError,
+  isGCSPreconditionFailedError,
+} from "@app/lib/file_storage/types";
 import { setTimeoutAsync, withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AllSupportedFileContentType } from "@app/types/files";
@@ -481,10 +484,13 @@ export class FileStorage {
 
   async delete(
     filePath: string,
-    { ignoreNotFound }: { ignoreNotFound?: boolean } = {}
+    {
+      ignoreNotFound,
+      ifGenerationMatch,
+    }: { ignoreNotFound?: boolean; ifGenerationMatch?: string } = {}
   ) {
     try {
-      return await this.file(filePath).delete();
+      return await this.file(filePath).delete({ ifGenerationMatch });
     } catch (err) {
       if (ignoreNotFound && isGCSNotFoundError(err)) {
         return;
@@ -505,7 +511,13 @@ export class FileStorage {
     srcPath: string,
     destPath: string,
     destinationStorage: FileStorage = this,
-    { sourceGeneration }: { sourceGeneration?: string } = {}
+    {
+      destinationGenerationMatch,
+      sourceGeneration,
+    }: {
+      destinationGenerationMatch?: number;
+      sourceGeneration?: string;
+    } = {}
   ): Promise<void> {
     const destinationFile = destinationStorage.file(destPath);
     const sourceFile = sourceGeneration
@@ -518,9 +530,20 @@ export class FileStorage {
       attempt++
     ) {
       try {
-        await sourceFile.copy(destinationFile);
+        await sourceFile.copy(destinationFile, {
+          preconditionOpts:
+            destinationGenerationMatch !== undefined
+              ? { ifGenerationMatch: destinationGenerationMatch }
+              : undefined,
+        });
         return;
       } catch (err) {
+        // Preconditions are deterministic. In particular, a create-only copy
+        // must let its caller inspect the existing destination instead of
+        // retrying and potentially masking a concurrent writer.
+        if (isGCSPreconditionFailedError(err)) {
+          throw err;
+        }
         if (attempt === GCS_TRANSIENT_RETRY_MAX_ATTEMPTS) {
           throw err;
         }

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -56,6 +56,24 @@ type RawContentSaveOptions = Pick<
   "preconditionOpts" | "resumable"
 >;
 
+export type FileCopyResult = {
+  destinationFile: File;
+  destinationGeneration: string;
+};
+
+function isCopyResponseWithGeneration(
+  response: unknown
+): response is { generation: string | number } {
+  if (
+    !response ||
+    typeof response !== "object" ||
+    !("generation" in response)
+  ) {
+    return false;
+  }
+  return isString(response.generation) || isNumber(response.generation);
+}
+
 function isRetryableGCSError(err: unknown): boolean {
   // ApiError only adds optional fields on top of Error, so a normalized Error
   // is safe to hand to the SDK's default retryable check.
@@ -518,7 +536,7 @@ export class FileStorage {
       destinationGenerationMatch?: number;
       sourceGeneration?: string;
     } = {}
-  ): Promise<void> {
+  ): Promise<FileCopyResult> {
     const destinationFile = destinationStorage.file(destPath);
     const sourceFile = sourceGeneration
       ? this.bucket.file(srcPath, { generation: sourceGeneration })
@@ -530,13 +548,22 @@ export class FileStorage {
       attempt++
     ) {
       try {
-        await sourceFile.copy(destinationFile, {
-          preconditionOpts:
-            destinationGenerationMatch !== undefined
-              ? { ifGenerationMatch: destinationGenerationMatch }
-              : undefined,
-        });
-        return;
+        const [copiedFile, copyResponse] = await sourceFile.copy(
+          destinationFile,
+          {
+            preconditionOpts:
+              destinationGenerationMatch !== undefined
+                ? { ifGenerationMatch: destinationGenerationMatch }
+                : undefined,
+          }
+        );
+        if (!isCopyResponseWithGeneration(copyResponse)) {
+          throw new Error("GCS copy response is missing its generation.");
+        }
+        return {
+          destinationFile: copiedFile,
+          destinationGeneration: String(copyResponse.generation),
+        };
       } catch (err) {
         // Preconditions are deterministic. In particular, a create-only copy
         // must let its caller inspect the existing destination instead of
@@ -567,6 +594,8 @@ export class FileStorage {
         await setTimeoutAsync(delayMs);
       }
     }
+
+    throw new Error("GCS copy retry loop exhausted unexpectedly.");
   }
 
   async deleteByPrefix(prefix: string): Promise<void> {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -3,7 +3,10 @@ import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
+import {
+  FileResource,
+  FRAME_SHARE_NOTIFICATION_CONCURRENCY,
+} from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import {
   AuthorizedFileAccessModel,
@@ -29,11 +32,22 @@ import {
   frameContentType,
   frameV2ContentType,
   isUnverifiableFrameFileRefsShareError,
+  MAX_EMAILS_PER_INVITE,
   sandboxFunctionContentType,
 } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSendFrameSharedEmail } = vi.hoisted(() => ({
+  mockSendFrameSharedEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/share/frame_sharing", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/share/frame_sharing")>();
+  return { ...actual, sendFrameSharedEmail: mockSendFrameSharedEmail };
+});
 
 async function createFrameWithFunction(
   auth: Authenticator,
@@ -81,6 +95,50 @@ vi.mock("@app/lib/utils/files", () => ({
 describe("FileResource", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSendFrameSharedEmail.mockResolvedValue(undefined);
+  });
+
+  describe("sharing notifications", () => {
+    it("schedules bounded email delivery without waiting for it", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "Frame.tsx",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+      const emails = Array.from(
+        { length: MAX_EMAILS_PER_INVITE },
+        (_, index) => `viewer-${index}@example.com`
+      );
+      let releaseDeliveries: () => void = () => undefined;
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDeliveries = resolve;
+      });
+      mockSendFrameSharedEmail.mockImplementation(() => deliveryGate);
+
+      const grants = await frameFile.addSharingGrants(auth, { emails });
+
+      expect(grants).toHaveLength(emails.length);
+      await vi.waitFor(() => {
+        expect(mockSendFrameSharedEmail).toHaveBeenCalledTimes(
+          FRAME_SHARE_NOTIFICATION_CONCURRENCY
+        );
+      });
+
+      releaseDeliveries();
+      await vi.waitFor(() => {
+        expect(mockSendFrameSharedEmail).toHaveBeenCalledTimes(emails.length);
+      });
+    });
   });
 
   describe("fetchByShareTokenWithContent", () => {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -31,6 +31,7 @@ import {
   isUnverifiableFrameFileRefsShareError,
   sandboxFunctionContentType,
 } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1780,7 +1781,9 @@ describe("FileResource", () => {
       })
     ).toHaveLength(1);
 
-    const result = await frame.delete(auth);
+    const result = await frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
 
     expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
       true

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -659,18 +659,23 @@ export class FileResource extends BaseResource<FileModel> {
         // Delete mount file copies if set.
         await this.deleteMountFileCopies();
 
-        await this.getBucketForVersion("original")
-          .file(this.getCloudStoragePath(auth, "original"))
-          .delete();
+        // Frames v2 are contentless identities: their source lives at mountFilePath and their
+        // published/runtime data lives under the Frame prefix deleted above. They never own the
+        // canonical original/processed/public FileResource objects.
+        if (!this.isFrameV2) {
+          await this.getBucketForVersion("original")
+            .file(this.getCloudStoragePath(auth, "original"))
+            .delete();
 
-        // Delete the processed file if it exists.
-        await this.getBucketForVersion("processed")
-          .file(this.getCloudStoragePath(auth, "processed"))
-          .delete({ ignoreNotFound: true });
-        // Delete the public file if it exists.
-        await this.getBucketForVersion("public")
-          .file(this.getCloudStoragePath(auth, "public"))
-          .delete({ ignoreNotFound: true });
+          // Delete the processed file if it exists.
+          await this.getBucketForVersion("processed")
+            .file(this.getCloudStoragePath(auth, "processed"))
+            .delete({ ignoreNotFound: true });
+          // Delete the public file if it exists.
+          await this.getBucketForVersion("public")
+            .file(this.getCloudStoragePath(auth, "public"))
+            .delete({ ignoreNotFound: true });
+        }
 
         // Delete sharing grants and access snapshots before shareable file (FK constraint).
         const shareableFile = await FileResource.shareableFileModel.findOne({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -124,6 +124,8 @@ import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_mod
 
 export type FileVersion = "processed" | "original" | "public";
 
+export type FrameV2SourceDeletion = () => Promise<Result<void, Error>>;
+
 const FRAME_CONTENT_TYPES = new Set([
   frameContentType,
   frameSlideshowContentType,
@@ -718,16 +720,37 @@ export class FileResource extends BaseResource<FileModel> {
     }
   }
 
-  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+  async delete(
+    auth: Authenticator,
+    {
+      deleteFrameSource,
+    }: {
+      deleteFrameSource?: FrameV2SourceDeletion;
+      transaction?: Transaction;
+    } = {}
+  ): Promise<Result<undefined, Error>> {
     if (!this.isFrameV2) {
       return this.deleteAfterSandboxCleanup(auth);
     }
 
-    return withFramePublishLock(this.sId, () =>
-      FrameSandboxAdapter.deleteSandbox(auth, this, {
+    if (!deleteFrameSource) {
+      return new Err(
+        new Error(
+          "Frames v2 must be deleted through the package-aware Frame deletion flow."
+        )
+      );
+    }
+
+    return withFramePublishLock(this.sId, async () => {
+      const sourceResult = await deleteFrameSource();
+      if (sourceResult.isErr()) {
+        return sourceResult;
+      }
+
+      return FrameSandboxAdapter.deleteSandbox(auth, this, {
         afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
-      })
-    );
+      });
+    });
   }
 
   get sId(): string {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1752,7 +1752,8 @@ export class FileResource extends BaseResource<FileModel> {
 
   async setShareScope(
     auth: Authenticator,
-    scope: FileShareScope
+    scope: FileShareScope,
+    transaction?: Transaction
   ): Promise<void> {
     if (!this.isShareableFrame) {
       throw new Error("Only Frame files can be shared");
@@ -1765,6 +1766,7 @@ export class FileResource extends BaseResource<FileModel> {
     // Always update the existing ShareableFileModel record (never delete).
     const existingShare = await FileResource.shareableFileModel.findOne({
       where: { fileId: this.id, workspaceId: this.workspaceId },
+      transaction,
     });
 
     assert(
@@ -1772,11 +1774,14 @@ export class FileResource extends BaseResource<FileModel> {
       `ShareableFileModel record not found for file ${this.sId}`
     );
 
-    await existingShare.update({
-      shareScope: scope,
-      sharedBy: user.id,
-      sharedAt: new Date(),
-    });
+    await existingShare.update(
+      {
+        shareScope: scope,
+        sharedBy: user.id,
+        sharedAt: new Date(),
+      },
+      { transaction }
+    );
   }
 
   async getShareInfo(): Promise<{
@@ -2357,8 +2362,106 @@ export class FileResource extends BaseResource<FileModel> {
 
   // Sharing grants logic.
 
-  private async getShareableFileId(): Promise<ModelId> {
-    return (await this.getShareableFile()).id;
+  private async getShareableFileId(
+    transaction?: Transaction
+  ): Promise<ModelId> {
+    return (await this.getShareableFile(transaction)).id;
+  }
+
+  async addSharingGrantsAndGetCreatedEmails(
+    auth: Authenticator,
+    { emails }: { emails: string[] },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<string[]> {
+    assert(
+      this.isShareableFrame,
+      "addSharingGrantsAndGetCreatedEmails requires a Frame file"
+    );
+    const user = auth.getNonNullableUser();
+    const shareableFileId = await this.getShareableFileId(transaction);
+
+    const normalizedEmails = [
+      ...new Set(emails.map((email) => email.toLowerCase().trim())),
+    ];
+
+    const existingGrants = await SharingGrantModel.findAll({
+      where: {
+        workspaceId: this.workspaceId,
+        shareableFileId,
+        email: { [Op.in]: normalizedEmails },
+        revokedAt: null,
+      },
+      transaction,
+    });
+    const existingEmails = new Set(existingGrants.map((grant) => grant.email));
+    const createdEmails = normalizedEmails.filter(
+      (email) => !existingEmails.has(email)
+    );
+
+    if (createdEmails.length === 0) {
+      return [];
+    }
+
+    await SharingGrantModel.bulkCreate(
+      createdEmails.map((email) => ({
+        workspaceId: this.workspaceId,
+        shareableFileId,
+        email,
+        grantedBy: user.id,
+        grantedAt: new Date(),
+      })),
+      { transaction }
+    );
+
+    const sendNotifications = async () => {
+      const shareInfo = await this.getShareInfo();
+      if (!shareInfo) {
+        return;
+      }
+      const sharedByName = user.toJSON().fullName;
+      const frameUrl = shareInfo.shareUrl;
+      const shareToken = frameUrl.split("/").at(-1) ?? "";
+
+      await Promise.all(
+        createdEmails.map((email) =>
+          sendFrameSharedEmail({
+            to: email,
+            sharedByName,
+            frameUrl,
+            shareToken,
+          }).catch(() => {
+            // Email delivery is best effort and must not affect grant creation.
+            logger.info(
+              {
+                email,
+                fileId: this.sId,
+                workspaceId: this.workspaceId,
+              },
+              "Failed to send sharing notification email"
+            );
+          })
+        )
+      );
+    };
+
+    if (transaction) {
+      transaction.afterCommit(() =>
+        sendNotifications().catch((error) => {
+          logger.error(
+            {
+              error: normalizeError(error),
+              fileId: this.sId,
+              workspaceId: this.workspaceId,
+            },
+            "Failed to send Frame sharing notifications after commit"
+          );
+        })
+      );
+    } else {
+      void sendNotifications();
+    }
+
+    return createdEmails;
   }
 
   async addSharingGrants(
@@ -2367,67 +2470,7 @@ export class FileResource extends BaseResource<FileModel> {
   ): Promise<SharingGrantType[]> {
     assert(this.isShareableFrame, "addSharingGrants requires a Frame file");
     await this.ensureShareableFrame(auth);
-    const user = auth.getNonNullableUser();
-    const shareableFileId = await this.getShareableFileId();
-
-    const normalizedEmails = emails.map((e) => e.toLowerCase().trim());
-
-    // Find existing active grants for these emails.
-    const existingGrants = await SharingGrantModel.findAll({
-      where: {
-        workspaceId: this.workspaceId,
-        shareableFileId,
-        email: { [Op.in]: normalizedEmails },
-        revokedAt: null,
-      },
-    });
-
-    const existingEmails = new Set(existingGrants.map((g) => g.email));
-
-    const newEmails = normalizedEmails.filter((e) => !existingEmails.has(e));
-
-    if (newEmails.length > 0) {
-      await SharingGrantModel.bulkCreate(
-        newEmails.map((email) => ({
-          workspaceId: this.workspaceId,
-          shareableFileId,
-          email,
-          grantedBy: user.id,
-          grantedAt: new Date(),
-        }))
-      );
-
-      const shareInfo = await this.getShareInfo();
-      if (shareInfo) {
-        const sharedByName = user.toJSON().fullName;
-        const frameUrl = shareInfo.shareUrl;
-        const shareToken = frameUrl.split("/").at(-1) ?? "";
-
-        // Fire-and-forget: don't block grant creation on email delivery.
-        // TODO: Consider moving email delivery to a dedicated worker/queue  to avoid unbounded
-        // parallelism and improve reliability/retry handling.
-        void Promise.all(
-          newEmails.map((email) =>
-            sendFrameSharedEmail({
-              to: email,
-              sharedByName,
-              frameUrl,
-              shareToken,
-            }).catch(() => {
-              // Silently ignore, email failures should not affect grant creation.
-              logger.info(
-                {
-                  email,
-                  fileId: this.sId,
-                  workspaceId: this.workspaceId,
-                },
-                "Failed to send sharing notification email"
-              );
-            })
-          )
-        );
-      }
-    }
+    await this.addSharingGrantsAndGetCreatedEmails(auth, { emails });
 
     return this.listActiveSharingGrants();
   }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -53,6 +53,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { copyContent } from "@app/lib/utils/files";
 import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -133,6 +134,7 @@ const FRAME_CONTENT_TYPES = new Set([
 
 const BATCH_DESTROY_SIZE = 10_000;
 const FRAME_FUNCTION_DELETE_BATCH_SIZE = 1_000;
+export const FRAME_SHARE_NOTIFICATION_CONCURRENCY = 8;
 
 export interface FileUploadedRequestResponseBody {
   file: FileType & {
@@ -2422,43 +2424,50 @@ export class FileResource extends BaseResource<FileModel> {
       const frameUrl = shareInfo.shareUrl;
       const shareToken = frameUrl.split("/").at(-1) ?? "";
 
-      await Promise.all(
-        createdEmails.map((email) =>
-          sendFrameSharedEmail({
-            to: email,
-            sharedByName,
-            frameUrl,
-            shareToken,
-          }).catch(() => {
+      await concurrentExecutor(
+        createdEmails,
+        async (email) => {
+          try {
+            await sendFrameSharedEmail({
+              to: email,
+              sharedByName,
+              frameUrl,
+              shareToken,
+            });
+          } catch (error) {
             // Email delivery is best effort and must not affect grant creation.
             logger.info(
               {
                 email,
+                error: normalizeError(error),
                 fileId: this.sId,
                 workspaceId: this.workspaceId,
               },
               "Failed to send sharing notification email"
             );
-          })
-        )
+          }
+        },
+        { concurrency: FRAME_SHARE_NOTIFICATION_CONCURRENCY }
       );
     };
 
+    const scheduleNotifications = () => {
+      void sendNotifications().catch((error) => {
+        logger.error(
+          {
+            error: normalizeError(error),
+            fileId: this.sId,
+            workspaceId: this.workspaceId,
+          },
+          "Failed to send Frame sharing notifications"
+        );
+      });
+    };
+
     if (transaction) {
-      transaction.afterCommit(() =>
-        sendNotifications().catch((error) => {
-          logger.error(
-            {
-              error: normalizeError(error),
-              fileId: this.sId,
-              workspaceId: this.workspaceId,
-            },
-            "Failed to send Frame sharing notifications after commit"
-          );
-        })
-      );
+      transaction.afterCommit(scheduleNotifications);
     } else {
-      void sendNotifications();
+      scheduleNotifications();
     }
 
     return createdEmails;

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -197,7 +197,9 @@ describe("FrameSandboxAdapter", () => {
       deletedPrefixes.push(prefix)
     );
 
-    const deleteResult = await frame.delete(auth);
+    const deleteResult = await frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
 
     expect(
       deleteResult.isOk(),
@@ -277,7 +279,9 @@ describe("FrameSandboxAdapter", () => {
 
     try {
       mockExecuteWithLock.mockClear();
-      const deletionPromise = frame.delete(auth);
+      const deletionPromise = frame.delete(auth, {
+        deleteFrameSource: async () => new Ok(undefined),
+      });
       await deletionReachedFunctionCleanup.promise;
       expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
 

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  mockEnsureSandboxStateHealthOnSleep,
   mockExecuteWithLock,
   mockGetSandboxImage,
   mockGetSandboxProvider,
@@ -8,6 +9,7 @@ const {
   mockProviderDestroy,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
+  mockEnsureSandboxStateHealthOnSleep: vi.fn(),
   mockExecuteWithLock: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
@@ -15,6 +17,14 @@ const {
   mockProviderDestroy: vi.fn(),
   mockRevokeAllExecTokensForSandbox: vi.fn(),
 }));
+
+vi.mock("@app/lib/api/sandbox/db", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/api/sandbox/db")>();
+  return {
+    ...actual,
+    ensureSandboxStateHealthOnSleep: mockEnsureSandboxStateHealthOnSleep,
+  };
+});
 
 vi.mock("@app/lib/api/sandbox", () => ({
   getSandboxProvider: mockGetSandboxProvider,
@@ -49,7 +59,7 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 function createDeferred() {
   let resolvePromise: (() => void) | undefined;
@@ -109,6 +119,7 @@ describe("FrameSandboxAdapter", () => {
       destroy: mockProviderDestroy,
     });
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+    mockEnsureSandboxStateHealthOnSleep.mockResolvedValue(new Ok(undefined));
   });
 
   it("owns one sandbox per stable Frame identity", async () => {
@@ -305,6 +316,91 @@ describe("FrameSandboxAdapter", () => {
       releaseFunctionCleanup.resolve();
       deleteInvocationsSpy.mockRestore();
     }
+  });
+
+  it("flushes Frame state before destroying a runtime for a scope transition", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+
+    const transition = await FrameSandboxAdapter.withScopeTransition(
+      auth,
+      frame,
+      {
+        prepare: async () => new Ok(undefined),
+        commit: async () => new Ok(undefined),
+      }
+    );
+
+    expect(transition.isOk()).toBe(true);
+    expect(mockEnsureSandboxStateHealthOnSleep).toHaveBeenCalledWith(
+      auth,
+      sandboxResult.value.sandbox,
+      expect.objectContaining({ refreshMountCredential: expect.any(Function) })
+    );
+    expect(
+      mockEnsureSandboxStateHealthOnSleep.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockProviderDestroy.mock.invocationCallOrder[0]);
+  });
+
+  it("keeps the current runtime when state cannot be flushed", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    const sandboxResult = await FrameSandboxAdapter.ensureSandboxActive(
+      auth,
+      frame
+    );
+    if (sandboxResult.isErr()) {
+      throw sandboxResult.error;
+    }
+    mockEnsureSandboxStateHealthOnSleep.mockResolvedValue(
+      new Err(new Error("sync failed"))
+    );
+    mockProviderDestroy.mockClear();
+
+    const transition = await FrameSandboxAdapter.withScopeTransition(
+      auth,
+      frame,
+      {
+        prepare: async () => new Ok(undefined),
+        commit: async () => new Ok(undefined),
+      }
+    );
+
+    expect(transition.isErr() && transition.error.message).toContain(
+      "sync failed"
+    );
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+    expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toMatchObject({
+      id: sandboxResult.value.sandbox.id,
+      status: "running",
+    });
   });
 
   it("deletes Frame sandboxes during a workspace scrub", async () => {

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -13,6 +13,7 @@ import type {
   SandboxDeleteOwner,
   SandboxLifecycleOwner,
   SandboxPreSleepCheck,
+  ScopeTransitionDestroyError,
 } from "@app/lib/resources/sandbox_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
@@ -41,6 +42,8 @@ export type FrameSandboxScope = {
 };
 
 export class FrameGoneError extends Error {}
+
+export class FrameScopeTransitionStateError extends Error {}
 
 export class FrameSandboxAdapter {
   private static assertWorkspace(
@@ -270,6 +273,61 @@ export class FrameSandboxAdapter {
       this.toSandboxDeleteOwner(auth, frame),
       { afterSandboxCleanup }
     );
+  }
+
+  static async withScopeTransition<TPrep, T, E extends Error>(
+    auth: Authenticator,
+    frame: FrameSandboxScopeOwner,
+    {
+      prepare,
+      commit,
+    }: {
+      prepare: (freshFrame: FileResource) => Promise<Result<TPrep, E>>;
+      commit: (freshFrame: FileResource, prep: TPrep) => Promise<Result<T, E>>;
+    }
+  ): Promise<
+    Result<
+      T,
+      | E
+      | FrameGoneError
+      | FrameScopeTransitionStateError
+      | ScopeTransitionDestroyError
+    >
+  > {
+    return SandboxResource.runScopeTransition<
+      { freshFrame: FileResource; prep: TPrep },
+      T,
+      E | FrameGoneError | FrameScopeTransitionStateError
+    >(auth, this.toSandboxLifecycleOwner(auth, frame), {
+      prepare: async () => {
+        const freshFrame = await frame.fetchFreshFrameV2(auth);
+        if (!freshFrame) {
+          return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
+        }
+        const prepResult = await prepare(freshFrame);
+        if (prepResult.isErr()) {
+          return prepResult;
+        }
+
+        const sandbox = await this.fetchSandboxByFrame(auth, frame);
+        if (sandbox?.status === "running") {
+          const stateResult = await this.sqliteStatePreSleepCheck(
+            auth,
+            frame
+          )(sandbox);
+          if (stateResult.isErr()) {
+            return new Err(
+              new FrameScopeTransitionStateError(
+                `Failed to flush Frame state for scope transition: ${stateResult.error.message}`
+              )
+            );
+          }
+        }
+
+        return new Ok({ freshFrame, prep: prepResult.value });
+      },
+      commit: ({ freshFrame, prep }) => commit(freshFrame, prep),
+    });
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -63,6 +63,8 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame publish");
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
+    expect(instructions).toContain("dsbx frame move");
+    expect(instructions).toContain("registered Frame folder with raw");
     expect(instructions).toContain("package-like folder");
     expect(instructions).toContain("canonical Frame resource");
     expect(instructions).toContain("`index.tsx` by default");

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -64,6 +64,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("dsbx frame move");
+    expect(instructions).toContain("dsbx frame share");
     expect(instructions).toContain("dsbx frame delete");
     expect(instructions).toContain("registered Frame folder with raw");
     expect(instructions).toContain("package-like folder");

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -64,6 +64,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("dsbx frame move");
+    expect(instructions).toContain("dsbx frame delete");
     expect(instructions).toContain("registered Frame folder with raw");
     expect(instructions).toContain("package-like folder");
     expect(instructions).toContain("canonical Frame resource");

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -42,6 +42,18 @@ dsbx frame register /files/<scope>/<frame-folder>/manifest.json
 Registration validates the manifest and assigns its stable Frame identity. Repeating the command
 for the same manifest path returns the same Frame. Registration does not publish the source.
 
+## Move a registered Frame
+
+Use the CLI instead of \`mv\` so the Frame keeps its identity, active publication, sharing, and
+database state while its source folder moves:
+
+\`\`\`bash
+dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/<frame-folder>
+\`\`\`
+
+Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
+registered Frame folder with raw filesystem commands.
+
 ## Frames v2 source layout
 
 Keep one Frame and everything it owns in one folder:
@@ -321,7 +333,6 @@ Do not use the \`publish_interactive_content_file\` tool: the CLI replaces it un
 Other interactive-content tools remain available for Frame operations that the CLI does not cover
 yet. Use \`dsbx frame --help\` as the authority for available operations.
 
-Do not use \`mv\` or \`cp\` on a registered Frame folder: move and clone are not supported in this
-initial scope.
+Do not use \`cp\` to clone a registered Frame folder. Cloning is not supported yet.
 
 ${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}`;

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -54,6 +54,19 @@ dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/
 Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
 registered Frame folder with raw filesystem commands.
 
+## Share a registered Frame
+
+Configure Frame use rights through the CLI. This does not change who can edit its source:
+
+\`\`\`bash
+dsbx frame share /files/<scope>/<frame-folder> --scope workspace-and-emails
+dsbx frame share /files/<scope>/<frame-folder> --scope emails-only --email user@example.com
+dsbx frame share /files/<scope>/<frame-folder> --scope public
+\`\`\`
+
+Use \`--email\` more than once for multiple invitees. Workspace policy and the invoking member's
+Frame sharing permissions still apply. The command returns the stable Frame ID and share URL.
+
 ## Delete a registered Frame
 
 Use the CLI to permanently remove the source folder, stable identity, publications, functions,

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -54,6 +54,18 @@ dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/
 Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
 registered Frame folder with raw filesystem commands.
 
+## Delete a registered Frame
+
+Use the CLI to permanently remove the source folder, stable identity, publications, functions,
+invocations, sharing, sandbox, and database state:
+
+\`\`\`bash
+dsbx frame delete /files/<scope>/<frame-folder>
+\`\`\`
+
+Do not use \`rm\` on a registered Frame folder: it would only remove source files and leave the
+Frame-owned resources behind. Frame deletion cannot be undone.
+
 ## Frames v2 source layout
 
 Keep one Frame and everything it owns in one folder:

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -23,6 +23,14 @@ interface MockFileMetadata {
   size: string;
   contentEncoding?: string;
   contentDisposition?: string;
+  crc32c?: string;
+  generation?: string;
+  md5Hash?: string;
+}
+
+interface DeleteCall {
+  filePath: string;
+  options: { ifGenerationMatch?: string; ignoreNotFound?: boolean } | undefined;
 }
 
 class MockGcsError extends Error {
@@ -60,6 +68,9 @@ class FileStorageMock {
   private _signedUploadUrlCalls: SignedUrlCall[] = [];
   private _metadataCalls: string[] = [];
   private _objectStore = new Map<string, string>();
+  private _objectGenerations = new Map<string, string>();
+  private _nextGeneration = 1;
+  private _deleteCalls: DeleteCall[] = [];
   private _fetchNotFoundPredicate: (filePath: string) => boolean = () => false;
   private _existsPredicate: (filePath: string) => boolean = () => true;
   private _saveShouldFail: (filePath: string) => boolean = () => false;
@@ -70,6 +81,7 @@ class FileStorageMock {
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
+  private _deleteShouldFail: (filePath: string) => boolean = () => false;
   private _filesByPrefix: (
     prefix: string
   ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
@@ -101,6 +113,10 @@ class FileStorageMock {
 
   get metadataCalls(): readonly string[] {
     return this._metadataCalls;
+  }
+
+  get deleteCalls(): readonly DeleteCall[] {
+    return this._deleteCalls;
   }
 
   /**
@@ -154,6 +170,10 @@ class FileStorageMock {
    */
   setCopyFileFails(predicate: (src: string, dest: string) => boolean): void {
     this._copyFileShouldFail = predicate;
+  }
+
+  setDeleteFails(predicate: (filePath: string) => boolean): void {
+    this._deleteShouldFail = predicate;
   }
 
   /**
@@ -216,6 +236,7 @@ class FileStorageMock {
   // Seed the in-memory object store directly (no write path).
   setObject(filePath: string, content: string): void {
     this._objectStore.set(filePath, content);
+    this._objectGenerations.set(filePath, String(this._nextGeneration++));
   }
 
   reset(): void {
@@ -225,7 +246,10 @@ class FileStorageMock {
     this._signedUrlCalls.length = 0;
     this._signedUploadUrlCalls.length = 0;
     this._metadataCalls.length = 0;
+    this._deleteCalls.length = 0;
     this._objectStore.clear();
+    this._objectGenerations.clear();
+    this._nextGeneration = 1;
     this._fetchNotFoundPredicate = () => false;
     this._existsPredicate = () => true;
     this._saveShouldFail = () => false;
@@ -233,6 +257,7 @@ class FileStorageMock {
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
+    this._deleteShouldFail = () => false;
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
     this._deletedPrefixes.length = 0;
@@ -291,8 +316,24 @@ class FileStorageMock {
           }
           return stream;
         }),
-      delete: vi.fn().mockImplementation(() => {
-        this._objectStore.delete(filePath ?? "unknown");
+      delete: vi.fn().mockImplementation((options?: DeleteCall["options"]) => {
+        const path = filePath ?? "unknown";
+        this._deleteCalls.push({ filePath: path, options });
+        if (this._deleteShouldFail(path)) {
+          return Promise.reject(
+            new Error(`Simulated GCS delete failure: ${path}`)
+          );
+        }
+        if (
+          options?.ifGenerationMatch &&
+          this._objectGenerations.get(path) !== options.ifGenerationMatch
+        ) {
+          return Promise.reject(
+            new MockGcsError(412, `Object generation changed: ${path}`)
+          );
+        }
+        this._objectStore.delete(path);
+        this._objectGenerations.delete(path);
         return Promise.resolve(undefined);
       }),
       download: vi.fn().mockImplementation(() => {
@@ -308,7 +349,7 @@ class FileStorageMock {
         return Promise.resolve([
           this._metadataForPath(path) ?? {
             contentType: "text/plain",
-            generation: "1",
+            generation: this._objectGenerations.get(path) ?? "1",
             size: "0",
           },
         ]);
@@ -434,14 +475,33 @@ class FileStorageMock {
         }
         return Promise.resolve(new Uint8Array());
       }),
-      copyFile: vi.fn((src: string, dest: string) => {
-        if (this._copyFileShouldFail(src, dest)) {
-          return Promise.reject(
-            new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
+      copyFile: vi.fn(
+        (
+          src: string,
+          dest: string,
+          _destinationStorage?: unknown,
+          options?: { destinationGenerationMatch?: number }
+        ) => {
+          if (
+            options?.destinationGenerationMatch === 0 &&
+            this._objectStore.has(dest)
+          ) {
+            return Promise.reject(
+              new MockGcsError(412, `Object already exists: ${dest}`)
+            );
+          }
+          if (this._copyFileShouldFail(src, dest)) {
+            return Promise.reject(
+              new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
+            );
+          }
+          this.setObject(
+            dest,
+            this._objectStore.get(src) ?? this._contentForPath(src) ?? ""
           );
+          return Promise.resolve(undefined);
         }
-        return Promise.resolve(undefined);
-      }),
+      ),
       // Mirrors real GCS compose: concatenates each source's stored content, in order,
       // into the destination object.
       composeFiles: vi.fn((sourcePaths: string[], destinationPath: string) => {
@@ -458,8 +518,23 @@ class FileStorageMock {
         });
         return Promise.resolve(undefined);
       }),
-      delete: vi.fn((filePath: string) => {
+      delete: vi.fn((filePath: string, options?: DeleteCall["options"]) => {
+        this._deleteCalls.push({ filePath, options });
+        if (this._deleteShouldFail(filePath)) {
+          return Promise.reject(
+            new Error(`Simulated GCS delete failure: ${filePath}`)
+          );
+        }
+        if (
+          options?.ifGenerationMatch &&
+          this._objectGenerations.get(filePath) !== options.ifGenerationMatch
+        ) {
+          return Promise.reject(
+            new MockGcsError(412, `Object generation changed: ${filePath}`)
+          );
+        }
         this._objectStore.delete(filePath);
+        this._objectGenerations.delete(filePath);
         return Promise.resolve(undefined);
       }),
       deleteByPrefix: vi.fn(async (prefix: string) => {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -308,6 +308,7 @@ class FileStorageMock {
         return Promise.resolve([
           this._metadataForPath(path) ?? {
             contentType: "text/plain",
+            generation: "1",
             size: "0",
           },
         ]);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -82,6 +82,7 @@ class FileStorageMock {
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
+  private _afterCopyFile: (src: string, dest: string) => void = () => {};
   private _deleteShouldFail: (filePath: string) => boolean = () => false;
   private _filesByPrefix: (
     prefix: string
@@ -126,6 +127,10 @@ class FileStorageMock {
    */
   setFileExists(predicate: (filePath: string) => boolean): void {
     this._existsPredicate = predicate;
+  }
+
+  setAfterCopyFile(callback: (src: string, dest: string) => void): void {
+    this._afterCopyFile = callback;
   }
 
   /**
@@ -263,6 +268,7 @@ class FileStorageMock {
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
+    this._afterCopyFile = () => {};
     this._deleteShouldFail = () => false;
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
@@ -522,7 +528,12 @@ class FileStorageMock {
               this._contentForPath(src) ??
               ""
           );
-          return Promise.resolve(undefined);
+          const copiedGeneration = this._objectGenerations.get(dest);
+          this._afterCopyFile(src, dest);
+          return Promise.resolve({
+            destinationFile: this.createMockGCSFile(dest),
+            destinationGeneration: copiedGeneration,
+          });
         }
       ),
       // Mirrors real GCS compose: concatenates each source's stored content, in order,

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -69,6 +69,7 @@ class FileStorageMock {
   private _metadataCalls: string[] = [];
   private _objectStore = new Map<string, string>();
   private _objectGenerations = new Map<string, string>();
+  private _objectVersions = new Map<string, Map<string, string>>();
   private _nextGeneration = 1;
   private _deleteCalls: DeleteCall[] = [];
   private _fetchNotFoundPredicate: (filePath: string) => boolean = () => false;
@@ -235,8 +236,12 @@ class FileStorageMock {
 
   // Seed the in-memory object store directly (no write path).
   setObject(filePath: string, content: string): void {
+    const generation = String(this._nextGeneration++);
     this._objectStore.set(filePath, content);
-    this._objectGenerations.set(filePath, String(this._nextGeneration++));
+    this._objectGenerations.set(filePath, generation);
+    const versions = this._objectVersions.get(filePath) ?? new Map();
+    versions.set(generation, content);
+    this._objectVersions.set(filePath, versions);
   }
 
   reset(): void {
@@ -249,6 +254,7 @@ class FileStorageMock {
     this._deleteCalls.length = 0;
     this._objectStore.clear();
     this._objectGenerations.clear();
+    this._objectVersions.clear();
     this._nextGeneration = 1;
     this._fetchNotFoundPredicate = () => false;
     this._existsPredicate = () => true;
@@ -480,7 +486,10 @@ class FileStorageMock {
           src: string,
           dest: string,
           _destinationStorage?: unknown,
-          options?: { destinationGenerationMatch?: number }
+          options?: {
+            destinationGenerationMatch?: number;
+            sourceGeneration?: string;
+          }
         ) => {
           if (
             options?.destinationGenerationMatch === 0 &&
@@ -495,9 +504,23 @@ class FileStorageMock {
               new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
             );
           }
+          const versionedContent = options?.sourceGeneration
+            ? this._objectVersions.get(src)?.get(options.sourceGeneration)
+            : undefined;
+          if (options?.sourceGeneration && versionedContent === undefined) {
+            return Promise.reject(
+              new MockGcsError(
+                404,
+                `Source generation does not exist: ${src}@${options.sourceGeneration}`
+              )
+            );
+          }
           this.setObject(
             dest,
-            this._objectStore.get(src) ?? this._contentForPath(src) ?? ""
+            versionedContent ??
+              this._objectStore.get(src) ??
+              this._contentForPath(src) ??
+              ""
           );
           return Promise.resolve(undefined);
         }

--- a/front/types/api/frame_function_reference.test.ts
+++ b/front/types/api/frame_function_reference.test.ts
@@ -1,4 +1,12 @@
-import { resolveFrameFunctionReference } from "@app/types/api/frame_function_reference";
+import {
+  getFrameFunctionReferenceKind,
+  resolveFrameFunctionReference,
+} from "@app/types/api/frame_function_reference";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
 import { describe, expect, it } from "vitest";
 
 describe("resolveFrameFunctionReference", () => {
@@ -31,5 +39,21 @@ describe("resolveFrameFunctionReference", () => {
     expect(result.isOk() && result.value).toBe(
       "pod_123/comments__list-comments"
     );
+  });
+});
+
+describe("getFrameFunctionReferenceKind", () => {
+  it("classifies only known Frame MIME types", () => {
+    expect(getFrameFunctionReferenceKind(frameV2ContentType)).toBe("v2");
+    expect(getFrameFunctionReferenceKind(frameContentType)).toBe("legacy");
+    expect(getFrameFunctionReferenceKind(frameSlideshowContentType)).toBe(
+      "legacy"
+    );
+  });
+
+  it("does not treat absent or unknown metadata as legacy", () => {
+    expect(getFrameFunctionReferenceKind(null)).toBeNull();
+    expect(getFrameFunctionReferenceKind(undefined)).toBeNull();
+    expect(getFrameFunctionReferenceKind("text/plain")).toBeNull();
   });
 });

--- a/front/types/api/frame_function_reference.test.ts
+++ b/front/types/api/frame_function_reference.test.ts
@@ -1,0 +1,35 @@
+import { resolveFrameFunctionReference } from "@app/types/api/frame_function_reference";
+import { describe, expect, it } from "vitest";
+
+describe("resolveFrameFunctionReference", () => {
+  it("qualifies a Frames v2 function with the stable Frame identity", () => {
+    const result = resolveFrameFunctionReference("list-comments", {
+      kind: "v2",
+      frameId: "file_123",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe("file_123/list-comments");
+  });
+
+  it("rejects cross-Frame references from Frames v2", () => {
+    const result = resolveFrameFunctionReference("file_other/list-comments", {
+      kind: "v2",
+      frameId: "file_123",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("keeps legacy Pod-relative resolution unchanged", () => {
+    const result = resolveFrameFunctionReference("list-comments", {
+      kind: "legacy",
+      podFunctionScope: { podId: "pod_123", appPrefix: "comments" },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe(
+      "pod_123/comments__list-comments"
+    );
+  });
+});

--- a/front/types/api/frame_function_reference.ts
+++ b/front/types/api/frame_function_reference.ts
@@ -3,6 +3,7 @@ import {
   isRelativePodFunctionReference,
   resolvePodFunctionReference,
 } from "@app/types/api/pod_function_reference";
+import { frameV2ContentType, isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -10,6 +11,21 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 export type FrameFunctionReferenceScope =
   | { kind: "v2"; frameId: string }
   | { kind: "legacy"; podFunctionScope: PodFunctionScope | null };
+
+export type FrameFunctionReferenceKind = FrameFunctionReferenceScope["kind"];
+
+/** Classify only known Frame MIME types. Missing metadata must never imply a legacy Frame. */
+export function getFrameFunctionReferenceKind(
+  contentType: string | null | undefined
+): FrameFunctionReferenceKind | null {
+  if (contentType === frameV2ContentType) {
+    return "v2";
+  }
+  if (contentType && isInteractiveContentType(contentType)) {
+    return "legacy";
+  }
+  return null;
+}
 
 /** Resolve the function reference emitted by a Frame against that Frame's trusted host identity. */
 export function resolveFrameFunctionReference(

--- a/front/types/api/frame_function_reference.ts
+++ b/front/types/api/frame_function_reference.ts
@@ -1,0 +1,34 @@
+import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
+import {
+  isRelativePodFunctionReference,
+  resolvePodFunctionReference,
+} from "@app/types/api/pod_function_reference";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type FrameFunctionReferenceScope =
+  | { kind: "v2"; frameId: string }
+  | { kind: "legacy"; podFunctionScope: PodFunctionScope | null };
+
+/** Resolve the function reference emitted by a Frame against that Frame's trusted host identity. */
+export function resolveFrameFunctionReference(
+  reference: string,
+  scope: FrameFunctionReferenceScope
+): Result<string, Error> {
+  switch (scope.kind) {
+    case "v2":
+      if (!isRelativePodFunctionReference(reference)) {
+        return new Err(
+          new Error(
+            `'${reference}' is not a Frames v2 function name: expected a bare manifest function name.`
+          )
+        );
+      }
+      return new Ok(`${scope.frameId}/${reference}`);
+    case "legacy":
+      return resolvePodFunctionReference(reference, scope.podFunctionScope);
+    default:
+      return assertNever(scope);
+  }
+}

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -63,6 +63,12 @@ export type FileUseCaseMetadata = {
   frameEntryRelPath?: string;
   // Immutable Frames v2 publication currently served by the Frame.
   activePublicationId?: string;
+  // Set only while a Frames v2 source move owns its destination mount path.
+  // Keeping this on the stable FileResource makes an interrupted move retryable.
+  pendingFrameSourceMove?: {
+    sourceMountFilePath: string;
+    destinationMountFilePath: string;
+  };
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

- Add `dsbx frame share` for workspace, invite-only and public Frame use rights.
- Resolve the stable Frame from its writable source package and enforce existing workspace sharing permissions.
- Commit scope, authorized-file access and new email grants in one transaction. Audits and notifications run only after commit.
- Reuse the current sharing records and permission checks. Legacy Frame sharing is unchanged.

## Tests

Added sandbox-token coverage for a published v2 Frame, idempotent grants and validation rollback. Re-ran all existing share-scope and email-grant route tests.

## Risk

Authorized-file validation completes before mutation. Scope, allowlist and grants then commit atomically, so a failed share leaves prior use rights unchanged. The existing 28 web-route tests pass unchanged. The new endpoint is internal, feature-flagged and restricted to registered v2 packages in writable mounts.

## Deploy Plan

Standard deploy after the parent stack merges.