### PR TITLE
[front] enh: add button to copy link to skill

### DIFF
--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -43,10 +43,6 @@ export function SkillDetailsButtonBar({
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
   const [isSkillLinkCopied, copySkillLink] = useCopyToClipboard();
 
-  if (!skill.canAdministrate && !onFavoriteChange) {
-    return null;
-  }
-
   return (
     <>
       <ArchiveSkillDialog
@@ -68,6 +64,18 @@ export function SkillDetailsButtonBar({
             }
           />
         )}
+        <Button
+          size="sm"
+          tooltip="Copy link"
+          variant="outline"
+          icon={isSkillLinkCopied ? ClipboardCheck : Link01}
+          onClick={(e) => {
+            e.stopPropagation();
+            void copySkillLink(
+              `${config.getAppUrl()}${getManageSkillsRoute(owner.sId, skill.sId)}`
+            );
+          }}
+        />
         {skill.canAdministrate && (
           <Button
             size="sm"
@@ -89,16 +97,6 @@ export function SkillDetailsButtonBar({
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
-              <DropdownMenuItem
-                label="Copy link"
-                icon={isSkillLinkCopied ? ClipboardCheck : Link01}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void copySkillLink(
-                    `${config.getAppUrl()}${getManageSkillsRoute(owner.sId, skill.sId)}`
-                  );
-                }}
-              />
               <DropdownMenuItem
                 label="Archive"
                 icon={Trash01}

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,6 +1,11 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
-import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import { useSendNotification } from "@app/hooks/useNotification";
+import config from "@app/lib/api/config";
+import {
+  getManageSkillsRoute,
+  getSkillBuilderRoute,
+} from "@app/lib/utils/router";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -11,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Edit04,
+  Link01,
   Trash01,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -34,6 +40,7 @@ export function SkillDetailsButtonBar({
   onFavoriteChange,
 }: SkillDetailsButtonBarProps) {
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
+  const sendNotification = useSendNotification();
 
   if (!skill.canAdministrate && !onFavoriteChange) {
     return null;
@@ -81,6 +88,20 @@ export function SkillDetailsButtonBar({
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <DropdownMenuItem
+                label="Copy link"
+                icon={Link01}
+                onClick={async (e) => {
+                  e.stopPropagation();
+                  await navigator.clipboard.writeText(
+                    `${config.getAppUrl()}${getManageSkillsRoute(owner.sId, skill.sId)}`
+                  );
+                  sendNotification({
+                    type: "success",
+                    title: "Skill link copied to clipboard",
+                  });
+                }}
+              />
               <DropdownMenuItem
                 label="Archive"
                 icon={Trash01}

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -76,7 +76,7 @@ export function SkillDetailsButtonBar({
         )}
         <Button
           size="sm"
-          label={isSkillLinkCopied ? "Copied!" : "Copy link"}
+          tooltip={isSkillLinkCopied ? "Copied!" : "Copy link"}
           variant="outline"
           icon={isSkillLinkCopied ? ClipboardCheck : Clipboard}
           onClick={(e) => {

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,6 +1,5 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
-import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import {
   getManageSkillsRoute,
@@ -10,6 +9,7 @@ import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
+  ClipboardCheck,
   DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +18,7 @@ import {
   Edit04,
   Link01,
   Trash01,
+  useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -40,7 +41,7 @@ export function SkillDetailsButtonBar({
   onFavoriteChange,
 }: SkillDetailsButtonBarProps) {
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
-  const sendNotification = useSendNotification();
+  const [isSkillLinkCopied, copySkillLink] = useCopyToClipboard();
 
   if (!skill.canAdministrate && !onFavoriteChange) {
     return null;
@@ -81,7 +82,7 @@ export function SkillDetailsButtonBar({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
-                icon={DotsHorizontal}
+                icon={isSkillLinkCopied ? ClipboardCheck : DotsHorizontal}
                 size="sm"
                 variant="ghost"
                 tooltip="Skill options"
@@ -91,15 +92,11 @@ export function SkillDetailsButtonBar({
               <DropdownMenuItem
                 label="Copy link"
                 icon={Link01}
-                onClick={async (e) => {
+                onClick={(e) => {
                   e.stopPropagation();
-                  await navigator.clipboard.writeText(
+                  void copySkillLink(
                     `${config.getAppUrl()}${getManageSkillsRoute(owner.sId, skill.sId)}`
                   );
-                  sendNotification({
-                    type: "success",
-                    title: "Skill link copied to clipboard",
-                  });
                 }}
               />
               <DropdownMenuItem

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -82,7 +82,7 @@ export function SkillDetailsButtonBar({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
-                icon={isSkillLinkCopied ? ClipboardCheck : DotsHorizontal}
+                icon={DotsHorizontal}
                 size="sm"
                 variant="ghost"
                 tooltip="Skill options"
@@ -91,7 +91,7 @@ export function SkillDetailsButtonBar({
             <DropdownMenuContent>
               <DropdownMenuItem
                 label="Copy link"
-                icon={Link01}
+                icon={isSkillLinkCopied ? ClipboardCheck : Link01}
                 onClick={(e) => {
                   e.stopPropagation();
                   void copySkillLink(

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -76,7 +76,7 @@ export function SkillDetailsButtonBar({
         )}
         <Button
           size="sm"
-          tooltip="Copy link"
+          label={isSkillLinkCopied ? "Copied!" : "Copy link"}
           variant="outline"
           icon={isSkillLinkCopied ? ClipboardCheck : Clipboard}
           onClick={(e) => {

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -64,6 +64,16 @@ export function SkillDetailsButtonBar({
             }
           />
         )}
+        {skill.canAdministrate && (
+          <Button
+            size="sm"
+            tooltip="Edit skill"
+            href={getSkillBuilderRoute(owner.sId, skill.sId)}
+            replace={replaceOnEdit}
+            variant="outline"
+            icon={Edit04}
+          />
+        )}
         <Button
           size="sm"
           tooltip="Copy link"
@@ -76,16 +86,6 @@ export function SkillDetailsButtonBar({
             );
           }}
         />
-        {skill.canAdministrate && (
-          <Button
-            size="sm"
-            tooltip="Edit skill"
-            href={getSkillBuilderRoute(owner.sId, skill.sId)}
-            replace={replaceOnEdit}
-            variant="outline"
-            icon={Edit04}
-          />
-        )}
         {skill.canAdministrate && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -9,6 +9,7 @@ import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
+  Clipboard,
   ClipboardCheck,
   DotsHorizontal,
   DropdownMenu,
@@ -16,7 +17,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Edit04,
-  Link01,
   Trash01,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
@@ -68,7 +68,7 @@ export function SkillDetailsButtonBar({
           size="sm"
           tooltip="Copy link"
           variant="outline"
-          icon={isSkillLinkCopied ? ClipboardCheck : Link01}
+          icon={isSkillLinkCopied ? ClipboardCheck : Clipboard}
           onClick={(e) => {
             e.stopPropagation();
             void copySkillLink(

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -570,6 +570,7 @@ export function SkillsTable({
                       ? ClipboardCheck
                       : Clipboard,
                   onClick: async (e: React.MouseEvent) => {
+                    e.preventDefault();
                     e.stopPropagation();
                     setCopiedSkillId(skill.sId);
                     await copySkillLink(

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -350,11 +350,22 @@ const lastEditedColumn = {
   meta: { className: "hidden @sm:w-32 @sm:table-cell" },
 };
 
+function SkillActionsMenuButton({ menuItems }: { menuItems: MenuItem[] }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <DataTable.MoreButton
+      menuItems={menuItems}
+      dropdownMenuProps={{ open: isOpen, onOpenChange: setIsOpen }}
+    />
+  );
+}
+
 const menuColumn = {
   header: "",
   accessorKey: "menuItems",
   cell: (info: CellContext<RowData, MenuItem[]>) => {
-    return <DataTable.MoreButton menuItems={info.getValue()} />;
+    return <SkillActionsMenuButton menuItems={info.getValue()} />;
   },
   meta: {
     className: "w-14",

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -350,6 +350,7 @@ const lastEditedColumn = {
   meta: { className: "hidden @sm:w-32 @sm:table-cell" },
 };
 
+// Control the menu locally so "Copy link" can keep it open without changing Sparkle.
 function SkillActionsMenuButton({ menuItems }: { menuItems: MenuItem[] }) {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -20,12 +20,12 @@ import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Checkbox,
   Chip,
+  Clipboard,
   ClipboardCheck,
   DataTable,
   Edit04,
   Eye,
   Label,
-  Link01,
   LoadingBlock,
   Tooltip,
   Trash01,
@@ -568,7 +568,7 @@ export function SkillsTable({
                   icon:
                     isSkillLinkCopied && copiedSkillId === skill.sId
                       ? ClipboardCheck
-                      : Link01,
+                      : Clipboard,
                   onClick: async (e: React.MouseEvent) => {
                     e.stopPropagation();
                     setCopiedSkillId(skill.sId);

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -350,7 +350,7 @@ const lastEditedColumn = {
   meta: { className: "hidden @sm:w-32 @sm:table-cell" },
 };
 
-// Control the menu locally so "Copy link" can keep it open without changing Sparkle.
+// Control the menu locally so clicking "Copy link" does not close it.
 function SkillActionsMenuButton({ menuItems }: { menuItems: MenuItem[] }) {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -564,7 +564,10 @@ export function SkillsTable({
                   kind: "item" as const,
                 },
                 {
-                  label: "Copy link",
+                  label:
+                    isSkillLinkCopied && copiedSkillId === skill.sId
+                      ? "Copied!"
+                      : "Copy link",
                   icon:
                     isSkillLinkCopied && copiedSkillId === skill.sId
                       ? ClipboardCheck

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -3,10 +3,14 @@ import type { BatchAvailabilityAction } from "@app/components/skills/SkillsBatch
 import { SkillsBatchEditBar } from "@app/components/skills/SkillsBatchEdit";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
+import config from "@app/lib/api/config";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
-import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import {
+  getManageSkillsRoute,
+  getSkillBuilderRoute,
+} from "@app/lib/utils/router";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
@@ -16,13 +20,16 @@ import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Checkbox,
   Chip,
+  ClipboardCheck,
   DataTable,
   Edit04,
   Eye,
   Label,
+  Link01,
   LoadingBlock,
   Tooltip,
   Trash01,
+  useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import type {
   CellContext,
@@ -490,6 +497,8 @@ export function SkillsTable({
   const [skillToArchive, setSkillToArchive] = useState<
     GetSkillsWithRelationsResponseBody["skills"][number] | null
   >(null);
+  const [copiedSkillId, setCopiedSkillId] = useState<string | null>(null);
+  const [isSkillLinkCopied, copySkillLink] = useCopyToClipboard();
 
   // Stable columns identity: rebuilding them on every selection change makes the
   // table re-render all rows.
@@ -555,6 +564,21 @@ export function SkillsTable({
                   kind: "item" as const,
                 },
                 {
+                  label: "Copy link",
+                  icon:
+                    isSkillLinkCopied && copiedSkillId === skill.sId
+                      ? ClipboardCheck
+                      : Link01,
+                  onClick: async (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    setCopiedSkillId(skill.sId);
+                    await copySkillLink(
+                      `${config.getAppUrl()}${getManageSkillsRoute(owner.sId, skill.sId)}`
+                    );
+                  },
+                  kind: "item" as const,
+                },
+                {
                   label: "Archive",
                   icon: Trash01,
                   disabled: !skill.canAdministrate,
@@ -569,7 +593,14 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, owner.sId]
+    [
+      skills,
+      onSkillClick,
+      owner.sId,
+      isSkillLinkCopied,
+      copiedSkillId,
+      copySkillLink,
+    ]
   );
 
   const selectionSet = useMemo(

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1062,9 +1062,7 @@ const renderRegularItem = (
       onClick={(event) => {
         event.stopPropagation();
         itemProps.onClick?.(event);
-        if (!event.defaultPrevented) {
-          onItemClick?.();
-        }
+        onItemClick?.();
       }}
     />
   );

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1062,7 +1062,9 @@ const renderRegularItem = (
       onClick={(event) => {
         event.stopPropagation();
         itemProps.onClick?.(event);
-        onItemClick?.();
+        if (!event.defaultPrevented) {
+          onItemClick?.();
+        }
       }}
     />
   );


### PR DESCRIPTION
## Description

This PR adds a button in Manage skills to copy the link to a skill.
This link points to the Manage skills page, opened on the skill.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
