### PR TITLE
[marketing] add EU to Enterprise data residency highlight

### DIFF
--- a/marketing/pages/home/pricing.tsx
+++ b/marketing/pages/home/pricing.tsx
@@ -166,7 +166,7 @@ const PLANS: Plan[] = [
       "Unlimited connectors & MCP servers",
       "Workspace-pooled credits & volume pricing",
       "SCIM, audit logs & custom data retention",
-      "US data residency & single-tenant deployment",
+      "US & EU data residency & single-tenant deployment",
       "Dedicated CSM, priority support & SLA",
       "Custom legal terms (MSA, DPA)",
     ],


### PR DESCRIPTION
## Description

Updates the Enterprise plan feature highlight on the marketing pricing page to reflect that EU data residency is now available alongside US data residency.

## Tests

Visual check on the pricing page — no logic change.

## Risk

None.

## Deploy Plan

Deploy marketing.