### PR TITLE
[sparkle] add Databricks platform logo

### DIFF
--- a/sparkle/src/logo/platforms/Databricks.tsx
+++ b/sparkle/src/logo/platforms/Databricks.tsx
@@ -1,0 +1,29 @@
+import type { SVGProps } from "react";
+import * as React from "react";
+
+const SvgDatabricks = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlSpace="preserve"
+    width="1em"
+    height="1em"
+    viewBox="0 0 193 200"
+    style={{
+      fillRule: "evenodd",
+      clipRule: "evenodd",
+      strokeLinejoin: "round",
+      strokeMiterlimit: 2,
+    }}
+    {...props}
+  >
+    <path
+      d="m18.318 9.275-8.631 4.859L.445 8.942 0 9.182v3.77l9.687 5.431 8.63-4.84v1.995l-8.63 4.86-9.242-5.192-.445.24v.646l9.687 5.432 9.668-5.432v-3.769l-.445-.24-9.223 5.173-8.65-4.84V10.42l8.65 4.84 9.668-5.43V6.114l-.482-.277-9.186 5.155L1.482 6.41l8.205-4.6 6.741 3.787.593-.332v-.462L9.687.684 0 6.115v.592l9.687 5.432 8.63-4.86z"
+      style={{
+        fill: "#ee3d2c",
+        fillRule: "nonzero",
+      }}
+      transform="matrix(9.92432 0 0 9.59693 0 -6.564)"
+    />
+  </svg>
+);
+export default SvgDatabricks;

--- a/sparkle/src/logo/platforms/index.ts
+++ b/sparkle/src/logo/platforms/index.ts
@@ -15,6 +15,7 @@ export { default as CohereLogo } from "./Cohere";
 export { default as ConfluenceLogo } from "./Confluence";
 export { default as ContentsquareLogo } from "./Contentsquare";
 export { default as CostoryLogo } from "./Costory";
+export { default as DatabricksLogo } from "./Databricks";
 export { default as DatadogLogo } from "./Datadog";
 export { default as DeepseekLogo } from "./Deepseek";
 export { default as DiscordLogo } from "./Discord";

--- a/sparkle/src/logo/platforms/registry.ts
+++ b/sparkle/src/logo/platforms/registry.ts
@@ -17,6 +17,7 @@ import CohereLogo from "./Cohere";
 import ConfluenceLogo from "./Confluence";
 import ContentsquareLogo from "./Contentsquare";
 import CostoryLogo from "./Costory";
+import DatabricksLogo from "./Databricks";
 import DatadogLogo from "./Datadog";
 import DeepseekLogo from "./Deepseek";
 import DiscordLogo from "./Discord";
@@ -129,6 +130,7 @@ export const PLATFORM_LOGOS = {
   ConfluenceLogo,
   ContentsquareLogo,
   CostoryLogo,
+  DatabricksLogo,
   DatadogLogo,
   DeepseekLogo,
   DiscordLogo,

--- a/sparkle/src/logo/src/platforms/Databricks.svg
+++ b/sparkle/src/logo/src/platforms/Databricks.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg width="100%" height="100%" viewBox="0 0 193 200" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(9.924318,0,0,9.596929,0,-6.564299)">
+        <path d="M18.318,9.275L9.687,14.134L0.445,8.942L0,9.182L0,12.952L9.687,18.383L18.317,13.543L18.317,15.538L9.687,20.398L0.445,15.206L-0,15.446L-0,16.092L9.687,21.524L19.355,16.092L19.355,12.323L18.91,12.083L9.687,17.256L1.037,12.416L1.037,10.42L9.687,15.26L19.355,9.83L19.355,6.114L18.873,5.837L9.687,10.992L1.482,6.41L9.687,1.81L16.428,5.597L17.021,5.265L17.021,4.803L9.687,0.684L0,6.115L0,6.707L9.687,12.139L18.317,7.279L18.318,9.275Z" style="fill:rgb(238,61,44);fill-rule:nonzero;"/>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds a `DatabricksLogo` platform logo to the Sparkle design system, so it can be used as the icon for the upcoming Databricks managed MCP server presets (SQL, Genie).

## Changes
- `src/logo/src/platforms/Databricks.svg` — source SVG (brand red `#ee3d2c`).
- `src/logo/platforms/Databricks.tsx` — generated component (svgr; `1em`, viewBox preserved).
- `src/logo/platforms/index.ts` — export `DatabricksLogo`.
- `src/logo/platforms/registry.ts` — add to `PLATFORM_LOGOS` (so it appears in the Assets → Platform Logos catalog).

## Test plan
- `tsgo` clean; biome clean.
- Visible under Storybook → Assets → Platform Logos.
- tested locally

## deploy
- sparkle only
