### PR TITLE
Reuse safe Frame source copying

### DIFF
--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -4,17 +4,14 @@ import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
 import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
+import type { GCSObjectGeneration } from "@app/lib/api/frames/source_copy";
 import {
-  MAX_FRAME_SOURCE_BYTES,
-  MAX_FRAME_SOURCE_FILE_COUNT,
-} from "@app/lib/api/frames/source_limits";
+  cleanupFrameSourceCopy,
+  copyFrameSourceAsNew,
+} from "@app/lib/api/frames/source_copy";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-  getPrivateUploadBucket,
-} from "@app/lib/file_storage";
-import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { FrameScopeTransitionStateError } from "@app/lib/resources/frame_sandbox_adapter";
@@ -33,7 +30,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { File, FileMetadata } from "@google-cloud/storage";
 import { UniqueConstraintError } from "sequelize";
 
 const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
@@ -183,65 +179,6 @@ function assertFrameAtSource(
   return new Ok(undefined);
 }
 
-function metadataValue(metadata: FileMetadata, key: keyof FileMetadata) {
-  const value = metadata[key];
-  return value === undefined || value === null ? null : String(value);
-}
-
-function isSameGCSObject(source: File, destination: File): boolean {
-  const sourceMd5 = metadataValue(source.metadata, "md5Hash");
-  const destinationMd5 = metadataValue(destination.metadata, "md5Hash");
-  if (sourceMd5 && destinationMd5) {
-    return sourceMd5 === destinationMd5;
-  }
-
-  const sourceCrc32c = metadataValue(source.metadata, "crc32c");
-  const destinationCrc32c = metadataValue(destination.metadata, "crc32c");
-  return Boolean(
-    sourceCrc32c &&
-      destinationCrc32c &&
-      sourceCrc32c === destinationCrc32c &&
-      metadataValue(source.metadata, "size") ===
-        metadataValue(destination.metadata, "size")
-  );
-}
-
-type GCSObjectGeneration = { filePath: string; generation: string };
-type FrameSourceCopy = {
-  destinationObjects: GCSObjectGeneration[];
-  hasPreexistingDestinationObjects: boolean;
-  sourceObjects: GCSObjectGeneration[];
-};
-type FrameSourceCopyFailure = {
-  destinationObjects: GCSObjectGeneration[];
-  error: FrameSourceMoveError;
-  hasPreexistingDestinationObjects: boolean;
-};
-
-async function cleanupDestinationObjects(
-  objects: GCSObjectGeneration[]
-): Promise<boolean> {
-  const bucket = getPrivateUploadBucket();
-  try {
-    await concurrentExecutor(
-      objects,
-      ({ filePath, generation }) =>
-        bucket.delete(filePath, {
-          ignoreNotFound: true,
-          ifGenerationMatch: generation,
-        }),
-      { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
-    );
-    return true;
-  } catch (error) {
-    logger.error(
-      { error: normalizeError(error) },
-      "Failed to clean up a Frame move destination"
-    );
-    return false;
-  }
-}
-
 async function deleteCopiedSourceObjects(
   objects: GCSObjectGeneration[],
   sourceMountPrefix: string
@@ -269,221 +206,6 @@ async function deleteCopiedSourceObjects(
     );
     return false;
   }
-}
-
-async function copyFrameSourceAsNew({
-  allowMatchingDestinationObjects,
-  destinationMountPrefix,
-  sourceManifestPath,
-  sourceMountPrefix,
-}: {
-  allowMatchingDestinationObjects: boolean;
-  destinationMountPrefix: string;
-  sourceManifestPath: string;
-  sourceMountPrefix: string;
-}): Promise<Result<FrameSourceCopy, FrameSourceCopyFailure>> {
-  const bucket = getPrivateUploadBucket();
-  const [sourceFiles, destinationFiles] = await Promise.all([
-    bucket.getFiles({
-      prefix: sourceMountPrefix,
-      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
-    }),
-    bucket.getFiles({
-      prefix: destinationMountPrefix,
-      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
-    }),
-  ]);
-  if (sourceFiles.length === 0) {
-    return new Err({
-      destinationObjects: [],
-      error: new FrameSourceMoveError(
-        "invalid_source",
-        "Frame source folder is empty or no longer exists."
-      ),
-      hasPreexistingDestinationObjects: destinationFiles.length > 0,
-    });
-  }
-  if (!sourceFiles.some((file) => file.name === sourceManifestPath)) {
-    return new Err({
-      destinationObjects: [],
-      error: new FrameSourceMoveError(
-        "invalid_source",
-        "Frame source manifest is missing."
-      ),
-      hasPreexistingDestinationObjects: destinationFiles.length > 0,
-    });
-  }
-  const totalSourceSize = sourceFiles.reduce(
-    (total, file) => total + Number(file.metadata.size ?? 0),
-    0
-  );
-  if (
-    sourceFiles.length > MAX_FRAME_SOURCE_FILE_COUNT ||
-    totalSourceSize > MAX_FRAME_SOURCE_BYTES
-  ) {
-    return new Err({
-      destinationObjects: [],
-      error: new FrameSourceMoveError(
-        "invalid_source",
-        "Frame source exceeds the move size limit."
-      ),
-      hasPreexistingDestinationObjects: destinationFiles.length > 0,
-    });
-  }
-  if (destinationFiles.length > MAX_FRAME_SOURCE_FILE_COUNT) {
-    return new Err({
-      destinationObjects: [],
-      error: new FrameSourceMoveError(
-        "conflict",
-        "Frame destination exceeds the move file count limit."
-      ),
-      hasPreexistingDestinationObjects: true,
-    });
-  }
-
-  const sourceRelativePaths = new Set(
-    sourceFiles.map((file) => file.name.slice(sourceMountPrefix.length))
-  );
-  const unexpectedDestination = destinationFiles.find(
-    (file) =>
-      !sourceRelativePaths.has(file.name.slice(destinationMountPrefix.length))
-  );
-  if (unexpectedDestination) {
-    return new Err({
-      destinationObjects: [],
-      error: new FrameSourceMoveError(
-        "conflict",
-        `Destination file already exists: ${unexpectedDestination.name.slice(destinationMountPrefix.length)}`
-      ),
-      hasPreexistingDestinationObjects: true,
-    });
-  }
-
-  const destinationByRelativePath = new Map(
-    destinationFiles.map((file) => [
-      file.name.slice(destinationMountPrefix.length),
-      file,
-    ])
-  );
-  const copyResults = await concurrentExecutor(
-    sourceFiles,
-    async (sourceFile) => {
-      let hasPreexistingDestinationObject = false;
-      try {
-        const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
-        const destinationPath = `${destinationMountPrefix}${relativePath}`;
-        const sourceGeneration = metadataValue(
-          sourceFile.metadata,
-          "generation"
-        );
-        if (!sourceGeneration) {
-          throw new FrameSourceMoveError(
-            "internal",
-            `Source generation is missing: ${relativePath}`
-          );
-        }
-        let destinationFile = destinationByRelativePath.get(relativePath);
-        let ownedDestinationObject: GCSObjectGeneration | null = null;
-        hasPreexistingDestinationObject = Boolean(destinationFile);
-
-        if (!destinationFile) {
-          try {
-            const copied = await bucket.copyFile(
-              sourceFile.name,
-              destinationPath,
-              undefined,
-              {
-                destinationGenerationMatch:
-                  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-                sourceGeneration,
-              }
-            );
-            destinationFile = copied.destinationFile;
-            ownedDestinationObject = {
-              filePath: destinationPath,
-              generation: copied.destinationGeneration,
-            };
-          } catch (error) {
-            if (!isGCSPreconditionFailedError(error)) {
-              throw error;
-            }
-            if (!allowMatchingDestinationObjects) {
-              throw new FrameSourceMoveError(
-                "conflict",
-                `Destination file already exists: ${relativePath}`
-              );
-            }
-            hasPreexistingDestinationObject = true;
-            destinationFile = bucket.file(destinationPath);
-            const [metadata] = await destinationFile.getMetadata();
-            destinationFile.metadata = metadata;
-          }
-        }
-
-        if (
-          !ownedDestinationObject &&
-          (!allowMatchingDestinationObjects ||
-            !isSameGCSObject(sourceFile, destinationFile))
-        ) {
-          throw new FrameSourceMoveError(
-            "conflict",
-            `Destination file already exists: ${relativePath}`
-          );
-        }
-
-        return new Ok<{
-          destination: GCSObjectGeneration | null;
-          hasPreexistingDestinationObject: boolean;
-          source: GCSObjectGeneration;
-        }>({
-          destination: ownedDestinationObject,
-          hasPreexistingDestinationObject,
-          source: {
-            filePath: sourceFile.name,
-            generation: sourceGeneration,
-          },
-        });
-      } catch (error) {
-        return new Err({
-          error:
-            error instanceof FrameSourceMoveError
-              ? error
-              : new FrameSourceMoveError(
-                  "internal",
-                  `Failed to copy the Frame source: ${normalizeError(error).message}`
-                ),
-          hasPreexistingDestinationObject,
-        });
-      }
-    },
-    { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
-  );
-  const copiedObjects = copyResults
-    .filter((result) => result.isOk())
-    .map((result) => result.value);
-  const destinationObjects = copiedObjects.flatMap(({ destination }) =>
-    destination ? [destination] : []
-  );
-  const hasPreexistingDestinationObjects =
-    destinationFiles.length > 0 ||
-    copyResults.some((result) =>
-      result.isOk()
-        ? result.value.hasPreexistingDestinationObject
-        : result.error.hasPreexistingDestinationObject
-    );
-  const failedCopy = copyResults.find((result) => result.isErr());
-  if (failedCopy?.isErr()) {
-    return new Err({
-      destinationObjects,
-      error: failedCopy.error.error,
-      hasPreexistingDestinationObjects,
-    });
-  }
-  return new Ok({
-    destinationObjects,
-    hasPreexistingDestinationObjects,
-    sourceObjects: copiedObjects.map(({ source }) => source),
-  });
 }
 
 /** Move a registered Frame folder while retaining its stable FileResource identity. */
@@ -717,8 +439,13 @@ export async function moveFrameV2Source(
       sourceMountPrefix,
     });
     if (copyResult.isErr()) {
-      const cleaned = await cleanupDestinationObjects(
-        copyResult.error.destinationObjects
+      const copyError = new FrameSourceMoveError(
+        copyResult.error.error.code,
+        copyResult.error.error.message
+      );
+      const cleaned = await cleanupFrameSourceCopy(
+        copyResult.error.destinationObjects,
+        { operation: "move" }
       );
       if (!cleaned) {
         return new Err(
@@ -729,11 +456,11 @@ export async function moveFrameV2Source(
         );
       }
       if (isRecovery && copyResult.error.hasPreexistingDestinationObjects) {
-        return new Err(copyResult.error.error);
+        return new Err(copyError);
       }
       const restored = await restoreSourceReservation();
       return restored
-        ? new Err(copyResult.error.error)
+        ? new Err(copyError)
         : new Err(
             new FrameSourceMoveError(
               "internal",
@@ -800,8 +527,9 @@ export async function moveFrameV2Source(
           });
 
     if (updateResult.isErr()) {
-      const cleaned = await cleanupDestinationObjects(
-        copyResult.value.destinationObjects
+      const cleaned = await cleanupFrameSourceCopy(
+        copyResult.value.destinationObjects,
+        { operation: "move" }
       );
       const restored =
         cleaned &&

--- a/front/lib/api/frames/source_copy.ts
+++ b/front/lib/api/frames/source_copy.ts
@@ -1,0 +1,312 @@
+import {
+  MAX_FRAME_SOURCE_BYTES,
+  MAX_FRAME_SOURCE_FILE_COUNT,
+} from "@app/lib/api/frames/source_limits";
+import {
+  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
+import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { File, FileMetadata } from "@google-cloud/storage";
+
+const FRAME_SOURCE_COPY_CONCURRENCY = 4;
+
+export type FrameSourceCopyErrorCode =
+  | "conflict"
+  | "internal"
+  | "invalid_source";
+
+export class FrameSourceCopyError extends Error {
+  constructor(
+    readonly code: FrameSourceCopyErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceCopyError";
+  }
+}
+
+export type GCSObjectGeneration = {
+  filePath: string;
+  generation: string;
+};
+
+export type FrameSourceCopy = {
+  destinationObjects: GCSObjectGeneration[];
+  hasPreexistingDestinationObjects: boolean;
+  sourceObjects: GCSObjectGeneration[];
+};
+
+type FrameSourceCopyFailure = {
+  destinationObjects: GCSObjectGeneration[];
+  error: FrameSourceCopyError;
+  hasPreexistingDestinationObjects: boolean;
+};
+
+function metadataValue(metadata: FileMetadata, key: keyof FileMetadata) {
+  const value = metadata[key];
+  return value === undefined || value === null ? null : String(value);
+}
+
+function isSameGCSObject(source: File, destination: File): boolean {
+  const sourceMd5 = metadataValue(source.metadata, "md5Hash");
+  const destinationMd5 = metadataValue(destination.metadata, "md5Hash");
+  if (sourceMd5 && destinationMd5) {
+    return sourceMd5 === destinationMd5;
+  }
+
+  const sourceCrc32c = metadataValue(source.metadata, "crc32c");
+  const destinationCrc32c = metadataValue(destination.metadata, "crc32c");
+  return Boolean(
+    sourceCrc32c &&
+      destinationCrc32c &&
+      sourceCrc32c === destinationCrc32c &&
+      metadataValue(source.metadata, "size") ===
+        metadataValue(destination.metadata, "size")
+  );
+}
+
+export async function cleanupFrameSourceCopy(
+  objects: GCSObjectGeneration[],
+  { operation }: { operation: "clone" | "move" }
+): Promise<boolean> {
+  const bucket = getPrivateUploadBucket();
+  try {
+    await concurrentExecutor(
+      objects,
+      ({ filePath, generation }) =>
+        bucket.delete(filePath, {
+          ignoreNotFound: true,
+          ifGenerationMatch: generation,
+        }),
+      { concurrency: FRAME_SOURCE_COPY_CONCURRENCY }
+    );
+    return true;
+  } catch (error) {
+    logger.error(
+      { error: normalizeError(error), operation },
+      "Failed to clean up a Frame source copy destination"
+    );
+    return false;
+  }
+}
+
+export async function copyFrameSourceAsNew({
+  allowMatchingDestinationObjects,
+  destinationMountPrefix,
+  sourceManifestPath,
+  sourceMountPrefix,
+}: {
+  allowMatchingDestinationObjects: boolean;
+  destinationMountPrefix: string;
+  sourceManifestPath: string;
+  sourceMountPrefix: string;
+}): Promise<Result<FrameSourceCopy, FrameSourceCopyFailure>> {
+  const bucket = getPrivateUploadBucket();
+  const [sourceFiles, destinationFiles] = await Promise.all([
+    bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    }),
+    bucket.getFiles({
+      prefix: destinationMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    }),
+  ]);
+  if (sourceFiles.length === 0) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceCopyError(
+        "invalid_source",
+        "Frame source folder is empty or no longer exists."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  if (!sourceFiles.some((file) => file.name === sourceManifestPath)) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceCopyError(
+        "invalid_source",
+        "Frame source manifest is missing."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  const totalSourceSize = sourceFiles.reduce(
+    (total, file) => total + Number(file.metadata.size ?? 0),
+    0
+  );
+  if (
+    sourceFiles.length > MAX_FRAME_SOURCE_FILE_COUNT ||
+    totalSourceSize > MAX_FRAME_SOURCE_BYTES
+  ) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceCopyError(
+        "invalid_source",
+        "Frame source exceeds the copy size limit."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  if (destinationFiles.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceCopyError(
+        "conflict",
+        "Frame destination exceeds the copy file count limit."
+      ),
+      hasPreexistingDestinationObjects: true,
+    });
+  }
+
+  const sourceRelativePaths = new Set(
+    sourceFiles.map((file) => file.name.slice(sourceMountPrefix.length))
+  );
+  const unexpectedDestination = destinationFiles.find(
+    (file) =>
+      !sourceRelativePaths.has(file.name.slice(destinationMountPrefix.length))
+  );
+  if (unexpectedDestination) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceCopyError(
+        "conflict",
+        `Destination file already exists: ${unexpectedDestination.name.slice(destinationMountPrefix.length)}`
+      ),
+      hasPreexistingDestinationObjects: true,
+    });
+  }
+
+  const destinationByRelativePath = new Map(
+    destinationFiles.map((file) => [
+      file.name.slice(destinationMountPrefix.length),
+      file,
+    ])
+  );
+  const copyResults = await concurrentExecutor(
+    sourceFiles,
+    async (sourceFile) => {
+      let hasPreexistingDestinationObject = false;
+      try {
+        const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
+        const destinationPath = `${destinationMountPrefix}${relativePath}`;
+        const sourceGeneration = metadataValue(
+          sourceFile.metadata,
+          "generation"
+        );
+        if (!sourceGeneration) {
+          throw new FrameSourceCopyError(
+            "internal",
+            `Source generation is missing: ${relativePath}`
+          );
+        }
+        let destinationFile = destinationByRelativePath.get(relativePath);
+        let ownedDestinationObject: GCSObjectGeneration | null = null;
+        hasPreexistingDestinationObject = Boolean(destinationFile);
+
+        if (!destinationFile) {
+          try {
+            const copied = await bucket.copyFile(
+              sourceFile.name,
+              destinationPath,
+              undefined,
+              {
+                destinationGenerationMatch:
+                  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+                sourceGeneration,
+              }
+            );
+            destinationFile = copied.destinationFile;
+            ownedDestinationObject = {
+              filePath: destinationPath,
+              generation: copied.destinationGeneration,
+            };
+          } catch (error) {
+            if (!isGCSPreconditionFailedError(error)) {
+              throw error;
+            }
+            if (!allowMatchingDestinationObjects) {
+              throw new FrameSourceCopyError(
+                "conflict",
+                `Destination file already exists: ${relativePath}`
+              );
+            }
+            hasPreexistingDestinationObject = true;
+            destinationFile = bucket.file(destinationPath);
+            const [metadata] = await destinationFile.getMetadata();
+            destinationFile.metadata = metadata;
+          }
+        }
+
+        if (
+          !ownedDestinationObject &&
+          (!allowMatchingDestinationObjects ||
+            !isSameGCSObject(sourceFile, destinationFile))
+        ) {
+          throw new FrameSourceCopyError(
+            "conflict",
+            `Destination file already exists: ${relativePath}`
+          );
+        }
+
+        return new Ok<{
+          destination: GCSObjectGeneration | null;
+          hasPreexistingDestinationObject: boolean;
+          source: GCSObjectGeneration;
+        }>({
+          destination: ownedDestinationObject,
+          hasPreexistingDestinationObject,
+          source: {
+            filePath: sourceFile.name,
+            generation: sourceGeneration,
+          },
+        });
+      } catch (error) {
+        return new Err({
+          error:
+            error instanceof FrameSourceCopyError
+              ? error
+              : new FrameSourceCopyError(
+                  "internal",
+                  `Failed to copy the Frame source: ${normalizeError(error).message}`
+                ),
+          hasPreexistingDestinationObject,
+        });
+      }
+    },
+    { concurrency: FRAME_SOURCE_COPY_CONCURRENCY }
+  );
+  const copiedObjects = copyResults
+    .filter((result) => result.isOk())
+    .map((result) => result.value);
+  const destinationObjects = copiedObjects.flatMap(({ destination }) =>
+    destination ? [destination] : []
+  );
+  const hasPreexistingDestinationObjects =
+    destinationFiles.length > 0 ||
+    copyResults.some((result) =>
+      result.isOk()
+        ? result.value.hasPreexistingDestinationObject
+        : result.error.hasPreexistingDestinationObject
+    );
+  const failedCopy = copyResults.find((result) => result.isErr());
+  if (failedCopy?.isErr()) {
+    return new Err({
+      destinationObjects,
+      error: failedCopy.error.error,
+      hasPreexistingDestinationObjects,
+    });
+  }
+  return new Ok({
+    destinationObjects,
+    hasPreexistingDestinationObjects,
+    sourceObjects: copiedObjects.map(({ source }) => source),
+  });
+}


### PR DESCRIPTION
## Description

- Extract the current bounded, generation-pinned Frame source copier and exact-generation cleanup for clone reuse.
- Keep Frame move behavior unchanged while preserving manifest completeness, create-only destination ownership, concurrent-source-edit safety, and recovery bookkeeping.

## Tests

- 14 focused Frame move lifecycle tests.
- Front typecheck.
- Biome checks and git diff check for all changed files.

## Risk

Refactor only. The move path delegates to the extracted helper without changing its copy, recovery, or cleanup behavior.

## Deploy Plan

Standard deploy after the parent stack merges.