### PR TITLE
Instrument Frames v2 function execution

### DIFF
--- a/front/lib/api/sandbox/instrumentation.test.ts
+++ b/front/lib/api/sandbox/instrumentation.test.ts
@@ -1,0 +1,43 @@
+import { recordSandboxFunctionRun } from "@app/lib/api/sandbox/instrumentation";
+import { statsDMetrics } from "@app/lib/utils/statsd";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("recordSandboxFunctionRun", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "frame",
+    "pod",
+  ] as const)("tags %s function metrics by owner", (ownerKind) => {
+    const increment = vi
+      .spyOn(statsDMetrics, "increment")
+      .mockImplementation(() => undefined);
+    const distribution = vi
+      .spyOn(statsDMetrics, "distribution")
+      .mockImplementation(() => undefined);
+
+    recordSandboxFunctionRun({
+      ownerKind,
+      runnerKind: "warm",
+      status: "success",
+      durationMs: 42,
+    });
+
+    expect(increment).toHaveBeenCalledWith(
+      "sandbox.functions.run",
+      1,
+      expect.arrayContaining([
+        `owner_kind:${ownerKind}`,
+        "runner_kind:warm",
+        "status:success",
+      ])
+    );
+    expect(distribution).toHaveBeenCalledWith(
+      "sandbox.functions.run.duration",
+      42,
+      expect.arrayContaining([`owner_kind:${ownerKind}`])
+    );
+  });
+});

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -99,20 +99,27 @@ export function recordLifecycleOperation(
 }
 
 /**
- * One fast Pod function run, tagged by which runner served it (resident warm
- * server vs cold spawn). The warm share is the number the warm-runner rollout
- * turns on; duration is the exec's wall time as front saw it.
+ * One sandbox function run, tagged by owner and by which runner served it
+ * (resident warm server vs cold spawn). The warm share is the number the
+ * warm-runner rollout turns on; duration is the exec's wall time as front saw it.
  */
 export function recordSandboxFunctionRun({
+  ownerKind,
   runnerKind,
   status,
   durationMs,
 }: {
+  ownerKind: "frame" | "pod";
   runnerKind: "warm" | "cold" | "unknown";
   status: "success" | "error";
   durationMs: number;
 }): void {
-  const tags = [regionTag(), `runner_kind:${runnerKind}`, `status:${status}`];
+  const tags = [
+    regionTag(),
+    `owner_kind:${ownerKind}`,
+    `runner_kind:${runnerKind}`,
+    `status:${status}`,
+  ];
   statsDMetrics.increment("sandbox.functions.run", 1, tags);
   statsDMetrics.distribution(
     "sandbox.functions.run.duration",

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -18,6 +18,7 @@ import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_res
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -37,6 +38,41 @@ import {
 import { Err, Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tracerMocks = vi.hoisted(() => {
+  const setTag = vi.fn();
+  return {
+    setTag,
+    trace: vi.fn(
+      (
+        _name: string,
+        optionsOrCallback: unknown,
+        maybeCallback?: (span: { setTag: typeof setTag }) => unknown
+      ) => {
+        const callback =
+          typeof optionsOrCallback === "function"
+            ? optionsOrCallback
+            : maybeCallback;
+        return callback?.({ setTag });
+      }
+    ),
+  };
+});
+
+vi.mock("@app/logger/tracer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/logger/tracer")>();
+  return {
+    default: new Proxy(actual.default, {
+      get(target, property) {
+        if (property === "trace") {
+          return tracerMocks.trace;
+        }
+        const value = Reflect.get(target, property);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }),
+  };
+});
 
 vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
   ensureFrameSandboxReady: vi.fn(),
@@ -765,6 +801,9 @@ describe("SandboxFunctionInvocationResource", () => {
     const { authenticator, space, sandboxFunction, sandbox, invocation } =
       await setupExecutionTest();
     const updateLastActivityAtSpy = vi.spyOn(sandbox, "updateLastActivityAt");
+    const loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
     const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 0,
@@ -816,6 +855,25 @@ describe("SandboxFunctionInvocationResource", () => {
       }
     );
     expect(execSpy).toHaveBeenCalledTimes(1);
+    expect(tracerMocks.trace).toHaveBeenCalledWith(
+      "sandbox.function.execute",
+      { resource: "pod" },
+      expect.any(Function)
+    );
+    expect(tracerMocks.setTag).toHaveBeenCalledWith(
+      "function.owner_kind",
+      "pod"
+    );
+    expect(tracerMocks.setTag).toHaveBeenCalledWith("pod.space_id", space.sId);
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionOwnerKind: "pod",
+        functionName: sandboxFunction.slug,
+        invocationId: invocation.sId,
+        spaceId: space.sId,
+      }),
+      "Sandbox function stdout result delivery"
+    );
 
     const execCall = execSpy.mock.calls[0];
     expect(execCall).toBeDefined();
@@ -884,6 +942,9 @@ describe("SandboxFunctionInvocationResource", () => {
       .mockResolvedValue(
         new Ok({ exitCode: 0, stdout: SUCCEEDED_STDOUT, stderr: "" })
       );
+    const loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
 
     const result = await invocation.execute(authenticator);
 
@@ -914,6 +975,36 @@ describe("SandboxFunctionInvocationResource", () => {
     });
     expect(invocation.gcsPath).toBe(
       `w/${authenticator.getNonNullableWorkspace().sId}/frames/${frame.sId}/invocations/${invocation.sId}`
+    );
+    expect(tracerMocks.trace).toHaveBeenCalledWith(
+      "sandbox.function.execute",
+      { resource: "frame" },
+      expect.any(Function)
+    );
+    expect(tracerMocks.setTag).toHaveBeenCalledWith("frame.id", frame.sId);
+    expect(tracerMocks.setTag).toHaveBeenCalledWith(
+      "frame.publication_id",
+      publicationId
+    );
+    expect(tracerMocks.setTag).toHaveBeenCalledWith(
+      "frame.source_scope",
+      "pod"
+    );
+    expect(tracerMocks.setTag).toHaveBeenCalledWith(
+      "frame.source_scope_id",
+      space.sId
+    );
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frameId: frame.sId,
+        frameSourceScope: "pod",
+        frameSourceScopeId: space.sId,
+        functionOwnerKind: "frame",
+        functionName: sandboxFunction.slug,
+        invocationId: invocation.sId,
+        publicationId,
+      }),
+      "Sandbox function stdout result delivery"
     );
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -51,6 +51,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -360,6 +361,38 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return `w/${auth.getNonNullableWorkspace().sId}/sandbox_functions/${this.sandboxFunction.sId}/invocations/${this.sId}`;
   }
 
