### PR TITLE
[front] fix: reject incomplete Slack OAuth grants

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -21,6 +21,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isRecord, isString } from "@app/types/shared/utils/general";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { KnownBlock, WebAPICallResult } from "@slack/web-api";
 import { WebClient } from "@slack/web-api";
@@ -49,14 +50,46 @@ const CHANNEL_CACHE_TTL_MS = 60 * 10 * 1000;
 export const MAX_USER_SEARCH_RESULTS = 20;
 const USER_CACHE_TTL_MS = 60 * 10 * 1000;
 
-export function isSlackMissingScope(error: unknown): boolean {
+function hasStringProperty<Property extends string>(
+  value: unknown,
+  property: Property
+): value is Record<Property, string> {
   return (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof error.message === "string" &&
+    typeof value === "object" &&
+    value !== null &&
+    isRecord(value) &&
+    property in value &&
+    isString(value[property])
+  );
+}
+
+type SlackMissingScopeError = Record<"message", string> & {
+  data?: unknown;
+};
+
+function hasSlackMissingScopeData(
+  error: SlackMissingScopeError
+): error is SlackMissingScopeError & {
+  data: Record<"needed", string>;
+} {
+  return hasStringProperty(error.data, "needed");
+}
+
+export function isSlackMissingScope(
+  error: unknown
+): error is SlackMissingScopeError {
+  return (
+    hasStringProperty(error, "message") &&
     error.message.includes("missing_scope")
   );
+}
+
+export function getSlackMissingScope(error: unknown): string | undefined {
+  if (!isSlackMissingScope(error) || !hasSlackMissingScopeData(error)) {
+    return undefined;
+  }
+
+  return error.data.needed;
 }
 
 export const getSlackClient = async (accessToken?: string) => {

--- a/front/lib/api/actions/servers/slack_personal/tools/index.test.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.test.ts
@@ -1,0 +1,180 @@
+import type { BaseToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  executeReadThreadMessages,
+  getSlackClient,
+} from "@app/lib/api/actions/servers/slack/helpers";
+import {
+  createSlackPersonalTools,
+  slackSearch,
+} from "@app/lib/api/actions/servers/slack_personal/tools";
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissions } from "@app/lib/resources/group_permission_registry";
+import { WebClient } from "@slack/web-api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/lib/api/actions/servers/slack/helpers",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/actions/servers/slack/helpers")
+      >();
+
+    return {
+      ...actual,
+      executeReadThreadMessages: vi.fn(),
+      getSlackClient: vi.fn(),
+    };
+  }
+);
+
+function makeAuth() {
+  return new Authenticator({
+    authMethod: "internal",
+    groupModelIds: [],
+    permissions: GroupPermissions.empty(),
+    role: "none",
+  });
+}
+
+function makeHandlerExtra(token = "test-token"): BaseToolHandlerExtra {
+  return {
+    authInfo: {
+      token,
+      clientId: "",
+      scopes: [],
+    },
+    requestId: "slack-personal-tools-test",
+    sendNotification: async () => {},
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request");
+    },
+    signal: new AbortController().signal,
+  };
+}
+
+function expectAuthenticationScope(
+  result: Awaited<
+    ReturnType<
+      ReturnType<
+        typeof createSlackPersonalTools
+      >["commonTools"][number]["handler"]
+    >
+  >,
+  scope: string
+) {
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toContainEqual({
+      type: "resource",
+      resource: expect.objectContaining({
+        type: "tool_personal_auth_required",
+        provider: "slack_tools",
+        scope,
+      }),
+    });
+  }
+}
+
+describe("Slack personal tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards Slack's required scope to the authentication flow", async () => {
+    const slackClient = new WebClient("test-token");
+    vi.spyOn(slackClient.reactions, "get").mockRejectedValue(
+      Object.assign(new Error("An API error occurred: missing_scope"), {
+        data: {
+          ok: false,
+          error: "missing_scope",
+          needed: "reactions:read",
+          provided: "channels:history,channels:read",
+        },
+      })
+    );
+    vi.mocked(getSlackClient).mockResolvedValue(slackClient);
+
+    const auth = makeAuth();
+    const getReactionsTool = createSlackPersonalTools(
+      auth,
+      "ims_test"
+    ).commonTools.find((tool) => tool.name === "get_reactions");
+    expect(getReactionsTool).toBeDefined();
+    if (!getReactionsTool) {
+      throw new Error("get_reactions tool not found");
+    }
+
+    const result = await getReactionsTool.handler(
+      {
+        channel: "C123",
+        timestamp: "123.456",
+        full: true,
+      },
+      makeHandlerExtra()
+    );
+
+    expectAuthenticationScope(result, "reactions:read");
+  });
+
+  it("preserves the required scope returned by Slack search", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: "missing_scope",
+            needed: "search:read.public",
+            provided: "channels:history,channels:read",
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    await expect(slackSearch("incident", "test-token")).rejects.toMatchObject({
+      data: {
+        error: "missing_scope",
+        needed: "search:read.public",
+      },
+    });
+  });
+
+  it("pauses thread reads with Slack's required scope", async () => {
+    vi.mocked(executeReadThreadMessages).mockRejectedValue(
+      Object.assign(new Error("An API error occurred: missing_scope"), {
+        data: {
+          ok: false,
+          error: "missing_scope",
+          needed: "channels:history",
+          provided: "channels:read",
+        },
+      })
+    );
+
+    const auth = makeAuth();
+    const readThreadTool = createSlackPersonalTools(
+      auth,
+      "ims_test"
+    ).commonTools.find((tool) => tool.name === "read_thread_messages");
+    expect(readThreadTool).toBeDefined();
+    if (!readThreadTool) {
+      throw new Error("read_thread_messages tool not found");
+    }
+
+    const result = await readThreadTool.handler(
+      {
+        channel: "C123",
+        threadTs: "123.456",
+      },
+      makeHandlerExtra()
+    );
+
+    expectAuthenticationScope(result, "channels:history");
+  });
+});

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -2,7 +2,7 @@ import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
-  ToolDefinition,
+  BaseToolHandlerExtra,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -25,6 +25,7 @@ import {
   executeSetUserStatus,
   executeWriteCanvas,
   getSlackClient,
+  getSlackMissingScope,
   isSlackMissingScope,
   resolveChannelDisplayName,
   resolveChannelId,
@@ -64,6 +65,8 @@ type SlackSearchMatch = {
 type SlackSearchResponse = {
   ok: boolean;
   error?: string;
+  needed?: string;
+  provided?: string;
   results: {
     messages: Array<{
       author_id?: string;
@@ -145,7 +148,7 @@ class SlackRateLimitError extends Error {
   }
 }
 
-const slackSearch = async (
+export const slackSearch = async (
   query: string,
   accessToken: string
 ): Promise<SlackSearchMatch[]> => {
@@ -181,7 +184,7 @@ const slackSearch = async (
     if (data.error === SLACK_RATE_LIMITED_ERROR) {
       throw new SlackRateLimitError();
     }
-    throw new Error(data.error ?? "unknown_error");
+    throw Object.assign(new Error(data.error ?? "unknown_error"), { data });
   }
 
   // Transform API response to match SlackSearchMatch format.
@@ -332,8 +335,16 @@ function isSlackTokenRevoked(error: unknown): boolean {
 // Returns an authentication error response if the error is token-related,
 // or null if the error should be handled by the caller.
 function handleSlackAuthError(error: unknown) {
-  if (isSlackTokenRevoked(error) || isSlackMissingScope(error)) {
+  if (isSlackTokenRevoked(error)) {
     return new Ok(makePersonalAuthenticationError("slack_tools").content);
+  }
+  if (isSlackMissingScope(error)) {
+    return new Ok(
+      makePersonalAuthenticationError(
+        "slack_tools",
+        getSlackMissingScope(error)
+      ).content
+    );
   }
   return null;
 }
@@ -360,21 +371,19 @@ function handleSlackSearchError(error: unknown) {
   );
 }
 
-interface SlackPersonalToolsResult {
-  searchMessagesTool: ToolDefinition;
-  semanticSearchMessagesTool: ToolDefinition;
-  commonTools: ToolDefinition[];
-}
-
 export function createSlackPersonalTools(
   auth: Authenticator,
   mcpServerId: string,
   toolContext?: ToolContext
-): SlackPersonalToolsResult {
+) {
   const allowFooterRemoval =
     auth.workspace()?.metadata?.slackPersonalAllowFooterRemoval ?? false;
 
-  const handlers: ToolHandlers<typeof SLACK_PERSONAL_TOOLS_METADATA> = {
+  const handlers: ToolHandlers<
+    typeof SLACK_PERSONAL_TOOLS_METADATA,
+    (typeof SLACK_PERSONAL_TOOLS_METADATA)[number]["name"],
+    BaseToolHandlerExtra
+  > = {
     search_messages: async (
       {
         keywords,
@@ -880,15 +889,25 @@ export function createSlackPersonalTools(
         return new Err(new MCPError("Access token not found"));
       }
 
-      return executeReadThreadMessages({
-        channel,
-        threadTs,
-        limit,
-        cursor,
-        oldest,
-        latest,
-        accessToken,
-      });
+      try {
+        return await executeReadThreadMessages({
+          channel,
+          threadTs,
+          limit,
+          cursor,
+          oldest,
+          latest,
+          accessToken,
+        });
+      } catch (error) {
+        const authError = handleSlackAuthError(error);
+        if (authError) {
+          return authError;
+        }
+        return new Err(
+          new MCPError(`Error reading thread: ${normalizeError(error)}`)
+        );
+      }
     },
 
     get_channel_canvases: async ({ channel_id }, { authInfo }) => {

--- a/front/lib/api/oauth/providers/slack_tools.test.ts
+++ b/front/lib/api/oauth/providers/slack_tools.test.ts
@@ -1,0 +1,122 @@
+import { SlackToolsOAuthProvider } from "@app/lib/api/oauth/providers/slack_tools";
+import type { OAuthConnectionType } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function makeConnection(metadata: Record<string, string>): OAuthConnectionType {
+  return {
+    connection_id: "connection-id",
+    created: Date.now(),
+    metadata,
+    provider: "slack_tools",
+    status: "finalized",
+  };
+}
+
+describe("SlackToolsOAuthProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a required scope for personal authentication", () => {
+    const provider = new SlackToolsOAuthProvider();
+
+    expect(
+      provider.isExtraConfigValid(
+        {
+          mcp_server_id: "ims_test",
+          scope: "reactions:read",
+        },
+        "personal_actions"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a finalized connection that did not grant the required scope", async () => {
+    const getAccessTokenSpy = vi
+      .spyOn(OAuthAPI.prototype, "getAccessToken")
+      .mockResolvedValue(
+        new Ok({
+          connection: makeConnection({ scope: "reactions:read" }),
+          access_token: "test-token",
+          access_token_expiry: null,
+          scrubbed_raw_json: {
+            authed_user: {
+              scope: "channels:history,channels:read",
+            },
+          },
+        })
+      );
+
+    const provider = new SlackToolsOAuthProvider();
+    const result = await provider.checkConnectionValidPostFinalize(
+      makeConnection({
+        scope: "reactions:read",
+        requested_team_id: "T123",
+        team_id: "T123",
+      })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("reactions:read");
+      expect(result.error.message).toContain("Slack workspace admin");
+    }
+    expect(getAccessTokenSpy).toHaveBeenCalledWith({
+      connectionId: "connection-id",
+    });
+  });
+
+  it("accepts a finalized connection that granted the required scope", async () => {
+    const getAccessTokenSpy = vi
+      .spyOn(OAuthAPI.prototype, "getAccessToken")
+      .mockResolvedValue(
+        new Ok({
+          connection: makeConnection({ scope: "reactions:read" }),
+          access_token: "test-token",
+          access_token_expiry: null,
+          scrubbed_raw_json: {
+            authed_user: {
+              scope: "channels:history,reactions:read",
+            },
+          },
+        })
+      );
+
+    const provider = new SlackToolsOAuthProvider();
+    const result = await provider.checkConnectionValidPostFinalize(
+      makeConnection({
+        scope: "reactions:read",
+        requested_team_id: "T123",
+        team_id: "T123",
+      })
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(getAccessTokenSpy).toHaveBeenCalledWith({
+      connectionId: "connection-id",
+    });
+  });
+
+  it("rejects a connection to a different Slack team before checking scopes", async () => {
+    const getAccessTokenSpy = vi.spyOn(OAuthAPI.prototype, "getAccessToken");
+    const provider = new SlackToolsOAuthProvider();
+    const result = await provider.checkConnectionValidPostFinalize(
+      makeConnection({
+        scope: "reactions:read",
+        requested_team_id: "T123",
+        requested_team_name: "Expected workspace",
+        team_id: "T456",
+        team_name: "Other workspace",
+      })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Expected workspace (T123)");
+      expect(result.error.message).toContain("Other workspace (T456)");
+    }
+    expect(getAccessTokenSpy).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -14,8 +14,32 @@ import type {
 } from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type { ParsedUrlQuery } from "querystring";
+
+type SlackOAuthResponseWithUserScope = {
+  authed_user: {
+    scope: string;
+  };
+};
+
+function hasSlackOAuthUserScope(
+  value: unknown
+): value is SlackOAuthResponseWithUserScope {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("authed_user" in value) ||
+    typeof value.authed_user !== "object" ||
+    value.authed_user === null ||
+    !("scope" in value.authed_user)
+  ) {
+    return false;
+  }
+
+  return isString(value.authed_user.scope);
+}
 
 /**
  * OAuth provider for Slack Tools MCP server.
@@ -168,44 +192,98 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
 
   isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
     if (useCase === "personal_actions") {
+      const keys = Object.keys(extraConfig);
       return (
-        Object.keys(extraConfig).length === 1 && "mcp_server_id" in extraConfig
+        typeof extraConfig.mcp_server_id === "string" &&
+        extraConfig.mcp_server_id.length > 0 &&
+        keys.every((key) => key === "mcp_server_id" || key === "scope") &&
+        (extraConfig.scope === undefined || extraConfig.scope.length > 0)
       );
     }
     // For platform_actions, no extra config is required.
     return Object.keys(extraConfig).length === 0;
   }
 
-  checkConnectionValidPostFinalize(connection: OAuthConnectionType) {
+  async checkConnectionValidPostFinalize(connection: OAuthConnectionType) {
     // If a team was requested, we need to check that the team id is the same as the requested team id.
     if ("requested_team_id" in connection.metadata) {
       if (
-        connection.metadata.team_id === connection.metadata.requested_team_id
+        connection.metadata.team_id !== connection.metadata.requested_team_id
       ) {
-        return new Ok(undefined);
+        logger.warn(
+          {
+            requestedTeamId: connection.metadata.requested_team_id,
+            requestedTeamName: connection.metadata.requested_team_name,
+            actualTeamId: connection.metadata.team_id,
+            actualTeamName: connection.metadata.team_name,
+          },
+          "OAuth: Slack team mismatch on Slack tools connection"
+        );
+        return new Err({
+          message:
+            "You must select `" +
+            connection.metadata.requested_team_name +
+            " (" +
+            connection.metadata.requested_team_id +
+            ")` as the team to connect, instead of `" +
+            connection.metadata.team_name +
+            " (" +
+            connection.metadata.team_id +
+            ")`.",
+        });
       }
-      logger.warn(
+    }
+
+    const requiredScopes = connection.metadata.scope
+      ?.split(/[\s,]+/)
+      .filter(Boolean);
+    if (!requiredScopes?.length) {
+      return new Ok(undefined);
+    }
+
+    const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const tokenRes = await oauthApi.getAccessToken({
+      connectionId: connection.connection_id,
+    });
+    if (tokenRes.isErr()) {
+      logger.error(
         {
-          requestedTeamId: connection.metadata.requested_team_id,
-          requestedTeamName: connection.metadata.requested_team_name,
-          actualTeamId: connection.metadata.team_id,
-          actualTeamName: connection.metadata.team_name,
+          connectionId: connection.connection_id,
+          error: tokenRes.error,
         },
-        "OAuth: Slack team mismatch on Slack tools connection"
+        "OAuth: Failed to verify Slack tools connection scopes"
       );
       return new Err({
         message:
-          "You must select `" +
-          connection.metadata.requested_team_name +
-          " (" +
-          connection.metadata.requested_team_id +
-          ")` as the team to connect, instead of `" +
-          connection.metadata.team_name +
-          " (" +
-          connection.metadata.team_id +
-          ")`.",
+          "Failed to verify the permissions granted by Slack. Please try again.",
       });
     }
+
+    const rawJson = tokenRes.value.scrubbed_raw_json;
+    const grantedScopeString = hasSlackOAuthUserScope(rawJson)
+      ? rawJson.authed_user.scope
+      : "";
+    const grantedScopes = new Set(
+      grantedScopeString.split(/[\s,]+/).filter(Boolean)
+    );
+    const missingScopes = requiredScopes.filter(
+      (scope) => !grantedScopes.has(scope)
+    );
+    if (missingScopes.length > 0) {
+      logger.warn(
+        {
+          connectionId: connection.connection_id,
+          missingScopes,
+        },
+        "OAuth: Slack tools connection missing required scopes"
+      );
+      return new Err({
+        message:
+          `Slack did not grant the required permission${missingScopes.length > 1 ? "s" : ""}: ` +
+          `${missingScopes.join(", ")}. Ask a Slack workspace admin to reconnect this Slack tool and approve the missing permissions, then try again.`,
+      });
+    }
+
     return new Ok(undefined);
   }
 }


### PR DESCRIPTION
## Description

Fixes the recurring Slack personal-auth loop reported in https://github.com/dust-tt/tasks/issues/10230.

Slack Tools already requests reaction scopes, but Slack may finalize an existing workspace's authorization without granting newly added user scopes. We currently accept that connection, resolve the blocked action, and immediately re-block when Slack returns `missing_scope`.

This change:

- propagates Slack's `needed` scope into the personal-auth request;
- verifies that the finalized Slack user token actually contains that scope;
- keeps the action unresolved and tells the user to ask a Slack workspace admin to reconnect and approve missing permissions when Slack omits it.

## Tests

- Added Slack reaction, search, and thread-tool regression tests for forwarding required scopes.
- Added Slack OAuth-provider tests for missing and granted scopes.
- `NODE_ENV=test npm test` (696 files passed, 75 skipped; 8,957 tests passed, 81 skipped)
- `npx tsgo --noEmit`
- `npx biome check` on all five changed files

## Risk

Low and isolated to Slack Tools personal OAuth retries triggered by `missing_scope`. Ordinary authentication without a requested scope does not perform the added grant check. Successful scope grants continue unchanged. The failure mode is recoverable through Slack admin reauthorization followed by a user retry.

## Deploy Plan

Standard front deploy. Monitor `OAuth: Slack tools connection missing required scopes` warnings and personal-auth completion/reblock rates. Roll back if valid Slack grants are rejected.
