### PR TITLE
[front] Narrow immediate seat writes: assignSeatForUser + pro↔max credit carry

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -1,5 +1,4 @@
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
   isMetronomeBillingEnabled,
   restoreWorkspaceAfterSubscription,
@@ -601,11 +600,17 @@ export async function handleSubscriptionActivationSuccess({
       checkoutPayment.seatType,
       checkoutPayment.billingPeriod
     );
+    // `isDirectSync` makes this immediately assign the target user's single seat
+    // (and reconcile their credit state) so they land correctly without waiting
+    // for the 15 s debounce — while the workspace-wide reconcile still goes
+    // through the debounced Temporal workflow it launches. This avoids running a
+    // second full reconcile here in parallel with the workflow.
     const seatResult = await updateMembershipSeatAndTrack({
       user: targetUser,
       workspace: lightWorkspace,
       newSeatType: membershipSeatType,
       author: "no-author",
+      isDirectSync: true,
     });
     if (seatResult.isErr()) {
       logger.error(
@@ -627,23 +632,6 @@ export async function handleSubscriptionActivationSuccess({
         },
         "[Business Activation] Target user seat updated"
       );
-
-      // Immediately sync seats so the user lands in the correct credit state
-      // without waiting for the debounced Temporal workflow (15 s delay).
-      const syncResult = await syncMetronomeSeatCountForWorkspace({
-        workspace: lightWorkspace,
-      });
-      if (syncResult.isErr()) {
-        logger.warn(
-          { workspaceId: workspace.sId, err: syncResult.error.message },
-          "[Business Activation] Immediate seat sync failed; debounced workflow will retry"
-        );
-      } else {
-        logger.info(
-          { workspaceId: workspace.sId, syncStatus: syncResult.value.status },
-          "[Business Activation] Immediate seat sync completed"
-        );
-      }
     }
   }
 

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -4,7 +4,7 @@ import {
   emitAuditLogEventDirect,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
+import { assignSeatForUser } from "@app/lib/api/metronome/seat_sync";
 import type { AuditLogActor } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -967,9 +967,16 @@ export async function updateMembershipSeatAndTrack({
   }
 
   if (isDirectSync && resultingActiveSeatType !== previousSeatType) {
-    const directSyncResult = await syncMetronomeSeatCountForWorkspace({
+    // Immediate, single-seat write only (never a full reconcile): assign this
+    // user's seat + reconcile their credit state so they're unblocked now. The
+    // debounced workflow launched above owns the workspace-wide reconcile —
+    // running a second full reconcile here in parallel is what stacked
+    // open-ended unassigned-seat edits in the seat-sync incident.
+    const directSyncResult = await assignSeatForUser({
       workspace,
-      reconcileUserId: user.sId,
+      userId: user.sId,
+      seatType: resultingActiveSeatType,
+      previousSeatType,
     });
     if (directSyncResult.isErr()) {
       logger.warn(
@@ -978,7 +985,7 @@ export async function updateMembershipSeatAndTrack({
           userId: user.sId,
           err: directSyncResult.error.message,
         },
-        "[Metronome] Direct seat sync failed; debounced workflow will retry"
+        "[Metronome] Immediate seat assignment failed; debounced workflow will retry"
       );
     }
   }

--- a/front/lib/api/metronome/seat_sync.test.ts
+++ b/front/lib/api/metronome/seat_sync.test.ts
@@ -1,0 +1,153 @@
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { assignSeatForUser } from "./seat_sync";
+
+const {
+  mockMoveSeatWithCreditCarry,
+  mockGetActiveContract,
+  mockGetProductSeatTypes,
+  mockReconcileUser,
+  mockFetchActiveSubscription,
+  mockFetchWorkspaceById,
+  mockInternalAdmin,
+} = vi.hoisted(() => ({
+  mockMoveSeatWithCreditCarry: vi.fn(),
+  mockGetActiveContract: vi.fn(),
+  mockGetProductSeatTypes: vi.fn(),
+  mockReconcileUser: vi.fn(),
+  mockFetchActiveSubscription: vi.fn(),
+  mockFetchWorkspaceById: vi.fn(),
+  mockInternalAdmin: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/seats", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seats")
+  >("@app/lib/metronome/seats");
+  return { ...actual, moveSeatWithCreditCarry: mockMoveSeatWithCreditCarry };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/plan_type")
+  >("@app/lib/metronome/plan_type");
+  return { ...actual, getActiveContract: mockGetActiveContract };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return { ...actual, getProductSeatTypes: mockGetProductSeatTypes };
+});
+
+vi.mock("@app/lib/api/metronome/reconcile_credit_state", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/api/metronome/reconcile_credit_state")
+  >("@app/lib/api/metronome/reconcile_credit_state");
+  return { ...actual, reconcileUser: mockReconcileUser };
+});
+
+vi.mock("@app/lib/resources/subscription_resource", () => ({
+  SubscriptionResource: {
+    fetchActiveByWorkspaceModelId: mockFetchActiveSubscription,
+  },
+}));
+
+vi.mock("@app/lib/resources/workspace_resource", () => ({
+  WorkspaceResource: { fetchById: mockFetchWorkspaceById },
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  Authenticator: { internalAdminForWorkspace: mockInternalAdmin },
+}));
+
+const WORKSPACE = {
+  sId: "ws_1",
+  id: 1,
+  metronomeCustomerId: "cus_1",
+} as unknown as LightWorkspaceType;
+
+describe("assignSeatForUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchActiveSubscription.mockResolvedValue({
+      metronomeContractId: "con_1",
+    });
+    mockGetActiveContract.mockResolvedValue({} as CachedContract);
+    mockGetProductSeatTypes.mockResolvedValue(new Map());
+    mockMoveSeatWithCreditCarry.mockResolvedValue(new Ok(undefined));
+    mockReconcileUser.mockResolvedValue(new Ok({}));
+    mockFetchWorkspaceById.mockResolvedValue({ sId: "ws_1" });
+    mockInternalAdmin.mockResolvedValue({});
+  });
+
+  it("delegates the single-seat move (with credit carry) then reconciles the user", async () => {
+    const result = await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockMoveSeatWithCreditCarry).toHaveBeenCalledTimes(1);
+    expect(mockMoveSeatWithCreditCarry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: "cus_1",
+        contractId: "con_1",
+        userId: "u1",
+        fromSeatType: undefined,
+        toSeatType: "pro",
+      })
+    );
+    expect(mockReconcileUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the from→to seat types for a pro→max upgrade (drives the ledger carry)", async () => {
+    await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "max",
+      previousSeatType: "pro",
+    });
+
+    expect(mockMoveSeatWithCreditCarry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        fromSeatType: "pro",
+        toSeatType: "max",
+      })
+    );
+  });
+
+  it("returns Err (and still reconciles nothing extra) when the seat move fails", async () => {
+    mockMoveSeatWithCreditCarry.mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await assignSeatForUser({
+      workspace: WORKSPACE,
+      userId: "u1",
+      seatType: "max",
+      previousSeatType: "pro",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockReconcileUser).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the workspace is not on Metronome", async () => {
+    const result = await assignSeatForUser({
+      workspace: { ...WORKSPACE, metronomeCustomerId: null },
+      userId: "u1",
+      seatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockFetchActiveSubscription).not.toHaveBeenCalled();
+    expect(mockMoveSeatWithCreditCarry).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -6,9 +6,11 @@ import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/def
 import { Authenticator } from "@app/lib/auth";
 import { getMetronomeContractById } from "@app/lib/metronome/client";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { getProductSeatTypes } from "@app/lib/metronome/seat_types";
 import type { SyncSeatCountSummary } from "@app/lib/metronome/seats";
 import {
   hasContractSeatSubscription,
+  moveSeatWithCreditCarry,
   remapMembershipSeatTypesForContract,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
@@ -17,6 +19,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { heartbeat } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -236,6 +239,109 @@ export async function syncMetronomeSeatCountForWorkspace({
     activeContractSummary,
     workspaceUserCreditStatesReconciled: true,
   });
+}
+
+/**
+ * Immediately assign (or move) a SINGLE user's seat in Metronome, plus reconcile
+ * that one user's credit state — nothing else.
+ *
+ * This is the only seat write allowed outside the debounced Temporal workflow.
+ * It touches just this user's `seat_id` (and their per-user credit); it never
+ * writes the unassigned pool, other users, alerts, or credit transfers. That
+ * narrow scope is what makes it safe to run concurrently with the workflow's
+ * full reconcile — unlike a full `syncMetronomeSeatCountForWorkspace`, which
+ * must be serialized: two full reconciles in parallel stack open-ended
+ * unassigned-seat deltas (the seat-sync rate-limit incident). Callers that need
+ * to unblock a just-upgraded user should call this AND launch the debounced
+ * workflow as the workspace-wide backstop (unassigned floor, other members,
+ * alerts, transfers).
+ *
+ * Best-effort and idempotent: `add_seat_ids` of an already-assigned seat is a
+ * no-op, and the credit state is reconciled from live balances. A missing
+ * contract or a target seat type with no billable subscription is skipped (the
+ * workflow reconciles it). Downgrades to a non-billable seat type only reconcile
+ * credit state here; the seat removal is left to the workflow (access is
+ * DB-gated, so billing removal is not latency-sensitive).
+ */
+export async function assignSeatForUser({
+  workspace,
+  userId,
+  seatType,
+  previousSeatType,
+}: {
+  workspace: LightWorkspaceType;
+  userId: string;
+  seatType: MembershipSeatType;
+  previousSeatType?: MembershipSeatType;
+}): Promise<Result<undefined, Error>> {
+  const workspaceId = workspace.sId;
+  if (!workspace.metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+  if (!activeSubscription?.metronomeContractId) {
+    return new Ok(undefined);
+  }
+  const contractId = activeSubscription.metronomeContractId;
+
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    return new Ok(undefined);
+  }
+  const productSeatTypes = await getProductSeatTypes();
+
+  // Move (or add) just this user's seat, carrying seat-credit consumption across
+  // a recurring-credit change (pro↔max: empty the old credit, carry consumed AWU
+  // onto the new one). Scoped to this one user — never the unassigned pool or
+  // other members — so it's safe to run alongside the debounced workflow, which
+  // still owns the workspace-wide reconcile. The carry has to happen here (not
+  // only in the later workflow sync) because we move the seat immediately, which
+  // would otherwise hide the seat-type change from the workflow.
+  const moveResult = await moveSeatWithCreditCarry({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId,
+    contract,
+    productSeatTypes,
+    workspaceId,
+    userId,
+    fromSeatType: previousSeatType,
+    toSeatType: seatType,
+  });
+  if (moveResult.isErr()) {
+    logger.warn(
+      { workspaceId, userId, seatType, err: moveResult.error.message },
+      "[SeatSync] Immediate single-seat assignment failed; debounced workflow will reconcile"
+    );
+    return new Err(moveResult.error);
+  }
+
+  // Reconcile just this user's credit state from live balances so they land in
+  // the correct seat↔pool state immediately. Never fails the assignment.
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspaceResource = await WorkspaceResource.fetchById(workspaceId);
+  if (workspaceResource) {
+    const userReconcile = await reconcileUser({
+      auth,
+      workspace: workspaceResource,
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      userId,
+      execute: true,
+    });
+    if (userReconcile.isErr()) {
+      logger.warn(
+        { workspaceId, userId, err: userReconcile.error.message },
+        "[SeatSync] Single-user credit-state reconcile failed; continuing"
+      );
+    }
+  }
+
+  logger.info(
+    { workspaceId, userId, seatType },
+    "[SeatSync] assignSeatForUser done"
+  );
+  return new Ok(undefined);
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1165,6 +1165,39 @@ async function emptyOriginSeatCreditsForTransfers({
     allocationBySeatType,
   });
 
+  return emptyOriginCreditsForTransfers({
+    metronomeCustomerId,
+    contractId,
+    workspaceId,
+    transfers,
+    subscriptionIdBySeatType,
+    recurringCreditIdBySeatType,
+  });
+}
+
+/**
+ * Empty each transfer's origin seat credit (reclaim its unused balance) so the
+ * consumed amount can be carried onto the new seat once it's assigned. Shared by
+ * the workspace-wide sync (which computes `transfers` from Metronome's current
+ * state) and the single-user immediate move (which knows the from→to types from
+ * the DB). Returns the transfers whose origin was handled — a fully-consumed
+ * origin is kept (nothing to reclaim, but its consumption still carries).
+ */
+async function emptyOriginCreditsForTransfers({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+  transfers,
+  subscriptionIdBySeatType,
+  recurringCreditIdBySeatType,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+  transfers: SeatCreditTransfer[];
+  subscriptionIdBySeatType: Map<MembershipSeatType, string>;
+  recurringCreditIdBySeatType: Map<MembershipSeatType, string>;
+}): Promise<SeatCreditTransfer[]> {
   const segmentCache = new Map<
     string,
     { creditId: string; segmentId: string; segmentStartingAt: string } | null
@@ -1400,6 +1433,168 @@ async function carryConsumptionToNewSeatCredits({
       );
     }
   }
+}
+
+/**
+ * Move (or add) a single user's seat in Metronome, carrying seat-credit
+ * consumption across a recurring-credit seat-type change (e.g. pro→max: empty
+ * the pro credit, carry the consumed AWU onto the max credit) — the same ledger
+ * transfer `syncSeatCount` performs workspace-wide, but scoped to one user and
+ * driven off the known from→to seat types rather than Metronome's pre-move
+ * assignment.
+ *
+ * This is the immediate-unblock primitive behind `assignSeatForUser`: it MUST do
+ * the carry itself, because it moves the seat_id right away — which would
+ * otherwise hide the seat-type change from the debounced workspace sync (that
+ * detects moves by diffing Metronome's assignment against the DB, and would see
+ * the user already on the new seat). It touches only this user's seat + credits,
+ * never the unassigned pool or other users, so it stays safe to run alongside
+ * the debounced workflow.
+ *
+ * Order matches `syncSeatCount`: empty origin credit (while still on the old
+ * seat) → move the seat → carry consumption onto the new credit (now active).
+ * The credit steps are best-effort; a seat-move failure is returned as `Err`.
+ */
+export async function moveSeatWithCreditCarry({
+  metronomeCustomerId,
+  contractId,
+  contract,
+  productSeatTypes,
+  workspaceId,
+  userId,
+  fromSeatType,
+  toSeatType,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  contract: CachedContract;
+  productSeatTypes: Map<string, MembershipSeatType>;
+  workspaceId: string;
+  userId: string;
+  fromSeatType: MembershipSeatType | undefined;
+  toSeatType: MembershipSeatType;
+}): Promise<Result<undefined, Error>> {
+  const seatSubscriptions = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
+  ].flatMap(([seatType, sub]) => (sub.id ? [{ seatType, sub }] : []));
+
+  const targetSubId = seatSubscriptions.find((s) => s.seatType === toSeatType)
+    ?.sub.id;
+  const previousSubId = fromSeatType
+    ? seatSubscriptions.find((s) => s.seatType === fromSeatType)?.sub.id
+    : undefined;
+
+  if (!targetSubId) {
+    // Non-billable target (e.g. "none", or a type not entitled here). Leave the
+    // seat removal + any credit cleanup to the debounced workspace sync.
+    logger.info(
+      { workspaceId, userId, toSeatType },
+      "[Metronome] No billable subscription for target seat type — leaving to debounced workflow"
+    );
+    return new Ok(undefined);
+  }
+
+  // Seat-type → subscription / recurring-credit / allocation maps for the
+  // recurring-credit seat types (same derivation as `syncSeatCount`).
+  const subscriptionIdBySeatType = new Map<MembershipSeatType, string>(
+    seatSubscriptions.flatMap(({ sub, seatType }) =>
+      sub.id && getSeatCreditNameForSeatType(seatType)
+        ? [[seatType, sub.id] as const]
+        : []
+    )
+  );
+  const recurringCreditIdBySeatType = new Map<MembershipSeatType, string>();
+  const allocationBySeatType = new Map<MembershipSeatType, number>();
+  for (const { sub, seatType } of seatSubscriptions) {
+    if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
+      continue;
+    }
+    const recurringCredit = (contract.recurring_credits ?? []).find(
+      (c) => c.subscription_config?.subscription_id === sub.id
+    );
+    if (recurringCredit?.id) {
+      recurringCreditIdBySeatType.set(seatType, recurringCredit.id);
+    }
+    allocationBySeatType.set(
+      seatType,
+      getAwuAllocationForSeatType(contract, seatType, productSeatTypes)
+    );
+  }
+
+  // Compute the single-user transfer (only when both ends carry a recurring
+  // credit). We know the move from the DB, so we don't rely on Metronome's
+  // pre-move assignment to detect it.
+  let transfers: SeatCreditTransfer[] = [];
+  if (
+    fromSeatType &&
+    fromSeatType !== toSeatType &&
+    getSeatCreditNameForSeatType(fromSeatType) &&
+    getSeatCreditNameForSeatType(toSeatType)
+  ) {
+    const balancesRes = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      seatIds: [userId],
+    });
+    if (balancesRes.isErr()) {
+      logger.error(
+        { workspaceId, userId, error: balancesRes.error },
+        "[Metronome] Failed to read origin seat balance for single-user transfer — skipping carry"
+      );
+    } else {
+      const awuCreditTypeId = getCreditTypeAwuId();
+      const remaining = balancesRes.value
+        .find((s) => s.seat_id === userId)
+        ?.balances.find((b) => b.credit_type_id === awuCreditTypeId)?.balance;
+      const balanceByUser = new Map<string, number>();
+      if (remaining !== undefined) {
+        balanceByUser.set(userId, remaining);
+      }
+      const computed = computeSeatCreditTransfers({
+        metronomeSeatByUser: new Map([[userId, fromSeatType]]),
+        desiredSeatByUser: new Map([[userId, toSeatType]]),
+        balanceByUser,
+        allocationBySeatType,
+      });
+      // Empty the origin credit while the user is still on the old seat.
+      transfers = await emptyOriginCreditsForTransfers({
+        metronomeCustomerId,
+        contractId,
+        workspaceId,
+        transfers: computed,
+        subscriptionIdBySeatType,
+        recurringCreditIdBySeatType,
+      });
+    }
+  }
+
+  // Move (or add) the seat.
+  const isMove = !!previousSubId && previousSubId !== targetSubId;
+  const seatUpdate = await updateSubscriptionSeats({
+    metronomeCustomerId,
+    contractId,
+    fromSubscriptionId: isMove ? previousSubId : targetSubId,
+    toSubscriptionId: isMove ? targetSubId : undefined,
+    addSeatIds: [userId],
+    removeSeatIds: isMove ? [userId] : [],
+  });
+  if (seatUpdate.isErr()) {
+    return new Err(seatUpdate.error);
+  }
+
+  // Carry consumption onto the new credit now that the seat is assigned.
+  if (transfers.length > 0) {
+    await carryConsumptionToNewSeatCredits({
+      metronomeCustomerId,
+      contractId,
+      workspaceId,
+      transfers,
+      subscriptionIdBySeatType,
+      recurringCreditIdBySeatType,
+      allocationBySeatType,
+    });
+  }
+  return new Ok(undefined);
 }
 
 // Summary of the work `syncSeatCount` actually did, surfaced up to the poke

