### PR TITLE
Present Frame packages in the file explorer

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -9,6 +9,7 @@ import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -30,6 +31,7 @@ export function ConversationFileExplorer({
   owner,
 }: ConversationFileExplorerProps) {
   const { closePanel, openPanel } = useConversationSidePanelContext();
+  const { hasFeature } = useFeatureFlags();
   const isPod = isPodConversation(conversation);
 
   const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
@@ -105,6 +107,7 @@ export function ConversationFileExplorer({
         <FileExplorer
           currentFolderPath={currentFolderPath}
           defaultViewMode={isPod ? "list" : "grid"}
+          displayFramePackages={hasFeature("frames_v2")}
           files={files}
           hideBreadcrumbAtRoot={!isPod}
           isLoading={

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -1,9 +1,18 @@
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { frameV2ContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { useState } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClientFetch = vi.fn();
 vi.mock("@app/lib/egress/client", () => ({
@@ -16,11 +25,13 @@ vi.mock("@app/lib/swr/useIsMobile", () => ({
 function makeFile({
   contentType,
   fileName,
+  fileResourceContentType,
   lastModifiedMs,
   path = fileName,
 }: {
   contentType: string;
   fileName: string;
+  fileResourceContentType?: string;
   lastModifiedMs: number;
   path?: string;
 }): FileSystemFileEntry {
@@ -30,6 +41,7 @@ function makeFile({
     path: `conversation-c1/${path}`,
     contentType,
     fileId: `file-${fileName}`,
+    fileResourceContentType,
     sizeBytes: 100,
     lastModifiedMs,
     thumbnailUrl: null,
@@ -54,6 +66,15 @@ function ControlledFileExplorer(props: ControlledFileExplorerProps) {
     />
   );
 }
+
+beforeAll(() => {
+  // Radix relies on this browser API when opening dropdown content.
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
 
 describe("FileExplorer file opening", () => {
   beforeEach(() => {
@@ -180,5 +201,73 @@ describe("FileExplorer navigation", () => {
     fireEvent.click(screen.getByText("folder"));
 
     expect(screen.getByText("nested.txt")).toBeInTheDocument();
+  });
+});
+
+describe("FileExplorer Frame packages", () => {
+  it("opens the Frame and exposes its source without generic file actions", async () => {
+    const user = userEvent.setup();
+    mockClientFetch.mockResolvedValue(new Response("preview content"));
+    const manifest = makeFile({
+      contentType: "application/json",
+      fileName: "manifest.json",
+      fileResourceContentType: frameV2ContentType,
+      lastModifiedMs: 2,
+      path: "status/manifest.json",
+    });
+    const source = makeFile({
+      contentType: "text/typescript",
+      fileName: "index.tsx",
+      lastModifiedMs: 1,
+      path: "status/index.tsx",
+    });
+    const onOpenInteractive = vi.fn();
+
+    render(
+      <ControlledFileExplorer
+        defaultViewMode="list"
+        displayFramePackages
+        files={[manifest, source]}
+        getFileUrl={(path) => `/files/${path}`}
+        isLoading={false}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+        onFileDownload={vi.fn().mockResolvedValue(undefined)}
+        onMoveFile={vi.fn().mockResolvedValue(new Ok(undefined))}
+        onOpenInteractive={onOpenInteractive}
+        onRename={vi.fn()}
+      />
+    );
+
+    const packageTitle = screen.getByText("status");
+    fireEvent.click(packageTitle);
+    expect(onOpenInteractive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: "file-manifest.json",
+        kind: "frame_package",
+        path: "conversation-c1/status/manifest.json",
+        sourceFolderPath: "status",
+      })
+    );
+
+    const packageRow = packageTitle.closest("div.cursor-pointer");
+    expect(packageRow).toBeInstanceOf(HTMLElement);
+    if (!(packageRow instanceof HTMLElement)) {
+      throw new Error("Frame package row not found.");
+    }
+    await user.click(within(packageRow).getByRole("button"));
+    expect(screen.getByText("View source")).toBeInTheDocument();
+    expect(screen.queryByText("Rename")).not.toBeInTheDocument();
+    expect(screen.queryByText("Move to…")).not.toBeInTheDocument();
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View source"));
+    const manifestTitle = await screen.findByText("manifest.json");
+    expect(screen.getByText("index.tsx")).toBeInTheDocument();
+
+    fireEvent.click(manifestTitle);
+    expect(
+      await screen.findByRole("dialog", { name: "manifest.json" })
+    ).toBeInTheDocument();
+    expect(await screen.findByText("preview content")).toBeInTheDocument();
   });
 });

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -18,6 +18,7 @@ import type {
   FileExplorerSortMode,
   FileSystemTreeNode,
   FolderEntry,
+  FramePackageEntry,
 } from "@app/components/file_explorer/types";
 import {
   buildFolderTree,
@@ -42,6 +43,7 @@ interface FileExplorerProps {
   emptyState?: React.ReactNode;
   hideBreadcrumbAtRoot?: boolean;
   currentFolderPath: string;
+  displayFramePackages?: boolean;
   files: FileExplorerPathEntry[];
   getFileUrl: (path: string) => string;
   toolbarExtraActions?: React.ReactNode;
@@ -53,7 +55,7 @@ interface FileExplorerProps {
     entry: FileEntry,
     parentRelativePath: string
   ) => Promise<Result<void, Error>>;
-  onOpenInteractive?: (entry: FileEntryWithId) => void;
+  onOpenInteractive?: (entry: FileEntryWithId | FramePackageEntry) => void;
   onOpenInPanel?: (entry: FileEntry) => boolean;
   onRename?: (entry: FileEntry | FolderEntry) => void;
   owner?: LightWorkspaceType;
@@ -68,6 +70,7 @@ export function FileExplorer({
   contentClassName,
   contentNodes = [],
   defaultViewMode = "grid",
+  displayFramePackages = false,
   emptyState,
   currentFolderPath,
   files,
@@ -109,6 +112,7 @@ export function FileExplorer({
       getFileExplorerPipeline({
         contentNodes,
         currentFolderPath,
+        displayFramePackages,
         files,
         searchQuery,
         activeFilter,
@@ -118,6 +122,7 @@ export function FileExplorer({
     [
       contentNodes,
       currentFolderPath,
+      displayFramePackages,
       files,
       searchQuery,
       activeFilter,
@@ -136,6 +141,18 @@ export function FileExplorer({
     (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
       const items: FileExplorerMenuAction[] =
         getExtraFileMenuItems?.(entry) ?? [];
+      if (entry.kind === "frame_package") {
+        items.push({
+          label: "View source",
+          icon: FolderOpen,
+          onClick: (e) => {
+            e.stopPropagation();
+            onCurrentFolderChange(entry.sourceFolderPath);
+            setActiveFilter("all");
+          },
+        });
+        return items;
+      }
       if (onRename && (entry.kind === "file" || entry.kind === "folder")) {
         items.push({
           label: "Rename",
@@ -175,7 +192,14 @@ export function FileExplorer({
       }
       return items;
     },
-    [getExtraFileMenuItems, onDelete, onMoveFile, onRename, totalFolderCount]
+    [
+      getExtraFileMenuItems,
+      onCurrentFolderChange,
+      onDelete,
+      onMoveFile,
+      onRename,
+      totalFolderCount,
+    ]
   );
 
   const handleMoveToFolder = useCallback(
@@ -241,6 +265,10 @@ export function FileExplorer({
     }
     setPreviewFile(entry);
     setShowPreviewSheet(true);
+  };
+
+  const handleFramePackageOpen = (entry: FramePackageEntry) => {
+    onOpenInteractive?.(entry);
   };
 
   const handleNodeOpen = (entry: ContentNodeEntry) => {
@@ -320,11 +348,16 @@ export function FileExplorer({
             fileDragEnabled={fileDragEnabled}
             onFolderNavigate={handleFolderNavigate}
             onFileOpen={handleFileOpen}
+            onFramePackageOpen={handleFramePackageOpen}
             onFileDownload={onFileDownload}
             onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
             onNodeOpen={handleNodeOpen}
             getFileMenuItems={
-              onDelete || onRename || onMoveFile || getExtraFileMenuItems
+              displayFramePackages ||
+              onDelete ||
+              onRename ||
+              onMoveFile ||
+              getExtraFileMenuItems
                 ? getMenuItems
                 : undefined
             }

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -4,6 +4,7 @@ import {
   FileExplorerEmptyState,
   FileExplorerFileCard,
   FileExplorerFolderCard,
+  FileExplorerFramePackageCard,
 } from "@app/components/file_explorer/FileExplorerItem";
 import type {
   ContentNodeEntry,
@@ -12,6 +13,7 @@ import type {
   FileExplorerMenuAction,
   FileSystemTreeNode,
   FolderEntry,
+  FramePackageEntry,
 } from "@app/components/file_explorer/types";
 import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -31,6 +33,7 @@ interface FileExplorerContentProps {
   fileDragEnabled?: boolean;
   onFolderNavigate: (node: FileSystemTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
+  onFramePackageOpen: (entry: FramePackageEntry) => void;
   onFileDownload: (entry: FileEntry) => Promise<void>;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
   onNodeOpen: (entry: ContentNodeEntry) => void;
@@ -49,6 +52,7 @@ export function FileExplorerContent({
   fileDragEnabled,
   onFolderNavigate,
   onFileOpen,
+  onFramePackageOpen,
   onFileDownload,
   onMoveFileDrop,
   onNodeOpen,
@@ -105,6 +109,18 @@ export function FileExplorerContent({
             viewMode={viewMode}
             onOpen={onFileOpen}
             onDownload={onFileDownload}
+            extraMenuItems={getFileMenuItems?.(entry)}
+          />
+        );
+
+      case "frame_package":
+        return (
+          <FileExplorerFramePackageCard
+            key={`frame-package:${entry.sourceFolderPath}`}
+            entry={entry}
+            searchFolderPath={searchFolderPath}
+            viewMode={viewMode}
+            onOpen={onFramePackageOpen}
             extraMenuItems={getFileMenuItems?.(entry)}
           />
         );

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -9,6 +9,7 @@ import type {
   FileEntry,
   FileExplorerMenuAction,
   FileSystemTreeNode,
+  FramePackageEntry,
 } from "@app/components/file_explorer/types";
 import {
   getCategoryFromContentType,
@@ -442,6 +443,40 @@ export function FileExplorerFileCard({
     >
       {item}
     </FileExplorerDraggableWrapper>
+  );
+}
+
+interface FileExplorerFramePackageCardProps {
+  entry: FramePackageEntry;
+  /** When set, title shows path relative to this folder (search mode). */
+  searchFolderPath?: string;
+  viewMode: ViewMode;
+  onOpen: (entry: FramePackageEntry) => void;
+  extraMenuItems?: FileExplorerMenuAction[];
+}
+
+export function FileExplorerFramePackageCard({
+  entry,
+  searchFolderPath,
+  viewMode,
+  onOpen,
+  extraMenuItems,
+}: FileExplorerFramePackageCardProps) {
+  const title =
+    searchFolderPath !== undefined
+      ? getFileExplorerSearchResultTitle(entry, searchFolderPath)
+      : entry.fileName;
+
+  return (
+    <FileExplorerItem
+      kind="icon"
+      visual={getFileTypeIcon(entry.contentType, entry.fileName)}
+      viewMode={viewMode}
+      title={title}
+      subtitle="Frame"
+      onOpen={() => onOpen(entry)}
+      extraMenuItems={extraMenuItems}
+    />
   );
 }
 

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -835,6 +835,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         contentClassName="max-w-4xl mx-auto w-full"
         contentNodes={contentNodeEntries}
         defaultViewMode="list"
+        displayFramePackages={hasFeature("frames_v2")}
         emptyState={hasFiles ? undefined : emptyState}
         files={podGCSFiles}
         getFileUrl={getFileUrl}


### PR DESCRIPTION
## Description

- Collapse registered Frames v2 folders into one package entry in conversation and Pod file explorers behind `frames_v2`.
- Open the Frame on primary click and expose raw source through `View source`.
- Keep generic rename, move, and delete actions off package entries.

## Tests

- `npm test components/file_explorer/FileExplorer.test.tsx`
- `npm run tsgo`
- `npx biome check --error-on-warnings` on all six changed files

## Risk

The presentation is feature-flagged. Source listing metadata and package construction are isolated in the two preceding PRs.

## Deploy Plan

Standard deploy after #31533 and #31535.
