### PR TITLE
[front] Fix Metronome seat-sync edit storm: serialize full reconcile, narrow immediate seat writes

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -1,5 +1,4 @@
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
   isMetronomeBillingEnabled,
   restoreWorkspaceAfterSubscription,
@@ -601,11 +600,17 @@ export async function handleSubscriptionActivationSuccess({
       checkoutPayment.seatType,
       checkoutPayment.billingPeriod
     );
+    // `isDirectSync` makes this immediately assign the target user's single seat
+    // (and reconcile their credit state) so they land correctly without waiting
+    // for the 15 s debounce — while the workspace-wide reconcile still goes
+    // through the debounced Temporal workflow it launches. This avoids running a
+    // second full reconcile here in parallel with the workflow.
     const seatResult = await updateMembershipSeatAndTrack({
       user: targetUser,
       workspace: lightWorkspace,
       newSeatType: membershipSeatType,
       author: "no-author",
+      isDirectSync: true,
     });
     if (seatResult.isErr()) {
       logger.error(
@@ -627,23 +632,6 @@ export async function handleSubscriptionActivationSuccess({
         },
         "[Business Activation] Target user seat updated"
       );
-
-      // Immediately sync seats so the user lands in the correct credit state
-      // without waiting for the debounced Temporal workflow (15 s delay).
-      const syncResult = await syncMetronomeSeatCountForWorkspace({
-        workspace: lightWorkspace,
-      });
-      if (syncResult.isErr()) {
-        logger.warn(
-          { workspaceId: workspace.sId, err: syncResult.error.message },
-          "[Business Activation] Immediate seat sync failed; debounced workflow will retry"
-        );
-      } else {
-        logger.info(
-          { workspaceId: workspace.sId, syncStatus: syncResult.value.status },
-          "[Business Activation] Immediate seat sync completed"
-        );
-      }
     }
   }
 

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,6 +1,5 @@
 import { passesBillingGate } from "@app/lib/api/credits/auto_seat_upgrade";
 import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import type { Authenticator } from "@app/lib/auth";
 import { isEnterprisePlanPrefix, isFreePlan } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
@@ -12,6 +11,7 @@ import {
   DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
 } from "@app/lib/resources/storage/models/credit_usage_configurations";
 import logger from "@app/logger/logger";
+import { launchMetronomeSeatCountSyncWorkflow } from "@app/temporal/usage_queue/client";
 import type {
   CreditUsageConfigurationBody,
   PatchCreditUsageConfigurationBody,
@@ -150,9 +150,13 @@ export async function updateUsageConfiguration(
   }
 
   if (enablingAutoSeatUpgrade) {
-    // Best-effort: a failure here must not fail the configuration update.
-    const reconcileResult = await syncMetronomeSeatCountForWorkspace({
-      workspace: auth.getNonNullableWorkspace(),
+    // Route the whole-workspace reconcile through the debounced Temporal
+    // workflow (the single serialized path per workspace) rather than running a
+    // full reconcile inline — two full reconciles in parallel stack open-ended
+    // unassigned-seat edits. Best-effort: a failure here must not fail the
+    // configuration update.
+    const reconcileResult = await launchMetronomeSeatCountSyncWorkflow({
+      workspaceId: auth.getNonNullableWorkspace().sId,
     });
     if (reconcileResult.isErr()) {
       logger.warn(
@@ -160,7 +164,7 @@ export async function updateUsageConfiguration(
           workspaceId: auth.getNonNullableWorkspace().sId,
           err: reconcileResult.error.message,
         },
-        "[UsageConfiguration] Whole-workspace reconcile after enabling auto-upgrade failed"
+        "[UsageConfiguration] Failed to launch whole-workspace reconcile after enabling auto-upgrade"
       );
     }
   }

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -4,7 +4,7 @@ import {
   emitAuditLogEventDirect,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
+import { assignSeatForUser } from "@app/lib/api/metronome/seat_sync";
 import type { AuditLogActor } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -967,9 +967,16 @@ export async function updateMembershipSeatAndTrack({
   }
 
   if (isDirectSync && resultingActiveSeatType !== previousSeatType) {
-    const directSyncResult = await syncMetronomeSeatCountForWorkspace({
+    // Immediate, single-seat write only (never a full reconcile): assign this
+    // user's seat + reconcile their credit state so they're unblocked now. The
+    // debounced workflow launched above owns the workspace-wide reconcile —
+    // running a second full reconcile here in parallel is what stacked
+    // open-ended unassigned-seat edits in the seat-sync incident.
+    const directSyncResult = await assignSeatForUser({
       workspace,
-      reconcileUserId: user.sId,
+      userId: user.sId,
+      seatType: resultingActiveSeatType,
+      previousSeatType,
     });
     if (directSyncResult.isErr()) {
       logger.warn(
@@ -978,7 +985,7 @@ export async function updateMembershipSeatAndTrack({
           userId: user.sId,
           err: directSyncResult.error.message,
         },
-        "[Metronome] Direct seat sync failed; debounced workflow will retry"
+        "[Metronome] Immediate seat assignment failed; debounced workflow will retry"
       );
     }
   }

--- a/front/lib/api/metronome/seat_sync.test.ts
+++ b/front/lib/api/metronome/seat_sync.test.ts
@@ -1,35 +1,33 @@
 import type { CachedContract } from "@app/lib/metronome/plan_type";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { assignSeatForUser } from "./seat_sync";
 
 const {
-  mockUpdateSubscriptionSeats,
+  mockMoveSeatWithCreditCarry,
   mockGetActiveContract,
   mockGetProductSeatTypes,
-  mockGetSeatSubscriptionsFromContract,
   mockReconcileUser,
   mockFetchActiveSubscription,
   mockFetchWorkspaceById,
   mockInternalAdmin,
 } = vi.hoisted(() => ({
-  mockUpdateSubscriptionSeats: vi.fn(),
+  mockMoveSeatWithCreditCarry: vi.fn(),
   mockGetActiveContract: vi.fn(),
   mockGetProductSeatTypes: vi.fn(),
-  mockGetSeatSubscriptionsFromContract: vi.fn(),
   mockReconcileUser: vi.fn(),
   mockFetchActiveSubscription: vi.fn(),
   mockFetchWorkspaceById: vi.fn(),
   mockInternalAdmin: vi.fn(),
 }));
 
-vi.mock("@app/lib/metronome/client", async () => {
+vi.mock("@app/lib/metronome/seats", async () => {
   const actual = await vi.importActual<
-    typeof import("@app/lib/metronome/client")
-  >("@app/lib/metronome/client");
-  return { ...actual, updateSubscriptionSeats: mockUpdateSubscriptionSeats };
+    typeof import("@app/lib/metronome/seats")
+  >("@app/lib/metronome/seats");
+  return { ...actual, moveSeatWithCreditCarry: mockMoveSeatWithCreditCarry };
 });
 
 vi.mock("@app/lib/metronome/plan_type", async () => {
@@ -43,11 +41,7 @@ vi.mock("@app/lib/metronome/seat_types", async () => {
   const actual = await vi.importActual<
     typeof import("@app/lib/metronome/seat_types")
   >("@app/lib/metronome/seat_types");
-  return {
-    ...actual,
-    getProductSeatTypes: mockGetProductSeatTypes,
-    getSeatSubscriptionsFromContract: mockGetSeatSubscriptionsFromContract,
-  };
+  return { ...actual, getProductSeatTypes: mockGetProductSeatTypes };
 });
 
 vi.mock("@app/lib/api/metronome/reconcile_credit_state", async () => {
@@ -85,19 +79,13 @@ describe("assignSeatForUser", () => {
     });
     mockGetActiveContract.mockResolvedValue({} as CachedContract);
     mockGetProductSeatTypes.mockResolvedValue(new Map());
-    mockGetSeatSubscriptionsFromContract.mockReturnValue(
-      new Map([
-        ["pro", { id: "sub_pro" }],
-        ["max", { id: "sub_max" }],
-      ])
-    );
-    mockUpdateSubscriptionSeats.mockResolvedValue(new Ok(undefined));
+    mockMoveSeatWithCreditCarry.mockResolvedValue(new Ok(undefined));
     mockReconcileUser.mockResolvedValue(new Ok({}));
     mockFetchWorkspaceById.mockResolvedValue({ sId: "ws_1" });
     mockInternalAdmin.mockResolvedValue({});
   });
 
-  it("assigns only the user's single seat — never touches the unassigned pool", async () => {
+  it("delegates the single-seat move (with credit carry) then reconciles the user", async () => {
     const result = await assignSeatForUser({
       workspace: WORKSPACE,
       userId: "u1",
@@ -105,24 +93,41 @@ describe("assignSeatForUser", () => {
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledTimes(1);
-    // A single add of this user's seat to the target sub — and crucially, no
-    // add/remove_unassigned in the payload (that math belongs to the workflow).
-    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith({
-      metronomeCustomerId: "cus_1",
-      contractId: "con_1",
-      fromSubscriptionId: "sub_pro",
-      toSubscriptionId: undefined,
-      addSeatIds: ["u1"],
-      removeSeatIds: [],
-    });
-    const call = mockUpdateSubscriptionSeats.mock.calls[0][0];
-    expect(call.addUnassignedSeats).toBeUndefined();
-    expect(call.removeUnassignedSeats).toBeUndefined();
+    expect(mockMoveSeatWithCreditCarry).toHaveBeenCalledTimes(1);
+    expect(mockMoveSeatWithCreditCarry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: "cus_1",
+        contractId: "con_1",
+        userId: "u1",
+        fromSeatType: undefined,
+        toSeatType: "pro",
+      })
+    );
     expect(mockReconcileUser).toHaveBeenCalledTimes(1);
   });
 
-  it("moves the seat between subscriptions on a seat-type change", async () => {
+  it("passes the from→to seat types for a pro→max upgrade (drives the ledger carry)", async () => {
+    await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "max",
+      previousSeatType: "pro",
+    });
+
+    expect(mockMoveSeatWithCreditCarry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        fromSeatType: "pro",
+        toSeatType: "max",
+      })
+    );
+  });
+
+  it("returns Err (and still reconciles nothing extra) when the seat move fails", async () => {
+    mockMoveSeatWithCreditCarry.mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
     const result = await assignSeatForUser({
       workspace: WORKSPACE,
       userId: "u1",
@@ -130,30 +135,8 @@ describe("assignSeatForUser", () => {
       previousSeatType: "pro",
     });
 
-    expect(result.isOk()).toBe(true);
-    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith({
-      metronomeCustomerId: "cus_1",
-      contractId: "con_1",
-      fromSubscriptionId: "sub_pro",
-      toSubscriptionId: "sub_max",
-      addSeatIds: ["u1"],
-      removeSeatIds: ["u1"],
-    });
-  });
-
-  it("skips the seat edit when the target seat type has no billable subscription", async () => {
-    const result = await assignSeatForUser({
-      workspace: WORKSPACE,
-      userId: "u1",
-      seatType: "none",
-      previousSeatType: "pro",
-    });
-
-    expect(result.isOk()).toBe(true);
-    // No seat write for a non-billable target (the workflow handles removal),
-    // but the user's credit state is still reconciled.
-    expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalled();
-    expect(mockReconcileUser).toHaveBeenCalledTimes(1);
+    expect(result.isErr()).toBe(true);
+    expect(mockReconcileUser).not.toHaveBeenCalled();
   });
 
   it("no-ops when the workspace is not on Metronome", async () => {
@@ -165,6 +148,6 @@ describe("assignSeatForUser", () => {
 
     expect(result.isOk()).toBe(true);
     expect(mockFetchActiveSubscription).not.toHaveBeenCalled();
-    expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalled();
+    expect(mockMoveSeatWithCreditCarry).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/metronome/seat_sync.test.ts
+++ b/front/lib/api/metronome/seat_sync.test.ts
@@ -1,0 +1,170 @@
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { assignSeatForUser } from "./seat_sync";
+
+const {
+  mockUpdateSubscriptionSeats,
+  mockGetActiveContract,
+  mockGetProductSeatTypes,
+  mockGetSeatSubscriptionsFromContract,
+  mockReconcileUser,
+  mockFetchActiveSubscription,
+  mockFetchWorkspaceById,
+  mockInternalAdmin,
+} = vi.hoisted(() => ({
+  mockUpdateSubscriptionSeats: vi.fn(),
+  mockGetActiveContract: vi.fn(),
+  mockGetProductSeatTypes: vi.fn(),
+  mockGetSeatSubscriptionsFromContract: vi.fn(),
+  mockReconcileUser: vi.fn(),
+  mockFetchActiveSubscription: vi.fn(),
+  mockFetchWorkspaceById: vi.fn(),
+  mockInternalAdmin: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return { ...actual, updateSubscriptionSeats: mockUpdateSubscriptionSeats };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/plan_type")
+  >("@app/lib/metronome/plan_type");
+  return { ...actual, getActiveContract: mockGetActiveContract };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return {
+    ...actual,
+    getProductSeatTypes: mockGetProductSeatTypes,
+    getSeatSubscriptionsFromContract: mockGetSeatSubscriptionsFromContract,
+  };
+});
+
+vi.mock("@app/lib/api/metronome/reconcile_credit_state", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/api/metronome/reconcile_credit_state")
+  >("@app/lib/api/metronome/reconcile_credit_state");
+  return { ...actual, reconcileUser: mockReconcileUser };
+});
+
+vi.mock("@app/lib/resources/subscription_resource", () => ({
+  SubscriptionResource: {
+    fetchActiveByWorkspaceModelId: mockFetchActiveSubscription,
+  },
+}));
+
+vi.mock("@app/lib/resources/workspace_resource", () => ({
+  WorkspaceResource: { fetchById: mockFetchWorkspaceById },
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  Authenticator: { internalAdminForWorkspace: mockInternalAdmin },
+}));
+
+const WORKSPACE = {
+  sId: "ws_1",
+  id: 1,
+  metronomeCustomerId: "cus_1",
+} as unknown as LightWorkspaceType;
+
+describe("assignSeatForUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchActiveSubscription.mockResolvedValue({
+      metronomeContractId: "con_1",
+    });
+    mockGetActiveContract.mockResolvedValue({} as CachedContract);
+    mockGetProductSeatTypes.mockResolvedValue(new Map());
+    mockGetSeatSubscriptionsFromContract.mockReturnValue(
+      new Map([
+        ["pro", { id: "sub_pro" }],
+        ["max", { id: "sub_max" }],
+      ])
+    );
+    mockUpdateSubscriptionSeats.mockResolvedValue(new Ok(undefined));
+    mockReconcileUser.mockResolvedValue(new Ok({}));
+    mockFetchWorkspaceById.mockResolvedValue({ sId: "ws_1" });
+    mockInternalAdmin.mockResolvedValue({});
+  });
+
+  it("assigns only the user's single seat — never touches the unassigned pool", async () => {
+    const result = await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledTimes(1);
+    // A single add of this user's seat to the target sub — and crucially, no
+    // add/remove_unassigned in the payload (that math belongs to the workflow).
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      fromSubscriptionId: "sub_pro",
+      toSubscriptionId: undefined,
+      addSeatIds: ["u1"],
+      removeSeatIds: [],
+    });
+    const call = mockUpdateSubscriptionSeats.mock.calls[0][0];
+    expect(call.addUnassignedSeats).toBeUndefined();
+    expect(call.removeUnassignedSeats).toBeUndefined();
+    expect(mockReconcileUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves the seat between subscriptions on a seat-type change", async () => {
+    const result = await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "max",
+      previousSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      fromSubscriptionId: "sub_pro",
+      toSubscriptionId: "sub_max",
+      addSeatIds: ["u1"],
+      removeSeatIds: ["u1"],
+    });
+  });
+
+  it("skips the seat edit when the target seat type has no billable subscription", async () => {
+    const result = await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "none",
+      previousSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    // No seat write for a non-billable target (the workflow handles removal),
+    // but the user's credit state is still reconciled.
+    expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalled();
+    expect(mockReconcileUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when the workspace is not on Metronome", async () => {
+    const result = await assignSeatForUser({
+      workspace: { ...WORKSPACE, metronomeCustomerId: null },
+      userId: "u1",
+      seatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockFetchActiveSubscription).not.toHaveBeenCalled();
+    expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -4,8 +4,15 @@ import {
 } from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/default_user_spend_limit";
 import { Authenticator } from "@app/lib/auth";
-import { getMetronomeContractById } from "@app/lib/metronome/client";
+import {
+  getMetronomeContractById,
+  updateSubscriptionSeats,
+} from "@app/lib/metronome/client";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
 import type { SyncSeatCountSummary } from "@app/lib/metronome/seats";
 import {
   hasContractSeatSubscription,
@@ -17,6 +24,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { heartbeat } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -236,6 +244,121 @@ export async function syncMetronomeSeatCountForWorkspace({
     activeContractSummary,
     workspaceUserCreditStatesReconciled: true,
   });
+}
+
+/**
+ * Immediately assign (or move) a SINGLE user's seat in Metronome, plus reconcile
+ * that one user's credit state — nothing else.
+ *
+ * This is the only seat write allowed outside the debounced Temporal workflow.
+ * It touches just this user's `seat_id` (and their per-user credit); it never
+ * writes the unassigned pool, other users, alerts, or credit transfers. That
+ * narrow scope is what makes it safe to run concurrently with the workflow's
+ * full reconcile — unlike a full `syncMetronomeSeatCountForWorkspace`, which
+ * must be serialized: two full reconciles in parallel stack open-ended
+ * unassigned-seat deltas (the seat-sync rate-limit incident). Callers that need
+ * to unblock a just-upgraded user should call this AND launch the debounced
+ * workflow as the workspace-wide backstop (unassigned floor, other members,
+ * alerts, transfers).
+ *
+ * Best-effort and idempotent: `add_seat_ids` of an already-assigned seat is a
+ * no-op, and the credit state is reconciled from live balances. A missing
+ * contract or a target seat type with no billable subscription is skipped (the
+ * workflow reconciles it). Downgrades to a non-billable seat type only reconcile
+ * credit state here; the seat removal is left to the workflow (access is
+ * DB-gated, so billing removal is not latency-sensitive).
+ */
+export async function assignSeatForUser({
+  workspace,
+  userId,
+  seatType,
+  previousSeatType,
+}: {
+  workspace: LightWorkspaceType;
+  userId: string;
+  seatType: MembershipSeatType;
+  previousSeatType?: MembershipSeatType;
+}): Promise<Result<undefined, Error>> {
+  const workspaceId = workspace.sId;
+  if (!workspace.metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+  if (!activeSubscription?.metronomeContractId) {
+    return new Ok(undefined);
+  }
+  const contractId = activeSubscription.metronomeContractId;
+
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    return new Ok(undefined);
+  }
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+  const targetSubId = seatSubscriptions.get(seatType)?.id;
+  const previousSubId = previousSeatType
+    ? seatSubscriptions.get(previousSeatType)?.id
+    : undefined;
+
+  // Only touch Metronome seats when the target seat type maps to a billable
+  // subscription. Anything else ("none", or a type not entitled on this
+  // contract) is left to the debounced workflow.
+  if (targetSubId) {
+    const isMove = !!previousSubId && previousSubId !== targetSubId;
+    const seatUpdate = await updateSubscriptionSeats({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      contractId,
+      // On a seat-type move, remove from the old sub and add to the new one in
+      // a single edit; on a plain add, just add to the target sub.
+      fromSubscriptionId: isMove ? previousSubId : targetSubId,
+      toSubscriptionId: isMove ? targetSubId : undefined,
+      addSeatIds: [userId],
+      removeSeatIds: isMove ? [userId] : [],
+    });
+    if (seatUpdate.isErr()) {
+      logger.warn(
+        { workspaceId, userId, seatType, err: seatUpdate.error.message },
+        "[SeatSync] Immediate single-seat assignment failed; debounced workflow will reconcile"
+      );
+      return new Err(seatUpdate.error);
+    }
+  } else {
+    logger.info(
+      { workspaceId, userId, seatType },
+      "[SeatSync] No billable subscription for target seat type — leaving to debounced workflow"
+    );
+  }
+
+  // Reconcile just this user's credit state from live balances so they land in
+  // the correct seat↔pool state immediately. Never fails the assignment.
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspaceResource = await WorkspaceResource.fetchById(workspaceId);
+  if (workspaceResource) {
+    const userReconcile = await reconcileUser({
+      auth,
+      workspace: workspaceResource,
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      userId,
+      execute: true,
+    });
+    if (userReconcile.isErr()) {
+      logger.warn(
+        { workspaceId, userId, err: userReconcile.error.message },
+        "[SeatSync] Single-user credit-state reconcile failed; continuing"
+      );
+    }
+  }
+
+  logger.info(
+    { workspaceId, userId, seatType },
+    "[SeatSync] assignSeatForUser done"
+  );
+  return new Ok(undefined);
 }
 
 /**

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -4,18 +4,13 @@ import {
 } from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/default_user_spend_limit";
 import { Authenticator } from "@app/lib/auth";
-import {
-  getMetronomeContractById,
-  updateSubscriptionSeats,
-} from "@app/lib/metronome/client";
+import { getMetronomeContractById } from "@app/lib/metronome/client";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
-import {
-  getProductSeatTypes,
-  getSeatSubscriptionsFromContract,
-} from "@app/lib/metronome/seat_types";
+import { getProductSeatTypes } from "@app/lib/metronome/seat_types";
 import type { SyncSeatCountSummary } from "@app/lib/metronome/seats";
 import {
   hasContractSeatSubscription,
+  moveSeatWithCreditCarry,
   remapMembershipSeatTypesForContract,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
@@ -296,42 +291,30 @@ export async function assignSeatForUser({
     return new Ok(undefined);
   }
   const productSeatTypes = await getProductSeatTypes();
-  const seatSubscriptions = getSeatSubscriptionsFromContract(
-    contract,
-    productSeatTypes
-  );
-  const targetSubId = seatSubscriptions.get(seatType)?.id;
-  const previousSubId = previousSeatType
-    ? seatSubscriptions.get(previousSeatType)?.id
-    : undefined;
 
-  // Only touch Metronome seats when the target seat type maps to a billable
-  // subscription. Anything else ("none", or a type not entitled on this
-  // contract) is left to the debounced workflow.
-  if (targetSubId) {
-    const isMove = !!previousSubId && previousSubId !== targetSubId;
-    const seatUpdate = await updateSubscriptionSeats({
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      contractId,
-      // On a seat-type move, remove from the old sub and add to the new one in
-      // a single edit; on a plain add, just add to the target sub.
-      fromSubscriptionId: isMove ? previousSubId : targetSubId,
-      toSubscriptionId: isMove ? targetSubId : undefined,
-      addSeatIds: [userId],
-      removeSeatIds: isMove ? [userId] : [],
-    });
-    if (seatUpdate.isErr()) {
-      logger.warn(
-        { workspaceId, userId, seatType, err: seatUpdate.error.message },
-        "[SeatSync] Immediate single-seat assignment failed; debounced workflow will reconcile"
-      );
-      return new Err(seatUpdate.error);
-    }
-  } else {
-    logger.info(
-      { workspaceId, userId, seatType },
-      "[SeatSync] No billable subscription for target seat type — leaving to debounced workflow"
+  // Move (or add) just this user's seat, carrying seat-credit consumption across
+  // a recurring-credit change (pro↔max: empty the old credit, carry consumed AWU
+  // onto the new one). Scoped to this one user — never the unassigned pool or
+  // other members — so it's safe to run alongside the debounced workflow, which
+  // still owns the workspace-wide reconcile. The carry has to happen here (not
+  // only in the later workflow sync) because we move the seat immediately, which
+  // would otherwise hide the seat-type change from the workflow.
+  const moveResult = await moveSeatWithCreditCarry({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId,
+    contract,
+    productSeatTypes,
+    workspaceId,
+    userId,
+    fromSeatType: previousSeatType,
+    toSeatType: seatType,
+  });
+  if (moveResult.isErr()) {
+    logger.warn(
+      { workspaceId, userId, seatType, err: moveResult.error.message },
+      "[SeatSync] Immediate single-seat assignment failed; debounced workflow will reconcile"
     );
+    return new Err(moveResult.error);
   }
 
   // Reconcile just this user's credit state from live balances so they land in

--- a/front/lib/api/poke/plugins/workspaces/sync_metronome_seats.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_metronome_seats.ts
@@ -1,17 +1,18 @@
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import { createPlugin } from "@app/lib/api/poke/types";
+import { launchMetronomeSeatCountSyncWorkflow } from "@app/temporal/usage_queue/client";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const syncMetronomeSeatsPlugin = createPlugin({
   manifest: {
     id: "sync-metronome-seats",
     name: "Sync Metronome Seat Count",
     description:
-      "Reconcile this workspace's Metronome seat subscriptions to the current " +
-      "membership state right now, bypassing the debounce. Use to apply a seat " +
-      "change immediately or to repair a drifted seat/unassigned count.",
+      "Schedule a reconcile of this workspace's Metronome seat subscriptions to " +
+      "the current membership state. Runs through the debounced Temporal workflow " +
+      "(the single serialized reconcile path per workspace, ~15 s) so it can never " +
+      "run in parallel with an automatic sync. Use to repair a drifted " +
+      "seat/unassigned count.",
     resourceTypes: ["workspaces"],
     args: {},
     requiredRoles: ["billing"],
@@ -25,61 +26,23 @@ export const syncMetronomeSeatsPlugin = createPlugin({
   execute: async (auth) => {
     const workspace = auth.getNonNullableWorkspace();
 
-    // `syncMetronomeSeatCountForWorkspace` returns a domain `Result`: a
-    // Metronome failure is returned as `Err`, not thrown, so we propagate it
-    // straight to the operator instead of swallowing it.
-    //
-    // `forceFreeCreditRevokeCheck: true` here (unlike the automatic/debounced
-    // sync) because an operator running this manually is asking for a
-    // thorough pass, not the fast path optimized for frequent, automatic runs.
-    const result = await syncMetronomeSeatCountForWorkspace({
-      workspace,
-      forceFreeCreditRevokeCheck: true,
+    // Route through the debounced workflow rather than reconciling inline: the
+    // full workspace reconcile must run only on the single serialized per-
+    // workspace path. Two full reconciles in parallel stack open-ended
+    // unassigned-seat edits (the seat-sync rate-limit incident).
+    const result = await launchMetronomeSeatCountSyncWorkflow({
+      workspaceId: workspace.sId,
     });
     if (result.isErr()) {
       return new Err(result.error);
     }
 
-    const outcome = result.value;
-    switch (outcome.status) {
-      case "synced": {
-        const lines = ["Metronome seat count synced."];
-        if (outcome.stagedPendingContract) {
-          lines.push(
-            "- A pending future contract was also staged (mid contract-switch migration)."
-          );
-        }
-        const s = outcome.activeContractSummary;
-        if (s) {
-          lines.push(
-            `- Active contract: ${s.seatSubscriptionCount} seat subscription(s), ` +
-              `${s.distinctTimestampCount} distinct scheduled moment(s) → ` +
-              `${s.reconcileSegmentCallCount} segment reconcile call(s), ` +
-              `${s.transferCount} pro/max transfer(s), ` +
-              `${s.freeUserCount} free-seat user(s), ` +
-              `${s.didMutateSeatData ? "changes applied" : "no changes needed"}, ` +
-              `${s.durationMs}ms.`
-          );
-        } else {
-          lines.push("- No active contract to sync (pending contract only).");
-        }
-        lines.push(
-          outcome.workspaceUserCreditStatesReconciled
-            ? "- Workspace-wide credit states reconciled."
-            : "- Credit-state reconcile skipped (single-user scope)."
-        );
-        return new Ok({
-          display: "text",
-          value: lines.join("\n"),
-        });
-      }
-      case "skipped":
-        return new Ok({
-          display: "text",
-          value: `Nothing to sync: ${outcome.reason}.`,
-        });
-      default:
-        return assertNever(outcome);
-    }
+    return new Ok({
+      display: "text",
+      value:
+        "Metronome seat count sync scheduled — it will run through the debounced " +
+        "workflow within ~15 seconds. Check the [SeatSync]/[Metronome] logs for " +
+        "the outcome.",
+    });
   },
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1165,6 +1165,39 @@ async function emptyOriginSeatCreditsForTransfers({
     allocationBySeatType,
   });
 
+  return emptyOriginCreditsForTransfers({
+    metronomeCustomerId,
+    contractId,
+    workspaceId,
+    transfers,
+    subscriptionIdBySeatType,
+    recurringCreditIdBySeatType,
+  });
+}
+
+/**
+ * Empty each transfer's origin seat credit (reclaim its unused balance) so the
+ * consumed amount can be carried onto the new seat once it's assigned. Shared by
+ * the workspace-wide sync (which computes `transfers` from Metronome's current
+ * state) and the single-user immediate move (which knows the from→to types from
+ * the DB). Returns the transfers whose origin was handled — a fully-consumed
+ * origin is kept (nothing to reclaim, but its consumption still carries).
+ */
+async function emptyOriginCreditsForTransfers({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+  transfers,
+  subscriptionIdBySeatType,
+  recurringCreditIdBySeatType,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+  transfers: SeatCreditTransfer[];
+  subscriptionIdBySeatType: Map<MembershipSeatType, string>;
+  recurringCreditIdBySeatType: Map<MembershipSeatType, string>;
+}): Promise<SeatCreditTransfer[]> {
   const segmentCache = new Map<
     string,
     { creditId: string; segmentId: string; segmentStartingAt: string } | null
@@ -1400,6 +1433,168 @@ async function carryConsumptionToNewSeatCredits({
       );
     }
   }
+}
+
+/**
+ * Move (or add) a single user's seat in Metronome, carrying seat-credit
+ * consumption across a recurring-credit seat-type change (e.g. pro→max: empty
+ * the pro credit, carry the consumed AWU onto the max credit) — the same ledger
+ * transfer `syncSeatCount` performs workspace-wide, but scoped to one user and
+ * driven off the known from→to seat types rather than Metronome's pre-move
+ * assignment.
+ *
+ * This is the immediate-unblock primitive behind `assignSeatForUser`: it MUST do
+ * the carry itself, because it moves the seat_id right away — which would
+ * otherwise hide the seat-type change from the debounced workspace sync (that
+ * detects moves by diffing Metronome's assignment against the DB, and would see
+ * the user already on the new seat). It touches only this user's seat + credits,
+ * never the unassigned pool or other users, so it stays safe to run alongside
+ * the debounced workflow.
+ *
+ * Order matches `syncSeatCount`: empty origin credit (while still on the old
+ * seat) → move the seat → carry consumption onto the new credit (now active).
+ * The credit steps are best-effort; a seat-move failure is returned as `Err`.
+ */
+export async function moveSeatWithCreditCarry({
+  metronomeCustomerId,
+  contractId,
+  contract,
+  productSeatTypes,
+  workspaceId,
+  userId,
+  fromSeatType,
+  toSeatType,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  contract: CachedContract;
+  productSeatTypes: Map<string, MembershipSeatType>;
+  workspaceId: string;
+  userId: string;
+  fromSeatType: MembershipSeatType | undefined;
+  toSeatType: MembershipSeatType;
+}): Promise<Result<undefined, Error>> {
+  const seatSubscriptions = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
+  ].flatMap(([seatType, sub]) => (sub.id ? [{ seatType, sub }] : []));
+
+  const targetSubId = seatSubscriptions.find((s) => s.seatType === toSeatType)
+    ?.sub.id;
+  const previousSubId = fromSeatType
+    ? seatSubscriptions.find((s) => s.seatType === fromSeatType)?.sub.id
+    : undefined;
+
+  if (!targetSubId) {
+    // Non-billable target (e.g. "none", or a type not entitled here). Leave the
+    // seat removal + any credit cleanup to the debounced workspace sync.
+    logger.info(
+      { workspaceId, userId, toSeatType },
+      "[Metronome] No billable subscription for target seat type — leaving to debounced workflow"
+    );
+    return new Ok(undefined);
+  }
+
+  // Seat-type → subscription / recurring-credit / allocation maps for the
+  // recurring-credit seat types (same derivation as `syncSeatCount`).
+  const subscriptionIdBySeatType = new Map<MembershipSeatType, string>(
+    seatSubscriptions.flatMap(({ sub, seatType }) =>
+      sub.id && getSeatCreditNameForSeatType(seatType)
+        ? [[seatType, sub.id] as const]
+        : []
+    )
+  );
+  const recurringCreditIdBySeatType = new Map<MembershipSeatType, string>();
+  const allocationBySeatType = new Map<MembershipSeatType, number>();
+  for (const { sub, seatType } of seatSubscriptions) {
+    if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
+      continue;
+    }
+    const recurringCredit = (contract.recurring_credits ?? []).find(
+      (c) => c.subscription_config?.subscription_id === sub.id
+    );
+    if (recurringCredit?.id) {
+      recurringCreditIdBySeatType.set(seatType, recurringCredit.id);
+    }
+    allocationBySeatType.set(
+      seatType,
+      getAwuAllocationForSeatType(contract, seatType, productSeatTypes)
+    );
+  }
+
+  // Compute the single-user transfer (only when both ends carry a recurring
+  // credit). We know the move from the DB, so we don't rely on Metronome's
+  // pre-move assignment to detect it.
+  let transfers: SeatCreditTransfer[] = [];
+  if (
+    fromSeatType &&
+    fromSeatType !== toSeatType &&
+    getSeatCreditNameForSeatType(fromSeatType) &&
+    getSeatCreditNameForSeatType(toSeatType)
+  ) {
+    const balancesRes = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      seatIds: [userId],
+    });
+    if (balancesRes.isErr()) {
+      logger.error(
+        { workspaceId, userId, error: balancesRes.error },
+        "[Metronome] Failed to read origin seat balance for single-user transfer — skipping carry"
+      );
+    } else {
+      const awuCreditTypeId = getCreditTypeAwuId();
+      const remaining = balancesRes.value
+        .find((s) => s.seat_id === userId)
+        ?.balances.find((b) => b.credit_type_id === awuCreditTypeId)?.balance;
+      const balanceByUser = new Map<string, number>();
+      if (remaining !== undefined) {
+        balanceByUser.set(userId, remaining);
+      }
+      const computed = computeSeatCreditTransfers({
+        metronomeSeatByUser: new Map([[userId, fromSeatType]]),
+        desiredSeatByUser: new Map([[userId, toSeatType]]),
+        balanceByUser,
+        allocationBySeatType,
+      });
+      // Empty the origin credit while the user is still on the old seat.
+      transfers = await emptyOriginCreditsForTransfers({
+        metronomeCustomerId,
+        contractId,
+        workspaceId,
+        transfers: computed,
+        subscriptionIdBySeatType,
+        recurringCreditIdBySeatType,
+      });
+    }
+  }
+
+  // Move (or add) the seat.
+  const isMove = !!previousSubId && previousSubId !== targetSubId;
+  const seatUpdate = await updateSubscriptionSeats({
+    metronomeCustomerId,
+    contractId,
+    fromSubscriptionId: isMove ? previousSubId : targetSubId,
+    toSubscriptionId: isMove ? targetSubId : undefined,
+    addSeatIds: [userId],
+    removeSeatIds: isMove ? [userId] : [],
+  });
+  if (seatUpdate.isErr()) {
+    return new Err(seatUpdate.error);
+  }
+
+  // Carry consumption onto the new credit now that the seat is assigned.
+  if (transfers.length > 0) {
+    await carryConsumptionToNewSeatCredits({
+      metronomeCustomerId,
+      contractId,
+      workspaceId,
+      transfers,
+      subscriptionIdBySeatType,
+      recurringCreditIdBySeatType,
+      allocationBySeatType,
+    });
+  }
+  return new Ok(undefined);
 }
 
 // Summary of the work `syncSeatCount` actually did, surfaced up to the poke

--- a/front/lib/metronome/seats_credit_carry.test.ts
+++ b/front/lib/metronome/seats_credit_carry.test.ts
@@ -1,0 +1,226 @@
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { moveSeatWithCreditCarry } from "@app/lib/metronome/seats";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockUpdateSubscriptionSeats,
+  mockListSeatBalances,
+  mockFindSeatCreditSegment,
+  mockGetSeatActiveSince,
+  mockAdjustSeatCreditBalances,
+  mockGetSeatSubscriptions,
+  mockGetAwuAllocation,
+  mockGetCreditTypeAwuId,
+} = vi.hoisted(() => ({
+  mockUpdateSubscriptionSeats: vi.fn(),
+  mockListSeatBalances: vi.fn(),
+  mockFindSeatCreditSegment: vi.fn(),
+  mockGetSeatActiveSince: vi.fn(),
+  mockAdjustSeatCreditBalances: vi.fn(),
+  mockGetSeatSubscriptions: vi.fn(),
+  mockGetAwuAllocation: vi.fn(),
+  mockGetCreditTypeAwuId: vi.fn(),
+}));
+
+// Fully replace the client module (no importActual) so importing it never pulls
+// the real dependency graph that touches Redis at module load.
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractById: vi.fn(),
+  updateSubscriptionQuantity: vi.fn(),
+  updateSubscriptionSeats: mockUpdateSubscriptionSeats,
+  getMetronomeSubscriptionSeatState: vi.fn(),
+  listCustomerPerUserCreditUserIds: vi.fn(),
+  listCustomerPerUserCreditBalances: vi.fn(),
+  addPerUserCreditToCustomer: vi.fn(),
+  revokePerUserCustomerCredit: vi.fn(),
+  listMetronomeSeatBalances: mockListSeatBalances,
+  findSeatCreditSegmentForPeriod: mockFindSeatCreditSegment,
+  getMetronomeSeatActiveSince: mockGetSeatActiveSince,
+  adjustSeatCreditBalances: mockAdjustSeatCreditBalances,
+}));
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return {
+    ...actual,
+    getSeatSubscriptionsFromContract: mockGetSeatSubscriptions,
+    getAwuAllocationForSeatType: mockGetAwuAllocation,
+  };
+});
+
+vi.mock("@app/lib/metronome/constants", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/constants")
+  >("@app/lib/metronome/constants");
+  return { ...actual, getCreditTypeAwuId: mockGetCreditTypeAwuId };
+});
+
+// seats.ts wires a `cacheWithRedis` at import time — stub so importing it never
+// touches Redis.
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: (fn: unknown) => fn,
+  invalidateCacheWithRedis: () => async () => {},
+  bestEffortInvalidateCacheWithRedis: () => async () => {},
+}));
+
+// Not used by `moveSeatWithCreditCarry`, but seats.ts imports these and their
+// real module graph touches Redis at import — stub them out.
+vi.mock("@app/lib/metronome/alerts/per_user_credit_balance", () => ({
+  upsertPerUserCreditBalanceAlerts: vi.fn(),
+  clearPerUserCreditBalanceAlerts: vi.fn(),
+}));
+vi.mock("@app/lib/resources/membership_resource", () => ({
+  MembershipResource: {},
+}));
+vi.mock("@app/lib/resources/workspace_seat_limit_resource", () => ({
+  WorkspaceSeatLimitResource: {},
+}));
+
+const AWU = "awu";
+
+// A contract whose recurring credits link each seat subscription to its credit.
+const CONTRACT = {
+  recurring_credits: [
+    { id: "cred_pro", subscription_config: { subscription_id: "sub_pro" } },
+    { id: "cred_max", subscription_config: { subscription_id: "sub_max" } },
+  ],
+} as unknown as CachedContract;
+
+function seatBalance(balance: number) {
+  return new Ok([
+    {
+      seat_id: "u1",
+      balances: [{ credit_type_id: AWU, balance, starting_balance: 8000 }],
+    },
+  ]);
+}
+
+describe("moveSeatWithCreditCarry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCreditTypeAwuId.mockReturnValue(AWU);
+    mockGetSeatSubscriptions.mockReturnValue(
+      new Map([
+        ["pro", { id: "sub_pro" }],
+        ["max", { id: "sub_max" }],
+      ])
+    );
+    mockGetAwuAllocation.mockImplementation(
+      (_contract: unknown, seatType: MembershipSeatType) =>
+        seatType === "max" ? 40000 : 8000
+    );
+    mockUpdateSubscriptionSeats.mockResolvedValue(new Ok(undefined));
+    mockFindSeatCreditSegment.mockResolvedValue(
+      new Ok({
+        creditId: "seg_credit",
+        segmentId: "seg_1",
+        segmentStartingAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
+    mockGetSeatActiveSince.mockResolvedValue(
+      new Ok(new Date("2026-01-01T00:00:00.000Z"))
+    );
+    mockAdjustSeatCreditBalances.mockResolvedValue(new Ok(undefined));
+  });
+
+  it("pro→max: empties the pro credit, moves the seat, then carries consumption onto max", async () => {
+    // Origin (pro) balance read first (3000 of 8000 left ⇒ 5000 consumed), then
+    // the new (max) credit balance read during the carry (fresh 40000).
+    mockListSeatBalances
+      .mockResolvedValueOnce(seatBalance(3000))
+      .mockResolvedValueOnce(seatBalance(40000));
+
+    const result = await moveSeatWithCreditCarry({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      contract: CONTRACT,
+      productSeatTypes: new Map(),
+      workspaceId: "ws_1",
+      userId: "u1",
+      fromSeatType: "pro",
+      toSeatType: "max",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Emptied the origin (pro) credit by the remaining 3000.
+    const emptyCall = mockAdjustSeatCreditBalances.mock.calls.find((c) =>
+      c[0].reason.includes("empty origin credit")
+    );
+    expect(emptyCall?.[0].perSeatAmounts).toEqual({ u1: -3000 });
+
+    // Moved the seat from the pro sub to the max sub.
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        toSubscriptionId: "sub_max",
+        addSeatIds: ["u1"],
+        removeSeatIds: ["u1"],
+      })
+    );
+
+    // Carried consumption: max credit set to allocation − consumed = 40000 −
+    // 5000 = 35000; current fresh balance is 40000, so delta −5000.
+    const carryCall = mockAdjustSeatCreditBalances.mock.calls.find((c) =>
+      c[0].reason.includes("carry over consumed AWU")
+    );
+    expect(carryCall?.[0].perSeatAmounts).toEqual({ u1: -5000 });
+
+    // Order: empty origin BEFORE the move BEFORE the carry.
+    const emptyOrder = mockAdjustSeatCreditBalances.mock.invocationCallOrder[0];
+    const moveOrder = mockUpdateSubscriptionSeats.mock.invocationCallOrder[0];
+    const carryOrder = mockAdjustSeatCreditBalances.mock.invocationCallOrder[1];
+    expect(emptyOrder).toBeLessThan(moveOrder);
+    expect(moveOrder).toBeLessThan(carryOrder);
+  });
+
+  it("plain add (no previous seat): moves the seat, no balance read or ledger transfer", async () => {
+    const result = await moveSeatWithCreditCarry({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      contract: CONTRACT,
+      productSeatTypes: new Map(),
+      workspaceId: "ws_1",
+      userId: "u1",
+      fromSeatType: undefined,
+      toSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockListSeatBalances).not.toHaveBeenCalled();
+    expect(mockAdjustSeatCreditBalances).not.toHaveBeenCalled();
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        toSubscriptionId: undefined,
+        addSeatIds: ["u1"],
+        removeSeatIds: [],
+      })
+    );
+  });
+
+  it("no billable subscription for the target seat type: does nothing", async () => {
+    mockGetSeatSubscriptions.mockReturnValue(
+      new Map([["pro", { id: "sub_pro" }]])
+    );
+
+    const result = await moveSeatWithCreditCarry({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      contract: CONTRACT,
+      productSeatTypes: new Map(),
+      workspaceId: "ws_1",
+      userId: "u1",
+      fromSeatType: "pro",
+      toSeatType: "none",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalled();
+    expect(mockAdjustSeatCreditBalances).not.toHaveBeenCalled();
+  });
+});

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -1,0 +1,490 @@
+/**
+ * Read-only audit of a workspace's seat state: compares what Dust believes
+ * (DB membership seat types) against what Metronome actually holds (assigned
+ * seat IDs + unassigned pool per seat subscription) and the per-user seat
+ * credit balances.
+ *
+ * Written to diagnose the seat-sync loop on workspaces where `syncSeatCount`
+ * keeps re-issuing the same seat edit because some users desired in Dust never
+ * land in Metronome's assigned set (so the reconcile never converges). It
+ * surfaces exactly which users are missing / stale per seat type, and each
+ * assigned seat's live balance, so we can figure out why they won't assign
+ * before touching credit state.
+ *
+ * Purely diagnostic — makes only READ calls to Metronome and the DB. There is
+ * nothing to --execute; it always just reports.
+ *
+ *   npx tsx scripts/audit_metronome_seat_state.ts --workspaceId <wId>
+ */
+import config from "@app/lib/api/config";
+import {
+  getMetronomeClient,
+  getMetronomeSubscriptionSeatState,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { makeScript } from "./helpers";
+
+// Metronome publishes an 11 RPS API limit. Stay well under it so an audit run
+// never adds rate-limit pressure to production traffic on the same key.
+const METRONOME_MAX_RPS = 8;
+const METRONOME_MIN_INTERVAL_MS = 1000 / METRONOME_MAX_RPS;
+let metronomeNextSlotAt = 0;
+
+async function paceMetronome<T>(fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const slot = Math.max(now, metronomeNextSlotAt);
+  metronomeNextSlotAt = slot + METRONOME_MIN_INTERVAL_MS;
+  const wait = slot - now;
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
+  }
+  return fn();
+}
+
+const setDiff = (a: string[], b: Set<string>): string[] =>
+  a.filter((x) => !b.has(x));
+
+// Raw shape of the (untyped) getSubscriptionSeatsHistory endpoint — the same
+// one `getMetronomeSubscriptionSeatState` wraps. Fetched directly here so we
+// can see EVERY segment (not just the resolved one) and verify how the read
+// picks a segment when a future scheduled floor change adds extra segments.
+interface RawSeatsHistoryResponse {
+  data: Array<{
+    starting_at: string;
+    ending_before?: string | null;
+    assigned_seat_ids: string[];
+    total_quantity?: string;
+  }>;
+}
+
+async function fetchRawSeatSegments({
+  metronomeCustomerId,
+  contractId,
+  subscriptionId,
+  coveringDate,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subscriptionId: string;
+  coveringDate: Date;
+}): Promise<
+  Array<{
+    startingAt: string;
+    endingBefore: string | null;
+    assignedCount: number;
+    totalQuantity: number | null;
+    unassigned: number | null;
+  }>
+> {
+  const response = await getMetronomeClient().post<RawSeatsHistoryResponse>(
+    "/v1/contracts/getSubscriptionSeatsHistory",
+    {
+      body: {
+        customer_id: metronomeCustomerId,
+        contract_id: contractId,
+        subscription_id: subscriptionId,
+        covering_date: coveringDate.toISOString(),
+      },
+    }
+  );
+  return (response.data ?? []).map((seg) => {
+    const assignedCount = seg.assigned_seat_ids?.length ?? 0;
+    const total = Number(seg.total_quantity);
+    const totalQuantity = Number.isFinite(total) ? total : null;
+    return {
+      startingAt: seg.starting_at,
+      endingBefore: seg.ending_before ?? null,
+      assignedCount,
+      totalQuantity,
+      unassigned: totalQuantity === null ? null : totalQuantity - assignedCount,
+    };
+  });
+}
+
+// Probe one subscription at several covering dates spanning the scheduled
+// floor changes, and dump the raw segments — to confirm (or refute) that the
+// scheduled future minSeats change is what makes the "now" read unstable.
+async function probeSubscriptionSegments({
+  metronomeCustomerId,
+  contractId,
+  subId,
+  seatType,
+  scheduleSegments,
+  workspaceId,
+  logger,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subId: string;
+  seatType: MembershipSeatType;
+  scheduleSegments: Array<{
+    startAt: Date;
+    endAt: Date | null;
+    minSeats: number;
+  }>;
+  workspaceId: string;
+  logger: Logger;
+}): Promise<void> {
+  const now = new Date();
+
+  // Covering dates: now + every schedule boundary (start/end) that is in the
+  // future, plus a point clearly after the last boundary. These are exactly the
+  // moments `syncSeatCount` reconciles as distinct segments.
+  const boundaryMs = new Set<number>([now.getTime()]);
+  let maxFutureMs = now.getTime();
+  for (const seg of scheduleSegments) {
+    for (const d of [seg.startAt, seg.endAt]) {
+      if (d && d.getTime() > now.getTime()) {
+        boundaryMs.add(d.getTime());
+        maxFutureMs = Math.max(maxFutureMs, d.getTime());
+      }
+    }
+  }
+  if (maxFutureMs > now.getTime()) {
+    // One day past the last boundary, to read the terminal segment.
+    boundaryMs.add(maxFutureMs + 24 * 60 * 60 * 1000);
+  }
+  const coveringDates = [...boundaryMs]
+    .sort((a, b) => a - b)
+    .map((ms) => new Date(ms));
+
+  logger.info(
+    {
+      workspaceId,
+      seatType,
+      subscriptionId: subId,
+      scheduledFloors: scheduleSegments.map((s) => ({
+        minSeats: s.minSeats,
+        startAt: s.startAt.toISOString(),
+        endAt: s.endAt?.toISOString() ?? null,
+      })),
+    },
+    "[SeatAudit] probe: seat-limit schedule"
+  );
+
+  // What `getMetronomeSubscriptionSeatState` (the code path syncSeatCount uses)
+  // resolves at each covering date.
+  for (const coveringDate of coveringDates) {
+    const res = await paceMetronome(() =>
+      getMetronomeSubscriptionSeatState({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: subId,
+        coveringDate,
+      })
+    );
+    if (res.isErr()) {
+      logger.error(
+        {
+          workspaceId,
+          seatType,
+          coveringDate: coveringDate.toISOString(),
+          err: res.error.message,
+        },
+        "[SeatAudit] probe: getMetronomeSubscriptionSeatState failed"
+      );
+      continue;
+    }
+    logger.info(
+      {
+        workspaceId,
+        seatType,
+        subscriptionId: subId,
+        coveringDate: coveringDate.toISOString(),
+        resolvedAssigned: res.value.assignedSeatIds.length,
+        resolvedUnassigned: res.value.unassignedSeats,
+      },
+      "[SeatAudit] probe: resolved seat state (as syncSeatCount reads it)"
+    );
+  }
+
+  // Raw segments as returned at covering_date=now and at the far-future point —
+  // shows whether multiple segments coexist and what `data[data.length - 1]`
+  // (the entry the resolver picks) actually is.
+  for (const coveringDate of [
+    now,
+    new Date(maxFutureMs + 24 * 60 * 60 * 1000),
+  ]) {
+    try {
+      const segments = await paceMetronome(() =>
+        fetchRawSeatSegments({
+          metronomeCustomerId,
+          contractId,
+          subscriptionId: subId,
+          coveringDate,
+        })
+      );
+      logger.info(
+        {
+          workspaceId,
+          seatType,
+          subscriptionId: subId,
+          coveringDate: coveringDate.toISOString(),
+          segmentCount: segments.length,
+          // The resolver takes the LAST entry — highlight it.
+          lastSegment: segments[segments.length - 1] ?? null,
+          segments,
+        },
+        "[SeatAudit] probe: raw seat-history segments"
+      );
+    } catch (err) {
+      logger.error(
+        {
+          workspaceId,
+          seatType,
+          coveringDate: coveringDate.toISOString(),
+          err: normalizeError(err).message,
+        },
+        "[SeatAudit] probe: raw seat-history fetch failed"
+      );
+    }
+  }
+}
+
+async function auditWorkspace(
+  workspaceId: string,
+  probe: boolean,
+  logger: Logger
+) {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.error({ workspaceId }, "[SeatAudit] workspace not found");
+    return;
+  }
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const { metronomeCustomerId } = lightWorkspace;
+  if (!metronomeCustomerId) {
+    logger.error(
+      { workspaceId },
+      "[SeatAudit] workspace is not provisioned on Metronome"
+    );
+    return;
+  }
+
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+  const contractId = activeSubscription?.metronomeContractId ?? null;
+  if (!contractId) {
+    logger.error(
+      { workspaceId, metronomeCustomerId },
+      "[SeatAudit] no active Metronome contract on the subscription"
+    );
+    return;
+  }
+  const planCode = activeSubscription?.getPlan().code ?? null;
+
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    logger.error(
+      { workspaceId, contractId },
+      "[SeatAudit] could not resolve the active contract from Metronome"
+    );
+    return;
+  }
+
+  // Metronome side: entitled seat subscriptions on the active contract.
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
+  ].flatMap(([seatType, sub]) => (sub.id ? [{ seatType, subId: sub.id }] : []));
+
+  // Dust side: DB membership seat types. Match the billed set exactly (see
+  // syncSeatCount) — active window open AND firstUsedAt set. Provisioned-but-
+  // never-used members are excluded from billing, so report them separately.
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: lightWorkspace,
+  });
+  const desiredBySeatType = new Map<MembershipSeatType, Set<string>>();
+  const provisionedUnusedBySeatType = new Map<MembershipSeatType, string[]>();
+  for (const m of memberships) {
+    const userSId = m.user?.sId;
+    if (!userSId) {
+      continue;
+    }
+    if (m.firstUsedAt === null) {
+      const bucket = provisionedUnusedBySeatType.get(m.seatType) ?? [];
+      bucket.push(userSId);
+      provisionedUnusedBySeatType.set(m.seatType, bucket);
+      continue;
+    }
+    const set = desiredBySeatType.get(m.seatType) ?? new Set<string>();
+    set.add(userSId);
+    desiredBySeatType.set(m.seatType, set);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      contractId,
+      planCode,
+      seatSubscriptions: seatSubscriptions.map((s) => s.seatType),
+      dustDesiredCounts: Object.fromEntries(
+        [...desiredBySeatType].map(([t, s]) => [t, s.size])
+      ),
+      dustProvisionedUnusedCounts: Object.fromEntries(
+        [...provisionedUnusedBySeatType].map(([t, s]) => [t, s.length])
+      ),
+    },
+    "[SeatAudit] context"
+  );
+
+  const allSeatIds = new Set<string>();
+
+  // Per seat subscription: compare Metronome assignment vs Dust desired.
+  for (const { seatType, subId } of seatSubscriptions) {
+    const stateRes = await paceMetronome(() =>
+      getMetronomeSubscriptionSeatState({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: subId,
+      })
+    );
+    if (stateRes.isErr()) {
+      logger.error(
+        { workspaceId, seatType, subId, err: stateRes.error.message },
+        "[SeatAudit] failed to read Metronome seat state"
+      );
+      continue;
+    }
+    const { assignedSeatIds, unassignedSeats } = stateRes.value;
+    const assignedSet = new Set(assignedSeatIds);
+    const desired = desiredBySeatType.get(seatType) ?? new Set<string>();
+
+    const missingInMetronome = setDiff([...desired], assignedSet);
+    const staleInMetronome = setDiff(assignedSeatIds, desired);
+
+    assignedSeatIds.forEach((id) => allSeatIds.add(id));
+    desired.forEach((id) => allSeatIds.add(id));
+
+    logger.info(
+      {
+        workspaceId,
+        seatType,
+        subscriptionId: subId,
+        metronomeAssigned: assignedSeatIds.length,
+        metronomeUnassigned: unassignedSeats,
+        metronomeTotal: assignedSeatIds.length + unassignedSeats,
+        dustDesired: desired.size,
+        missingInMetronomeCount: missingInMetronome.length,
+        staleInMetronomeCount: staleInMetronome.length,
+        // The actual users that keep the reconcile from converging.
+        missingInMetronome,
+        staleInMetronome,
+      },
+      "[SeatAudit] seat subscription diff"
+    );
+  }
+
+  // Per-user seat credit balances for every seat id we saw (assigned or
+  // desired). Flags seats with no balance row and non-positive balances.
+  const balancesRes = await paceMetronome(() =>
+    listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      seatIds: [...allSeatIds],
+    })
+  );
+  if (balancesRes.isErr()) {
+    logger.error(
+      { workspaceId, err: balancesRes.error.message },
+      "[SeatAudit] failed to read seat balances"
+    );
+    return;
+  }
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const balanceBySeatId = new Map(
+    balancesRes.value.map((b) => [b.seat_id, b.balances])
+  );
+
+  const seatsWithoutBalance: string[] = [];
+  const seatsNonPositiveBalance: Array<{ seatId: string; awuBalance: number }> =
+    [];
+  for (const seatId of allSeatIds) {
+    const balances = balanceBySeatId.get(seatId);
+    if (!balances) {
+      seatsWithoutBalance.push(seatId);
+      continue;
+    }
+    const awu = balances.find((b) => b.credit_type_id === awuCreditTypeId);
+    if (awu && awu.balance <= 0) {
+      seatsNonPositiveBalance.push({ seatId, awuBalance: awu.balance });
+    }
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      contractId,
+      seatIdsChecked: allSeatIds.size,
+      seatsWithBalance: balanceBySeatId.size,
+      seatsWithoutBalanceCount: seatsWithoutBalance.length,
+      seatsWithoutBalance,
+      seatsNonPositiveBalanceCount: seatsNonPositiveBalance.length,
+      seatsNonPositiveBalance,
+    },
+    "[SeatAudit] seat balances summary"
+  );
+
+  if (!probe) {
+    return;
+  }
+
+  // Segment probe: read each subscription at multiple covering dates and dump
+  // the raw seat-history segments, to confirm the scheduled future floor change
+  // is what destabilizes the "now" unassigned read.
+  const seatLimitSchedule =
+    await WorkspaceSeatLimitResource.fetchScheduleByWorkspace({
+      workspace: lightWorkspace,
+    });
+  for (const { seatType, subId } of seatSubscriptions) {
+    await probeSubscriptionSegments({
+      metronomeCustomerId,
+      contractId,
+      subId,
+      seatType,
+      scheduleSegments: seatLimitSchedule.get(seatType) ?? [],
+      workspaceId,
+      logger,
+    });
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+      describe: "sId of the workspace to audit",
+    },
+    probe: {
+      type: "boolean",
+      default: false,
+      describe:
+        "Also probe each subscription at multiple covering dates and dump raw " +
+        "seat-history segments (to inspect scheduled future floor changes)",
+    },
+  },
+  async ({ workspaceId, probe }, logger) => {
+    if (!config.getMetronomeApiKey()) {
+      logger.error({}, "[SeatAudit] METRONOME_API_KEY is not configured");
+      return;
+    }
+    await auditWorkspace(workspaceId, probe, logger);
+  }
+);