--- a/front/lib/metronome/seats_credit_carry.test.ts
+++ b/front/lib/metronome/seats_credit_carry.test.ts
@@ -1,0 +1,226 @@
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { moveSeatWithCreditCarry } from "@app/lib/metronome/seats";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockUpdateSubscriptionSeats,
+  mockListSeatBalances,
+  mockFindSeatCreditSegment,
+  mockGetSeatActiveSince,
+  mockAdjustSeatCreditBalances,
+  mockGetSeatSubscriptions,
+  mockGetAwuAllocation,
+  mockGetCreditTypeAwuId,
+} = vi.hoisted(() => ({
+  mockUpdateSubscriptionSeats: vi.fn(),
+  mockListSeatBalances: vi.fn(),
+  mockFindSeatCreditSegment: vi.fn(),
+  mockGetSeatActiveSince: vi.fn(),
+  mockAdjustSeatCreditBalances: vi.fn(),
+  mockGetSeatSubscriptions: vi.fn(),
+  mockGetAwuAllocation: vi.fn(),
+  mockGetCreditTypeAwuId: vi.fn(),
+}));
+
+// Fully replace the client module (no importActual) so importing it never pulls
+// the real dependency graph that touches Redis at module load.
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractById: vi.fn(),
+  updateSubscriptionQuantity: vi.fn(),
+  updateSubscriptionSeats: mockUpdateSubscriptionSeats,
+  getMetronomeSubscriptionSeatState: vi.fn(),
+  listCustomerPerUserCreditUserIds: vi.fn(),
+  listCustomerPerUserCreditBalances: vi.fn(),
+  addPerUserCreditToCustomer: vi.fn(),
+  revokePerUserCustomerCredit: vi.fn(),
+  listMetronomeSeatBalances: mockListSeatBalances,
+  findSeatCreditSegmentForPeriod: mockFindSeatCreditSegment,
+  getMetronomeSeatActiveSince: mockGetSeatActiveSince,
+  adjustSeatCreditBalances: mockAdjustSeatCreditBalances,
+}));
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return {
+    ...actual,
+    getSeatSubscriptionsFromContract: mockGetSeatSubscriptions,
+    getAwuAllocationForSeatType: mockGetAwuAllocation,
+  };
+});
+
+vi.mock("@app/lib/metronome/constants", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/constants")
+  >("@app/lib/metronome/constants");
+  return { ...actual, getCreditTypeAwuId: mockGetCreditTypeAwuId };
+});
+
+// seats.ts wires a `cacheWithRedis` at import time — stub so importing it never
+// touches Redis.
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: (fn: unknown) => fn,
+  invalidateCacheWithRedis: () => async () => {},
+  bestEffortInvalidateCacheWithRedis: () => async () => {},
+}));
+
+// Not used by `moveSeatWithCreditCarry`, but seats.ts imports these and their
+// real module graph touches Redis at import — stub them out.
+vi.mock("@app/lib/metronome/alerts/per_user_credit_balance", () => ({
+  upsertPerUserCreditBalanceAlerts: vi.fn(),
+  clearPerUserCreditBalanceAlerts: vi.fn(),
+}));
+vi.mock("@app/lib/resources/membership_resource", () => ({
+  MembershipResource: {},
+}));
+vi.mock("@app/lib/resources/workspace_seat_limit_resource", () => ({
+  WorkspaceSeatLimitResource: {},
+}));
+
+const AWU = "awu";
+
+// A contract whose recurring credits link each seat subscription to its credit.
+const CONTRACT = {
+  recurring_credits: [
+    { id: "cred_pro", subscription_config: { subscription_id: "sub_pro" } },
+    { id: "cred_max", subscription_config: { subscription_id: "sub_max" } },
+  ],
+} as unknown as CachedContract;
+
+function seatBalance(balance: number) {
+  return new Ok([
+    {
+      seat_id: "u1",
+      balances: [{ credit_type_id: AWU, balance, starting_balance: 8000 }],
+    },
+  ]);
+}
+
+describe("moveSeatWithCreditCarry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCreditTypeAwuId.mockReturnValue(AWU);
+    mockGetSeatSubscriptions.mockReturnValue(
+      new Map([
+        ["pro", { id: "sub_pro" }],
+        ["max", { id: "sub_max" }],
+      ])
+    );
+    mockGetAwuAllocation.mockImplementation(
+      (_contract: unknown, seatType: MembershipSeatType) =>
+        seatType === "max" ? 40000 : 8000
+    );
+    mockUpdateSubscriptionSeats.mockResolvedValue(new Ok(undefined));
+    mockFindSeatCreditSegment.mockResolvedValue(
+      new Ok({
+        creditId: "seg_credit",
+        segmentId: "seg_1",
+        segmentStartingAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
+    mockGetSeatActiveSince.mockResolvedValue(
+      new Ok(new Date("2026-01-01T00:00:00.000Z"))
+    );
+    mockAdjustSeatCreditBalances.mockResolvedValue(new Ok(undefined));
+  });
+
+  it("pro→max: empties the pro credit, moves the seat, then carries consumption onto max", async () => {
+    // Origin (pro) balance read first (3000 of 8000 left ⇒ 5000 consumed), then
+    // the new (max) credit balance read during the carry (fresh 40000).
+    mockListSeatBalances
+      .mockResolvedValueOnce(seatBalance(3000))
+      .mockResolvedValueOnce(seatBalance(40000));
+
+    const result = await moveSeatWithCreditCarry({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      contract: CONTRACT,
+      productSeatTypes: new Map(),
+      workspaceId: "ws_1",
+      userId: "u1",
+      fromSeatType: "pro",
+      toSeatType: "max",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Emptied the origin (pro) credit by the remaining 3000.
+    const emptyCall = mockAdjustSeatCreditBalances.mock.calls.find((c) =>
+      c[0].reason.includes("empty origin credit")
+    );
+    expect(emptyCall?.[0].perSeatAmounts).toEqual({ u1: -3000 });
+
+    // Moved the seat from the pro sub to the max sub.
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        toSubscriptionId: "sub_max",
+        addSeatIds: ["u1"],
+        removeSeatIds: ["u1"],
+      })
+    );
+
+    // Carried consumption: max credit set to allocation − consumed = 40000 −
+    // 5000 = 35000; current fresh balance is 40000, so delta −5000.
+    const carryCall = mockAdjustSeatCreditBalances.mock.calls.find((c) =>
+      c[0].reason.includes("carry over consumed AWU")
+    );
+    expect(carryCall?.[0].perSeatAmounts).toEqual({ u1: -5000 });
+
+    // Order: empty origin BEFORE the move BEFORE the carry.
+    const emptyOrder = mockAdjustSeatCreditBalances.mock.invocationCallOrder[0];
+    const moveOrder = mockUpdateSubscriptionSeats.mock.invocationCallOrder[0];
+    const carryOrder = mockAdjustSeatCreditBalances.mock.invocationCallOrder[1];
+    expect(emptyOrder).toBeLessThan(moveOrder);
+    expect(moveOrder).toBeLessThan(carryOrder);
+  });
+
+  it("plain add (no previous seat): moves the seat, no balance read or ledger transfer", async () => {
+    const result = await moveSeatWithCreditCarry({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      contract: CONTRACT,
+      productSeatTypes: new Map(),
+      workspaceId: "ws_1",
+      userId: "u1",
+      fromSeatType: undefined,
+      toSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockListSeatBalances).not.toHaveBeenCalled();
+    expect(mockAdjustSeatCreditBalances).not.toHaveBeenCalled();
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        toSubscriptionId: undefined,
+        addSeatIds: ["u1"],
+        removeSeatIds: [],
+      })
+    );
+  });
+
+  it("no billable subscription for the target seat type: does nothing", async () => {
+    mockGetSeatSubscriptions.mockReturnValue(
+      new Map([["pro", { id: "sub_pro" }]])
+    );
+
+    const result = await moveSeatWithCreditCarry({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      contract: CONTRACT,
+      productSeatTypes: new Map(),
+      workspaceId: "ws_1",
+      userId: "u1",
+      fromSeatType: "pro",
+      toSeatType: "none",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalled();
+    expect(mockAdjustSeatCreditBalances).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Part of the seat-sync follow-ups (incident fix is #31422; poke/usage-config → workflow routing is #31568). This PR narrows the **immediate** (non-debounced) seat path so it no longer runs a full workspace reconcile inline.

- The full `syncSeatCount` (which manages the unassigned-seat pool that stacked in the incident) now runs **only on the single serialized per-workspace Temporal workflow**.
- The immediate path (auto-upgrade `free→pro`/`pro→max`, business activation — the only `isDirectSync` callers) uses a new narrow **`assignSeatForUser`** that writes just that one user's seat:
  - membership immediate path → `assignSeatForUser` (+ workflow backstop, launched unconditionally)
  - `business_activation` → `isDirectSync` (single-seat + workflow backstop)
- **`moveSeatWithCreditCarry`** carries the seat-credit consumption on a `pro↔max` move: `assignSeatForUser` pre-moves the seat_id, which would hide the transition from the later debounced sync (it detects moves by diffing Metronome vs the DB) and drop the ledger transfer. So it does the per-user carry directly — **empty origin credit → move seat → carry consumed AWU onto the new credit** (same order/logic as the workspace sync). The empty-origin loop is extracted into a shared `emptyOriginCreditsForTransfers` reused by both paths.

**Scope notes:**
- Admin-driven / debounced seat changes are unchanged (they already carry via `syncSeatCount`).
- Free-seat credit grant/revoke stays **workflow-owned**; the immediate path only handles pro/max (the `isDirectSync` upgrade targets — it never assigns a free seat). A `free→pro` upgrade's free-credit *revoke* lags to the debounced workflow (~15s) — a brief over-allowance, never a block.
- The seat move on the immediate path is load-bearing (the new tier's credit only exists once the seat is assigned, and that's what un-caps the user) — a creditState-only update can't unblock an upgraded user.

## Tests

- New `lib/metronome/seats_credit_carry.test.ts`: `pro→max` empties the origin credit, moves the seat, then carries consumption — in that order; a plain add does no ledger transfer; a non-billable target no-ops.
- New `lib/api/metronome/seat_sync.test.ts`: `assignSeatForUser` delegates to `moveSeatWithCreditCarry` with the correct from→to seat types, reconciles the user, no-ops when not on Metronome.
- Existing `seats_sync.test.ts` / `reconcile_credit_state.test.ts` still pass. `tsgo --noEmit` clean.

## Risk

- Medium — touches the immediate seat path + seat-credit ledger. Immediate seat updates do a narrow single-seat write + per-user credit carry, relying on the debounced workflow for the workspace-wide reconcile. Worst case if the narrow op overlaps the workflow is an off-by-one on the unassigned pool, self-corrected next sync. Follow-up worth considering: drop `maxRetries` to 0 for seat edits so an immediate-path edit can't stack on a 504 (see incident notes). Safe to roll back by reverting.

## Deploy Plan

- Standard deploy; no migration. Merge after #31422; independent of #31568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)