### PR TITLE
chore: gate file_generation to conversations without the sandbox

### DIFF
--- a/front/components/shared/tools_picker/MCPServerViewsContext.tsx
+++ b/front/components/shared/tools_picker/MCPServerViewsContext.tsx
@@ -5,7 +5,9 @@ import {
   mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import groupBy from "lodash/groupBy";
@@ -55,9 +57,11 @@ export const MCPServerViewsContext = createContext<
 function getGroupedMCPServerViews({
   mcpServerViews,
   spaces,
+  hasSandbox,
 }: {
   mcpServerViews: MCPServerViewType[];
   spaces: SpaceType[];
+  hasSandbox: boolean;
 }) {
   if (!mcpServerViews || !Array.isArray(mcpServerViews)) {
     return {
@@ -104,8 +108,14 @@ function getGroupedMCPServerViews({
         : "mcpServerViewsWithoutKnowledge"
     );
 
+  // The sandbox generates and converts files itself, so file_generation is not offered when
+  // it is available.
+  const selectableViewsWithoutKnowledge = (
+    mcpServerViewsWithoutKnowledge || []
+  ).filter((view) => !hasSandbox || view.server.name !== "file_generation");
+
   const grouped = groupBy(
-    mcpServerViewsWithoutKnowledge,
+    selectableViewsWithoutKnowledge,
     (view) => view.server.availability
   );
 
@@ -146,6 +156,7 @@ export const MCPServerViewsProvider = ({
   includeRestrictedToSkills = false,
 }: MCPServerViewsProviderProps) => {
   const { spaces, isSpacesLoading } = useSpacesContext();
+  const { featureFlags } = useFeatureFlags();
 
   const {
     serverViews: mcpServerViews,
@@ -167,8 +178,9 @@ export const MCPServerViewsProvider = ({
       return getGroupedMCPServerViews({
         mcpServerViews: sortedMCPServerViews,
         spaces,
+        hasSandbox: isComputerFeatureEnabled(featureFlags),
       });
-    }, [sortedMCPServerViews, spaces]);
+    }, [sortedMCPServerViews, spaces, featureFlags]);
 
   const value: MCPServerViewsContextType = useMemo(() => {
     return {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -80,6 +80,7 @@ import {
   isClientSideMCPToolConfiguration,
   isMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
+  isServerSideMCPServerConfigurationWithName,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 import { getBaseServerId } from "@app/lib/api/actions/mcp/client_side_registry";
@@ -1028,7 +1029,7 @@ export function deduplicateMCPServerConfigurations({
   jitServers: MCPServerConfigurationType[];
 }): MCPServerConfigurationType[] {
   const seen = new Set<string>();
-  return [
+  const configs = [
     ...agentActions,
     ...clientSideActions,
     ...skillServers,
@@ -1043,6 +1044,20 @@ export function deduplicateMCPServerConfigurations({
     seen.add(key);
     return true;
   });
+
+  // The sandbox generates and converts files itself, so file_generation is only exposed to
+  // conversations running without it.
+  const hasSandbox = configs.some((config) =>
+    isServerSideMCPServerConfigurationWithName(config, "sandbox")
+  );
+  if (hasSandbox) {
+    return configs.filter(
+      (config) =>
+        !isServerSideMCPServerConfigurationWithName(config, "file_generation")
+    );
+  }
+
+  return configs;
 }
 
 /**


### PR DESCRIPTION
## Description

The sandbox already generates and converts files, so keeping `file_generation` next to it gives the model two ways to do the same thing. It is now dropped from the resolved server list whenever the sandbox is part of a run (in `deduplicateMCPServerConfigurations`, so the sandbox child-action path gets it too), and hidden from the tools picker when the computer feature is enabled. Existing agents that have it configured still resolve and render fine, and conversations without the sandbox keep the tool.

## Tests

By hand

## Risk

Low. First step to deprecation of this tool until we fully release sbx.

## Deploy Plan

Deploy front.