### PR TITLE
Garbage collect retired Frame publications

### DIFF
--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -107,7 +107,7 @@ app.post(
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
         return apiError(ctx, {
-          status_code: 401,
+          status_code: invocationResult.error.status,
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -130,7 +130,7 @@ app.post(
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
         return apiError(ctx, {
-          status_code: 401,
+          status_code: invocationResult.error.status,
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front/lib/api/frames/clone_source.ts
+++ b/front/lib/api/frames/clone_source.ts
@@ -6,8 +6,8 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationError } from "@app/lib/api/frames/publication_storage";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
 import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
 import { registerFrameV2FromSourceUsingFileSystem } from "@app/lib/api/frames/register_from_source";
 import {

--- a/front/lib/api/frames/convert_from_source.ts
+++ b/front/lib/api/frames/convert_from_source.ts
@@ -6,8 +6,8 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationError } from "@app/lib/api/frames/publication_storage";
-import { withFrameSourceLock } from "@app/lib/api/frames/publication_storage";
 import { publishFrameV2FromSourceWithLockHeld } from "@app/lib/api/frames/publish_from_source";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/frames/delete_from_source.test.ts
+++ b/front/lib/api/frames/delete_from_source.test.ts
@@ -12,11 +12,9 @@ vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
   return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
 });
 
-vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
+vi.mock("@app/lib/api/frames/operation_lock", async (importActual) => {
   const actual =
-    await importActual<
-      typeof import("@app/lib/api/frames/publication_storage")
-    >();
+    await importActual<typeof import("@app/lib/api/frames/operation_lock")>();
   return {
     ...actual,
     withFrameSourceAndPublishLock: async (

--- a/front/lib/api/frames/delete_from_source.ts
+++ b/front/lib/api/frames/delete_from_source.ts
@@ -6,7 +6,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import { removeFileFromProject } from "@app/lib/api/projects/context";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -2,11 +2,9 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/frames/publication_storage", async (importActual) => {
+vi.mock("@app/lib/api/frames/operation_lock", async (importActual) => {
   const actual =
-    await importActual<
-      typeof import("@app/lib/api/frames/publication_storage")
-    >();
+    await importActual<typeof import("@app/lib/api/frames/operation_lock")>();
   return {
     ...actual,
     withFramePublishLock: async (

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import {
   cleanupFrameSourceCopy,
   copyFrameSourceAsNew,

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,0 +1,94 @@
+import { getRedisStreamClient } from "@app/lib/api/redis";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { distributedLock, distributedUnlock } from "@app/lib/lock";
+import tracer from "@app/logger/tracer";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+
+const FRAME_OPERATION_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+const FRAME_OPERATION_LOCK_RETRY_INTERVAL_MS = 100;
+// Frame operations are synchronous and bounded. Lease expiry defines an abandoned operation;
+// stale-prefix recovery may remove uncommitted artifacts once a new publisher owns the lock.
+const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
+
+export function getFramePublishLockName(frameId: string): string {
+  return `frame:publish:${frameId}`;
+}
+
+function getFrameSourceLockName(frameId: string): string {
+  return `frame:source:${frameId}`;
+}
+
+async function withFrameOperationLock<T, E>(
+  lockName: string,
+  resource: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  const client = await getRedisStreamClient({ origin: "lock" });
+  const lockValue = await tracer.trace(
+    "lock.acquire",
+    { resource },
+    async () => {
+      const startMs = Date.now();
+      while (Date.now() - startMs < FRAME_OPERATION_LOCK_ACQUIRE_TIMEOUT_MS) {
+        const acquired = await distributedLock(
+          client,
+          lockName,
+          FRAME_OPERATION_LOCK_TTL_MS
+        );
+        if (acquired) {
+          return acquired;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, FRAME_OPERATION_LOCK_RETRY_INTERVAL_MS)
+        );
+      }
+      return undefined;
+    }
+  );
+  if (!lockValue) {
+    return new Err(
+      new SandboxFunctionError(
+        "publish_conflict",
+        "Another operation is in progress for this Frame; retry shortly."
+      )
+    );
+  }
+
+  try {
+    return await callback();
+  } finally {
+    await distributedUnlock(client, lockName, lockValue);
+  }
+}
+
+export async function withFramePublishLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withFrameOperationLock(
+    getFramePublishLockName(frameId),
+    "frame.publish",
+    callback
+  );
+}
+
+export async function withFrameSourceLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withFrameOperationLock(
+    getFrameSourceLockName(frameId),
+    "frame.source",
+    callback
+  );
+}
+
+export async function withFrameSourceAndPublishLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withFrameSourceLock(frameId, () =>
+    withFramePublishLock(frameId, callback)
+  );
+}

--- a/front/lib/api/frames/publication_cleanup.test.ts
+++ b/front/lib/api/frames/publication_cleanup.test.ts
@@ -2,8 +2,8 @@ import { cleanupRetiredFramePublication } from "@app/lib/api/frames/publication_
 import type { Authenticator } from "@app/lib/auth";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -113,13 +113,9 @@ describe("cleanupRetiredFramePublication", () => {
 
   it("retains a publication while an invocation is running", async () => {
     const { auth, frame, sandboxFunction } = await setup();
-    await SandboxFunctionInvocationModel.create({
-      workspaceId: auth.getNonNullableWorkspace().id,
-      sandboxFunctionId: sandboxFunction.id,
-      userId: null,
-      origin: "delegated",
-      status: "created",
-      gcsPath: "sandbox-functions/invocations/running.json",
+    await SandboxFunctionInvocationResource.makeNew(auth, {
+      sandboxFunction,
+      input: {},
     });
     const deletedPrefixes: string[] = [];
     fileStorageMock.setOnDeleteByPrefix((prefix) =>
@@ -144,14 +140,11 @@ describe("cleanupRetiredFramePublication", () => {
 
   it("cleans artifacts but retains function rows referenced by history", async () => {
     const { auth, frame, sandboxFunction } = await setup();
-    await SandboxFunctionInvocationModel.create({
-      workspaceId: auth.getNonNullableWorkspace().id,
-      sandboxFunctionId: sandboxFunction.id,
-      userId: null,
-      origin: "delegated",
-      status: "succeeded",
-      gcsPath: "sandbox-functions/invocations/succeeded.json",
+    const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
+      sandboxFunction,
+      input: {},
     });
+    await invocation.succeed({ ok: true });
 
     await expect(
       cleanupRetiredFramePublication(auth, {
@@ -191,5 +184,19 @@ describe("cleanupRetiredFramePublication", () => {
         publicationId: retiredPublicationId,
       })
     ).resolves.toHaveLength(1);
+  });
+
+  it("rejects invocation admission for a retired publication", async () => {
+    const { auth, sandboxFunction } = await setup();
+
+    const result = await sandboxFunction.invoke(auth, { input: {} });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        code: "sandbox_function_not_found",
+        status: 404,
+      });
+    }
   });
 });

--- a/front/lib/api/frames/publication_cleanup.test.ts
+++ b/front/lib/api/frames/publication_cleanup.test.ts
@@ -1,0 +1,195 @@
+import { cleanupRetiredFramePublication } from "@app/lib/api/frames/publication_cleanup";
+import type { Authenticator } from "@app/lib/auth";
+import { distributedLock, distributedUnlock } from "@app/lib/lock";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { getFramePublicationBasePath } from "@app/types/api/frame_storage";
+import { frameV2ContentType } from "@app/types/files";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    distributedLock: vi.fn(),
+    distributedUnlock: vi.fn(),
+  };
+});
+
+const retiredPublicationId = "retired-publication";
+
+async function setup({
+  activePublicationId = "active-publication",
+}: {
+  activePublicationId?: string;
+} = {}): Promise<{
+  auth: Authenticator;
+  frame: FileResource;
+  sandboxFunction: SandboxFunctionResource;
+}> {
+  const { authenticator: auth } = await createResourceTest({ role: "admin" });
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 0,
+    status: "ready",
+    useCase: "project_context",
+    useCaseMetadata: { activePublicationId },
+  });
+  await withTransaction((transaction) =>
+    SandboxFunctionResource.createForFramePublication(
+      auth,
+      {
+        frame,
+        publicationId: retiredPublicationId,
+        functions: [
+          {
+            name: "list-tasks",
+            description: "List tasks.",
+            executionMode: "durable",
+            defaultStake: "low",
+            bundleCode: "export async function run() {}",
+            userIdentity: "workspace_user_required",
+            inputSchema: { type: "object" },
+            outputSchema: { type: "object" },
+          },
+        ],
+      },
+      transaction
+    )
+  );
+  const [sandboxFunction] =
+    await SandboxFunctionResource.listByFramePublication(auth, {
+      frame,
+      publicationId: retiredPublicationId,
+    });
+  if (!sandboxFunction) {
+    throw new Error("Expected retired Frame function.");
+  }
+
+  return { auth, frame, sandboxFunction };
+}
+
+beforeEach(() => {
+  vi.mocked(distributedLock).mockResolvedValue("test-frame-publish-lock");
+  vi.mocked(distributedUnlock).mockResolvedValue(undefined);
+  fileStorageMock.reset();
+});
+
+describe("cleanupRetiredFramePublication", () => {
+  it("deletes retired artifacts and unreferenced function rows", async () => {
+    const { auth, frame } = await setup();
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    await expect(
+      cleanupRetiredFramePublication(auth, {
+        frameId: frame.sId,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toBe(true);
+
+    expect(deletedPrefixes).toEqual([
+      getFramePublicationBasePath({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        frameId: frame.sId,
+        publicationId: retiredPublicationId,
+      }),
+    ]);
+    await expect(
+      SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toEqual([]);
+  });
+
+  it("retains a publication while an invocation is running", async () => {
+    const { auth, frame, sandboxFunction } = await setup();
+    await SandboxFunctionInvocationModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      sandboxFunctionId: sandboxFunction.id,
+      userId: null,
+      origin: "delegated",
+      status: "created",
+      gcsPath: "sandbox-functions/invocations/running.json",
+    });
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    await expect(
+      cleanupRetiredFramePublication(auth, {
+        frameId: frame.sId,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toBe(false);
+
+    expect(deletedPrefixes).toEqual([]);
+    await expect(
+      SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toHaveLength(1);
+  });
+
+  it("cleans artifacts but retains function rows referenced by history", async () => {
+    const { auth, frame, sandboxFunction } = await setup();
+    await SandboxFunctionInvocationModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      sandboxFunctionId: sandboxFunction.id,
+      userId: null,
+      origin: "delegated",
+      status: "succeeded",
+      gcsPath: "sandbox-functions/invocations/succeeded.json",
+    });
+
+    await expect(
+      cleanupRetiredFramePublication(auth, {
+        frameId: frame.sId,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toBe(true);
+
+    await expect(
+      SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toHaveLength(1);
+  });
+
+  it("never deletes an active publication", async () => {
+    const { auth, frame } = await setup({
+      activePublicationId: retiredPublicationId,
+    });
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    await expect(
+      cleanupRetiredFramePublication(auth, {
+        frameId: frame.sId,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toBe(true);
+
+    expect(deletedPrefixes).toEqual([]);
+    await expect(
+      SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: retiredPublicationId,
+      })
+    ).resolves.toHaveLength(1);
+  });
+});

--- a/front/lib/api/frames/publication_cleanup.ts
+++ b/front/lib/api/frames/publication_cleanup.ts
@@ -1,4 +1,4 @@
-import { withFramePublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/lib/api/frames/publication_cleanup.ts
+++ b/front/lib/api/frames/publication_cleanup.ts
@@ -1,0 +1,62 @@
+import { withFramePublishLock } from "@app/lib/api/frames/publication_storage";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { getFramePublicationBasePath } from "@app/types/api/frame_storage";
+import { Ok } from "@app/types/shared/result";
+
+/**
+ * Deletes one retired publication once no invocation still needs its immutable artifacts.
+ * Returns false while a running invocation keeps the publication alive.
+ */
+export async function cleanupRetiredFramePublication(
+  auth: Authenticator,
+  {
+    frameId,
+    publicationId,
+  }: {
+    frameId: string;
+    publicationId: string;
+  }
+): Promise<boolean> {
+  const owner = auth.getNonNullableWorkspace();
+  const result = await withFramePublishLock(frameId, async () => {
+    const frame = await FileResource.fetchById(auth, frameId);
+    if (frame?.useCaseMetadata?.activePublicationId === publicationId) {
+      return new Ok(true);
+    }
+
+    if (
+      frame?.isFrameV2 &&
+      (await SandboxFunctionResource.hasRunningInvocationsForFramePublication(
+        auth,
+        { frame, publicationId }
+      ))
+    ) {
+      return new Ok(false);
+    }
+
+    await getPrivateUploadBucket().deleteByPrefix(
+      getFramePublicationBasePath({
+        workspaceId: owner.sId,
+        frameId,
+        publicationId,
+      })
+    );
+
+    if (frame?.isFrameV2) {
+      await SandboxFunctionResource.deleteUnreferencedFramePublicationFunctions(
+        auth,
+        { frame, publicationId }
+      );
+    }
+
+    return new Ok(true);
+  });
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -16,6 +16,7 @@ import {
   SandboxFunctionResource,
 } from "@app/lib/resources/sandbox_function_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { launchRetiredFramePublicationCleanupWorkflow } from "@app/temporal/sandbox_functions/client";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -47,6 +48,10 @@ vi.mock("@app/lib/lock", async (importOriginal) => {
     distributedUnlock: vi.fn(),
   };
 });
+
+vi.mock("@app/temporal/sandbox_functions/client", () => ({
+  launchRetiredFramePublicationCleanupWorkflow: vi.fn(),
+}));
 
 async function setupFrame(): Promise<{
   frame: FileResource;
@@ -137,6 +142,9 @@ beforeEach(() => {
   vi.mocked(distributedLock).mockResolvedValue("test-frame-publish-lock");
   vi.mocked(distributedUnlock).mockResolvedValue(undefined);
   vi.mocked(reconcileFramePublicationDatabases).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(launchRetiredFramePublicationCleanupWorkflow).mockResolvedValue(
     new Ok(undefined)
   );
   fileStorageMock.reset();
@@ -849,6 +857,15 @@ describe("activateFramePublication", () => {
     expect(frame.useCaseMetadata?.activePublicationId).toBe(
       second.isOk() ? second.value.publicationId : undefined
     );
+    if (first.isOk()) {
+      expect(launchRetiredFramePublicationCleanupWorkflow).toHaveBeenCalledWith(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          frameId: frame.sId,
+          publicationId: first.value.publicationId,
+        }
+      );
+    }
   });
 });
 
@@ -899,7 +916,7 @@ describe("publishFramePublication", () => {
     );
   });
 
-  it("cleans only stale uncommitted publication artifacts", async () => {
+  it("cleans uncommitted artifacts and schedules committed publications", async () => {
     const { auth, frame } = await setupFrame();
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
     const committedPublicationId = "243542bc-54b1-4dfe-9bb9-e02f75a0fb9f";
@@ -927,6 +944,16 @@ describe("publishFramePublication", () => {
     expect(deletedPrefixes).toEqual([
       `w/${auth.getNonNullableWorkspace().sId}/frames/${frame.sId}/publications/${stalePublicationId}/`,
     ]);
+    expect(launchRetiredFramePublicationCleanupWorkflow).toHaveBeenCalledWith({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      frameId: frame.sId,
+      publicationId: committedPublicationId,
+    });
+    expect(launchRetiredFramePublicationCleanupWorkflow).toHaveBeenCalledWith({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      frameId: frame.sId,
+      publicationId: activePublicationId,
+    });
   });
 
   it("publishes when stale artifact cleanup fails", async () => {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -23,6 +23,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
+import { launchRetiredFramePublicationCleanupWorkflow } from "@app/temporal/sandbox_functions/client";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
@@ -286,6 +287,11 @@ async function cleanupStaleFramePublicationArtifacts(
                 publicationId,
               })
             );
+          } else {
+            await scheduleRetiredFramePublicationCleanup(
+              frameIdentity.value,
+              publicationId
+            );
           }
         } catch (error) {
           logger.error(
@@ -309,6 +315,28 @@ async function cleanupStaleFramePublicationArtifacts(
         workspaceId: frameIdentity.value.workspaceId,
       },
       "Failed to list stale Frame publication artifacts"
+    );
+  }
+}
+
+async function scheduleRetiredFramePublicationCleanup(
+  { frameId, workspaceId }: { frameId: string; workspaceId: string },
+  publicationId: string
+): Promise<void> {
+  const result = await launchRetiredFramePublicationCleanupWorkflow({
+    frameId,
+    publicationId,
+    workspaceId,
+  });
+  if (result.isErr()) {
+    logger.error(
+      {
+        err: result.error,
+        frameId,
+        publicationId,
+        workspaceId,
+      },
+      "Failed to schedule retired Frame publication cleanup"
     );
   }
 }
@@ -820,6 +848,8 @@ export async function publishFramePublication(
     { publicationId: string },
     FramePublicationError | SandboxFunctionError
   >(frame.sId, async () => {
+    const previousActivePublicationId = (await frame.fetchFreshFrameV2(auth))
+      ?.useCaseMetadata?.activePublicationId;
     await cleanupStaleFramePublicationArtifacts(auth, { frame });
 
     const publication = await storeFramePublication(auth, {
@@ -857,6 +887,18 @@ export async function publishFramePublication(
       }
 
       publicationActivated = true;
+      if (
+        previousActivePublicationId &&
+        previousActivePublicationId !== publicationId
+      ) {
+        await scheduleRetiredFramePublicationCleanup(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            frameId: frame.sId,
+          },
+          previousActivePublicationId
+        );
+      }
       return publication;
     } finally {
       if (!publicationActivated) {

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -5,8 +5,8 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { reconcileFramePublicationDatabases } from "@app/lib/api/frames/database_reconciliation";
-import { getRedisStreamClient } from "@app/lib/api/redis";
-import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,14 +15,12 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
-import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
-import tracer from "@app/logger/tracer";
 import { launchRetiredFramePublicationCleanupWorkflow } from "@app/temporal/sandbox_functions/client";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
@@ -53,11 +51,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 const FRAME_PUBLICATION_UPLOAD_CONCURRENCY = 4;
 const FRAME_PUBLICATION_READ_CONCURRENCY = 4;
-const FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
-const FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS = 100;
-// Publication work is synchronous and bounded. Lease expiry defines an abandoned publisher;
-// stale-prefix recovery may remove its uncommitted artifacts once a new publisher owns the lock.
-const FRAME_PUBLISH_LOCK_TTL_MS = 10 * 60_000;
 
 export type FramePublicationSourceFile = {
   relativePath: string;
@@ -90,88 +83,6 @@ export class FramePublicationError extends Error {
     super(message);
     this.name = "FramePublicationError";
   }
-}
-
-export function getFramePublishLockName(frameId: string): string {
-  return `frame:publish:${frameId}`;
-}
-
-function getFrameSourceLockName(frameId: string): string {
-  return `frame:source:${frameId}`;
-}
-
-async function withFrameOperationLock<T, E>(
-  lockName: string,
-  resource: string,
-  callback: () => Promise<Result<T, E>>
-): Promise<Result<T, E | SandboxFunctionError>> {
-  const client = await getRedisStreamClient({ origin: "lock" });
-  const lockValue = await tracer.trace(
-    "lock.acquire",
-    { resource },
-    async () => {
-      const startMs = Date.now();
-      while (Date.now() - startMs < FRAME_PUBLISH_LOCK_ACQUIRE_TIMEOUT_MS) {
-        const acquired = await distributedLock(
-          client,
-          lockName,
-          FRAME_PUBLISH_LOCK_TTL_MS
-        );
-        if (acquired) {
-          return acquired;
-        }
-        await new Promise((resolve) =>
-          setTimeout(resolve, FRAME_PUBLISH_LOCK_RETRY_INTERVAL_MS)
-        );
-      }
-      return undefined;
-    }
-  );
-  if (!lockValue) {
-    return new Err(
-      new SandboxFunctionError(
-        "publish_conflict",
-        "Another publication or source operation is in progress for this Frame; retry shortly."
-      )
-    );
-  }
-
-  try {
-    return await callback();
-  } finally {
-    await distributedUnlock(client, lockName, lockValue);
-  }
-}
-
-export async function withFramePublishLock<T, E>(
-  frameId: string,
-  callback: () => Promise<Result<T, E>>
-): Promise<Result<T, E | SandboxFunctionError>> {
-  return withFrameOperationLock(
-    getFramePublishLockName(frameId),
-    "frame.publish",
-    callback
-  );
-}
-
-export async function withFrameSourceLock<T, E>(
-  frameId: string,
-  callback: () => Promise<Result<T, E>>
-): Promise<Result<T, E | SandboxFunctionError>> {
-  return withFrameOperationLock(
-    getFrameSourceLockName(frameId),
-    "frame.source",
-    callback
-  );
-}
-
-export async function withFrameSourceAndPublishLock<T, E>(
-  frameId: string,
-  callback: () => Promise<Result<T, E>>
-): Promise<Result<T, E | SandboxFunctionError>> {
-  return withFrameSourceLock(frameId, () =>
-    withFramePublishLock(frameId, callback)
-  );
 }
 
 function sha256(content: string | Buffer): string {

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -3,11 +3,9 @@ import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
-import {
-  FramePublicationError,
-  withFrameSourceLock,
-} from "@app/lib/api/frames/publication_storage";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import {
   MAX_FRAME_SOURCE_BYTES,
   MAX_FRAME_SOURCE_FILE_COUNT,

--- a/front/lib/api/frames/share_from_source.ts
+++ b/front/lib/api/frames/share_from_source.ts
@@ -6,7 +6,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/publication_storage";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import {
   checkFrameEmailGrantPermission,

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -27,11 +27,28 @@ export function isSandboxFunctionError(
 }
 
 export class SandboxFunctionInvocationError extends Error {
-  readonly code = "user_authentication_required";
+  readonly code: "user_authentication_required" | "sandbox_function_not_found";
+  readonly status: 401 | 404;
 
-  constructor(message: string) {
+  constructor(
+    message: string,
+    {
+      code = "user_authentication_required",
+      status = 401,
+    }:
+      | {
+          code?: "user_authentication_required";
+          status?: 401;
+        }
+      | {
+          code: "sandbox_function_not_found";
+          status: 404;
+        } = {}
+  ) {
     super(message);
     this.name = "SandboxFunctionInvocationError";
+    this.code = code;
+    this.status = status;
   }
 }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -1128,7 +1128,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return resource;
   }
 
-  static async createAndStartExecution(
+  static async createForExecution(
     auth: Authenticator,
     {
       sandboxFunction,
@@ -1139,7 +1139,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       body: PostSandboxFunctionInvocationRequestBody;
       origin?: SandboxFunctionInvocationOrigin;
     }
-  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+  ): Promise<SandboxFunctionInvocationResource> {
     // An inline invocation runs in the request that creates it. Only a fast function qualifies:
     // a durable one may call a tool that waits on the user for approval or authentication, and
     // holding the request there would deadlock, since the approval card only renders once the
@@ -1148,7 +1148,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     // Deferring is only safe because no other process reads the blob during execution, which
     // holds because every run is started with `--result-delivery stdout`: the result comes back
     // on the exec's own stdout, so nothing fetches the invocation, and its blob, mid-execution.
-    const invocation = await this.makeNew(
+    return this.makeNew(
       auth,
       {
         sandboxFunction,
@@ -1159,6 +1159,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       undefined,
       { deferInitialWrite: inline }
     );
+  }
+
+  async startExecution(
+    auth: Authenticator
+  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+    const invocation = this;
+    const { sandboxFunction } = invocation;
+    const inline = sandboxFunction.executionMode === "fast";
     const publishCreated = () =>
       publishSandboxFunctionInvocationEvent(
         {
@@ -1235,6 +1243,18 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     }
 
     return new Ok(invocation);
+  }
+
+  static async createAndStartExecution(
+    auth: Authenticator,
+    args: {
+      sandboxFunction: SandboxFunctionResource;
+      body: PostSandboxFunctionInvocationRequestBody;
+      origin?: SandboxFunctionInvocationOrigin;
+    }
+  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+    const invocation = await this.createForExecution(auth, args);
+    return invocation.startExecution(auth);
   }
 
   async markCreatedAsErrored(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,3 +1,4 @@
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
 import type {
   PokePodFunction,
   PokePodFunctionDetails,
@@ -720,8 +721,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         publicationId,
       },
     });
-    const functionIds = functions.map(({ id }) => id);
-    if (functionIds.length === 0) {
+    const sandboxFunctionModelIds = functions.map(({ id }) => id);
+    if (sandboxFunctionModelIds.length === 0) {
       return;
     }
 
@@ -729,21 +730,21 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       attributes: ["sandboxFunctionId"],
       where: {
         workspaceId: owner.id,
-        sandboxFunctionId: { [Op.in]: functionIds },
+        sandboxFunctionId: { [Op.in]: sandboxFunctionModelIds },
       },
       group: ["sandboxFunctionId"],
     });
-    const referencedFunctionIds = new Set(
+    const referencedSandboxFunctionModelIds = new Set(
       referencedFunctions.map(({ sandboxFunctionId }) => sandboxFunctionId)
     );
-    const unreferencedFunctionIds = functionIds.filter(
-      (id) => !referencedFunctionIds.has(id)
+    const unreferencedSandboxFunctionModelIds = sandboxFunctionModelIds.filter(
+      (id) => !referencedSandboxFunctionModelIds.has(id)
     );
-    if (unreferencedFunctionIds.length > 0) {
+    if (unreferencedSandboxFunctionModelIds.length > 0) {
       await this.model.destroy({
         where: {
           workspaceId: owner.id,
-          id: { [Op.in]: unreferencedFunctionIds },
+          id: { [Op.in]: unreferencedSandboxFunctionModelIds },
         },
       });
     }
@@ -962,25 +963,78 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         )
       );
     }
+    const authorize = async (
+      frame: FileResource | null
+    ): Promise<Result<undefined, SandboxFunctionInvocationError>> => {
+      const authorization = await authorizeSandboxFunctionInvocation(auth, {
+        userIdentity: this.userIdentity,
+        origin,
+        owner: frame
+          ? { kind: "frame" as const, frame }
+          : { kind: "pod" as const, space: this.space },
+      });
+      if (!authorization.authorized) {
+        return new Err(
+          new SandboxFunctionInvocationError(authorization.errorMessage)
+        );
+      }
+      return new Ok(undefined);
+    };
+
     const frame = this.frame;
-    const authorization = await authorizeSandboxFunctionInvocation(auth, {
-      userIdentity: this.userIdentity,
-      origin,
-      owner: frame
-        ? { kind: "frame", frame }
-        : { kind: "pod", space: this.space },
-    });
-    if (!authorization.authorized) {
-      return new Err(
-        new SandboxFunctionInvocationError(authorization.errorMessage)
-      );
+    if (!frame) {
+      const authorization = await authorize(null);
+      if (authorization.isErr()) {
+        return authorization;
+      }
+      return SandboxFunctionInvocationResource.createAndStartExecution(auth, {
+        sandboxFunction: this,
+        body,
+        origin,
+      });
     }
 
-    return SandboxFunctionInvocationResource.createAndStartExecution(auth, {
-      sandboxFunction: this,
-      body,
-      origin,
+    // Publishing, invocation admission, and retired-publication cleanup share this lock. Once
+    // admission persists a `created` invocation, cleanup keeps the immutable publication until
+    // that invocation settles. If cleanup wins first, this fresh active-publication check rejects
+    // the stale function before it can create an invocation against deleted artifacts.
+    const admission = await withFramePublishLock(frame.sId, async () => {
+      const freshFrame = await frame.fetchFreshFrameV2(auth);
+      if (
+        !freshFrame ||
+        !this.publicationId ||
+        freshFrame.useCaseMetadata?.activePublicationId !== this.publicationId
+      ) {
+        return new Err(
+          new SandboxFunctionInvocationError(
+            "This Frame function is no longer active.",
+            {
+              code: "sandbox_function_not_found",
+              status: 404,
+            }
+          )
+        );
+      }
+
+      this.file = freshFrame;
+      const authorization = await authorize(freshFrame);
+      if (authorization.isErr()) {
+        return authorization;
+      }
+
+      const invocation =
+        await SandboxFunctionInvocationResource.createForExecution(auth, {
+          sandboxFunction: this,
+          body,
+          origin,
+        });
+      return new Ok(invocation);
     });
+    if (admission.isErr()) {
+      return admission;
+    }
+
+    return admission.value.startExecution(auth);
   }
 
   toPokeJSON(author: UserResource | null): PokePodFunction {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -51,6 +51,7 @@ import assert from "assert";
 import { createHash } from "crypto";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionResource
@@ -667,6 +668,85 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       where: { fileId: frame.id, publicationId },
       includeFrameFunctions: true,
     });
+  }
+
+  static async hasRunningInvocationsForFramePublication(
+    auth: Authenticator,
+    { frame, publicationId }: { frame: FileResource; publicationId: string }
+  ): Promise<boolean> {
+    const owner = auth.getNonNullableWorkspace();
+    assert(
+      frame.isFrameV2 && frame.workspaceId === owner.id,
+      "Frame publication functions require a Frames v2 file from the current workspace."
+    );
+
+    const runningInvocationCount = await SandboxFunctionInvocationModel.count({
+      include: [
+        {
+          model: SandboxFunctionModel,
+          as: "sandboxFunction",
+          attributes: [],
+          required: true,
+          where: {
+            workspaceId: owner.id,
+            fileId: frame.id,
+            publicationId,
+          },
+        },
+      ],
+      where: {
+        workspaceId: owner.id,
+        status: "created",
+      },
+    });
+    return runningInvocationCount > 0;
+  }
+
+  static async deleteUnreferencedFramePublicationFunctions(
+    auth: Authenticator,
+    { frame, publicationId }: { frame: FileResource; publicationId: string }
+  ): Promise<void> {
+    const owner = auth.getNonNullableWorkspace();
+    assert(
+      frame.isFrameV2 && frame.workspaceId === owner.id,
+      "Frame publication functions require a Frames v2 file from the current workspace."
+    );
+
+    const functions = await this.model.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: owner.id,
+        fileId: frame.id,
+        publicationId,
+      },
+    });
+    const functionIds = functions.map(({ id }) => id);
+    if (functionIds.length === 0) {
+      return;
+    }
+
+    const referencedFunctions = await SandboxFunctionInvocationModel.findAll({
+      attributes: ["sandboxFunctionId"],
+      where: {
+        workspaceId: owner.id,
+        sandboxFunctionId: { [Op.in]: functionIds },
+      },
+      group: ["sandboxFunctionId"],
+    });
+    const referencedFunctionIds = new Set(
+      referencedFunctions.map(({ sandboxFunctionId }) => sandboxFunctionId)
+    );
+    const unreferencedFunctionIds = functionIds.filter(
+      (id) => !referencedFunctionIds.has(id)
+    );
+    if (unreferencedFunctionIds.length > 0) {
+      await this.model.destroy({
+        where: {
+          workspaceId: owner.id,
+          id: { [Op.in]: unreferencedFunctionIds },
+        },
+      });
+    }
   }
 
   static async fetchByFramePublicationAndSlug(

--- a/front/temporal/sandbox_functions/activities/cleanup_retired_frame_publication.ts
+++ b/front/temporal/sandbox_functions/activities/cleanup_retired_frame_publication.ts
@@ -1,0 +1,26 @@
+import { cleanupRetiredFramePublication } from "@app/lib/api/frames/publication_cleanup";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getFramePublicationBasePath } from "@app/types/api/frame_storage";
+
+export async function cleanupRetiredFramePublicationActivity({
+  frameId,
+  publicationId,
+  workspaceId,
+}: {
+  frameId: string;
+  publicationId: string;
+  workspaceId: string;
+}): Promise<boolean> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    await getPrivateUploadBucket().deleteByPrefix(
+      getFramePublicationBasePath({ workspaceId, frameId, publicationId })
+    );
+    return true;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  return cleanupRetiredFramePublication(auth, { frameId, publicationId });
+}

--- a/front/temporal/sandbox_functions/client.ts
+++ b/front/temporal/sandbox_functions/client.ts
@@ -5,10 +5,12 @@ import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_functio
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { QUEUE_NAME } from "@app/temporal/sandbox_functions/config";
 import {
+  makeRetiredFramePublicationCleanupWorkflowId,
   makeSandboxFunctionInvocationWorkflowId,
   makeSandboxFunctionToolWorkflowId,
 } from "@app/temporal/sandbox_functions/lib/workflow_ids";
 import {
+  cleanupRetiredFramePublicationWorkflow,
   runSandboxFunctionInvocationWorkflow,
   runSandboxFunctionToolWorkflow,
 } from "@app/temporal/sandbox_functions/workflows";
@@ -16,6 +18,46 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+export async function launchRetiredFramePublicationCleanupWorkflow({
+  frameId,
+  publicationId,
+  workspaceId,
+}: {
+  frameId: string;
+  publicationId: string;
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
+  const workflowId = makeRetiredFramePublicationCleanupWorkflowId({
+    workspaceId,
+    frameId,
+    publicationId,
+  });
+
+  try {
+    const client = await getTemporalClientForFrontNamespace();
+    await client.workflow.start(cleanupRetiredFramePublicationWorkflow, {
+      args: [{ frameId, publicationId, workspaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        workspaceId: [workspaceId],
+      },
+      memo: {
+        frameId,
+        publicationId,
+        workspaceId,
+      },
+    });
+  } catch (error) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      return new Ok(undefined);
+    }
+    return new Err(normalizeError(error));
+  }
+
+  return new Ok(undefined);
+}
 
 export async function launchSandboxFunctionToolWorkflow(
   auth: Authenticator,

--- a/front/temporal/sandbox_functions/lib/workflow_ids.ts
+++ b/front/temporal/sandbox_functions/lib/workflow_ids.ts
@@ -17,3 +17,15 @@ export function makeSandboxFunctionInvocationWorkflowId({
 }) {
   return `sandbox-function-invocation-workflow-${workspaceId}-${invocationId}`;
 }
+
+export function makeRetiredFramePublicationCleanupWorkflowId({
+  workspaceId,
+  frameId,
+  publicationId,
+}: {
+  workspaceId: string;
+  frameId: string;
+  publicationId: string;
+}) {
+  return `retired-frame-publication-cleanup-${workspaceId}-${frameId}-${publicationId}`;
+}

--- a/front/temporal/sandbox_functions/worker.ts
+++ b/front/temporal/sandbox_functions/worker.ts
@@ -5,6 +5,7 @@ import {
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import { cleanupRetiredFramePublicationActivity } from "@app/temporal/sandbox_functions/activities/cleanup_retired_frame_publication";
 import { markSandboxFunctionInvocationFailedActivity } from "@app/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed";
 import { runSandboxFunctionInvocationActivity } from "@app/temporal/sandbox_functions/activities/run_sandbox_function_invocation";
 import { runSandboxFunctionToolActivity } from "@app/temporal/sandbox_functions/activities/run_sandbox_function_tool";
@@ -25,6 +26,7 @@ export async function runSandboxFunctionsWorker() {
       getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities: {
+      cleanupRetiredFramePublicationActivity,
       markSandboxFunctionInvocationFailedActivity,
       runSandboxFunctionInvocationActivity,
       runSandboxFunctionToolActivity,

--- a/front/temporal/sandbox_functions/workflows.ts
+++ b/front/temporal/sandbox_functions/workflows.ts
@@ -4,10 +4,11 @@ import {
 } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
+import type * as cleanupRetiredFramePublicationActivities from "@app/temporal/sandbox_functions/activities/cleanup_retired_frame_publication";
 import type * as markSandboxFunctionInvocationFailedActivities from "@app/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed";
 import type * as runSandboxFunctionInvocationActivities from "@app/temporal/sandbox_functions/activities/run_sandbox_function_invocation";
 import type * as runSandboxFunctionToolActivities from "@app/temporal/sandbox_functions/activities/run_sandbox_function_tool";
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, sleep } from "@temporalio/workflow";
 
 const toolActivityStartToCloseTimeoutMs =
   Math.max(RUN_AGENT_CALL_TOOL_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS) +
@@ -44,6 +45,33 @@ const { markSandboxFunctionInvocationFailedActivity } = proxyActivities<
     maximumAttempts: 5,
   },
 });
+
+const { cleanupRetiredFramePublicationActivity } = proxyActivities<
+  typeof cleanupRetiredFramePublicationActivities
+>({
+  startToCloseTimeout: "1 minute",
+  retry: {
+    initialInterval: "10 seconds",
+    maximumInterval: "5 minutes",
+  },
+});
+
+const RETIRED_FRAME_PUBLICATION_GRACE_PERIOD_MS = 60 * 60 * 1000;
+const RETIRED_FRAME_PUBLICATION_RETRY_DELAY_MS = 60 * 60 * 1000;
+
+export async function cleanupRetiredFramePublicationWorkflow(args: {
+  frameId: string;
+  publicationId: string;
+  workspaceId: string;
+}) {
+  // A canonical invocation can resolve the old active publication immediately before a publish
+  // commits and create its invocation row immediately after. The grace period closes that small
+  // resolver-to-row race before the activity decides whether the publication is still referenced.
+  await sleep(RETIRED_FRAME_PUBLICATION_GRACE_PERIOD_MS);
+  while (!(await cleanupRetiredFramePublicationActivity(args))) {
+    await sleep(RETIRED_FRAME_PUBLICATION_RETRY_DELAY_MS);
+  }
+}
 
 export async function runSandboxFunctionToolWorkflow({
   authType,

--- a/front/temporal/sandbox_functions/workflows.ts
+++ b/front/temporal/sandbox_functions/workflows.ts
@@ -8,7 +8,7 @@ import type * as cleanupRetiredFramePublicationActivities from "@app/temporal/sa
 import type * as markSandboxFunctionInvocationFailedActivities from "@app/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed";
 import type * as runSandboxFunctionInvocationActivities from "@app/temporal/sandbox_functions/activities/run_sandbox_function_invocation";
 import type * as runSandboxFunctionToolActivities from "@app/temporal/sandbox_functions/activities/run_sandbox_function_tool";
-import { proxyActivities, sleep } from "@temporalio/workflow";
+import { continueAsNew, proxyActivities, sleep } from "@temporalio/workflow";
 
 const toolActivityStartToCloseTimeoutMs =
   Math.max(RUN_AGENT_CALL_TOOL_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS) +
@@ -58,19 +58,29 @@ const { cleanupRetiredFramePublicationActivity } = proxyActivities<
 
 const RETIRED_FRAME_PUBLICATION_GRACE_PERIOD_MS = 60 * 60 * 1000;
 const RETIRED_FRAME_PUBLICATION_RETRY_DELAY_MS = 60 * 60 * 1000;
+const RETIRED_FRAME_PUBLICATION_ATTEMPTS_PER_RUN = 24;
 
 export async function cleanupRetiredFramePublicationWorkflow(args: {
   frameId: string;
   publicationId: string;
   workspaceId: string;
 }) {
-  // A canonical invocation can resolve the old active publication immediately before a publish
-  // commits and create its invocation row immediately after. The grace period closes that small
-  // resolver-to-row race before the activity decides whether the publication is still referenced.
-  await sleep(RETIRED_FRAME_PUBLICATION_GRACE_PERIOD_MS);
-  while (!(await cleanupRetiredFramePublicationActivity(args))) {
-    await sleep(RETIRED_FRAME_PUBLICATION_RETRY_DELAY_MS);
+  for (
+    let attempt = 0;
+    attempt < RETIRED_FRAME_PUBLICATION_ATTEMPTS_PER_RUN;
+    attempt++
+  ) {
+    await sleep(
+      attempt === 0
+        ? RETIRED_FRAME_PUBLICATION_GRACE_PERIOD_MS
+        : RETIRED_FRAME_PUBLICATION_RETRY_DELAY_MS
+    );
+    if (await cleanupRetiredFramePublicationActivity(args)) {
+      return;
+    }
   }
+
+  await continueAsNew<typeof cleanupRetiredFramePublicationWorkflow>(args);
 }
 
 export async function runSandboxFunctionToolWorkflow({


### PR DESCRIPTION
## Description

Schedule durable cleanup whenever a Frames v2 publication is retired. Invocation admission revalidates the active publication and persists its invocation row under the same per-Frame lock used by publishing and cleanup, so cleanup cannot delete artifacts needed by an admitted invocation. Cleanup waits one hour, retries while any invocation is running, removes immutable GCS artifacts, deletes only unreferenced function rows, preserves invocation history, and never removes the active publication. Existing committed publications are discovered on the next publish. The workflow continues as new every 24 attempts to bound history.

## Tests

- `front`: 44 relevant files, 422 tests passed across Frames v2, legacy Frames, Pod Functions, publication storage, invocation execution, sharing, mounts, UI rendering, and Temporal activities
- `front-api`: 9 relevant files, 124 tests passed across public and authenticated Frame routes, canonical and legacy function invocation, and SSE
- `front` and `front-api`: `npx tsgo --noEmit`
- `front`: all 30 Temporal bundles built
- `npm run format:changed` and Biome on changed files

## Risk

Moderate. This deletes retired publication artifacts. Deletion runs only after a grace period, under the Frame operation lock, after confirming the publication is inactive and has no running invocation. Invocation admission creates its durable reference under that same lock. Cleanup retries durably, workflow history is bounded, and scheduling failures do not break publishing.

## Deploy Plan

Deploy the front service and sandbox-functions Temporal worker normally behind the existing Frames v2 feature flag.