--- a/front/scripts/fix_metronome_future_seat_segment.ts
+++ b/front/scripts/fix_metronome_future_seat_segment.ts
@@ -1,0 +1,217 @@
+/**
+ * One-off correction for a corrupted FUTURE seat-subscription segment.
+ *
+ * Background: when a subscription is under its committed floor (so it carries
+ * "unassigned" padding seats) AND has a scheduled future floor change, the seat
+ * reconcile could loop, issuing open-ended `add/remove_unassigned` edits that
+ * stacked in the post-boundary segment (Vanta incident: Pro segment from
+ * 2026-11-13 ballooned to total 1141 / 548 unassigned instead of 730 / 137).
+ * The current/now segment self-healed once the loop stopped, but the future
+ * segment stayed inflated and would bill the wrong committed quantity once it
+ * starts.
+ *
+ * This script recomputes, for each seat subscription that has a scheduled
+ * future floor change, the correct unassigned count at each future boundary
+ * (`minSeats − desiredAssigned`, floored at 0) and issues the exact
+ * `add/remove_unassigned` delta at that boundary to converge it — a careful,
+ * single-shot manual reconcile of the future segments only. The now/base
+ * segment is left untouched.
+ *
+ * Dry-run by default; pass --execute to actually apply the edits.
+ *
+ *   npx tsx scripts/fix_metronome_future_seat_segment.ts --workspaceId <wId>
+ *   npx tsx scripts/fix_metronome_future_seat_segment.ts --workspaceId <wId> --execute
+ */
+import config from "@app/lib/api/config";
+import {
+  getMetronomeSubscriptionSeatState,
+  updateSubscriptionSeats,
+} from "@app/lib/metronome/client";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
+
+import { makeScript } from "./helpers";
+
+async function fixWorkspace(
+  workspaceId: string,
+  execute: boolean,
+  logger: Logger
+) {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.error({ workspaceId }, "[SeatFix] workspace not found");
+    return;
+  }
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const { metronomeCustomerId } = lightWorkspace;
+  if (!metronomeCustomerId) {
+    logger.error({ workspaceId }, "[SeatFix] workspace not on Metronome");
+    return;
+  }
+
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+  const contractId = activeSubscription?.metronomeContractId ?? null;
+  if (!contractId) {
+    logger.error({ workspaceId }, "[SeatFix] no active Metronome contract");
+    return;
+  }
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    logger.error(
+      { workspaceId, contractId },
+      "[SeatFix] contract not resolved"
+    );
+    return;
+  }
+
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
+  ].flatMap(([seatType, sub]) => (sub.id ? [{ seatType, subId: sub.id }] : []));
+
+  // Desired billed assigned count per seat type (active window + firstUsedAt
+  // set — the same set syncSeatCount bills). No scheduled seat-type changes are
+  // assumed here, so the assigned count is the same at every future boundary.
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: lightWorkspace,
+  });
+  const desiredAssignedBySeatType = new Map<MembershipSeatType, number>();
+  for (const m of memberships) {
+    if (m.user?.sId && m.firstUsedAt !== null) {
+      desiredAssignedBySeatType.set(
+        m.seatType,
+        (desiredAssignedBySeatType.get(m.seatType) ?? 0) + 1
+      );
+    }
+  }
+
+  const schedule = await WorkspaceSeatLimitResource.fetchScheduleByWorkspace({
+    workspace: lightWorkspace,
+  });
+  const nowMs = Date.now();
+
+  for (const { seatType, subId } of seatSubscriptions) {
+    const segments = schedule.get(seatType) ?? [];
+    const futureBoundaries = segments
+      .filter((s) => s.startAt.getTime() > nowMs)
+      .sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+    if (futureBoundaries.length === 0) {
+      continue;
+    }
+    const desiredAssigned = desiredAssignedBySeatType.get(seatType) ?? 0;
+
+    for (const seg of futureBoundaries) {
+      const startingAt = seg.startAt.toISOString();
+      // Read the segment as it is projected at its own start.
+      const stateRes = await getMetronomeSubscriptionSeatState({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: subId,
+        coveringDate: seg.startAt,
+      });
+      if (stateRes.isErr()) {
+        logger.error(
+          { workspaceId, seatType, startingAt, err: stateRes.error.message },
+          "[SeatFix] failed to read future segment state"
+        );
+        continue;
+      }
+      const currentUnassigned = stateRes.value.unassignedSeats;
+      const currentAssigned = stateRes.value.assignedSeatIds.length;
+      const desiredUnassigned = Math.max(0, seg.minSeats - desiredAssigned);
+      const addUnassignedSeats = Math.max(
+        0,
+        desiredUnassigned - currentUnassigned
+      );
+      const removeUnassignedSeats = Math.max(
+        0,
+        currentUnassigned - desiredUnassigned
+      );
+
+      const plan = {
+        workspaceId,
+        seatType,
+        subscriptionId: subId,
+        startingAt,
+        minSeats: seg.minSeats,
+        desiredAssigned,
+        currentAssigned,
+        currentUnassigned,
+        desiredUnassigned,
+        addUnassignedSeats,
+        removeUnassignedSeats,
+      };
+
+      if (currentAssigned !== desiredAssigned) {
+        // Assigned mismatch is out of scope for this unassigned-only fixup —
+        // surface it rather than guessing which seat IDs to move.
+        logger.warn(
+          plan,
+          "[SeatFix] future segment assigned count != desired; skipping " +
+            "(this script only corrects the unassigned pool)"
+        );
+        continue;
+      }
+      if (addUnassignedSeats === 0 && removeUnassignedSeats === 0) {
+        logger.info(
+          plan,
+          "[SeatFix] future segment already correct — skipping"
+        );
+        continue;
+      }
+
+      if (!execute) {
+        logger.info(
+          plan,
+          "[SeatFix] DRY RUN — would correct future segment unassigned pool"
+        );
+        continue;
+      }
+
+      const res = await updateSubscriptionSeats({
+        metronomeCustomerId,
+        contractId,
+        fromSubscriptionId: subId,
+        addUnassignedSeats,
+        removeUnassignedSeats,
+        startingAt,
+      });
+      if (res.isErr()) {
+        logger.error(
+          { ...plan, err: res.error.message },
+          "[SeatFix] failed to correct future segment"
+        );
+        continue;
+      }
+      logger.info(plan, "[SeatFix] corrected future segment unassigned pool");
+    }
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+      describe: "sId of the workspace to correct",
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    if (!config.getMetronomeApiKey()) {
+      logger.error({}, "[SeatFix] METRONOME_API_KEY is not configured");
+      return;
+    }
+    await fixWorkspace(workspaceId, execute, logger);
+  }
+);

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -41,9 +41,24 @@ const { emitMetronomeUsageEventsActivity } = proxyActivities<typeof activities>(
   }
 );
 
