### PR TITLE
Clone Frames into fresh runtime ownership

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/clone.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/clone.ts
@@ -1,0 +1,123 @@
+import {
+  type CloneFrameV2SourceError,
+  type CloneFrameV2SourceResult,
+  cloneFrameV2Source,
+  isFrameSourceCloneError,
+} from "@app/lib/api/frames/clone_source";
+import { isFramePublicationError } from "@app/lib/api/frames/publication_storage";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { isSandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameCloneRequestSchema = z.object({
+  destinationDirectoryPath: z.string().min(1),
+  sourceDirectoryPath: z.string().min(1),
+});
+
+function frameCloneErrorStatus(
+  error: CloneFrameV2SourceError
+): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFrameSourceCloneError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFramePublicationError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return 400;
+  }
+  if (isSandboxFunctionError(error)) {
+    return ["internal", "reconcile_failed", "sandbox_unavailable"].includes(
+      error.code
+    )
+      ? 500
+      : 400;
+  }
+  return 500;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameCloneRequestSchema),
+  async (ctx): HandlerResult<CloneFrameV2SourceResult> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot clone Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { destinationDirectoryPath, sourceDirectoryPath } =
+      ctx.req.valid("json");
+    const cloned = await cloneFrameV2Source(auth, {
+      conversation: conversation.toJSON(),
+      destinationDirectoryPath,
+      sourceDirectoryPath,
+    });
+    if (cloned.isErr()) {
+      const status = frameCloneErrorStatus(cloned.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: cloned.error.message,
+          },
+        },
+        cloned.error
+      );
+    }
+
+    return ctx.json(cloned.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -2,12 +2,16 @@
 // @vitest-environment node
 
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
-import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
+import {
+  getFramePublicationDescriptorPath,
+  getFramePublicationUiBundlePath,
+} from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
@@ -76,6 +80,22 @@ function requestFrameMove(
   destinationDirectoryPath: string
 ) {
   return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/move`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourceDirectoryPath, destinationDirectoryPath }),
+  });
+}
+
+function requestFrameClone(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string,
+  destinationDirectoryPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/clone`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${token}`,
@@ -289,6 +309,182 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.toScopedPath(context.auth)).toBe(
       `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
     );
+  });
+
+  it("clones a Frame into a fresh identity, publication, sharing record, and state", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const sourcePublicationResponse = await requestFramePublish(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(sourcePublicationResponse.status).toBe(200);
+    const sourcePublication = await sourcePublicationResponse.json();
+
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const destinationDirectoryPath = sourceDirectoryPath.replace(
+      "/Status",
+      "/Status Copy"
+    );
+    const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Status`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Status Copy`;
+    const sourceEntries = [
+      {
+        relativePath: FRAME_MANIFEST_FILE,
+        content: manifest,
+        contentType: "application/json",
+      },
+      {
+        relativePath: "index.tsx",
+        content: uiSource,
+        contentType: "text/typescript",
+      },
+    ];
+    fileStorageMock.setFileExists(
+      (filePath) =>
+        filePath.startsWith(`${sourceGcsDirectoryPath}/`) ||
+        fileStorageMock.getObject(filePath) !== undefined
+    );
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      const directory =
+        prefix === `${sourceGcsDirectoryPath}/`
+          ? sourceGcsDirectoryPath
+          : prefix === `${destinationGcsDirectoryPath}/` &&
+              fileStorageMock.getObject(
+                `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+              ) !== undefined
+            ? destinationGcsDirectoryPath
+            : null;
+      return directory
+        ? sourceEntries.map(({ content, contentType, relativePath }) => ({
+            name: `${directory}/${relativePath}`,
+            metadata: {
+              contentType,
+              generation: "1",
+              md5Hash: relativePath,
+              size: String(Buffer.byteLength(content)),
+            },
+          }))
+        : null;
+    });
+
+    const response = await requestFrameClone(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      destinationDirectoryPath
+    );
+
+    const cloned = await response.json();
+    expect(response.status, JSON.stringify(cloned)).toBe(200);
+    expect(cloned).toMatchObject({
+      destinationDirectoryPath,
+      sourceDirectoryPath,
+    });
+    expect(cloned.frameId).not.toBe(context.frame.sId);
+    expect(cloned.publicationId).not.toBe(sourcePublication.publicationId);
+
+    const clonedFrame = await FileResource.fetchById(
+      context.auth,
+      cloned.frameId
+    );
+    expect(clonedFrame?.useCaseMetadata?.activePublicationId).toBe(
+      cloned.publicationId
+    );
+    expect(clonedFrame?.toScopedPath(context.auth)).toBe(
+      `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect((await clonedFrame?.getShareInfo())?.shareUrl).not.toBe(
+      (await context.frame.getShareInfo())?.shareUrl
+    );
+    expect(
+      fileStorageMock.getObject(
+        getFramePublicationDescriptorPath({
+          workspaceId: context.workspace.sId,
+          frameId: cloned.frameId,
+          publicationId: cloned.publicationId,
+        })
+      )
+    ).toBeDefined();
+    await expect(
+      FrameSandboxAdapter.fetchSandbox(context.auth, clonedFrame!)
+    ).resolves.toBeNull();
+  });
+
+  it("removes a partial clone when its first publication fails", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const destinationDirectoryPath = sourceDirectoryPath.replace(
+      "/Status",
+      "/Broken Copy"
+    );
+    const filesBasePath = getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    });
+    const sourceGcsDirectoryPath = `${filesBasePath}Status`;
+    const destinationGcsDirectoryPath = `${filesBasePath}Broken Copy`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setFileExists(
+      (filePath) =>
+        filePath === `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}` ||
+        fileStorageMock.getObject(filePath) !== undefined
+    );
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      const hasCopiedManifest =
+        fileStorageMock.getObject(destinationManifestPath) !== undefined;
+      const directory =
+        prefix === `${sourceGcsDirectoryPath}/`
+          ? sourceGcsDirectoryPath
+          : prefix === `${destinationGcsDirectoryPath}/` && hasCopiedManifest
+            ? destinationGcsDirectoryPath
+            : null;
+      return directory
+        ? [
+            {
+              name: `${directory}/${FRAME_MANIFEST_FILE}`,
+              metadata: {
+                contentType: "application/json",
+                generation: "1",
+                md5Hash: "manifest",
+                size: String(Buffer.byteLength(manifest)),
+              },
+            },
+          ]
+        : null;
+    });
+
+    const response = await requestFrameClone(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      destinationDirectoryPath
+    );
+
+    expect(response.status).toBe(400);
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
+    const destinationFrames = await FileResource.fetchByMountFilePaths(
+      context.auth,
+      [destinationManifestPath]
+    );
+    expect(destinationFrames).toEqual([]);
+    await expect(
+      FileResource.fetchById(context.auth, context.frame.sId)
+    ).resolves.not.toBeNull();
   });
 
   it("deletes a registered Frames v2 package through the sandbox token", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -3,6 +3,7 @@
 
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -192,6 +193,51 @@ async function setup({ registered = true }: { registered?: boolean } = {}) {
   return { ...context, frame, manifestPath };
 }
 
+function configureCloneStorage(
+  sourceGcsDirectoryPath: string,
+  destinationGcsDirectoryPath: string
+) {
+  const sourceEntries = [
+    {
+      relativePath: FRAME_MANIFEST_FILE,
+      content: manifest,
+      contentType: "application/json",
+    },
+    {
+      relativePath: "index.tsx",
+      content: uiSource,
+      contentType: "text/typescript",
+    },
+  ];
+  fileStorageMock.setFileExists(
+    (filePath) =>
+      filePath.startsWith(`${sourceGcsDirectoryPath}/`) ||
+      fileStorageMock.getObject(filePath) !== undefined
+  );
+  fileStorageMock.setFilesByPrefix((prefix) => {
+    const directory =
+      prefix === `${sourceGcsDirectoryPath}/`
+        ? sourceGcsDirectoryPath
+        : prefix === `${destinationGcsDirectoryPath}/` &&
+            fileStorageMock.getObject(
+              `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+            ) !== undefined
+          ? destinationGcsDirectoryPath
+          : null;
+    return directory
+      ? sourceEntries.map(({ content, contentType, relativePath }, index) => ({
+          name: `${directory}/${relativePath}`,
+          metadata: {
+            contentType,
+            generation: String(index + 1),
+            md5Hash: relativePath,
+            size: String(Buffer.byteLength(content)),
+          },
+        }))
+      : null;
+  });
+}
+
 async function setupLegacyFrame() {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -338,45 +384,7 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
       workspaceId: context.workspace.sId,
       conversationId: context.conversation.sId,
     })}Status Copy`;
-    const sourceEntries = [
-      {
-        relativePath: FRAME_MANIFEST_FILE,
-        content: manifest,
-        contentType: "application/json",
-      },
-      {
-        relativePath: "index.tsx",
-        content: uiSource,
-        contentType: "text/typescript",
-      },
-    ];
-    fileStorageMock.setFileExists(
-      (filePath) =>
-        filePath.startsWith(`${sourceGcsDirectoryPath}/`) ||
-        fileStorageMock.getObject(filePath) !== undefined
-    );
-    fileStorageMock.setFilesByPrefix((prefix) => {
-      const directory =
-        prefix === `${sourceGcsDirectoryPath}/`
-          ? sourceGcsDirectoryPath
-          : prefix === `${destinationGcsDirectoryPath}/` &&
-              fileStorageMock.getObject(
-                `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
-              ) !== undefined
-            ? destinationGcsDirectoryPath
-            : null;
-      return directory
-        ? sourceEntries.map(({ content, contentType, relativePath }) => ({
-            name: `${directory}/${relativePath}`,
-            metadata: {
-              contentType,
-              generation: "1",
-              md5Hash: relativePath,
-              size: String(Buffer.byteLength(content)),
-            },
-          }))
-        : null;
-    });
+    configureCloneStorage(sourceGcsDirectoryPath, destinationGcsDirectoryPath);
 
     const response = await requestFrameClone(
       context.workspace.sId,
@@ -419,6 +427,63 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     await expect(
       FrameSandboxAdapter.fetchSandbox(context.auth, clonedFrame!)
     ).resolves.toBeNull();
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.cloned",
+        metadata: {
+          destination_path: destinationDirectoryPath,
+          publication_id: cloned.publicationId,
+          source_frame_id: context.frame.sId,
+          source_path: sourceDirectoryPath,
+        },
+      })
+    );
+  });
+
+  it("clones into another writable conversation", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const destinationConversation = await ConversationFactory.create(
+      context.auth,
+      {
+        agentConfigurationId: context.agentConfig.sId,
+        messagesCreatedAt: [],
+      }
+    );
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const destinationDirectoryPath = `conversation-${destinationConversation.sId}/Status Copy`;
+    const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Status`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: destinationConversation.sId,
+    })}Status Copy`;
+    configureCloneStorage(sourceGcsDirectoryPath, destinationGcsDirectoryPath);
+
+    const response = await requestFrameClone(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      destinationDirectoryPath
+    );
+
+    const cloned = await response.json();
+    expect(response.status, JSON.stringify(cloned)).toBe(200);
+    const clonedFrame = await FileResource.fetchById(
+      context.auth,
+      cloned.frameId
+    );
+    expect(clonedFrame?.toScopedPath(context.auth)).toBe(
+      `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(clonedFrame?.useCaseMetadata).toMatchObject({
+      conversationId: destinationConversation.sId,
+    });
   });
 
   it("removes a partial clone when its first publication fails", async () => {
@@ -475,7 +540,8 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
       destinationDirectoryPath
     );
 
-    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(response.status, JSON.stringify(body)).toBe(400);
     expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
     const destinationFrames = await FileResource.fetchByMountFilePaths(
       context.auth,

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -16,6 +16,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
+import clone from "./clone";
 import deleteFrame from "./delete";
 import move from "./move";
 import register from "./register";
@@ -71,6 +72,7 @@ function frameErrorStatus(error: PublishFrameFromSourceError): 400 | 403 | 500 {
 const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
+app.route("/clone", clone);
 app.route("/delete", deleteFrame);
 app.route("/move", move);
 app.route("/register", register);

--- a/front/admin/audit_log_schemas/frame.cloned.json
+++ b/front/admin/audit_log_schemas/frame.cloned.json
@@ -1,0 +1,13 @@
+{
+  "action": "frame.cloned",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "destination_path": "string",
+    "publication_id": "string",
+    "source_frame_id": "string",
+    "source_path": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.cloned": 1,
   "frame.deleted": 1,
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -176,6 +176,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.cloned",
   "frame.deleted",
   "frame.deleted_admin",
   "frame.email_grant_added",

--- a/front/lib/api/frames/clone_source.ts
+++ b/front/lib/api/frames/clone_source.ts
@@ -1,10 +1,15 @@
 import path from "node:path";
 
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationError } from "@app/lib/api/frames/publication_storage";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
 import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
-import { registerFrameV2FromSource } from "@app/lib/api/frames/register_from_source";
+import { registerFrameV2FromSourceUsingFileSystem } from "@app/lib/api/frames/register_from_source";
 import {
   cleanupFrameSourceCopy,
   copyFrameSourceAsNew,
@@ -212,7 +217,7 @@ export async function cloneFrameV2Source(
     const copyResult = await copyFrameSourceAsNew({
       allowMatchingDestinationObjects: false,
       destinationMountPrefix: `${path.posix.dirname(destinationMountPath)}/`,
-      makeError: (code, message) => new FrameSourceCloneError(code, message),
+      sourceManifestPath: sourceMountPath,
       sourceMountPrefix: `${path.posix.dirname(sourceMountPath)}/`,
     });
     if (copyResult.isErr()) {
@@ -221,21 +226,25 @@ export async function cloneFrameV2Source(
         { operation: "clone" }
       );
       return cleaned
-        ? new Err(copyResult.error.error)
+        ? cloneError(
+            copyResult.error.error.code,
+            copyResult.error.error.message
+          )
         : cloneError(
             "internal",
             "The Frame source copy failed and its destination objects could not be cleaned up."
           );
     }
 
-    const registration = await registerFrameV2FromSource(auth, {
-      conversation,
+    const registration = await registerFrameV2FromSourceUsingFileSystem(auth, {
+      dustFs,
       manifestPath: destinationManifestPath,
     });
     if (registration.isErr()) {
-      const cleaned = await cleanupFrameSourceCopy(copyResult.value, {
-        operation: "clone",
-      });
+      const cleaned = await cleanupFrameSourceCopy(
+        copyResult.value.destinationObjects,
+        { operation: "clone" }
+      );
       if (!cleaned) {
         return cloneError(
           "internal",
@@ -258,21 +267,26 @@ export async function cloneFrameV2Source(
       manifestPath: destinationManifestPath,
     });
     if (publication.isErr()) {
-      const sourceCleaned = await cleanupFrameSourceCopy(copyResult.value, {
-        operation: "clone",
+      const resourceCleanup = await clonedFrame.delete(auth, {
+        deleteFrameSource: async () => {
+          const sourceCleaned = await cleanupFrameSourceCopy(
+            copyResult.value.destinationObjects,
+            { operation: "clone" }
+          );
+          return sourceCleaned
+            ? new Ok(undefined)
+            : new Err(
+                new Error("The cloned Frame source could not be cleaned up.")
+              );
+        },
       });
-      const resourceCleanup = sourceCleaned
-        ? await clonedFrame.delete(auth)
-        : null;
-      if (!sourceCleaned || resourceCleanup?.isErr()) {
+      if (resourceCleanup.isErr()) {
         logger.error(
           {
             destinationDirectoryPath: destination,
             frameId: clonedFrame.sId,
             publicationError: publication.error,
-            resourceCleanupError: resourceCleanup?.isErr()
-              ? resourceCleanup.error
-              : null,
+            resourceCleanupError: resourceCleanup.error,
             sourceDirectoryPath: source,
             workspaceId: auth.getNonNullableWorkspace().sId,
           },
@@ -297,6 +311,25 @@ export async function cloneFrameV2Source(
       },
       "Cloned Frame v2"
     );
+
+    void emitAuditLogEvent({
+      auth,
+      action: "frame.cloned",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("frame", {
+          sId: clonedFrame.sId,
+          name: path.posix.basename(destination),
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        destination_path: destination,
+        publication_id: publication.value.publicationId,
+        source_frame_id: freshSource.sId,
+        source_path: source,
+      },
+    });
 
     return new Ok({
       destinationDirectoryPath: destination,

--- a/front/lib/api/frames/clone_source.ts
+++ b/front/lib/api/frames/clone_source.ts
@@ -1,0 +1,308 @@
+import path from "node:path";
+
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import type { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
+import { registerFrameV2FromSource } from "@app/lib/api/frames/register_from_source";
+import {
+  cleanupFrameSourceCopy,
+  copyFrameSourceAsNew,
+} from "@app/lib/api/frames/source_copy";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export class FrameSourceCloneError extends Error {
+  constructor(
+    readonly code: "conflict" | "internal" | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceCloneError";
+  }
+}
+
+export function isFrameSourceCloneError(
+  error: unknown
+): error is FrameSourceCloneError {
+  return error instanceof FrameSourceCloneError;
+}
+
+export type CloneFrameV2SourceError =
+  | DustFileSystemError
+  | FramePublicationError
+  | FrameSourceCloneError
+  | SandboxFunctionError;
+
+export type CloneFrameV2SourceResult = {
+  destinationDirectoryPath: string;
+  frameId: string;
+  publicationId: string;
+  sourceDirectoryPath: string;
+};
+
+function cloneError(
+  code: FrameSourceCloneError["code"],
+  message: string
+): Err<FrameSourceCloneError> {
+  return new Err(new FrameSourceCloneError(code, message));
+}
+
+function isFrameDirectoryPath(scopedPath: string): boolean {
+  const parsed = parseScopedPrefix(scopedPath);
+  const slash = scopedPath.indexOf("/");
+  return Boolean(
+    parsed &&
+      (parsed.kind === "conversation" || parsed.kind === "pod") &&
+      slash >= 0 &&
+      scopedPath.slice(slash + 1).length > 0
+  );
+}
+
+/** Clone a registered Frame package into a fresh identity and publication. */
+export async function cloneFrameV2Source(
+  auth: Authenticator,
+  {
+    conversation,
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    destinationDirectoryPath: string;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<CloneFrameV2SourceResult, CloneFrameV2SourceError>> {
+  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  const destination = DustFileSystem.normalizeScopedPath(
+    destinationDirectoryPath
+  );
+  if (
+    !source ||
+    !destination ||
+    !isFrameDirectoryPath(source) ||
+    !isFrameDirectoryPath(destination)
+  ) {
+    return cloneError(
+      "invalid_source",
+      "Frame source and destination must be folders in a conversation or Pod mount."
+    );
+  }
+  if (source === destination) {
+    return cloneError(
+      "invalid_source",
+      "Frame source and destination must be different."
+    );
+  }
+  if (destination.startsWith(`${source}/`)) {
+    return cloneError(
+      "invalid_source",
+      "A Frame cannot be cloned inside its own source folder."
+    );
+  }
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [source, destination],
+  });
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return cloneError(
+      "invalid_source",
+      "Frames v2 source clones do not yet support the database-backed filesystem."
+    );
+  }
+
+  const destinationWriteAccess = dustFs.checkWriteAccess(destination);
+  if (destinationWriteAccess.isErr()) {
+    return new Err(destinationWriteAccess.error);
+  }
+  const sourceListing = await dustFs.list(source, { maxFiles: 1 });
+  if (sourceListing.isErr()) {
+    return new Err(sourceListing.error);
+  }
+
+  const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
+  const destinationManifestPath = path.posix.join(
+    destination,
+    FRAME_MANIFEST_FILE
+  );
+  const sourceMountPath = dustFs.toMountFilePath(sourceManifestPath);
+  const destinationMountPath = dustFs.toMountFilePath(destinationManifestPath);
+  if (!sourceMountPath || !destinationMountPath) {
+    return cloneError(
+      "invalid_source",
+      "Invalid Frame source or destination path."
+    );
+  }
+
+  const candidates = await FileResource.fetchByMountFilePaths(auth, [
+    sourceMountPath,
+    destinationMountPath,
+  ]);
+  const sourceFrame = candidates.find(
+    (candidate) => candidate.mountFilePath === sourceMountPath
+  );
+  if (!sourceFrame?.isFrameV2) {
+    return cloneError(
+      "invalid_source",
+      `No registered Frames v2 package found at ${source}.`
+    );
+  }
+  if (
+    candidates.some(
+      (candidate) => candidate.mountFilePath === destinationMountPath
+    )
+  ) {
+    return cloneError(
+      "conflict",
+      "A registered file already uses the destination path."
+    );
+  }
+
+  return withFrameSourceAndPublishLock<
+    CloneFrameV2SourceResult,
+    CloneFrameV2SourceError
+  >(sourceFrame.sId, async () => {
+    const freshSource = await FileResource.fetchById(auth, sourceFrame.sId);
+    if (
+      !freshSource?.isFrameV2 ||
+      freshSource.toScopedPath(auth) !== sourceManifestPath
+    ) {
+      return cloneError(
+        "conflict",
+        "The Frame source changed while it was being cloned; retry from its current path."
+      );
+    }
+
+    const [registeredDestination] = await FileResource.fetchByMountFilePaths(
+      auth,
+      [destinationMountPath]
+    );
+    if (registeredDestination) {
+      return cloneError(
+        "conflict",
+        "A registered file already uses the destination path."
+      );
+    }
+    const destinationContents = await dustFs.list(destination, { maxFiles: 1 });
+    if (destinationContents.isErr()) {
+      return new Err(destinationContents.error);
+    }
+    const destinationExists = await dustFs.exists(destination);
+    if (destinationExists.isErr()) {
+      return new Err(destinationExists.error);
+    }
+    if (destinationExists.value || destinationContents.value.length > 0) {
+      return cloneError(
+        "conflict",
+        "A file or folder already exists at the destination."
+      );
+    }
+
+    const copyResult = await copyFrameSourceAsNew({
+      allowMatchingDestinationObjects: false,
+      destinationMountPrefix: `${path.posix.dirname(destinationMountPath)}/`,
+      makeError: (code, message) => new FrameSourceCloneError(code, message),
+      sourceMountPrefix: `${path.posix.dirname(sourceMountPath)}/`,
+    });
+    if (copyResult.isErr()) {
+      const cleaned = await cleanupFrameSourceCopy(
+        copyResult.error.destinationObjects,
+        { operation: "clone" }
+      );
+      return cleaned
+        ? new Err(copyResult.error.error)
+        : cloneError(
+            "internal",
+            "The Frame source copy failed and its destination objects could not be cleaned up."
+          );
+    }
+
+    const registration = await registerFrameV2FromSource(auth, {
+      conversation,
+      manifestPath: destinationManifestPath,
+    });
+    if (registration.isErr()) {
+      const cleaned = await cleanupFrameSourceCopy(copyResult.value, {
+        operation: "clone",
+      });
+      if (!cleaned) {
+        return cloneError(
+          "internal",
+          "The Frame clone could not be registered or cleaned up."
+        );
+      }
+      return new Err(registration.error);
+    }
+    if (!registration.value.created) {
+      return cloneError(
+        "conflict",
+        "A registered Frame already uses the destination path."
+      );
+    }
+
+    const clonedFrame = registration.value.frame;
+    const publication = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame: clonedFrame,
+      manifestPath: destinationManifestPath,
+    });
+    if (publication.isErr()) {
+      const sourceCleaned = await cleanupFrameSourceCopy(copyResult.value, {
+        operation: "clone",
+      });
+      const resourceCleanup = sourceCleaned
+        ? await clonedFrame.delete(auth)
+        : null;
+      if (!sourceCleaned || resourceCleanup?.isErr()) {
+        logger.error(
+          {
+            destinationDirectoryPath: destination,
+            frameId: clonedFrame.sId,
+            publicationError: publication.error,
+            resourceCleanupError: resourceCleanup?.isErr()
+              ? resourceCleanup.error
+              : null,
+            sourceDirectoryPath: source,
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          },
+          "Failed to roll back a Frame clone"
+        );
+        return cloneError(
+          "internal",
+          "Frame publication failed and the partial clone could not be cleaned up."
+        );
+      }
+      return new Err(publication.error);
+    }
+
+    logger.info(
+      {
+        destinationDirectoryPath: destination,
+        frameId: clonedFrame.sId,
+        publicationId: publication.value.publicationId,
+        sourceDirectoryPath: source,
+        sourceFrameId: freshSource.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Cloned Frame v2"
+    );
+
+    return new Ok({
+      destinationDirectoryPath: destination,
+      frameId: clonedFrame.sId,
+      publicationId: publication.value.publicationId,
+      sourceDirectoryPath: source,
+    });
+  });
+}

--- a/front/lib/api/frames/register_from_source.ts
+++ b/front/lib/api/frames/register_from_source.ts
@@ -45,14 +45,13 @@ export type RegisterFrameV2FromSourceError =
   | DustFileSystemError
   | FramePublicationError;
 
-/** Register the manifest already present on the invoking conversation's mounted GCS filesystem. */
-export async function registerFrameV2FromSource(
+export async function registerFrameV2FromSourceUsingFileSystem(
   auth: Authenticator,
   {
-    conversation,
+    dustFs,
     manifestPath,
   }: {
-    conversation: ConversationWithoutContentType;
+    dustFs: DustFileSystem;
     manifestPath: string;
   }
 ): Promise<
@@ -71,11 +70,6 @@ export async function registerFrameV2FromSource(
     );
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
-  if (fsResult.isErr()) {
-    return new Err(fsResult.error);
-  }
-  const dustFs = fsResult.value;
   if (!dustFs.isGCSBacked()) {
     return registrationError(
       "Frames v2 registration does not yet support the database-backed filesystem."
@@ -160,4 +154,31 @@ export async function registerFrameV2FromSource(
     assert(concurrent.value, "Frame not found after mount path conflict");
     return new Ok({ frame: concurrent.value, created: false });
   }
+}
+
+/** Register a manifest from the invoking conversation's mounted GCS filesystem. */
+export async function registerFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { frame: FileResource; created: boolean },
+    RegisterFrameV2FromSourceError
+  >
+> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+
+  return registerFrameV2FromSourceUsingFileSystem(auth, {
+    dustFs: fsResult.value,
+    manifestPath,
+  });
 }

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -305,8 +305,10 @@ class FileStorageMock {
       copy: vi.fn().mockResolvedValue(undefined),
       createReadStream: vi.fn(() => {
         this._readStreamCalls.push(filePath ?? "unknown");
-        const content = this._contentForPath(filePath ?? "");
-        if (content !== null) {
+        const path = filePath ?? "";
+        const content =
+          this._objectStore.get(path) ?? this._contentForPath(path);
+        if (content !== null && content !== undefined) {
           return Readable.from([Buffer.from(content, "utf8")]);
         }
         return new PassThrough();


### PR DESCRIPTION
## Description

- Add the feature-flagged internal Frame clone lifecycle used by DSBX.
- Copy source without overwriting, register a new Frame identity, and publish a new immutable publication across authorized conversation or Pod mounts.
- Start from a distinct sharing record with no inherited sandbox or SQLite state.
- Remove copied objects and the new identity if the first publication fails.
- Emit a registered `frame.cloned` audit event after the complete lifecycle succeeds.

## Tests

- Twelve sandbox Frame route tests cover same-conversation and cross-conversation clone, fresh identity/publication/sharing/runtime ownership, audit emission, publication rollback, and legacy Frame publish behavior.
- Two direct registration tests.
- Nine audit schema consistency tests.
- Front and Front API typechecks.

## Risk

Clone spans GCS and Postgres. Destination writes use conditional creation and the exact generation returned by GCS for cleanup. A failed cleanup preserves the registered partial clone so it remains explicitly deletable instead of risking newer destination data.

## Deploy Plan

Standard deploy after the parent stack merges.