### PR TITLE
Expose canonical Frames v2 invocation endpoint

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9335,6 +9335,78 @@
         }
       }
     },
+    "/api/w/{wId}/frames/{frameId}/functions/{name}/invocations": {
+      "post": {
+        "summary": "Invoke an active Frames v2 function",
+        "description": "Resolves a bare function name from the Frame's active immutable publication, checks Frame use rights, and starts an invocation pinned to that publication.",
+        "tags": [
+          "Private Frames"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "frameId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "description": "Bare function name declared by the active Frame publication.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateFrameFunctionInvocationRequest"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Invocation created. Fast invocations may also include their terminal outcome.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateFrameFunctionInvocationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The function requires a workspace member or a stricter caller identity."
+          },
+          "404": {
+            "description": "Frame, active publication, function, or Frame use right not found."
+          },
+          "500": {
+            "description": "Invocation failed before it could be created."
+          }
+        }
+      }
+    },
     "/api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events": {
       "get": {
         "summary": "Stream sandbox function invocation events",
@@ -13236,6 +13308,123 @@
           "userId": {
             "type": "string",
             "description": "sId of the user who owns the wake-up."
+          }
+        }
+      },
+      "PrivateSandboxFunctionInvocation": {
+        "type": "object",
+        "required": [
+          "sId",
+          "functionId",
+          "status",
+          "createdAt"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "functionId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "errored",
+              "succeeded"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PrivateSandboxFunctionCallError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Classification forwarded from the runner, API, or invocation layer."
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateFrameFunctionInvocationRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "input": {
+            "description": "Input validated against the published function contract."
+          },
+          "context": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "timezone": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "PrivateFrameFunctionInvocationResponse": {
+        "type": "object",
+        "required": [
+          "invocation"
+        ],
+        "properties": {
+          "invocation": {
+            "$ref": "#/components/schemas/PrivateSandboxFunctionInvocation"
+          },
+          "outcome": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "status",
+                  "result"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "succeeded"
+                    ]
+                  },
+                  "result": {
+                    "description": "Parsed result validated against the function output schema."
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "status",
+                  "error"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "errored"
+                    ]
+                  },
+                  "error": {
+                    "$ref": "#/components/schemas/PrivateSandboxFunctionCallError"
+                  }
+                }
+              }
+            ]
           }
         }
       },

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1654,6 +1654,67 @@
  *         userId:
  *           type: string
  *           description: sId of the user who owns the wake-up.
