### PR TITLE
[front] consumption chart: paint today label above bars

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -305,15 +305,6 @@ export function ConsumptionDailyChart({
           content={renderTooltip}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
         />
-        {partialTimestamp !== undefined && (
-          <ReferenceLine
-            x={partialTimestamp}
-            stroke="var(--color-primary)"
-            strokeDasharray="5 5"
-            label={{ position: "top", content: TodayPartialLabel }}
-            ifOverflow="extendDomain"
-          />
-        )}
         {orderedGroups.map((group, rank) => {
           const colorClassName = getConsumptionChartColor(rank);
 
@@ -342,6 +333,15 @@ export function ConsumptionDailyChart({
             </Bar>
           );
         })}
+        {partialTimestamp !== undefined && (
+          <ReferenceLine
+            x={partialTimestamp}
+            stroke="var(--color-primary)"
+            strokeDasharray="5 5"
+            label={{ position: "top", content: TodayPartialLabel }}
+            ifOverflow="extendDomain"
+          />
+        )}
       </BarChart>
     </ChartContainer>
   );


### PR DESCRIPTION
On the analytics consumption chart, the "Today (partial)" pill was painted behind the bars: the `ReferenceLine` was declared before the `Bar` series, and recharts paints SVG children in JSX order. When the tallest bar of the period sits next to the today line and reaches near the top of the axis, it covers the label.

Fix: declare the `ReferenceLine` after the bars so the line and its label paint on top.

Before / After:
<kbd><img width="1121" height="485" alt="Screenshot 2026-08-31 at 11 29 44" src="https://github.com/user-attachments/assets/b10c2d59-b0ec-4fd6-84bc-5def12f3c0f0" /></kbd>
<kbd><img width="1107" height="490" alt="Screenshot 2026-08-31 at 11 34 02" src="https://github.com/user-attachments/assets/be4090a9-6124-4ab1-aee1-4e3eb279f7c8" /></kbd>

