### PR TITLE
Add tracking for Customization tab and "Chat with..." toggle

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -24,6 +24,7 @@ import {
   useUserMemory,
 } from "@app/lib/swr/user";
 import { useAuthContext } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
 import {
   MAX_USER_MEMORY_CHARS,
   MAX_USER_MEMORY_CONTENT_LENGTH,
@@ -428,9 +429,15 @@ function CustomizationSection() {
           action={
             <SliderToggle
               selected={localAgentsSectionVisible}
-              onClick={() =>
-                setLocalAgentsSectionVisible(!localAgentsSectionVisible)
-              }
+              onClick={() => {
+                const nextValue = !localAgentsSectionVisible;
+                setLocalAgentsSectionVisible(nextValue);
+                trackEvent({
+                  area: TRACKING_AREAS.SETTINGS,
+                  object: "chat_with_toggle",
+                  extra: { enabled: nextValue },
+                });
+              }}
             />
           }
         />
@@ -737,6 +744,15 @@ export function UserSettingsPopover({
     }
   }, [open, mutateAuthContext]);
 
+  const handleSectionChange = (section: SettingsSection) => {
+    setActiveSection(section);
+    trackEvent({
+      area: TRACKING_AREAS.SETTINGS,
+      object: "settings_tab",
+      extra: { section },
+    });
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -757,7 +773,7 @@ export function UserSettingsPopover({
               onValueChange={(value) => {
                 const item = navItems.find((i) => i.section === value);
                 if (item) {
-                  setActiveSection(item.section);
+                  handleSectionChange(item.section);
                 }
               }}
               className="px-2"
@@ -789,7 +805,7 @@ export function UserSettingsPopover({
                   icon={icon}
                   label={label}
                   selected={activeSection === section}
-                  onClick={() => setActiveSection(section)}
+                  onClick={() => handleSectionChange(section)}
                 />
               ))}
             </NavigationList>

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -333,9 +333,6 @@ function CustomizationSection() {
     }
     if (localAgentsSectionVisible !== isAgentsSectionVisible) {
       setAgentsSectionVisible(localAgentsSectionVisible);
-      // Person property (not a click event) so we can query, per user, the
-      // actual resting preference for the home "Chat with..." section
-      // rather than counting toggle clicks that may never get saved.
       posthog.setPersonProperties({
         chat_with_section_enabled: localAgentsSectionVisible,
       });

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -70,6 +70,7 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
+import posthog from "posthog-js";
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useController, useForm } from "react-hook-form";
@@ -330,7 +331,15 @@ function CustomizationSection() {
     if (typeof window !== "undefined") {
       localStorage.setItem("submitMessageKey", submitKey);
     }
-    setAgentsSectionVisible(localAgentsSectionVisible);
+    if (localAgentsSectionVisible !== isAgentsSectionVisible) {
+      setAgentsSectionVisible(localAgentsSectionVisible);
+      // Person property (not a click event) so we can query, per user, the
+      // actual resting preference for the home "Chat with..." section
+      // rather than counting toggle clicks that may never get saved.
+      posthog.setPersonProperties({
+        chat_with_section_enabled: localAgentsSectionVisible,
+      });
+    }
   };
 
   return (
@@ -429,15 +438,9 @@ function CustomizationSection() {
           action={
             <SliderToggle
               selected={localAgentsSectionVisible}
-              onClick={() => {
-                const nextValue = !localAgentsSectionVisible;
-                setLocalAgentsSectionVisible(nextValue);
-                trackEvent({
-                  area: TRACKING_AREAS.SETTINGS,
-                  object: "chat_with_toggle",
-                  extra: { enabled: nextValue },
-                });
-              }}
+              onClick={() =>
+                setLocalAgentsSectionVisible(!localAgentsSectionVisible)
+              }
             />
           }
         />


### PR DESCRIPTION
## Why

We wanted to understand how people react to the "Show your agents on the home page" toggle (the one that hides/shows the "Chat with..." section on the home page) in Personal Settings.

## What's tracked

1. **Opening a settings tab** (Personal, Customization, Notifications, etc.) → a PostHog event fires every time, with the name of the tab. This tells us how many people go into Customization.

2. **The "Chat with..." preference itself** → instead of tracking every click on the toggle, we record the final state as info attached to the user's profile in PostHog, and only when they click **Save**.

We deliberately avoided tracking the raw click on the toggle, because the change only takes effect once Save is clicked — someone could click the toggle "just to try it" and then close the modal without saving, which would have skewed the numbers.

## What this lets us do in PostHog

With the info attached to the user's profile, we can directly ask PostHog "how many users currently have the section disabled / enabled", without having to reconstruct that from a stream of clicks.

## How to test before merging

1. Open the PR preview and add `?__posthog_debug=true` to the URL.
2. Open the browser Console.
3. Go to Personal Settings → Customization, toggle it, click Save.
4. Check the Console for a PostHog call containing `chat_with_section_enabled: true/false` with the expected value.