### PR TITLE
[front] enh: add try skill action

### DIFF
--- a/front/components/pages/conversation/ConversationPage.tsx
+++ b/front/components/pages/conversation/ConversationPage.tsx
@@ -3,6 +3,7 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAgentFromSearchParam } from "@app/hooks/useAgentFromSearchParam";
 import { useGoTemplateFromSearchParam } from "@app/hooks/useGoTemplateFromSearchParam";
 import { useOnboardingConversation } from "@app/hooks/useOnboardingConversation";
+import { useSkillFromSearchParam } from "@app/hooks/useSkillFromSearchParam";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { useEffect } from "react";
@@ -41,6 +42,9 @@ export function ConversationPage() {
 
   // Consume ?go= param: fetch Contentful template, prefill composer, clean up URL.
   useGoTemplateFromSearchParam(owner.sId);
+
+  // Consume ?skill= param: fetch the skill, prefill the composer, clean up URL.
+  useSkillFromSearchParam(owner.sId);
 
   return (
     <ConversationContainerVirtuoso

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -2,6 +2,7 @@ import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { SkillFavoriteButton } from "@app/components/skills/SkillFavoriteButton";
 import config from "@app/lib/api/config";
 import {
+  getConversationRoute,
   getManageSkillsRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
@@ -17,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Edit04,
+  MessagePlusCircle,
   Trash01,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
@@ -64,6 +66,13 @@ export function SkillDetailsButtonBar({
             }
           />
         )}
+        <Button
+          size="sm"
+          tooltip="Try skill"
+          href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
+          variant="outline"
+          icon={MessagePlusCircle}
+        />
         {skill.canAdministrate && (
           <Button
             size="sm"

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -57,13 +57,6 @@ export function SkillDetailsButtonBar({
         }}
       />
       <div className="flex flex-row items-center gap-2 px-1.5">
-        <Button
-          size="sm"
-          tooltip="Try skill"
-          href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
-          variant="outline"
-          icon={MessagePlusCircle}
-        />
         {onFavoriteChange && (
           <SkillFavoriteButton
             isFavorite={skill.isFavorite ?? false}
@@ -73,6 +66,13 @@ export function SkillDetailsButtonBar({
             }
           />
         )}
+        <Button
+          size="sm"
+          tooltip="Try skill"
+          href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
+          variant="outline"
+          icon={MessagePlusCircle}
+        />
         {skill.canAdministrate && (
           <Button
             size="sm"

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -57,6 +57,13 @@ export function SkillDetailsButtonBar({
         }}
       />
       <div className="flex flex-row items-center gap-2 px-1.5">
+        <Button
+          size="sm"
+          tooltip="Try skill"
+          href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
+          variant="outline"
+          icon={MessagePlusCircle}
+        />
         {onFavoriteChange && (
           <SkillFavoriteButton
             isFavorite={skill.isFavorite ?? false}
@@ -66,13 +73,6 @@ export function SkillDetailsButtonBar({
             }
           />
         )}
-        <Button
-          size="sm"
-          tooltip="Try skill"
-          href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
-          variant="outline"
-          icon={MessagePlusCircle}
-        />
         {skill.canAdministrate && (
           <Button
             size="sm"

--- a/front/hooks/useSkillFromSearchParam.ts
+++ b/front/hooks/useSkillFromSearchParam.ts
@@ -1,0 +1,46 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useSearchParam } from "@app/lib/platform";
+import { serializeSkillTag } from "@app/lib/skills/format";
+import { useSkill } from "@app/lib/swr/skill_configurations";
+import { useContext, useEffect } from "react";
+
+/**
+ * Reads the ?skill= search param, fetches the corresponding skill, pre-fills
+ * the composer with a skill reference, and cleans up the param from the URL.
+ */
+export function useSkillFromSearchParam(workspaceId: string) {
+  const skillId = useSearchParam("skill");
+  const { setPendingInputText } = useContext(InputBarContext);
+
+  const { skill } = useSkill({
+    workspaceId,
+    skillId,
+    disabled: !skillId,
+  });
+
+  useEffect(() => {
+    if (!skill) {
+      return;
+    }
+
+    setPendingInputText(
+      `Use the skill ${serializeSkillTag({
+        id: skill.sId,
+        name: skill.name,
+        icon: skill.icon,
+      })}`,
+      { replace: true }
+    );
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("skill")) {
+      params.delete("skill");
+      const queryString = params.toString();
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${queryString ? `?${queryString}` : ""}${window.location.hash}`
+      );
+    }
+  }, [skill, setPendingInputText]);
+}

--- a/front/hooks/useSkillFromSearchParam.ts
+++ b/front/hooks/useSkillFromSearchParam.ts
@@ -24,11 +24,11 @@ export function useSkillFromSearchParam(workspaceId: string) {
     }
 
     setPendingInputText(
-      `Use the skill ${serializeSkillTag({
+      `Use ${serializeSkillTag({
         id: skill.sId,
         name: skill.name,
         icon: skill.icon,
-      })}`,
+      })} for this request:`,
       { replace: true }
     );
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/pull/31410 added a button to copy a link to inspect a skill, by redirecting to the Manage Skills page, opened on the skill.

This PR adds a button to copy a link to try the skill, that opens the conversation page, prefilled with the skill.
Re-used the pattern for agents (`useAgentFromSearchParam`).

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
