### PR TITLE
[front] agents table: show model tier chip

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -394,7 +394,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "hidden @sm:w-28 @sm:table-cell @xl:w-60",
+        className: "hidden @sm:w-28 @sm:table-cell @xl:w-56",
       },
     },
     {

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -25,6 +25,7 @@ import type {
   AgentUsageType,
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getTieredReasoningEffort } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type {
@@ -360,6 +361,11 @@ const getTableColumns = ({
             ? `${modelName} ${capitalize(reasoningEffort)}`
             : modelName;
 
+        // Streams are named after their tier: the chip alone carries the info.
+        const isStreamModel = modelConfig
+          ? isModelStreamId(modelConfig.modelId)
+          : false;
+
         return (
           <Tooltip
             tooltipTriggerAsChild
@@ -374,9 +380,11 @@ const getTableColumns = ({
                   iconClassName="mr-2"
                 >
                   <div className="flex min-w-0 items-center gap-2">
-                    <span className="hidden min-w-0 truncate @xl:inline">
-                      {modelName}
-                    </span>
+                    {!isStreamModel && (
+                      <span className="hidden min-w-0 truncate @xl:inline">
+                        {modelName}
+                      </span>
+                    )}
                     {!modelIcon && <span className="@xl:hidden">-</span>}
                     {modelConfig && (
                       <div className="shrink-0">

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -394,7 +394,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "hidden @sm:w-28 @sm:table-cell @xl:w-72",
+        className: "hidden @sm:w-28 @sm:table-cell @xl:w-60",
       },
     },
     {

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -366,10 +366,7 @@ const getTableColumns = ({
             label={tooltipLabel}
             trigger={
               <div className="inline-flex">
-                <DataTable.CellContent
-                  icon={modelIcon}
-                  iconClassName="mr-0 @xl:mr-2"
-                >
+                <DataTable.CellContent icon={modelIcon} iconClassName="mr-2">
                   <div className="flex min-w-0 items-center gap-2">
                     <span className="hidden min-w-0 truncate @xl:inline">
                       {modelName}

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -25,6 +25,7 @@ import type {
   AgentUsageType,
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
+import { getTieredReasoningEffort } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -50,6 +51,7 @@ import {
   Trash01,
 } from "@dust-tt/sparkle";
 import type { CellContext, HeaderContext } from "@tanstack/react-table";
+import capitalize from "lodash/capitalize";
 import type { ComponentType, ReactNode } from "react";
 import { useMemo, useState } from "react";
 
@@ -348,10 +350,20 @@ const getTableColumns = ({
         const { modelIcon, modelConfig, modelReasoningEffort } =
           info.row.original;
 
+        // Surface the reasoning effort the tier resolves at: two agents on the
+        // same model can be on different tiers because of it.
+        const reasoningEffort = modelConfig
+          ? getTieredReasoningEffort(modelConfig, modelReasoningEffort)
+          : null;
+        const tooltipLabel =
+          reasoningEffort && reasoningEffort !== "none"
+            ? `${modelName} ${capitalize(reasoningEffort)}`
+            : modelName;
+
         return (
           <Tooltip
             tooltipTriggerAsChild
-            label={modelName}
+            label={tooltipLabel}
             trigger={
               <div className="inline-flex">
                 <DataTable.CellContent

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -365,8 +365,14 @@ const getTableColumns = ({
             tooltipTriggerAsChild
             label={tooltipLabel}
             trigger={
-              <div className="inline-flex">
-                <DataTable.CellContent icon={modelIcon} iconClassName="mr-2">
+              // Full width so the cell constrains the flex chain: the name
+              // truncates instead of the chip being clipped at the cell edge.
+              <div className="inline-flex w-full min-w-0">
+                <DataTable.CellContent
+                  className="w-full min-w-0"
+                  icon={modelIcon}
+                  iconClassName="mr-2"
+                >
                   <div className="flex min-w-0 items-center gap-2">
                     <span className="hidden min-w-0 truncate @xl:inline">
                       {modelName}
@@ -388,7 +394,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "hidden @sm:w-28 @sm:table-cell @xl:w-60",
+        className: "hidden @sm:w-28 @sm:table-cell @xl:w-72",
       },
     },
     {

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -4,6 +4,7 @@ import { SCOPE_INFO } from "@app/components/assistant/details/AgentDetailsSheet"
 import { GlobalAgentAction } from "@app/components/assistant/manager/GlobalAgentAction";
 import { TableTagSelector } from "@app/components/assistant/manager/TableTagSelector";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
+import { ModelTierChip } from "@app/components/model_picker/ModelTierChip";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
@@ -25,6 +26,10 @@ import type {
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import { getModelMaker } from "@app/types/assistant/models/providers";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { TagType } from "@app/types/tag";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -62,6 +67,8 @@ type RowData = {
   scope: AgentConfigurationScope;
   model: string;
   modelIcon: ComponentType | undefined;
+  modelConfig: ModelConfigurationType | null;
+  modelReasoningEffort: ReasoningEffort | undefined;
   onClick?: () => void;
   menuItems?: MenuItem[];
   agentTags: TagType[];
@@ -85,6 +92,8 @@ const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
     scope: "hidden",
     model: "",
     modelIcon: undefined,
+    modelConfig: null,
+    modelReasoningEffort: undefined,
     agentTags: [],
     agentTagsAsString: "",
     canArchive: false,
@@ -336,7 +345,8 @@ const getTableColumns = ({
       accessorKey: "model",
       cell: (info: CellContext<RowData, string>) => {
         const modelName = info.getValue() || "-";
-        const modelIcon = info.row.original.modelIcon;
+        const { modelIcon, modelConfig, modelReasoningEffort } =
+          info.row.original;
 
         return (
           <Tooltip
@@ -348,8 +358,20 @@ const getTableColumns = ({
                   icon={modelIcon}
                   iconClassName="mr-0 @xl:mr-2"
                 >
-                  <span className="hidden @xl:inline">{modelName}</span>
-                  {!modelIcon && <span className="@xl:hidden">-</span>}
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="hidden min-w-0 truncate @xl:inline">
+                      {modelName}
+                    </span>
+                    {!modelIcon && <span className="@xl:hidden">-</span>}
+                    {modelConfig && (
+                      <div className="shrink-0">
+                        <ModelTierChip
+                          model={modelConfig}
+                          reasoningEffort={modelReasoningEffort}
+                        />
+                      </div>
+                    )}
+                  </div>
                 </DataTable.CellContent>
               </div>
             }
@@ -357,7 +379,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "hidden @sm:w-20 @sm:table-cell @xl:w-48",
+        className: "hidden @sm:w-28 @sm:table-cell @xl:w-60",
       },
     },
     {
@@ -634,6 +656,8 @@ export function AssistantsTable({
           modelIcon: modelConfig
             ? getModelMakerLogo(getModelMaker(modelConfig), isDark)
             : undefined,
+          modelConfig,
+          modelReasoningEffort: agentConfiguration.model.reasoningEffort,
           agentTags: agentConfiguration.tags,
           agentTagsAsString:
             agentConfiguration.tags.length > 0

--- a/front/components/model_picker/ModelTierChip.tsx
+++ b/front/components/model_picker/ModelTierChip.tsx
@@ -1,6 +1,6 @@
 import {
   getModelsTierDisplayName,
-  getTierForModel,
+  getTierForModelConfiguration,
 } from "@app/types/assistant/models/model_tiers";
 import type {
   ModelConfigurationType,
@@ -13,16 +13,8 @@ interface ModelTierChipProps {
   reasoningEffort?: ReasoningEffort;
 }
 
-export function ModelTierChip({
-  model,
-  reasoningEffort = model.defaultReasoningEffort,
-}: ModelTierChipProps) {
-  // An agent can carry a reasoning effort its model no longer maps to a tier
-  // (e.g. "medium" kept from a previous model after switching to "auto");
-  // fall back to the model's default effort rather than showing nothing.
-  const tier =
-    getTierForModel(model.modelId, reasoningEffort) ??
-    getTierForModel(model.modelId, model.defaultReasoningEffort);
+export function ModelTierChip({ model, reasoningEffort }: ModelTierChipProps) {
+  const tier = getTierForModelConfiguration(model, reasoningEffort);
   if (!tier) {
     return null;
   }

--- a/front/components/model_picker/ModelTierChip.tsx
+++ b/front/components/model_picker/ModelTierChip.tsx
@@ -1,3 +1,4 @@
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import {
   getModelsTierDisplayName,
   getTierForModelConfiguration,
@@ -14,6 +15,11 @@ interface ModelTierChipProps {
 }
 
 export function ModelTierChip({ model, reasoningEffort }: ModelTierChipProps) {
+  // Streams are named after their tier: the chip would repeat the model name.
+  if (isModelStreamId(model.modelId)) {
+    return null;
+  }
+
   const tier = getTierForModelConfiguration(model, reasoningEffort);
   if (!tier) {
     return null;

--- a/front/components/model_picker/ModelTierChip.tsx
+++ b/front/components/model_picker/ModelTierChip.tsx
@@ -1,4 +1,3 @@
-import { isModelStreamId } from "@app/types/assistant/models/auto";
 import {
   getModelsTierDisplayName,
   getTierForModelConfiguration,
@@ -15,11 +14,6 @@ interface ModelTierChipProps {
 }
 
 export function ModelTierChip({ model, reasoningEffort }: ModelTierChipProps) {
-  // Streams are named after their tier: the chip would repeat the model name.
-  if (isModelStreamId(model.modelId)) {
-    return null;
-  }
-
   const tier = getTierForModelConfiguration(model, reasoningEffort);
   if (!tier) {
     return null;

--- a/front/components/model_picker/ModelTierChip.tsx
+++ b/front/components/model_picker/ModelTierChip.tsx
@@ -17,7 +17,12 @@ export function ModelTierChip({
   model,
   reasoningEffort = model.defaultReasoningEffort,
 }: ModelTierChipProps) {
-  const tier = getTierForModel(model.modelId, reasoningEffort);
+  // An agent can carry a reasoning effort its model no longer maps to a tier
+  // (e.g. "medium" kept from a previous model after switching to "auto");
+  // fall back to the model's default effort rather than showing nothing.
+  const tier =
+    getTierForModel(model.modelId, reasoningEffort) ??
+    getTierForModel(model.modelId, model.defaultReasoningEffort);
   if (!tier) {
     return null;
   }

--- a/front/types/assistant/models/model_tiers.test.ts
+++ b/front/types/assistant/models/model_tiers.test.ts
@@ -3,8 +3,10 @@ import {
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import {
   getTierForModel,
+  getTierForModelConfiguration,
   getTierForSelection,
   MODELS_TIERS,
   STATIC_MODEL_SUPPORTED_REASONING_EFFORTS,
@@ -134,5 +136,42 @@ describe("model_tiers", () => {
         reasoningEffort: "high",
       })
     ).toBe("premium");
+  });
+
+  describe("getTierForModelConfiguration", () => {
+    const getConfig = (modelId: ModelIdType) => {
+      const config = SUPPORTED_MODEL_CONFIGS.find(
+        (c) => c.modelId === modelId
+      );
+      if (!config) {
+        throw new Error(`No supported model config for ${modelId}`);
+      }
+      return config;
+    };
+
+    it("resolves the tier for a mapped reasoning effort", () => {
+      expect(
+        getTierForModelConfiguration(
+          getConfig(CLAUDE_SONNET_5_MODEL_ID),
+          "high"
+        )
+      ).toBe("premium");
+    });
+
+    it("falls back to the default effort when none is given", () => {
+      const config = getConfig(CLAUDE_SONNET_5_MODEL_ID);
+
+      expect(getTierForModelConfiguration(config)).toBe(
+        getTierForModel(config.modelId, config.defaultReasoningEffort)
+      );
+    });
+
+    it("falls back to the default effort for a stale unmapped effort", () => {
+      // The auto stream only maps "none"; a stale "medium" kept from a
+      // previous model must resolve to the stream's own tier, not to no tier.
+      expect(getTierForModelConfiguration(AUTO_MODEL_CONFIG, "medium")).toBe(
+        "balanced"
+      );
+    });
   });
 });

--- a/front/types/assistant/models/model_tiers.test.ts
+++ b/front/types/assistant/models/model_tiers.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/types/assistant/models/anthropic";
 import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import {
+  getTieredReasoningEffort,
   getTierForModel,
   getTierForModelConfiguration,
   getTierForSelection,
@@ -169,6 +170,25 @@ describe("model_tiers", () => {
       // previous model must resolve to the stream's own tier, not to no tier.
       expect(getTierForModelConfiguration(AUTO_MODEL_CONFIG, "medium")).toBe(
         "balanced"
+      );
+    });
+  });
+
+  describe("getTieredReasoningEffort", () => {
+    it("keeps a mapped effort and replaces a stale one", () => {
+      const sonnet = SUPPORTED_MODEL_CONFIGS.find(
+        (c) => c.modelId === CLAUDE_SONNET_5_MODEL_ID
+      );
+      if (!sonnet) {
+        throw new Error("No supported model config for sonnet");
+      }
+
+      expect(getTieredReasoningEffort(sonnet, "high")).toBe("high");
+      expect(getTieredReasoningEffort(sonnet)).toBe(
+        sonnet.defaultReasoningEffort
+      );
+      expect(getTieredReasoningEffort(AUTO_MODEL_CONFIG, "medium")).toBe(
+        "none"
       );
     });
   });

--- a/front/types/assistant/models/model_tiers.test.ts
+++ b/front/types/assistant/models/model_tiers.test.ts
@@ -140,9 +140,7 @@ describe("model_tiers", () => {
 
   describe("getTierForModelConfiguration", () => {
     const getConfig = (modelId: ModelIdType) => {
-      const config = SUPPORTED_MODEL_CONFIGS.find(
-        (c) => c.modelId === modelId
-      );
+      const config = SUPPORTED_MODEL_CONFIGS.find((c) => c.modelId === modelId);
       if (!config) {
         throw new Error(`No supported model config for ${modelId}`);
       }

--- a/front/types/assistant/models/model_tiers.ts
+++ b/front/types/assistant/models/model_tiers.ts
@@ -2,6 +2,7 @@ import type { StaticModelIdType } from "@app/types/assistant/models/models";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import { STATIC_MODEL_SUPPORTED_REASONING_EFFORTS } from "@app/types/assistant/models/static_model_reasoning_efforts";
 import type {
+  ModelConfigurationType,
   ModelIdType,
   ModelProviderIdType,
   ReasoningEffort,
@@ -486,4 +487,19 @@ export function getTierForModel(
     return "premium";
   }
   return STATIC_MODEL_TIERS[modelId][reasoningEffort] ?? null;
+}
+
+// A stored selection can carry a reasoning effort its model maps to no tier
+// (e.g. an effort kept from a previous model after switching to a stream);
+// fall back to the model's default effort rather than resolving no tier.
+export function getTierForModelConfiguration(
+  model: ModelConfigurationType,
+  reasoningEffort?: ReasoningEffort
+): ModelsTierName | null {
+  return (
+    getTierForModel(
+      model.modelId,
+      reasoningEffort ?? model.defaultReasoningEffort
+    ) ?? getTierForModel(model.modelId, model.defaultReasoningEffort)
+  );
 }

--- a/front/types/assistant/models/model_tiers.ts
+++ b/front/types/assistant/models/model_tiers.ts
@@ -496,10 +496,12 @@ export function getTierForModelConfiguration(
   model: ModelConfigurationType,
   reasoningEffort?: ReasoningEffort
 ): ModelsTierName | null {
-  return (
-    getTierForModel(
-      model.modelId,
-      reasoningEffort ?? model.defaultReasoningEffort
-    ) ?? getTierForModel(model.modelId, model.defaultReasoningEffort)
-  );
+  if (reasoningEffort) {
+    const tier = getTierForModel(model.modelId, reasoningEffort);
+    if (tier) {
+      return tier;
+    }
+  }
+
+  return getTierForModel(model.modelId, model.defaultReasoningEffort);
 }

--- a/front/types/assistant/models/model_tiers.ts
+++ b/front/types/assistant/models/model_tiers.ts
@@ -491,17 +491,24 @@ export function getTierForModel(
 
 // A stored selection can carry a reasoning effort its model maps to no tier
 // (e.g. an effort kept from a previous model after switching to a stream);
-// fall back to the model's default effort rather than resolving no tier.
+// fall back to the model's default effort rather than resolving no effort.
+export function getTieredReasoningEffort(
+  model: ModelConfigurationType,
+  reasoningEffort?: ReasoningEffort
+): ReasoningEffort {
+  if (reasoningEffort && getTierForModel(model.modelId, reasoningEffort)) {
+    return reasoningEffort;
+  }
+
+  return model.defaultReasoningEffort;
+}
+
 export function getTierForModelConfiguration(
   model: ModelConfigurationType,
   reasoningEffort?: ReasoningEffort
 ): ModelsTierName | null {
-  if (reasoningEffort) {
-    const tier = getTierForModel(model.modelId, reasoningEffort);
-    if (tier) {
-      return tier;
-    }
-  }
-
-  return getTierForModel(model.modelId, model.defaultReasoningEffort);
+  return getTierForModel(
+    model.modelId,
+    getTieredReasoningEffort(model, reasoningEffort)
+  );
 }


### PR DESCRIPTION
On the manage agents page, the Model column now shows the model's tier (Basic / Standard / Premium) next to the provider icon and model name, reusing `ModelTierChip`.

The tier resolves from the agent's model and stored reasoning effort. Some stored efforts map to no tier for their model (e.g. `medium` kept from a previous model after switching to the `auto` stream, which is only tiered at `none`): in that case resolution falls back to the model's default effort, so the chip always shows a tier. This lives in `getTierForModelConfiguration` and `getTieredReasoningEffort`, next to `getTierForModel`, with tests.

Since two agents on the same model can be on different tiers because of their reasoning effort, the cell tooltip shows the effort the tier resolves at (e.g. "Claude Opus 4.8 High"), following the model picker's naming.

Streams (`auto`, `auto_fast`, `auto_complex`) show only the chip, no model name: they are named after their tier, so the name would repeat the chip.

Long model names truncate with an ellipsis before the chip does, so the chip is always fully visible.

Test it here: https://pr-31440-merge--app.preview.dust.tt/w/0ec9852c2f/builder/agents#?selectedTab=all