### PR TITLE
fix(mcp): Keep offline_access when resource metadata advertises it

### DIFF
--- a/front/lib/resources/remote_mcp_servers_resource.test.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.test.ts
@@ -118,10 +118,30 @@ describe("getMCPAuthorizationScope", () => {
     ).toBe("files.read offline_access");
   });
 
-  it("omits offline access when the authorization server does not support it", () => {
+  it("requests offline access when only the protected resource metadata advertises it", () => {
+    // Atlassian's authv2 advertises offline_access in the protected resource metadata while its
+    // authorization server metadata publishes no scopes at all.
+    expect(
+      getMCPAuthorizationScope({
+        resourceScopes: ["read:jira-work", "offline_access"],
+        authorizationServerScopes: undefined,
+      })
+    ).toBe("read:jira-work offline_access");
+  });
+
+  it("keeps an explicitly configured offline access even when metadata omits it", () => {
     expect(
       getMCPAuthorizationScope({
         extraScopes: "files.read offline_access",
+        authorizationServerScopes: ["files.read"],
+      })
+    ).toBe("files.read offline_access");
+  });
+
+  it("does not add offline access when no source mentions it", () => {
+    expect(
+      getMCPAuthorizationScope({
+        extraScopes: "files.read",
         authorizationServerScopes: ["files.read"],
       })
     ).toBe("files.read");

--- a/front/lib/resources/remote_mcp_servers_resource.test.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.test.ts
@@ -118,6 +118,15 @@ describe("getMCPAuthorizationScope", () => {
     ).toBe("files.read offline_access");
   });
 
+  it("omits offline access when the authorization server does not support it", () => {
+    expect(
+      getMCPAuthorizationScope({
+        extraScopes: "files.read offline_access",
+        authorizationServerScopes: ["files.read"],
+      })
+    ).toBe("files.read");
+  });
+
   it("requests offline access when only the protected resource metadata advertises it", () => {
     // Atlassian's authv2 advertises offline_access in the protected resource metadata while its
     // authorization server metadata publishes no scopes at all.
@@ -127,24 +136,6 @@ describe("getMCPAuthorizationScope", () => {
         authorizationServerScopes: undefined,
       })
     ).toBe("read:jira-work offline_access");
-  });
-
-  it("keeps an explicitly configured offline access even when metadata omits it", () => {
-    expect(
-      getMCPAuthorizationScope({
-        extraScopes: "files.read offline_access",
-        authorizationServerScopes: ["files.read"],
-      })
-    ).toBe("files.read offline_access");
-  });
-
-  it("does not add offline access when no source mentions it", () => {
-    expect(
-      getMCPAuthorizationScope({
-        extraScopes: "files.read",
-        authorizationServerScopes: ["files.read"],
-      })
-    ).toBe("files.read");
   });
 });
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -71,14 +71,14 @@ export function getMCPAuthorizationScope({
 
   // `offline_access` gates refresh tokens on some providers, and either metadata document may be
   // the one advertising it (e.g. Atlassian's authv2 lists it in the protected resource metadata
-  // while its authorization server metadata publishes no scopes at all), so honor both. An
-  // explicitly configured `offline_access` (extraScopes) is kept even when neither document
-  // advertises it: the curated configuration knows the server better than incomplete metadata.
+  // while its authorization server metadata publishes no scopes at all), so honor both.
   if (
     resourceScopes?.includes("offline_access") ||
     authorizationServerScopes?.includes("offline_access")
   ) {
     scopes.add("offline_access");
+  } else {
+    scopes.delete("offline_access");
   }
 
   return scopes.size > 0 ? [...scopes].join(" ") : undefined;

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -69,10 +69,16 @@ export function getMCPAuthorizationScope({
       : (resourceScopes ?? authorizationServerScopes ?? [])
   );
 
-  if (authorizationServerScopes?.includes("offline_access")) {
+  // `offline_access` gates refresh tokens on some providers, and either metadata document may be
+  // the one advertising it (e.g. Atlassian's authv2 lists it in the protected resource metadata
+  // while its authorization server metadata publishes no scopes at all), so honor both. An
+  // explicitly configured `offline_access` (extraScopes) is kept even when neither document
+  // advertises it: the curated configuration knows the server better than incomplete metadata.
+  if (
+    resourceScopes?.includes("offline_access") ||
+    authorizationServerScopes?.includes("offline_access")
+  ) {
     scopes.add("offline_access");
-  } else {
-    scopes.delete("offline_access");
   }
 
   return scopes.size > 0 ? [...scopes].join(" ") : undefined;


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/10201. Relates to #30313.

## Problem

Some providers advertise `offline_access` in the **protected resource** metadata while their authorization server metadata publishes no `scopes_supported` at all. Atlassian's `https://mcp.atlassian.com/v1/mcp/authv2` is one.

## Fix

Keep `offline_access` when **either** metadata document advertises it.

## Tests

- Added one
