### PR TITLE
[front] feat: rework usage page header and credit pool footer

### DIFF
--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -24,6 +24,7 @@ import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTie
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
+import { WorkspaceCreditPoolSection } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useTableRowsSelection } from "@app/hooks/useTableRowsSelection";
 import {
@@ -47,7 +48,6 @@ import {
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   isCreditPricedFreePlan,
-  isEnterprisePlanPrefix,
   isFreePlan,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
@@ -120,7 +120,6 @@ import {
   Page,
   ProgressBar,
   SearchInput,
-  Spinner,
   Tabs,
   TabsContent,
   TabsList,
@@ -465,6 +464,12 @@ export function UsagePageRedesign() {
     totalRemainingCredits,
     totalActiveCredits,
     overageCredits,
+    currentCycleConsumedCredits,
+    currentCycleStartMs,
+    currentCycleEndMs,
+    excessConsumedCredits,
+    programmaticConsumedCredits,
+    otherConsumedCredits,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
     mutateAwuPoolSummary,
@@ -856,7 +861,6 @@ export function UsagePageRedesign() {
   const { usageSettings } = useUsageSettings({ workspaceId: owner.sId });
 
   const plan = subscription.plan;
-  const isEnterprise = isEnterprisePlanPrefix(plan.code);
   const isFreePlanWorkspace = isFreePlan(plan.code);
 
   const isManualInvitationsEnabled =
@@ -895,6 +899,9 @@ export function UsagePageRedesign() {
 
   const initialTotalCredits = creditUsage?.capCredits ?? totalActiveCredits;
   const hasPool = totalActiveCredits > 0;
+  // No pool, but there's still PAYG excess consumption to show — either live
+  // (this cycle) or as history from previous invoices.
+  const hasExcessData = excessConsumedCredits !== null;
 
   const usedPercentage =
     creditUsage?.status.usedPercentage ??
@@ -1122,18 +1129,20 @@ export function UsagePageRedesign() {
             description="Control credit consumption across your workspace."
           />
         ) : (
-          <div className="flex items-center justify-between">
-            <Page.Header title="Usage" />
-            {!isReadOnly && usageSettings.topUpEnabled && isWorkspaceAdmin && (
-              <Button
-                label="Top up"
-                icon={ArrowUp}
-                size="sm"
-                variant="outline"
-                onClick={() => setShowBuyCreditDialog(true)}
-              />
-            )}
-          </div>
+          <Page.Header
+            title={
+              <div className="flex w-full items-center justify-between gap-4">
+                <Page.H variant="h3">Usage</Page.H>
+                <Button
+                  label="Breakdown in analytics"
+                  iconRight={LinkExternal01}
+                  size="xs"
+                  variant="highlight-ghost"
+                  href={`/w/${owner.sId}/analytics/consumption`}
+                />
+              </div>
+            }
+          />
         )}
 
         {!isReadOnly && isCreditPricedFreePlan(subscription.plan.code) && (
@@ -1258,46 +1267,21 @@ export function UsagePageRedesign() {
           </Page.Vertical>
         ) : null}
 
-        {!showConsumptionAnalytics &&
-        !isAwuPoolSummaryLoading &&
-        (isAwuPoolSummaryError || hasPool || isReadOnly) ? (
-          <Page.Vertical gap="xs" align="stretch">
-            <Page.H variant="h4">Workspace credit pool</Page.H>
-
-            {isAwuPoolSummaryError ? (
-              <ContentMessage
-                title="Failed to load Workspace Credits Pool"
-                icon={AlertCircle}
-                variant="warning"
-              >
-                An error occurred while loading your Workspace Credits Pool
-                data. Please refresh the page or contact support if the issue
-                persists.
-              </ContentMessage>
-            ) : isAwuPoolSummaryLoading ? (
-              <div className="flex justify-center py-8">
-                <Spinner />
-              </div>
-            ) : (
-              <>
-                <div className="flex items-baseline gap-1">
-                  <span className="heading-mono-4xl text-foreground">
-                    {formatCredits(totalConsumedCredits)}
-                  </span>
-                  <span className="copy-sm text-muted-foreground">
-                    /{formatCredits(initialTotalCredits)}
-                  </span>
-                </div>
-                {hasPool && (
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/20">
-                    <div
-                      className="h-full rounded-full bg-foreground/80 transition-all"
-                      style={{
-                        width: `${Math.min(100, initialTotalCredits > 0 ? (totalConsumedCredits / initialTotalCredits) * 100 : 0)}%`,
-                      }}
-                    />
-                  </div>
-                )}
+        {!showConsumptionAnalytics && (
+          <WorkspaceCreditPoolSection
+            isLoading={isAwuPoolSummaryLoading}
+            isError={!!isAwuPoolSummaryError}
+            showPoolBranch={hasPool || isReadOnly}
+            isVisible={hasPool || isReadOnly || hasExcessData}
+            totalRemainingCredits={totalRemainingCredits}
+            currentCycleConsumedCredits={currentCycleConsumedCredits}
+            currentCycleStartMs={currentCycleStartMs}
+            currentCycleEndMs={currentCycleEndMs}
+            excessConsumedCredits={excessConsumedCredits}
+            programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
+            poolSecondaryContent={
+              <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2">
                   {isReadOnly ? (
                     <span className="copy-sm text-muted-foreground">
@@ -1305,24 +1289,28 @@ export function UsagePageRedesign() {
                       period
                     </span>
                   ) : (
-                    <>
-                      {overageCredits !== null && overageCredits > 0 && (
-                        <span className="copy-sm text-muted-foreground">
-                          {formatCredits(overageCredits)} overage credits
-                        </span>
-                      )}
-                      {isEnterprise && (
-                        <span className="copy-sm text-muted-foreground">
-                          Contact your Dust sales representative to buy credits
-                        </span>
-                      )}
-                    </>
+                    overageCredits !== null &&
+                    overageCredits > 0 && (
+                      <span className="copy-sm text-muted-foreground">
+                        {formatCredits(overageCredits)} overage credits
+                      </span>
+                    )
                   )}
                 </div>
+              </div>
+            }
+            footer={
+              <>
+                <div className="pt-2">
+                  <Page.Separator />
+                </div>
+                <div className="flex items-center justify-end pt-2">
+                  {topUpButton}
+                </div>
               </>
-            )}
-          </Page.Vertical>
-        ) : null}
+            }
+          />
+        )}
 
         <Tabs
           value={usageTab}

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,0 +1,257 @@
+import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
+import { formatCredits } from "@app/lib/client/credits";
+import {
+  AlertCircle,
+  ContentMessage,
+  Page,
+  Spinner,
+  ValueCard,
+} from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+function formatCycleDayLabel(
+  currentCycleStartMs: number | null,
+  currentCycleEndMs: number | null
+): string | null {
+  if (
+    currentCycleStartMs === null ||
+    currentCycleEndMs === null ||
+    currentCycleEndMs <= currentCycleStartMs
+  ) {
+    return null;
+  }
+  const totalDays = Math.round(
+    (currentCycleEndMs - currentCycleStartMs) / ONE_DAY_MS
+  );
+  const elapsedDays = Math.min(
+    totalDays,
+    Math.max(0, Math.ceil((Date.now() - currentCycleStartMs) / ONE_DAY_MS))
+  );
+  return `Day ${elapsedDays}/${totalDays}`;
+}
+
+interface WorkspaceCreditPoolValueCardsProps {
+  totalRemainingCredits: number;
+  currentCycleConsumedCredits: number | null;
+  currentCycleStartMs: number | null;
+  currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
+  isLoading: boolean;
+}
+
+export function WorkspaceCreditPoolValueCards({
+  totalRemainingCredits,
+  currentCycleConsumedCredits,
+  currentCycleStartMs,
+  currentCycleEndMs,
+  programmaticConsumedCredits,
+  otherConsumedCredits,
+  isLoading,
+}: WorkspaceCreditPoolValueCardsProps) {
+  const cycleDayLabel = formatCycleDayLabel(
+    currentCycleStartMs,
+    currentCycleEndMs
+  );
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <ValueCard
+        title="Remaining credits pool"
+        isLoading={isLoading}
+        content={
+          <div className="truncate text-2xl text-foreground">
+            {formatCredits(totalRemainingCredits)}
+          </div>
+        }
+      />
+      <ValueCard
+        title="Consumed this cycle"
+        isLoading={isLoading}
+        content={
+          <div className="flex items-baseline gap-2">
+            <div className="truncate text-2xl text-foreground">
+              {typeof currentCycleConsumedCredits === "number"
+                ? formatCredits(currentCycleConsumedCredits)
+                : "—"}
+            </div>
+            {cycleDayLabel && (
+              <span className="copy-sm text-muted-foreground">
+                {cycleDayLabel}
+              </span>
+            )}
+          </div>
+        }
+      />
+      <ValueCard
+        title="Programmatic / Other usage"
+        isLoading={isLoading}
+        content={
+          <div className="flex flex-col gap-1">
+            <div className="truncate text-2xl text-foreground">
+              {typeof programmaticConsumedCredits === "number"
+                ? formatCredits(programmaticConsumedCredits)
+                : "—"}
+            </div>
+            <span className="copy-sm text-muted-foreground">
+              Other:{" "}
+              {typeof otherConsumedCredits === "number"
+                ? formatCredits(otherConsumedCredits)
+                : "—"}
+            </span>
+          </div>
+        }
+      />
+    </div>
+  );
+}
+
+interface WorkspaceExcessCreditsValueCardProps {
+  excessConsumedCredits: number | null;
+  currentCycleStartMs: number | null;
+  currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
+  isLoading: boolean;
+}
+
+export function WorkspaceExcessCreditsValueCard({
+  excessConsumedCredits,
+  currentCycleStartMs,
+  currentCycleEndMs,
+  programmaticConsumedCredits,
+  otherConsumedCredits,
+  isLoading,
+}: WorkspaceExcessCreditsValueCardProps) {
+  const cycleDayLabel = formatCycleDayLabel(
+    currentCycleStartMs,
+    currentCycleEndMs
+  );
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <ValueCard
+        title="Consumed this cycle"
+        isLoading={isLoading}
+        content={
+          <div className="flex items-baseline gap-2">
+            <div className="truncate text-2xl text-foreground">
+              {typeof excessConsumedCredits === "number"
+                ? formatCredits(excessConsumedCredits)
+                : "—"}
+            </div>
+            {cycleDayLabel && (
+              <span className="copy-sm text-muted-foreground">
+                {cycleDayLabel}
+              </span>
+            )}
+          </div>
+        }
+      />
+      <ValueCard
+        title="Programmatic / Other usage"
+        isLoading={isLoading}
+        content={
+          <div className="flex flex-col gap-1">
+            <div className="truncate text-2xl text-foreground">
+              {typeof programmaticConsumedCredits === "number"
+                ? formatCredits(programmaticConsumedCredits)
+                : "—"}
+            </div>
+            <span className="copy-sm text-muted-foreground">
+              Other:{" "}
+              {typeof otherConsumedCredits === "number"
+                ? formatCredits(otherConsumedCredits)
+                : "—"}
+            </span>
+          </div>
+        }
+      />
+    </div>
+  );
+}
+
+interface WorkspaceCreditPoolSectionProps {
+  isLoading: boolean;
+  isError: boolean;
+  showPoolBranch: boolean;
+  isVisible: boolean;
+  totalRemainingCredits: number;
+  currentCycleConsumedCredits: number | null;
+  currentCycleStartMs: number | null;
+  currentCycleEndMs: number | null;
+  excessConsumedCredits: number | null;
+  programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
+  poolSecondaryContent?: ReactNode;
+  footer?: ReactNode;
+}
+
+// Single source of truth for the "Workspace credit pool" / "Excess credit
+// consumption" block so the customer-facing usage page and its Poke mirror
+// can't drift from each other on this section's structure
+export function WorkspaceCreditPoolSection({
+  isLoading,
+  isError,
+  showPoolBranch,
+  isVisible,
+  totalRemainingCredits,
+  currentCycleConsumedCredits,
+  currentCycleStartMs,
+  currentCycleEndMs,
+  excessConsumedCredits,
+  programmaticConsumedCredits,
+  otherConsumedCredits,
+  poolSecondaryContent,
+  footer,
+}: WorkspaceCreditPoolSectionProps) {
+  if (!isLoading && !isError && !isVisible) {
+    return null;
+  }
+
+  return (
+    <Page.Vertical gap="xs" align="stretch">
+      <Page.H variant="h4">
+        {showPoolBranch ? "Workspace credit pool" : "Excess credit consumption"}
+      </Page.H>
+
+      {isError ? (
+        <ContentMessage
+          title="Failed to load Workspace Credits Pool"
+          icon={AlertCircle}
+          variant="warning"
+        >
+          An error occurred while loading the workspace&apos;s credit pool data.
+        </ContentMessage>
+      ) : isLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner />
+        </div>
+      ) : showPoolBranch ? (
+        <>
+          <WorkspaceCreditPoolValueCards
+            totalRemainingCredits={totalRemainingCredits}
+            currentCycleConsumedCredits={currentCycleConsumedCredits}
+            currentCycleStartMs={currentCycleStartMs}
+            currentCycleEndMs={currentCycleEndMs}
+            programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
+            isLoading={false}
+          />
+          {poolSecondaryContent}
+          {footer}
+        </>
+      ) : (
+        <>
+          <WorkspaceExcessCreditsValueCard
+            excessConsumedCredits={excessConsumedCredits}
+            currentCycleStartMs={currentCycleStartMs}
+            currentCycleEndMs={currentCycleEndMs}
+            programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
+            isLoading={false}
+          />
+          {footer}
+        </>
+      )}
+    </Page.Vertical>
+  );
+}


### PR DESCRIPTION
## Description

Reworks the usage page header and adds a credit pool summary section: cards for remaining balance, current-cycle consumption, and programmatic/other usage, with an equivalent view for workspaces that don't have a credit pool.

Third PR in the stack reworking the Usage page.

## Tests

Type-checked; manually verified the redesigned page behind the `usage_page_redesign` flag, with and without a credit pool.

## Risk

Low. UI-only change behind the feature flag.

## Deploy Plan

Deploy front.
