### PR TITLE
Type Frames v2 guest invocation failures

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,5 +1,6 @@
 import {
   getFrameRuntimeAccess,
+  getSandboxFunctionInvocationAccessError,
   VisualizationActionIframe,
 } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
@@ -126,6 +127,35 @@ describe("getFrameRuntimeAccess", () => {
         isPodMember: false,
         user,
       },
+    });
+  });
+});
+
+describe("getSandboxFunctionInvocationAccessError", () => {
+  it("returns a typed workspace-membership error to a Frames v2 guest", () => {
+    expect(
+      getSandboxFunctionInvocationAccessError(
+        { kind: "v2", frameId: "fil_frame" },
+        false,
+        false
+      )
+    ).toEqual({
+      code: "user_authentication_required",
+      message:
+        "This Frame function requires a logged-in user from its workspace.",
+    });
+  });
+
+  it("keeps the generic unsupported error for disabled legacy calls", () => {
+    expect(
+      getSandboxFunctionInvocationAccessError(
+        { kind: "legacy", podFunctionScope: null },
+        false,
+        false
+      )
+    ).toEqual({
+      code: "not_supported",
+      message: "Function calls are not available in this Frame.",
     });
   });
 });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -113,6 +113,26 @@ export function getFrameRuntimeAccess(
   };
 }
 
+export function getSandboxFunctionInvocationAccessError(
+  scope: FrameFunctionReferenceScope,
+  canInvokeFunctions: boolean,
+  isWorkspaceMember: boolean
+): SandboxFunctionCallError | null {
+  if (canInvokeFunctions) {
+    return null;
+  }
+  return scope.kind === "v2" && !isWorkspaceMember
+    ? {
+        code: "user_authentication_required",
+        message:
+          "This Frame function requires a logged-in user from its workspace.",
+      }
+    : {
+        code: "not_supported",
+        message: "Function calls are not available in this Frame.",
+      };
+}
+
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
   request: { command: T } & VisualizationRPCRequest,
   response: CommandResultMap[T],
@@ -882,11 +902,13 @@ export const VisualizationActionIframe = forwardRef<
       >
     > => {
       try {
-        if (!runtimeAccess.canInvokeFunctions) {
-          return new Err({
-            code: "not_supported",
-            message: "Function calls are not available in this Frame.",
-          });
+        const accessError = getSandboxFunctionInvocationAccessError(
+          functionReferenceScope,
+          runtimeAccess.canInvokeFunctions,
+          runtimeAccess.userIdentity.isWorkspaceMember
+        );
+        if (accessError) {
+          return new Err(accessError);
         }
 
         const body: PostSandboxFunctionInvocationRequestBody = {
@@ -933,7 +955,9 @@ export const VisualizationActionIframe = forwardRef<
       }
     },
     [
+      functionReferenceScope,
       runtimeAccess.canInvokeFunctions,
+      runtimeAccess.userIdentity.isWorkspaceMember,
       workspaceId,
       props.viewer?.frameShareToken,
     ]


### PR DESCRIPTION
## Description

Return a typed `user_authentication_required` error when a guest or link viewer attempts to invoke a Frames v2 function without workspace membership.

Legacy Frames and other disabled function calls retain the existing `not_supported` error. The renderer can therefore distinguish an authorization failure from an unsupported capability and present the appropriate UI.

## Tests

- Added focused coverage for Frames v2 guest errors and the unchanged legacy fallback.
- `VisualizationActionIframe` tests pass.
- `front` typecheck and Biome pass.

## Risk

Low. This only specializes the existing client-side disabled-call error for Frames v2 non-members.

## Deploy Plan

Deploy normally. No migration or coordinated rollout is required.
