### PR TITLE
[front] Filter model tiers modal to workspace-available models

### DIFF
--- a/front/components/workspace/ModelTiersInfoModal.tsx
+++ b/front/components/workspace/ModelTiersInfoModal.tsx
@@ -1,5 +1,7 @@
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import type { ModelTierExplainerTier } from "@app/lib/client/model_tiers_explainer";
 import { getModelTierExplainer } from "@app/lib/client/model_tiers_explainer";
+import { useModels } from "@app/lib/swr/models";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   Button,
@@ -14,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
   Icon,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type { ReactNode } from "react";
@@ -99,17 +102,23 @@ function TierCard({ tier }: TierCardProps) {
                 Reasoning effort
               </span>
             </div>
-            {tier.models.map((model) => (
-              <div
-                key={model.displayName}
-                className="flex items-center justify-between gap-3 border-t border-border py-3 dark:border-border-dark"
-              >
-                <span className="text-sm text-foreground dark:text-foreground-night">
-                  {model.displayName}
-                </span>
-                <Chip size="xs" color="primary" label={model.effortsLabel} />
+            {tier.models.length === 0 ? (
+              <div className="border-t border-border py-3 text-sm text-muted-foreground dark:border-border-dark dark:text-muted-foreground-night">
+                No model in this tier is available in this workspace.
               </div>
-            ))}
+            ) : (
+              tier.models.map((model) => (
+                <div
+                  key={model.displayName}
+                  className="flex items-center justify-between gap-3 border-t border-border py-3 dark:border-border-dark"
+                >
+                  <span className="text-sm text-foreground dark:text-foreground-night">
+                    {model.displayName}
+                  </span>
+                  <Chip size="xs" color="primary" label={model.effortsLabel} />
+                </div>
+              ))
+            )}
           </div>
         </CollapsibleContent>
       </div>
@@ -123,7 +132,12 @@ interface ModelTiersInfoDialogProps {
 }
 
 function ModelTiersInfoDialog({ isOpen, onClose }: ModelTiersInfoDialogProps) {
-  const tiers = useMemo(() => getModelTierExplainer(), []);
+  const owner = useWorkspace();
+  const { models, isModelsLoading } = useModels({ owner, disabled: !isOpen });
+  const tiers = useMemo(
+    () => getModelTierExplainer(new Set(models.map((model) => model.modelId))),
+    [models]
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -161,11 +175,17 @@ function ModelTiersInfoDialog({ isOpen, onClose }: ModelTiersInfoDialogProps) {
               Select a tier to see the models and reasoning efforts it includes.
             </InfoSection>
           </div>
-          <div className="flex flex-col gap-2">
-            {tiers.map((tier) => (
-              <TierCard key={tier.name} tier={tier} />
-            ))}
-          </div>
+          {isModelsLoading ? (
+            <div className="flex justify-center py-8">
+              <Spinner size="md" />
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {tiers.map((tier) => (
+                <TierCard key={tier.name} tier={tier} />
+              ))}
+            </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/front/lib/client/model_tiers_explainer.ts
+++ b/front/lib/client/model_tiers_explainer.ts
@@ -40,15 +40,6 @@ function formatEffortsLabel(
   return inTierEfforts.join(" · ");
 }
 
-/**
- * Describes what each model tier contains, restricted to the models this
- * workspace can actually reach (`availableModelIds`, from `useModels`).
- *
- * Reasoning efforts are read from the static configs on purpose: the viewer's
- * own tier cap must not narrow them here. This powers the "How model tiers
- * work" modal, which explains the whole catalog the workspace can reach rather
- * than what the viewer is allowed to select.
- */
 export function getModelTierExplainer(
   availableModelIds: Set<string>
 ): ModelTierExplainerTier[] {

--- a/front/lib/client/model_tiers_explainer.ts
+++ b/front/lib/client/model_tiers_explainer.ts
@@ -40,12 +40,24 @@ function formatEffortsLabel(
   return inTierEfforts.join(" · ");
 }
 
-export function getModelTierExplainer(): ModelTierExplainerTier[] {
+/**
+ * Describes what each model tier contains, restricted to the models this
+ * workspace can actually reach (`availableModelIds`, from `useModels`).
+ *
+ * Reasoning efforts are read from the static configs on purpose: the viewer's
+ * own tier cap must not narrow them here. This powers the "How model tiers
+ * work" modal, which explains the whole catalog the workspace can reach rather
+ * than what the viewer is allowed to select.
+ */
+export function getModelTierExplainer(
+  availableModelIds: Set<string>
+): ModelTierExplainerTier[] {
   return MODELS_TIERS.map((tier) => {
     const models: ModelTierExplainerEntry[] = [];
 
     for (const config of USED_MODEL_CONFIGS) {
       if (
+        !availableModelIds.has(config.modelId) ||
         HIDDEN_PROVIDER_IDS.has(config.providerId) ||
         isModelStreamId(config.modelId) ||
         !isStaticModelId(config.modelId)


### PR DESCRIPTION
## Description

The "How model tiers work" modal in `/usage` built its tier lists straight from the static `USED_MODEL_CONFIGS` catalog, so it advertised every model in the codebase regardless of what the workspace can actually reach — e.g. Fable 5 showed up under Premium for workspaces without `claude_fable_5_feature`.

Now restricted to available models per workspace!

## Tests

Tested locally

## Risk

low -- display only

## Deploy Plan

Standard deploy, no ordering constraints.