### PR TITLE
Expose Frame clone through dsbx

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.52"
+version = "0.1.53"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,10 +9,10 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FrameDeleteRequest, FrameDeleteResponse, FrameMoveRequest,
-    FrameMoveResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
-    FrameRegisterResponse, FrameShareRequest, FrameShareResponse, MCPServerView,
-    SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FrameCloneRequest, FrameCloneResponse, FrameDeleteRequest,
+    FrameDeleteResponse, FrameMoveRequest, FrameMoveResponse, FramePublishRequest,
+    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, FrameShareRequest,
+    FrameShareResponse, MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -165,6 +165,22 @@ impl DustApiClient {
         self.post_with_timeout(
             "sandbox/frames/move",
             &FrameMoveRequest {
+                source_directory_path,
+                destination_directory_path,
+            },
+            POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn clone_frame(
+        &self,
+        source_directory_path: &str,
+        destination_directory_path: &str,
+    ) -> anyhow::Result<FrameCloneResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/clone",
+            &FrameCloneRequest {
                 source_directory_path,
                 destination_directory_path,
             },

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -24,6 +24,13 @@ pub struct FrameMoveRequest<'a> {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct FrameCloneRequest<'a> {
+    pub source_directory_path: &'a str,
+    pub destination_directory_path: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FrameDeleteRequest<'a> {
     pub source_directory_path: &'a str,
 }
@@ -61,6 +68,15 @@ pub struct FrameMoveResponse {
     pub frame_id: String,
     pub destination_directory_path: String,
     pub source_deletion_failed: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameCloneResponse {
+    pub frame_id: String,
+    pub publication_id: String,
+    pub source_directory_path: String,
+    pub destination_directory_path: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/cli/dust-sandbox/src/commands/frame/clone.rs
+++ b/cli/dust-sandbox/src/commands/frame/clone.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_path};
+
+pub async fn run(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(source)?;
+    let destination_directory_path = scoped_path(destination)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .clone_frame(&source_directory_path, &destination_directory_path)
+        .await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,3 +1,4 @@
+mod clone;
 mod create;
 mod delete;
 mod move_frame;
@@ -10,6 +11,7 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{bail, Context};
 use clap::{Subcommand, ValueEnum};
 
+pub use clone::run as cmd_frame_clone;
 pub use create::run as cmd_frame_create;
 pub use delete::run as cmd_frame_delete;
 pub use move_frame::run as cmd_frame_move;
@@ -38,6 +40,13 @@ impl FrameShareScope {
 
 #[derive(Subcommand)]
 pub enum FrameCommand {
+    /// Clone a registered Frame into a fresh identity, publication, sharing record, and state
+    Clone {
+        /// Existing Frame folder under /files
+        source: PathBuf,
+        /// New Frame folder path under /files
+        destination: PathBuf,
+    },
     /// Create and register a new Frame folder
     Create {
         /// Frame folder under /files/conversation-... or /files/pod-...

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -14,8 +14,8 @@ pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
 pub use frame::{
-    cmd_frame_create, cmd_frame_delete, cmd_frame_move, cmd_frame_publish, cmd_frame_register,
-    cmd_frame_share,
+    cmd_frame_clone, cmd_frame_create, cmd_frame_delete, cmd_frame_move, cmd_frame_publish,
+    cmd_frame_register, cmd_frame_share,
 };
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -131,6 +131,10 @@ async fn run() -> anyhow::Result<()> {
             commands::db::DbCommand::Query { name } => commands::cmd_db_query(&name).await?,
         },
         Commands::Frame { command } => match command {
+            commands::frame::FrameCommand::Clone {
+                source,
+                destination,
+            } => commands::cmd_frame_clone(&source, &destination).await?,
             commands::frame::FrameCommand::Create {
                 directory,
                 name,
@@ -534,6 +538,38 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected move"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_clone_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "clone",
+            "/files/conversation-conv_123/Status",
+            "/files/pod-vlt_123/Status Copy",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Clone {
+                        source,
+                        destination,
+                    },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+                assert_eq!(
+                    destination,
+                    std::path::PathBuf::from("/files/pod-vlt_123/Status Copy")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected clone"),
             _ => panic!("expected frame"),
         }
     }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.100",
+      tag: "0.8.101",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.52/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.53/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.100";
-const DSBX_CLI_VERSION = "0.1.52";
+const DUST_BASE_IMAGE_VERSION = "0.8.101";
+const DSBX_CLI_VERSION = "0.1.53";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -64,6 +64,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("dsbx frame move");
+    expect(instructions).toContain("dsbx frame clone");
     expect(instructions).toContain("dsbx frame share");
     expect(instructions).toContain("dsbx frame delete");
     expect(instructions).toContain("registered Frame folder with raw");

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -54,6 +54,17 @@ dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/
 Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
 registered Frame folder with raw filesystem commands.
 
+## Clone a registered Frame
+
+Use the CLI instead of \`cp\` to create a new Frame with copied source but a fresh identity,
+publication, sharing record, sandbox ownership, and empty database state:
+
+\`\`\`bash
+dsbx frame clone /files/<source-scope>/<frame-folder> /files/<destination-scope>/<new-folder>
+\`\`\`
+
+The destination must not exist. The source Frame and its sharing and database state are unchanged.
+
 ## Share a registered Frame
 
 Configure Frame use rights through the CLI. This does not change who can edit its source:
@@ -357,7 +368,5 @@ dsbx frame publish /files/<scope>/<frame>.tsx
 Do not use the \`publish_interactive_content_file\` tool: the CLI replaces it under Frames v2.
 Other interactive-content tools remain available for Frame operations that the CLI does not cover
 yet. Use \`dsbx frame --help\` as the authority for available operations.
-
-Do not use \`cp\` to clone a registered Frame folder. Cloning is not supported yet.
 
 ${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}`;

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -54,9 +54,9 @@ dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/
 Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
 registered Frame folder with raw filesystem commands.
 
-## Clone a registered Frame
+## Clone a registered Frames v2 package
 
-Use the CLI instead of \`cp\` to create a new Frame with copied source but a fresh identity,
+Use the CLI instead of \`cp\` to clone a registered Frames v2 package with copied source but a fresh identity,
 publication, sharing record, sandbox ownership, and empty database state:
 
 \`\`\`bash


### PR DESCRIPTION
## Description

- Add `dsbx frame clone <source> <destination>` backed by the internal Frame clone lifecycle.
- Print the fresh Frame and publication identity returned by the server.
- Document that registered Frames v2 packages clone source into fresh sharing, sandbox ownership, and empty SQLite state.
- Tell agents to use the lifecycle command instead of raw filesystem copy.
- Release `dsbx` 0.1.53 and pin it in `dust-base` 0.8.101 so the documented command exists in live sandboxes.

## Tests

- 405 Rust unit tests plus the local forwarder end-to-end test.
- Rust clippy across all targets with warnings denied.
- Twenty-one sandbox image registry tests and ten Frames skill tests.
- Front typecheck and Biome checks.

## Risk

The command is additive and calls the feature-gated internal route from the parent PR. Legacy Frames and Pod Functions are unchanged. The sandbox image change is acknowledged with `sandbox-image-ack`.

## Deploy Plan

1. Publish the `dsbx-v0.1.53` release artifact.
2. Build and deploy `dust-base:0.8.101`.
3. Deploy front with the new image registry pin and Frames skill.
4. Roll existing sandboxes through `/poke/kill` so they recreate on the new base image before agents use clone.