+  private observabilityContext(auth?: Authenticator) {
+    const frame = this.sandboxFunction.frame;
+    const sourceConversationId = frame?.useCaseMetadata?.conversationId;
+    const sourceSpaceId = frame?.useCaseMetadata?.spaceId;
+
+    return {
+      ...(auth
+        ? { workspaceId: auth.getNonNullableWorkspace().sId }
+        : { workspaceModelId: this.workspaceId }),
+      functionOwnerKind: frame ? "frame" : "pod",
+      sandboxFunctionId: this.sandboxFunction.sId,
+      functionName: this.sandboxFunction.slug,
+      invocationId: this.sId,
+      ...(frame
+        ? {
+            frameId: frame.sId,
+            ...(this.sandboxFunction.publicationId
+              ? { publicationId: this.sandboxFunction.publicationId }
+              : {}),
+            frameSourceScope: sourceSpaceId
+              ? "pod"
+              : sourceConversationId
+                ? "conversation"
+                : "unknown",
+            ...(sourceSpaceId || sourceConversationId
+              ? { frameSourceScopeId: sourceSpaceId ?? sourceConversationId }
+              : {}),
+          }
+        : { spaceId: this.sandboxFunction.space.sId }),
+    };
+  }
+
   get input(): unknown {
     return this.data.input;
   }
