### PR TITLE
fix: cap and scroll the tool approval details modal

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -125,7 +125,7 @@ function ToolValidationDetailsDialog({
             {displayLabel}
           </DialogDescription>
         </DialogHeader>
-        <DialogContainer className="p-0">
+        <DialogContainer className="max-h-[60vh] overflow-y-auto p-0">
           <ToolValidationDetails
             blockedAction={validationRequest}
             user={currentUser}


### PR DESCRIPTION
## Description

The "Review details" dialog on a tool approval card grew with its content, so a tool call with a large payload pushed the modal past the screen and the bottom of the inputs was unreachable. The <ScrollArea> needs a max height to allow the user to scroll. The body now caps at 60vh and scrolls.

## Tests

Manual: opened a tool approval with a long payload and scrolled through the details.

## Risk

Low, one class on one dialog.

## Deploy Plan

Deploy front.