+ *     PrivateSandboxFunctionInvocation:
+ *       type: object
+ *       required: [sId, functionId, status, createdAt]
+ *       properties:
+ *         sId:
+ *           type: string
+ *         functionId:
+ *           type: string
+ *         status:
+ *           type: string
+ *           enum: [created, errored, succeeded]
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *     PrivateSandboxFunctionCallError:
+ *       type: object
+ *       required: [code, message]
+ *       properties:
+ *         code:
+ *           type: string
+ *           description: Classification forwarded from the runner, API, or invocation layer.
+ *         message:
+ *           type: string
+ *         status:
+ *           type: integer
+ *     PrivateFrameFunctionInvocationRequest:
+ *       type: object
+ *       additionalProperties: false
+ *       properties:
+ *         input:
+ *           description: Input validated against the published function contract.
+ *         context:
+ *           type: object
+ *           additionalProperties: false
+ *           properties:
+ *             timezone:
+ *               type: string
+ *     PrivateFrameFunctionInvocationResponse:
+ *       type: object
+ *       required: [invocation]
+ *       properties:
+ *         invocation:
+ *           $ref: '#/components/schemas/PrivateSandboxFunctionInvocation'
+ *         outcome:
+ *           oneOf:
+ *             - type: object
+ *               required: [status, result]
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   enum: [succeeded]
+ *                 result:
+ *                   description: Parsed result validated against the function output schema.
+ *             - type: object
+ *               required: [status, error]
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   enum: [errored]
+ *                 error:
+ *                   $ref: '#/components/schemas/PrivateSandboxFunctionCallError'
  *     PrivateSandboxFunctionInvocationEvent:
  *       type: object
  *       description: Server-Sent Event for sandbox function invocation streaming. Discriminated on the `type` field.

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import invocations from "./invocations";
+
+const app = workspaceApp();
+
+app.route("/invocations", invocations);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.test.ts
@@ -1,0 +1,228 @@
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...mod,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+    getSandboxFunctionInvocationEvents: vi.fn(async function* () {}),
+  };
+});
+
+vi.mock("@app/temporal/sandbox_functions/client", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/temporal/sandbox_functions/client")
+    >();
+  return {
+    ...mod,
+    launchSandboxFunctionInvocationWorkflow: vi.fn(
+      async () => new Ok(undefined)
+    ),
+  };
+});
+
+import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
+
+const inputSchema: JSONSchema = { type: "object" };
+const outputSchema: JSONSchema = { type: "object" };
+
+async function setupFrameFunction({
+  enableFramesV2 = true,
+  shareScope = "workspace_and_emails",
+}: {
+  enableFramesV2?: boolean;
+  shareScope?: "emails_only" | "workspace_and_emails";
+} = {}) {
+  const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  if (enableFramesV2) {
+    await FeatureFlagFactory.basic(adminAuth, "frames_v2");
+  }
+  const space = await SpaceFactory.project(workspace);
+  const publicationId = "publication-1";
+  const frame = await FileFactory.create(adminAuth, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 100,
+    status: "ready",
+    useCase: "project_context",
+    useCaseMetadata: {
+      spaceId: space.sId,
+      activePublicationId: publicationId,
+    },
+  });
+  await frame.setShareScope(adminAuth, shareScope);
+  await withTransaction((transaction) =>
+    SandboxFunctionResource.createForFramePublication(
+      adminAuth,
+      {
+        frame,
+        publicationId,
+        functions: [
+          {
+            name: "run-function",
+            description: "Run the Frame function.",
+            userIdentity: "optional",
+            executionMode: "durable",
+            defaultStake: "low",
+            bundleCode:
+              "export default { fetch: async () => Response.json({}) };",
+            inputSchema,
+            outputSchema,
+          },
+        ],
+      },
+      transaction
+    )
+  );
+  const sandboxFunction =
+    await SandboxFunctionResource.fetchByFramePublicationAndSlug(adminAuth, {
+      frame,
+      publicationId,
+      slug: "run-function",
+    });
+  if (!sandboxFunction) {
+    throw new Error("Expected the Frame function to exist.");
+  }
+
+  await createPrivateApiMockRequest({
+    role: "user",
+    workspace,
+  });
+
+  return {
+    frame,
+    sandboxFunction,
+    workspace,
+  };
+}
+
+function postInvocation({
+  workspaceId,
+  frameId,
+  functionName = "run-function",
+}: {
+  workspaceId: string;
+  frameId: string;
+  functionName?: string;
+}) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/frames/${frameId}/functions/${functionName}/invocations`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: { message: "hello" } }),
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/w/:wId/frames/:frameId/functions/:name/invocations", () => {
+  it("invokes the named function from the active publication", async () => {
+    const { workspace, frame, sandboxFunction } = await setupFrameFunction();
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      invocation: {
+        functionId: sandboxFunction.sId,
+        status: "created",
+      },
+    });
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sandboxFunction: expect.objectContaining({
+          sId: sandboxFunction.sId,
+          publicationId: "publication-1",
+        }),
+      })
+    );
+  });
+
+  it("does not resolve a function outside the active publication", async () => {
+    const { workspace, frame } = await setupFrameFunction();
+    await frame.setActiveFramePublication("publication-2");
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("rejects a publication that becomes inactive while resolving", async () => {
+    const { workspace, frame } = await setupFrameFunction();
+    const fetchFunction =
+      SandboxFunctionResource.fetchByFramePublicationAndSlug.bind(
+        SandboxFunctionResource
+      );
+    vi.spyOn(
+      SandboxFunctionResource,
+      "fetchByFramePublicationAndSlug"
+    ).mockImplementationOnce(async (...args) => {
+      await frame.setActiveFramePublication("publication-2");
+      return fetchFunction(...args);
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("enforces Frame use rights", async () => {
+    const { workspace, frame } = await setupFrameFunction({
+      shareScope: "emails_only",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("is available only behind frames_v2", async () => {
+    const { workspace, frame } = await setupFrameFunction({
+      enableFramesV2: false,
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+    });
+
+    expect(response.status).toBe(403);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -1,0 +1,147 @@
+import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
+import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
+import { resolveActiveFrameFunctionForUse } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  PostSandboxFunctionInvocationResponseBody,
+} from "@app/types/api/sandbox_functions";
+import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  frameId: z.string().min(1),
+  name: z.string().refine(isValidSandboxFunctionSlug),
+});
+
+const PostFrameFunctionInvocationBodySchema = z
+  .object({
+    input: z.unknown().optional(),
+    context: z
+      .object({
+        timezone: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strict();
+
+const app = workspaceApp();
+
+/**
+ * @swagger
+ * /api/w/{wId}/frames/{frameId}/functions/{name}/invocations:
+ *   post:
+ *     summary: Invoke an active Frames v2 function
+ *     description: Resolves a bare function name from the Frame's active immutable publication, checks Frame use rights, and starts an invocation pinned to that publication.
+ *     tags:
+ *       - Private Frames
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: frameId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         description: Bare function name declared by the active Frame publication.
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/PrivateFrameFunctionInvocationRequest'
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Invocation created. Fast invocations may also include their terminal outcome.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateFrameFunctionInvocationResponse'
+ *       401:
+ *         description: The function requires a workspace member or a stricter caller identity.
+ *       404:
+ *         description: Frame, active publication, function, or Frame use right not found.
+ *       500:
+ *         description: Invocation failed before it could be created.
+ */
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostFrameFunctionInvocationBodySchema),
+  async (ctx): HandlerResult<PostSandboxFunctionInvocationResponseBody> => {
+    const auth = ctx.get("auth");
+    const { frameId, name } = ctx.req.valid("param");
+    const body: PostSandboxFunctionInvocationRequestBody =
+      ctx.req.valid("json");
+
+    const sandboxFunction = await resolveActiveFrameFunctionForUse(auth, {
+      frameId,
+      functionName: name,
+    });
+    if (!sandboxFunction) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_not_found",
+          message: "Frame function not found.",
+        },
+      });
+    }
+
+    const invocationResult = await sandboxFunction.invoke(auth, body, {
+      origin:
+        auth.authMethod() === "session" ? "interactive_session" : "delegated",
+    });
+    if (invocationResult.isErr()) {
+      if (isSandboxFunctionInvocationError(invocationResult.error)) {
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: invocationResult.error.code,
+            message: invocationResult.error.message,
+          },
+        });
+      }
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Frame function invocation failed.",
+          },
+        },
+        invocationResult.error
+      );
+    }
+
+    const invocation = invocationResult.value;
+    const outcome =
+      invocation.settledOutcome() ??
+      (await awaitSandboxFunctionInvocationOutcome({
+        invocationId: invocation.sId,
+      }));
+
+    return ctx.json(
+      {
+        invocation: invocation.toJSON(),
+        ...(outcome ? { outcome } : {}),
+      },
+      201
+    );
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import functionName from "./[name]";
+
+const app = workspaceApp();
+
+app.route("/:name", functionName);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import functions from "./functions";
+
+const app = workspaceApp();
+
+app.route("/functions", functions);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/index.ts
+++ b/front-api/routes/w/[wId]/frames/index.ts
@@ -1,0 +1,17 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+
+import frameId from "./[frameId]";
+
+const app = workspaceApp();
+
+app.use(
+  "*",
+  withFeatureFlag("frames_v2", {
+    message: "Frames v2 are not enabled for this workspace.",
+  })
+);
+
+app.route("/:frameId", frameId);
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -54,6 +54,7 @@ import extension from "./extension";
 import fairUseCredits from "./fair-use-credits";
 import featureFlags from "./feature-flags";
 import files from "./files";
+import frames from "./frames";
 import googleDrivePickerToken from "./google_drive/picker_token";
 import googleDriveSearchForAuthorization from "./google_drive/search_for_authorization";
 import governancePermissions from "./governance-permissions";
@@ -1053,6 +1054,7 @@ app.route("/dust_app_secrets", dustAppSecrets);
 app.route("/extension", extension);
 app.route("/fair-use-credits", fairUseCredits);
 app.route("/files", files);
+app.route("/frames", frames);
 app.route("/google_drive/picker_token", googleDrivePickerToken);
 app.route(
   "/google_drive/search_for_authorization",

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -68,8 +68,7 @@ export async function resolveSandboxFunctionWithCapability(
     if (isFramesV2Enabled) {
       const frameFunction = await resolveFrameV2FunctionReference(
         auth,
-        functionIdOrSlug,
-        { allowInactivePublication: allowInactiveFramePublication }
+        functionIdOrSlug
       );
       if (frameFunction) {
         return frameFunction;
@@ -95,8 +94,7 @@ export async function resolveSandboxFunctionWithCapability(
 
 async function resolveFrameV2FunctionReference(
   auth: Authenticator,
-  functionIdOrReference: string,
-  { allowInactivePublication }: { allowInactivePublication: boolean }
+  functionIdOrReference: string
 ): Promise<SandboxFunctionResource | null> {
   const [frameId, slug, ...rest] = functionIdOrReference.split("/");
   if (
@@ -108,20 +106,48 @@ async function resolveFrameV2FunctionReference(
   ) {
     return null;
   }
-  const frame = await FileResource.fetchById(auth, frameId);
-  const publicationId = frame?.useCaseMetadata?.activePublicationId;
-  if (!frame?.isFrameV2 || !publicationId) {
+  return resolveActiveFrameFunctionForUse(auth, {
+    frameId,
+    functionName: slug,
+  });
+}
+
+/** Resolve one function from the active publication of a Frame the caller may use. */
+export async function resolveActiveFrameFunctionForUse(
+  auth: Authenticator,
+  {
+    frameId,
+    functionName,
+  }: {
+    frameId: string;
+    functionName: string;
+  }
+): Promise<SandboxFunctionResource | null> {
+  if (
+    !isResourceSId("file", frameId) ||
+    !isValidSandboxFunctionSlug(functionName)
+  ) {
     return null;
   }
+
+  const frame = await FileResource.fetchById(auth, frameId);
+  const publicationId = frame?.useCaseMetadata?.activePublicationId;
+  if (
+    !frame?.isFrameV2 ||
+    !publicationId ||
+    !(await frame.canCurrentUserUseFrame(auth))
+  ) {
+    return null;
+  }
+
   const sandboxFunction =
     await SandboxFunctionResource.fetchByFramePublicationAndSlug(auth, {
       frame,
       publicationId,
-      slug,
+      slug: functionName,
     });
-
   return resolveFrameV2FunctionAccess(auth, sandboxFunction, {
-    allowInactivePublication,
+    allowInactivePublication: false,
   });
 }
 

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -135,6 +135,9 @@ export function isValidSandboxFunctionSlug(value: unknown): value is string {
   return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);
 }
 
+/**
+ * @swaggerschema PrivateSandboxFunctionInvocation (swagger_private_schemas.ts)
+ */
 export type SandboxFunctionInvocationType = {
   sId: string;
   functionId: string;
@@ -178,6 +181,9 @@ export type SandboxFunctionCallErrorCode =
   | SandboxFunctionFrontErrorCode
   | APIErrorType;
 
+/**
+ * @swaggerschema PrivateSandboxFunctionCallError (swagger_private_schemas.ts)
+ */
 export type SandboxFunctionCallError = {
   code: SandboxFunctionCallErrorCode;
   message: string;
@@ -241,6 +247,9 @@ export type SandboxFunctionInvocationContext = {
   timezone?: string;
 };
 
+/**
+ * @swaggerschema PrivateFrameFunctionInvocationRequest (swagger_private_schemas.ts)
+ */
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;
   context?: SandboxFunctionInvocationContext;
@@ -252,6 +261,9 @@ export type SandboxFunctionInvocationOutcome =
   | { status: "succeeded"; result: unknown }
   | { status: "errored"; error: SandboxFunctionCallError };
 
+/**
+ * @swaggerschema PrivateFrameFunctionInvocationResponse (swagger_private_schemas.ts)
+ */
 export type PostSandboxFunctionInvocationResponseBody = {
   invocation: SandboxFunctionInvocationType;
   // Set when the invocation settled before the response was sent. Callers that get an outcome are


### PR DESCRIPTION
## Description

Add the canonical POST endpoint for invoking a Frames v2 function by stable Frame id and bare function name. Resolution is pinned to the active immutable publication, reuses the existing Frame use-rights check, and preserves the existing caller-identity policy and invocation response shape.

This private API is additive and feature-gated. Legacy Frame and Pod Function routes are unchanged. The client switch and canonical SSE route are intentionally separate so both servers can land independently. Based directly on `main`.

## Tests

- focused Front API Vitest: 1 file / 4 tests passed
- `npm run lint:swagger-annotations` in `front-api`
- `npm run docs` in `front-api`
- pre-commit Biome, Swagger docs check, and Front typecheck
- synthetic POST + SSE final tree: POST 4/4 and SSE 4/4 tests passed after regenerating Swagger
- `git diff --check`

## Risk

Low and feature-gated. The route is additive, fails closed for a missing Frame, inactive publication, missing function, or missing use right, and delegates identity enforcement to the existing invocation authorization path. Rollback is reverting this PR.

## Deploy Plan

Deploy normally. No migration or backfill. Enable the client switch only after both canonical POST and SSE server routes are available.