### PR TITLE
[front] enh: add CTA to test a skill upon creation

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -14,13 +14,13 @@ import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/S
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderSuggestionsPanel } from "@app/components/skill_builder/SkillBuilderSuggestionsPanel";
-import { SkillCreatedDialog } from "@app/components/skill_builder/SkillCreatedDialog";
 import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
 import { SkillBuilderVersionComparisonFooter } from "@app/components/skill_builder/SkillBuilderVersionComparisonFooter";
 import {
   SkillVersionComparisonProvider,
   useSkillVersionComparisonContext,
 } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import { SkillCreatedDialog } from "@app/components/skill_builder/SkillCreatedDialog";
 import {
   SkillSpaceRestrictionsProvider,
   useSkillSpaceRestrictionsContext,

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -14,6 +14,7 @@ import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/S
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderSuggestionsPanel } from "@app/components/skill_builder/SkillBuilderSuggestionsPanel";
+import { SkillCreatedDialog } from "@app/components/skill_builder/SkillCreatedDialog";
 import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
 import { SkillBuilderVersionComparisonFooter } from "@app/components/skill_builder/SkillBuilderVersionComparisonFooter";
 import {
@@ -42,7 +43,9 @@ import {
 } from "@app/lib/swr/skill_editors";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { isString } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
 import {
   BarFooter,
@@ -70,6 +73,7 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
+  const [isCreatedDialogOpen, setIsCreatedDialogOpen] = useState(false);
   const [isAddingSelfAsEditor, setIsAddingSelfAsEditor] = useState(false);
   const isMobile = useIsMobile();
 
@@ -143,6 +147,21 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
 
   useNavigationLock(isDirty && !isSaving);
 
+  useEffect(() => {
+    const createdParam = router.query.showCreatedDialog;
+    const shouldOpenDialog =
+      Boolean(skill) &&
+      isString(createdParam) &&
+      (createdParam === "1" || createdParam === "true");
+
+    if (!shouldOpenDialog) {
+      return;
+    }
+
+    setIsCreatedDialogOpen(true);
+    void removeParamFromRouter(router, "showCreatedDialog");
+  }, [router, router.query.showCreatedDialog, skill]);
+
   const handleAddSelfAsEditor = async () => {
     if (!skill || isAddingSelfAsEditor) {
       return;
@@ -208,7 +227,7 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
     onSaved();
 
     if (isCreatingNew && savedSkill.sId) {
-      const newUrl = `/w/${owner.sId}/builder/skills/${savedSkill.sId}`;
+      const newUrl = `/w/${owner.sId}/builder/skills/${savedSkill.sId}?showCreatedDialog=1`;
       await router.replace(newUrl, undefined, { shallow: true });
     } else {
       form.reset(form.getValues(), { keepValues: true });
@@ -338,6 +357,15 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
   return (
     <SkillBuilderFormContext.Provider value={form}>
       <FormProvider form={form} asForm={false}>
+        {skill && (
+          <SkillCreatedDialog
+            open={isCreatedDialogOpen}
+            onOpenChange={setIsCreatedDialogOpen}
+            skillName={skill.name}
+            skillId={skill.sId}
+            owner={owner}
+          />
+        )}
         <SkillVersionComparisonProvider>
           <SkillSpaceRestrictionsProvider
             initialRequestedSpaceIds={skill?.requestedSpaceIds}

--- a/front/components/skill_builder/SkillCreatedDialog.tsx
+++ b/front/components/skill_builder/SkillCreatedDialog.tsx
@@ -38,7 +38,7 @@ export function SkillCreatedDialog({
           <DialogTitle>Skill {skillName} created!</DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          You can now use {skillName} in conversations. Try it in a chat or keep
+          You can now use {skillName}. Try it in a new conversation or keep
           editing this skill.
         </DialogContainer>
         <DialogFooter

--- a/front/components/skill_builder/SkillCreatedDialog.tsx
+++ b/front/components/skill_builder/SkillCreatedDialog.tsx
@@ -50,7 +50,7 @@ export function SkillCreatedDialog({
             },
           }}
           rightButtonProps={{
-            label: "Try skill",
+            label: "Start conversation",
             icon: MessageCircle01,
             href: conversationRoute,
           }}

--- a/front/components/skill_builder/SkillCreatedDialog.tsx
+++ b/front/components/skill_builder/SkillCreatedDialog.tsx
@@ -1,0 +1,61 @@
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  MessageCircle01,
+} from "@dust-tt/sparkle";
+
+interface SkillCreatedDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  skillName: string;
+  skillId: string;
+  owner: WorkspaceType;
+}
+
+export function SkillCreatedDialog({
+  open,
+  onOpenChange,
+  skillName,
+  skillId,
+  owner,
+}: SkillCreatedDialogProps) {
+  const conversationRoute = getConversationRoute(
+    owner.sId,
+    "new",
+    `skill=${skillId}`
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Skill {skillName} created!</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          You can now use {skillName} in conversations. Try it in a chat or keep
+          editing this skill.
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Keep editing",
+            variant: "outline",
+            onClick: () => {
+              onOpenChange(false);
+            },
+          }}
+          rightButtonProps={{
+            label: "Try skill",
+            icon: MessageCircle01,
+            href: conversationRoute,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/hooks/useSkillFromSearchParam.ts
+++ b/front/hooks/useSkillFromSearchParam.ts
@@ -23,7 +23,6 @@ export function useSkillFromSearchParam(workspaceId: string) {
       return;
     }
 
-    // Keep a space between the prefill and what the user types.
     setPendingInputText(
       `Use ${serializeSkillTag({
         id: skill.sId,

--- a/front/hooks/useSkillFromSearchParam.ts
+++ b/front/hooks/useSkillFromSearchParam.ts
@@ -23,12 +23,13 @@ export function useSkillFromSearchParam(workspaceId: string) {
       return;
     }
 
+    // Keep a space between the prefill and what the user types.
     setPendingInputText(
       `Use ${serializeSkillTag({
         id: skill.sId,
         name: skill.name,
         icon: skill.icon,
-      })} for this request:`,
+      })} for this request: `,
       { replace: true }
     );
 


### PR DESCRIPTION
## Description

This PR adds a dialog that prompts the user to test the skill in-conversation after saving it for the first time, following the Agent Builder pattern.

The dialog offers two options: `Keep editing` and `Try skill`; `Try skill` opens the prefilled conversation path from #31427.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
