### PR TITLE
[front] feat: name the group behind an inherited pool credit spend limit

### DIFF
--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -176,6 +176,7 @@ export function PersonalUsageCard({
                 seatBalanceAwu={myUsage?.seatBalanceAwu ?? null}
                 effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
                 spendLimitSource={myUsage?.spendLimitSource ?? "none"}
+                spendLimitGroupName={myUsage?.spendLimitGroupName ?? null}
                 seatType={myUsage?.seatType ?? null}
                 isTotalAllowedUsagePending={false}
               />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -155,6 +155,7 @@ function memberFromUpgradeRequest(
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
+    spendLimitGroupName: null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -153,6 +153,7 @@ function memberFromUpgradeRequest(
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
+    spendLimitGroupName: null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -91,6 +91,7 @@ type RowData = {
   consumedFromPoolAwuCredits: number;
   spendLimitAwuCredits: number | null;
   spendLimitSource: EffectiveSpendLimitSource;
+  spendLimitGroupName: string | null;
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
   isTotalAllowedUsagePending: boolean;
@@ -183,6 +184,9 @@ interface AwuUsageBarProps {
   effectiveLimit: number | null;
   // Where `effectiveLimit` comes from — shown as a tooltip on the limit figure.
   spendLimitSource: EffectiveSpendLimitSource;
+  // Name of the group behind `effectiveLimit` when `spendLimitSource` is
+  // `"group"`. Null for every other source.
+  spendLimitGroupName: string | null;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
   // Shows only the workspace-pool portion of usage (pool consumed / pool
@@ -196,13 +200,16 @@ interface AwuUsageBarProps {
 // Human-readable origin of the effective spend limit, or null when there is
 // nothing worth explaining (no limit configured).
 function spendLimitSourceLabel(
-  source: EffectiveSpendLimitSource
+  source: EffectiveSpendLimitSource,
+  groupName: string | null
 ): string | null {
   switch (source) {
     case "override":
       return "Limit set specifically for this member";
     case "group":
-      return "Limit from a group";
+      return groupName
+        ? `Limit from the "${groupName}" group`
+        : "Limit from a group";
     case "default":
       return "Workspace default limit";
     case "none":
@@ -221,13 +228,17 @@ export function AwuUsageBar({
   seatBalanceAwu,
   effectiveLimit,
   spendLimitSource,
+  spendLimitGroupName,
   seatType,
   isTotalAllowedUsagePending: isPending,
   poolOnly = false,
 }: AwuUsageBarProps) {
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
-  const sourceLabel = spendLimitSourceLabel(spendLimitSource);
+  const sourceLabel = spendLimitSourceLabel(
+    spendLimitSource,
+    spendLimitGroupName
+  );
   // For free seats: use lifetime consumed (derived from the live Metronome
   // balance) instead of period spend, so the bar reflects remaining credit.
   const isFreeWithBalance =
@@ -584,6 +595,7 @@ function buildPoolCreditUsageColumn(
           seatBalanceAwu={info.row.original.seatBalanceAwu}
           effectiveLimit={info.row.original.spendLimitAwuCredits}
           spendLimitSource={info.row.original.spendLimitSource}
+          spendLimitGroupName={info.row.original.spendLimitGroupName}
           seatType={info.row.original.seatType}
           isTotalAllowedUsagePending={
             info.row.original.isTotalAllowedUsagePending
@@ -994,6 +1006,7 @@ export function MembersUsageTable({
           consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
           spendLimitAwuCredits: m.spendLimitAwuCredits,
           spendLimitSource: m.spendLimitSource,
+          spendLimitGroupName: m.spendLimitGroupName,
           scheduledSeatType: m.scheduledSeatType,
           scheduledSeatChangeAt: m.scheduledSeatChangeAt,
           isTotalAllowedUsagePending: totalAllowedUsagePendingMemberIds.has(

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -208,7 +208,7 @@ function spendLimitSourceLabel(
       return "Limit set specifically for this member";
     case "group":
       return groupName
-        ? `Limit from the "${groupName}" group`
+        ? `Limit inherited from the "${groupName}" group`
         : "Limit from a group";
     case "default":
       return "Workspace default limit";

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -141,6 +141,10 @@ export type MemberUsageType = {
   // Where `spendLimitAwuCredits` comes from: a user-specific `override`, the
   // seat-type `default`, or `none` (no cap configured / unlimited).
   spendLimitSource: EffectiveSpendLimitSource;
+  // Name of the group behind `spendLimitAwuCredits` when `spendLimitSource`
+  // is `"group"` (the cap-eligible group with the highest pool cap among the
+  // member's groups). Null for every other source.
+  spendLimitGroupName: string | null;
   // Id of the Metronome alert backing the effective cap (override or default),
   // for deep-linking to the dashboard. Null when uncapped.
   spendLimitAlertId: string | null;
@@ -1492,17 +1496,18 @@ export async function getMemberUsage({
     return { member: null };
   }
 
-  const [groupNamesByUserModelId, groupCapByUserModelId] = await Promise.all([
-    GroupResource.listGroupNamesByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [userResource.id],
-      groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
-    }),
-    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [userResource.id],
-    }),
-  ]);
+  const [groupNamesByUserModelId, maxPoolCapGroupByUserModelId] =
+    await Promise.all([
+      GroupResource.listGroupNamesByUserModelIdInWorkspace({
+        workspace,
+        userModelIds: [userResource.id],
+        groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+      }),
+      GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
+        workspace,
+        userModelIds: [userResource.id],
+      }),
+    ]);
 
   const metronomeUserId =
     membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
@@ -1569,8 +1574,8 @@ export async function getMemberUsage({
 
   // Max group cap (pool-only) + seat allowance, matching override/default units.
   // Only pool-bearing seats (pro/max/workspace) get a group cap.
-  const groupPoolCapAwuCredits =
-    groupCapByUserModelId.get(userResource.id) ?? null;
+  const maxPoolCapGroup = maxPoolCapGroupByUserModelId.get(userResource.id);
+  const groupPoolCapAwuCredits = maxPoolCapGroup?.capAwuCredits ?? null;
   const groupCapAwuCredits =
     groupPoolCapAwuCredits !== null && normalizedSeatType !== null
       ? groupPoolCapAwuCredits +
@@ -1612,6 +1617,10 @@ export async function getMemberUsage({
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource,
+    spendLimitGroupName:
+      spendLimitSource === "group"
+        ? (maxPoolCapGroup?.groupName ?? null)
+        : null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,
@@ -1787,9 +1796,7 @@ type MembersUsagePagePrefetch = {
     ReturnType<typeof fetchEffectivePerUserSpendLimits>
   >;
   groupCapByUserModelId?: Awaited<
-    ReturnType<
-      typeof GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace
-    >
+    ReturnType<typeof GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace>
   >;
 };
 
@@ -1891,7 +1898,7 @@ async function resolveMembersUsagePageUsers({
               freeBalanceByUserId: new Map<string, number>(),
               freeStartingByUserId: new Map<string, number>(),
             }),
-        GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+        GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
           workspace,
           userModelIds: allUsers.map((u) => u.id),
         }),
@@ -1931,7 +1938,8 @@ async function resolveMembersUsagePageUsers({
           seatType !== "none"
             ? membership.poolCapOverrideAwuCredits + seatAllowance
             : null;
-        const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+        const groupPoolCapAwuCredits =
+          groupCapByUserModelId.get(u.id)?.capAwuCredits ?? null;
         const groupCapAwuCredits =
           groupPoolCapAwuCredits !== null && normalizedSeatType !== null
             ? groupPoolCapAwuCredits + seatAllowance
@@ -2224,7 +2232,7 @@ export async function getMembersUsage({
       groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     }),
     prefetch.groupCapByUserModelId ??
-      GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
         workspace,
         userModelIds: users.map((u) => u.id),
       }),
@@ -2406,7 +2414,8 @@ export async function getMembersUsage({
     // Max group cap (pool-only, stored on the group) + seat allowance, to match
     // the units of override/default above. Only pool-bearing seats
     // (pro/max/workspace) get a group cap; free/none have no pool.
-    const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+    const maxPoolCapGroup = groupCapByUserModelId.get(u.id);
+    const groupPoolCapAwuCredits = maxPoolCapGroup?.capAwuCredits ?? null;
     const groupCapAwuCredits =
       groupPoolCapAwuCredits !== null && normalizedSeatType !== null
         ? groupPoolCapAwuCredits +
@@ -2478,6 +2487,10 @@ export async function getMembersUsage({
           ? (metronomeConsumedByUserId.get(userId) ?? 0)
           : null,
         spendLimitSource,
+        spendLimitGroupName:
+          spendLimitSource === "group"
+            ? (maxPoolCapGroup?.groupName ?? null)
+            : null,
         spendLimitAlertId,
         spendLimitWarningAlertId,
         freeCreditLowAlert: freeCreditAlerts?.low ?? null,

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -934,6 +934,43 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("listMaxPoolCapGroupByUserModelIdInWorkspace", () => {
+    it("returns the winning group's name alongside its cap", async () => {
+      const capped500 = await GroupResource.makeNew(
+        {
+          name: "Capped 500",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-500",
+        },
+        { memberIds: [user.id] }
+      );
+      await capped500.updatePoolCap(authenticator, 500);
+
+      const capped800 = await GroupResource.makeNew(
+        {
+          name: "Capped 800",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-800",
+        },
+        { memberIds: [user.id] }
+      );
+      await capped800.updatePoolCap(authenticator, 800);
+
+      const result =
+        await GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
+          workspace,
+          userModelIds: [user.id],
+        });
+
+      expect(result.get(user.id)).toEqual({
+        capAwuCredits: 800,
+        groupName: "Capped 800",
+      });
+    });
+  });
+
   describe("listWorkspaceGroupsFromKey", () => {
     it("system key: populates cache on first call and serves from cache on second", async () => {
       const key = await KeyFactory.system(systemGroup);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1332,19 +1332,23 @@ export class GroupResource extends BaseResource<GroupModel> {
     return result;
   }
 
-  // For each user, the highest per-group pool cap (excluding seat allowance)
-  // among the cap-eligible (provisioned) groups they belong to. Users with no
-  // capped group are absent from the map (the caller falls back to the workspace
-  // default). Used to resolve the "max(group caps)" term of a user's effective
-  // spend limit.
-  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+  // For each user, the cap-eligible (provisioned) group with the highest pool
+  // cap (excluding seat allowance) among the groups they belong to, and the
+  // cap itself. Users with no capped group are absent from the map (the
+  // caller falls back to the workspace default). Used to resolve the
+  // "max(group caps)" term of a user's effective spend limit, and to name the
+  // group behind that term in the UI.
+  static async listMaxPoolCapGroupByUserModelIdInWorkspace({
     workspace,
     userModelIds,
   }: {
     workspace: LightWorkspaceType;
     userModelIds: ModelId[];
-  }): Promise<Map<ModelId, number>> {
-    const result = new Map<ModelId, number>();
+  }): Promise<Map<ModelId, { capAwuCredits: number; groupName: string }>> {
+    const result = new Map<
+      ModelId,
+      { capAwuCredits: number; groupName: string }
+    >();
     if (userModelIds.length === 0) {
       return result;
     }
@@ -1372,22 +1376,48 @@ export class GroupResource extends BaseResource<GroupModel> {
         poolCapAwuCredits: { [Op.ne]: null },
       },
     });
-    const capByGroupId = new Map(
-      groups.map((g) => [g.id, g.poolCapAwuCredits])
-    );
+    const cappedGroupById = new Map(groups.map((g) => [g.id, g]));
 
     for (const m of memberships) {
-      const cap = capByGroupId.get(m.groupId);
-      if (cap === undefined || cap === null) {
+      const group = cappedGroupById.get(m.groupId);
+      if (!group || group.poolCapAwuCredits === null) {
         continue;
       }
       const existing = result.get(m.userId);
-      if (existing === undefined || cap > existing) {
-        result.set(m.userId, cap);
+      if (
+        existing === undefined ||
+        group.poolCapAwuCredits > existing.capAwuCredits
+      ) {
+        result.set(m.userId, {
+          capAwuCredits: group.poolCapAwuCredits,
+          groupName: group.name,
+        });
       }
     }
 
     return result;
+  }
+
+  // Numeric-only view of `listMaxPoolCapGroupByUserModelIdInWorkspace`, for
+  // callers that only need the cap amount (spend-limit resolution) and not
+  // the group's identity.
+  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+  }): Promise<Map<ModelId, number>> {
+    const byGroup = await this.listMaxPoolCapGroupByUserModelIdInWorkspace({
+      workspace,
+      userModelIds,
+    });
+    return new Map(
+      [...byGroup].map(([userModelId, { capAwuCredits }]) => [
+        userModelId,
+        capAwuCredits,
+      ])
+    );
   }
 
   static async getMemberCountsForGroups(


### PR DESCRIPTION
The spend-limit tooltip on a member's pool credit usage said "Limit
from a group" whenever the cap was inherited from a group, without
saying which one. Track the winning group's name alongside its cap so
the tooltip can name it; override and workspace-default limits are
unaffected.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