+// A failing seat sync (e.g. a Metronome edit that can't converge) must not
+// retry forever: without a cap it inherits Temporal's default policy (unlimited
+// attempts), and since every attempt re-runs the full sync — re-issuing the
+// same Metronome contract edits — an unconvergeable sync becomes a multi-day
+// edit storm that saturates Metronome's rate limit (incident: ~300 edits over
+// 25h on a single workspace). Bound both the attempts and the total lifetime so
+// a stuck sync fails loudly instead of hammering Metronome; the next real
+// membership change re-triggers a fresh run anyway.
 const { syncMetronomeSeatCountActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
   heartbeatTimeout: "1 minute",
+  retry: {
+    initialInterval: "30s",
+    backoffCoefficient: 2,
+    maximumInterval: "5 minutes",
+    maximumAttempts: 5,
+  },
+  scheduleToCloseTimeout: "1 hour",
 });
 
 const { reconcileApiKeyCreditStateActivity } = proxyActivities<


### PR DESCRIPTION
## Description

Fixes the Metronome seat-sync rate-limit incident (workspace Vanta: ~300 contract edits over ~25h, Metronome blocked contract edits for the customer).

Root cause was **concurrent, uncoordinated full seat reconciles** — not a formula bug (the reconcile is correct and idempotent when run serially, confirmed by local repro). Two families of full reconcile ran with no shared lock: the debounced Temporal workflow, and direct in-request `syncMetronomeSeatCountForWorkspace` calls. `membership.ts` fired **both** a workflow launch and a direct full sync for a single seat transition; `business_activation`, `usage_configuration`, and the poke plugin also ran direct full syncs. Overlapping runners each read the same pre-edit unassigned count and issued their own **open-ended** `add_unassigned_seats` delta (Metronome seat edits have `starting_at` only, no `ending_before`), so the unassigned pool **stacked** to multiples of the floor gap and never converged.

