### PR TITLE
Admin governance: drop the builder role from tests

### DIFF
--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
@@ -82,7 +82,7 @@ function getEvents(
 async function setupConversation() {
   const { workspace, key } = await createPublicApiMockRequest();
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId

--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.test.ts
@@ -77,7 +77,7 @@ function getMessageEvents(
 async function setupAgentMessage() {
   const { workspace, key } = await createPublicApiMockRequest();
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId

--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -173,7 +173,7 @@ async function setupTest({
   endDate?: string;
   timezone?: string;
   format?: string;
-  role?: "user" | "builder" | "admin";
+  role?: "user" | "admin";
   method?: string;
 } = {}) {
   const { workspace, key } = await createPublicApiMockRequest({ role });
@@ -216,18 +216,6 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     const { response } = await setupTest();
 
     expect(response.status).toBe(200);
-  });
-
-  it("returns 403 for builder API key", async () => {
-    const { response } = await setupTest({ role: "builder" });
-
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "workspace_auth_error",
-        message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
-      },
-    });
   });
 
   it("returns 403 for read-only API key (insufficient scope)", async () => {

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
@@ -39,7 +39,7 @@ async function setupTestAgents(workspace: WorkspaceType) {
   await SpaceFactory.defaults(internalAdminAuth);
 
   const agentOwner = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, agentOwner, { role: "builder" });
+  await MembershipFactory.associate(workspace, agentOwner, { role: "user" });
   const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     agentOwner.sId,
     workspace.sId
@@ -97,7 +97,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
 
   it("rejects the all_unrestricted view for non-admin keys", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
-      role: "builder",
+      role: "user",
     });
 
     const response = await listAgents(workspace, key, {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].test.ts
@@ -18,7 +18,7 @@ const { mockGetFileContentType, mockCreateReadStream } = vi.hoisted(() => ({
 async function setup() {
   const { workspace, key } = await createPublicApiMockRequest();
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -19,7 +19,7 @@ async function setupGetRequest() {
   });
 
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId
@@ -137,7 +137,7 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
     });
 
     const user = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, user, { role: "builder" });
+    await MembershipFactory.associate(workspace, user, { role: "user" });
     const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.test.ts
@@ -35,7 +35,7 @@ async function setupTest() {
 
   // Create a user and agent for testing
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId

--- a/front-api/routes/v1/w/[wId]/assistant/mentions/parse.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/mentions/parse.test.ts
@@ -13,7 +13,7 @@ async function setupTest() {
 
   // Create a user and agent for testing
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId

--- a/front-api/routes/v1/w/[wId]/assistant/mentions/suggestions.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/mentions/suggestions.test.ts
@@ -34,7 +34,7 @@ async function setup() {
 
   // Create a user and agent for testing
   const user = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  await MembershipFactory.associate(workspace, user, { role: "user" });
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
     workspace.sId

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -425,9 +425,9 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       workspace.sId
     );
     await SpaceFactory.defaults(adminAuth);
-    // The mock key's role ("builder") doesn't grant create/skill by itself anymore — it
-    // requires a group grant. The key is scoped to the workspace's global group, so granting
-    // the capability to everybody satisfies it.
+    // The mock key's role doesn't grant create/skill by itself — it requires a group grant. The
+    // key is scoped to the workspace's global group, so granting the capability to everybody
+    // satisfies it.
     await GroupPermissionResource.setForEverybody(adminAuth, {
       grantType: "create",
       resourceType: "skill",
@@ -441,10 +441,10 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     const firstEditor = await UserFactory.basic();
     const secondEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, firstEditor, {
-      role: "builder",
+      role: "user",
     });
     await MembershipFactory.associate(workspace, secondEditor, {
-      role: "builder",
+      role: "user",
     });
 
     const firstImport = await importSkillsFromFiles(auth, {
@@ -502,7 +502,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     );
   });
 
-  it("rejects the import for a non-builder API key", async () => {
+  it("rejects the import for a key without the create/skill capability", async () => {
     const { auth, workspace } = await createPublicApiMockRequest({
       role: "user",
     });

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -80,7 +80,7 @@ function postWebhook(
 async function makeTriggerEditorAuth(workspace: WorkspaceType) {
   const triggerEditor = await UserFactory.basic();
   await MembershipFactory.associate(workspace, triggerEditor, {
-    role: "builder",
+    role: "user",
   });
 
   return Authenticator.fromUserIdAndWorkspaceId(

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -8,6 +8,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import type { UserType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
@@ -18,8 +19,8 @@ vi.mock("@app/lib/api/assistant/recent_authors", () => ({
 
 async function setupTest(
   options: {
-    agentOwnerRole?: "admin" | "builder" | "user";
-    requestUserRole?: "admin" | "builder" | "user";
+    agentOwnerRole?: MembershipRoleType;
+    requestUserRole?: MembershipRoleType;
   } = {}
 ) {
   const agentOwnerRole = options.agentOwnerRole ?? "admin";
@@ -87,8 +88,8 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/editors", () => {
 
   it("should return 200 and only light user fields for non-admin editor", async () => {
     const { workspace, agent, agentOwner } = await setupTest({
-      agentOwnerRole: "builder",
-      requestUserRole: "builder",
+      agentOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const response = await getEditors(workspace, agent.sId);
@@ -149,7 +150,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
 
     const newEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, newEditor, {
-      role: "builder",
+      role: "user",
     });
 
     const response = await patchEditors(workspace, agent.sId, {
@@ -165,7 +166,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
 
   it("admin who is not an agent editor can become an editor", async () => {
     const { workspace, agent, agentOwner, requestUser } = await setupTest({
-      agentOwnerRole: "builder",
+      agentOwnerRole: "user",
       requestUserRole: "admin",
     });
 
@@ -187,7 +188,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
 
     const editorToRemove = await UserFactory.basic();
     await MembershipFactory.associate(workspace, editorToRemove, {
-      role: "builder",
+      role: "user",
     });
     const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,
@@ -213,8 +214,8 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
 
   it("editor should successfully add another editor and get light response", async () => {
     const { workspace, agent, agentOwner } = await setupTest({
-      agentOwnerRole: "builder",
-      requestUserRole: "builder",
+      agentOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const newEditor = await UserFactory.basic();
@@ -235,8 +236,8 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
 
   it("editor should successfully remove another editor", async () => {
     const { workspace, agent, agentOwner, requestUser } = await setupTest({
-      agentOwnerRole: "builder",
-      requestUserRole: "builder",
+      agentOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const editorToRemove = await UserFactory.basic();
@@ -380,7 +381,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
 
     const editorToAdd = await UserFactory.basic();
     await MembershipFactory.associate(workspace, editorToAdd, {
-      role: "builder",
+      role: "user",
     });
 
     const response = await patchEditors(workspace, agent.sId, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/feedbacks/[fId].test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/feedbacks/[fId].test.ts
@@ -79,7 +79,7 @@ function patchFeedback(
 describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/feedbacks/:fId", () => {
   it("allows an editor of the agent to dismiss feedback", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
       method: "PATCH",
     });
 
@@ -101,9 +101,9 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/feedbacks/:fId",
     expect(refetched?.dismissed).toBe(true);
   });
 
-  it("returns 403 for a builder who is not an editor of the agent", async () => {
+  it("returns 403 for a user who is not an editor of the agent", async () => {
     const { workspace } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
       method: "PATCH",
     });
 
@@ -111,7 +111,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/feedbacks/:fId",
     // editor even though they have the builder role.
     const agentOwner: UserResource = await UserFactory.basic();
     await MembershipFactory.associate(workspace, agentOwner, {
-      role: "builder",
+      role: "user",
     });
     const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -142,7 +142,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId - non-editor adm
 
     const { agentOwner, agentOwnerAuth } = await setupAgentOwner(
       workspace,
-      "builder"
+      "user"
     );
     const agent =
       await AgentConfigurationFactory.createTestAgent(agentOwnerAuth);

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -17,7 +17,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
   it("should return 200 with empty array when agent has no skills", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "builder",
+      role: "user",
     });
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -38,7 +38,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
   it("should return 200 with skills when agent has skills", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "builder",
+      role: "user",
     });
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -82,7 +82,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
   it("should return 404 when agent does not exist", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "builder",
+      role: "user",
     });
 
     const response = await getSkills(workspace, "non_existent_agent_sId");
@@ -100,7 +100,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
   it("should only return skills from the correct workspace", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "builder",
+      role: "user",
     });
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -123,8 +123,8 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
     expect(data.skills[0].name).toBe("Workspace Skill");
   });
 
-  it("should work for builder roles (builder, admin)", async () => {
-    for (const role of ["builder", "admin"] as const) {
+  it("should work for user and admin roles", async () => {
+    for (const role of ["user", "admin"] as const) {
       const { workspace, user } = await createPrivateApiMockRequest({
         method: "GET",
         role: role as MembershipRoleType,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
@@ -11,7 +11,7 @@ import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function setupTest(options: { role?: MembershipRoleType } = {}) {
-  const role = options.role ?? "builder";
+  const role = options.role ?? "user";
   const { workspace, auth } = await createPrivateApiMockRequest({ role });
   const agent = await AgentConfigurationFactory.createTestAgent(auth);
   return { workspace, auth, agent };
@@ -56,7 +56,7 @@ function patchSuggestions(
 describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/suggestions", () => {
   it("returns 404 for non-existent agent", async () => {
     const { workspace } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
     });
 
     const response = await patchSuggestions(workspace, "non-existent-agent", {
@@ -265,7 +265,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/suggestions", ()
 
     const agentOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, agentOwner, {
-      role: "builder",
+      role: "user",
     });
     const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,
@@ -430,7 +430,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/suggestions", () =
 
     const agentOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, agentOwner, {
-      role: "builder",
+      role: "user",
     });
     const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
@@ -14,6 +14,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
@@ -44,7 +45,7 @@ async function findTargetModel(auth: Authenticator) {
   return target;
 }
 
-async function setupTest(role: "admin" | "user") {
+async function setupTest(role: MembershipRoleType) {
   const { workspace, auth } = await createPrivateApiMockRequest({ role });
 
   const agent = await AgentConfigurationFactory.createTestAgent(auth, {
@@ -70,7 +71,7 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", (
     // require a space the acting admin is not a member of: what "Show hidden agents" surfaces.
     const agentOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, agentOwner, {
-      role: "builder",
+      role: "user",
     });
     const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,
@@ -217,7 +218,7 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", (
     const { workspace, auth } = await createPrivateApiMockRequest({
       role: "admin",
     });
-    const { agentOwnerAuth } = await setupAgentOwner(workspace, "builder");
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
 
     // Authored by, and only editable by, someone else.
     const agent = await AgentConfigurationFactory.createTestAgent(

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.test.ts
@@ -30,7 +30,7 @@ async function createOtherMemberAgent(
   { name }: { name: string }
 ) {
   const agentOwner = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, agentOwner, { role: "builder" });
+  await MembershipFactory.associate(workspace, agentOwner, { role: "user" });
   const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     agentOwner.sId,
     workspace.sId
@@ -73,7 +73,7 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_scope", (
   it("returns 403 for non-admins", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
 
     const response = await batchUpdateScope(workspace, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -75,7 +75,7 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", ()
     // acting admin is not a member of: exactly what "Show hidden agents" surfaces.
     const agentOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, agentOwner, {
-      role: "builder",
+      role: "user",
     });
     const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -15,6 +15,7 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { MembershipRoleType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -45,7 +46,7 @@ const TEST_AGENT_PARAMS = {
 
 export async function setupAgentOwner(
   workspace: LightWorkspaceType,
-  agentOwnerRole: "admin" | "builder" | "user"
+  agentOwnerRole: MembershipRoleType
 ) {
   const agentOwner = await UserFactory.basic();
   await MembershipFactory.associate(workspace, agentOwner, {
@@ -279,7 +280,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
 
     // Both agents belong to another member: one is unpublished and the admin is not an editor,
     // the other requires a space the admin is not a member of.
-    const { agentOwnerAuth } = await setupAgentOwner(workspace, "builder");
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
     const restrictedSpace = await SpaceFactory.regular(workspace);
     await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
       name: "Unpublished agent",
@@ -313,7 +314,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
   it("returns 403 for the manage_unrestricted view without admin role", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "builder",
+      role: "user",
     });
 
     const response = await listAgents(workspace, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/similar.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/similar.test.ts
@@ -3,6 +3,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,7 +15,7 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 
 import { honoApp } from "@front-api/app";
 
-async function setup(role: "builder" | "user" | "admin" = "builder") {
+async function setup(role: MembershipRoleType = "user") {
   const { workspace, user } = await createPrivateApiMockRequest({ role });
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,

--- a/front-api/routes/w/[wId]/assistant/mentions/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/mentions/index.test.ts
@@ -26,7 +26,7 @@ import { honoApp } from "@front-api/app";
 
 async function setup() {
   const { workspace, auth } = await createPrivateApiMockRequest({
-    role: "builder",
+    role: "user",
   });
   const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
     name: "Test Agent",

--- a/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
+++ b/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
@@ -25,7 +25,7 @@ vi.mock("@app/lib/reinforcement/aggregate_suggestions", () => ({
 import { honoApp } from "@front-api/app";
 
 async function setup(options: { role?: MembershipRoleType } = {}) {
-  const role = options.role ?? "builder";
+  const role = options.role ?? "user";
   const { workspace, auth } = await createPrivateApiMockRequest({ role });
 
   const skill = await SkillFactory.create(auth);
@@ -40,7 +40,7 @@ async function setupAdminWithOtherBuilderSkill() {
 
   const skillOwner = await UserFactory.basic();
   await MembershipFactory.associate(workspace, skillOwner, {
-    role: "builder",
+    role: "user",
   });
   const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     skillOwner.sId,
@@ -92,7 +92,7 @@ function get(
 describe("PATCH /api/w/:wId/assistant/skills/:sId/suggestions", () => {
   it("returns 404 for non-existent skill", async () => {
     const { workspace } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
     });
 
     const response = await patch(workspace, "non-existent-skill", {
@@ -294,7 +294,7 @@ describe("PATCH /api/w/:wId/assistant/skills/:sId/suggestions", () => {
 
     const skillOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, skillOwner, {
-      role: "builder",
+      role: "user",
     });
     const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       skillOwner.sId,
@@ -514,7 +514,7 @@ describe("GET /api/w/:wId/assistant/skills/:sId/suggestions", () => {
 
     const skillOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, skillOwner, {
-      role: "builder",
+      role: "user",
     });
     const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       skillOwner.sId,

--- a/front-api/routes/w/[wId]/builder/skills/suggestions.test.ts
+++ b/front-api/routes/w/[wId]/builder/skills/suggestions.test.ts
@@ -18,7 +18,7 @@ import { honoApp } from "@front-api/app";
 
 async function setup() {
   const { workspace } = await createPrivateApiMockRequest({
-    role: "builder",
+    role: "user",
     method: "POST",
   });
   return { workspace };

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -367,7 +367,7 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     expect(response.status).toBe(204);
   });
 
-  it("should deny non-author without builder role from deleting upload files", async () => {
+  it("should deny a non-author from deleting upload files", async () => {
     const { auth, workspace, globalSpace } = await createPrivateApiMockRequest({
       method: "DELETE",
       role: "user",
@@ -478,7 +478,7 @@ describe("POST /api/w/:wId/files/:fileId", () => {
     vi.clearAllMocks();
   });
 
-  it("should allow a non-builder skill editor to upload an attachment", async () => {
+  it("should allow a skill editor to upload an attachment", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",
@@ -500,10 +500,10 @@ describe("POST /api/w/:wId/files/:fileId", () => {
     expect(response.status).toBe(200);
   });
 
-  it("should deny a builder who is not a skill editor", async () => {
+  it("should deny a member who is not a skill editor", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const skill = await SkillFactory.create(auth, {
       addCurrentUserAsEditor: false,
@@ -563,10 +563,10 @@ describe("POST /api/w/:wId/files/:fileId", () => {
     expect(response.status).toBe(200);
   });
 
-  it("should allow builder to upload any file", async () => {
+  it("should allow a workspace member to upload any file", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
 
     const conversation = await ConversationFactory.create(auth, {
@@ -618,7 +618,7 @@ describe("POST /api/w/:wId/files/:fileId", () => {
     expect(response.status).toBe(200);
   });
 
-  it("should deny non-author without builder role from uploading to space", async () => {
+  it("should deny a non-author from uploading to space", async () => {
     const { auth, workspace, globalSpace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
@@ -43,7 +43,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
   it("should return 400 when fileName is missing", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "user",
     });
 
     const file = await FileFactory.create(auth, user, {
@@ -63,7 +63,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
   it("should return 400 when fileName is empty", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "user",
     });
 
     const file = await FileFactory.create(auth, user, {

--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -284,10 +284,10 @@ describe("POST /api/w/:wId/groups", () => {
     expect((await response.json()).error.type).toBe("workspace_auth_error");
   });
 
-  it("returns 403 for a builder", async () => {
+  it("returns 403 for a regular user", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
 
     const response = await postGroup(workspace, { name: "Nope" });

--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -56,7 +56,7 @@ describe("POST /api/w/:wId (reinforcement caps)", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await post(workspace, {
@@ -131,7 +131,7 @@ describe("POST /api/w/:wId (workspace default agent)", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await post(workspace, {
@@ -180,7 +180,7 @@ describe("POST /api/w/:wId (published agents restricted models)", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await post(workspace, {
@@ -225,7 +225,7 @@ describe("POST /api/w/:wId (workspace analytics opt-out)", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await post(workspace, {

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -19,7 +19,7 @@ describe("GET /api/w/:wId/keys — secret visibility", () => {
         userId: user.id,
         isSystem: false,
         status: "active",
-        role: "builder",
+        role: "user",
       },
       [globalGroup]
     );
@@ -47,7 +47,7 @@ describe("GET /api/w/:wId/keys — secret visibility", () => {
         userId: user.id,
         isSystem: false,
         status: "active",
-        role: "builder",
+        role: "user",
       },
       [globalGroup]
     );

--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.test.ts
@@ -3,10 +3,11 @@ import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_r
 import { makeSId } from "@app/lib/resources/string_ids";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace, auth, systemSpace } = await createPrivateApiMockRequest({
     role,
   });

--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.test.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.test.ts
@@ -7,6 +7,7 @@ import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it, vi } from "vitest";
@@ -51,7 +52,7 @@ function metadataWithTools(tools: MCPToolType[]): Omit<MCPServerType, "sId"> {
   };
 }
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace, auth, systemSpace } = await createPrivateApiMockRequest({
     role,
     method: "POST",

--- a/front-api/routes/w/[wId]/mcp/deregister.test.ts
+++ b/front-api/routes/w/[wId]/mcp/deregister.test.ts
@@ -1,4 +1,5 @@
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockDeregisterMCPServer } = vi.hoisted(() => ({
@@ -21,7 +22,7 @@ vi.mock(
 
 import { honoApp } from "@front-api/app";
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace } = await createPrivateApiMockRequest({
     role,
     method: "POST",

--- a/front-api/routes/w/[wId]/mcp/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/index.test.ts
@@ -15,6 +15,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -35,7 +36,7 @@ vi.mock(import("@app/lib/actions/mcp_metadata"), async (importOriginal) => {
 
 import { honoApp } from "@front-api/app";
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace, auth } = await createPrivateApiMockRequest({ role });
   await SpaceFactory.defaults(auth);
   return { workspace, auth };

--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.test.ts
@@ -8,10 +8,11 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace, auth, globalSpace, systemSpace } =
     await createPrivateApiMockRequest({ role });
   return { workspace, globalSpace, systemSpace, auth };

--- a/front-api/routes/w/[wId]/members/[uId]/index.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.test.ts
@@ -257,7 +257,7 @@ describe("POST /api/w/:wId/members/:uId", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ role: "builder" }),
+          body: JSON.stringify({ role: "user" }),
         }
       );
 
@@ -481,7 +481,7 @@ describe("POST /api/w/:wId/members/:uId", () => {
 
       const targetUser = await UserFactory.basic();
       await MembershipFactory.associate(workspace, targetUser, {
-        role: "builder",
+        role: "user",
       });
 
       const response = await honoApp.request(
@@ -494,7 +494,7 @@ describe("POST /api/w/:wId/members/:uId", () => {
         new Set(Object.keys(data.member))
       );
       expect(data.member.id).toBe(targetUser.sId);
-      expect(data.member.role).toBe("builder");
+      expect(data.member.role).toBe("user");
     });
 
     it("should return 200 when non-admin user requests another user's data", async () => {

--- a/front-api/routes/w/[wId]/members/index.test.ts
+++ b/front-api/routes/w/[wId]/members/index.test.ts
@@ -2,13 +2,14 @@ import { parseQueryString } from "@app/lib/utils/router";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
 import { describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "./index";
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace } = await createPrivateApiMockRequest({ role });
   return { workspace };
 }
@@ -60,8 +61,8 @@ describe("GET /api/w/:wId/members", () => {
     });
   });
 
-  it("returns 403 for builder users", async () => {
-    const { workspace } = await setup("builder");
+  it("returns 403 for non-admin users", async () => {
+    const { workspace } = await setup("user");
 
     const response = await honoApp.request(membersUrl(workspace.sId));
 

--- a/front-api/routes/w/[wId]/members/search.test.ts
+++ b/front-api/routes/w/[wId]/members/search.test.ts
@@ -3,6 +3,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { describe, expect, it, vi } from "vitest";
@@ -74,7 +75,7 @@ vi.mock(import("@app/lib/user_search/search"), async (importOriginal) => {
 
 import { honoApp } from "@front-api/app";
 
-async function setup(role: "builder" | "user" | "admin" = "admin") {
+async function setup(role: MembershipRoleType = "admin") {
   const { workspace, user } = await createPrivateApiMockRequest({ role });
   return { workspace, user };
 }

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -46,7 +46,7 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     const skill = await SkillFactory.create(auth);
     const builderUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, builderUser, {
-      role: "builder",
+      role: "user",
     });
 
     await skill.archive(auth);
@@ -70,14 +70,14 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     );
   });
 
-  it("allows adding builder as editor", async () => {
+  it("allows adding a workspace member as editor", async () => {
     const { workspace, auth } = await setup();
 
     const skill = await SkillFactory.create(auth);
 
     const builderUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, builderUser, {
-      role: "builder",
+      role: "user",
     });
 
     const response = await patch(workspace, skill.sId, {
@@ -117,7 +117,7 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
 
     const builderUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, builderUser, {
-      role: "builder",
+      role: "user",
     });
     const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
       builderUser.sId,
@@ -155,14 +155,14 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     expect(data.editors).toHaveLength(2); // admin + regular user
   });
 
-  it("allows a mixed batch (builder + user)", async () => {
+  it("allows a mixed batch of members", async () => {
     const { workspace, auth } = await setup();
 
     const skill = await SkillFactory.create(auth);
 
     const builderUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, builderUser, {
-      role: "builder",
+      role: "user",
     });
 
     const regularUser = await UserFactory.basic();
@@ -211,7 +211,7 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     });
 
     const outsider = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, outsider, { role: "builder" });
+    await MembershipFactory.associate(workspace, outsider, { role: "user" });
 
     const response = await patch(workspace, skill.sId, {
       addEditorIds: [outsider.sId],
@@ -237,7 +237,7 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     const space = await SpaceFactory.regular(workspace);
 
     const peer = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, peer, { role: "builder" });
+    await MembershipFactory.associate(workspace, peer, { role: "user" });
     await space.addMembers(adminAuth, { userIds: [user.sId, peer.sId] });
 
     const skill = await SkillFactory.create(auth, {
@@ -261,7 +261,7 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     });
 
     const outsider = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, outsider, { role: "builder" });
+    await MembershipFactory.associate(workspace, outsider, { role: "user" });
 
     const response = await patch(workspace, skill.sId, {
       addEditorIds: [outsider.sId],

--- a/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.test.ts
@@ -117,7 +117,7 @@ describe("GET /api/w/:wId/skills/:sId/files/:fileId/content", () => {
   it("returns 404 for non-skill attachment files", async () => {
     const { auth, workspace, user } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "builder",
+      role: "user",
     });
     const skill = await SkillFactory.create(auth);
 

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.test.ts
@@ -3,13 +3,14 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function setupOtherBuilderSkill({
   requestUserRole,
 }: {
-  requestUserRole: "admin" | "builder";
+  requestUserRole: MembershipRoleType;
 }) {
   const { workspace } = await createPrivateApiMockRequest({
     role: requestUserRole,
@@ -17,7 +18,7 @@ async function setupOtherBuilderSkill({
 
   const skillOwner = await UserFactory.basic();
   await MembershipFactory.associate(workspace, skillOwner, {
-    role: "builder",
+    role: "user",
   });
   const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     skillOwner.sId,
@@ -46,7 +47,7 @@ describe("GET /api/w/:wId/skills/:sId/history", () => {
 
   it("returns 404 for a non-admin user who cannot administrate the skill", async () => {
     const { workspace, skill } = await setupOtherBuilderSkill({
-      requestUserRole: "builder",
+      requestUserRole: "user",
     });
 
     const response = await get(workspace, skill.sId);

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -15,14 +15,15 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import type { WhereOptions } from "sequelize";
 import { describe, expect, it } from "vitest";
 
 async function setupTest(
   options: {
-    skillOwnerRole?: "admin" | "builder" | "user";
-    requestUserRole?: "admin" | "builder" | "user";
+    skillOwnerRole?: MembershipRoleType;
+    requestUserRole?: MembershipRoleType;
   } = {}
 ) {
   const skillOwnerRole = options.skillOwnerRole ?? "admin";
@@ -255,7 +256,7 @@ describe("GET /api/w/:wId/skills/:sId", () => {
 describe("PATCH /api/w/:wId/skills/:sId", () => {
   it("should return 403 for non-editor user", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
+      skillOwnerRole: "admin",
       requestUserRole: "user",
     });
 
@@ -487,7 +488,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
 
   it("denies any edit to a non-editor even with the publish permission", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
+      skillOwnerRole: "user",
       requestUserRole: "admin",
     });
 
@@ -832,7 +833,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     });
 
     const coEditor = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, coEditor, { role: "builder" });
+    await MembershipFactory.associate(workspace, coEditor, { role: "user" });
     const addRes = await skill.addEditors(requestUserAuth, [coEditor]);
     if (addRes.isErr()) {
       throw new Error("Failed to add the co-editor");
@@ -874,7 +875,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     );
 
     const coEditor = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, coEditor, { role: "builder" });
+    await MembershipFactory.associate(workspace, coEditor, { role: "user" });
     await restrictedSpace.addMembers(adminAuth, {
       userIds: [requestUser.sId, coEditor.sId],
     });
@@ -1252,8 +1253,8 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
   it("should update file attachments", async () => {
     const { auth, workspace, skill, requestUser, requestUserAuth } =
       await setupTest({
-        skillOwnerRole: "builder",
-        requestUserRole: "builder",
+        skillOwnerRole: "user",
+        requestUserRole: "user",
       });
 
     const file = await FileFactory.create(auth, requestUser, {
@@ -1294,8 +1295,8 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
 
   it("should succeed without file attachments", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
-      requestUserRole: "builder",
+      skillOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const response = await patchSkill(workspace, skill.sId, {
@@ -1315,8 +1316,8 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
   it("should remove file attachments when updating with empty array", async () => {
     const { auth, workspace, skill, requestUser, requestUserAuth } =
       await setupTest({
-        skillOwnerRole: "builder",
-        requestUserRole: "builder",
+        skillOwnerRole: "user",
+        requestUserRole: "user",
       });
 
     const file = await FileFactory.create(auth, requestUser, {
@@ -1382,7 +1383,7 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
 describe("DELETE /api/w/:wId/skills/:sId", () => {
   it("should return 403 for non-editor user", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
+      skillOwnerRole: "admin",
       requestUserRole: "user",
     });
 
@@ -1425,7 +1426,7 @@ describe("DELETE /api/w/:wId/skills/:sId", () => {
 
   it("allows a workspace admin to archive a skill they do not edit", async () => {
     const { workspace, requestUserAuth, skill } = await setupTest({
-      skillOwnerRole: "builder",
+      skillOwnerRole: "user",
       requestUserRole: "admin",
     });
 

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -6,13 +6,14 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function setupTest(
   options: {
-    skillOwnerRole?: "admin" | "builder" | "user";
-    requestUserRole?: "admin" | "builder" | "user";
+    skillOwnerRole?: MembershipRoleType;
+    requestUserRole?: MembershipRoleType;
   } = {}
 ) {
   const skillOwnerRole = options.skillOwnerRole ?? "admin";
@@ -135,7 +136,7 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
   it("allows a workspace admin to update reinforcement for a skill they do not edit", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
-      skillOwnerRole: "builder",
+      skillOwnerRole: "user",
       requestUserRole: "admin",
     });
 
@@ -167,7 +168,7 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
   it("returns 403 for a non-editor user", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
+      skillOwnerRole: "admin",
       requestUserRole: "user",
     });
 
@@ -315,8 +316,8 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
   it("returns 403 when a non-admin tries to set selfImprovementLock", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
-      requestUserRole: "builder",
+      skillOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const response = await patch(workspace, skill.sId, {
@@ -334,8 +335,8 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
   it("returns 403 when a non-admin tries to set the per-skill cap", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
-      requestUserRole: "builder",
+      skillOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const response = await patch(workspace, skill.sId, {
@@ -347,8 +348,8 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
   it("returns 403 when a non-admin tries to set the per-skill AWU credits cap", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
-      requestUserRole: "builder",
+      skillOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     const response = await patch(workspace, skill.sId, {
@@ -360,8 +361,8 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
   it("returns 403 when a non-admin tries to flip reinforcement on a locked skill", async () => {
     const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
-      requestUserRole: "builder",
+      skillOwnerRole: "user",
+      requestUserRole: "user",
     });
 
     // Lock the skill via direct resource update — admin-only via the API.

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.test.ts
@@ -4,16 +4,17 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function setupTest(
   options: {
-    requestUserRole?: "admin" | "builder" | "user";
-    skillOwnerRole?: "admin" | "builder";
+    requestUserRole?: MembershipRoleType;
+    skillOwnerRole?: MembershipRoleType;
   } = {}
 ) {
-  const requestUserRole = options.requestUserRole ?? "builder";
+  const requestUserRole = options.requestUserRole ?? "user";
   const skillOwnerRole = options.skillOwnerRole ?? requestUserRole;
   const { workspace, user } = await createPrivateApiMockRequest({
     role: requestUserRole,
@@ -53,7 +54,7 @@ function post(workspace: { sId: string }, sId: string) {
 describe("POST /api/w/:wId/skills/:sId/restore", () => {
   it("should return 200 and restore skill when user can administrate", async () => {
     const { workspace, skill, auth } = await setupTest({
-      requestUserRole: "builder",
+      requestUserRole: "user",
     });
 
     const response = await post(workspace, skill.sId);
@@ -68,7 +69,7 @@ describe("POST /api/w/:wId/skills/:sId/restore", () => {
   it("allows a workspace admin to restore a skill they do not edit", async () => {
     const { workspace, skill, auth } = await setupTest({
       requestUserRole: "admin",
-      skillOwnerRole: "builder",
+      skillOwnerRole: "user",
     });
 
     const response = await post(workspace, skill.sId);
@@ -82,7 +83,7 @@ describe("POST /api/w/:wId/skills/:sId/restore", () => {
 
   it("should return 403 when user cannot administrate", async () => {
     const { workspace, skill } = await setupTest({
-      requestUserRole: "builder",
+      requestUserRole: "user",
       skillOwnerRole: "admin",
     });
 

--- a/front-api/routes/w/[wId]/skills/archive.test.ts
+++ b/front-api/routes/w/[wId]/skills/archive.test.ts
@@ -14,7 +14,7 @@ async function setupTest(role: MembershipRoleType = "admin") {
   });
   const skillOwner = await UserFactory.basic();
   await MembershipFactory.associate(workspace, skillOwner, {
-    role: "builder",
+    role: "user",
   });
 
   const requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -66,7 +66,7 @@ describe("POST /api/w/:wId/skills/archive", () => {
 
   it("denies a caller who cannot administrate every skill", async () => {
     const { workspace, requestUserAuth, skillOwnerAuth } =
-      await setupTest("builder");
+      await setupTest("user");
     const administratedSkill = await SkillFactory.create(requestUserAuth, {
       name: "Administrated Skill",
     });

--- a/front-api/routes/w/[wId]/skills/availability.test.ts
+++ b/front-api/routes/w/[wId]/skills/availability.test.ts
@@ -18,7 +18,7 @@ async function setupTest(role: MembershipRoleType = "admin") {
   // editor group: the batch endpoint relies on the publish permission alone.
   const skillOwner = await UserFactory.basic();
   await MembershipFactory.associate(workspace, skillOwner, {
-    role: "builder",
+    role: "user",
   });
   const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     skillOwner.sId,
@@ -156,7 +156,7 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
   });
 
   it("denies a caller without the publish permission", async () => {
-    const { workspace, skillOwnerAuth } = await setupTest("builder");
+    const { workspace, skillOwnerAuth } = await setupTest("user");
     const skill = await SkillFactory.create(skillOwnerAuth);
 
     const response = await patchSkillsAvailability(workspace, {
@@ -168,8 +168,7 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
   });
 
   it("denies making skills auto-discoverable without the make_discoverable permission", async () => {
-    const { workspace, requestUser, skillOwnerAuth } =
-      await setupTest("builder");
+    const { workspace, requestUser, skillOwnerAuth } = await setupTest("user");
     // The caller can publish skills, but not make them auto-discoverable.
     await grantWorkspacePermission(workspace, requestUser, {
       grantType: "publish",
@@ -195,7 +194,7 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
 
   it("denies changing an auto-discoverable skill's availability without the make_discoverable permission", async () => {
     const { workspace, requestUser, requestUserAuth, skillOwnerAuth } =
-      await setupTest("builder");
+      await setupTest("user");
     // The caller can publish skills, but not make them auto-discoverable.
     await grantWorkspacePermission(workspace, requestUser, {
       grantType: "publish",
@@ -221,7 +220,7 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
 
   it("allows changing an auto-discoverable skill's availability with the make_discoverable permission", async () => {
     const { workspace, requestUser, requestUserAuth, skillOwnerAuth } =
-      await setupTest("builder");
+      await setupTest("user");
     await grantWorkspacePermission(workspace, requestUser, {
       grantType: "publish",
       resourceType: "skill",
@@ -249,7 +248,7 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
 
   it("allows making skills auto-discoverable with the make_discoverable permission", async () => {
     const { workspace, requestUser, requestUserAuth, skillOwnerAuth } =
-      await setupTest("builder");
+      await setupTest("user");
     await grantWorkspacePermission(workspace, requestUser, {
       grantType: "publish",
       resourceType: "skill",

--- a/front-api/routes/w/[wId]/skills/import/github-connection/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/import/github-connection/index.test.ts
@@ -85,7 +85,7 @@ describe("POST /api/w/:wId/skills/import/github-connection", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await post(workspace, {
@@ -129,12 +129,14 @@ describe("GET /api/w/:wId/skills/import/github-connection", () => {
     expect(await response.json()).toEqual({ connection: null });
   });
 
-  it("returns 403 for non-builder users", async () => {
-    const { workspace } = await setup("user");
+  it("returns 403 without the create/skill capability", async () => {
+    for (const role of ["user", "manager"] as const) {
+      const { workspace } = await setup(role);
 
-    const response = await get(workspace);
+      const response = await get(workspace);
 
-    expect(response.status).toBe(403);
+      expect(response.status).toBe(403);
+    }
   });
 });
 
@@ -155,7 +157,7 @@ describe("DELETE /api/w/:wId/skills/import/github-connection", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await del(workspace);

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -32,14 +32,13 @@ import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
 
-async function setupTest(role: MembershipRoleType = "builder") {
+async function setupTest(role: MembershipRoleType = "user") {
   return createPrivateApiMockRequest({ role });
 }
 
-// The test's own "builder" membership role doesn't grant create/skill by itself anymore — it
-// requires a group grant. Used by tests that specifically need a non-admin caller (e.g. to
-// exercise space-access checks admins would otherwise bypass) while still being allowed to
-// create a skill.
+// A non-admin membership role doesn't grant create/skill by itself — it requires a group grant.
+// Used by tests that specifically need a non-admin caller (e.g. to exercise space-access checks
+// admins would otherwise bypass) while still being allowed to create a skill.
 async function grantCreateSkillCapability(
   workspace: Awaited<ReturnType<typeof setupTest>>["workspace"],
   user: Awaited<ReturnType<typeof setupTest>>["user"]
@@ -137,7 +136,7 @@ describe("GET /api/w/:wId/skills", () => {
     // Skills created by another user: the requester is not in their editor groups.
     const otherUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, otherUser, {
-      role: "builder",
+      role: "user",
     });
     const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
       otherUser.sId,
@@ -231,7 +230,7 @@ describe("GET /api/w/:wId/skills", () => {
     // scoped to suggestions, not to admins at large (that is bypassEditorVisibility's job).
     const skillOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, skillOwner, {
-      role: "builder",
+      role: "user",
     });
     const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       skillOwner.sId,
@@ -290,7 +289,7 @@ describe("GET /api/w/:wId/skills", () => {
 
     const skillOwner = await UserFactory.basic();
     await MembershipFactory.associate(workspace, skillOwner, {
-      role: "builder",
+      role: "user",
     });
     const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       skillOwner.sId,
@@ -321,7 +320,7 @@ describe("GET /api/w/:wId/skills", () => {
   });
 
   it("rejects bypassEditorVisibility for non-admins", async () => {
-    const { workspace } = await setupTest("builder");
+    const { workspace } = await setupTest("user");
 
     const response = await getSkills(workspace, {
       bypassEditorVisibility: "true",
@@ -489,8 +488,8 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).not.toContain("Archived Skill");
   });
 
-  it("should work for builder and admin roles", async () => {
-    for (const role of ["builder", "admin"] as const) {
+  it("should work for user and admin roles", async () => {
+    for (const role of ["user", "admin"] as const) {
       const { workspace, user } = await setupTest(role);
 
       const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -1430,7 +1429,7 @@ describe("POST /api/w/:wId/skills", () => {
   });
 
   it("rejects additional requested spaces the user cannot access", async () => {
-    const { workspace, user } = await setupTest("builder");
+    const { workspace, user } = await setupTest("user");
     await grantCreateSkillCapability(workspace, user);
 
     const restrictedSpace = await SpaceFactory.regular(workspace);
@@ -1457,7 +1456,7 @@ describe("POST /api/w/:wId/skills", () => {
   });
 
   it("allows restricting a skill to an open Pod the user can access", async () => {
-    const { workspace, globalGroup, user } = await setupTest("builder");
+    const { workspace, globalGroup, user } = await setupTest("user");
     await grantCreateSkillCapability(workspace, user);
 
     const openPod = await SpaceFactory.project(workspace);
@@ -1710,7 +1709,7 @@ describe("POST /api/w/:wId/skills", () => {
 
 describe("POST /api/w/:wId/skills - file attachments", () => {
   it("creates a skill with file attachments", async () => {
-    const { auth, workspace, user } = await setupTest("builder");
+    const { auth, workspace, user } = await setupTest("user");
     await grantCreateSkillCapability(workspace, user);
 
     const file1 = await FileFactory.create(auth, user, {

--- a/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.test.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.test.ts
@@ -105,7 +105,7 @@ describe("GET /api/w/:wId/skills/reinforcement_daily_spend", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await get(workspace);

--- a/front-api/routes/w/[wId]/skills/reinforcement_spend.test.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_spend.test.ts
@@ -105,7 +105,7 @@ describe("GET /api/w/:wId/skills/reinforcement_spend", () => {
   });
 
   it("returns 403 for non-admin users", async () => {
-    for (const role of ["builder", "user"] as const) {
+    for (const role of ["user", "manager"] as const) {
       const { workspace } = await setup(role);
 
       const response = await get(workspace);

--- a/front-api/routes/w/[wId]/skills/similar.test.ts
+++ b/front-api/routes/w/[wId]/skills/similar.test.ts
@@ -2,6 +2,7 @@ import { SKILLS_PER_LLM_CALL } from "@app/lib/api/skills/existing_skill_checker"
 import { Authenticator } from "@app/lib/auth";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,7 +14,7 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { honoApp } from "@front-api/app";
 
-async function setup(role: "builder" | "user" | "admin" = "builder") {
+async function setup(role: MembershipRoleType = "user") {
   const { workspace, user } = await createPrivateApiMockRequest({ role });
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -87,7 +87,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/mcp_views/:svId", () => {
 
   it("returns 403 when user is not authorized to delete a server view", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
     });
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -128,7 +128,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/webhook_source_views", () => {
 
   it("returns 403 when user is not admin", async () => {
     const { workspace } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
     });
     const regularSpace = await SpaceFactory.regular(workspace);
 
@@ -232,7 +232,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/webhook_source_views/:webhookSource
 
   it("returns 403 when user is not admin", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
-      role: "builder",
+      role: "user",
     });
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId

--- a/front-api/routes/w/[wId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/triggers/index.test.ts
@@ -71,7 +71,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("creates a trigger scoped to an open pod", async () => {
     const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -100,7 +100,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("creates a trigger scoped to a restricted pod the user is a member of", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -121,7 +121,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("rejects a restricted pod the user is not a member of", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -145,7 +145,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("rejects a space that is not a Pod", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -166,7 +166,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("creates a trigger with no pod (backward compatible default)", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -186,7 +186,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("rejects a Pod that does not exist", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -208,7 +208,7 @@ describe("PATCH /api/w/:wId/triggers (spaceId)", () => {
   it("updates an existing trigger to run inside a Pod", async () => {
     const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -242,7 +242,7 @@ describe("PATCH /api/w/:wId/triggers (spaceId)", () => {
   it("rejects updating a trigger to a Pod the user is not a member of", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -282,7 +282,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
   it("rejects a non-admin editor re-enabling an admin-locked trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -303,7 +303,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
   it("rejects a non-admin editor re-enabling a relocating trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -376,7 +376,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
   it("lets an editor save other fields of a system-disabled trigger, status echoed unchanged", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -443,7 +443,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
   it("lets a non-admin editor edit other fields of an admin-locked trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -498,7 +498,7 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
   it("rejects creating a workspace pool trigger without the permission", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
@@ -545,7 +545,7 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
   it("rejects an update to the workspace pool without the permission", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,

--- a/front/components/navigation/config.test.ts
+++ b/front/components/navigation/config.test.ts
@@ -46,8 +46,8 @@ describe("subNavigationAdmin automation entry", () => {
     expect(item?.disabled).toBe(false);
   });
 
-  it("is absent for a builder, who has no admin sidebar at all", () => {
-    const item = automationNavItem(ownerWithRole("builder"));
+  it("is absent for a regular user, who has no admin sidebar at all", () => {
+    const item = automationNavItem(ownerWithRole("user"));
     expect(item).toBeUndefined();
   });
 });

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -112,16 +112,16 @@ describe("workspaceManagerGuard (via an in-memory MCP tool)", () => {
     expect(JSON.stringify(result.content)).toContain("guarded ok");
   });
 
-  it("blocks a builder from a guarded tool", async () => {
-    const auth = await authForRole("builder");
+  it("blocks a regular user from a guarded tool", async () => {
+    const auth = await authForRole("user");
     const result = await callTestTool(auth, "guarded_tool");
 
     expect(result.isError).toBe(true);
     expect(JSON.stringify(result.content)).toContain("admins");
   });
 
-  it("lets a builder call an unguarded tool", async () => {
-    const auth = await authForRole("builder");
+  it("lets a regular user call an unguarded tool", async () => {
+    const auth = await authForRole("user");
     const result = await callTestTool(auth, "open_tool");
 
     expect(result.isError).toBeFalsy();

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -64,11 +64,11 @@ function makeExtra(auth: Authenticator) {
   return extra as ToolHandlerExtra;
 }
 
-// A "builder" role membership no longer grants create/skill by itself — it requires a group
-// grant. Drop-in replacement for createResourceTest({ role: "builder" }) for tests that create a
-// skill via the CREATE_SKILL_TOOL_NAME tool.
-async function createBuilderTestContext() {
-  const result = await createResourceTest({ role: "builder" });
+// A non-admin role membership does not grant create/skill by itself — it requires a group grant.
+// Drop-in replacement for createResourceTest({ role: "user" }) for tests that create a skill via
+// the CREATE_SKILL_TOOL_NAME tool.
+async function createSkillAuthorTestContext() {
+  const result = await createResourceTest({ role: "user" });
   await grantWorkspacePermission(result.workspace, result.user, {
     grantType: "create",
     resourceType: "skill",
@@ -95,7 +95,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("creates, lists, reads, and updates a skill", async () => {
-    const { authenticator, workspace } = await createBuilderTestContext();
+    const { authenticator, workspace } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -173,7 +173,7 @@ describe("skill_authoring tools", () => {
 
     const otherUser = await UserFactory.basic();
     const owner = authenticator.getNonNullableWorkspace();
-    await MembershipFactory.associate(owner, otherUser, { role: "builder" });
+    await MembershipFactory.associate(owner, otherUser, { role: "user" });
     const otherAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
       otherUser.sId,
       workspace.sId
@@ -242,7 +242,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("returns an MCPError without an interactive user", async () => {
-    const { workspace } = await createBuilderTestContext();
+    const { workspace } = await createSkillAuthorTestContext();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const result = await getTool(CREATE_SKILL_TOOL_NAME).handler(
@@ -286,7 +286,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("ignores an invalid icon on create and falls back to a valid one", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -318,7 +318,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects an invalid icon on update", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -363,7 +363,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("applies a targeted instructions edit with old_string/new_string", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -405,7 +405,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects an edit when old_string is not found", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -450,7 +450,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects an edit when the replacement count does not match", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -506,7 +506,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that drops a knowledge tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions =
       'Summarize the runbook. <knowledge id="data_xyz" title="Runbook" />';
     const skill = await seedSkill(authenticator, {
@@ -546,7 +546,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a targeted edit that drops a knowledge tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions =
       'Summarize the runbook. <knowledge id="data_xyz" title="Runbook" />';
     const skill = await seedSkill(authenticator, {
@@ -574,7 +574,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a targeted edit that drops a nested skill tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -620,7 +620,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that strips knowledge tag attributes", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions =
       'Use <knowledge id="n1" title="Runbook" space="sp1" dsv="dsv1" hasChildren="true" /> for context.';
     const skill = await seedSkill(authenticator, {
@@ -647,7 +647,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("allows a full replace that reorders knowledge tag attributes", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions =
       'Use <knowledge id="n1" title="Runbook" space="sp1" dsv="dsv1" hasChildren="true" /> for context.';
     const reorderedInstructions =
@@ -671,7 +671,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that strips tool tag attributes", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions =
       'Use <tool id="tool_1" name="Search" icon="ActionListIcon" /> for research.';
     const skill = await seedSkill(authenticator, {
@@ -698,7 +698,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("keeps nested skill references in sync when editing instructions", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -736,7 +736,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects creating a skill that embeds a knowledge tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -759,7 +759,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects creating a skill that embeds a tool tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -782,7 +782,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects creating a skill that embeds a nested skill reference", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -810,7 +810,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that adds a knowledge tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions =
       "Summarize the runbook in three bullet points.";
     const skill = await seedSkill(authenticator, {
@@ -838,7 +838,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a targeted edit that adds a tool tag", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
     const originalInstructions = "Use the search step for research.";
     const skill = await seedSkill(authenticator, {
       name: "Plain Tool Skill",
@@ -865,7 +865,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects combining a full instructions replace with a targeted edit", async () => {
-    const { authenticator } = await createBuilderTestContext();
+    const { authenticator } = await createSkillAuthorTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {

--- a/front/lib/api/actions/servers/workspace_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_management/tools/index.test.ts
@@ -93,7 +93,7 @@ async function callToolLines(
 // does not edit, and one published agent requesting a space the caller cannot read.
 async function setupOtherMembersAgents(workspace: LightWorkspaceType) {
   const agentOwner = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, agentOwner, { role: "builder" });
+  await MembershipFactory.associate(workspace, agentOwner, { role: "user" });
   const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     agentOwner.sId,
     workspace.sId
@@ -479,7 +479,7 @@ describe("workspace_management tools", () => {
       const salesUser = await UserFactory.basic();
       const engineeringUser = await UserFactory.basic();
       await MembershipFactory.associate(workspace, salesUser, {
-        role: "builder",
+        role: "admin",
       });
       await MembershipFactory.associate(workspace, engineeringUser, {
         role: "user",
@@ -500,7 +500,7 @@ describe("workspace_management tools", () => {
 
       expect(lines).toHaveLength(2);
       expect(lines[0]).toContain(salesUser.sId);
-      expect(lines[0]).toContain(") - builder");
+      expect(lines[0]).toContain(") - admin");
       expect(lines[0]).toContain("groups: Enterprise Sales");
       expect(lines[1]).toContain(engineeringUser.sId);
       expect(lines[1]).toContain(") - user");

--- a/front/lib/api/agent_actions.test.ts
+++ b/front/lib/api/agent_actions.test.ts
@@ -85,7 +85,7 @@ describe("getToolsUsage", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(testContext.workspace, user, {
-      role: "builder",
+      role: "user",
     });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,

--- a/front/lib/api/analytics/consumption/facet_catalog.test.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.test.ts
@@ -61,7 +61,7 @@ describe("listConsumptionFacetCatalog", () => {
       name: "Production key",
       workspaceId: workspace.id,
       status: "active" as const,
-      role: "builder" as const,
+      role: "user" as const,
     };
     await KeyResource.makeNew({ ...keyInput, isSystem: false }, [globalGroup]);
     await KeyResource.makeNew({ ...keyInput, isSystem: false }, [globalGroup]);

--- a/front/lib/api/assistant/agent_suggestion_pruning.test.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.test.ts
@@ -35,7 +35,7 @@ describe("pruneSuggestionsForAgent", () => {
   let agentConfiguration: LightAgentConfigurationType;
 
   beforeEach(async () => {
-    const testSetup = await createResourceTest({ role: "builder" });
+    const testSetup = await createResourceTest({ role: "user" });
     authenticator = testSetup.authenticator;
 
     agentConfiguration =

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -942,7 +942,7 @@ describe("updateAgentConfigurationsScope", () => {
 
   it("skips agents the caller cannot edit and is not admin of", async () => {
     const { authenticator: ownerAuth, workspace } = await createResourceTest({
-      role: "builder",
+      role: "user",
     });
     const ownedAgent = await AgentConfigurationFactory.createTestAgent(
       ownerAuth,
@@ -951,7 +951,7 @@ describe("updateAgentConfigurationsScope", () => {
 
     // Another builder who has no editing rights on the agent.
     const outsider = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, outsider, { role: "builder" });
+    await MembershipFactory.associate(workspace, outsider, { role: "user" });
     const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
       outsider.sId,
       workspace.sId
@@ -983,7 +983,7 @@ describe("updateAgentConfigurationsScope", () => {
     // A workspace member who is not in the agent's editor group.
     const nonEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, nonEditor, {
-      role: "builder",
+      role: "user",
     });
 
     // Trigger owned by the admin (member of the editor group).

--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -72,10 +72,6 @@ describe("analyst global agent visibility", () => {
     expect(await fetchAnalyst("manager", true)).toEqual([]);
   });
 
-  it("is hidden from builders even by default", async () => {
-    expect(await fetchAnalyst("builder")).toEqual([]);
-  });
-
   it("is hidden from regular users even by default", async () => {
     expect(await fetchAnalyst("user")).toEqual([]);
   });

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
@@ -17,7 +17,7 @@ async function authForRole(role: MembershipRoleType): Promise<Authenticator> {
 
 describe("canRoleSeeAudience", () => {
   it("makes 'everyone' visible to every role", async () => {
-    for (const role of ["admin", "manager", "builder", "user"] as const) {
+    for (const role of ["admin", "manager", "user"] as const) {
       const auth = await authForRole(role);
       expect(canRoleSeeAudience("everyone", auth)).toBe(true);
     }
@@ -26,9 +26,6 @@ describe("canRoleSeeAudience", () => {
   it("makes 'admins' visible to admins only", async () => {
     expect(canRoleSeeAudience("admins", await authForRole("admin"))).toBe(true);
     expect(canRoleSeeAudience("admins", await authForRole("manager"))).toBe(
-      false
-    );
-    expect(canRoleSeeAudience("admins", await authForRole("builder"))).toBe(
       false
     );
     expect(canRoleSeeAudience("admins", await authForRole("user"))).toBe(false);
@@ -40,9 +37,6 @@ describe("canRoleSeeAudience", () => {
     );
     expect(canRoleSeeAudience("managers", await authForRole("manager"))).toBe(
       true
-    );
-    expect(canRoleSeeAudience("managers", await authForRole("builder"))).toBe(
-      false
     );
     expect(canRoleSeeAudience("managers", await authForRole("user"))).toBe(
       false

--- a/front/lib/api/data_sources.test.ts
+++ b/front/lib/api/data_sources.test.ts
@@ -60,14 +60,14 @@ vi.mock("@app/poke/temporal/client", () => ({
 }));
 
 describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
-  let builderAuth: Authenticator;
+  let managerAuth: Authenticator;
   let userAuth: Authenticator;
   let folderDataSource: DataSourceResource;
 
   beforeEach(async () => {
-    // Setup builder user
-    const builderSetup = await createResourceTest({ role: "builder" });
-    builderAuth = builderSetup.authenticator;
+    // Setup a manager, who has write access on the global space.
+    const managerSetup = await createResourceTest({ role: "manager" });
+    managerAuth = managerSetup.authenticator;
 
     // Setup regular user
     const userSetup = await createResourceTest({
@@ -75,11 +75,11 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
     });
     userAuth = userSetup.authenticator;
 
-    // Create a folder data source owned by the builder in their workspace
+    // Create a folder data source owned by the manager in their workspace
     const dataSourceView = await DataSourceViewFactory.folder(
-      builderSetup.workspace,
-      builderSetup.globalSpace,
-      builderSetup.user
+      managerSetup.workspace,
+      managerSetup.globalSpace,
+      managerSetup.user
     );
     folderDataSource = dataSourceView.dataSource;
 
@@ -142,15 +142,15 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
   });
 
   describe("successful deletions", () => {
-    it("should allow builder to delete folder data source", async () => {
+    it("should allow a workspace manager to delete folder data source", async () => {
       const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        builderAuth,
+        managerAuth,
         { dataSource: folderDataSource }
       );
 
       expect(result.isOk()).toBe(true);
       expect(launchScrubDataSourceWorkflow).toHaveBeenCalledWith(
-        builderAuth.workspace(),
+        managerAuth.workspace(),
         folderDataSource
       );
       expect(launchScrubDataSourceWorkflow).toHaveBeenCalledTimes(1);
@@ -173,16 +173,16 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
       ] as any);
 
       const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        builderAuth,
+        managerAuth,
         { dataSource: folderDataSource }
       );
 
       expect(result.isOk()).toBe(true);
-      expect(view1.delete).toHaveBeenCalledWith(builderAuth, {
+      expect(view1.delete).toHaveBeenCalledWith(managerAuth, {
         transaction: undefined,
         hardDelete: false,
       });
-      expect(view2.delete).toHaveBeenCalledWith(builderAuth, {
+      expect(view2.delete).toHaveBeenCalledWith(managerAuth, {
         transaction: undefined,
         hardDelete: false,
       });
@@ -191,7 +191,7 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
 
     it("should launch scrub workflow with correct workspace and data source", async () => {
       const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        builderAuth,
+        managerAuth,
         { dataSource: folderDataSource }
       );
 
@@ -200,7 +200,7 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
         expect(result.value.sId).toBe(folderDataSource.sId);
       }
       expect(launchScrubDataSourceWorkflow).toHaveBeenCalledWith(
-        builderAuth.workspace(),
+        managerAuth.workspace(),
         folderDataSource
       );
     });

--- a/front/lib/api/skills/conversation_files.test.ts
+++ b/front/lib/api/skills/conversation_files.test.ts
@@ -32,7 +32,7 @@ async function setupConversationAndSkillPermissions() {
     authenticator: auth,
     user,
     workspace,
-  } = await createResourceTest({ role: "builder" });
+  } = await createResourceTest({ role: "user" });
 
   if (!(await auth.hasWorkspacePermission("create", "skill"))) {
     await grantWorkspacePermission(workspace, user, {

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -402,7 +402,7 @@ describe("computeAuthorizedFileAccess", () => {
         workspaceId: globalGroup.workspaceId,
         isSystem: false,
         status: "active",
-        role: "builder",
+        role: "user",
         userId: user.id,
       },
       [globalGroup]

--- a/front/lib/reinforcement/utils.test.ts
+++ b/front/lib/reinforcement/utils.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 describe("getAuthForWorkspace", () => {
   it("returns an auth that can edit skills", async () => {
     const { workspace, authenticator } = await createResourceTest({
-      role: "builder",
+      role: "user",
     });
     const skill = await SkillFactory.create(authenticator);
 

--- a/front/lib/resources/agent_message_feedback_resource.test.ts
+++ b/front/lib/resources/agent_message_feedback_resource.test.ts
@@ -29,7 +29,7 @@ describe("AgentMessageFeedbackResource.getFeedbackCountsByConversationIds", () =
   let auth: Authenticator;
 
   beforeEach(async () => {
-    const setup = await createResourceTest({ role: "builder" });
+    const setup = await createResourceTest({ role: "user" });
     auth = setup.authenticator;
   });
 

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -15,7 +15,7 @@ describe("AgentSuggestionResource", () => {
   let agentConfiguration: LightAgentConfigurationType;
 
   beforeEach(async () => {
-    const testSetup = await createResourceTest({ role: "builder" });
+    const testSetup = await createResourceTest({ role: "user" });
     workspace = testSetup.workspace;
     authenticator = testSetup.authenticator;
 
@@ -960,7 +960,7 @@ describe("AgentSuggestionResource", () => {
 
       // Create a second workspace with its own suggestion
       const { authenticator: authenticator2 } = await createResourceTest({
-        role: "builder",
+        role: "user",
       });
 
       const agentConfiguration2 =

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -226,7 +226,7 @@ describe("MembershipResource", () => {
         await MembershipResource.updateMembershipRole({
           user,
           workspace,
-          newRole: "builder",
+          newRole: "admin",
           author: "no-author",
         });
 
@@ -574,7 +574,7 @@ describe("MembershipResource", () => {
         await MembershipResource.createMembership({
           user,
           workspace: lightWorkspace,
-          role: "builder",
+          role: "admin",
         });
 
         const role = await MembershipResource.getActiveRoleForUserInWorkspace({
@@ -582,7 +582,7 @@ describe("MembershipResource", () => {
           workspace: lightWorkspace,
         });
 
-        expect(role).toBe("builder");
+        expect(role).toBe("admin");
       });
 
       it("should return 'none' when no membership exists", async () => {

--- a/front/lib/resources/skill/code_defined/global/skill_authoring.test.ts
+++ b/front/lib/resources/skill/code_defined/global/skill_authoring.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 describe("skill authoring code-defined skill", () => {
   it("is available to every workspace without a feature flag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createResourceTest({ role: "user" });
 
     const skill = await GlobalSkillsRegistry.getById(
       authenticator,

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.test.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 
 describe("workspace-analytics code-defined skill", () => {
   it("is hidden from non-admins", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createResourceTest({ role: "user" });
 
     const skill = await GlobalSkillsRegistry.getById(
       authenticator,

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -30,6 +30,7 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import type { MembershipRoleType } from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1445,7 +1446,7 @@ describe("SkillResource", () => {
     it("rejects a caller without the publish permission, even an editor", async () => {
       const builder = await UserFactory.basic();
       await MembershipFactory.associate(testContext.workspace, builder, {
-        role: "builder",
+        role: "user",
       });
       const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
         builder.sId,
@@ -3075,7 +3076,7 @@ describe("SkillResource", () => {
     it("keeps a non-editor out, and lets a workspace admin administrate but not write", async () => {
       const { skill } = await setupSkillWithEditor("Role Rules Skill");
 
-      const authFor = async (role: "user" | "admin") => {
+      const authFor = async (role: MembershipRoleType) => {
         const user = await UserFactory.basic();
         await MembershipFactory.associate(testContext.workspace, user, {
           role,

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -17,7 +17,7 @@ describe("SkillSuggestionResource", () => {
   let skill: SkillResource;
 
   beforeEach(async () => {
-    const testSetup = await createResourceTest({ role: "builder" });
+    const testSetup = await createResourceTest({ role: "user" });
     workspace = testSetup.workspace;
     authenticator = testSetup.authenticator;
 
@@ -841,7 +841,7 @@ describe("SkillSuggestionResource", () => {
       // of conversation2.
       const otherUser = await UserFactory.basic();
       await MembershipFactory.associate(workspace, otherUser, {
-        role: "builder",
+        role: "user",
       });
       const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
         otherUser.sId,
@@ -879,7 +879,7 @@ describe("SkillSuggestionResource", () => {
       // Create a second user's conversation.
       const otherUser = await UserFactory.basic();
       await MembershipFactory.associate(workspace, otherUser, {
-        role: "builder",
+        role: "user",
       });
       const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
         otherUser.sId,

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -469,7 +469,7 @@ describe("TriggerResource", () => {
   });
   describe("setExecutionMode", () => {
     it("refuses the workspace pool without the governance grant", async () => {
-      const { authenticator } = await createResourceTest({ role: "builder" });
+      const { authenticator } = await createResourceTest({ role: "user" });
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
         authenticator,
         { name: "Test Agent" }

--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -15,7 +15,7 @@ const MISSING_TRIGGER_MODEL_ID = 9_000_000_000;
 
 describe("runTriggeredAgentsActivity", () => {
   it("skips missing triggers without failing the activity", async () => {
-    const { user, workspace } = await createResourceTest({ role: "builder" });
+    const { user, workspace } = await createResourceTest({ role: "user" });
     const triggerId = TriggerResource.modelIdToSId({
       id: MISSING_TRIGGER_MODEL_ID,
       workspaceId: workspace.id,
@@ -31,7 +31,7 @@ describe("runTriggeredAgentsActivity", () => {
   });
 
   it("skips missing users without failing the activity", async () => {
-    const { workspace } = await createResourceTest({ role: "builder" });
+    const { workspace } = await createResourceTest({ role: "user" });
     const triggerId = TriggerResource.modelIdToSId({
       id: MISSING_TRIGGER_MODEL_ID,
       workspaceId: workspace.id,
@@ -50,7 +50,7 @@ describe("runTriggeredAgentsActivity", () => {
 describe("wake-up activities", () => {
   it("skips terminal wake-ups without failing the activity", async () => {
     const { authenticator, user, workspace } = await createResourceTest({
-      role: "builder",
+      role: "user",
     });
     const conversation = await createConversation(authenticator, {
       title: null,
@@ -82,7 +82,7 @@ describe("wake-up activities", () => {
   });
 
   it("skips missing wake-ups without failing the activity", async () => {
-    const { workspace } = await createResourceTest({ role: "builder" });
+    const { workspace } = await createResourceTest({ role: "user" });
     const wakeUpId = WakeUpResource.modelIdToSId({
       id: MISSING_WAKE_UP_MODEL_ID,
       workspaceId: workspace.id,

--- a/front/tests/utils/AgentOwnerFactory.ts
+++ b/front/tests/utils/AgentOwnerFactory.ts
@@ -1,11 +1,12 @@
 import { Authenticator } from "@app/lib/auth";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export async function setupAgentOwner(
   workspace: LightWorkspaceType,
-  agentOwnerRole: "admin" | "builder" | "user"
+  agentOwnerRole: MembershipRoleType
 ) {
   const agentOwner = await UserFactory.basic();
   await MembershipFactory.associate(workspace, agentOwner, {

--- a/front/tests/utils/MembershipInvitationFactory.ts
+++ b/front/tests/utils/MembershipInvitationFactory.ts
@@ -10,6 +10,8 @@ export class MembershipInvitationFactory {
     overrides: {
       inviteEmail?: string;
       status?: "pending" | "consumed" | "revoked";
+      // `builder` is still accepted so tests can seed a legacy pending invitation and exercise
+      // the downgrade-to-user path.
       initialRole?: "user" | "builder" | "admin";
       createdAt?: Date;
     } = {}

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -13,6 +13,7 @@ import type {
   MessageFeedback,
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
+import type { MembershipRoleType } from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { UserType } from "@app/types/user";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -38,7 +39,7 @@ export function makeExtra(
 }
 
 export async function setupPlainConversation(
-  role: "admin" | "user" = "admin"
+  role: MembershipRoleType = "admin"
 ): Promise<{
   auth: Authenticator;
   conversation: ConversationResource;
@@ -53,7 +54,7 @@ export async function setupPlainConversation(
 }
 
 export async function setupProjectConversation(
-  role: "admin" | "user" = "admin"
+  role: MembershipRoleType = "admin"
 ): Promise<{
   auth: Authenticator;
   conversation: ConversationResource;


### PR DESCRIPTION
## Description

Remove "builder" usage in tests

 - replace by "users" when possible, sometimes by admin when necessary
 - Uses MembershipRoleType to type "any roles" instead of listing them all
 - fixes some tests doing "all non admin roles" with [builder, user] to [manager, user]

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
deploy front-sse
