### PR TITLE
[front] fix: stop autoscroll after scrolling up

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -298,6 +298,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
 
     const canUp = fullyAboveIndices.length > 0;
     const canDown =
+      !context.isAutoScrollEnabledRef.current &&
       (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
       !methods.getScrollLocation().isAtBottom;
 
@@ -337,7 +338,13 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         }
       },
     };
-  }, [methods, listOffset, visibleListHeight, bottomOffset]);
+  }, [
+    context.isAutoScrollEnabledRef,
+    methods,
+    listOffset,
+    visibleListHeight,
+    bottomOffset,
+  ]);
 
   const blockedActionItems = getBlockedActionItems(context.user.sId);
   const blockedActions = blockedActionItems.map((item) => item.blockedAction);

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -298,7 +298,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
 
     const canUp = fullyAboveIndices.length > 0;
     const canDown =
-      !context.isAutoScrollEnabledRef.current &&
       (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
       !methods.getScrollLocation().isAtBottom;
 
@@ -338,13 +337,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         }
       },
     };
-  }, [
-    context.isAutoScrollEnabledRef,
-    methods,
-    listOffset,
-    visibleListHeight,
-    bottomOffset,
-  ]);
+  }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
   const blockedActionItems = getBlockedActionItems(context.user.sId);
   const blockedActions = blockedActionItems.map((item) => item.blockedAction);

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -326,6 +326,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           });
         } else if (bottomOffset > 0) {
           // No more user messages below, but there's content - scroll to bottom.
+          context.enableAutoScroll();
           methods.scrollToItem({
             index: "LAST",
             align: "end",
@@ -337,7 +338,13 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         }
       },
     };
-  }, [methods, listOffset, visibleListHeight, bottomOffset]);
+  }, [
+    methods,
+    listOffset,
+    visibleListHeight,
+    bottomOffset,
+    context.enableAutoScroll,
+  ]);
 
   const blockedActionItems = getBlockedActionItems(context.user.sId);
   const blockedActions = blockedActionItems.map((item) => item.blockedAction);

--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -222,7 +222,10 @@ function renderAgentMessage({
       isOnboardingConversation={false}
       handleSubmit={async () => new Ok(undefined)}
       isAutoScrollEnabledRef={{ current: true } as { current: boolean }}
-      lastUserScrollAtRef={{ current: null }}
+      userScrollActivity={{
+        isActive: () => false,
+        subscribeToEnd: () => () => undefined,
+      }}
     />
   );
 }

--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -222,6 +222,7 @@ function renderAgentMessage({
       isOnboardingConversation={false}
       handleSubmit={async () => new Ok(undefined)}
       isAutoScrollEnabledRef={{ current: true } as { current: boolean }}
+      lastUserScrollAtRef={{ current: null }}
     />
   );
 }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -248,6 +248,7 @@ interface AgentMessageProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
+  lastUserScrollAtRef: MutableRefObject<number | null>;
   isProjectArchived?: boolean;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;
 }
