### PR TITLE
Skills: Store manually requested spaces 2.5/4: backfill archived and suggested skills

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2127,6 +2127,34 @@ describe("SkillResource", () => {
     });
   });
 
+  describe("fetchByModelIds", () => {
+    it("returns active skills only unless a status is given", async () => {
+      const activeSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Active Skill",
+      });
+      const archivedSkill = await SkillFactory.create(
+        testContext.authenticator,
+        { name: "Archived Skill", status: "archived" }
+      );
+      const modelIds = [activeSkill.id, archivedSkill.id];
+
+      const defaultFetch = await SkillResource.fetchByModelIds(
+        testContext.authenticator,
+        modelIds
+      );
+      expect(defaultFetch.map((skill) => skill.id)).toEqual([activeSkill.id]);
+
+      const withArchived = await SkillResource.fetchByModelIds(
+        testContext.authenticator,
+        modelIds,
+        { status: ["active", "archived"] }
+      );
+      expect(withArchived.map((skill) => skill.id).sort()).toEqual(
+        [...modelIds].sort()
+      );
+    });
+  });
+
   describe("fetchByIds", () => {
     it("skips heavy hydration when it is not requested", async () => {
       const server = await RemoteMCPServerFactory.create(testContext.workspace);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -916,9 +916,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ids: ModelId[],
     {
       dangerouslySkipPermissionFiltering,
+      status,
       withTools = true,
     }: {
       dangerouslySkipPermissionFiltering?: boolean;
+      // `baseFetch` returns active skills only unless a status is given.
+      status?: SkillStatus | SkillStatus[];
       withTools?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
@@ -929,6 +932,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           id: {
             [Op.in]: ids,
           },
+          ...(status ? { status } : {}),
         },
         onlyCustom: true,
         withTools,

--- a/front/migrations/20260828_backfill_skill_manually_requested_spaces.ts
+++ b/front/migrations/20260828_backfill_skill_manually_requested_spaces.ts
@@ -234,6 +234,9 @@ async function backfillWorkspaceSkills(
   // ids need dropping from the manual list rather than being copied into it.
   const skills = await SkillResource.fetchByModelIds(auth, skillModelIds, {
     dangerouslySkipPermissionFiltering: true,
+    // `fetchByModelIds` returns active skills only by default. An archived or suggested skill still
+    // holds its requested spaces and can be restored and saved, so it needs the provenance too.
+    status: ["active", "archived", "suggested"],
   });
   if (skills.length !== skillModelIds.length) {
     logger.warn(


### PR DESCRIPTION
## Description:
Related to https://github.com/dust-tt/tasks/issues/9896

Follow-up to #31341. The backfill logged `Some skills could not be fetched and are left untouched` and skipped archived and suggested skills: `baseFetch` filters to `status: "active"` unless a caller overrides it, and `fetchByModelIds` did not expose that option. Those skills still hold their requested spaces and can be restored and saved, so they need the provenance stored too — otherwise 3/4 would drop their hand-picked spaces on the next save. `fetchByModelIds` now takes a `status` option, like the other fetchers, and the backfill asks for all three statuses.

## Tests
Exercised against a local database seeded with an active, an archived and a suggested skill, each holding requested spaces: before the fix the script reported 3 requested / 1 fetched and processed only the active one, after the fix it processes all three and the warning is gone.

## Deploy plan
Deploy front. No migration to run, but the backfill must be re-run afterwards so the skills it skipped are covered:
`npx tsx migrations/20260828_backfill_skill_manually_requested_spaces.ts --execute`