Fix — eliminate the concurrency by construction:
- The **full workspace reconcile runs only on the single serialized per-workspace Temporal workflow path**.
- New **`assignSeatForUser`** for the immediate-unblock need (auto-upgrade, business activation): writes only that one user's seat. Never touches the unassigned pool, other users, or alerts, so it is safe to overlap the workflow.
- **`moveSeatWithCreditCarry`** backs `assignSeatForUser` and does the per-user **seat-credit consumption carry** across a recurring-credit change (pro↔max: empty the old credit → move the seat → carry consumed AWU onto the new credit). This is required because the immediate path moves the seat right away, which would otherwise hide the pro→max transition from the debounced workspace sync and drop the carry (leaving the user a full fresh max allowance on top of what they already spent). The empty-origin loop is extracted into a shared helper reused by both the workspace sync and the single-user move.
- Repoint callers: membership immediate path → `assignSeatForUser` (workflow launch stays as backstop); `business_activation` → `isDirectSync` (single-seat + workflow backstop); `usage_configuration` + poke plugin → `launchMetronomeSeatCountSyncWorkflow`.
- Bound the activity retry policy (maxAttempts 5, scheduleToClose 1h) so a stuck sync can't retry unbounded and pile on self-overlap.

Admin-driven / debounced seat changes are unchanged — they already carry consumption correctly via `syncSeatCount`.