@@ -443,9 +476,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         if (writeResult.isErr()) {
           logger.error(
             {
-              workspaceModelId: this.workspaceId,
-              sandboxFunctionId: this.sandboxFunction.sId,
-              invocationId: this.sId,
+              ...this.observabilityContext(),
               claimedStatus: claimed,
               err: writeResult.error,
             },
@@ -473,9 +504,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (!released) {
       logger.error(
         {
-          workspaceModelId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
+          ...this.observabilityContext(),
           fromStatus: from,
         },
         "Failed to release sandbox function terminal claim after blob write failure"
@@ -498,9 +527,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (!claimed) {
       logger.warn(
         {
-          workspaceModelId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
+          ...this.observabilityContext(),
           attemptedStatus: "errored",
           attemptedError: callError,
         },
@@ -544,9 +571,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (!claimed) {
       logger.warn(
         {
-          workspaceModelId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
+          ...this.observabilityContext(),
           attemptedStatus: "succeeded",
           attemptedResult: truncate(
             JSON.stringify(result),
@@ -598,9 +623,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (this.status !== "created") {
       logger.info(
         {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
+          ...this.observabilityContext(auth),
           invocationStatus: this.status,
         },
         "Skipping execution of a terminal sandbox function invocation"
@@ -817,38 +840,71 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           });
 
       const execStartedAtMs = Date.now();
-      const execResult = await sandbox.exec(auth, command, {
-        workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
-        envVars: {
-          DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
-          DUST_FUNCTIONS_DIR: functionsDirectory,
-          // The app prefix comes from the slug, so `db("chat")` in the bundle resolves to this
-          // app's own database without the source naming the app.
-          ...databaseEnvVars,
-          DUST_SANDBOX_TOKEN: token,
-          // Durable functions may still spawn tool clients that inherit the function process's
-          // native environment. Keep them cold until all tool calls read the invocation context;
-          // fast functions cannot call tools and are safe to serve from a resident worker.
-          [FUNCTION_WARM_ENABLED_ENV]: noTools ? "1" : "0",
-          // Set this for every invocation so userless calls cannot inherit a sandbox-level value.
-          [POD_USER_IDENTITY_ENV]: userIdentity
-            ? JSON.stringify(userIdentity)
-            : "",
-        },
-        stdin: JSON.stringify(inputEnvelope),
-        // The envelope is this function's own input, and the same exec already hands it a token
-        // through the environment, so there is nothing here that the environment newly exposes.
-        // Worth two fewer round trips to the sandbox on the latency-sensitive path.
-        allowStdinInEnvironment: true,
-        timeoutMs: inline
-          ? SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS
-          : SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
-        user: "agent-proxied",
-      });
+      const execResult = await tracer.trace(
+        "sandbox.function.execute",
+        { resource: frame ? "frame" : "pod" },
+        async (span) => {
+          span?.setTag("workspace.id", auth.getNonNullableWorkspace().sId);
+          span?.setTag("function.owner_kind", frame ? "frame" : "pod");
+          span?.setTag("sandbox_function.id", sandboxFunction.sId);
+          span?.setTag("function.name", sandboxFunction.slug);
+          span?.setTag("invocation.id", this.sId);
+          if (frame) {
+            span?.setTag("frame.id", frame.sId);
+            span?.setTag("frame.publication_id", publicationId ?? "unknown");
+            span?.setTag(
+              "frame.source_scope",
+              frame.useCaseMetadata?.spaceId
+                ? "pod"
+                : frame.useCaseMetadata?.conversationId
+                  ? "conversation"
+                  : "unknown"
+            );
+            span?.setTag(
+              "frame.source_scope_id",
+              frame.useCaseMetadata?.spaceId ??
+                frame.useCaseMetadata?.conversationId ??
+                "unknown"
+            );
+          } else {
+            span?.setTag("pod.space_id", sandboxFunction.space.sId);
+          }
+
+          return sandbox.exec(auth, command, {
+            workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
+            envVars: {
+              DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
+              DUST_FUNCTIONS_DIR: functionsDirectory,
+              // The app prefix comes from the slug, so `db("chat")` in the bundle resolves to this
+              // app's own database without the source naming the app.
+              ...databaseEnvVars,
+              DUST_SANDBOX_TOKEN: token,
+              // Durable functions may still spawn tool clients that inherit the function process's
+              // native environment. Keep them cold until all tool calls read the invocation context;
+              // fast functions cannot call tools and are safe to serve from a resident worker.
+              [FUNCTION_WARM_ENABLED_ENV]: noTools ? "1" : "0",
+              // Set this for every invocation so userless calls cannot inherit a sandbox-level value.
+              [POD_USER_IDENTITY_ENV]: userIdentity
+                ? JSON.stringify(userIdentity)
+                : "",
+            },
+            stdin: JSON.stringify(inputEnvelope),
+            // The envelope is this function's own input, and the same exec already hands it a token
+            // through the environment, so there is nothing here that the environment newly exposes.
+            // Worth two fewer round trips to the sandbox on the latency-sensitive path.
+            allowStdinInEnvironment: true,
+            timeoutMs: inline
+              ? SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS
+              : SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
+            user: "agent-proxied",
+          });
+        }
+      );
       if (execResult.isErr()) {
         // Exec-level failures (timeouts included) must land in the same metric as served runs,
         // or the duration distribution silently drops the slowest attempts.
         recordSandboxFunctionRun({
+          ownerKind: frame ? "frame" : "pod",
           runnerKind: "unknown",
           status: "error",
           durationMs: Date.now() - execStartedAtMs,
@@ -861,10 +917,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           // durable the way a refused tool call does.
           logger.info(
             {
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              sandboxFunctionId: sandboxFunction.sId,
-              slug: sandboxFunction.slug,
-              invocationId: this.sId,
+              ...this.observabilityContext(auth),
               timeoutMs: SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS,
               error: execResult.error.message,
             },
@@ -881,9 +934,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       const { timings } = parsed;
       logger.info(
         {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          sandboxFunctionId: sandboxFunction.sId,
-          invocationId: this.sId,
+          ...this.observabilityContext(auth),
           exitCode,
           stdoutBytes: Buffer.byteLength(stdout, "utf8"),
           ...(parsed.spill === null
@@ -901,6 +952,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
               sandbox.readFile(auth, path)
             );
       recordSandboxFunctionRun({
+        ownerKind: frame ? "frame" : "pod",
         runnerKind: timings?.runnerKind ?? "unknown",
         status: normalized.ok ? "success" : "error",
         durationMs: Date.now() - execStartedAtMs,
@@ -909,13 +961,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         // Without the raw stdout/stderr there is no way to diagnose a rejected envelope.
         logger.error(
           {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            ...(frame
-              ? { frameId: frame.sId }
-              : { spaceId: sandboxFunction.space.sId }),
-            sandboxFunctionId: sandboxFunction.sId,
-            slug: sandboxFunction.slug,
-            invocationId: this.sId,
+            ...this.observabilityContext(auth),
             exitCode,
             stdout: truncate(stdout, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
             stderr: truncate(stderr, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
@@ -962,7 +1008,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // over one unreadable record: a truncated write, or a blob a newer deploy wrote mid-rollout.
       // Degrade to an empty record and keep the rest of the listing readable.
       logger.error(
-        { gcsPath: this.gcsPath, error: storedResult.error.message },
+        {
+          ...this.observabilityContext(),
+          gcsPath: this.gcsPath,
+          error: storedResult.error.message,
+        },
         "Invalid sandbox function invocation data"
       );
       this.data = { version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION };
@@ -1062,9 +1112,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
             // so a failed initial upload only matters if the invocation never settles.
             logger.error(
               {
-                workspaceModelId: resource.workspaceId,
-                sandboxFunctionId: sandboxFunction.sId,
-                invocationId: resource.sId,
+                ...resource.observabilityContext(auth),
                 err: result.error,
               },
               "Deferred sandbox function invocation blob write failed"
@@ -1135,9 +1183,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           // event), but losing one must be visible.
           logger.error(
             {
-              workspaceModelId: invocation.workspaceId,
-              sandboxFunctionId: sandboxFunction.sId,
-              invocationId: invocation.sId,
+              ...invocation.observabilityContext(auth),
               err: normalizeError(error),
             },
             "Deferred sandbox function invocation created-event publish failed"
@@ -1163,9 +1209,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // workflow, which owns waits that outlive a request.
       logger.info(
         {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          sandboxFunctionId: sandboxFunction.sId,
-          invocationId: invocation.sId,
+          ...invocation.observabilityContext(auth),
           reason: "sandbox_not_running",
         },
         "Escalating a fast sandbox function invocation to the invocation workflow"
@@ -1203,9 +1247,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (!claimed) {
       logger.warn(
         {
-          workspaceModelId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
+          ...this.observabilityContext(),
           attemptedStatus: "errored",
           attemptedError: error,
         },


### PR DESCRIPTION
## Description

- Distinguish Frame and Pod function executions in shared runtime metrics.
- Add an execution trace carrying workspace, Frame, publication, function, invocation, and source-scope identity.
- Add the same Frame context to shared invocation logs and use owner-neutral log messages.

## Tests

Added metric-tag coverage for both owners plus Frame and Pod execution assertions for trace and log context. Ran 48 focused front tests and the front typecheck locally.

## Risk

Low. Execution, persistence, and authorization are unchanged. Existing Datadog queries matching the renamed Pod-specific messages or the `slug` field should migrate to the owner-neutral messages and `functionName`.

## Deploy Plan

Standard deploy; this PR is independent of the Frames v2 core path.