@@ -269,6 +270,7 @@ export function AgentMessage({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   isAutoScrollEnabledRef,
+  lastUserScrollAtRef,
   isProjectArchived = false,
   setLimitReachedCode,
 }: AgentMessageProps) {
@@ -325,6 +327,7 @@ export function AgentMessage({
     agentMessage: agentMessage,
     conversationId,
     isAutoScrollEnabledRef,
+    lastUserScrollAtRef,
     owner,
     onEventCallback: useCallback(
       (eventPayload: {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -18,6 +18,7 @@ import type {
   AgentMessageStateWithControlEvent,
   AgentMessageWithStreaming,
   UiView,
+  UserScrollActivity,
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
@@ -248,7 +249,7 @@ interface AgentMessageProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
-  lastUserScrollAtRef: MutableRefObject<number | null>;
+  userScrollActivity: UserScrollActivity;
   isProjectArchived?: boolean;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;
 }
@@ -270,7 +271,7 @@ export function AgentMessage({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   isAutoScrollEnabledRef,
-  lastUserScrollAtRef,
+  userScrollActivity,
   isProjectArchived = false,
   setLimitReachedCode,
 }: AgentMessageProps) {
@@ -327,7 +328,7 @@ export function AgentMessage({
     agentMessage: agentMessage,
     conversationId,
     isAutoScrollEnabledRef,
-    lastUserScrollAtRef,
+    userScrollActivity,
     owner,
     onEventCallback: useCallback(
       (eventPayload: {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -2,6 +2,7 @@ import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { getWorkspaceLimitForSubmitError } from "@app/components/app/ReachedLimitPopup";
 import { ConversationViewerEmptyState } from "@app/components/assistant/ConversationViewerEmptyState";
 import { AgentInputBar } from "@app/components/assistant/conversation/AgentInputBar";
+import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
 import {
   parseDataAsMessageIdAndActionId,
   useConversationSidePanelContext,
@@ -33,6 +34,10 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
+import {
+  findFirstUnreadMessageIndex,
+  getAutoScrollEnabled,
+} from "@app/components/assistant/conversation/utils";
 import {
   requestConversationMarkAsRead,
   useConversation,
@@ -105,8 +110,6 @@ import {
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
-import { ConversationErrorDisplay } from "./ConversationError";
-import { findFirstUnreadMessageIndex, getAutoScrollEnabled } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
 // SSE is the fast path; poll slowly in case the completion event is missed before subscription.

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -266,9 +266,11 @@ export const ConversationViewer = ({
     >(null);
   const isMobile = useIsMobile();
   const isAutoScrollEnabledRef = useRef(true);
+  const hasLeftBottomSinceDetachRef = useRef(false);
   const lastTouchYRef = useRef<number | null>(null);
   const detachFromAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = false;
+    hasLeftBottomSinceDetachRef.current = false;
     virtuosoMessageListRef.current?.cancelSmoothScroll();
   }, []);
   const sendNotification = useSendNotification();
@@ -1185,6 +1187,7 @@ export const ConversationViewer = ({
 
         if (!hasRunningAgent) {
           isAutoScrollEnabledRef.current = true;
+          hasLeftBottomSinceDetachRef.current = false;
         }
 
         if (hasRunningAgent && conversationId) {
@@ -1357,8 +1360,13 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      if (location.bottomOffset <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX) {
-        isAutoScrollEnabledRef.current = true;
+      if (!isAutoScrollEnabledRef.current) {
+        if (location.bottomOffset > AUTO_SCROLL_BOTTOM_THRESHOLD_PX) {
+          hasLeftBottomSinceDetachRef.current = true;
+        } else if (hasLeftBottomSinceDetachRef.current) {
+          isAutoScrollEnabledRef.current = true;
+          hasLeftBottomSinceDetachRef.current = false;
+        }
       }
 
       const isLoadingData =

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -96,7 +96,6 @@ import {
   VirtuosoMessageList,
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
-import type { TouchEvent, WheelEvent } from "react";
 import {
   useCallback,
   useContext,
@@ -266,44 +265,15 @@ export const ConversationViewer = ({
   const isMobile = useIsMobile();
   const isAutoScrollEnabledRef = useRef(true);
   const hasLeftBottomSinceDetachRef = useRef(false);
-  const lastTouchYRef = useRef<number | null>(null);
-  const previousScrollPositionRef = useRef({
-    scrollHeight: 0,
-    scrollTop: 0,
-  });
-  const getScrollElement = useCallback(
-    () =>
-      isMobile
-        ? document.scrollingElement
-        : virtuosoMessageListRef.current?.scrollerElement(),
-    [isMobile]
-  );
-  const captureScrollPosition = useCallback(() => {
-    const scrollElement = getScrollElement();
-    if (scrollElement) {
-      previousScrollPositionRef.current = {
-        scrollHeight: scrollElement.scrollHeight,
-        scrollTop: scrollElement.scrollTop,
-      };
-    }
-  }, [getScrollElement]);
-  const detachFromAutoScroll = useCallback(() => {
-    captureScrollPosition();
-    if (!isAutoScrollEnabledRef.current) {
-      return;
-    }
-
-    isAutoScrollEnabledRef.current = false;
-    hasLeftBottomSinceDetachRef.current = false;
-    virtuosoMessageListRef.current?.cancelSmoothScroll();
-  }, [captureScrollPosition]);
 
   // While the list's scroll direction is "up", Virtuoso compensates row-height
   // growth by adding the same delta to scrollTop. Streaming markdown can keep
   // that compensation alive indefinitely. A native listener recognizes those
   // matching deltas and restores the detached position before the next paint.
   useEffect(() => {
-    const scrollElement = getScrollElement();
+    const scrollElement = isMobile
+      ? (document.scrollingElement as HTMLElement | null)
+      : virtuosoMessageListRef.current?.scrollerElement();
     if (!scrollElement) {
       return;
     }
@@ -311,7 +281,25 @@ export const ConversationViewer = ({
     const scrollTarget = isMobile ? window : scrollElement;
     const listElement =
       virtuosoMessageListRef.current?.scrollerElement()?.firstElementChild;
-    captureScrollPosition();
+    let previousScrollHeight = scrollElement.scrollHeight;
+    let previousScrollTop = scrollElement.scrollTop;
+    let lastTouchY: number | null = null;
+
+    const captureScrollPosition = () => {
+      previousScrollHeight = scrollElement.scrollHeight;
+      previousScrollTop = scrollElement.scrollTop;
+    };
+
+    const detachFromAutoScroll = () => {
+      captureScrollPosition();
+      if (!isAutoScrollEnabledRef.current) {
+        return;
+      }
+
+      isAutoScrollEnabledRef.current = false;
+      hasLeftBottomSinceDetachRef.current = false;
+      virtuosoMessageListRef.current?.cancelSmoothScroll();
+    };
 
     const resizeObserver = new ResizeObserver(() => {
       // Keep the height baseline current when the list grows without moving.
@@ -319,7 +307,7 @@ export const ConversationViewer = ({
       // to recognize and undo Virtuoso's height compensation.
       if (
         !isAutoScrollEnabledRef.current &&
-        scrollElement.scrollTop === previousScrollPositionRef.current.scrollTop
+        scrollElement.scrollTop === previousScrollTop
       ) {
         captureScrollPosition();
       }
@@ -330,15 +318,17 @@ export const ConversationViewer = ({
 
     const preserveDetachedScrollPosition = () => {
       const scrollHeight = scrollElement.scrollHeight;
-      const previousScrollPosition = previousScrollPositionRef.current;
       let scrollTop = scrollElement.scrollTop;
-      const scrollHeightDelta =
-        scrollHeight - previousScrollPosition.scrollHeight;
-      const scrollTopDelta = scrollTop - previousScrollPosition.scrollTop;
+      const scrollHeightDelta = scrollHeight - previousScrollHeight;
+      const scrollTopDelta = scrollTop - previousScrollTop;
+      const isHeightCompensation =
+        scrollHeightDelta !== 0 &&
+        Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
 
       if (
         isAutoScrollEnabledRef.current &&
-        scrollTop < previousScrollPosition.scrollTop &&
+        scrollTopDelta < 0 &&
+        !isHeightCompensation &&
         virtuosoMessageListRef.current?.getScrollLocation().isAtBottom === false
       ) {
         isAutoScrollEnabledRef.current = false;
@@ -346,29 +336,64 @@ export const ConversationViewer = ({
         virtuosoMessageListRef.current?.cancelSmoothScroll();
       }
 
-      if (
-        !isAutoScrollEnabledRef.current &&
-        scrollHeightDelta !== 0 &&
-        Math.abs(scrollTopDelta - scrollHeightDelta) <= 1
-      ) {
+      if (!isAutoScrollEnabledRef.current && isHeightCompensation) {
         scrollElement.scrollTop -= scrollTopDelta;
         scrollTop = scrollElement.scrollTop;
       }
 
-      previousScrollPositionRef.current = { scrollHeight, scrollTop };
+      previousScrollHeight = scrollHeight;
+      previousScrollTop = scrollTop;
+    };
+
+    const onWheel = (event: globalThis.WheelEvent) => {
+      if (event.ctrlKey) {
+        return;
+      }
+
+      if (event.deltaY < 0) {
+        detachFromAutoScroll();
+      } else if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
+      }
+    };
+
+    const onTouchStart = (event: globalThis.TouchEvent) => {
+      lastTouchY = event.touches[0]?.clientY ?? null;
+    };
+
+    const onTouchMove = (event: globalThis.TouchEvent) => {
+      const touchY = event.touches[0]?.clientY;
+      if (touchY === undefined) {
+        return;
+      }
+
+      if (lastTouchY !== null && touchY > lastTouchY) {
+        detachFromAutoScroll();
+      } else if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
+      }
+      lastTouchY = touchY;
     };
 
     scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
       passive: true,
     });
+    scrollElement.addEventListener("wheel", onWheel, { passive: true });
+    scrollElement.addEventListener("touchstart", onTouchStart, {
+      passive: true,
+    });
+    scrollElement.addEventListener("touchmove", onTouchMove, { passive: true });
     return () => {
       resizeObserver.disconnect();
       scrollTarget.removeEventListener(
         "scroll",
         preserveDetachedScrollPosition
       );
+      scrollElement.removeEventListener("wheel", onWheel);
+      scrollElement.removeEventListener("touchstart", onTouchStart);
+      scrollElement.removeEventListener("touchmove", onTouchMove);
     };
-  }, [captureScrollPosition, getScrollElement, isMobile]);
+  }, [isMobile]);
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
   const { peekPendingFirstMessage } = useContext(InputBarContext);
@@ -1487,42 +1512,6 @@ export const ConversationViewer = ({
     ]
   );
 
-  const onWheel = useCallback(
-    (event: WheelEvent<HTMLDivElement>) => {
-      if (event.ctrlKey) {
-        return;
-      }
-
-      if (event.deltaY < 0) {
-        detachFromAutoScroll();
-      } else if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
-      }
-    },
-    [captureScrollPosition, detachFromAutoScroll]
-  );
-
-  const onTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
-    lastTouchYRef.current = event.touches[0]?.clientY ?? null;
-  }, []);
-
-  const onTouchMove = useCallback(
-    (event: TouchEvent<HTMLDivElement>) => {
-      const touchY = event.touches[0]?.clientY;
-      if (touchY === undefined) {
-        return;
-      }
-
-      if (lastTouchYRef.current !== null && touchY > lastTouchYRef.current) {
-        detachFromAutoScroll();
-      } else if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
-      }
-      lastTouchYRef.current = touchY;
-    },
-    [captureScrollPosition, detachFromAutoScroll]
-  );
-
   const computeItemKey = useCallback(
     ({
       data,
@@ -1654,9 +1643,6 @@ export const ConversationViewer = ({
           shortSizeAlign="top"
           computeItemKey={computeItemKey}
           onScroll={onScroll}
-          onWheel={onWheel}
-          onTouchStart={onTouchStart}
-          onTouchMove={onTouchMove}
           context={context}
           itemIdentity={itemIdentity}
           EmptyPlaceholder={ConversationViewerEmptyState}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -268,11 +268,133 @@ export const ConversationViewer = ({
   const isAutoScrollEnabledRef = useRef(true);
   const hasLeftBottomSinceDetachRef = useRef(false);
   const lastTouchYRef = useRef<number | null>(null);
+  const previousScrollHeightRef = useRef<number | null>(null);
+  const previousScrollTopRef = useRef<number | null>(null);
+  const getScrollElement = useCallback(
+    () =>
+      isMobile
+        ? document.scrollingElement
+        : virtuosoMessageListRef.current?.scrollerElement(),
+    [isMobile]
+  );
+  const captureScrollPosition = useCallback(() => {
+    const scrollElement = getScrollElement();
+    previousScrollHeightRef.current = scrollElement?.scrollHeight ?? null;
+    previousScrollTopRef.current = scrollElement?.scrollTop ?? null;
+  }, [getScrollElement]);
   const detachFromAutoScroll = useCallback(() => {
+    captureScrollPosition();
+    if (!isAutoScrollEnabledRef.current) {
+      return;
+    }
+
     isAutoScrollEnabledRef.current = false;
     hasLeftBottomSinceDetachRef.current = false;
     virtuosoMessageListRef.current?.cancelSmoothScroll();
-  }, []);
+  }, [captureScrollPosition]);
+
+  // While the list's scroll direction is "up", Virtuoso compensates row-height
+  // growth by adding the same delta to scrollTop. Streaming markdown can keep
+  // that compensation alive indefinitely. A native listener recognizes those
+  // matching deltas and restores the detached position before the next paint.
+  useEffect(() => {
+    const scrollElement = getScrollElement();
+    if (!scrollElement) {
+      return;
+    }
+
+    const scrollTarget = isMobile ? window : scrollElement;
+    const listElement =
+      virtuosoMessageListRef.current?.scrollerElement()?.firstElementChild;
+    previousScrollHeightRef.current = scrollElement.scrollHeight;
+    previousScrollTopRef.current = scrollElement.scrollTop;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Keep the height baseline current when the list grows without moving.
+      // If scrollTop changed, the scroll listener still needs the old values
+      // to recognize and undo Virtuoso's height compensation.
+      if (
+        !isAutoScrollEnabledRef.current &&
+        scrollElement.scrollTop === previousScrollTopRef.current
+      ) {
+        previousScrollHeightRef.current = scrollElement.scrollHeight;
+      }
+    });
+    if (listElement) {
+      resizeObserver.observe(listElement);
+    }
+
+    const preserveDetachedScrollPosition = () => {
+      const scrollHeight = scrollElement.scrollHeight;
+      const previousScrollHeight = previousScrollHeightRef.current;
+      const previousScrollTop = previousScrollTopRef.current;
+      let scrollTop = scrollElement.scrollTop;
+      const scrollHeightDelta =
+        previousScrollHeight === null ? 0 : scrollHeight - previousScrollHeight;
+      const scrollTopDelta =
+        previousScrollTop === null ? 0 : scrollTop - previousScrollTop;
+      const viewportHeight = isMobile
+        ? window.innerHeight
+        : scrollElement.clientHeight;
+      const bottomOffset = scrollHeight - viewportHeight - scrollTop;
+
+      if (
+        isAutoScrollEnabledRef.current &&
+        previousScrollTop !== null &&
+        scrollTop < previousScrollTop &&
+        bottomOffset > AUTO_SCROLL_BOTTOM_THRESHOLD_PX
+      ) {
+        isAutoScrollEnabledRef.current = false;
+        hasLeftBottomSinceDetachRef.current = true;
+        virtuosoMessageListRef.current?.cancelSmoothScroll();
+      }
+
+      // Reattach before correcting a concurrent height change. Otherwise a
+      // stream update landing with the user's scroll-to-bottom can move the
+      // viewport back up and make the reattachment miss.
+      if (
+        !isAutoScrollEnabledRef.current &&
+        hasLeftBottomSinceDetachRef.current &&
+        bottomOffset <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX
+      ) {
+        isAutoScrollEnabledRef.current = true;
+        hasLeftBottomSinceDetachRef.current = false;
+      }
+
+      if (
+        !isAutoScrollEnabledRef.current &&
+        scrollHeightDelta !== 0 &&
+        Math.abs(scrollTopDelta - scrollHeightDelta) <= 1
+      ) {
+        scrollElement.scrollTop -= scrollTopDelta;
+        scrollTop = scrollElement.scrollTop;
+      }
+
+      if (!isAutoScrollEnabledRef.current) {
+        const correctedBottomOffset = scrollHeight - viewportHeight - scrollTop;
+        if (correctedBottomOffset > AUTO_SCROLL_BOTTOM_THRESHOLD_PX) {
+          hasLeftBottomSinceDetachRef.current = true;
+        } else if (hasLeftBottomSinceDetachRef.current) {
+          isAutoScrollEnabledRef.current = true;
+          hasLeftBottomSinceDetachRef.current = false;
+        }
+      }
+
+      previousScrollHeightRef.current = scrollHeight;
+      previousScrollTopRef.current = scrollTop;
+    };
+
+    scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
+      passive: true,
+    });
+    return () => {
+      resizeObserver.disconnect();
+      scrollTarget.removeEventListener(
+        "scroll",
+        preserveDetachedScrollPosition
+      );
+    };
+  }, [getScrollElement, isMobile]);
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
   const { peekPendingFirstMessage } = useContext(InputBarContext);
@@ -1360,15 +1482,6 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      if (!isAutoScrollEnabledRef.current) {
-        if (location.bottomOffset > AUTO_SCROLL_BOTTOM_THRESHOLD_PX) {
-          hasLeftBottomSinceDetachRef.current = true;
-        } else if (hasLeftBottomSinceDetachRef.current) {
-          isAutoScrollEnabledRef.current = true;
-          hasLeftBottomSinceDetachRef.current = false;
-        }
-      }
-
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
 
@@ -1393,11 +1506,17 @@ export const ConversationViewer = ({
 
   const onWheel = useCallback(
     (event: WheelEvent<HTMLDivElement>) => {
-      if (!event.ctrlKey && event.deltaY < 0) {
+      if (event.ctrlKey) {
+        return;
+      }
+
+      if (event.deltaY < 0) {
         detachFromAutoScroll();
+      } else if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
       }
     },
-    [detachFromAutoScroll]
+    [captureScrollPosition, detachFromAutoScroll]
   );
 
   const onTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
@@ -1411,12 +1530,15 @@ export const ConversationViewer = ({
         return;
       }
 
+      if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
+      }
       if (lastTouchYRef.current !== null && touchY > lastTouchYRef.current) {
         detachFromAutoScroll();
       }
       lastTouchYRef.current = touchY;
     },
-    [detachFromAutoScroll]
+    [captureScrollPosition, detachFromAutoScroll]
   );
 
   const onTouchEnd = useCallback(() => {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -34,11 +34,7 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
-import type { AutoScrollEvent } from "@app/components/assistant/conversation/utils";
-import {
-  findFirstUnreadMessageIndex,
-  getNextAutoScrollState,
-} from "@app/components/assistant/conversation/utils";
+import { findFirstUnreadMessageIndex } from "@app/components/assistant/conversation/utils";
 import {
   requestConversationMarkAsRead,
   useConversation,
@@ -114,6 +110,7 @@ import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
 
 const DEFAULT_PAGE_LIMIT = 50;
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 4;
 const TOUCH_SCROLL_UP_THRESHOLD_PX = 4;
 // SSE is the fast path; poll slowly in case the completion event is missed before subscription.
 const FORK_PREPARATION_POLL_INTERVAL_MS = 60_000;
@@ -270,22 +267,10 @@ export const ConversationViewer = ({
     >(null);
   const isMobile = useIsMobile();
   const isAutoScrollEnabledRef = useRef(true);
-  const hasLeftBottomSinceDetachRef = useRef(false);
   const touchStartYRef = useRef<number | null>(null);
-  const updateAutoScrollState = useCallback((event: AutoScrollEvent) => {
-    const wasAutoScrollEnabled = isAutoScrollEnabledRef.current;
-    const nextState = getNextAutoScrollState(
-      {
-        isEnabled: wasAutoScrollEnabled,
-        hasLeftBottom: hasLeftBottomSinceDetachRef.current,
-      },
-      event
-    );
-
-    isAutoScrollEnabledRef.current = nextState.isEnabled;
-    hasLeftBottomSinceDetachRef.current = nextState.hasLeftBottom;
-
-    if (wasAutoScrollEnabled && !nextState.isEnabled) {
+  const detachFromAutoScroll = useCallback(() => {
+    if (isAutoScrollEnabledRef.current) {
+      isAutoScrollEnabledRef.current = false;
       virtuosoMessageListRef.current?.cancelSmoothScroll();
     }
   }, []);
@@ -1202,7 +1187,7 @@ export const ConversationViewer = ({
           );
 
         if (!hasRunningAgent) {
-          updateAutoScrollState({ type: "attach" });
+          isAutoScrollEnabledRef.current = true;
         }
 
         if (hasRunningAgent && conversationId) {
@@ -1370,16 +1355,14 @@ export const ConversationViewer = ({
       submitMessage,
       user,
       incrementPendingSteeringCount,
-      updateAutoScrollState,
     ]
   );
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      updateAutoScrollState({
-        type: "scroll",
-        bottomOffset: location.bottomOffset,
-      });
+      if (location.bottomOffset <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX) {
+        isAutoScrollEnabledRef.current = true;
+      }
 
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
@@ -1400,17 +1383,16 @@ export const ConversationViewer = ({
       setSize,
       size,
       messages,
-      updateAutoScrollState,
     ]
   );
 
   const onWheel = useCallback(
     (event: WheelEvent<HTMLDivElement>) => {
       if (!event.ctrlKey && event.deltaY < 0) {
-        updateAutoScrollState({ type: "user_scrolled_up" });
+        detachFromAutoScroll();
       }
     },
-    [updateAutoScrollState]
+    [detachFromAutoScroll]
   );
 
   const onTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
@@ -1425,10 +1407,10 @@ export const ConversationViewer = ({
         touchStartYRef.current !== null &&
         touchY - touchStartYRef.current >= TOUCH_SCROLL_UP_THRESHOLD_PX
       ) {
-        updateAutoScrollState({ type: "user_scrolled_up" });
+        detachFromAutoScroll();
       }
     },
-    [updateAutoScrollState]
+    [detachFromAutoScroll]
   );
 
   const onTouchEnd = useCallback(() => {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -264,7 +264,7 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const isMobile = useIsMobile();
-  const { enableAutoScroll, isAutoScrollEnabledRef } =
+  const { enableAutoScroll, isAutoScrollEnabledRef, lastUserScrollAtRef } =
     useConversationAutoScroll({
       isMobile,
       messageListRef: virtuosoMessageListRef,
@@ -1447,6 +1447,7 @@ export const ConversationViewer = ({
       projectSpaceName: spaceInfo?.name,
       enableAutoScroll,
       isAutoScrollEnabledRef,
+      lastUserScrollAtRef,
       isNoSeat: limitReachedCode === "no_seat",
       setLimitReachedCode,
     };
@@ -1470,6 +1471,7 @@ export const ConversationViewer = ({
     setLimitReachedCode,
     enableAutoScroll,
     isAutoScrollEnabledRef,
+    lastUserScrollAtRef,
   ]);
 
   return (

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -34,9 +34,10 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
+import type { AutoScrollEvent } from "@app/components/assistant/conversation/utils";
 import {
   findFirstUnreadMessageIndex,
-  getAutoScrollEnabled,
+  getNextAutoScrollState,
 } from "@app/components/assistant/conversation/utils";
 import {
   requestConversationMarkAsRead,
@@ -99,6 +100,7 @@ import {
   VirtuosoMessageList,
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
+import type { TouchEvent, WheelEvent } from "react";
 import {
   useCallback,
   useContext,
@@ -112,6 +114,7 @@ import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
 
 const DEFAULT_PAGE_LIMIT = 50;
+const TOUCH_SCROLL_UP_THRESHOLD_PX = 4;
 // SSE is the fast path; poll slowly in case the completion event is missed before subscription.
 const FORK_PREPARATION_POLL_INTERVAL_MS = 60_000;
 
@@ -267,10 +270,25 @@ export const ConversationViewer = ({
     >(null);
   const isMobile = useIsMobile();
   const isAutoScrollEnabledRef = useRef(true);
-  const prevScrollLocationRef = useRef({
-    bottomOffset: 0,
-    listOffset: 0,
-  });
+  const hasLeftBottomSinceDetachRef = useRef(false);
+  const touchStartYRef = useRef<number | null>(null);
+  const updateAutoScrollState = useCallback((event: AutoScrollEvent) => {
+    const wasAutoScrollEnabled = isAutoScrollEnabledRef.current;
+    const nextState = getNextAutoScrollState(
+      {
+        isEnabled: wasAutoScrollEnabled,
+        hasLeftBottom: hasLeftBottomSinceDetachRef.current,
+      },
+      event
+    );
+
+    isAutoScrollEnabledRef.current = nextState.isEnabled;
+    hasLeftBottomSinceDetachRef.current = nextState.hasLeftBottom;
+
+    if (wasAutoScrollEnabled && !nextState.isEnabled) {
+      virtuosoMessageListRef.current?.cancelSmoothScroll();
+    }
+  }, []);
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
   const { peekPendingFirstMessage } = useContext(InputBarContext);
@@ -1183,6 +1201,10 @@ export const ConversationViewer = ({
               !isPlaceholderMessage(m)
           );
 
+        if (!hasRunningAgent) {
+          updateAutoScrollState({ type: "attach" });
+        }
+
         if (hasRunningAgent && conversationId) {
           incrementPendingSteeringCount(conversationId);
         }
@@ -1348,25 +1370,16 @@ export const ConversationViewer = ({
       submitMessage,
       user,
       incrementPendingSteeringCount,
+      updateAutoScrollState,
     ]
   );
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      const wasAutoScrollEnabled = isAutoScrollEnabledRef.current;
-      isAutoScrollEnabledRef.current = getAutoScrollEnabled({
-        isAutoScrollEnabled: wasAutoScrollEnabled,
-        location,
-        previousLocation: prevScrollLocationRef.current,
-      });
-      prevScrollLocationRef.current = {
+      updateAutoScrollState({
+        type: "scroll",
         bottomOffset: location.bottomOffset,
-        listOffset: location.listOffset,
-      };
-
-      if (wasAutoScrollEnabled && !isAutoScrollEnabledRef.current) {
-        virtuosoMessageListRef.current?.cancelSmoothScroll();
-      }
+      });
 
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
@@ -1387,8 +1400,40 @@ export const ConversationViewer = ({
       setSize,
       size,
       messages,
+      updateAutoScrollState,
     ]
   );
+
+  const onWheel = useCallback(
+    (event: WheelEvent<HTMLDivElement>) => {
+      if (!event.ctrlKey && event.deltaY < 0) {
+        updateAutoScrollState({ type: "user_scrolled_up" });
+      }
+    },
+    [updateAutoScrollState]
+  );
+
+  const onTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    touchStartYRef.current = event.touches[0]?.clientY ?? null;
+  }, []);
+
+  const onTouchMove = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      const touchY = event.touches[0]?.clientY;
+      if (
+        touchY !== undefined &&
+        touchStartYRef.current !== null &&
+        touchY - touchStartYRef.current >= TOUCH_SCROLL_UP_THRESHOLD_PX
+      ) {
+        updateAutoScrollState({ type: "user_scrolled_up" });
+      }
+    },
+    [updateAutoScrollState]
+  );
+
+  const onTouchEnd = useCallback(() => {
+    touchStartYRef.current = null;
+  }, []);
 
   const computeItemKey = useCallback(
     ({
@@ -1521,6 +1566,11 @@ export const ConversationViewer = ({
           shortSizeAlign="top"
           computeItemKey={computeItemKey}
           onScroll={onScroll}
+          onWheel={onWheel}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchEnd}
           context={context}
           itemIdentity={itemIdentity}
           EmptyPlaceholder={ConversationViewerEmptyState}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -94,7 +94,6 @@ import {
   VirtuosoMessageList,
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
-import type { MutableRefObject } from "react";
 import {
   useCallback,
   useContext,
@@ -107,7 +106,7 @@ import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
 import { ConversationErrorDisplay } from "./ConversationError";
-import { findFirstUnreadMessageIndex } from "./utils";
+import { findFirstUnreadMessageIndex, getAutoScrollEnabled } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
 // SSE is the fast path; poll slowly in case the completion event is missed before subscription.
@@ -137,35 +136,6 @@ function customSmoothScroll() {
     animationFrameCount: 30,
     easing: easeOutQuint,
   };
-}
-
-// This function is used to update the auto scroll enabled state based on the scroll location.
-// Goal is to detect when the user is scrolling manually to pause the auto scroll.
-function updateAutoScrollEnabledFromLocation({
-  isAutoScrollEnabledRef,
-  location,
-  prevLocationRef,
-}: {
-  isAutoScrollEnabledRef: MutableRefObject<boolean>;
-  location: Pick<ListScrollLocation, "scrollHeight" | "bottomOffset">;
-  prevLocationRef: MutableRefObject<
-    Pick<ListScrollLocation, "scrollHeight" | "bottomOffset">
-  >;
-}) {
-  const { scrollHeight, bottomOffset } = location;
-  const prev = prevLocationRef.current;
-
-  // Scroll up with out change in content.
-  if (scrollHeight === prev.scrollHeight && bottomOffset > prev.bottomOffset) {
-    isAutoScrollEnabledRef.current = false;
-  }
-
-  // Scroll to bottom with no change in content.
-  if (scrollHeight === prev.scrollHeight && bottomOffset == 0) {
-    isAutoScrollEnabledRef.current = true;
-  }
-
-  prevLocationRef.current = { scrollHeight, bottomOffset };
 }
 
 function makeConversationForkNoticeMessage(
@@ -295,8 +265,8 @@ export const ConversationViewer = ({
   const isMobile = useIsMobile();
   const isAutoScrollEnabledRef = useRef(true);
   const prevScrollLocationRef = useRef({
-    scrollHeight: 0,
     bottomOffset: 0,
+    listOffset: 0,
   });
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
@@ -1380,11 +1350,20 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      updateAutoScrollEnabledFromLocation({
-        isAutoScrollEnabledRef,
+      const wasAutoScrollEnabled = isAutoScrollEnabledRef.current;
+      isAutoScrollEnabledRef.current = getAutoScrollEnabled({
+        isAutoScrollEnabled: wasAutoScrollEnabled,
         location,
-        prevLocationRef: prevScrollLocationRef,
+        previousLocation: prevScrollLocationRef.current,
       });
+      prevScrollLocationRef.current = {
+        bottomOffset: location.bottomOffset,
+        listOffset: location.listOffset,
+      };
+
+      if (wasAutoScrollEnabled && !isAutoScrollEnabledRef.current) {
+        virtuosoMessageListRef.current?.cancelSmoothScroll();
+      }
 
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -34,6 +34,7 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
+import { useConversationAutoScroll } from "@app/components/assistant/conversation/useConversationAutoScroll";
 import { findFirstUnreadMessageIndex } from "@app/components/assistant/conversation/utils";
 import {
   requestConversationMarkAsRead,
@@ -263,137 +264,14 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const isMobile = useIsMobile();
-  const isAutoScrollEnabledRef = useRef(true);
-  const hasLeftBottomSinceDetachRef = useRef(false);
-
-  // While the list's scroll direction is "up", Virtuoso compensates row-height
-  // growth by adding the same delta to scrollTop. Streaming markdown can keep
-  // that compensation alive indefinitely. A native listener recognizes those
-  // matching deltas and restores the detached position before the next paint.
-  useEffect(() => {
-    const scrollElement = isMobile
-      ? (document.scrollingElement as HTMLElement | null)
-      : virtuosoMessageListRef.current?.scrollerElement();
-    if (!scrollElement) {
-      return;
-    }
-
-    const scrollTarget = isMobile ? window : scrollElement;
-    const listElement =
-      virtuosoMessageListRef.current?.scrollerElement()?.firstElementChild;
-    let previousScrollHeight = scrollElement.scrollHeight;
-    let previousScrollTop = scrollElement.scrollTop;
-    let lastTouchY: number | null = null;
-
-    const captureScrollPosition = () => {
-      previousScrollHeight = scrollElement.scrollHeight;
-      previousScrollTop = scrollElement.scrollTop;
-    };
-
-    const detachFromAutoScroll = () => {
-      captureScrollPosition();
-      if (!isAutoScrollEnabledRef.current) {
-        return;
-      }
-
-      isAutoScrollEnabledRef.current = false;
-      hasLeftBottomSinceDetachRef.current = false;
-      virtuosoMessageListRef.current?.cancelSmoothScroll();
-    };
-
-    const resizeObserver = new ResizeObserver(() => {
-      // Keep the height baseline current when the list grows without moving.
-      // If scrollTop changed, the scroll listener still needs the old values
-      // to recognize and undo Virtuoso's height compensation.
-      if (
-        !isAutoScrollEnabledRef.current &&
-        scrollElement.scrollTop === previousScrollTop
-      ) {
-        captureScrollPosition();
-      }
-    });
-    if (listElement) {
-      resizeObserver.observe(listElement);
-    }
-
-    const preserveDetachedScrollPosition = () => {
-      const scrollHeight = scrollElement.scrollHeight;
-      let scrollTop = scrollElement.scrollTop;
-      const scrollHeightDelta = scrollHeight - previousScrollHeight;
-      const scrollTopDelta = scrollTop - previousScrollTop;
-      const isHeightCompensation =
-        scrollHeightDelta !== 0 &&
-        Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
-
-      if (
-        isAutoScrollEnabledRef.current &&
-        scrollTopDelta < 0 &&
-        !isHeightCompensation &&
-        virtuosoMessageListRef.current?.getScrollLocation().isAtBottom === false
-      ) {
-        isAutoScrollEnabledRef.current = false;
-        hasLeftBottomSinceDetachRef.current = true;
-        virtuosoMessageListRef.current?.cancelSmoothScroll();
-      }
-
-      if (!isAutoScrollEnabledRef.current && isHeightCompensation) {
-        scrollElement.scrollTop -= scrollTopDelta;
-        scrollTop = scrollElement.scrollTop;
-      }
-
-      previousScrollHeight = scrollHeight;
-      previousScrollTop = scrollTop;
-    };
-
-    const onWheel = (event: globalThis.WheelEvent) => {
-      if (event.ctrlKey) {
-        return;
-      }
-
-      if (event.deltaY < 0) {
-        detachFromAutoScroll();
-      } else if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
-      }
-    };
-
-    const onTouchStart = (event: globalThis.TouchEvent) => {
-      lastTouchY = event.touches[0]?.clientY ?? null;
-    };
-
-    const onTouchMove = (event: globalThis.TouchEvent) => {
-      const touchY = event.touches[0]?.clientY;
-      if (touchY === undefined) {
-        return;
-      }
-
-      if (lastTouchY !== null && touchY > lastTouchY) {
-        detachFromAutoScroll();
-      } else if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
-      }
-      lastTouchY = touchY;
-    };
-
-    scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
-      passive: true,
-    });
-    scrollElement.addEventListener("wheel", onWheel, { passive: true });
-    scrollElement.addEventListener("touchstart", onTouchStart, {
-      passive: true,
-    });
-    scrollElement.addEventListener("touchmove", onTouchMove, { passive: true });
-    return () => {
-      resizeObserver.disconnect();
-      scrollTarget.removeEventListener(
-        "scroll",
-        preserveDetachedScrollPosition
-      );
-      scrollElement.removeEventListener("wheel", onWheel);
-      scrollElement.removeEventListener("touchstart", onTouchStart);
-      scrollElement.removeEventListener("touchmove", onTouchMove);
-    };
-  }, [isMobile]);
+  const {
+    enableAutoScroll,
+    handleScroll: handleAutoScroll,
+    isAutoScrollEnabledRef,
+  } = useConversationAutoScroll({
+    isMobile,
+    messageListRef: virtuosoMessageListRef,
+  });
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
   const { peekPendingFirstMessage } = useContext(InputBarContext);
@@ -1307,8 +1185,7 @@ export const ConversationViewer = ({
           );
 
         if (!hasRunningAgent) {
-          isAutoScrollEnabledRef.current = true;
-          hasLeftBottomSinceDetachRef.current = false;
+          enableAutoScroll();
         }
 
         if (hasRunningAgent && conversationId) {
@@ -1470,6 +1347,7 @@ export const ConversationViewer = ({
       clientSideMCPServerIds,
       agentBuilderContext?.skipToolsValidation,
       conversationId,
+      enableAutoScroll,
       mutateConversations,
       sendNotification,
       setLimitReachedCode,
@@ -1481,14 +1359,7 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      if (!isAutoScrollEnabledRef.current) {
-        if (!location.isAtBottom) {
-          hasLeftBottomSinceDetachRef.current = true;
-        } else if (hasLeftBottomSinceDetachRef.current) {
-          isAutoScrollEnabledRef.current = true;
-          hasLeftBottomSinceDetachRef.current = false;
-        }
-      }
+      handleAutoScroll(location);
 
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
@@ -1506,6 +1377,7 @@ export const ConversationViewer = ({
       isLoadingInitialData,
       isMessagesLoading,
       isValidating,
+      handleAutoScroll,
       setSize,
       size,
       messages,
@@ -1601,6 +1473,7 @@ export const ConversationViewer = ({
     spaceInfo?.name,
     limitReachedCode,
     setLimitReachedCode,
+    isAutoScrollEnabledRef,
   ]);
 
   return (

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -111,7 +111,6 @@ import { mutate } from "swr";
 
 const DEFAULT_PAGE_LIMIT = 50;
 const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 4;
-const TOUCH_SCROLL_UP_THRESHOLD_PX = 4;
 // SSE is the fast path; poll slowly in case the completion event is missed before subscription.
 const FORK_PREPARATION_POLL_INTERVAL_MS = 60_000;
 
@@ -267,12 +266,10 @@ export const ConversationViewer = ({
     >(null);
   const isMobile = useIsMobile();
   const isAutoScrollEnabledRef = useRef(true);
-  const touchStartYRef = useRef<number | null>(null);
+  const lastTouchYRef = useRef<number | null>(null);
   const detachFromAutoScroll = useCallback(() => {
-    if (isAutoScrollEnabledRef.current) {
-      isAutoScrollEnabledRef.current = false;
-      virtuosoMessageListRef.current?.cancelSmoothScroll();
-    }
+    isAutoScrollEnabledRef.current = false;
+    virtuosoMessageListRef.current?.cancelSmoothScroll();
   }, []);
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
@@ -1396,25 +1393,26 @@ export const ConversationViewer = ({
   );
 
   const onTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
-    touchStartYRef.current = event.touches[0]?.clientY ?? null;
+    lastTouchYRef.current = event.touches[0]?.clientY ?? null;
   }, []);
 
   const onTouchMove = useCallback(
     (event: TouchEvent<HTMLDivElement>) => {
       const touchY = event.touches[0]?.clientY;
-      if (
-        touchY !== undefined &&
-        touchStartYRef.current !== null &&
-        touchY - touchStartYRef.current >= TOUCH_SCROLL_UP_THRESHOLD_PX
-      ) {
+      if (touchY === undefined) {
+        return;
+      }
+
+      if (lastTouchYRef.current !== null && touchY > lastTouchYRef.current) {
         detachFromAutoScroll();
       }
+      lastTouchYRef.current = touchY;
     },
     [detachFromAutoScroll]
   );
 
   const onTouchEnd = useCallback(() => {
-    touchStartYRef.current = null;
+    lastTouchYRef.current = null;
   }, []);
 
   const computeItemKey = useCallback(

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -264,7 +264,7 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const isMobile = useIsMobile();
-  const { enableAutoScroll, isAutoScrollEnabledRef, lastUserScrollAtRef } =
+  const { enableAutoScroll, isAutoScrollEnabledRef, userScrollActivity } =
     useConversationAutoScroll({
       isMobile,
       messageListRef: virtuosoMessageListRef,
@@ -1447,7 +1447,7 @@ export const ConversationViewer = ({
       projectSpaceName: spaceInfo?.name,
       enableAutoScroll,
       isAutoScrollEnabledRef,
-      lastUserScrollAtRef,
+      userScrollActivity,
       isNoSeat: limitReachedCode === "no_seat",
       setLimitReachedCode,
     };
@@ -1471,7 +1471,7 @@ export const ConversationViewer = ({
     setLimitReachedCode,
     enableAutoScroll,
     isAutoScrollEnabledRef,
-    lastUserScrollAtRef,
+    userScrollActivity,
   ]);
 
   return (

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -110,7 +110,6 @@ import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
 
 const DEFAULT_PAGE_LIMIT = 50;
-const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 4;
 // SSE is the fast path; poll slowly in case the completion event is missed before subscription.
 const FORK_PREPARATION_POLL_INTERVAL_MS = 60_000;
 
@@ -268,8 +267,10 @@ export const ConversationViewer = ({
   const isAutoScrollEnabledRef = useRef(true);
   const hasLeftBottomSinceDetachRef = useRef(false);
   const lastTouchYRef = useRef<number | null>(null);
-  const previousScrollHeightRef = useRef<number | null>(null);
-  const previousScrollTopRef = useRef<number | null>(null);
+  const previousScrollPositionRef = useRef({
+    scrollHeight: 0,
+    scrollTop: 0,
+  });
   const getScrollElement = useCallback(
     () =>
       isMobile
@@ -279,8 +280,12 @@ export const ConversationViewer = ({
   );
   const captureScrollPosition = useCallback(() => {
     const scrollElement = getScrollElement();
-    previousScrollHeightRef.current = scrollElement?.scrollHeight ?? null;
-    previousScrollTopRef.current = scrollElement?.scrollTop ?? null;
+    if (scrollElement) {
+      previousScrollPositionRef.current = {
+        scrollHeight: scrollElement.scrollHeight,
+        scrollTop: scrollElement.scrollTop,
+      };
+    }
   }, [getScrollElement]);
   const detachFromAutoScroll = useCallback(() => {
     captureScrollPosition();
@@ -306,8 +311,7 @@ export const ConversationViewer = ({
     const scrollTarget = isMobile ? window : scrollElement;
     const listElement =
       virtuosoMessageListRef.current?.scrollerElement()?.firstElementChild;
-    previousScrollHeightRef.current = scrollElement.scrollHeight;
-    previousScrollTopRef.current = scrollElement.scrollTop;
+    captureScrollPosition();
 
     const resizeObserver = new ResizeObserver(() => {
       // Keep the height baseline current when the list grows without moving.
@@ -315,9 +319,9 @@ export const ConversationViewer = ({
       // to recognize and undo Virtuoso's height compensation.
       if (
         !isAutoScrollEnabledRef.current &&
-        scrollElement.scrollTop === previousScrollTopRef.current
+        scrollElement.scrollTop === previousScrollPositionRef.current.scrollTop
       ) {
-        previousScrollHeightRef.current = scrollElement.scrollHeight;
+        captureScrollPosition();
       }
     });
     if (listElement) {
@@ -326,39 +330,20 @@ export const ConversationViewer = ({
 
     const preserveDetachedScrollPosition = () => {
       const scrollHeight = scrollElement.scrollHeight;
-      const previousScrollHeight = previousScrollHeightRef.current;
-      const previousScrollTop = previousScrollTopRef.current;
+      const previousScrollPosition = previousScrollPositionRef.current;
       let scrollTop = scrollElement.scrollTop;
       const scrollHeightDelta =
-        previousScrollHeight === null ? 0 : scrollHeight - previousScrollHeight;
-      const scrollTopDelta =
-        previousScrollTop === null ? 0 : scrollTop - previousScrollTop;
-      const viewportHeight = isMobile
-        ? window.innerHeight
-        : scrollElement.clientHeight;
-      const bottomOffset = scrollHeight - viewportHeight - scrollTop;
+        scrollHeight - previousScrollPosition.scrollHeight;
+      const scrollTopDelta = scrollTop - previousScrollPosition.scrollTop;
 
       if (
         isAutoScrollEnabledRef.current &&
-        previousScrollTop !== null &&
-        scrollTop < previousScrollTop &&
-        bottomOffset > AUTO_SCROLL_BOTTOM_THRESHOLD_PX
+        scrollTop < previousScrollPosition.scrollTop &&
+        virtuosoMessageListRef.current?.getScrollLocation().isAtBottom === false
       ) {
         isAutoScrollEnabledRef.current = false;
         hasLeftBottomSinceDetachRef.current = true;
         virtuosoMessageListRef.current?.cancelSmoothScroll();
-      }
-
-      // Reattach before correcting a concurrent height change. Otherwise a
-      // stream update landing with the user's scroll-to-bottom can move the
-      // viewport back up and make the reattachment miss.
-      if (
-        !isAutoScrollEnabledRef.current &&
-        hasLeftBottomSinceDetachRef.current &&
-        bottomOffset <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX
-      ) {
-        isAutoScrollEnabledRef.current = true;
-        hasLeftBottomSinceDetachRef.current = false;
       }
 
       if (
@@ -370,18 +355,7 @@ export const ConversationViewer = ({
         scrollTop = scrollElement.scrollTop;
       }
 
-      if (!isAutoScrollEnabledRef.current) {
-        const correctedBottomOffset = scrollHeight - viewportHeight - scrollTop;
-        if (correctedBottomOffset > AUTO_SCROLL_BOTTOM_THRESHOLD_PX) {
-          hasLeftBottomSinceDetachRef.current = true;
-        } else if (hasLeftBottomSinceDetachRef.current) {
-          isAutoScrollEnabledRef.current = true;
-          hasLeftBottomSinceDetachRef.current = false;
-        }
-      }
-
-      previousScrollHeightRef.current = scrollHeight;
-      previousScrollTopRef.current = scrollTop;
+      previousScrollPositionRef.current = { scrollHeight, scrollTop };
     };
 
     scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
@@ -394,7 +368,7 @@ export const ConversationViewer = ({
         preserveDetachedScrollPosition
       );
     };
-  }, [getScrollElement, isMobile]);
+  }, [captureScrollPosition, getScrollElement, isMobile]);
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
   const { peekPendingFirstMessage } = useContext(InputBarContext);
@@ -1482,6 +1456,15 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
+      if (!isAutoScrollEnabledRef.current) {
+        if (!location.isAtBottom) {
+          hasLeftBottomSinceDetachRef.current = true;
+        } else if (hasLeftBottomSinceDetachRef.current) {
+          isAutoScrollEnabledRef.current = true;
+          hasLeftBottomSinceDetachRef.current = false;
+        }
+      }
+
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
 
@@ -1530,20 +1513,15 @@ export const ConversationViewer = ({
         return;
       }
 
-      if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
-      }
       if (lastTouchYRef.current !== null && touchY > lastTouchYRef.current) {
         detachFromAutoScroll();
+      } else if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
       }
       lastTouchYRef.current = touchY;
     },
     [captureScrollPosition, detachFromAutoScroll]
   );
-
-  const onTouchEnd = useCallback(() => {
-    lastTouchYRef.current = null;
-  }, []);
 
   const computeItemKey = useCallback(
     ({
@@ -1679,8 +1657,6 @@ export const ConversationViewer = ({
           onWheel={onWheel}
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
-          onTouchEnd={onTouchEnd}
-          onTouchCancel={onTouchEnd}
           context={context}
           itemIdentity={itemIdentity}
           EmptyPlaceholder={ConversationViewerEmptyState}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1445,6 +1445,7 @@ export const ConversationViewer = ({
       isProjectArchived: !!spaceInfo?.archivedAt,
       projectId: conversation?.spaceId ?? undefined,
       projectSpaceName: spaceInfo?.name,
+      enableAutoScroll,
       isAutoScrollEnabledRef,
       isNoSeat: limitReachedCode === "no_seat",
       setLimitReachedCode,
@@ -1467,6 +1468,7 @@ export const ConversationViewer = ({
     spaceInfo?.name,
     limitReachedCode,
     setLimitReachedCode,
+    enableAutoScroll,
     isAutoScrollEnabledRef,
   ]);
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -264,14 +264,11 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const isMobile = useIsMobile();
-  const {
-    enableAutoScroll,
-    handleScroll: handleAutoScroll,
-    isAutoScrollEnabledRef,
-  } = useConversationAutoScroll({
-    isMobile,
-    messageListRef: virtuosoMessageListRef,
-  });
+  const { enableAutoScroll, isAutoScrollEnabledRef } =
+    useConversationAutoScroll({
+      isMobile,
+      messageListRef: virtuosoMessageListRef,
+    });
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
   const { peekPendingFirstMessage } = useContext(InputBarContext);
@@ -1359,8 +1356,6 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      handleAutoScroll(location);
-
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
 
@@ -1377,7 +1372,6 @@ export const ConversationViewer = ({
       isLoadingInitialData,
       isMessagesLoading,
       isValidating,
-      handleAutoScroll,
       setSize,
       size,
       messages,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -362,6 +362,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               }
               additionalMarkdownPlugins={context.additionalMarkdownPlugins}
               isAutoScrollEnabledRef={context.isAutoScrollEnabledRef}
+              lastUserScrollAtRef={context.lastUserScrollAtRef}
               isProjectArchived={context.isProjectArchived}
               setLimitReachedCode={context.setLimitReachedCode}
             />

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -362,7 +362,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               }
               additionalMarkdownPlugins={context.additionalMarkdownPlugins}
               isAutoScrollEnabledRef={context.isAutoScrollEnabledRef}
-              lastUserScrollAtRef={context.lastUserScrollAtRef}
+              userScrollActivity={context.userScrollActivity}
               isProjectArchived={context.isProjectArchived}
               setLimitReachedCode={context.setLimitReachedCode}
             />

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -147,6 +147,7 @@ export type VirtuosoMessageListContext = {
   isProjectArchived?: boolean;
   projectId?: string;
   projectSpaceName?: string;
+  enableAutoScroll: () => void;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
   isNoSeat?: boolean;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -112,6 +112,11 @@ export type VirtuosoMessage =
   | CompactionMessageType
   | ConversationForkNotice;
 
+export interface UserScrollActivity {
+  isActive: () => boolean;
+  subscribeToEnd: (listener: () => void) => () => void;
+}
+
 export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;
   user: UserType;
@@ -149,7 +154,7 @@ export type VirtuosoMessageListContext = {
   projectSpaceName?: string;
   enableAutoScroll: () => void;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
-  lastUserScrollAtRef: MutableRefObject<number | null>;
+  userScrollActivity: UserScrollActivity;
   isNoSeat?: boolean;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;
 };

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -149,6 +149,7 @@ export type VirtuosoMessageListContext = {
   projectSpaceName?: string;
   enableAutoScroll: () => void;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
+  lastUserScrollAtRef: MutableRefObject<number | null>;
   isNoSeat?: boolean;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;
 };

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -21,6 +21,10 @@ const originalInnerHeightDescriptor = Object.getOwnPropertyDescriptor(
   window,
   "innerHeight"
 );
+const originalDocumentScrollEndDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "onscrollend"
+);
 
 function makeScrollLocation(
   overrides: Partial<ListScrollLocation> = {}
@@ -37,7 +41,10 @@ function makeScrollLocation(
   };
 }
 
-function setupAutoScroll({ isMobile = false } = {}) {
+function setupAutoScroll({
+  isMobile = false,
+  supportsNativeScrollEnd = true,
+} = {}) {
   const scrollElement = document.createElement("div");
   let scrollHeight = 1000;
   let location = makeScrollLocation();
@@ -58,6 +65,12 @@ function setupAutoScroll({ isMobile = false } = {}) {
       value: 500,
     });
   }
+
+  const scrollEndTarget = isMobile ? document : scrollElement;
+  Object.defineProperty(scrollEndTarget, "onscrollend", {
+    configurable: true,
+    value: supportsNativeScrollEnd ? null : undefined,
+  });
 
   const methods: ScrollMethods = {
     cancelSmoothScroll: vi.fn(),
@@ -97,6 +110,12 @@ function setupAutoScroll({ isMobile = false } = {}) {
     });
   };
 
+  const dispatchScrollEnd = (target: EventTarget = scrollEndTarget) => {
+    act(() => {
+      target.dispatchEvent(new Event("scrollend"));
+    });
+  };
+
   const makeTouch = (clientY: number): Touch => ({
     clientX: 0,
     clientY,
@@ -112,21 +131,39 @@ function setupAutoScroll({ isMobile = false } = {}) {
     target: scrollElement,
   });
 
-  const dispatchTouch = (startY: number, endY: number) => {
+  const dispatchTouchStart = (clientY: number) => {
     act(() => {
       scrollElement.dispatchEvent(
-        new TouchEvent("touchstart", { touches: [makeTouch(startY)] })
-      );
-      scrollElement.dispatchEvent(
-        new TouchEvent("touchmove", { touches: [makeTouch(endY)] })
+        new TouchEvent("touchstart", { touches: [makeTouch(clientY)] })
       );
     });
+  };
+
+  const dispatchTouchMove = (clientY: number) => {
+    act(() => {
+      scrollElement.dispatchEvent(
+        new TouchEvent("touchmove", { touches: [makeTouch(clientY)] })
+      );
+    });
+  };
+
+  const dispatchTouchEnd = () => {
+    act(() => {
+      scrollElement.dispatchEvent(new TouchEvent("touchend", { touches: [] }));
+    });
+  };
+
+  const dispatchTouch = (startY: number, endY: number) => {
+    dispatchTouchStart(startY);
+    dispatchTouchMove(endY);
   };
 
   return {
     ...hook,
     dispatchScroll,
+    dispatchScrollEnd,
     dispatchTouch,
+    dispatchTouchEnd,
     dispatchWheel,
     methods,
     scrollElement,
@@ -139,6 +176,32 @@ function detach(harness: ReturnType<typeof setupAutoScroll>, scrollTop = 400) {
     location: { bottomOffset: 500, isAtBottom: false },
   });
   expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+}
+
+function mockAnimationFrames() {
+  let nextId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const id = nextId++;
+    callbacks.set(id, callback);
+    return id;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    callbacks.delete(id);
+  });
+
+  return {
+    runFrame: () => {
+      act(() => {
+        const frameCallbacks = Array.from(callbacks.values());
+        callbacks.clear();
+        for (const callback of frameCallbacks) {
+          callback(0);
+        }
+      });
+    },
+  };
 }
 
 afterEach(() => {
@@ -158,6 +221,16 @@ afterEach(() => {
     Object.defineProperty(window, "innerHeight", originalInnerHeightDescriptor);
   } else {
     Reflect.deleteProperty(window, "innerHeight");
+  }
+
+  if (originalDocumentScrollEndDescriptor) {
+    Object.defineProperty(
+      document,
+      "onscrollend",
+      originalDocumentScrollEndDescriptor
+    );
+  } else {
+    Reflect.deleteProperty(document, "onscrollend");
   }
 });
 
@@ -346,45 +419,74 @@ describe("useConversationAutoScroll", () => {
       expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
     });
 
+    it("does not reuse a completed downward gesture for later content growth", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 410,
+        location: { bottomOffset: 200, isAtBottom: false },
+      });
+      harness.dispatchScrollEnd();
+
+      harness.dispatchScroll({
+        scrollTop: 510,
+        scrollHeight: 1100,
+        location: { bottomOffset: 0, isAtBottom: true },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
     it("can be explicitly re-enabled for a new message", () => {
       const harness = setupAutoScroll();
       detach(harness);
 
-      expect(harness.result.current.lastUserScrollAtRef.current).not.toBeNull();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
 
       act(() => harness.result.current.enableAutoScroll());
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
-      expect(harness.result.current.lastUserScrollAtRef.current).toBeNull();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
       expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
     });
   });
 
   describe("tracking user scroll activity", () => {
-    it("records wheel gestures and their resulting scroll events", () => {
+    it("ends a wheel gesture on native scrollend", () => {
       const harness = setupAutoScroll();
-      const now = vi.spyOn(Date, "now");
 
-      now.mockReturnValue(1000);
       harness.dispatchWheel(-100);
-      expect(harness.result.current.lastUserScrollAtRef.current).toBe(1000);
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
 
-      now.mockReturnValue(1100);
       harness.dispatchScroll({
         scrollTop: 400,
         location: { bottomOffset: 500, isAtBottom: false },
       });
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
 
-      expect(harness.result.current.lastUserScrollAtRef.current).toBe(1100);
+      harness.dispatchScrollEnd();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
     });
 
-    it("records touch gestures", () => {
-      const harness = setupAutoScroll();
-      vi.spyOn(Date, "now").mockReturnValue(1000);
+    it("uses document scrollend for a mobile touch gesture", () => {
+      const animationFrames = mockAnimationFrames();
+      const harness = setupAutoScroll({ isMobile: true });
 
       harness.dispatchTouch(100, 120);
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+      harness.dispatchTouchEnd();
+      animationFrames.runFrame();
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
 
-      expect(harness.result.current.lastUserScrollAtRef.current).toBe(1000);
+      harness.dispatchScrollEnd();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
     });
 
     it("does not treat list height compensation as user activity", () => {
@@ -396,7 +498,80 @@ describe("useConversationAutoScroll", () => {
         location: { bottomOffset: 100, isAtBottom: false },
       });
 
-      expect(harness.result.current.lastUserScrollAtRef.current).toBeNull();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
+    });
+
+    it("notifies subscribers when scrolling ends", () => {
+      const harness = setupAutoScroll();
+      const onScrollEnd = vi.fn();
+      const unsubscribe =
+        harness.result.current.userScrollActivity.subscribeToEnd(onScrollEnd);
+
+      harness.dispatchWheel(-100);
+      harness.dispatchScrollEnd();
+
+      expect(onScrollEnd).toHaveBeenCalledOnce();
+
+      unsubscribe();
+      harness.dispatchWheel(-100);
+      harness.dispatchScrollEnd();
+      expect(onScrollEnd).toHaveBeenCalledOnce();
+    });
+
+    it("waits for touch release and stable frames without scrollend support", () => {
+      const animationFrames = mockAnimationFrames();
+      const harness = setupAutoScroll({ supportsNativeScrollEnd: false });
+
+      harness.dispatchTouch(100, 120);
+      animationFrames.runFrame();
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+
+      harness.dispatchTouchEnd();
+      harness.dispatchScroll({
+        scrollTop: 450,
+        location: { bottomOffset: 550, isAtBottom: false },
+      });
+      animationFrames.runFrame();
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
+    });
+
+    it("waits for wheel movement to become stable without scrollend support", () => {
+      const animationFrames = mockAnimationFrames();
+      const harness = setupAutoScroll({ supportsNativeScrollEnd: false });
+
+      harness.dispatchWheel(-100);
+      harness.dispatchScroll({
+        scrollTop: 450,
+        location: { bottomOffset: 550, isAtBottom: false },
+      });
+      animationFrames.runFrame();
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 600, isAtBottom: false },
+      });
+      animationFrames.runFrame();
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
+    });
+
+    it("ends a native gesture that produces no scroll event", () => {
+      const animationFrames = mockAnimationFrames();
+      const harness = setupAutoScroll();
+
+      harness.dispatchWheel(-100);
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+
+      animationFrames.runFrame();
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
     });
   });
 

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -97,16 +97,6 @@ function setupAutoScroll({ isMobile = false } = {}) {
     });
   };
 
-  const updateLayout = ({
-    scrollTop,
-    scrollHeight: nextScrollHeight = scrollHeight,
-  }: ScrollUpdate) => {
-    act(() => {
-      scrollHeight = nextScrollHeight;
-      scrollElement.scrollTop = scrollTop;
-    });
-  };
-
   const makeTouch = (clientY: number): Touch => ({
     clientX: 0,
     clientY,
@@ -140,7 +130,6 @@ function setupAutoScroll({ isMobile = false } = {}) {
     dispatchWheel,
     methods,
     scrollElement,
-    updateLayout,
   };
 }
 
@@ -153,6 +142,8 @@ function detach(harness: ReturnType<typeof setupAutoScroll>, scrollTop = 400) {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
+
   if (originalScrollingElementDescriptor) {
     Object.defineProperty(
       document,
@@ -359,77 +350,53 @@ describe("useConversationAutoScroll", () => {
       const harness = setupAutoScroll();
       detach(harness);
 
+      expect(harness.result.current.lastUserScrollAtRef.current).not.toBeNull();
+
       act(() => harness.result.current.enableAutoScroll());
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.result.current.lastUserScrollAtRef.current).toBeNull();
       expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
     });
   });
 
-  describe("holding the detached position", () => {
-    it("removes streamed row growth from Virtuoso's scroll compensation", () => {
+  describe("tracking user scroll activity", () => {
+    it("records wheel gestures and their resulting scroll events", () => {
       const harness = setupAutoScroll();
+      const now = vi.spyOn(Date, "now");
 
+      now.mockReturnValue(1000);
       harness.dispatchWheel(-100);
+      expect(harness.result.current.lastUserScrollAtRef.current).toBe(1000);
+
+      now.mockReturnValue(1100);
       harness.dispatchScroll({
         scrollTop: 400,
         location: { bottomOffset: 500, isAtBottom: false },
       });
-      harness.dispatchScroll({
-        scrollTop: 460,
-        scrollHeight: 1060,
-        location: { bottomOffset: 500, isAtBottom: false },
-      });
 
-      expect(harness.scrollElement.scrollTop).toBe(400);
+      expect(harness.result.current.lastUserScrollAtRef.current).toBe(1100);
     });
 
-    it("preserves upward movement concurrent with streamed row growth", () => {
+    it("records touch gestures", () => {
+      const harness = setupAutoScroll();
+      vi.spyOn(Date, "now").mockReturnValue(1000);
+
+      harness.dispatchTouch(100, 120);
+
+      expect(harness.result.current.lastUserScrollAtRef.current).toBe(1000);
+    });
+
+    it("does not treat list height compensation as user activity", () => {
       const harness = setupAutoScroll();
 
-      harness.dispatchWheel(-100);
       harness.dispatchScroll({
         scrollTop: 400,
-        location: { bottomOffset: 500, isAtBottom: false },
-      });
-      // Virtuoso moved down by 60px while the user moved up by 30px, leaving
-      // a positive net delta of 30px.
-      harness.dispatchScroll({
-        scrollTop: 430,
-        scrollHeight: 1060,
-        location: { bottomOffset: 500, isAtBottom: false },
+        scrollHeight: 900,
+        location: { bottomOffset: 100, isAtBottom: false },
       });
 
-      expect(harness.scrollElement.scrollTop).toBe(370);
-    });
-
-    it("uses the current height baseline for a later upward gesture", () => {
-      const harness = setupAutoScroll();
-      detach(harness);
-
-      harness.updateLayout({ scrollTop: 400, scrollHeight: 1060 });
-      harness.dispatchWheel(-50);
-      harness.dispatchScroll({
-        scrollTop: 350,
-        scrollHeight: 1060,
-        location: { bottomOffset: 500, isAtBottom: false },
-      });
-
-      expect(harness.scrollElement.scrollTop).toBe(350);
-    });
-
-    it("does not correct the native scroll event that first detaches", () => {
-      const harness = setupAutoScroll();
-
-      harness.updateLayout({ scrollTop: 500, scrollHeight: 1060 });
-      harness.dispatchScroll({
-        scrollTop: 450,
-        scrollHeight: 1060,
-        location: { bottomOffset: 500, isAtBottom: false },
-      });
-
-      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
-      expect(harness.scrollElement.scrollTop).toBe(450);
+      expect(harness.result.current.lastUserScrollAtRef.current).toBeNull();
     });
   });
 

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -1,11 +1,26 @@
 import { useConversationAutoScroll } from "@app/components/assistant/conversation/useConversationAutoScroll";
 import { act, renderHook } from "@testing-library/react";
 import type { ListScrollLocation } from "@virtuoso.dev/message-list";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 type ScrollMethods = NonNullable<
   Parameters<typeof useConversationAutoScroll>[0]["messageListRef"]["current"]
 >;
+
+interface ScrollUpdate {
+  scrollTop: number;
+  scrollHeight?: number;
+  location?: Partial<ListScrollLocation>;
+}
+
+const originalScrollingElementDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "scrollingElement"
+);
+const originalInnerHeightDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "innerHeight"
+);
 
 function makeScrollLocation(
   overrides: Partial<ListScrollLocation> = {}
@@ -22,7 +37,7 @@ function makeScrollLocation(
   };
 }
 
-function setupAutoScroll() {
+function setupAutoScroll({ isMobile = false } = {}) {
   const scrollElement = document.createElement("div");
   let scrollHeight = 1000;
   let location = makeScrollLocation();
@@ -33,6 +48,17 @@ function setupAutoScroll() {
   });
   scrollElement.scrollTop = 500;
 
+  if (isMobile) {
+    Object.defineProperty(document, "scrollingElement", {
+      configurable: true,
+      value: scrollElement,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 500,
+    });
+  }
+
   const methods: ScrollMethods = {
     cancelSmoothScroll: vi.fn(),
     getScrollLocation: () => location,
@@ -41,68 +67,309 @@ function setupAutoScroll() {
   };
   const messageListRef = { current: methods };
   const hook = renderHook(() =>
-    useConversationAutoScroll({ isMobile: false, messageListRef })
+    useConversationAutoScroll({ isMobile, messageListRef })
   );
+  const defaultScrollTarget = isMobile ? window : scrollElement;
+
+  const dispatchScroll = (
+    {
+      scrollTop,
+      scrollHeight: nextScrollHeight = scrollHeight,
+      location: locationOverrides = {},
+    }: ScrollUpdate,
+    target: EventTarget = defaultScrollTarget
+  ) => {
+    act(() => {
+      scrollHeight = nextScrollHeight;
+      scrollElement.scrollTop = scrollTop;
+      location = {
+        ...location,
+        scrollHeight: nextScrollHeight,
+        ...locationOverrides,
+      };
+      target.dispatchEvent(new Event("scroll"));
+    });
+  };
+
+  const dispatchWheel = (deltaY: number, ctrlKey = false) => {
+    act(() => {
+      scrollElement.dispatchEvent(new WheelEvent("wheel", { ctrlKey, deltaY }));
+    });
+  };
+
+  const makeTouch = (clientY: number): Touch => ({
+    clientX: 0,
+    clientY,
+    force: 0,
+    identifier: 0,
+    pageX: 0,
+    pageY: clientY,
+    radiusX: 0,
+    radiusY: 0,
+    rotationAngle: 0,
+    screenX: 0,
+    screenY: clientY,
+    target: scrollElement,
+  });
+
+  const dispatchTouch = (startY: number, endY: number) => {
+    act(() => {
+      scrollElement.dispatchEvent(
+        new TouchEvent("touchstart", { touches: [makeTouch(startY)] })
+      );
+      scrollElement.dispatchEvent(
+        new TouchEvent("touchmove", { touches: [makeTouch(endY)] })
+      );
+    });
+  };
 
   return {
     ...hook,
+    dispatchScroll,
+    dispatchTouch,
+    dispatchWheel,
     methods,
     scrollElement,
-    setLocation: (nextLocation: ListScrollLocation) => {
-      location = nextLocation;
-    },
-    setScrollHeight: (nextScrollHeight: number) => {
-      scrollHeight = nextScrollHeight;
-    },
   };
 }
 
+function detach(harness: ReturnType<typeof setupAutoScroll>, scrollTop = 400) {
+  harness.dispatchScroll({
+    scrollTop,
+    location: { bottomOffset: 500, isAtBottom: false },
+  });
+  expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+}
+
+afterEach(() => {
+  if (originalScrollingElementDescriptor) {
+    Object.defineProperty(
+      document,
+      "scrollingElement",
+      originalScrollingElementDescriptor
+    );
+  } else {
+    Reflect.deleteProperty(document, "scrollingElement");
+  }
+
+  if (originalInnerHeightDescriptor) {
+    Object.defineProperty(window, "innerHeight", originalInnerHeightDescriptor);
+  } else {
+    Reflect.deleteProperty(window, "innerHeight");
+  }
+});
+
 describe("useConversationAutoScroll", () => {
-  it("reattaches when the user scrolls down while streamed content grows", () => {
-    const { methods, result, scrollElement, setLocation, setScrollHeight } =
-      setupAutoScroll();
+  describe("detaching", () => {
+    it("detaches on a native upward scroll", () => {
+      const harness = setupAutoScroll();
 
-    act(() => {
-      scrollElement.scrollTop = 400;
-      setLocation(makeScrollLocation({ bottomOffset: 100, isAtBottom: false }));
-      scrollElement.dispatchEvent(new Event("scroll"));
-    });
-    expect(result.current.isAutoScrollEnabledRef.current).toBe(false);
+      detach(harness);
 
-    act(() => {
-      scrollElement.dispatchEvent(new WheelEvent("wheel", { deltaY: 100 }));
-      setScrollHeight(1100);
-      scrollElement.scrollTop = 600;
-      setLocation(
-        makeScrollLocation({
-          bottomOffset: 0,
-          isAtBottom: true,
-          scrollHeight: 1100,
-        })
-      );
-      scrollElement.dispatchEvent(new Event("scroll"));
+      expect(harness.methods.cancelSmoothScroll).toHaveBeenCalledOnce();
     });
 
-    expect(result.current.isAutoScrollEnabledRef.current).toBe(true);
-    expect(methods.scrollToItem).toHaveBeenCalledWith({
-      index: "LAST",
-      align: "end",
-      behavior: "instant",
+    it("ignores an upward scroll caused entirely by list height compensation", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchScroll({
+        scrollTop: 400,
+        scrollHeight: 900,
+        location: { bottomOffset: 100, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.methods.cancelSmoothScroll).not.toHaveBeenCalled();
+    });
+
+    it("detaches when upward movement exceeds the concurrent height change", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchScroll({
+        scrollTop: 350,
+        scrollHeight: 900,
+        location: { bottomOffset: 150, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+    });
+
+    it("honors an upward wheel gesture despite a positive net scroll", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchWheel(-20);
+      harness.dispatchScroll({
+        scrollTop: 520,
+        location: { bottomOffset: 20, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
+    it("ignores pinch-zoom and zero-delta wheel events", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchWheel(-20, true);
+      harness.dispatchWheel(0);
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.methods.cancelSmoothScroll).not.toHaveBeenCalled();
+    });
+
+    it("detaches when a touch gesture moves toward earlier content", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchTouch(100, 120);
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+    });
+
+    it("uses window scroll events on mobile", () => {
+      const harness = setupAutoScroll({ isMobile: true });
+      const update = {
+        scrollTop: 400,
+        location: { bottomOffset: 100, isAtBottom: false },
+      };
+
+      harness.dispatchScroll(update, harness.scrollElement);
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+
+      harness.dispatchScroll(update, window);
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
     });
   });
 
-  it("detaches on an upward wheel gesture despite a positive net scroll", () => {
-    const { methods, result, scrollElement, setLocation } = setupAutoScroll();
+  describe("reattaching", () => {
+    it("reattaches when a wheel gesture reaches the bottom while content grows", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
 
-    act(() => {
-      scrollElement.dispatchEvent(new WheelEvent("wheel", { deltaY: -20 }));
-      scrollElement.scrollTop = 520;
-      setLocation(makeScrollLocation({ bottomOffset: 20, isAtBottom: false }));
-      scrollElement.dispatchEvent(new Event("scroll"));
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 600,
+        scrollHeight: 1100,
+        location: { bottomOffset: 0, isAtBottom: true },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.methods.scrollToItem).toHaveBeenCalledWith({
+        index: "LAST",
+        align: "end",
+        behavior: "instant",
+      });
     });
 
-    expect(result.current.isAutoScrollEnabledRef.current).toBe(false);
-    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
-    expect(methods.scrollToItem).not.toHaveBeenCalled();
+    it("reattaches after a mobile touch gesture while content grows", () => {
+      const harness = setupAutoScroll({ isMobile: true });
+      harness.dispatchTouch(100, 120);
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+
+      harness.dispatchTouch(120, 100);
+      harness.dispatchScroll({
+        scrollTop: 600,
+        scrollHeight: 1100,
+        location: { bottomOffset: 0, isAtBottom: true },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.methods.scrollToItem).toHaveBeenCalledOnce();
+    });
+
+    it("reattaches after a stable native downward scroll", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchScroll({
+        scrollTop: 450,
+        location: { bottomOffset: 20, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.methods.scrollToItem).toHaveBeenCalledOnce();
+    });
+
+    it("reattaches at the sticky footer boundary", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 450,
+        location: { bottomOffset: 80, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+    });
+
+    it("stays detached just outside the sticky footer boundary", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 450,
+        location: { bottomOffset: 81, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
+    it("does not treat content growth as downward user movement", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchScroll({
+        scrollTop: 500,
+        scrollHeight: 1100,
+        location: { bottomOffset: 20, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
+    it("does not reuse a downward gesture after its scroll event", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 450,
+        location: { bottomOffset: 200, isAtBottom: false },
+      });
+      harness.dispatchScroll({
+        scrollTop: 550,
+        scrollHeight: 1100,
+        location: { bottomOffset: 20, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
+    it("can be explicitly re-enabled for a new message", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      act(() => harness.result.current.enableAutoScroll());
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+  });
+
+  it("removes gesture listeners when unmounted", () => {
+    const harness = setupAutoScroll();
+
+    harness.unmount();
+    harness.dispatchWheel(-20);
+
+    expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+    expect(harness.methods.cancelSmoothScroll).not.toHaveBeenCalled();
   });
 });

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -331,7 +331,7 @@ describe("useConversationAutoScroll", () => {
       harness.dispatchScroll({
         scrollTop: 600,
         scrollHeight: 1100,
-        location: { bottomOffset: 0, isAtBottom: true },
+        location: { bottomOffset: 200, isAtBottom: false },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
@@ -371,7 +371,7 @@ describe("useConversationAutoScroll", () => {
 
       harness.dispatchScroll({
         scrollTop: 450,
-        location: { bottomOffset: 80, isAtBottom: false },
+        location: { bottomOffset: 200, isAtBottom: false },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
@@ -399,23 +399,6 @@ describe("useConversationAutoScroll", () => {
       harness.dispatchScroll({
         scrollTop: 419,
         location: { bottomOffset: 81, isAtBottom: false },
-      });
-
-      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
-      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
-    });
-
-    it("uses Virtuoso's bottom offset instead of the document geometry", () => {
-      const harness = setupAutoScroll();
-      detach(harness);
-
-      harness.dispatchWheel(100);
-      harness.dispatchScroll({
-        // The raw DOM geometry says this is the bottom (1100 - 600 - 500),
-        // while Virtuoso still has 200px of list content below the viewport.
-        scrollTop: 600,
-        scrollHeight: 1100,
-        location: { bottomOffset: 200, isAtBottom: false },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
@@ -495,6 +478,41 @@ describe("useConversationAutoScroll", () => {
   });
 
   describe("tracking user scroll activity", () => {
+    it("ignores scrollend before a wheel gesture produces a scroll event", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchWheel(-100);
+      harness.dispatchScrollEnd();
+
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+      harness.dispatchScrollEnd();
+
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
+    });
+
+    it("ignores scrollend while a touch gesture is still active", () => {
+      const harness = setupAutoScroll({ isMobile: true });
+
+      harness.dispatchTouch(100, 120);
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+      harness.dispatchScrollEnd();
+
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+
+      harness.dispatchTouchEnd();
+      harness.dispatchScrollEnd();
+
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
+    });
+
     it("ends a wheel gesture on native scrollend", () => {
       const harness = setupAutoScroll();
 
@@ -548,12 +566,20 @@ describe("useConversationAutoScroll", () => {
         harness.result.current.userScrollActivity.subscribeToEnd(onScrollEnd);
 
       harness.dispatchWheel(-100);
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
       harness.dispatchScrollEnd();
 
       expect(onScrollEnd).toHaveBeenCalledOnce();
 
       unsubscribe();
       harness.dispatchWheel(-100);
+      harness.dispatchScroll({
+        scrollTop: 300,
+        location: { bottomOffset: 600, isAtBottom: false },
+      });
       harness.dispatchScrollEnd();
       expect(onScrollEnd).toHaveBeenCalledOnce();
     });

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -97,6 +97,16 @@ function setupAutoScroll({ isMobile = false } = {}) {
     });
   };
 
+  const updateLayout = ({
+    scrollTop,
+    scrollHeight: nextScrollHeight = scrollHeight,
+  }: ScrollUpdate) => {
+    act(() => {
+      scrollHeight = nextScrollHeight;
+      scrollElement.scrollTop = scrollTop;
+    });
+  };
+
   const makeTouch = (clientY: number): Touch => ({
     clientX: 0,
     clientY,
@@ -130,6 +140,7 @@ function setupAutoScroll({ isMobile = false } = {}) {
     dispatchWheel,
     methods,
     scrollElement,
+    updateLayout,
   };
 }
 
@@ -352,6 +363,73 @@ describe("useConversationAutoScroll", () => {
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
       expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("holding the detached position", () => {
+    it("removes streamed row growth from Virtuoso's scroll compensation", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchWheel(-100);
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+      harness.dispatchScroll({
+        scrollTop: 460,
+        scrollHeight: 1060,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+
+      expect(harness.scrollElement.scrollTop).toBe(400);
+    });
+
+    it("preserves upward movement concurrent with streamed row growth", () => {
+      const harness = setupAutoScroll();
+
+      harness.dispatchWheel(-100);
+      harness.dispatchScroll({
+        scrollTop: 400,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+      // Virtuoso moved down by 60px while the user moved up by 30px, leaving
+      // a positive net delta of 30px.
+      harness.dispatchScroll({
+        scrollTop: 430,
+        scrollHeight: 1060,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+
+      expect(harness.scrollElement.scrollTop).toBe(370);
+    });
+
+    it("uses the current height baseline for a later upward gesture", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.updateLayout({ scrollTop: 400, scrollHeight: 1060 });
+      harness.dispatchWheel(-50);
+      harness.dispatchScroll({
+        scrollTop: 350,
+        scrollHeight: 1060,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+
+      expect(harness.scrollElement.scrollTop).toBe(350);
+    });
+
+    it("does not correct the native scroll event that first detaches", () => {
+      const harness = setupAutoScroll();
+
+      harness.updateLayout({ scrollTop: 500, scrollHeight: 1060 });
+      harness.dispatchScroll({
+        scrollTop: 450,
+        scrollHeight: 1060,
+        location: { bottomOffset: 500, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.scrollElement.scrollTop).toBe(450);
     });
   });
 

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -331,7 +331,7 @@ describe("useConversationAutoScroll", () => {
       harness.dispatchScroll({
         scrollTop: 600,
         scrollHeight: 1100,
-        location: { bottomOffset: 200, isAtBottom: false },
+        location: { bottomOffset: 0, isAtBottom: true },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
@@ -371,7 +371,7 @@ describe("useConversationAutoScroll", () => {
 
       harness.dispatchScroll({
         scrollTop: 450,
-        location: { bottomOffset: 200, isAtBottom: false },
+        location: { bottomOffset: 80, isAtBottom: false },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
@@ -403,6 +403,45 @@ describe("useConversationAutoScroll", () => {
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
       expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
+    it("uses Virtuoso's bottom offset instead of the document geometry", () => {
+      const harness = setupAutoScroll();
+      detach(harness);
+
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        // The raw DOM geometry says this is the bottom (1100 - 600 - 500),
+        // while Virtuoso still has 200px of list content below the viewport.
+        scrollTop: 600,
+        scrollHeight: 1100,
+        location: { bottomOffset: 200, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
+    });
+
+    it("keeps content buffered until a reattaching gesture actually ends", () => {
+      const harness = setupAutoScroll();
+      const onScrollEnd = vi.fn();
+      harness.result.current.userScrollActivity.subscribeToEnd(onScrollEnd);
+      detach(harness);
+
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 420,
+        location: { bottomOffset: 80, isAtBottom: false },
+      });
+
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+      expect(onScrollEnd).not.toHaveBeenCalled();
+
+      harness.dispatchScrollEnd();
+
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
+      expect(onScrollEnd).toHaveBeenCalledOnce();
     });
 
     it("does not treat content growth as downward user movement", () => {
@@ -443,8 +482,9 @@ describe("useConversationAutoScroll", () => {
     it("can be explicitly re-enabled for a new message", () => {
       const harness = setupAutoScroll();
       detach(harness);
+      harness.dispatchScrollEnd();
 
-      expect(harness.result.current.userScrollActivity.isActive()).toBe(true);
+      expect(harness.result.current.userScrollActivity.isActive()).toBe(false);
 
       act(() => harness.result.current.enableAutoScroll());
 

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -203,6 +203,10 @@ describe("useConversationAutoScroll", () => {
         scrollTop: 520,
         location: { bottomOffset: 20, isAtBottom: false },
       });
+      harness.dispatchScroll({
+        scrollTop: 530,
+        location: { bottomOffset: 0, isAtBottom: true },
+      });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
       expect(harness.methods.cancelSmoothScroll).toHaveBeenCalledOnce();
@@ -252,7 +256,7 @@ describe("useConversationAutoScroll", () => {
       harness.dispatchScroll({
         scrollTop: 600,
         scrollHeight: 1100,
-        location: { bottomOffset: 0, isAtBottom: true },
+        location: { bottomOffset: 200, isAtBottom: false },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
@@ -279,13 +283,20 @@ describe("useConversationAutoScroll", () => {
       expect(harness.methods.scrollToItem).toHaveBeenCalledOnce();
     });
 
-    it("reattaches after a stable native downward scroll", () => {
+    it("keeps a downward gesture until a later scroll event reaches the bottom", () => {
       const harness = setupAutoScroll();
       detach(harness);
 
+      harness.dispatchWheel(100);
+      harness.dispatchScroll({
+        scrollTop: 410,
+        location: { bottomOffset: 200, isAtBottom: false },
+      });
+      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
+
       harness.dispatchScroll({
         scrollTop: 450,
-        location: { bottomOffset: 20, isAtBottom: false },
+        location: { bottomOffset: 200, isAtBottom: false },
       });
 
       expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(true);
@@ -298,7 +309,7 @@ describe("useConversationAutoScroll", () => {
 
       harness.dispatchWheel(100);
       harness.dispatchScroll({
-        scrollTop: 450,
+        scrollTop: 420,
         location: { bottomOffset: 80, isAtBottom: false },
       });
 
@@ -311,7 +322,7 @@ describe("useConversationAutoScroll", () => {
 
       harness.dispatchWheel(100);
       harness.dispatchScroll({
-        scrollTop: 450,
+        scrollTop: 419,
         location: { bottomOffset: 81, isAtBottom: false },
       });
 
@@ -324,26 +335,7 @@ describe("useConversationAutoScroll", () => {
       detach(harness);
 
       harness.dispatchScroll({
-        scrollTop: 500,
-        scrollHeight: 1100,
-        location: { bottomOffset: 20, isAtBottom: false },
-      });
-
-      expect(harness.result.current.isAutoScrollEnabledRef.current).toBe(false);
-      expect(harness.methods.scrollToItem).not.toHaveBeenCalled();
-    });
-
-    it("does not reuse a downward gesture after its scroll event", () => {
-      const harness = setupAutoScroll();
-      detach(harness);
-
-      harness.dispatchWheel(100);
-      harness.dispatchScroll({
-        scrollTop: 450,
-        location: { bottomOffset: 200, isAtBottom: false },
-      });
-      harness.dispatchScroll({
-        scrollTop: 550,
+        scrollTop: 520,
         scrollHeight: 1100,
         location: { bottomOffset: 20, isAtBottom: false },
       });

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -1,0 +1,108 @@
+import { useConversationAutoScroll } from "@app/components/assistant/conversation/useConversationAutoScroll";
+import { act, renderHook } from "@testing-library/react";
+import type { ListScrollLocation } from "@virtuoso.dev/message-list";
+import { describe, expect, it, vi } from "vitest";
+
+type ScrollMethods = NonNullable<
+  Parameters<typeof useConversationAutoScroll>[0]["messageListRef"]["current"]
+>;
+
+function makeScrollLocation(
+  overrides: Partial<ListScrollLocation> = {}
+): ListScrollLocation {
+  return {
+    listOffset: -500,
+    visibleListHeight: 420,
+    scrollHeight: 1000,
+    bottomOffset: 0,
+    isAtBottom: true,
+    lastVisibleItemIndex: 1,
+    lastItemBottomOffset: 0,
+    ...overrides,
+  };
+}
+
+function setupAutoScroll() {
+  const scrollElement = document.createElement("div");
+  let scrollHeight = 1000;
+  let location = makeScrollLocation();
+
+  Object.defineProperties(scrollElement, {
+    clientHeight: { configurable: true, value: 500 },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+  });
+  scrollElement.scrollTop = 500;
+
+  const methods: ScrollMethods = {
+    cancelSmoothScroll: vi.fn(),
+    getScrollLocation: () => location,
+    scrollerElement: () => scrollElement,
+    scrollToItem: vi.fn(),
+  };
+  const messageListRef = { current: methods };
+  const hook = renderHook(() =>
+    useConversationAutoScroll({ isMobile: false, messageListRef })
+  );
+
+  return {
+    ...hook,
+    methods,
+    scrollElement,
+    setLocation: (nextLocation: ListScrollLocation) => {
+      location = nextLocation;
+    },
+    setScrollHeight: (nextScrollHeight: number) => {
+      scrollHeight = nextScrollHeight;
+    },
+  };
+}
+
+describe("useConversationAutoScroll", () => {
+  it("reattaches when the user scrolls down while streamed content grows", () => {
+    const { methods, result, scrollElement, setLocation, setScrollHeight } =
+      setupAutoScroll();
+
+    act(() => {
+      scrollElement.scrollTop = 400;
+      setLocation(makeScrollLocation({ bottomOffset: 100, isAtBottom: false }));
+      scrollElement.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.isAutoScrollEnabledRef.current).toBe(false);
+
+    act(() => {
+      scrollElement.dispatchEvent(new WheelEvent("wheel", { deltaY: 100 }));
+      setScrollHeight(1100);
+      scrollElement.scrollTop = 600;
+      setLocation(
+        makeScrollLocation({
+          bottomOffset: 0,
+          isAtBottom: true,
+          scrollHeight: 1100,
+        })
+      );
+      scrollElement.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current.isAutoScrollEnabledRef.current).toBe(true);
+    expect(methods.scrollToItem).toHaveBeenCalledWith({
+      index: "LAST",
+      align: "end",
+      behavior: "instant",
+    });
+  });
+
+  it("detaches on an upward wheel gesture despite a positive net scroll", () => {
+    const { methods, result, scrollElement, setLocation } = setupAutoScroll();
+
+    act(() => {
+      scrollElement.dispatchEvent(new WheelEvent("wheel", { deltaY: -20 }));
+      scrollElement.scrollTop = 520;
+      setLocation(makeScrollLocation({ bottomOffset: 20, isAtBottom: false }));
+      scrollElement.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current.isAutoScrollEnabledRef.current).toBe(false);
+    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+    expect(methods.scrollToItem).not.toHaveBeenCalled();
+  });
+});

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -6,12 +6,19 @@ import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useRef } from "react";
 
+type ConversationAutoScrollMethods = Pick<
+  VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>,
+  | "cancelSmoothScroll"
+  | "getScrollLocation"
+  | "scrollerElement"
+  | "scrollToItem"
+>;
+
+type UserScrollDirection = "up" | "down";
+
 interface UseConversationAutoScrollProps {
   isMobile: boolean;
-  messageListRef: RefObject<VirtuosoMessageListMethods<
-    VirtuosoMessage,
-    VirtuosoMessageListContext
-  > | null>;
+  messageListRef: RefObject<ConversationAutoScrollMethods | null>;
 }
 
 export function useConversationAutoScroll({
@@ -23,8 +30,8 @@ export function useConversationAutoScroll({
     isAutoScrollEnabledRef.current = true;
   }, []);
 
-  // Compare native scroll movement with list height changes so Virtuoso's row
-  // remeasurement is not mistaken for user scroll intent.
+  // Track gestures separately from their resulting scroll movement so
+  // Virtuoso's concurrent movement cannot hide the user's direction.
   useEffect(() => {
     const methods = messageListRef.current;
     const scrollElement = isMobile
@@ -38,6 +45,7 @@ export function useConversationAutoScroll({
     let previousScrollHeight = scrollElement.scrollHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let lastTouchY: number | null = null;
+    let pendingUserScrollDirection: UserScrollDirection | null = null;
 
     const captureScrollPosition = () => {
       previousScrollHeight = scrollElement.scrollHeight;
@@ -80,13 +88,18 @@ export function useConversationAutoScroll({
       );
       const isNearBottom =
         location.isAtBottom || location.bottomOffset <= stickyFooterHeight;
+      const isUserScrollingDown =
+        pendingUserScrollDirection === "down" ||
+        (pendingUserScrollDirection === null &&
+          scrollTopDelta > 0 &&
+          scrollHeightDelta === 0);
 
       // The sticky input bar hides the last part of the viewport. Reattach on
-      // downward user movement into that area, but ignore list height changes.
+      // downward user movement into that area. Gesture direction takes
+      // precedence over deltas that may also include list height changes.
       if (
         !isAutoScrollEnabledRef.current &&
-        scrollTopDelta > 0 &&
-        scrollHeightDelta === 0 &&
+        isUserScrollingDown &&
         isNearBottom
       ) {
         enableAutoScroll();
@@ -99,6 +112,18 @@ export function useConversationAutoScroll({
 
       previousScrollHeight = scrollHeight;
       previousScrollTop = scrollElement.scrollTop;
+      pendingUserScrollDirection = null;
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey || event.deltaY === 0) {
+        return;
+      }
+
+      pendingUserScrollDirection = event.deltaY < 0 ? "up" : "down";
+      if (pendingUserScrollDirection === "up") {
+        detachFromAutoScroll();
+      }
     };
 
     const onTouchStart = (event: TouchEvent) => {
@@ -111,20 +136,23 @@ export function useConversationAutoScroll({
         return;
       }
 
-      if (lastTouchY !== null && touchY > lastTouchY) {
-        detachFromAutoScroll();
-      } else if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
+      if (lastTouchY !== null && touchY !== lastTouchY) {
+        pendingUserScrollDirection = touchY > lastTouchY ? "up" : "down";
+        if (pendingUserScrollDirection === "up") {
+          detachFromAutoScroll();
+        }
       }
       lastTouchY = touchY;
     };
 
     const passiveOptions = { passive: true };
     scrollTarget.addEventListener("scroll", onScroll, passiveOptions);
+    scrollElement.addEventListener("wheel", onWheel, passiveOptions);
     scrollElement.addEventListener("touchstart", onTouchStart, passiveOptions);
     scrollElement.addEventListener("touchmove", onTouchMove, passiveOptions);
     return () => {
       scrollTarget.removeEventListener("scroll", onScroll);
+      scrollElement.removeEventListener("wheel", onWheel);
       scrollElement.removeEventListener("touchstart", onTouchStart);
       scrollElement.removeEventListener("touchmove", onTouchMove);
     };

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -26,11 +26,13 @@ export function useConversationAutoScroll({
   messageListRef,
 }: UseConversationAutoScrollProps) {
   const isAutoScrollEnabledRef = useRef(true);
+  const lastUserScrollAtRef = useRef<number | null>(null);
   // A gesture can produce several scroll events. Keep its direction until the
   // user changes direction or auto-scroll is explicitly re-enabled.
   const userScrollDirectionRef = useRef<UserScrollDirection | null>(null);
   const enableAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = true;
+    lastUserScrollAtRef.current = null;
     userScrollDirectionRef.current = null;
   }, []);
 
@@ -64,7 +66,6 @@ export function useConversationAutoScroll({
     };
 
     const onScroll = () => {
-      const wasAutoScrollEnabled = isAutoScrollEnabledRef.current;
       const scrollHeight = scrollElement.scrollHeight;
       const scrollTop = scrollElement.scrollTop;
       const scrollHeightDelta = scrollHeight - previousScrollHeight;
@@ -74,6 +75,10 @@ export function useConversationAutoScroll({
         Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
       const location = methods.getScrollLocation();
 
+      if (userScrollDirectionRef.current !== null) {
+        lastUserScrollAtRef.current = Date.now();
+      }
+
       if (
         isAutoScrollEnabledRef.current &&
         scrollTopDelta < 0 &&
@@ -81,6 +86,7 @@ export function useConversationAutoScroll({
         !location.isAtBottom
       ) {
         userScrollDirectionRef.current = "up";
+        lastUserScrollAtRef.current = Date.now();
         detachFromAutoScroll();
       }
 
@@ -119,16 +125,6 @@ export function useConversationAutoScroll({
         });
       }
 
-      // Virtuoso preserves the bottom offset when a row grows during an active
-      // upward scroll. Remove that growth so it does not cancel user movement.
-      if (
-        !wasAutoScrollEnabled &&
-        userScrollDirectionRef.current === "up" &&
-        scrollHeightDelta > 0
-      ) {
-        scrollElement.scrollTop -= scrollHeightDelta;
-      }
-
       previousScrollHeight = scrollHeight;
       previousScrollTop = scrollElement.scrollTop;
     };
@@ -139,6 +135,7 @@ export function useConversationAutoScroll({
       }
 
       userScrollDirectionRef.current = event.deltaY < 0 ? "up" : "down";
+      lastUserScrollAtRef.current = Date.now();
       if (userScrollDirectionRef.current === "up") {
         detachFromAutoScroll();
       }
@@ -156,6 +153,7 @@ export function useConversationAutoScroll({
 
       if (lastTouchY !== null && touchY !== lastTouchY) {
         userScrollDirectionRef.current = touchY > lastTouchY ? "up" : "down";
+        lastUserScrollAtRef.current = Date.now();
         if (userScrollDirectionRef.current === "up") {
           detachFromAutoScroll();
         }
@@ -176,5 +174,9 @@ export function useConversationAutoScroll({
     };
   }, [enableAutoScroll, isMobile, messageListRef]);
 
-  return { enableAutoScroll, isAutoScrollEnabledRef };
+  return {
+    enableAutoScroll,
+    isAutoScrollEnabledRef,
+    lastUserScrollAtRef,
+  };
 }

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -26,8 +26,12 @@ export function useConversationAutoScroll({
   messageListRef,
 }: UseConversationAutoScrollProps) {
   const isAutoScrollEnabledRef = useRef(true);
+  // A gesture can produce several scroll events. Keep its direction until the
+  // user changes direction or auto-scroll is explicitly re-enabled.
+  const userScrollDirectionRef = useRef<UserScrollDirection | null>(null);
   const enableAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = true;
+    userScrollDirectionRef.current = null;
   }, []);
 
   // Track gestures separately from their resulting scroll movement so
@@ -45,7 +49,6 @@ export function useConversationAutoScroll({
     let previousScrollHeight = scrollElement.scrollHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let lastTouchY: number | null = null;
-    let pendingUserScrollDirection: UserScrollDirection | null = null;
 
     const captureScrollPosition = () => {
       previousScrollHeight = scrollElement.scrollHeight;
@@ -76,6 +79,7 @@ export function useConversationAutoScroll({
         !isHeightCompensation &&
         !location.isAtBottom
       ) {
+        userScrollDirectionRef.current = "up";
         detachFromAutoScroll();
       }
 
@@ -86,11 +90,15 @@ export function useConversationAutoScroll({
         0,
         viewportHeight - location.visibleListHeight
       );
+      const bottomOffset = Math.max(
+        0,
+        scrollHeight - scrollTop - viewportHeight
+      );
       const isNearBottom =
-        location.isAtBottom || location.bottomOffset <= stickyFooterHeight;
+        location.isAtBottom || bottomOffset <= stickyFooterHeight;
       const isUserScrollingDown =
-        pendingUserScrollDirection === "down" ||
-        (pendingUserScrollDirection === null &&
+        userScrollDirectionRef.current === "down" ||
+        (userScrollDirectionRef.current === null &&
           scrollTopDelta > 0 &&
           scrollHeightDelta === 0);
 
@@ -112,7 +120,6 @@ export function useConversationAutoScroll({
 
       previousScrollHeight = scrollHeight;
       previousScrollTop = scrollElement.scrollTop;
-      pendingUserScrollDirection = null;
     };
 
     const onWheel = (event: WheelEvent) => {
@@ -120,8 +127,8 @@ export function useConversationAutoScroll({
         return;
       }
 
-      pendingUserScrollDirection = event.deltaY < 0 ? "up" : "down";
-      if (pendingUserScrollDirection === "up") {
+      userScrollDirectionRef.current = event.deltaY < 0 ? "up" : "down";
+      if (userScrollDirectionRef.current === "up") {
         detachFromAutoScroll();
       }
     };
@@ -137,8 +144,8 @@ export function useConversationAutoScroll({
       }
 
       if (lastTouchY !== null && touchY !== lastTouchY) {
-        pendingUserScrollDirection = touchY > lastTouchY ? "up" : "down";
-        if (pendingUserScrollDirection === "up") {
+        userScrollDirectionRef.current = touchY > lastTouchY ? "up" : "down";
+        if (userScrollDirectionRef.current === "up") {
           detachFromAutoScroll();
         }
       }

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -19,11 +19,8 @@ export function useConversationAutoScroll({
   messageListRef,
 }: UseConversationAutoScrollProps) {
   const isAutoScrollEnabledRef = useRef(true);
-  const hasLeftBottomRef = useRef(false);
-
   const enableAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = true;
-    hasLeftBottomRef.current = false;
   }, []);
 
   // Virtuoso's public onScroll fires before its row-height compensation, so a
@@ -52,7 +49,6 @@ export function useConversationAutoScroll({
       captureScrollPosition();
       if (isAutoScrollEnabledRef.current) {
         isAutoScrollEnabledRef.current = false;
-        hasLeftBottomRef.current = false;
         methods.cancelSmoothScroll();
       }
     };
@@ -78,26 +74,42 @@ export function useConversationAutoScroll({
       const isHeightCompensation =
         scrollHeightDelta !== 0 &&
         Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
-      const isAtBottom = methods.getScrollLocation().isAtBottom;
+      const location = methods.getScrollLocation();
 
       if (
         isAutoScrollEnabledRef.current &&
         scrollTopDelta < 0 &&
         !isHeightCompensation &&
-        !isAtBottom
+        !location.isAtBottom
       ) {
         detachFromAutoScroll();
-        hasLeftBottomRef.current = true;
       }
 
-      // Reattach before correcting concurrent height compensation. Otherwise
-      // the correction can move the viewport away from the bottom again.
-      if (!isAutoScrollEnabledRef.current) {
-        if (!isAtBottom) {
-          hasLeftBottomRef.current = true;
-        } else if (hasLeftBottomRef.current) {
-          enableAutoScroll();
-        }
+      const viewportHeight = isMobile
+        ? window.innerHeight
+        : scrollElement.clientHeight;
+      const stickyFooterHeight = Math.max(
+        0,
+        viewportHeight - location.visibleListHeight
+      );
+      const isNearBottom =
+        location.isAtBottom || location.bottomOffset <= stickyFooterHeight;
+
+      // The sticky input bar hides the last part of the viewport. Reattach as
+      // soon as the user scrolls back down into that area, rather than making
+      // them catch a moving 4px target while the answer keeps growing.
+      if (
+        !isAutoScrollEnabledRef.current &&
+        scrollTopDelta > 0 &&
+        !isHeightCompensation &&
+        isNearBottom
+      ) {
+        enableAutoScroll();
+        methods.scrollToItem({
+          index: "LAST",
+          align: "end",
+          behavior: "instant",
+        });
       }
 
       if (!isAutoScrollEnabledRef.current && isHeightCompensation) {

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -1,0 +1,177 @@
+import type {
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+import type {
+  ListScrollLocation,
+  VirtuosoMessageListMethods,
+} from "@virtuoso.dev/message-list";
+import type { RefObject } from "react";
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseConversationAutoScrollProps {
+  isMobile: boolean;
+  messageListRef: RefObject<VirtuosoMessageListMethods<
+    VirtuosoMessage,
+    VirtuosoMessageListContext
+  > | null>;
+}
+
+export function useConversationAutoScroll({
+  isMobile,
+  messageListRef,
+}: UseConversationAutoScrollProps) {
+  const isAutoScrollEnabledRef = useRef(true);
+  const hasLeftBottomSinceDetachRef = useRef(false);
+
+  const enableAutoScroll = useCallback(() => {
+    isAutoScrollEnabledRef.current = true;
+    hasLeftBottomSinceDetachRef.current = false;
+  }, []);
+
+  const handleScroll = useCallback(
+    (location: Pick<ListScrollLocation, "isAtBottom">) => {
+      if (isAutoScrollEnabledRef.current) {
+        return;
+      }
+
+      if (!location.isAtBottom) {
+        hasLeftBottomSinceDetachRef.current = true;
+      } else if (hasLeftBottomSinceDetachRef.current) {
+        enableAutoScroll();
+      }
+    },
+    [enableAutoScroll]
+  );
+
+  // While the list's scroll direction is "up", Virtuoso compensates row-height
+  // growth by adding the same delta to scrollTop. Streaming markdown can keep
+  // that compensation alive indefinitely. A native listener recognizes those
+  // matching deltas and restores the detached position before the next paint.
+  useEffect(() => {
+    const scrollElement = isMobile
+      ? document.scrollingElement
+      : messageListRef.current?.scrollerElement();
+    if (!(scrollElement instanceof HTMLElement)) {
+      return;
+    }
+
+    const scrollTarget = isMobile ? window : scrollElement;
+    const listElement =
+      messageListRef.current?.scrollerElement()?.firstElementChild;
+    let previousScrollHeight = scrollElement.scrollHeight;
+    let previousScrollTop = scrollElement.scrollTop;
+    let lastTouchY: number | null = null;
+
+    const captureScrollPosition = () => {
+      previousScrollHeight = scrollElement.scrollHeight;
+      previousScrollTop = scrollElement.scrollTop;
+    };
+
+    const detachFromAutoScroll = () => {
+      captureScrollPosition();
+      if (!isAutoScrollEnabledRef.current) {
+        return;
+      }
+
+      isAutoScrollEnabledRef.current = false;
+      hasLeftBottomSinceDetachRef.current = false;
+      messageListRef.current?.cancelSmoothScroll();
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Keep the height baseline current when the list grows without moving.
+      // If scrollTop changed, the scroll listener still needs the old values
+      // to recognize and undo Virtuoso's height compensation.
+      if (
+        !isAutoScrollEnabledRef.current &&
+        scrollElement.scrollTop === previousScrollTop
+      ) {
+        captureScrollPosition();
+      }
+    });
+    if (listElement) {
+      resizeObserver.observe(listElement);
+    }
+
+    const preserveDetachedScrollPosition = () => {
+      const scrollHeight = scrollElement.scrollHeight;
+      let scrollTop = scrollElement.scrollTop;
+      const scrollHeightDelta = scrollHeight - previousScrollHeight;
+      const scrollTopDelta = scrollTop - previousScrollTop;
+      const isHeightCompensation =
+        scrollHeightDelta !== 0 &&
+        Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
+
+      if (
+        isAutoScrollEnabledRef.current &&
+        scrollTopDelta < 0 &&
+        !isHeightCompensation &&
+        messageListRef.current?.getScrollLocation().isAtBottom === false
+      ) {
+        isAutoScrollEnabledRef.current = false;
+        hasLeftBottomSinceDetachRef.current = true;
+        messageListRef.current?.cancelSmoothScroll();
+      }
+
+      if (!isAutoScrollEnabledRef.current && isHeightCompensation) {
+        scrollElement.scrollTop -= scrollTopDelta;
+        scrollTop = scrollElement.scrollTop;
+      }
+
+      previousScrollHeight = scrollHeight;
+      previousScrollTop = scrollTop;
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) {
+        return;
+      }
+
+      if (event.deltaY < 0) {
+        detachFromAutoScroll();
+      } else if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
+      }
+    };
+
+    const onTouchStart = (event: TouchEvent) => {
+      lastTouchY = event.touches[0]?.clientY ?? null;
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      const touchY = event.touches[0]?.clientY;
+      if (touchY === undefined) {
+        return;
+      }
+
+      if (lastTouchY !== null && touchY > lastTouchY) {
+        detachFromAutoScroll();
+      } else if (!isAutoScrollEnabledRef.current) {
+        captureScrollPosition();
+      }
+      lastTouchY = touchY;
+    };
+
+    scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
+      passive: true,
+    });
+    scrollElement.addEventListener("wheel", onWheel, { passive: true });
+    scrollElement.addEventListener("touchstart", onTouchStart, {
+      passive: true,
+    });
+    scrollElement.addEventListener("touchmove", onTouchMove, { passive: true });
+    return () => {
+      resizeObserver.disconnect();
+      scrollTarget.removeEventListener(
+        "scroll",
+        preserveDetachedScrollPosition
+      );
+      scrollElement.removeEventListener("wheel", onWheel);
+      scrollElement.removeEventListener("touchstart", onTouchStart);
+      scrollElement.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [isMobile, messageListRef]);
+
+  return { enableAutoScroll, handleScroll, isAutoScrollEnabledRef };
+}

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -2,10 +2,7 @@ import type {
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
-import type {
-  ListScrollLocation,
-  VirtuosoMessageListMethods,
-} from "@virtuoso.dev/message-list";
+import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -28,21 +25,6 @@ export function useConversationAutoScroll({
     isAutoScrollEnabledRef.current = true;
     hasLeftBottomSinceDetachRef.current = false;
   }, []);
-
-  const handleScroll = useCallback(
-    (location: Pick<ListScrollLocation, "isAtBottom">) => {
-      if (isAutoScrollEnabledRef.current) {
-        return;
-      }
-
-      if (!location.isAtBottom) {
-        hasLeftBottomSinceDetachRef.current = true;
-      } else if (hasLeftBottomSinceDetachRef.current) {
-        enableAutoScroll();
-      }
-    },
-    [enableAutoScroll]
-  );
 
   // While the list's scroll direction is "up", Virtuoso compensates row-height
   // growth by adding the same delta to scrollTop. Streaming markdown can keep
@@ -102,16 +84,28 @@ export function useConversationAutoScroll({
       const isHeightCompensation =
         scrollHeightDelta !== 0 &&
         Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
+      const isAtBottom =
+        messageListRef.current?.getScrollLocation().isAtBottom === true;
 
       if (
         isAutoScrollEnabledRef.current &&
         scrollTopDelta < 0 &&
         !isHeightCompensation &&
-        messageListRef.current?.getScrollLocation().isAtBottom === false
+        !isAtBottom
       ) {
         isAutoScrollEnabledRef.current = false;
         hasLeftBottomSinceDetachRef.current = true;
         messageListRef.current?.cancelSmoothScroll();
+      }
+
+      // Reattach before correcting concurrent height compensation. Otherwise
+      // the correction can move the viewport away from the bottom again.
+      if (!isAutoScrollEnabledRef.current) {
+        if (!isAtBottom) {
+          hasLeftBottomSinceDetachRef.current = true;
+        } else if (hasLeftBottomSinceDetachRef.current) {
+          enableAutoScroll();
+        }
       }
 
       if (!isAutoScrollEnabledRef.current && isHeightCompensation) {
@@ -157,7 +151,7 @@ export function useConversationAutoScroll({
       scrollElement.removeEventListener("touchstart", onTouchStart);
       scrollElement.removeEventListener("touchmove", onTouchMove);
     };
-  }, [isMobile, messageListRef]);
+  }, [enableAutoScroll, isMobile, messageListRef]);
 
-  return { enableAutoScroll, handleScroll, isAutoScrollEnabledRef };
+  return { enableAutoScroll, isAutoScrollEnabledRef };
 }

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -61,8 +61,7 @@ export function useConversationAutoScroll({
   const enableAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = true;
     userScrollDirectionRef.current = null;
-    finishUserScroll();
-  }, [finishUserScroll]);
+  }, []);
 
   // Track gestures separately from their resulting scroll movement so
   // Virtuoso's concurrent movement cannot hide the user's direction.
@@ -200,12 +199,8 @@ export function useConversationAutoScroll({
         0,
         viewportHeight - location.visibleListHeight
       );
-      const bottomOffset = Math.max(
-        0,
-        scrollHeight - scrollTop - viewportHeight
-      );
       const isNearBottom =
-        location.isAtBottom || bottomOffset <= stickyFooterHeight;
+        location.isAtBottom || location.bottomOffset <= stickyFooterHeight;
       const isUserScrollingDown =
         userScrollDirectionRef.current === "down" ||
         (userScrollDirectionRef.current === null &&

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -19,28 +19,26 @@ export function useConversationAutoScroll({
   messageListRef,
 }: UseConversationAutoScrollProps) {
   const isAutoScrollEnabledRef = useRef(true);
-  const hasLeftBottomSinceDetachRef = useRef(false);
+  const hasLeftBottomRef = useRef(false);
 
   const enableAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = true;
-    hasLeftBottomSinceDetachRef.current = false;
+    hasLeftBottomRef.current = false;
   }, []);
 
-  // While the list's scroll direction is "up", Virtuoso compensates row-height
-  // growth by adding the same delta to scrollTop. Streaming markdown can keep
-  // that compensation alive indefinitely. A native listener recognizes those
-  // matching deltas and restores the detached position before the next paint.
+  // Virtuoso's public onScroll fires before its row-height compensation, so a
+  // native listener restores the detached position after Virtuoso updates it.
   useEffect(() => {
+    const methods = messageListRef.current;
     const scrollElement = isMobile
       ? document.scrollingElement
-      : messageListRef.current?.scrollerElement();
-    if (!(scrollElement instanceof HTMLElement)) {
+      : methods?.scrollerElement();
+    if (!methods || !(scrollElement instanceof HTMLElement)) {
       return;
     }
 
     const scrollTarget = isMobile ? window : scrollElement;
-    const listElement =
-      messageListRef.current?.scrollerElement()?.firstElementChild;
+    const listElement = methods.scrollerElement()?.firstElementChild;
     let previousScrollHeight = scrollElement.scrollHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let lastTouchY: number | null = null;
@@ -52,40 +50,35 @@ export function useConversationAutoScroll({
 
     const detachFromAutoScroll = () => {
       captureScrollPosition();
-      if (!isAutoScrollEnabledRef.current) {
-        return;
+      if (isAutoScrollEnabledRef.current) {
+        isAutoScrollEnabledRef.current = false;
+        hasLeftBottomRef.current = false;
+        methods.cancelSmoothScroll();
       }
-
-      isAutoScrollEnabledRef.current = false;
-      hasLeftBottomSinceDetachRef.current = false;
-      messageListRef.current?.cancelSmoothScroll();
     };
 
     const resizeObserver = new ResizeObserver(() => {
-      // Keep the height baseline current when the list grows without moving.
-      // If scrollTop changed, the scroll listener still needs the old values
-      // to recognize and undo Virtuoso's height compensation.
+      // Advance the height baseline when content grows without scrolling.
       if (
         !isAutoScrollEnabledRef.current &&
         scrollElement.scrollTop === previousScrollTop
       ) {
-        captureScrollPosition();
+        previousScrollHeight = scrollElement.scrollHeight;
       }
     });
     if (listElement) {
       resizeObserver.observe(listElement);
     }
 
-    const preserveDetachedScrollPosition = () => {
+    const onScroll = () => {
       const scrollHeight = scrollElement.scrollHeight;
-      let scrollTop = scrollElement.scrollTop;
+      const scrollTop = scrollElement.scrollTop;
       const scrollHeightDelta = scrollHeight - previousScrollHeight;
       const scrollTopDelta = scrollTop - previousScrollTop;
       const isHeightCompensation =
         scrollHeightDelta !== 0 &&
         Math.abs(scrollTopDelta - scrollHeightDelta) <= 1;
-      const isAtBottom =
-        messageListRef.current?.getScrollLocation().isAtBottom === true;
+      const isAtBottom = methods.getScrollLocation().isAtBottom;
 
       if (
         isAutoScrollEnabledRef.current &&
@@ -93,28 +86,26 @@ export function useConversationAutoScroll({
         !isHeightCompensation &&
         !isAtBottom
       ) {
-        isAutoScrollEnabledRef.current = false;
-        hasLeftBottomSinceDetachRef.current = true;
-        messageListRef.current?.cancelSmoothScroll();
+        detachFromAutoScroll();
+        hasLeftBottomRef.current = true;
       }
 
       // Reattach before correcting concurrent height compensation. Otherwise
       // the correction can move the viewport away from the bottom again.
       if (!isAutoScrollEnabledRef.current) {
         if (!isAtBottom) {
-          hasLeftBottomSinceDetachRef.current = true;
-        } else if (hasLeftBottomSinceDetachRef.current) {
+          hasLeftBottomRef.current = true;
+        } else if (hasLeftBottomRef.current) {
           enableAutoScroll();
         }
       }
 
       if (!isAutoScrollEnabledRef.current && isHeightCompensation) {
-        scrollElement.scrollTop -= scrollTopDelta;
-        scrollTop = scrollElement.scrollTop;
+        scrollElement.scrollTop = previousScrollTop;
       }
 
       previousScrollHeight = scrollHeight;
-      previousScrollTop = scrollTop;
+      previousScrollTop = scrollElement.scrollTop;
     };
 
     const onTouchStart = (event: TouchEvent) => {
@@ -135,19 +126,13 @@ export function useConversationAutoScroll({
       lastTouchY = touchY;
     };
 
-    scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
-      passive: true,
-    });
-    scrollElement.addEventListener("touchstart", onTouchStart, {
-      passive: true,
-    });
-    scrollElement.addEventListener("touchmove", onTouchMove, { passive: true });
+    const passiveOptions = { passive: true };
+    scrollTarget.addEventListener("scroll", onScroll, passiveOptions);
+    scrollElement.addEventListener("touchstart", onTouchStart, passiveOptions);
+    scrollElement.addEventListener("touchmove", onTouchMove, passiveOptions);
     return () => {
       resizeObserver.disconnect();
-      scrollTarget.removeEventListener(
-        "scroll",
-        preserveDetachedScrollPosition
-      );
+      scrollTarget.removeEventListener("scroll", onScroll);
       scrollElement.removeEventListener("touchstart", onTouchStart);
       scrollElement.removeEventListener("touchmove", onTouchMove);
     };

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -123,18 +123,6 @@ export function useConversationAutoScroll({
       previousScrollTop = scrollTop;
     };
 
-    const onWheel = (event: WheelEvent) => {
-      if (event.ctrlKey) {
-        return;
-      }
-
-      if (event.deltaY < 0) {
-        detachFromAutoScroll();
-      } else if (!isAutoScrollEnabledRef.current) {
-        captureScrollPosition();
-      }
-    };
-
     const onTouchStart = (event: TouchEvent) => {
       lastTouchY = event.touches[0]?.clientY ?? null;
     };
@@ -156,7 +144,6 @@ export function useConversationAutoScroll({
     scrollTarget.addEventListener("scroll", preserveDetachedScrollPosition, {
       passive: true,
     });
-    scrollElement.addEventListener("wheel", onWheel, { passive: true });
     scrollElement.addEventListener("touchstart", onTouchStart, {
       passive: true,
     });
@@ -167,7 +154,6 @@ export function useConversationAutoScroll({
         "scroll",
         preserveDetachedScrollPosition
       );
-      scrollElement.removeEventListener("wheel", onWheel);
       scrollElement.removeEventListener("touchstart", onTouchStart);
       scrollElement.removeEventListener("touchmove", onTouchMove);
     };

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -85,6 +85,7 @@ export function useConversationAutoScroll({
     let isTouchActive = false;
     let scrollEventVersion = 0;
     let touchStartScrollEventVersion = 0;
+    let isWaitingForWheelScroll = false;
     let fallbackAnimationFrame: number | null = null;
 
     const startUserScroll = () => {
@@ -133,6 +134,7 @@ export function useConversationAutoScroll({
 
         if (stableFrameCount >= 2) {
           fallbackAnimationFrame = null;
+          isWaitingForWheelScroll = false;
           finishUserScroll();
           return;
         }
@@ -172,6 +174,9 @@ export function useConversationAutoScroll({
       const location = methods.getScrollLocation();
 
       if (userScrollDirectionRef.current !== null) {
+        if (scrollTopDelta !== 0) {
+          isWaitingForWheelScroll = false;
+        }
         startUserScroll();
         if (!supportsNativeScrollEnd) {
           observeScrollEndFallback();
@@ -199,8 +204,12 @@ export function useConversationAutoScroll({
         0,
         viewportHeight - location.visibleListHeight
       );
+      const bottomOffset = Math.max(
+        0,
+        scrollHeight - scrollTop - viewportHeight
+      );
       const isNearBottom =
-        location.isAtBottom || location.bottomOffset <= stickyFooterHeight;
+        location.isAtBottom || bottomOffset <= stickyFooterHeight;
       const isUserScrollingDown =
         userScrollDirectionRef.current === "down" ||
         (userScrollDirectionRef.current === null &&
@@ -233,6 +242,7 @@ export function useConversationAutoScroll({
       }
 
       userScrollDirectionRef.current = event.deltaY < 0 ? "up" : "down";
+      isWaitingForWheelScroll = true;
       startUserScroll();
       observeScrollEndFallback();
       if (userScrollDirectionRef.current === "up") {
@@ -278,6 +288,13 @@ export function useConversationAutoScroll({
     };
 
     const onScrollEnd = () => {
+      // Cancelling Virtuoso's smooth scroll may emit scrollend before the
+      // wheel event has produced its own scroll. Touch scrolling can likewise
+      // receive scrollend while the finger is still moving.
+      if (isTouchActive || isWaitingForWheelScroll) {
+        return;
+      }
+
       cancelScrollEndFallback();
       finishUserScroll();
     };

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -23,8 +23,8 @@ export function useConversationAutoScroll({
     isAutoScrollEnabledRef.current = true;
   }, []);
 
-  // Virtuoso's public onScroll fires before its row-height compensation, so a
-  // native listener restores the detached position after Virtuoso updates it.
+  // Compare native scroll movement with list height changes so Virtuoso's row
+  // remeasurement is not mistaken for user scroll intent.
   useEffect(() => {
     const methods = messageListRef.current;
     const scrollElement = isMobile
@@ -35,7 +35,6 @@ export function useConversationAutoScroll({
     }
 
     const scrollTarget = isMobile ? window : scrollElement;
-    const listElement = methods.scrollerElement()?.firstElementChild;
     let previousScrollHeight = scrollElement.scrollHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let lastTouchY: number | null = null;
@@ -52,19 +51,6 @@ export function useConversationAutoScroll({
         methods.cancelSmoothScroll();
       }
     };
-
-    const resizeObserver = new ResizeObserver(() => {
-      // Advance the height baseline when content grows without scrolling.
-      if (
-        !isAutoScrollEnabledRef.current &&
-        scrollElement.scrollTop === previousScrollTop
-      ) {
-        previousScrollHeight = scrollElement.scrollHeight;
-      }
-    });
-    if (listElement) {
-      resizeObserver.observe(listElement);
-    }
 
     const onScroll = () => {
       const scrollHeight = scrollElement.scrollHeight;
@@ -95,13 +81,12 @@ export function useConversationAutoScroll({
       const isNearBottom =
         location.isAtBottom || location.bottomOffset <= stickyFooterHeight;
 
-      // The sticky input bar hides the last part of the viewport. Reattach as
-      // soon as the user scrolls back down into that area, rather than making
-      // them catch a moving 4px target while the answer keeps growing.
+      // The sticky input bar hides the last part of the viewport. Reattach on
+      // downward user movement into that area, but ignore list height changes.
       if (
         !isAutoScrollEnabledRef.current &&
         scrollTopDelta > 0 &&
-        !isHeightCompensation &&
+        scrollHeightDelta === 0 &&
         isNearBottom
       ) {
         enableAutoScroll();
@@ -110,10 +95,6 @@ export function useConversationAutoScroll({
           align: "end",
           behavior: "instant",
         });
-      }
-
-      if (!isAutoScrollEnabledRef.current && isHeightCompensation) {
-        scrollElement.scrollTop = previousScrollTop;
       }
 
       previousScrollHeight = scrollHeight;
@@ -143,7 +124,6 @@ export function useConversationAutoScroll({
     scrollElement.addEventListener("touchstart", onTouchStart, passiveOptions);
     scrollElement.addEventListener("touchmove", onTouchMove, passiveOptions);
     return () => {
-      resizeObserver.disconnect();
       scrollTarget.removeEventListener("scroll", onScroll);
       scrollElement.removeEventListener("touchstart", onTouchStart);
       scrollElement.removeEventListener("touchmove", onTouchMove);

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -1,10 +1,11 @@
 import type {
+  UserScrollActivity,
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
 import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
 import type { RefObject } from "react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 type ConversationAutoScrollMethods = Pick<
   VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>,
@@ -26,15 +27,42 @@ export function useConversationAutoScroll({
   messageListRef,
 }: UseConversationAutoScrollProps) {
   const isAutoScrollEnabledRef = useRef(true);
-  const lastUserScrollAtRef = useRef<number | null>(null);
+  const isUserScrollingRef = useRef(false);
+  const userScrollEndListenersRef = useRef(new Set<() => void>());
   // A gesture can produce several scroll events. Keep its direction until the
-  // user changes direction or auto-scroll is explicitly re-enabled.
+  // gesture ends so concurrent stream movement cannot reverse its meaning.
   const userScrollDirectionRef = useRef<UserScrollDirection | null>(null);
+
+  const finishUserScroll = useCallback(() => {
+    if (!isUserScrollingRef.current) {
+      return;
+    }
+
+    isUserScrollingRef.current = false;
+    userScrollDirectionRef.current = null;
+    for (const listener of userScrollEndListenersRef.current) {
+      listener();
+    }
+  }, []);
+
+  const userScrollActivity = useMemo<UserScrollActivity>(
+    () => ({
+      isActive: () => isUserScrollingRef.current,
+      subscribeToEnd: (listener) => {
+        userScrollEndListenersRef.current.add(listener);
+        return () => {
+          userScrollEndListenersRef.current.delete(listener);
+        };
+      },
+    }),
+    []
+  );
+
   const enableAutoScroll = useCallback(() => {
     isAutoScrollEnabledRef.current = true;
-    lastUserScrollAtRef.current = null;
     userScrollDirectionRef.current = null;
-  }, []);
+    finishUserScroll();
+  }, [finishUserScroll]);
 
   // Track gestures separately from their resulting scroll movement so
   // Virtuoso's concurrent movement cannot hide the user's direction.
@@ -48,9 +76,77 @@ export function useConversationAutoScroll({
     }
 
     const scrollTarget = isMobile ? window : scrollElement;
+    const scrollEndTarget = isMobile ? document : scrollElement;
+    const supportsNativeScrollEnd =
+      "onscrollend" in scrollEndTarget &&
+      scrollEndTarget.onscrollend !== undefined;
     let previousScrollHeight = scrollElement.scrollHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let lastTouchY: number | null = null;
+    let isTouchActive = false;
+    let scrollEventVersion = 0;
+    let touchStartScrollEventVersion = 0;
+    let fallbackAnimationFrame: number | null = null;
+
+    const startUserScroll = () => {
+      isUserScrollingRef.current = true;
+    };
+
+    const cancelScrollEndFallback = () => {
+      if (fallbackAnimationFrame !== null) {
+        window.cancelAnimationFrame(fallbackAnimationFrame);
+        fallbackAnimationFrame = null;
+      }
+    };
+
+    // Older Safari does not expose scrollend, and browsers do not emit it when
+    // a gesture causes no movement. Cover both cases without a time delay by
+    // waiting for pointer release and a stable scroll position.
+    const observeScrollEndFallback = () => {
+      if (isTouchActive || fallbackAnimationFrame !== null) {
+        return;
+      }
+
+      const initialScrollEventVersion = scrollEventVersion;
+      let previousObservedScrollTop = scrollElement.scrollTop;
+      let stableFrameCount = 0;
+      const observeScrollPosition = () => {
+        if (!isUserScrollingRef.current) {
+          fallbackAnimationFrame = null;
+          return;
+        }
+
+        if (
+          supportsNativeScrollEnd &&
+          scrollEventVersion !== initialScrollEventVersion
+        ) {
+          fallbackAnimationFrame = null;
+          return;
+        }
+
+        const scrollTop = scrollElement.scrollTop;
+        if (scrollTop === previousObservedScrollTop) {
+          stableFrameCount += 1;
+        } else {
+          stableFrameCount = 0;
+        }
+        previousObservedScrollTop = scrollTop;
+
+        if (stableFrameCount >= 2) {
+          fallbackAnimationFrame = null;
+          finishUserScroll();
+          return;
+        }
+
+        fallbackAnimationFrame = window.requestAnimationFrame(
+          observeScrollPosition
+        );
+      };
+
+      fallbackAnimationFrame = window.requestAnimationFrame(
+        observeScrollPosition
+      );
+    };
 
     const captureScrollPosition = () => {
       previousScrollHeight = scrollElement.scrollHeight;
@@ -66,6 +162,7 @@ export function useConversationAutoScroll({
     };
 
     const onScroll = () => {
+      scrollEventVersion += 1;
       const scrollHeight = scrollElement.scrollHeight;
       const scrollTop = scrollElement.scrollTop;
       const scrollHeightDelta = scrollHeight - previousScrollHeight;
@@ -76,7 +173,10 @@ export function useConversationAutoScroll({
       const location = methods.getScrollLocation();
 
       if (userScrollDirectionRef.current !== null) {
-        lastUserScrollAtRef.current = Date.now();
+        startUserScroll();
+        if (!supportsNativeScrollEnd) {
+          observeScrollEndFallback();
+        }
       }
 
       if (
@@ -86,7 +186,10 @@ export function useConversationAutoScroll({
         !location.isAtBottom
       ) {
         userScrollDirectionRef.current = "up";
-        lastUserScrollAtRef.current = Date.now();
+        startUserScroll();
+        if (!supportsNativeScrollEnd) {
+          observeScrollEndFallback();
+        }
         detachFromAutoScroll();
       }
 
@@ -135,13 +238,16 @@ export function useConversationAutoScroll({
       }
 
       userScrollDirectionRef.current = event.deltaY < 0 ? "up" : "down";
-      lastUserScrollAtRef.current = Date.now();
+      startUserScroll();
+      observeScrollEndFallback();
       if (userScrollDirectionRef.current === "up") {
         detachFromAutoScroll();
       }
     };
 
     const onTouchStart = (event: TouchEvent) => {
+      isTouchActive = true;
+      touchStartScrollEventVersion = scrollEventVersion;
       lastTouchY = event.touches[0]?.clientY ?? null;
     };
 
@@ -153,7 +259,7 @@ export function useConversationAutoScroll({
 
       if (lastTouchY !== null && touchY !== lastTouchY) {
         userScrollDirectionRef.current = touchY > lastTouchY ? "up" : "down";
-        lastUserScrollAtRef.current = Date.now();
+        startUserScroll();
         if (userScrollDirectionRef.current === "up") {
           detachFromAutoScroll();
         }
@@ -161,22 +267,49 @@ export function useConversationAutoScroll({
       lastTouchY = touchY;
     };
 
+    const onTouchEnd = () => {
+      isTouchActive = false;
+      lastTouchY = null;
+      if (!isUserScrollingRef.current) {
+        return;
+      }
+      if (
+        supportsNativeScrollEnd &&
+        scrollEventVersion !== touchStartScrollEventVersion
+      ) {
+        return;
+      }
+      observeScrollEndFallback();
+    };
+
+    const onScrollEnd = () => {
+      cancelScrollEndFallback();
+      finishUserScroll();
+    };
+
     const passiveOptions = { passive: true };
     scrollTarget.addEventListener("scroll", onScroll, passiveOptions);
+    scrollEndTarget.addEventListener("scrollend", onScrollEnd, passiveOptions);
     scrollElement.addEventListener("wheel", onWheel, passiveOptions);
     scrollElement.addEventListener("touchstart", onTouchStart, passiveOptions);
     scrollElement.addEventListener("touchmove", onTouchMove, passiveOptions);
+    scrollElement.addEventListener("touchend", onTouchEnd, passiveOptions);
+    scrollElement.addEventListener("touchcancel", onTouchEnd, passiveOptions);
     return () => {
+      cancelScrollEndFallback();
       scrollTarget.removeEventListener("scroll", onScroll);
+      scrollEndTarget.removeEventListener("scrollend", onScrollEnd);
       scrollElement.removeEventListener("wheel", onWheel);
       scrollElement.removeEventListener("touchstart", onTouchStart);
       scrollElement.removeEventListener("touchmove", onTouchMove);
+      scrollElement.removeEventListener("touchend", onTouchEnd);
+      scrollElement.removeEventListener("touchcancel", onTouchEnd);
     };
-  }, [enableAutoScroll, isMobile, messageListRef]);
+  }, [enableAutoScroll, finishUserScroll, isMobile, messageListRef]);
 
   return {
     enableAutoScroll,
     isAutoScrollEnabledRef,
-    lastUserScrollAtRef,
+    userScrollActivity,
   };
 }

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -64,6 +64,7 @@ export function useConversationAutoScroll({
     };
 
     const onScroll = () => {
+      const wasAutoScrollEnabled = isAutoScrollEnabledRef.current;
       const scrollHeight = scrollElement.scrollHeight;
       const scrollTop = scrollElement.scrollTop;
       const scrollHeightDelta = scrollHeight - previousScrollHeight;
@@ -116,6 +117,16 @@ export function useConversationAutoScroll({
           align: "end",
           behavior: "instant",
         });
+      }
+
+      // Virtuoso preserves the bottom offset when a row grows during an active
+      // upward scroll. Remove that growth so it does not cancel user movement.
+      if (
+        !wasAutoScrollEnabled &&
+        userScrollDirectionRef.current === "up" &&
+        scrollHeightDelta > 0
+      ) {
+        scrollElement.scrollTop -= scrollHeightDelta;
       }
 
       previousScrollHeight = scrollHeight;

--- a/front/components/assistant/conversation/utils.test.ts
+++ b/front/components/assistant/conversation/utils.test.ts
@@ -1,7 +1,4 @@
-import {
-  getGroupConversationsByUnreadAndActionRequired,
-  getNextAutoScrollState,
-} from "@app/components/assistant/conversation/utils";
+import { getGroupConversationsByUnreadAndActionRequired } from "@app/components/assistant/conversation/utils";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
 
@@ -79,56 +76,5 @@ describe("getGroupConversationsByUnreadAndActionRequired", () => {
 
     expect(triggeredConversations.map((c) => c.sId)).toEqual(["active"]);
     expect(inboxConversations).toEqual([]);
-  });
-});
-
-describe("getNextAutoScrollState", () => {
-  it("stays attached when streamed content moves the bottom away", () => {
-    expect(
-      getNextAutoScrollState(
-        { isEnabled: true, hasLeftBottom: false },
-        { type: "scroll", bottomOffset: 120 }
-      )
-    ).toEqual({ isEnabled: true, hasLeftBottom: false });
-  });
-
-  it("detaches immediately when the reader scrolls up", () => {
-    expect(
-      getNextAutoScrollState(
-        { isEnabled: true, hasLeftBottom: false },
-        { type: "user_scrolled_up" }
-      )
-    ).toEqual({ isEnabled: false, hasLeftBottom: false });
-  });
-
-  it("does not re-attach to a stale bottom event after detaching", () => {
-    expect(
-      getNextAutoScrollState(
-        { isEnabled: false, hasLeftBottom: false },
-        { type: "scroll", bottomOffset: 0 }
-      )
-    ).toEqual({ isEnabled: false, hasLeftBottom: false });
-  });
-
-  it("preserves the evidence that the reader left the bottom", () => {
-    const awayFromBottom = getNextAutoScrollState(
-      { isEnabled: false, hasLeftBottom: false },
-      { type: "scroll", bottomOffset: 100 }
-    );
-
-    expect(
-      getNextAutoScrollState(awayFromBottom, {
-        type: "user_scrolled_up",
-      })
-    ).toEqual({ isEnabled: false, hasLeftBottom: true });
-  });
-
-  it("re-attaches after the reader returns to the bottom", () => {
-    expect(
-      getNextAutoScrollState(
-        { isEnabled: false, hasLeftBottom: true },
-        { type: "scroll", bottomOffset: 0.5 }
-      )
-    ).toEqual({ isEnabled: true, hasLeftBottom: false });
   });
 });

--- a/front/components/assistant/conversation/utils.test.ts
+++ b/front/components/assistant/conversation/utils.test.ts
@@ -1,6 +1,6 @@
 import {
-  getAutoScrollEnabled,
   getGroupConversationsByUnreadAndActionRequired,
+  getNextAutoScrollState,
 } from "@app/components/assistant/conversation/utils";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
@@ -82,44 +82,53 @@ describe("getGroupConversationsByUnreadAndActionRequired", () => {
   });
 });
 
-describe("getAutoScrollEnabled", () => {
-  it("keeps following streamed content when the viewport does not move", () => {
+describe("getNextAutoScrollState", () => {
+  it("stays attached when streamed content moves the bottom away", () => {
     expect(
-      getAutoScrollEnabled({
-        isAutoScrollEnabled: true,
-        previousLocation: { bottomOffset: 0, listOffset: -600 },
-        location: { bottomOffset: 120, listOffset: -600 },
-      })
-    ).toBe(true);
+      getNextAutoScrollState(
+        { isEnabled: true, hasLeftBottom: false },
+        { type: "scroll", bottomOffset: 120 }
+      )
+    ).toEqual({ isEnabled: true, hasLeftBottom: false });
   });
 
-  it("detaches when the reader scrolls up while content grows", () => {
+  it("detaches immediately when the reader scrolls up", () => {
     expect(
-      getAutoScrollEnabled({
-        isAutoScrollEnabled: true,
-        previousLocation: { bottomOffset: 0, listOffset: -600 },
-        location: { bottomOffset: 200, listOffset: -520 },
-      })
-    ).toBe(false);
+      getNextAutoScrollState(
+        { isEnabled: true, hasLeftBottom: false },
+        { type: "user_scrolled_up" }
+      )
+    ).toEqual({ isEnabled: false, hasLeftBottom: false });
   });
 
-  it("stays detached while the reader scrolls down before the bottom", () => {
+  it("does not re-attach to a stale bottom event after detaching", () => {
     expect(
-      getAutoScrollEnabled({
-        isAutoScrollEnabled: false,
-        previousLocation: { bottomOffset: 200, listOffset: -520 },
-        location: { bottomOffset: 140, listOffset: -580 },
-      })
-    ).toBe(false);
+      getNextAutoScrollState(
+        { isEnabled: false, hasLeftBottom: false },
+        { type: "scroll", bottomOffset: 0 }
+      )
+    ).toEqual({ isEnabled: false, hasLeftBottom: false });
   });
 
-  it("re-attaches at the bottom while content grows", () => {
+  it("preserves the evidence that the reader left the bottom", () => {
+    const awayFromBottom = getNextAutoScrollState(
+      { isEnabled: false, hasLeftBottom: false },
+      { type: "scroll", bottomOffset: 100 }
+    );
+
     expect(
-      getAutoScrollEnabled({
-        isAutoScrollEnabled: false,
-        previousLocation: { bottomOffset: 200, listOffset: -520 },
-        location: { bottomOffset: 0, listOffset: -720 },
+      getNextAutoScrollState(awayFromBottom, {
+        type: "user_scrolled_up",
       })
-    ).toBe(true);
+    ).toEqual({ isEnabled: false, hasLeftBottom: true });
+  });
+
+  it("re-attaches after the reader returns to the bottom", () => {
+    expect(
+      getNextAutoScrollState(
+        { isEnabled: false, hasLeftBottom: true },
+        { type: "scroll", bottomOffset: 0.5 }
+      )
+    ).toEqual({ isEnabled: true, hasLeftBottom: false });
   });
 });

--- a/front/components/assistant/conversation/utils.test.ts
+++ b/front/components/assistant/conversation/utils.test.ts
@@ -1,4 +1,7 @@
-import { getGroupConversationsByUnreadAndActionRequired } from "@app/components/assistant/conversation/utils";
+import {
+  getAutoScrollEnabled,
+  getGroupConversationsByUnreadAndActionRequired,
+} from "@app/components/assistant/conversation/utils";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
 
@@ -76,5 +79,47 @@ describe("getGroupConversationsByUnreadAndActionRequired", () => {
 
     expect(triggeredConversations.map((c) => c.sId)).toEqual(["active"]);
     expect(inboxConversations).toEqual([]);
+  });
+});
+
+describe("getAutoScrollEnabled", () => {
+  it("keeps following streamed content when the viewport does not move", () => {
+    expect(
+      getAutoScrollEnabled({
+        isAutoScrollEnabled: true,
+        previousLocation: { bottomOffset: 0, listOffset: -600 },
+        location: { bottomOffset: 120, listOffset: -600 },
+      })
+    ).toBe(true);
+  });
+
+  it("detaches when the reader scrolls up while content grows", () => {
+    expect(
+      getAutoScrollEnabled({
+        isAutoScrollEnabled: true,
+        previousLocation: { bottomOffset: 0, listOffset: -600 },
+        location: { bottomOffset: 200, listOffset: -520 },
+      })
+    ).toBe(false);
+  });
+
+  it("stays detached while the reader scrolls down before the bottom", () => {
+    expect(
+      getAutoScrollEnabled({
+        isAutoScrollEnabled: false,
+        previousLocation: { bottomOffset: 200, listOffset: -520 },
+        location: { bottomOffset: 140, listOffset: -580 },
+      })
+    ).toBe(false);
+  });
+
+  it("re-attaches at the bottom while content grows", () => {
+    expect(
+      getAutoScrollEnabled({
+        isAutoScrollEnabled: false,
+        previousLocation: { bottomOffset: 200, listOffset: -520 },
+        location: { bottomOffset: 0, listOffset: -720 },
+      })
+    ).toBe(true);
   });
 });

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -18,6 +18,7 @@ import {
   isReinforcedSkillNotificationMetadata,
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { PodListItemType } from "@app/types/space";
 import moment from "moment";
@@ -25,33 +26,50 @@ import moment from "moment";
 const MAX_SOURCE_CONVERSATION_TITLE_LENGTH = 50;
 const UNNAMED_PARENT_CONVERSATION_TITLE = "Unnamed parent conversation";
 
-interface AutoScrollLocation {
-  bottomOffset: number;
-  listOffset: number;
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 4;
+
+export interface AutoScrollState {
+  isEnabled: boolean;
+  hasLeftBottom: boolean;
 }
 
-export function getAutoScrollEnabled({
-  isAutoScrollEnabled,
-  location,
-  previousLocation,
-}: {
-  isAutoScrollEnabled: boolean;
-  location: AutoScrollLocation;
-  previousLocation: AutoScrollLocation;
-}): boolean {
-  // Re-attach as soon as the reader reaches the bottom, including while the
-  // streamed message is still growing.
-  if (location.bottomOffset === 0) {
-    return true;
-  }
+export type AutoScrollEvent =
+  | { type: "attach" }
+  | { type: "user_scrolled_up" }
+  | { type: "scroll"; bottomOffset: number };
 
-  // Growing content can increase bottomOffset without user scrolling, but it
-  // cannot increase listOffset. An increase means that the viewport moved up.
-  if (location.listOffset > previousLocation.listOffset) {
-    return false;
-  }
+export function getNextAutoScrollState(
+  state: AutoScrollState,
+  event: AutoScrollEvent
+): AutoScrollState {
+  switch (event.type) {
+    case "attach":
+      return { isEnabled: true, hasLeftBottom: false };
+    case "user_scrolled_up":
+      // Keep the evidence that the reader has already left the bottom when more
+      // upward gestures arrive while detached.
+      return state.isEnabled
+        ? { isEnabled: false, hasLeftBottom: false }
+        : state;
+    case "scroll": {
+      if (state.isEnabled) {
+        return state;
+      }
 
-  return isAutoScrollEnabled;
+      const isAtBottom = event.bottomOffset <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+      if (!isAtBottom) {
+        return state.hasLeftBottom ? state : { ...state, hasLeftBottom: true };
+      }
+
+      // A smooth scroll can still report the bottom while it is being cancelled.
+      // Only re-attach after the detached viewport was observed away from it.
+      return state.hasLeftBottom
+        ? { isEnabled: true, hasLeftBottom: false }
+        : state;
+    }
+    default:
+      return assertNever(event);
+  }
 }
 
 function isReinforcedSkillConversation(

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -18,59 +18,12 @@ import {
   isReinforcedSkillNotificationMetadata,
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { PodListItemType } from "@app/types/space";
 import moment from "moment";
 
 const MAX_SOURCE_CONVERSATION_TITLE_LENGTH = 50;
 const UNNAMED_PARENT_CONVERSATION_TITLE = "Unnamed parent conversation";
-
-const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 4;
-
-export interface AutoScrollState {
-  isEnabled: boolean;
-  hasLeftBottom: boolean;
-}
-
-export type AutoScrollEvent =
-  | { type: "attach" }
-  | { type: "user_scrolled_up" }
-  | { type: "scroll"; bottomOffset: number };
-
-export function getNextAutoScrollState(
-  state: AutoScrollState,
-  event: AutoScrollEvent
-): AutoScrollState {
-  switch (event.type) {
-    case "attach":
-      return { isEnabled: true, hasLeftBottom: false };
-    case "user_scrolled_up":
-      // Keep the evidence that the reader has already left the bottom when more
-      // upward gestures arrive while detached.
-      return state.isEnabled
-        ? { isEnabled: false, hasLeftBottom: false }
-        : state;
-    case "scroll": {
-      if (state.isEnabled) {
-        return state;
-      }
-
-      const isAtBottom = event.bottomOffset <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
-      if (!isAtBottom) {
-        return state.hasLeftBottom ? state : { ...state, hasLeftBottom: true };
-      }
-
-      // A smooth scroll can still report the bottom while it is being cancelled.
-      // Only re-attach after the detached viewport was observed away from it.
-      return state.hasLeftBottom
-        ? { isEnabled: true, hasLeftBottom: false }
-        : state;
-    }
-    default:
-      return assertNever(event);
-  }
-}
 
 function isReinforcedSkillConversation(
   conversation: ConversationListItemType

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -1,3 +1,5 @@
+import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { isZeroHeightMessage } from "@app/components/assistant/conversation/types";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
 import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import type {
@@ -19,8 +21,6 @@ import type { ContentFragmentType } from "@app/types/content_fragment";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { PodListItemType } from "@app/types/space";
 import moment from "moment";
-import type { VirtuosoMessage } from "./types";
-import { isZeroHeightMessage } from "./types";
 
 const MAX_SOURCE_CONVERSATION_TITLE_LENGTH = 50;
 const UNNAMED_PARENT_CONVERSATION_TITLE = "Unnamed parent conversation";

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -25,6 +25,35 @@ import { isZeroHeightMessage } from "./types";
 const MAX_SOURCE_CONVERSATION_TITLE_LENGTH = 50;
 const UNNAMED_PARENT_CONVERSATION_TITLE = "Unnamed parent conversation";
 
+interface AutoScrollLocation {
+  bottomOffset: number;
+  listOffset: number;
+}
+
+export function getAutoScrollEnabled({
+  isAutoScrollEnabled,
+  location,
+  previousLocation,
+}: {
+  isAutoScrollEnabled: boolean;
+  location: AutoScrollLocation;
+  previousLocation: AutoScrollLocation;
+}): boolean {
+  // Re-attach as soon as the reader reaches the bottom, including while the
+  // streamed message is still growing.
+  if (location.bottomOffset === 0) {
+    return true;
+  }
+
+  // Growing content can increase bottomOffset without user scrolling, but it
+  // cannot increase listOffset. An increase means that the viewport moved up.
+  if (location.listOffset > previousLocation.listOffset) {
+    return false;
+  }
+
+  return isAutoScrollEnabled;
+}
+
 function isReinforcedSkillConversation(
   conversation: ConversationListItemType
 ): boolean {

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -20,16 +20,12 @@ const mockMutateContextUsage = vi.fn();
 const mockUseVirtuosoMethods = vi.fn();
 const mockIsAutoScrollEnabledRef = { current: true };
 
-function makeVirtuosoMethodsMock<T>(
-  map: (updater: (message: T) => T) => T[],
-  onMap?: (scrollToBottom: unknown) => void
-) {
+function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
   return {
     data: {
-      map: (updater: (message: T) => T, scrollToBottom?: unknown): T[] => {
-        const result = map(updater);
-        onMap?.(scrollToBottom);
-        return result;
+      map,
+      batch: (callback: () => void) => {
+        callback();
       },
     },
   };
@@ -295,100 +291,6 @@ describe("appendThinkingStep", () => {
 });
 
 describe("useAgentMessageStream", () => {
-  it("does not re-attach when generation switches from thinking to content", () => {
-    let currentMessage = makeInitialMessageStreamState(
-      makeLightAgentMessage({ content: null, chainOfThought: null })
-    );
-    let onEventCallback: ((event: string) => void) | null = null;
-    let autoScrollToBottom: { location: () => unknown } | null = null;
-
-    mockUseVirtuosoMethods.mockReturnValue(
-      makeVirtuosoMethodsMock(
-        (
-          updater: (message: typeof currentMessage) => typeof currentMessage
-        ) => {
-          currentMessage = updater(currentMessage);
-          return [currentMessage];
-        },
-        (scrollToBottom) => {
-          if (
-            typeof scrollToBottom === "object" &&
-            scrollToBottom !== null &&
-            "location" in scrollToBottom
-          ) {
-            autoScrollToBottom = scrollToBottom as {
-              location: () => unknown;
-            };
-          }
-        }
-      )
-    );
-
-    mockUseEventSource.mockImplementation(
-      (
-        _buildURL: unknown,
-        callback: (event: string) => void
-      ): { isError: null } => {
-        onEventCallback = callback;
-        return { isError: null };
-      }
-    );
-
-    renderHook(() =>
-      useAgentMessageStream({
-        agentMessage: currentMessage,
-        conversationId: "conv_123",
-        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        owner: mockOwner,
-        streamId: "stream_123",
-      })
-    );
-
-    act(() => {
-      onEventCallback!(
-        JSON.stringify({
-          eventId: "1-0",
-          data: {
-            type: "generation_tokens",
-            created: Date.now(),
-            configurationId: "agent_123",
-            messageId: currentMessage.sId,
-            text: "Thinking",
-            classification: "chain_of_thought",
-          },
-        })
-      );
-    });
-
-    expect(autoScrollToBottom).not.toBeNull();
-    expect(autoScrollToBottom!.location()).toEqual({
-      index: "LAST",
-      align: "end",
-      behavior: "instant",
-    });
-
-    mockIsAutoScrollEnabledRef.current = false;
-
-    act(() => {
-      onEventCallback!(
-        JSON.stringify({
-          eventId: "2-0",
-          data: {
-            type: "generation_tokens",
-            created: Date.now(),
-            configurationId: "agent_123",
-            messageId: currentMessage.sId,
-            text: "Answer",
-            classification: "tokens",
-          },
-        })
-      );
-    });
-
-    expect(mockIsAutoScrollEnabledRef.current).toBe(false);
-    expect(autoScrollToBottom!.location()).toBeNull();
-  });
-
   it("clears stale database content before replaying fresh-mount tokens", () => {
     let currentMessage = makeInitialMessageStreamState(makeLightAgentMessage());
     const snapshots: Array<{
@@ -636,6 +538,12 @@ describe("useAgentMessageStream", () => {
           },
         })
       );
+    });
+
+    // Scrolling up during thinking must survive the transition to answer content.
+    mockIsAutoScrollEnabledRef.current = false;
+
+    act(() => {
       onEventCallback!(
         JSON.stringify({
           eventId: "2-0",
@@ -680,6 +588,7 @@ describe("useAgentMessageStream", () => {
       },
     ]);
     expect(currentMessage.content).toBe("");
+    expect(mockIsAutoScrollEnabledRef.current).toBe(false);
   });
 
   it("applies the server-rendered content view at success", () => {

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -466,6 +466,20 @@ describe("useAgentMessageStream", () => {
     expect(harness.getContent()).toBe("Hello world");
   });
 
+  it("keeps content buffered when auto-scroll reattaches before scrolling ends", () => {
+    mockIsAutoScrollEnabledRef.current = false;
+    isUserScrollActive = true;
+    const harness = setupStreamingContentUpdateTest();
+
+    harness.sendToken("Hello");
+    mockIsAutoScrollEnabledRef.current = true;
+
+    expect(harness.getContent()).toBeNull();
+
+    act(() => finishUserScroll());
+    expect(harness.getContent()).toBe("Hello");
+  });
+
   it("cancels a deferred stream update when the message unmounts", () => {
     mockIsAutoScrollEnabledRef.current = false;
     isUserScrollActive = true;

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -20,12 +20,16 @@ const mockMutateContextUsage = vi.fn();
 const mockUseVirtuosoMethods = vi.fn();
 const mockIsAutoScrollEnabledRef = { current: true };
 
-function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
+function makeVirtuosoMethodsMock<T>(
+  map: (updater: (message: T) => T) => T[],
+  onBatch?: (scrollToBottom: unknown) => void
+) {
   return {
     data: {
       map,
-      batch: (callback: () => void) => {
+      batch: (callback: () => void, scrollToBottom?: unknown) => {
         callback();
+        onBatch?.(scrollToBottom);
       },
     },
   };
@@ -296,6 +300,9 @@ describe("useAgentMessageStream", () => {
       makeLightAgentMessage({ content: null, chainOfThought: null })
     );
     let onEventCallback: ((event: string) => void) | null = null;
+    let autoScrollToBottom:
+      | ((params: { scrollInProgress: boolean }) => unknown)
+      | null = null;
 
     mockUseVirtuosoMethods.mockReturnValue(
       makeVirtuosoMethodsMock(
@@ -304,6 +311,11 @@ describe("useAgentMessageStream", () => {
         ) => {
           currentMessage = updater(currentMessage);
           return [currentMessage];
+        },
+        (scrollToBottom) => {
+          if (typeof scrollToBottom === "function") {
+            autoScrollToBottom = scrollToBottom as typeof autoScrollToBottom;
+          }
         }
       )
     );
@@ -344,6 +356,13 @@ describe("useAgentMessageStream", () => {
       );
     });
 
+    expect(autoScrollToBottom).not.toBeNull();
+    expect(autoScrollToBottom!({ scrollInProgress: false })).toEqual({
+      index: "LAST",
+      align: "end",
+      behavior: "instant",
+    });
+
     mockIsAutoScrollEnabledRef.current = false;
 
     act(() => {
@@ -363,6 +382,7 @@ describe("useAgentMessageStream", () => {
     });
 
     expect(mockIsAutoScrollEnabledRef.current).toBe(false);
+    expect(autoScrollToBottom!({ scrollInProgress: false })).toBe(false);
   });
 
   it("clears stale database content before replaying fresh-mount tokens", () => {

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -22,14 +22,14 @@ const mockIsAutoScrollEnabledRef = { current: true };
 
 function makeVirtuosoMethodsMock<T>(
   map: (updater: (message: T) => T) => T[],
-  onBatch?: (scrollToBottom: unknown) => void
+  onMap?: (scrollToBottom: unknown) => void
 ) {
   return {
     data: {
-      map,
-      batch: (callback: () => void, scrollToBottom?: unknown) => {
-        callback();
-        onBatch?.(scrollToBottom);
+      map: (updater: (message: T) => T, scrollToBottom?: unknown): T[] => {
+        const result = map(updater);
+        onMap?.(scrollToBottom);
+        return result;
       },
     },
   };
@@ -300,9 +300,7 @@ describe("useAgentMessageStream", () => {
       makeLightAgentMessage({ content: null, chainOfThought: null })
     );
     let onEventCallback: ((event: string) => void) | null = null;
-    let autoScrollToBottom:
-      | ((params: { scrollInProgress: boolean }) => unknown)
-      | null = null;
+    let autoScrollToBottom: { location: () => unknown } | null = null;
 
     mockUseVirtuosoMethods.mockReturnValue(
       makeVirtuosoMethodsMock(
@@ -313,8 +311,14 @@ describe("useAgentMessageStream", () => {
           return [currentMessage];
         },
         (scrollToBottom) => {
-          if (typeof scrollToBottom === "function") {
-            autoScrollToBottom = scrollToBottom as typeof autoScrollToBottom;
+          if (
+            typeof scrollToBottom === "object" &&
+            scrollToBottom !== null &&
+            "location" in scrollToBottom
+          ) {
+            autoScrollToBottom = scrollToBottom as {
+              location: () => unknown;
+            };
           }
         }
       )
@@ -357,7 +361,7 @@ describe("useAgentMessageStream", () => {
     });
 
     expect(autoScrollToBottom).not.toBeNull();
-    expect(autoScrollToBottom!({ scrollInProgress: false })).toEqual({
+    expect(autoScrollToBottom!.location()).toEqual({
       index: "LAST",
       align: "end",
       behavior: "instant",
@@ -382,7 +386,7 @@ describe("useAgentMessageStream", () => {
     });
 
     expect(mockIsAutoScrollEnabledRef.current).toBe(false);
-    expect(autoScrollToBottom!({ scrollInProgress: false })).toBe(false);
+    expect(autoScrollToBottom!.location()).toBeNull();
   });
 
   it("clears stale database content before replaying fresh-mount tokens", () => {

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -142,6 +142,7 @@ beforeEach(() => {
   mockUseEventSource.mockReset();
   mockMutateContextUsage.mockReset();
   mockUseVirtuosoMethods.mockReset();
+  mockIsAutoScrollEnabledRef.current = true;
 });
 
 afterEach(() => {
@@ -290,6 +291,80 @@ describe("appendThinkingStep", () => {
 });
 
 describe("useAgentMessageStream", () => {
+  it("does not re-attach when generation switches from thinking to content", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Thinking",
+            classification: "chain_of_thought",
+          },
+        })
+      );
+    });
+
+    mockIsAutoScrollEnabledRef.current = false;
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Answer",
+            classification: "tokens",
+          },
+        })
+      );
+    });
+
+    expect(mockIsAutoScrollEnabledRef.current).toBe(false);
+  });
+
   it("clears stale database content before replaying fresh-mount tokens", () => {
     let currentMessage = makeInitialMessageStreamState(makeLightAgentMessage());
     const snapshots: Array<{

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -24,10 +24,13 @@ function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
   return {
     data: {
       map,
+      mapWithAnchor: (updater: (message: T) => T, _anchorItemIndex: number) =>
+        map(updater),
       batch: (callback: () => void) => {
         callback();
       },
     },
+    getScrollLocation: () => ({ lastVisibleItemIndex: 0 }),
   };
 }
 
@@ -291,6 +294,70 @@ describe("appendThinkingStep", () => {
 });
 
 describe("useAgentMessageStream", () => {
+  it("anchors the visible item when updating a detached stream", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+    const map = vi.fn(
+      (updater: (message: typeof currentMessage) => typeof currentMessage) => {
+        currentMessage = updater(currentMessage);
+        return [currentMessage];
+      }
+    );
+    const mapWithAnchor = vi.fn(
+      (
+        updater: (message: typeof currentMessage) => typeof currentMessage,
+        _anchorItemIndex: number
+      ) => map(updater)
+    );
+    const batch = vi.fn((callback: () => void) => callback());
+
+    mockUseVirtuosoMethods.mockReturnValue({
+      data: { batch, map, mapWithAnchor },
+      getScrollLocation: () => ({ lastVisibleItemIndex: 7 }),
+    });
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+    mockIsAutoScrollEnabledRef.current = false;
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Hello",
+            classification: "tokens",
+          },
+        })
+      );
+    });
+
+    expect(mapWithAnchor).toHaveBeenCalledWith(expect.any(Function), 7);
+    expect(batch).not.toHaveBeenCalled();
+  });
+
   it("clears stale database content before replaying fresh-mount tokens", () => {
     let currentMessage = makeInitialMessageStreamState(makeLightAgentMessage());
     const snapshots: Array<{

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -1,4 +1,7 @@
-import type { PendingToolCall } from "@app/components/assistant/conversation/types";
+import type {
+  PendingToolCall,
+  UserScrollActivity,
+} from "@app/components/assistant/conversation/types";
 import { makeInitialMessageStreamState } from "@app/components/assistant/conversation/types";
 import {
   appendThinkingStep,
@@ -19,7 +22,22 @@ const mockUseEventSource = vi.fn();
 const mockMutateContextUsage = vi.fn();
 const mockUseVirtuosoMethods = vi.fn();
 const mockIsAutoScrollEnabledRef = { current: true };
-const mockLastUserScrollAtRef = { current: null as number | null };
+let isUserScrollActive = false;
+const userScrollEndListeners = new Set<() => void>();
+const mockUserScrollActivity: UserScrollActivity = {
+  isActive: () => isUserScrollActive,
+  subscribeToEnd: (listener) => {
+    userScrollEndListeners.add(listener);
+    return () => userScrollEndListeners.delete(listener);
+  },
+};
+
+function finishUserScroll() {
+  isUserScrollActive = false;
+  for (const listener of userScrollEndListeners) {
+    listener();
+  }
+}
 
 function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
   return {
@@ -147,7 +165,8 @@ beforeEach(() => {
   mockMutateContextUsage.mockReset();
   mockUseVirtuosoMethods.mockReset();
   mockIsAutoScrollEnabledRef.current = true;
-  mockLastUserScrollAtRef.current = null;
+  isUserScrollActive = false;
+  userScrollEndListeners.clear();
 });
 
 afterEach(() => {
@@ -159,6 +178,7 @@ function setupStreamingContentUpdateTest() {
     makeLightAgentMessage({ content: null, chainOfThought: null })
   );
   let onEventCallback: ((event: string) => void) | null = null;
+  let nextEventId = 1;
 
   mockUseVirtuosoMethods.mockReturnValue(
     makeVirtuosoMethodsMock(
@@ -183,7 +203,7 @@ function setupStreamingContentUpdateTest() {
       agentMessage: currentMessage,
       conversationId: "conv_123",
       isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-      lastUserScrollAtRef: mockLastUserScrollAtRef,
+      userScrollActivity: mockUserScrollActivity,
       owner: mockOwner,
       streamId: "stream_123",
     })
@@ -195,7 +215,7 @@ function setupStreamingContentUpdateTest() {
       act(() => {
         onEventCallback!(
           JSON.stringify({
-            eventId: "1-0",
+            eventId: `${nextEventId++}-0`,
             data: {
               type: "generation_tokens",
               created: Date.now(),
@@ -393,7 +413,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -419,40 +439,43 @@ describe("useAgentMessageStream", () => {
     expect(batch).not.toHaveBeenCalled();
   });
 
-  it("waits for user scrolling to settle before growing streamed content", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1000);
+  it("waits for user scrolling to end before growing streamed content", () => {
     mockIsAutoScrollEnabledRef.current = false;
-    mockLastUserScrollAtRef.current = Date.now();
+    isUserScrollActive = true;
     const harness = setupStreamingContentUpdateTest();
 
     harness.sendToken("Hello");
 
     expect(harness.getContent()).toBeNull();
 
-    act(() => {
-      vi.advanceTimersByTime(100);
-      mockLastUserScrollAtRef.current = Date.now();
-      vi.advanceTimersByTime(149);
-    });
-    expect(harness.getContent()).toBeNull();
-
-    act(() => vi.advanceTimersByTime(1));
+    act(() => finishUserScroll());
     expect(harness.getContent()).toBe("Hello");
   });
 
-  it("cancels a deferred stream update when the message unmounts", () => {
+  it("renders the latest buffered content as soon as scrolling ends", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(1000);
     mockIsAutoScrollEnabledRef.current = false;
-    mockLastUserScrollAtRef.current = Date.now();
+    isUserScrollActive = true;
+    const harness = setupStreamingContentUpdateTest();
+
+    harness.sendToken("Hello");
+    harness.sendToken(" world");
+    expect(harness.getContent()).toBeNull();
+
+    act(() => finishUserScroll());
+    expect(harness.getContent()).toBe("Hello world");
+  });
+
+  it("cancels a deferred stream update when the message unmounts", () => {
+    mockIsAutoScrollEnabledRef.current = false;
+    isUserScrollActive = true;
     const harness = setupStreamingContentUpdateTest();
 
     harness.sendToken("Hello");
 
     act(() => {
       harness.unmount();
-      vi.runAllTimers();
+      finishUserScroll();
     });
 
     expect(harness.getContent()).toBeNull();
@@ -498,7 +521,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -566,7 +589,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -688,7 +711,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -793,7 +816,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -894,7 +917,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -1044,7 +1067,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -1216,7 +1239,7 @@ describe("useAgentMessageStream", () => {
           agentMessage: currentMessage,
           conversationId: "conv_123",
           isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-          lastUserScrollAtRef: mockLastUserScrollAtRef,
+          userScrollActivity: mockUserScrollActivity,
           owner: mockOwner,
           streamId: "stream_123",
         })
@@ -1305,7 +1328,7 @@ describe("useAgentMessageStream", () => {
           agentMessage: currentMessage,
           conversationId: "conv_123",
           isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-          lastUserScrollAtRef: mockLastUserScrollAtRef,
+          userScrollActivity: mockUserScrollActivity,
           owner: mockOwner,
           streamId: "stream_123",
         })
@@ -1400,7 +1423,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
-        lastUserScrollAtRef: mockLastUserScrollAtRef,
+        userScrollActivity: mockUserScrollActivity,
         owner: mockOwner,
         streamId: "stream_123",
       })

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -19,6 +19,7 @@ const mockUseEventSource = vi.fn();
 const mockMutateContextUsage = vi.fn();
 const mockUseVirtuosoMethods = vi.fn();
 const mockIsAutoScrollEnabledRef = { current: true };
+const mockLastUserScrollAtRef = { current: null as number | null };
 
 function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
   return {
@@ -146,11 +147,70 @@ beforeEach(() => {
   mockMutateContextUsage.mockReset();
   mockUseVirtuosoMethods.mockReset();
   mockIsAutoScrollEnabledRef.current = true;
+  mockLastUserScrollAtRef.current = null;
 });
 
 afterEach(() => {
   vi.useRealTimers();
 });
+
+function setupStreamingContentUpdateTest() {
+  let currentMessage = makeInitialMessageStreamState(
+    makeLightAgentMessage({ content: null, chainOfThought: null })
+  );
+  let onEventCallback: ((event: string) => void) | null = null;
+
+  mockUseVirtuosoMethods.mockReturnValue(
+    makeVirtuosoMethodsMock(
+      (updater: (message: typeof currentMessage) => typeof currentMessage) => {
+        currentMessage = updater(currentMessage);
+        return [currentMessage];
+      }
+    )
+  );
+  mockUseEventSource.mockImplementation(
+    (
+      _buildURL: unknown,
+      callback: (event: string) => void
+    ): { isError: null } => {
+      onEventCallback = callback;
+      return { isError: null };
+    }
+  );
+
+  const hook = renderHook(() =>
+    useAgentMessageStream({
+      agentMessage: currentMessage,
+      conversationId: "conv_123",
+      isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+      lastUserScrollAtRef: mockLastUserScrollAtRef,
+      owner: mockOwner,
+      streamId: "stream_123",
+    })
+  );
+
+  return {
+    getContent: () => currentMessage.content,
+    sendToken: (text: string) => {
+      act(() => {
+        onEventCallback!(
+          JSON.stringify({
+            eventId: "1-0",
+            data: {
+              type: "generation_tokens",
+              created: Date.now(),
+              configurationId: "agent_123",
+              messageId: currentMessage.sId,
+              text,
+              classification: "tokens",
+            },
+          })
+        );
+      });
+    },
+    unmount: hook.unmount,
+  };
+}
 
 describe("upsertPendingToolCall", () => {
   it("merges a later update for the same call id", () => {
@@ -333,6 +393,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -356,6 +417,45 @@ describe("useAgentMessageStream", () => {
 
     expect(mapWithAnchor).toHaveBeenCalledWith(expect.any(Function), 7);
     expect(batch).not.toHaveBeenCalled();
+  });
+
+  it("waits for user scrolling to settle before growing streamed content", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    mockIsAutoScrollEnabledRef.current = false;
+    mockLastUserScrollAtRef.current = Date.now();
+    const harness = setupStreamingContentUpdateTest();
+
+    harness.sendToken("Hello");
+
+    expect(harness.getContent()).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+      mockLastUserScrollAtRef.current = Date.now();
+      vi.advanceTimersByTime(149);
+    });
+    expect(harness.getContent()).toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(harness.getContent()).toBe("Hello");
+  });
+
+  it("cancels a deferred stream update when the message unmounts", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    mockIsAutoScrollEnabledRef.current = false;
+    mockLastUserScrollAtRef.current = Date.now();
+    const harness = setupStreamingContentUpdateTest();
+
+    harness.sendToken("Hello");
+
+    act(() => {
+      harness.unmount();
+      vi.runAllTimers();
+    });
+
+    expect(harness.getContent()).toBeNull();
   });
 
   it("clears stale database content before replaying fresh-mount tokens", () => {
@@ -398,6 +498,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -465,6 +566,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -586,6 +688,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -690,6 +793,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -790,6 +894,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -939,6 +1044,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -1110,6 +1216,7 @@ describe("useAgentMessageStream", () => {
           agentMessage: currentMessage,
           conversationId: "conv_123",
           isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+          lastUserScrollAtRef: mockLastUserScrollAtRef,
           owner: mockOwner,
           streamId: "stream_123",
         })
@@ -1198,6 +1305,7 @@ describe("useAgentMessageStream", () => {
           agentMessage: currentMessage,
           conversationId: "conv_123",
           isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+          lastUserScrollAtRef: mockLastUserScrollAtRef,
           owner: mockOwner,
           streamId: "stream_123",
         })
@@ -1292,6 +1400,7 @@ describe("useAgentMessageStream", () => {
         agentMessage: currentMessage,
         conversationId: "conv_123",
         isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        lastUserScrollAtRef: mockLastUserScrollAtRef,
         owner: mockOwner,
         streamId: "stream_123",
       })

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -31,26 +31,20 @@ type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessageListContext
 >;
 
-function createAutoScrollToBottomLocation(
-  isAutoScrollEnabledRef: MutableRefObject<boolean>
-) {
-  return () =>
-    isAutoScrollEnabledRef.current
-      ? {
-          index: "LAST" as const,
-          align: "end" as const,
-          behavior: "instant" as const,
-        }
-      : null;
-}
-
 function mapMessagesWithScrollPolicy(
   methods: VirtuosoMethods,
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
   mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
 ) {
   methods.data.map(mapFn, {
-    location: createAutoScrollToBottomLocation(isAutoScrollEnabledRef),
+    location: () =>
+      isAutoScrollEnabledRef.current
+        ? {
+            index: "LAST",
+            align: "end",
+            behavior: "instant",
+          }
+        : null,
   });
 }
 

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -2,6 +2,7 @@ import type {
   AgentMessageStateWithControlEvent,
   AgentMessageWithStreaming,
   PendingToolCall,
+  UserScrollActivity,
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
@@ -25,9 +26,6 @@ import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 const TOKEN_BUFFER_THRESHOLD_MS = 500;
-// Virtuoso keeps its upward-scroll compensation active for 100ms after the
-// last scroll event. Wait slightly longer before growing a streamed row.
-const USER_SCROLL_SETTLE_DELAY_MS = 150;
 
 type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessage,
@@ -80,9 +78,9 @@ function batchMapMessagesWithAutoScroll(
   );
 }
 
-function createUpdateMessageThrottled(
+function createStreamingMessageUpdater(
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
-  lastUserScrollAtRef: MutableRefObject<number | null>,
+  userScrollActivity: UserScrollActivity,
   methods: VirtuosoMethods
 ) {
   type MessageUpdate = {
@@ -91,26 +89,9 @@ function createUpdateMessageThrottled(
     sId: string;
   };
 
-  let scrollSettleTimeout: ReturnType<typeof setTimeout> | null = null;
+  let pendingUpdate: MessageUpdate | null = null;
 
-  const applyUpdate = (update: MessageUpdate) => {
-    const lastUserScrollAt = lastUserScrollAtRef.current;
-    const remainingDelay =
-      lastUserScrollAt === null
-        ? 0
-        : lastUserScrollAt + USER_SCROLL_SETTLE_DELAY_MS - Date.now();
-    if (remainingDelay > 0) {
-      if (scrollSettleTimeout !== null) {
-        clearTimeout(scrollSettleTimeout);
-      }
-      scrollSettleTimeout = setTimeout(
-        () => applyUpdate(update),
-        remainingDelay
-      );
-      return;
-    }
-
-    scrollSettleTimeout = null;
+  const renderUpdate = (update: MessageUpdate) => {
     const { chainOfThought, content, sId } = update;
     batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
       if (isAgentMessageWithStreaming(m) && m.sId === sId) {
@@ -124,21 +105,33 @@ function createUpdateMessageThrottled(
     });
   };
 
-  const updateMessageThrottled = throttle(
-    applyUpdate,
-    TOKEN_BUFFER_THRESHOLD_MS
-  );
-
-  const cancelThrottle = updateMessageThrottled.cancel;
-  updateMessageThrottled.cancel = () => {
-    cancelThrottle();
-    if (scrollSettleTimeout !== null) {
-      clearTimeout(scrollSettleTimeout);
-      scrollSettleTimeout = null;
+  const update = throttle((messageUpdate: MessageUpdate) => {
+    if (userScrollActivity.isActive()) {
+      pendingUpdate = messageUpdate;
+      return;
     }
-  };
 
-  return updateMessageThrottled;
+    pendingUpdate = null;
+    renderUpdate(messageUpdate);
+  }, TOKEN_BUFFER_THRESHOLD_MS);
+
+  return {
+    update,
+    flush: () => {
+      update.flush();
+      if (pendingUpdate === null) {
+        return;
+      }
+
+      const updateToRender = pendingUpdate;
+      pendingUpdate = null;
+      renderUpdate(updateToRender);
+    },
+    cancel: () => {
+      update.cancel();
+      pendingUpdate = null;
+    },
+  };
 }
 
 export function upsertPendingToolCall(
@@ -343,7 +336,7 @@ interface UseAgentMessageStreamParams {
   agentMessage: AgentMessageWithStreaming;
   conversationId: string | null;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
-  lastUserScrollAtRef: MutableRefObject<number | null>;
+  userScrollActivity: UserScrollActivity;
   owner: LightWorkspaceType;
   onEventCallback?: (event: {
     eventId: string;
@@ -356,7 +349,7 @@ export function useAgentMessageStream({
   agentMessage,
   conversationId,
   isAutoScrollEnabledRef,
-  lastUserScrollAtRef,
+  userScrollActivity,
   owner,
   onEventCallback: customOnEventCallback,
   streamId,
@@ -373,14 +366,14 @@ export function useAgentMessageStream({
     VirtuosoMessageListContext
   >();
 
-  const updateMessageThrottled = useMemo(
+  const streamingMessageUpdater = useMemo(
     () =>
-      createUpdateMessageThrottled(
+      createStreamingMessageUpdater(
         isAutoScrollEnabledRef,
-        lastUserScrollAtRef,
+        userScrollActivity,
         methods
       ),
-    [isAutoScrollEnabledRef, lastUserScrollAtRef, methods]
+    [isAutoScrollEnabledRef, methods, userScrollActivity]
   );
 
   const mapMessagesWithAutoScroll = useCallback(
@@ -399,10 +392,15 @@ export function useAgentMessageStream({
   const isStreamTerminated = useRef(false);
 
   useEffect(() => {
+    const unsubscribe = userScrollActivity.subscribeToEnd(
+      streamingMessageUpdater.flush
+    );
+
     return () => {
-      updateMessageThrottled.cancel();
+      unsubscribe();
+      streamingMessageUpdater.cancel();
     };
-  }, [updateMessageThrottled]);
+  }, [streamingMessageUpdater, userScrollActivity]);
 
   const shouldStream = useMemo(
     () =>
@@ -565,7 +563,7 @@ export function useAgentMessageStream({
               lastClassification.current !== null &&
               classification !== lastClassification.current
             ) {
-              updateMessageThrottled.cancel();
+              streamingMessageUpdater.cancel();
               const newAgentState =
                 classification === "tokens" ? "writing" : "thinking";
               mapMessagesWithAutoScroll((m) => {
@@ -630,7 +628,7 @@ export function useAgentMessageStream({
               }
             }
             if (!suppressUpdate) {
-              updateMessageThrottled({
+              streamingMessageUpdater.update({
                 chainOfThought: chainOfThought.current,
                 content: content.current,
                 sId,
@@ -688,7 +686,7 @@ export function useAgentMessageStream({
           break;
 
         case "tool_params":
-          updateMessageThrottled.cancel();
+          streamingMessageUpdater.cancel();
           const toolParams = eventPayload.data;
           mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
@@ -759,7 +757,7 @@ export function useAgentMessageStream({
         case "tool_error":
         case "agent_error":
           isStreamTerminated.current = true;
-          updateMessageThrottled.cancel();
+          streamingMessageUpdater.cancel();
           const error = eventPayload.data.error;
           mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
@@ -802,7 +800,7 @@ export function useAgentMessageStream({
 
         case "agent_generation_cancelled": {
           isStreamTerminated.current = true;
-          updateMessageThrottled.cancel();
+          streamingMessageUpdater.cancel();
           const cancelData = eventPayload.data;
           if (cancelData.type !== "agent_generation_cancelled") {
             break;
@@ -838,7 +836,7 @@ export function useAgentMessageStream({
         case "agent_message_gracefully_stopped":
         case "agent_message_success": {
           isStreamTerminated.current = true;
-          updateMessageThrottled.cancel();
+          streamingMessageUpdater.cancel();
           const messageSuccess = eventPayload.data;
           // Trust the server-rendered content view: it is computed from the
           // same persisted step contents reload uses, so it matches reload
@@ -885,7 +883,7 @@ export function useAgentMessageStream({
       mapMessagesWithAutoScroll,
       sId,
       mutateContextUsage,
-      updateMessageThrottled,
+      streamingMessageUpdater,
     ]
   );
 

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -62,6 +62,15 @@ function batchMapMessagesWithAutoScroll(
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
   mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
 ) {
+  if (!isAutoScrollEnabledRef.current) {
+    // Keep streamed row growth from displacing the detached viewport.
+    methods.data.mapWithAnchor(
+      mapFn,
+      methods.getScrollLocation().lastVisibleItemIndex
+    );
+    return;
+  }
+
   methods.data.batch(
     () => methods.data.map(mapFn),
     createAutoScrollToBottomBehavior(isAutoScrollEnabledRef)

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -25,6 +25,9 @@ import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 const TOKEN_BUFFER_THRESHOLD_MS = 500;
+// Virtuoso keeps its upward-scroll compensation active for 100ms after the
+// last scroll event. Wait slightly longer before growing a streamed row.
+const USER_SCROLL_SETTLE_DELAY_MS = 150;
 
 type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessage,
@@ -79,31 +82,63 @@ function batchMapMessagesWithAutoScroll(
 
 function createUpdateMessageThrottled(
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
+  lastUserScrollAtRef: MutableRefObject<number | null>,
   methods: VirtuosoMethods
 ) {
-  return throttle(
-    ({
-      chainOfThought,
-      content,
-      sId,
-    }: {
-      chainOfThought: string;
-      content: string;
-      sId: string;
-    }) => {
-      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
-        if (isAgentMessageWithStreaming(m) && m.sId === sId) {
-          return {
-            ...m,
-            content,
-            chainOfThought,
-          };
-        }
-        return m;
-      });
-    },
+  type MessageUpdate = {
+    chainOfThought: string;
+    content: string;
+    sId: string;
+  };
+
+  let scrollSettleTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const applyUpdate = (update: MessageUpdate) => {
+    const lastUserScrollAt = lastUserScrollAtRef.current;
+    const remainingDelay =
+      lastUserScrollAt === null
+        ? 0
+        : lastUserScrollAt + USER_SCROLL_SETTLE_DELAY_MS - Date.now();
+    if (remainingDelay > 0) {
+      if (scrollSettleTimeout !== null) {
+        clearTimeout(scrollSettleTimeout);
+      }
+      scrollSettleTimeout = setTimeout(
+        () => applyUpdate(update),
+        remainingDelay
+      );
+      return;
+    }
+
+    scrollSettleTimeout = null;
+    const { chainOfThought, content, sId } = update;
+    batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
+      if (isAgentMessageWithStreaming(m) && m.sId === sId) {
+        return {
+          ...m,
+          content,
+          chainOfThought,
+        };
+      }
+      return m;
+    });
+  };
+
+  const updateMessageThrottled = throttle(
+    applyUpdate,
     TOKEN_BUFFER_THRESHOLD_MS
   );
+
+  const cancelThrottle = updateMessageThrottled.cancel;
+  updateMessageThrottled.cancel = () => {
+    cancelThrottle();
+    if (scrollSettleTimeout !== null) {
+      clearTimeout(scrollSettleTimeout);
+      scrollSettleTimeout = null;
+    }
+  };
+
+  return updateMessageThrottled;
 }
 
 export function upsertPendingToolCall(
@@ -308,6 +343,7 @@ interface UseAgentMessageStreamParams {
   agentMessage: AgentMessageWithStreaming;
   conversationId: string | null;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
+  lastUserScrollAtRef: MutableRefObject<number | null>;
   owner: LightWorkspaceType;
   onEventCallback?: (event: {
     eventId: string;
@@ -320,6 +356,7 @@ export function useAgentMessageStream({
   agentMessage,
   conversationId,
   isAutoScrollEnabledRef,
+  lastUserScrollAtRef,
   owner,
   onEventCallback: customOnEventCallback,
   streamId,
@@ -337,8 +374,13 @@ export function useAgentMessageStream({
   >();
 
   const updateMessageThrottled = useMemo(
-    () => createUpdateMessageThrottled(isAutoScrollEnabledRef, methods),
-    [isAutoScrollEnabledRef, methods]
+    () =>
+      createUpdateMessageThrottled(
+        isAutoScrollEnabledRef,
+        lastUserScrollAtRef,
+        methods
+      ),
+    [isAutoScrollEnabledRef, lastUserScrollAtRef, methods]
   );
 
   const mapMessagesWithAutoScroll = useCallback(

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -31,31 +31,27 @@ type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessageListContext
 >;
 
-function createAutoScrollToBottomBehavior(
+function createAutoScrollToBottomLocation(
   isAutoScrollEnabledRef: MutableRefObject<boolean>
 ) {
-  return ({ scrollInProgress }: { scrollInProgress: boolean }) => {
-    if (!isAutoScrollEnabledRef.current || scrollInProgress) {
-      return false;
-    }
-
-    return {
-      index: "LAST" as const,
-      align: "end" as const,
-      behavior: "instant" as const,
-    };
-  };
+  return () =>
+    isAutoScrollEnabledRef.current
+      ? {
+          index: "LAST" as const,
+          align: "end" as const,
+          behavior: "instant" as const,
+        }
+      : null;
 }
 
-function batchMapMessagesWithAutoScroll(
+function mapMessagesWithScrollPolicy(
   methods: VirtuosoMethods,
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
   mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
 ) {
-  methods.data.batch(
-    () => methods.data.map(mapFn),
-    createAutoScrollToBottomBehavior(isAutoScrollEnabledRef)
-  );
+  methods.data.map(mapFn, {
+    location: createAutoScrollToBottomLocation(isAutoScrollEnabledRef),
+  });
 }
 
 function createUpdateMessageThrottled(
@@ -72,7 +68,7 @@ function createUpdateMessageThrottled(
       content: string;
       sId: string;
     }) => {
-      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
+      mapMessagesWithScrollPolicy(methods, isAutoScrollEnabledRef, (m) => {
         if (isAgentMessageWithStreaming(m) && m.sId === sId) {
           return {
             ...m,
@@ -324,7 +320,7 @@ export function useAgentMessageStream({
 
   const mapMessagesWithAutoScroll = useCallback(
     (mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage) => {
-      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, mapFn);
+      mapMessagesWithScrollPolicy(methods, isAutoScrollEnabledRef, mapFn);
     },
     [methods, isAutoScrollEnabledRef]
   );

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -84,13 +84,6 @@ function createUpdateMessageThrottled(
     }) => {
       batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
         if (isAgentMessageWithStreaming(m) && m.sId === sId) {
-          // Enable auto scroll if we are starting to receive content or chain of thought.
-          if (
-            (!m.content && content) ||
-            (!m.chainOfThought && chainOfThought)
-          ) {
-            isAutoScrollEnabledRef.current = true;
-          }
           return {
             ...m,
             content,

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -34,25 +34,15 @@ type VirtuosoMethods = VirtuosoMessageListMethods<
 function createAutoScrollToBottomBehavior(
   isAutoScrollEnabledRef: MutableRefObject<boolean>
 ) {
-  return ({
-    scrollLocation,
-    scrollInProgress,
-  }: {
-    scrollLocation: { bottomOffset: number };
-    scrollInProgress: boolean;
-  }) => {
+  return ({ scrollInProgress }: { scrollInProgress: boolean }) => {
     if (!isAutoScrollEnabledRef.current || scrollInProgress) {
-      return false;
-    }
-
-    if (scrollLocation.bottomOffset < 0) {
       return false;
     }
 
     return {
       index: "LAST" as const,
       align: "end" as const,
-      behavior: "smooth" as const,
+      behavior: "instant" as const,
     };
   };
 }

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -31,21 +31,41 @@ type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessageListContext
 >;
 
-function mapMessagesWithScrollPolicy(
+function createAutoScrollToBottomBehavior(
+  isAutoScrollEnabledRef: MutableRefObject<boolean>
+) {
+  return ({
+    scrollLocation,
+    scrollInProgress,
+  }: {
+    scrollLocation: { bottomOffset: number };
+    scrollInProgress: boolean;
+  }) => {
+    if (!isAutoScrollEnabledRef.current || scrollInProgress) {
+      return false;
+    }
+
+    if (scrollLocation.bottomOffset < 0) {
+      return false;
+    }
+
+    return {
+      index: "LAST" as const,
+      align: "end" as const,
+      behavior: "smooth" as const,
+    };
+  };
+}
+
+function batchMapMessagesWithAutoScroll(
   methods: VirtuosoMethods,
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
   mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
 ) {
-  methods.data.map(mapFn, {
-    location: () =>
-      isAutoScrollEnabledRef.current
-        ? {
-            index: "LAST",
-            align: "end",
-            behavior: "instant",
-          }
-        : null,
-  });
+  methods.data.batch(
+    () => methods.data.map(mapFn),
+    createAutoScrollToBottomBehavior(isAutoScrollEnabledRef)
+  );
 }
 
 function createUpdateMessageThrottled(
@@ -62,7 +82,7 @@ function createUpdateMessageThrottled(
       content: string;
       sId: string;
     }) => {
-      mapMessagesWithScrollPolicy(methods, isAutoScrollEnabledRef, (m) => {
+      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
         if (isAgentMessageWithStreaming(m) && m.sId === sId) {
           return {
             ...m,
@@ -314,7 +334,7 @@ export function useAgentMessageStream({
 
   const mapMessagesWithAutoScroll = useCallback(
     (mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage) => {
-      mapMessagesWithScrollPolicy(methods, isAutoScrollEnabledRef, mapFn);
+      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, mapFn);
     },
     [methods, isAutoScrollEnabledRef]
   );


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10209.

Long agent responses currently keep pulling the conversation to the bottom when someone scrolls up to read, which is especially disruptive on mobile because the screen is usually quite narrow, and when you try reading the message you are fighting against the scroll.

This PR makes auto-scroll distinguish streamed content growth from the user's upward viewport movement. If you don't do anything, content keeps following, but scrolling up "detaches" auto-scroll. Reaching the bottom re-attaches.

This was already what `updateAutoScrollEnabledFromLocation` was intended to do. It only worked if the user scrolled between content updates. In practice, during streaming `scrollHeight` changes constantly.

## Tests

- Added tests.
- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
