### PR TITLE
Enforce Frame database publication contracts

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -105,8 +105,10 @@ export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
 
 /** Valid database names (also the manifest/publish contract). */
 export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+export const SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION = 1;
 
 const framePublicationDatabaseContractSchema = z.object({
+  schemaVersion: z.literal(SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION),
   manifest: z.object({
     databases: z.array(
       z.object({

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -1,19 +1,22 @@
 import type { Changes, SQLQueryBindings, Statement } from "bun:sqlite";
 import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import { z } from "zod";
 
 import { podEnv } from "./context.ts";
 
 /**
- * Pod state databases.
+ * Frame and Pod state databases.
  *
- * `db(name)` returns a cached Drizzle instance over the pod's live SQLite
- * database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. Databases are
- * created by `dsbx db reconcile` (the db_reconcile tool), never here: the file
- * is opened must-exist so a typo'd name errors clearly instead of minting an
- * empty database. Functions that never call `db()` pay nothing.
+ * `db(name)` returns a cached Drizzle instance over the owner's live SQLite
+ * database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. The prefix only
+ * applies to Pod apps; Frame database names are unprefixed and enforced against
+ * the selected immutable publication descriptor. Databases are created by
+ * reconciliation, never here: the file is opened must-exist so a typo'd name
+ * errors clearly instead of minting an empty database. Functions that never
+ * call `db()` pay nothing.
  *
  * `name` is the app-relative name the function's source writes, and the app
  * prefix comes from the environment ({@link POD_DATABASE_PREFIX_ENV}) rather
@@ -58,6 +61,17 @@ export const POD_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
  */
 export const POD_SPACE_ID_ENV = "SPACE_ID";
 
+/** Sandbox-global Frame sId, set instead of SPACE_ID for Frame-owned state. */
+export const FRAME_ID_ENV = "FRAME_ID";
+
+/**
+ * Exact immutable publication descriptor selected for this Frame invocation.
+ * Front passes the mounted path per invocation so a warm worker can enforce
+ * the database declarations of the publication it is actually serving.
+ */
+export const FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV =
+  "DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH";
+
 /**
  * Env var carrying the per-database size quota in bytes, required. Like the
  * databases directory, the value is owned by front (1 GiB in production) and
@@ -92,6 +106,16 @@ export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
 /** Valid database names (also the manifest/publish contract). */
 export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
 
+const framePublicationDatabaseContractSchema = z.object({
+  manifest: z.object({
+    databases: z.array(
+      z.object({
+        name: z.string().regex(POD_DATABASE_NAME_REGEX),
+      })
+    ),
+  }),
+});
+
 export class PodDatabaseError extends Error {
   constructor(message: string) {
     super(message);
@@ -113,12 +137,41 @@ export class PodDatabaseInvalidNameError extends PodDatabaseError {
 export class PodDatabasesUnavailableError extends PodDatabaseError {
   constructor() {
     super(
-      `Pod databases are not available in this sandbox: ${POD_SPACE_ID_ENV} ` +
-        `is not set, which means this sandbox does not belong to a pod ` +
-        `(conversation sandboxes have no pod databases). db() only works in ` +
-        `functions running in a pod sandbox.`
+      `Databases are not available in this sandbox: neither ` +
+        `${POD_SPACE_ID_ENV} nor ${FRAME_ID_ENV} is set, which means this ` +
+        `sandbox belongs to neither a Pod nor a Frame (conversation sandboxes ` +
+        `have no databases). db() only works in functions running in a Pod ` +
+        `or Frame sandbox.`
     );
     this.name = "PodDatabasesUnavailableError";
+  }
+}
+
+export class FramePublicationDescriptorError extends PodDatabaseError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FramePublicationDescriptorError";
+  }
+}
+
+export class FrameDatabaseNotDeclaredError extends PodDatabaseError {
+  constructor(dbName: string) {
+    super(
+      `Frame database "${dbName}" is not declared in this publication. ` +
+        `Declare it in manifest.json and publish the Frame again.`
+    );
+    this.name = "FrameDatabaseNotDeclaredError";
+  }
+}
+
+export class FrameDatabaseUnavailableError extends PodDatabaseError {
+  constructor(dbName: string, path: string) {
+    super(
+      `Frame database "${dbName}" is declared but unavailable (no database ` +
+        `file at ${path}). Publish the Frame again to reconcile its database ` +
+        `state.`
+    );
+    this.name = "FrameDatabaseUnavailableError";
   }
 }
 
@@ -368,14 +421,82 @@ function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
 // One instance per resolved database file path, opened lazily on first db().
 const instances = new Map<string, PodDatabase>();
 
+// Publication descriptors are immutable. Cache their declarations by exact
+// mounted path so warm workers serving different publications cannot share a
+// declaration set accidentally.
+const frameDatabaseDeclarations = new Map<string, ReadonlySet<string>>();
+
+function declaredFrameDatabases(frameId: string): ReadonlySet<string> {
+  const descriptorPath = podEnv(FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV);
+  if (descriptorPath === undefined || descriptorPath.length === 0) {
+    throw new FramePublicationDescriptorError(
+      `${FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV} is not set for Frame ` +
+        `${frameId}: db() requires the selected publication descriptor.`
+    );
+  }
+
+  const cached = frameDatabaseDeclarations.get(descriptorPath);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let descriptorJson: unknown;
+  try {
+    descriptorJson = JSON.parse(readFileSync(descriptorPath, "utf8"));
+  } catch {
+    throw new FramePublicationDescriptorError(
+      `The Frame publication descriptor at ${descriptorPath} cannot be read ` +
+        `or is not valid JSON.`
+    );
+  }
+
+  const descriptor =
+    framePublicationDatabaseContractSchema.safeParse(descriptorJson);
+  if (!descriptor.success) {
+    throw new FramePublicationDescriptorError(
+      `The Frame publication descriptor at ${descriptorPath} has an invalid ` +
+        `database contract.`
+    );
+  }
+
+  const declarations = new Set(
+    descriptor.data.manifest.databases.map(({ name }) => name)
+  );
+  frameDatabaseDeclarations.set(descriptorPath, declarations);
+  return declarations;
+}
+
+/** Returns the Frame sId for Frame state, or null for Pod state. */
+function assertDatabaseOwnerCanUse(name: string): string | null {
+  const frameId = podEnv(FRAME_ID_ENV);
+  if (frameId !== undefined && frameId.length > 0) {
+    if (!declaredFrameDatabases(frameId).has(name)) {
+      throw new FrameDatabaseNotDeclaredError(name);
+    }
+    return frameId;
+  }
+
+  const spaceId = podEnv(POD_SPACE_ID_ENV);
+  if (spaceId === undefined || spaceId.length === 0) {
+    throw new PodDatabasesUnavailableError();
+  }
+  return null;
+}
+
 /**
- * Get the pod's Drizzle handle for database `name`, where `name` is the app's
- * own name for it (`db("chat")`) and the app prefix is applied by
- * {@link resolveDatabasePath} from the environment.
+ * Get the owner's Drizzle handle for database `name`. Pod functions resolve
+ * app-relative names through {@link resolveDatabasePath}; Frame functions use
+ * unprefixed names and must declare each database in the selected publication.
  *
  * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
- * @throws PodDatabasesUnavailableError when SPACE_ID is absent — this sandbox
- *   is not pod-owned (conversation sandboxes have no pod databases).
+ * @throws PodDatabasesUnavailableError when both SPACE_ID and FRAME_ID are
+ *   absent (conversation sandboxes have no databases).
+ * @throws FramePublicationDescriptorError when a Frame invocation has no valid
+ *   selected publication descriptor.
+ * @throws FrameDatabaseNotDeclaredError when a Frame publication does not
+ *   declare `name`, even if state from an older publication remains on disk.
+ * @throws FrameDatabaseUnavailableError when a declared Frame database has no
+ *   reconciled state file.
  * @throws PodDatabaseError when DUST_POD_DATABASES_DIR or
  *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
  *   in functions launched by `dsbx function run`.
@@ -387,10 +508,9 @@ export function db(name: string): PodDatabase {
   if (!POD_DATABASE_NAME_REGEX.test(name)) {
     throw new PodDatabaseInvalidNameError(name);
   }
-  const spaceId = podEnv(POD_SPACE_ID_ENV);
-  if (spaceId === undefined || spaceId.length === 0) {
-    throw new PodDatabasesUnavailableError();
-  }
+  // Run before the instance cache lookup: a warm worker may already hold this
+  // database for an older publication that declared it.
+  const frameId = assertDatabaseOwnerCanUse(name);
   const path = resolveDatabasePath(podDatabasesDir(), name);
   const cached = instances.get(path);
   if (cached !== undefined) {
@@ -403,6 +523,9 @@ export function db(name: string): PodDatabase {
     sqlite = new PodSqliteDatabase(path, name, maxSizeBytes);
   } catch (err) {
     if (isSqliteErrorWithCode(err, "SQLITE_CANTOPEN")) {
+      if (frameId !== null) {
+        throw new FrameDatabaseUnavailableError(name, path);
+      }
       throw new PodDatabaseNotDeclaredError(name, path);
     }
     throw err;

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -1,10 +1,15 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   db,
+  FRAME_ID_ENV,
+  FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV,
+  FrameDatabaseNotDeclaredError,
+  FrameDatabaseUnavailableError,
+  FramePublicationDescriptorError,
   POD_DATABASE_BUSY_TIMEOUT_MS,
   POD_DATABASE_MAX_SIZE_BYTES_ENV,
   POD_DATABASE_PREFIX_ENV,
@@ -56,6 +61,8 @@ function uniqueName(prefix: string): string {
 }
 
 let originalSpaceId: string | undefined;
+let originalFrameId: string | undefined;
+let originalFramePublicationDescriptorPath: string | undefined;
 
 beforeEach(() => {
   databasesDir = mkdtempSync(join(tmpdir(), "dust-pod-test-"));
@@ -65,6 +72,11 @@ beforeEach(() => {
   // Pod sandboxes carry SPACE_ID as a sandbox-global env var.
   originalSpaceId = process.env[POD_SPACE_ID_ENV];
   process.env[POD_SPACE_ID_ENV] = "spc_test_pod";
+  originalFrameId = process.env[FRAME_ID_ENV];
+  delete process.env[FRAME_ID_ENV];
+  originalFramePublicationDescriptorPath =
+    process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV];
+  delete process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV];
 });
 
 afterEach(() => {
@@ -76,6 +88,17 @@ afterEach(() => {
   } else {
     process.env[POD_SPACE_ID_ENV] = originalSpaceId;
   }
+  if (originalFrameId === undefined) {
+    delete process.env[FRAME_ID_ENV];
+  } else {
+    process.env[FRAME_ID_ENV] = originalFrameId;
+  }
+  if (originalFramePublicationDescriptorPath === undefined) {
+    delete process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV];
+  } else {
+    process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV] =
+      originalFramePublicationDescriptorPath;
+  }
   rmSync(databasesDir, { recursive: true, force: true });
 });
 
@@ -85,7 +108,7 @@ describe("pod sandbox guard", () => {
     createDatabaseFile(name);
     delete process.env[POD_SPACE_ID_ENV];
     expect(() => db(name)).toThrow(PodDatabasesUnavailableError);
-    expect(() => db(name)).toThrow(/does not belong to a pod/);
+    expect(() => db(name)).toThrow(/neither a Pod nor a Frame/);
   });
 
   test("empty SPACE_ID is treated as absent", () => {
@@ -98,6 +121,99 @@ describe("pod sandbox guard", () => {
   test("the guard runs before the missing-file check", () => {
     delete process.env[POD_SPACE_ID_ENV];
     expect(() => db(uniqueName("guard"))).toThrow(PodDatabasesUnavailableError);
+  });
+});
+
+describe("Frame publication database contract", () => {
+  function createPublicationDescriptor(databaseNames: string[]): string {
+    const descriptorPath = join(
+      databasesDir,
+      `${uniqueName("publication")}.json`
+    );
+    writeFileSync(
+      descriptorPath,
+      JSON.stringify({
+        manifest: {
+          databases: databaseNames.map((name) => ({
+            name,
+            schema: `databases/${name}.db.ts`,
+          })),
+        },
+      })
+    );
+    return descriptorPath;
+  }
+
+  function frameInvocationEnv(descriptorPath?: string) {
+    return {
+      [POD_DATABASES_DIR_ENV]: databasesDir,
+      [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+      [FRAME_ID_ENV]: "fil_test_frame",
+      ...(descriptorPath
+        ? { [FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV]: descriptorPath }
+        : {}),
+    };
+  }
+
+  test("opens an existing database declared by the selected publication", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+    const descriptorPath = createPublicationDescriptor([name]);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
+    ).not.toThrow();
+  });
+
+  test("rejects an undeclared database even when its state file exists", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+    const descriptorPath = createPublicationDescriptor([]);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
+    ).toThrow(FrameDatabaseNotDeclaredError);
+  });
+
+  test("reports declared state that reconciliation has not created", () => {
+    const name = uniqueName("frame_db");
+    const descriptorPath = createPublicationDescriptor([name]);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
+    ).toThrow(FrameDatabaseUnavailableError);
+    expect(existsSync(join(databasesDir, `${name}.db`))).toBe(false);
+  });
+
+  test("requires a readable publication descriptor for Frame invocations", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(), () => db(name))
+    ).toThrow(FramePublicationDescriptorError);
+
+    const descriptorPath = join(databasesDir, "invalid-publication.json");
+    writeFileSync(descriptorPath, "not-json");
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
+    ).toThrow(FramePublicationDescriptorError);
+  });
+
+  test("rechecks declarations before returning a warm cached database", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+    const declaringPublication = createPublicationDescriptor([name]);
+    const removingPublication = createPublicationDescriptor([]);
+
+    runWithInvocationEnv(frameInvocationEnv(declaringPublication), () =>
+      db(name)
+    );
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(removingPublication), () =>
+        db(name)
+      )
+    ).toThrow(FrameDatabaseNotDeclaredError);
   });
 });
 

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -21,6 +21,7 @@ import {
   PodDatabaseNotDeclaredError,
   PodDatabasesUnavailableError,
   runWithInvocationEnv,
+  SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION,
 } from "@dust/pod";
 import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
@@ -133,6 +134,7 @@ describe("Frame publication database contract", () => {
     writeFileSync(
       descriptorPath,
       JSON.stringify({
+        schemaVersion: SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION,
         manifest: {
           databases: databaseNames.map((name) => ({
             name,
@@ -195,6 +197,23 @@ describe("Frame publication database contract", () => {
 
     const descriptorPath = join(databasesDir, "invalid-publication.json");
     writeFileSync(descriptorPath, "not-json");
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
+    ).toThrow(FramePublicationDescriptorError);
+  });
+
+  test("rejects an unsupported publication descriptor version", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+    const descriptorPath = createPublicationDescriptor([name]);
+    writeFileSync(
+      descriptorPath,
+      JSON.stringify({
+        schemaVersion: SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION + 1,
+        manifest: { databases: [{ name }] },
+      })
+    );
+
     expect(() =>
       runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
     ).toThrow(FramePublicationDescriptorError);

--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -1,8 +1,8 @@
 /**
- * `@dust/pod` — the runtime library for code running in a Dust pod sandbox.
+ * `@dust/pod` — the runtime library for code running in a Dust Pod or Frame sandbox.
  *
  * Surfaces:
- * - `db(name)`: the pod's SQLite state databases, through Drizzle (./db.ts).
+ * - `db(name)`: the owner's SQLite state databases, through Drizzle (./db.ts).
  * - `currentUser()`: the workspace-scoped user attributed to this invocation.
  * - `podEnv(name)`: the invocation's environment (./context.ts).
  * - `resolveToolTextContent(block)`: full text of a tool output block,

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dust/pod",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
-  "description": "Runtime library for code running in a Dust pod sandbox.",
+  "description": "Runtime library for code running in a Dust Pod or Frame sandbox.",
   "type": "module",
   "main": "index.ts",
   "exports": { ".": "./index.ts" },

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -5,6 +5,8 @@ import {
   getBaseMountPathForWorkspace,
   getConversationFilePath,
   getConversationFilesBasePath,
+  getFramePublicationDescriptorMountPoint,
+  getFramePublicationFunctionsMountPoint,
   getPodFilesBasePath,
   getPodSandboxFunctionsBasePath,
   getPodStateBasePath,
@@ -69,6 +71,22 @@ describe("mount_path helpers", () => {
     it("should return a dedicated prefix separate from pod files and functions", () => {
       expect(getPodStateBasePath({ workspaceId: "ws1", podId: "spc1" })).toBe(
         "w/ws1/pods/spc1/state/"
+      );
+    });
+  });
+
+  describe("Frame publication mount paths", () => {
+    it("selects one immutable publication", () => {
+      const identity = {
+        frameId: "fil_123",
+        publicationId: "pub_456",
+      };
+
+      expect(getFramePublicationDescriptorMountPoint(identity)).toBe(
+        "/frames/fil_123/publications/pub_456/publication.json"
+      );
+      expect(getFramePublicationFunctionsMountPoint(identity)).toBe(
+        "/frames/fil_123/publications/pub_456/functions"
       );
     });
   });

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -9,7 +9,7 @@ import path from "path";
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
 export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.3.0";
+export const POD_PACKAGE_VERSION = "0.3.1";
 export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
 
 let podPackageSrcDir: string | undefined;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.100",
+      tag: "0.8.101",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -673,7 +673,7 @@ describe("sandbox image registry", () => {
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.3.0" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.3.1" }),
       ])
     );
   });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.100";
+const DUST_BASE_IMAGE_VERSION = "0.8.101";
 const DSBX_CLI_VERSION = "0.1.53";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
@@ -583,7 +583,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     name: POD_PACKAGE_NAME,
     version: POD_PACKAGE_VERSION,
     description:
-      "Pod database access: db(name) returns a drizzle instance over the pod's SQLite database",
+      "Frame and Pod database access: db(name) returns a Drizzle instance over the owner's SQLite database",
     runtime: "node",
   })
   .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -836,6 +836,9 @@ describe("SandboxFunctionInvocationResource", () => {
       DUST_SANDBOX_TOKEN: "sbt-function-token",
       DUST_FUNCTION_WARM_ENABLED: "0",
     });
+    expect(opts?.envVars).not.toHaveProperty(
+      "DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH"
+    );
     expect(
       JSON.parse(opts?.envVars?.DUST_POD_USER_IDENTITY ?? "")
     ).toMatchObject({
@@ -906,6 +909,7 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     const execOptions = execSpy.mock.calls[0]?.[2];
     expect(execOptions?.envVars).toMatchObject({
+      DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH: `/frames/${frame.sId}/publications/${publicationId}/publication.json`,
       DUST_POD_DATABASES_DIR: "/pod-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_POD_DATABASE_PREFIX: "",

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -62,6 +62,7 @@ import type {
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
 import {
+  getFramePublicationDescriptorMountPoint,
   getFramePublicationFunctionsMountPoint,
   getPodSandboxFunctionsMountPoint,
   sandboxDatabaseExecEnvVars,
@@ -788,6 +789,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       );
 
       let functionsDirectory: string;
+      let databaseEnvVars: ReturnType<typeof sandboxDatabaseExecEnvVars>;
       if (frame) {
         if (!publicationId) {
           return new Err(
@@ -798,16 +800,21 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           frameId: frame.sId,
           publicationId,
         });
+        databaseEnvVars = sandboxDatabaseExecEnvVars({
+          framePublicationDescriptorPath:
+            getFramePublicationDescriptorMountPoint({
+              frameId: frame.sId,
+              publicationId,
+            }),
+        });
       } else {
         functionsDirectory = getPodSandboxFunctionsMountPoint(
           sandboxFunction.space.sId
         );
+        databaseEnvVars = sandboxDatabaseExecEnvVars({
+          databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
+        });
       }
-      const databaseEnvVars = frame
-        ? sandboxDatabaseExecEnvVars()
-        : sandboxDatabaseExecEnvVars({
-            databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
-          });
 
       const execStartedAtMs = Date.now();
       const execResult = await sandbox.exec(auth, command, {

--- a/front/types/api/frame_publication.ts
+++ b/front/types/api/frame_publication.ts
@@ -5,6 +5,7 @@ import {
   FrameManifestSchema,
   isSafeFrameRelativePath,
 } from "@app/types/api/frame_manifest";
+import { FRAME_PUBLICATION_FILE } from "@app/types/api/frame_storage";
 import { SANDBOX_FUNCTION_USER_IDENTITY_POLICIES } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -13,7 +14,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export const FRAME_PUBLICATION_FILE = "publication.json";
+export { FRAME_PUBLICATION_FILE };
 export const FRAME_PUBLICATION_SCHEMA_VERSION = 1;
 
 const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -2,6 +2,8 @@ import { FRAME_DATABASE_NAME_REGEX } from "@app/types/api/frame_manifest";
 
 const SAFE_FRAME_STORAGE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
+export const FRAME_PUBLICATION_FILE = "publication.json";
+
 function safeSegment(value: string, label: string): string {
   if (!SAFE_FRAME_STORAGE_SEGMENT.test(value)) {
     throw new Error(`Invalid ${label} for Frame storage.`);
@@ -74,7 +76,7 @@ export function getFramePublicationDescriptorPath(args: {
   frameId: string;
   publicationId: string;
 }): string {
-  return `${getFramePublicationBasePath(args)}publication.json`;
+  return `${getFramePublicationBasePath(args)}${FRAME_PUBLICATION_FILE}`;
 }
 
 export function getFramePublicationUiBundlePath(args: {

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -7,6 +7,7 @@
 //                     the same Pod.
 
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { FRAME_PUBLICATION_FILE } from "@app/types/api/frame_storage";
 import {
   LEGACY_PREFIX_CONVERSATION,
   LEGACY_PREFIX_PROJECT,
@@ -117,6 +118,17 @@ export function getFramePublicationFunctionsMountPoint({
   return `${getFramePublicationsMountPoint(frameId)}/${publicationId}/functions`;
 }
 
+/** Exact immutable publication descriptor selected for one Frame invocation. */
+export function getFramePublicationDescriptorMountPoint({
+  frameId,
+  publicationId,
+}: {
+  frameId: string;
+  publicationId: string;
+}): string {
+  return `${getFramePublicationsMountPoint(frameId)}/${publicationId}/${FRAME_PUBLICATION_FILE}`;
+}
+
 /**
  * Frame-owned SQLite uses the same isolated local runtime directories as Pod SQLite. A Frame has
  * its own sandbox, so the live files cannot overlap another Frame or a Pod; only its Litestream
@@ -155,18 +167,27 @@ const SANDBOX_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
  */
 export function sandboxDatabaseExecEnvVars({
   databasePrefix,
+  framePublicationDescriptorPath,
 }: {
   databasePrefix?: string | null;
+  framePublicationDescriptorPath?: string;
 } = {}): {
   DUST_POD_DATABASES_DIR: string;
   DUST_POD_DATABASE_MAX_SIZE_BYTES: string;
   DUST_POD_DATABASE_PREFIX: string;
+  DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH?: string;
 } {
   return {
     DUST_POD_DATABASES_DIR: SANDBOX_STATE_DATABASES_DIR,
     DUST_POD_DATABASE_MAX_SIZE_BYTES: String(SANDBOX_DATABASE_MAX_SIZE_BYTES),
     // Empty means unprefixed, which is what the shim reads an absent value as.
     DUST_POD_DATABASE_PREFIX: databasePrefix ?? "",
+    ...(framePublicationDescriptorPath
+      ? {
+          DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH:
+            framePublicationDescriptorPath,
+        }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Description

- Enforce Frame database declarations from the exact immutable publication descriptor selected by each invocation.
- Preserve Pod database name resolution and errors while adding typed Frame contract failures.
- Vendor @dust/pod 0.3.1 in dust-base 0.8.101.

## Tests

Added warm-publication contract coverage and ran the @dust/pod suite, bundle build, focused Frame invocation and image tests locally.

## Risk

Frame database access requires dust-base 0.8.101. Pod Functions keep their existing SPACE_ID and prefix path.

## Deploy Plan

Stacked on #31409.

- [ ] Build and release dust-base 0.8.101.
- [ ] Deploy Front after the image is available.
- [ ] Recycle existing Frame sandboxes so they pick up @dust/pod 0.3.1.