Also includes ops tooling: `scripts/audit_metronome_seat_state.ts` (`--probe`) to diff Dust vs Metronome seat state and dump raw seat-history segments, and `scripts/fix_metronome_future_seat_segment.ts` (dry-run one-off) to repair an inflated future segment.

## Tests

- New `lib/metronome/seats_credit_carry.test.ts`: pro→max empties the origin credit, moves the seat, then carries consumption onto the new credit — in that order; a plain add does no ledger transfer; a non-billable target no-ops.
- New `lib/api/metronome/seat_sync.test.ts`: `assignSeatForUser` delegates the move to `moveSeatWithCreditCarry` with the correct from→to seat types, reconciles the user, and no-ops when not on Metronome.
- Existing `lib/metronome/seats_sync.test.ts` and `lib/api/metronome/reconcile_credit_state.test.ts` still pass (25 tests total). `tsgo --noEmit` clean.
- Reproduced the healthy/idempotent reconcile locally via the poke plugin against a workspace with a minSeats floor + scheduled future floor change (serial runs converge to a no-op).

## Risk

- Medium — billing-facing seat reconcile + seat-credit ledger. Immediate seat updates no longer run a full workspace reconcile inline: they do a narrow single-seat write + per-user credit carry, and rely on the debounced workflow for the workspace-wide reconcile (unassigned floor, other members, alerts). Worst case if the narrow op overlaps the workflow is an off-by-one on the unassigned pool, self-corrected on the next full sync.
- The poke "Sync Metronome Seat Count" plugin is now async (schedules the workflow, ~15s) instead of returning a synchronous summary — operators read the outcome from logs.
- Safe to roll back: revert the commits; the debounced workflow path is unchanged in behavior.

## Deploy Plan

- Standard deploy; no migration.
- Post-deploy operational follow-up (separate from this deploy): once Metronome re-enables contract edits for Vanta, run `npx tsx front/scripts/fix_metronome_future_seat_segment.ts --workspaceId HzXDVQGUQF` (dry-run) then `--execute` to correct its inflated future Pro segment (1141 → 730) **before 2026-11-13**, else that segment bills 1141 seats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)