### PR TITLE
[front] feat: rework redesigned usage page members table

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -36,6 +36,7 @@ const MEMBER_USAGE = {
   seatBalanceAwu: 100,
   spendLimitAlertId: null,
   spendLimitAwuCredits: null,
+  spendLimitGroupName: null,
   rateLimiterSpendAwuCredits: null,
   metronomeConsumedAwuCredits: null,
   spendLimitSource: "default" as const,

--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -174,6 +174,7 @@ export function PersonalUsageCard({
                 seatBalanceAwu={myUsage?.seatBalanceAwu ?? null}
                 effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
                 spendLimitSource={myUsage?.spendLimitSource ?? "none"}
+                spendLimitGroupName={myUsage?.spendLimitGroupName ?? null}
                 seatType={myUsage?.seatType ?? null}
                 isTotalAllowedUsagePending={false}
               />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -155,6 +155,7 @@ function memberFromUpgradeRequest(
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
+    spendLimitGroupName: null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -273,7 +273,7 @@ function UsagePageLegacy() {
 
   const sort = sorting[0];
   const membersOrderColumn =
-    sort?.id === "email" || sort?.id === "consumedAwuCredits"
+    sort?.id === "email" || sort?.id === "consumedFromPoolAwuCredits"
       ? sort.id
       : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -237,7 +237,7 @@ export function UsagePageRedesign() {
     pageSize: DEFAULT_PAGE_SIZE,
   });
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "name", desc: false },
+    { id: "consumedFromPoolAwuCredits", desc: true },
   ]);
 
   // Members are sorted server-side; reset to the first page when the sort
@@ -271,7 +271,9 @@ export function UsagePageRedesign() {
 
   const sort = sorting[0];
   const membersOrderColumn =
-    sort?.id === "email" || sort?.id === "consumedAwuCredits"
+    sort?.id === "email" ||
+    sort?.id === "consumedFromPoolAwuCredits" ||
+    sort?.id === "seatUsage"
       ? sort.id
       : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
@@ -1069,7 +1071,8 @@ export function UsagePageRedesign() {
       totalRowCount={totalMembersUsage}
       sorting={sorting}
       setSorting={handleSetSorting}
-      showGroupsColumn={groups.length > 0}
+      showGroupsColumn={false}
+      variant="compact"
       enableSelection={!isReadOnly}
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -153,6 +153,7 @@ function memberFromUpgradeRequest(
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
+    spendLimitGroupName: null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -27,16 +27,22 @@ import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
   isPaidSeatType,
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Clock,
+  CoinsStacked01,
+  cn,
   createSelectionColumn,
   DataTable,
   Icon,
@@ -85,6 +91,7 @@ type RowData = {
   consumedFromPoolAwuCredits: number;
   spendLimitAwuCredits: number | null;
   spendLimitSource: EffectiveSpendLimitSource;
+  spendLimitGroupName: string | null;
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
   isTotalAllowedUsagePending: boolean;
@@ -172,26 +179,37 @@ interface AwuUsageBarProps {
   // instead of period spend.
   seatBalanceAwu?: number | null;
   // The fully-resolved spend cap from `spendLimitAwuCredits` (member override,
-  // group cap or workspace default, all including seat allowance). Always
-  // non-null for seated users — workspace default pool cap treats null as 0
-  // (seat-only). Pass `?? 0` as a TypeScript guard only.
-  effectiveLimit: number;
+  // group cap or workspace default, all including seat allowance). `null`
+  // means uncapped
+  effectiveLimit: number | null;
   // Where `effectiveLimit` comes from — shown as a tooltip on the limit figure.
   spendLimitSource: EffectiveSpendLimitSource;
+  // Name of the group behind `effectiveLimit` when `spendLimitSource` is
+  // `"group"`. Null for every other source.
+  spendLimitGroupName: string | null;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
+  // Shows only the workspace-pool portion of usage (pool consumed / pool
+  // remaining + overage), hiding the seat-allowance section entirely. The
+  // limit figure above the bar becomes the pool limit instead of the
+  // combined (seat + pool) effective limit. Used by the redesigned usage
+  // page, which surfaces seat allowance separately in its own column.
+  poolOnly?: boolean;
 }
 
 // Human-readable origin of the effective spend limit, or null when there is
 // nothing worth explaining (no limit configured).
 function spendLimitSourceLabel(
-  source: EffectiveSpendLimitSource
+  source: EffectiveSpendLimitSource,
+  groupName: string | null
 ): string | null {
   switch (source) {
     case "override":
       return "Limit set specifically for this member";
     case "group":
-      return "Limit from a group";
+      return groupName
+        ? `Limit inherited from the "${groupName}" group`
+        : "Limit from a group";
     case "default":
       return "Workspace default limit";
     case "none":
@@ -210,12 +228,17 @@ export function AwuUsageBar({
   seatBalanceAwu,
   effectiveLimit,
   spendLimitSource,
+  spendLimitGroupName,
   seatType,
   isTotalAllowedUsagePending: isPending,
+  poolOnly = false,
 }: AwuUsageBarProps) {
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
-  const sourceLabel = spendLimitSourceLabel(spendLimitSource);
+  const sourceLabel = spendLimitSourceLabel(
+    spendLimitSource,
+    spendLimitGroupName
+  );
   // For free seats: use lifetime consumed (derived from the live Metronome
   // balance) instead of period spend, so the bar reflects remaining credit.
   const isFreeWithBalance =
@@ -252,20 +275,59 @@ export function AwuUsageBar({
   const overage =
     poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
 
+  if (poolOnly && poolLimit !== null && poolLimit <= 0) {
+    // No pool access, but credits were still consumed from it (e.g. legacy
+    // overage predating the seat's current limit). Surface the actual
+    // amount instead of hiding it behind "--".
+    const hasUnexpectedPoolConsumption = consumedFromPool > 0;
+    return (
+      <div className="flex w-full flex-col gap-1">
+        <div className="flex justify-between text-xs tabular-nums text-muted-foreground">
+          <span>
+            {hasUnexpectedPoolConsumption
+              ? formatCredits(consumedFromPool)
+              : "--"}
+          </span>
+          {isPending ? <Spinner size="xs" /> : <span>--</span>}
+        </div>
+        <div className="flex h-3 w-full items-center">
+          <ProgressBar
+            aria-label="Member credit usage"
+            aria-valuenow={hasUnexpectedPoolConsumption ? 100 : 0}
+            aria-valuetext={
+              hasUnexpectedPoolConsumption
+                ? `${formatCredits(consumedFromPool)} credits used from the workspace pool with no pool access`
+                : "No pool access"
+            }
+            className="h-1 w-full gap-px bg-transparent"
+            values={[
+              {
+                value: 1,
+                className: hasUnexpectedPoolConsumption
+                  ? OVERAGE_BAR_CLASSES.fill
+                  : MUTED_BAR_CLASSES.track,
+              },
+            ]}
+          />
+        </div>
+      </div>
+    );
+  }
+
   const sections: Array<{
     value: number;
     className: string;
     label: string;
   }> = [];
   const creditLabel = isFreeWithBalance ? "lifetime credits" : "seat allowance";
-  if (seatConsumed > 0) {
+  if (!poolOnly && seatConsumed > 0) {
     sections.push({
       value: seatConsumed,
       className: seatColors.fill,
       label: `${formatCredits(seatConsumed)} of ${formatCredits(allowance)} ${creditLabel} used`,
     });
   }
-  if (seatRemaining > 0) {
+  if (!poolOnly && seatRemaining > 0) {
     sections.push({
       value: seatRemaining,
       className: seatColors.track,
@@ -293,11 +355,15 @@ export function AwuUsageBar({
     total > 0
       ? Math.min(
           100,
-          Math.max(0, ((seatConsumed + poolConsumed) / total) * 100)
+          Math.max(
+            0,
+            ((poolOnly ? poolConsumed : seatConsumed + poolConsumed) / total) *
+              100
+          )
         )
       : 0;
 
-  const hasSeatSections = seatConsumed > 0 || seatRemaining > 0;
+  const hasSeatSections = !poolOnly && (seatConsumed > 0 || seatRemaining > 0);
   // Only surface the pool when there's actually a pool to spend from: a finite
   // positive limit, or uncapped (null). A zero pool limit (free) has no pool.
   const hasPoolSections =
@@ -381,30 +447,35 @@ export function AwuUsageBar({
     </div>
   );
 
+  const headlineConsumed = poolOnly
+    ? poolConsumed
+    : isFreeWithBalance
+      ? Math.min(lifetimeConsumed! + overage, allowance)
+      : effectiveLimit !== null
+        ? Math.min(consumed, effectiveLimit)
+        : consumed;
+  // null means uncapped
+  const headlineLimit = poolOnly
+    ? poolLimit
+    : isFreeWithBalance
+      ? allowance
+      : effectiveLimit;
+  const headlineLimitLabel =
+    headlineLimit === null ? "Unlimited" : formatCredits(headlineLimit);
   return (
     <div className="flex w-full flex-col gap-1">
       <div className="flex justify-between text-xs tabular-nums text-foreground">
-        <span>
-          {isFreeWithBalance
-            ? formatCredits(Math.min(lifetimeConsumed! + overage, allowance))
-            : formatCredits(
-                effectiveLimit !== null
-                  ? Math.min(consumed, effectiveLimit)
-                  : consumed
-              )}
-        </span>
+        <span>{formatCredits(headlineConsumed)}</span>
         {isPending ? (
           <Spinner size="xs" />
-        ) : isFreeWithBalance ? (
-          <span>{formatCredits(allowance)}</span>
-        ) : sourceLabel !== null ? (
+        ) : !isFreeWithBalance && sourceLabel !== null ? (
           <Tooltip
             tooltipTriggerAsChild
             label={sourceLabel}
-            trigger={<span>{formatCredits(effectiveLimit)}</span>}
+            trigger={<span>{headlineLimitLabel}</span>}
           />
         ) : (
-          <span>{formatCredits(effectiveLimit)}</span>
+          <span>{headlineLimitLabel}</span>
         )}
       </div>
       {tooltipContent ? (
@@ -483,14 +554,22 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function buildConsumedAwuCreditsColumn(
-  creditsResetAt: string | null
+function buildPoolCreditUsageColumn(
+  creditsResetAt: string | null,
+  variant: MembersUsageTableVariant
 ): ColumnDef<RowData, string> {
   return {
-    id: "consumedAwuCredits" as const,
+    id: "consumedFromPoolAwuCredits" as const,
     header: () => (
       <div className="flex flex-col">
-        <span>Credits usage this month</span>
+        <span className="flex items-center gap-1">
+          <Icon
+            visual={CoinsStacked01}
+            size="xs"
+            className="text-muted-foreground"
+          />
+          Pool credit usage
+        </span>
         {creditsResetAt && (
           <span className="text-xs font-normal text-muted-foreground">
             Limits reset on{" "}
@@ -503,7 +582,7 @@ function buildConsumedAwuCreditsColumn(
         )}
       </div>
     ),
-    accessorFn: (row) => row.consumedAwuCredits.toString(),
+    accessorFn: (row) => row.consumedFromPoolAwuCredits.toString(),
     cell: (info: Info) => (
       <div className="w-full pr-3">
         <AwuUsageBar
@@ -514,46 +593,253 @@ function buildConsumedAwuCreditsColumn(
           consumedFromPool={info.row.original.consumedFromPoolAwuCredits}
           memberUsageLimit={info.row.original.memberUsageLimit}
           seatBalanceAwu={info.row.original.seatBalanceAwu}
-          effectiveLimit={info.row.original.spendLimitAwuCredits ?? 0}
+          effectiveLimit={info.row.original.spendLimitAwuCredits}
           spendLimitSource={info.row.original.spendLimitSource}
+          spendLimitGroupName={info.row.original.spendLimitGroupName}
           seatType={info.row.original.seatType}
           isTotalAllowedUsagePending={
             info.row.original.isTotalAllowedUsagePending
           }
+          poolOnly={variant === "compact"}
         />
       </div>
     ),
     enableSorting: true,
+    sortDescFirst: true,
   };
 }
 
-const modelTiersColumn: ColumnDef<RowData, string> = {
-  id: "modelTiers" as const,
-  header: () => (
-    <span className="flex items-center gap-1">
-      Models tier
-      <ModelTiersInfoButton />
-    </span>
-  ),
-  enableSorting: false,
-  accessorFn: (row) => row.modelTiersSummary,
-  cell: (info: Info) => {
-    const summary = info.row.original.modelTiersSummary;
-    const customSuffix = info.row.original.hasUserLevelModelTiersOverride
-      ? " (custom)"
-      : "";
+function buildModelTiersColumn(
+  variant: MembersUsageTableVariant
+): ColumnDef<RowData, string> {
+  return {
+    id: "modelTiers" as const,
+    header: () => (
+      <span className="flex items-center gap-1">
+        {(() => {
+          switch (variant) {
+            case "compact":
+              return "Models";
+            case "legacy":
+              return "Models tier";
+            default:
+              return assertNever(variant);
+          }
+        })()}
+        <ModelTiersInfoButton />
+      </span>
+    ),
+    enableSorting: false,
+    accessorFn: (row) => row.modelTiersSummary,
+    cell: (info: Info) => {
+      const summary = info.row.original.modelTiersSummary;
+      const customSuffix = info.row.original.hasUserLevelModelTiersOverride
+        ? " (custom)"
+        : "";
 
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {summary}
+            {customSuffix}
+          </span>
+        </DataTable.CellContent>
+      );
+    },
+    meta: {
+      className: "w-48",
+    },
+  };
+}
+
+function computeSeatUsage({
+  seatType,
+  memberUsageLimit,
+  seatBalanceAwu,
+  consumedFromAllowanceAwuCredits,
+}: {
+  seatType: MembershipSeatType | null;
+  memberUsageLimit: number | null;
+  seatBalanceAwu: number | null;
+  consumedFromAllowanceAwuCredits: number;
+}): {
+  percent: number;
+  isOverAllowance: boolean;
+  consumed: number;
+  allowance: number;
+} {
+  const allowance = memberUsageLimit ?? 0;
+  const isFreeWithBalance =
+    seatType === "free" &&
+    typeof seatBalanceAwu === "number" &&
+    typeof memberUsageLimit === "number";
+  const consumed = isFreeWithBalance
+    ? Math.max(0, memberUsageLimit - seatBalanceAwu)
+    : consumedFromAllowanceAwuCredits;
+  if (allowance <= 0) {
+    return {
+      percent: consumed > 0 ? 100 : 0,
+      isOverAllowance: consumed > 0,
+      consumed,
+      allowance,
+    };
+  }
+  return {
+    percent: Math.min(100, (consumed / allowance) * 100),
+    isOverAllowance: consumed > allowance,
+    consumed,
+    allowance,
+  };
+}
+
+interface SeatUsageRingProps {
+  percent: number;
+  colorClassName: string;
+}
+
+function SeatUsageRing({ percent, colorClassName }: SeatUsageRingProps) {
+  const radius = 6;
+  const circumference = 2 * Math.PI * radius;
+  const clamped = Math.min(100, Math.max(0, percent));
+  const dashOffset = circumference * (1 - clamped / 100);
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" className="-rotate-90">
+      <circle
+        cx="8"
+        cy="8"
+        r={radius}
+        strokeWidth="2"
+        fill="none"
+        stroke="currentColor"
+        className="text-muted-background"
+      />
+      {clamped > 0 && (
+        <circle
+          cx="8"
+          cy="8"
+          r={radius}
+          strokeWidth="2"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          className={colorClassName}
+        />
+      )}
+    </svg>
+  );
+}
+
+const seatsIconColumn: ColumnDef<RowData, string> = {
+  id: "seatsIcon" as const,
+  header: "Seats",
+  enableSorting: false,
+  accessorFn: (row) => row.seatType ?? "",
+  cell: (info: Info) => {
+    if (info.row.original.isSeatChangePending) {
+      return (
+        <DataTable.CellContent className="justify-center">
+          <Spinner size="xs" />
+        </DataTable.CellContent>
+      );
+    }
+    const { seatType, scheduledSeatType, scheduledSeatChangeAt } =
+      info.row.original;
+    if (!seatType) {
+      return (
+        <DataTable.CellContent className="justify-center">
+          <span className="text-sm text-muted-foreground">--</span>
+        </DataTable.CellContent>
+      );
+    }
+    const tooltipLabel = scheduledSeatType
+      ? getScheduledSeatChangeLabel(
+          seatType,
+          scheduledSeatType,
+          scheduledSeatChangeAt
+        )
+      : `${seatTypeDisplayName(seatType)} seat`;
     return (
-      <DataTable.CellContent>
-        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {summary}
-          {customSuffix}
-        </span>
+      <DataTable.CellContent className="justify-center">
+        <Tooltip
+          tooltipTriggerAsChild
+          label={tooltipLabel}
+          trigger={
+            <span className="flex cursor-default items-center justify-center">
+              <SeatTypeIcon seatType={seatType} />
+            </span>
+          }
+        />
       </DataTable.CellContent>
     );
   },
   meta: {
-    className: "w-48",
+    className: "w-16",
+    headerAlign: "center",
+  },
+};
+
+const seatUsageColumn: ColumnDef<RowData, string> = {
+  id: "seatUsage" as const,
+  header: "Seat usage",
+  enableSorting: true,
+  sortDescFirst: true,
+  accessorFn: (row) =>
+    computeSeatUsage({
+      seatType: row.seatType,
+      memberUsageLimit: row.memberUsageLimit,
+      seatBalanceAwu: row.seatBalanceAwu,
+      consumedFromAllowanceAwuCredits: row.consumedFromAllowanceAwuCredits,
+    }).percent.toString(),
+  cell: (info: Info) => {
+    const { seatType, memberUsageLimit, seatBalanceAwu, isSeatChangePending } =
+      info.row.original;
+    if (
+      isSeatChangePending ||
+      !seatType ||
+      memberUsageLimit === null ||
+      memberUsageLimit <= 0
+    ) {
+      return (
+        <DataTable.CellContent className="justify-center">
+          <span className="text-sm text-muted-foreground">--</span>
+        </DataTable.CellContent>
+      );
+    }
+    const { percent, isOverAllowance, consumed, allowance } = computeSeatUsage({
+      seatType,
+      memberUsageLimit,
+      seatBalanceAwu,
+      consumedFromAllowanceAwuCredits:
+        info.row.original.consumedFromAllowanceAwuCredits,
+    });
+    const colorClassName = isOverAllowance
+      ? "text-warning-700"
+      : getSeatIconColorClass(seatType);
+    return (
+      <DataTable.CellContent className="justify-center">
+        <Tooltip
+          tooltipTriggerAsChild
+          label={`${formatCredits(consumed)} / ${formatCredits(allowance)} credits used`}
+          trigger={
+            <div className="flex items-center gap-2">
+              <span className={cn("text-xs font-medium", colorClassName)}>
+                {Math.round(percent)}%
+              </span>
+              <SeatUsageRing
+                percent={percent}
+                colorClassName={colorClassName}
+              />
+            </div>
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-24",
+    headerAlign: "center",
   },
 };
 
@@ -580,25 +866,43 @@ function buildColumns({
   showGroupsColumn,
   showModelTiersColumn,
   creditsResetAt,
+  variant,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
   showModelTiersColumn: boolean;
   creditsResetAt: string | null;
+  variant: MembersUsageTableVariant;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
     nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
-    ...(showModelTiersColumn ? [modelTiersColumn] : []),
-    seatTypeColumn,
+    ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
+    ...(() => {
+      switch (variant) {
+        case "compact":
+          return [seatsIconColumn, seatUsageColumn];
+        case "legacy":
+          return [seatTypeColumn];
+        default:
+          return assertNever(variant);
+      }
+    })(),
     {
-      ...buildConsumedAwuCreditsColumn(creditsResetAt),
+      ...buildPoolCreditUsageColumn(creditsResetAt, variant),
       meta: { className: "w-64" },
     },
     actionsColumn,
   ];
 }
+
+// "compact" is the redesigned usage page layout: no "Up to " prefix on the
+// Models tier summary, a "Models" header instead of "Models tier", and the
+// combined seat column split into an icon-only Seats column plus a Seat
+// usage ring column. "legacy" keeps the current usage page unchanged.
+// TODO(arthur, 2026-08-28): drop the "legacy" variant and this flag once the flip is complete.
+export type MembersUsageTableVariant = "legacy" | "compact";
 
 interface MembersUsageTableProps {
   members: MemberUsageType[];
@@ -623,6 +927,7 @@ interface MembersUsageTableProps {
     selection: UserModelTierSelection
   ) => void;
   showModelTiersColumn?: boolean;
+  variant?: MembersUsageTableVariant;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
   userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
   groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
@@ -656,6 +961,7 @@ export function MembersUsageTable({
   onEditSpendLimit,
   onSetUserModelTier,
   showModelTiersColumn = false,
+  variant = "legacy",
   userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
   userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
   groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
@@ -700,15 +1006,26 @@ export function MembersUsageTable({
           consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
           spendLimitAwuCredits: m.spendLimitAwuCredits,
           spendLimitSource: m.spendLimitSource,
+          spendLimitGroupName: m.spendLimitGroupName,
           scheduledSeatType: m.scheduledSeatType,
           scheduledSeatChangeAt: m.scheduledSeatChangeAt,
           isTotalAllowedUsagePending: totalAllowedUsagePendingMemberIds.has(
             m.sId
           ),
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
-          modelTiersSummary: formatModelTiersSummary(
-            getMaxTierName(resolvedModelTiers?.tiers ?? [])
-          ),
+          modelTiersSummary: (() => {
+            const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
+            switch (variant) {
+              case "compact":
+                return maxTierName
+                  ? getModelsTierDisplayName(maxTierName)
+                  : "--";
+              case "legacy":
+                return formatModelTiersSummary(maxTierName);
+              default:
+                return assertNever(variant);
+            }
+          })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
             ...(!m.seatType || m.seatType === "none"
@@ -793,6 +1110,7 @@ export function MembersUsageTable({
       isSeatBased,
       showSpendLimit,
       showModelTiersColumn,
+      variant,
       userModelTierSelectionByUserId,
       userAllowedModelTiersByUserId,
       groupModelTiersByGroupId,
@@ -814,8 +1132,15 @@ export function MembersUsageTable({
         showGroupsColumn,
         showModelTiersColumn,
         creditsResetAt,
+        variant,
       }),
-    [enableSelection, showGroupsColumn, showModelTiersColumn, creditsResetAt]
+    [
+      enableSelection,
+      showGroupsColumn,
+      showModelTiersColumn,
+      creditsResetAt,
+      variant,
+    ]
   );
 
   if (isLoading) {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1822,6 +1822,9 @@ async function computeMembersUsageRanking({
   restrictToUserIds: string[] | undefined;
   filterKey: string;
 }): Promise<SerializableMembersUsageRankingOutcome> {
+  const startTimeMs = performance.now();
+  const workspaceId = workspace.sId;
+
   const allUsersResult = await UserResource.searchAllUsers(auth, {
     searchTerm: search,
     restrictToUserIds,
@@ -2056,6 +2059,17 @@ async function computeMembersUsageRanking({
     }
     return a.sId < b.sId ? -1 : a.sId > b.sId ? 1 : 0;
   });
+
+  logger.info(
+    {
+      workspaceId,
+      orderColumn,
+      orderDirection,
+      matchedUserCount: allUsers.length,
+      durationMs: Math.round(performance.now() - startTimeMs),
+    },
+    "[MembersUsage] Computed members usage ranking"
+  );
 
   return {
     status: "ok",

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -142,6 +142,9 @@ export type MemberUsageType = {
   // Where `spendLimitAwuCredits` comes from: a user-specific `override`, the
   // seat-type `default`, or `none` (no cap configured / unlimited).
   spendLimitSource: EffectiveSpendLimitSource;
+  // Name of the group behind `spendLimitAwuCredits` when `spendLimitSource`
+  // is `"group"`. Null for every other source.
+  spendLimitGroupName: string | null;
   // Id of the Metronome alert backing the effective cap (override or default),
   // for deep-linking to the dashboard. Null when uncapped.
   spendLimitAlertId: string | null;
@@ -1488,17 +1491,18 @@ export async function getMemberUsage({
     return { member: null };
   }
 
-  const [groupNamesByUserModelId, groupCapByUserModelId] = await Promise.all([
-    GroupResource.listGroupNamesByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [userResource.id],
-      groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
-    }),
-    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [userResource.id],
-    }),
-  ]);
+  const [groupNamesByUserModelId, maxPoolCapGroupByUserModelId] =
+    await Promise.all([
+      GroupResource.listGroupNamesByUserModelIdInWorkspace({
+        workspace,
+        userModelIds: [userResource.id],
+        groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+      }),
+      GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
+        workspace,
+        userModelIds: [userResource.id],
+      }),
+    ]);
 
   const metronomeUserId =
     membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
@@ -1565,8 +1569,8 @@ export async function getMemberUsage({
 
   // Max group cap (pool-only) + seat allowance, matching override/default units.
   // Only pool-bearing seats (pro/max/workspace) get a group cap.
-  const groupPoolCapAwuCredits =
-    groupCapByUserModelId.get(userResource.id) ?? null;
+  const maxPoolCapGroup = maxPoolCapGroupByUserModelId.get(userResource.id);
+  const groupPoolCapAwuCredits = maxPoolCapGroup?.capAwuCredits ?? null;
   const groupCapAwuCredits =
     groupPoolCapAwuCredits !== null && normalizedSeatType !== null
       ? groupPoolCapAwuCredits +
@@ -1608,6 +1612,10 @@ export async function getMemberUsage({
     rateLimiterSpendAwuCredits: null,
     metronomeConsumedAwuCredits: null,
     spendLimitSource,
+    spendLimitGroupName:
+      spendLimitSource === "group"
+        ? (maxPoolCapGroup?.groupName ?? null)
+        : null,
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,
     freeCreditLowAlert: null,
@@ -1783,9 +1791,7 @@ type MembersUsagePagePrefetch = {
     ReturnType<typeof fetchEffectivePerUserSpendLimits>
   >;
   groupCapByUserModelId?: Awaited<
-    ReturnType<
-      typeof GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace
-    >
+    ReturnType<typeof GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace>
   >;
 };
 
@@ -1890,7 +1896,7 @@ async function computeMembersUsageRanking({
               freeBalanceByUserId: new Map<string, number>(),
               freeStartingByUserId: new Map<string, number>(),
             }),
-        GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+        GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
           workspace,
           userModelIds: allUsers.map((u) => u.id),
         }),
@@ -1921,7 +1927,8 @@ async function computeMembersUsageRanking({
           seatType !== "none"
             ? membership.poolCapOverrideAwuCredits + seatAllowance
             : null;
-        const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+        const groupPoolCapAwuCredits =
+          groupCapByUserModelId.get(u.id)?.capAwuCredits ?? null;
         const groupCapAwuCredits =
           groupPoolCapAwuCredits !== null && normalizedSeatType !== null
             ? groupPoolCapAwuCredits + seatAllowance
@@ -2299,7 +2306,7 @@ export async function getMembersUsage({
       groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     }),
     prefetch.groupCapByUserModelId ??
-      GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
         workspace,
         userModelIds: users.map((u) => u.id),
       }),
@@ -2481,7 +2488,8 @@ export async function getMembersUsage({
     // Max group cap (pool-only, stored on the group) + seat allowance, to match
     // the units of override/default above. Only pool-bearing seats
     // (pro/max/workspace) get a group cap; free/none have no pool.
-    const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+    const maxPoolCapGroup = groupCapByUserModelId.get(u.id);
+    const groupPoolCapAwuCredits = maxPoolCapGroup?.capAwuCredits ?? null;
     const groupCapAwuCredits =
       groupPoolCapAwuCredits !== null && normalizedSeatType !== null
         ? groupPoolCapAwuCredits +
@@ -2553,6 +2561,10 @@ export async function getMembersUsage({
           ? (metronomeConsumedByUserId.get(userId) ?? 0)
           : null,
         spendLimitSource,
+        spendLimitGroupName:
+          spendLimitSource === "group"
+            ? (maxPoolCapGroup?.groupName ?? null)
+            : null,
         spendLimitAlertId,
         spendLimitWarningAlertId,
         freeCreditLowAlert: freeCreditAlerts?.low ?? null,

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -941,6 +941,43 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("listMaxPoolCapGroupByUserModelIdInWorkspace", () => {
+    it("returns the winning group's name alongside its cap", async () => {
+      const capped500 = await GroupResource.makeNew(
+        {
+          name: "Capped 500",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-500",
+        },
+        { memberIds: [user.id] }
+      );
+      await capped500.updatePoolCap(authenticator, 500);
+
+      const capped800 = await GroupResource.makeNew(
+        {
+          name: "Capped 800",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-capped-800",
+        },
+        { memberIds: [user.id] }
+      );
+      await capped800.updatePoolCap(authenticator, 800);
+
+      const result =
+        await GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({
+          workspace,
+          userModelIds: [user.id],
+        });
+
+      expect(result.get(user.id)).toEqual({
+        capAwuCredits: 800,
+        groupName: "Capped 800",
+      });
+    });
+  });
+
   describe("listWorkspaceGroupsFromKey", () => {
     it("system key: populates cache on first call and serves from cache on second", async () => {
       const key = await KeyFactory.system(systemGroup);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1363,19 +1363,19 @@ export class GroupResource extends BaseResource<GroupModel> {
     return result;
   }
 
-  // For each user, the highest per-group pool cap (excluding seat allowance)
-  // among the cap-eligible (provisioned) groups they belong to. Users with no
-  // capped group are absent from the map (the caller falls back to the workspace
-  // default). Used to resolve the "max(group caps)" term of a user's effective
-  // spend limit.
-  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+  // For each user, the cap-eligible group with the highest pool cap among
+  // their groups; users with no capped group are absent.
+  static async listMaxPoolCapGroupByUserModelIdInWorkspace({
     workspace,
     userModelIds,
   }: {
     workspace: LightWorkspaceType;
     userModelIds: ModelId[];
-  }): Promise<Map<ModelId, number>> {
-    const result = new Map<ModelId, number>();
+  }): Promise<Map<ModelId, { capAwuCredits: number; groupName: string }>> {
+    const result = new Map<
+      ModelId,
+      { capAwuCredits: number; groupName: string }
+    >();
     if (userModelIds.length === 0) {
       return result;
     }
@@ -1403,22 +1403,45 @@ export class GroupResource extends BaseResource<GroupModel> {
         poolCapAwuCredits: { [Op.ne]: null },
       },
     });
-    const capByGroupId = new Map(
-      groups.map((g) => [g.id, g.poolCapAwuCredits])
-    );
+    const cappedGroupById = new Map(groups.map((g) => [g.id, g]));
 
     for (const m of memberships) {
-      const cap = capByGroupId.get(m.groupId);
-      if (cap === undefined || cap === null) {
+      const group = cappedGroupById.get(m.groupId);
+      if (!group || group.poolCapAwuCredits === null) {
         continue;
       }
       const existing = result.get(m.userId);
-      if (existing === undefined || cap > existing) {
-        result.set(m.userId, cap);
+      if (
+        existing === undefined ||
+        group.poolCapAwuCredits > existing.capAwuCredits
+      ) {
+        result.set(m.userId, {
+          capAwuCredits: group.poolCapAwuCredits,
+          groupName: group.name,
+        });
       }
     }
 
     return result;
+  }
+
+  static async listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+  }): Promise<Map<ModelId, number>> {
+    const byGroup = await this.listMaxPoolCapGroupByUserModelIdInWorkspace({
+      workspace,
+      userModelIds,
+    });
+    return new Map(
+      [...byGroup].map(([userModelId, { capAwuCredits }]) => [
+        userModelId,
+        capAwuCredits,
+      ])
+    );
   }
 
   static async getMemberCountsForGroups(

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -458,7 +458,7 @@ export function useMembersUsage({
   searchTerm?: string;
   pageIndex: number;
   pageSize: number;
-  orderColumn?: "name" | "email" | "consumedAwuCredits";
+  orderColumn?: "name" | "email" | "consumedFromPoolAwuCredits" | "seatUsage";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType | "none";
   groupId?: string;


### PR DESCRIPTION
## Description

Reworks the members table on the redesigned usage page: a new default sort order, a more compact layout, and naming the group behind an inherited spend limit in the spend-limit tooltip.

Fifth PR in the stack reworking the Usage page.

## Tests

Type-checked; manually verified behind the `usage_page_redesign` flag.

## Risk

Low. UI-only change behind the feature flag.

## Deploy Plan

Deploy front.
