### PR TITLE
Clean up stale Frame publication artifacts

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -899,6 +899,60 @@ describe("publishFramePublication", () => {
     );
   });
 
+  it("cleans only stale uncommitted publication artifacts", async () => {
+    const { auth, frame } = await setupFrame();
+    const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    const committedPublicationId = "243542bc-54b1-4dfe-9bb9-e02f75a0fb9f";
+    const stalePublicationId = "0c6eeec6-f2bc-4f89-a154-061fc08a1bdf";
+    await frame.setActiveFramePublication(activePublicationId);
+    fileStorageMock.setSubdirectoryNames(() => [
+      activePublicationId,
+      committedPublicationId,
+      stalePublicationId,
+    ]);
+    fileStorageMock.setFileExists((filePath) =>
+      filePath.includes(committedPublicationId)
+    );
+    const deletedPrefixes = captureDeletedPublicationPrefixes();
+
+    const published = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+
+    expect(published.isOk()).toBe(true);
+    expect(deletedPrefixes).toEqual([
+      `w/${auth.getNonNullableWorkspace().sId}/frames/${frame.sId}/publications/${stalePublicationId}/`,
+    ]);
+  });
+
+  it("publishes when stale artifact cleanup fails", async () => {
+    const { auth, frame } = await setupFrame();
+    const stalePublicationId = "0c6eeec6-f2bc-4f89-a154-061fc08a1bdf";
+    fileStorageMock.setSubdirectoryNames(() => [stalePublicationId]);
+    fileStorageMock.setFileExists(() => false);
+    fileStorageMock.setDeleteByPrefixFails((prefix) =>
+      prefix.includes(stalePublicationId)
+    );
+    const deletedPrefixes = captureDeletedPublicationPrefixes();
+
+    const published = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+
+    expect(published.isOk()).toBe(true);
+    expect(deletedPrefixes).toEqual([
+      `w/${auth.getNonNullableWorkspace().sId}/frames/${frame.sId}/publications/${stalePublicationId}/`,
+    ]);
+  });
+
   it("reconciles declared databases before activation", async () => {
     const { auth, frame } = await setupFrame();
     const databaseSchema = {

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -953,6 +953,21 @@ describe("publishFramePublication", () => {
     ]);
   });
 
+  it("publishes when stale artifact discovery fails", async () => {
+    const { auth, frame } = await setupFrame();
+    fileStorageMock.setListSubdirectoryNamesFails(() => true);
+
+    const published = await publishFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+
+    expect(published.isOk()).toBe(true);
+  });
+
   it("reconciles declared databases before activation", async () => {
     const { auth, frame } = await setupFrame();
     const databaseSchema = {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -54,6 +54,8 @@ const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
 const FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
 const FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS = 100;
+// Publication work is synchronous and bounded. Lease expiry defines an abandoned publisher;
+// stale-prefix recovery may remove its uncommitted artifacts once a new publisher owns the lock.
 const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
 
 export type FramePublicationSourceFile = {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -35,6 +35,7 @@ import {
   getFramePublicationBasePath,
   getFramePublicationDescriptorPath,
   getFramePublicationFunctionBundlePath,
+  getFramePublicationsBasePath,
   getFramePublicationUiBundlePath,
 } from "@app/types/api/frame_storage";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
@@ -243,6 +244,71 @@ function getFrameIdentity(
   }
 
   return new Ok({ workspaceId: owner.sId, frameId: frame.sId });
+}
+
+async function cleanupStaleFramePublicationArtifacts(
+  auth: Authenticator,
+  { frame }: { frame: FileResource }
+): Promise<void> {
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return;
+  }
+
+  const storage = getPrivateUploadBucket();
+  try {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    const activePublicationId =
+      freshFrame?.useCaseMetadata?.activePublicationId;
+    const publicationIds = await storage.listSubdirectoryNames({
+      prefix: getFramePublicationsBasePath(frameIdentity.value),
+    });
+
+    await concurrentExecutor(
+      publicationIds,
+      async (publicationId) => {
+        if (publicationId === activePublicationId) {
+          return;
+        }
+
+        try {
+          const descriptorPath = getFramePublicationDescriptorPath({
+            ...frameIdentity.value,
+            publicationId,
+          });
+          const [isCommitted] = await storage.file(descriptorPath).exists();
+          if (!isCommitted) {
+            await storage.deleteByPrefix(
+              getFramePublicationBasePath({
+                ...frameIdentity.value,
+                publicationId,
+              })
+            );
+          }
+        } catch (error) {
+          logger.error(
+            {
+              err: normalizeError(error),
+              frameId: frame.sId,
+              publicationId,
+              workspaceId: frameIdentity.value.workspaceId,
+            },
+            "Failed to clean up stale Frame publication artifacts"
+          );
+        }
+      },
+      { concurrency: FRAME_PUBLICATION_READ_CONCURRENCY }
+    );
+  } catch (error) {
+    logger.error(
+      {
+        err: normalizeError(error),
+        frameId: frame.sId,
+        workspaceId: frameIdentity.value.workspaceId,
+      },
+      "Failed to list stale Frame publication artifacts"
+    );
+  }
 }
 
 export async function storeFramePublication(
@@ -752,6 +818,8 @@ export async function publishFramePublication(
     { publicationId: string },
     FramePublicationError | SandboxFunctionError
   >(frame.sId, async () => {
+    await cleanupStaleFramePublicationArtifacts(auth, { frame });
+
     const publication = await storeFramePublication(auth, {
       frame,
       functionArtifacts,

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -88,6 +88,8 @@ class FileStorageMock {
   ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
     null;
   private _subdirectoryNames: (prefix: string) => string[] | null = () => null;
+  private _listSubdirectoryNamesShouldFail: (prefix: string) => boolean = () =>
+    false;
   private _deletedPrefixes: string[] = [];
   private _onDeleteByPrefix: (prefix: string) => void = () => {};
   private _deleteByPrefixShouldFail: (prefix: string) => boolean = () => false;
@@ -202,6 +204,10 @@ class FileStorageMock {
     this._subdirectoryNames = fn;
   }
 
+  setListSubdirectoryNamesFails(predicate: (prefix: string) => boolean): void {
+    this._listSubdirectoryNamesShouldFail = predicate;
+  }
+
   /**
    * Observe every `bucket.deleteByPrefix(prefix)` call, e.g. to assert the order of a delete
    * sequence. Reset between tests via `reset()`.
@@ -275,6 +281,7 @@ class FileStorageMock {
     this._deleteShouldFail = () => false;
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
+    this._listSubdirectoryNamesShouldFail = () => false;
     this._deletedPrefixes.length = 0;
     this._onDeleteByPrefix = () => {};
     this._deleteByPrefixShouldFail = () => false;
@@ -583,6 +590,11 @@ class FileStorageMock {
           )
       ),
       listSubdirectoryNames: vi.fn(({ prefix }: { prefix: string }) => {
+        if (this._listSubdirectoryNamesShouldFail(prefix)) {
+          return Promise.reject(
+            new Error(`Simulated GCS subdirectory list failure: ${prefix}`)
+          );
+        }
         const normalized = prefix.endsWith("/") ? prefix : `${prefix}/`;
         const names = (this._subdirectoryNames(prefix) ?? []).filter(
           (name) =>


### PR DESCRIPTION
## Description

- Remove publication prefixes left without a publication.json commit marker before the next publish.
- Run cleanup under the Frame publish lock and preserve the active publication plus all committed inactive publications.
- Keep recovery best effort so storage discovery or deletion cannot block a valid publish.

## Tests

Added focused coverage for active and committed publication retention, stale prefix deletion, discovery and deletion failures.

## Risk

Cleanup targets only uncommitted prefixes for the same Frame. The active publication is always skipped. A writer is considered abandoned after the existing 10-minute publish-lock lease expires.

## Deploy Plan

Deploy after #31407, then standard deploy.