### PR TITLE
[Admin Governance] Batch agent identity backfill

### DIFF
--- a/front/migrations/20260828_backfill_agent_identities.test.ts
+++ b/front/migrations/20260828_backfill_agent_identities.test.ts
@@ -22,12 +22,15 @@ describe("backfillAgentIdentities", () => {
       authenticator,
       firstVersion.sId
     );
+    await AgentConfigurationFactory.createTestAgent(authenticator, {
+      name: "Second Agent",
+    });
     await AgentConfigurationModel.update(
       { agentId: null },
-      { where: { sId: firstVersion.sId, workspaceId: workspace.id } }
+      { where: { workspaceId: workspace.id } }
     );
     await AgentModel.destroy({
-      where: { sId: firstVersion.sId, workspaceId: workspace.id },
+      where: { workspaceId: workspace.id },
     });
 
     const dryRun = await backfillAgentIdentities({
@@ -36,9 +39,9 @@ describe("backfillAgentIdentities", () => {
       workspace,
     });
     expect(dryRun).toMatchObject({
-      logicalAgentCount: 1,
-      identitiesToCreate: 1,
-      versionsToAttach: 2,
+      logicalAgentCount: 2,
+      identitiesToCreate: 2,
+      versionsToAttach: 3,
       orphanIdentityCount: 0,
     });
     expect(
@@ -47,13 +50,25 @@ describe("backfillAgentIdentities", () => {
       })
     ).toBeNull();
 
-    await backfillAgentIdentities({ execute: true, logger, workspace });
+    await backfillAgentIdentities({
+      execute: true,
+      logger,
+      workspace,
+      batchSize: 1,
+    });
     const versions = await AgentConfigurationModel.findAll({
-      where: { sId: firstVersion.sId, workspaceId: workspace.id },
-      attributes: ["agentId"],
+      where: { workspaceId: workspace.id },
+      attributes: ["agentId", "sId"],
     });
     expect(versions.every(({ agentId }) => agentId !== null)).toBe(true);
-    expect(new Set(versions.map(({ agentId }) => agentId)).size).toBe(1);
+    expect(new Set(versions.map(({ agentId }) => agentId)).size).toBe(2);
+    expect(
+      new Set(
+        versions
+          .filter(({ sId }) => sId === firstVersion.sId)
+          .map(({ agentId }) => agentId)
+      ).size
+    ).toBe(1);
 
     const rerun = await backfillAgentIdentities({
       execute: true,

--- a/front/migrations/20260828_backfill_agent_identities.ts
+++ b/front/migrations/20260828_backfill_agent_identities.ts
@@ -12,14 +12,14 @@ import { Op, QueryTypes } from "sequelize";
 
 const DEFAULT_BATCH_SIZE = 1_000;
 
-const SELECT_BATCH_SQL = `
-  SELECT DISTINCT "sId"
+// Applying the null check after grouping makes PostgreSQL scan one workspace once instead of
+// walking a global index to find matching configurations for every batch.
+const SELECT_MISSING_AGENT_IDS_SQL = `
+  SELECT "sId"
   FROM agent_configurations
   WHERE "workspaceId" = :workspaceId
-    AND "agentId" IS NULL
-    AND "sId" > :lastAgentId
-  ORDER BY "sId" ASC
-  LIMIT :batchSize
+  GROUP BY "sId"
+  HAVING BOOL_OR("agentId" IS NULL)
 `;
 
 const UPDATE_BATCH_SQL = `
@@ -123,21 +123,20 @@ export async function backfillAgentIdentities({
 
   await validateIdentityLinks(workspace);
   const stats = await getBackfillStats(workspace);
+  const rows = await frontSequelize.query<{ sId: string }>(
+    SELECT_MISSING_AGENT_IDS_SQL,
+    {
+      replacements: { workspaceId: workspace.id },
+      type: QueryTypes.SELECT,
+    }
+  );
 
   let batch = 0;
-  let lastAgentId = "";
   let totalUpdated = 0;
-  for (;;) {
-    const rows = await frontSequelize.query<{ sId: string }>(SELECT_BATCH_SQL, {
-      replacements: { workspaceId: workspace.id, lastAgentId, batchSize },
-      type: QueryTypes.SELECT,
-    });
-    if (rows.length === 0) {
-      break;
-    }
-
-    const agentIds = rows.map(({ sId }) => sId);
-    lastAgentId = agentIds[agentIds.length - 1];
+  for (let offset = 0; offset < rows.length; offset += batchSize) {
+    const agentIds = rows
+      .slice(offset, offset + batchSize)
+      .map(({ sId }) => sId);
     const existingIdentities = await AgentModel.findAll({
       where: {
         workspaceId: workspace.id,

--- a/front/migrations/20260828_backfill_agent_identities.ts
+++ b/front/migrations/20260828_backfill_agent_identities.ts
@@ -2,13 +2,36 @@ import {
   AgentConfigurationModel,
   AgentModel,
 } from "@app/lib/models/agent/agent";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
-import { literal, Op } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
+
+const DEFAULT_BATCH_SIZE = 1_000;
+
+const SELECT_BATCH_SQL = `
+  SELECT DISTINCT "sId"
+  FROM agent_configurations
+  WHERE "workspaceId" = :workspaceId
+    AND "agentId" IS NULL
+    AND "sId" > :lastAgentId
+  ORDER BY "sId" ASC
+  LIMIT :batchSize
+`;
+
+const UPDATE_BATCH_SQL = `
+  UPDATE agent_configurations AS configuration
+  SET "agentId" = agent.id
+  FROM agents AS agent
+  WHERE configuration."workspaceId" = :workspaceId
+    AND configuration."agentId" IS NULL
+    AND configuration."sId" IN (:agentIds)
+    AND agent."workspaceId" = configuration."workspaceId"
+    AND agent."sId" = configuration."sId"
+`;
 
 type MigrationWorkspace = Pick<LightWorkspaceType, "id" | "sId">;
 
@@ -19,123 +42,153 @@ export type AgentIdentityBackfillStats = {
   orphanIdentityCount: number;
 };
 
-function resolveIdentity(
-  sId: string,
-  configurations: AgentConfigurationModel[],
-  identitiesById: Map<number, AgentModel>,
-  identitiesBySId: Map<string, AgentModel>
-): AgentModel | null {
-  const linkedIds = new Set(
-    configurations.flatMap(({ agentId }) => (agentId === null ? [] : [agentId]))
+async function validateIdentityLinks(workspace: MigrationWorkspace) {
+  const [invalidLink] = await frontSequelize.query<{ sId: string }>(
+    `
+      SELECT configuration."sId"
+      FROM agent_configurations AS configuration
+      INNER JOIN agents AS agent ON agent.id = configuration."agentId"
+      WHERE configuration."workspaceId" = :workspaceId
+        AND (
+          agent."workspaceId" != configuration."workspaceId"
+          OR agent."sId" != configuration."sId"
+        )
+      LIMIT 1
+    `,
+    {
+      replacements: { workspaceId: workspace.id },
+      type: QueryTypes.SELECT,
+    }
   );
-  if (linkedIds.size > 1) {
-    throw new Error(`Agent ${sId} is linked to multiple identities.`);
+  if (invalidLink) {
+    throw new Error(
+      `Agent ${invalidLink.sId} is linked to an invalid identity.`
+    );
   }
+}
 
-  const linkedId = linkedIds.values().next().value;
-  const linkedIdentity =
-    linkedId === undefined ? undefined : identitiesById.get(linkedId);
-  if (linkedId !== undefined && linkedIdentity?.sId !== sId) {
-    throw new Error(`Agent ${sId} is linked to an invalid identity.`);
-  }
+async function getBackfillStats(
+  workspace: MigrationWorkspace
+): Promise<AgentIdentityBackfillStats> {
+  const [logicalAgentCount, versionsToAttach, [{ count }]] = await Promise.all([
+    AgentConfigurationModel.count({
+      where: { workspaceId: workspace.id },
+      distinct: true,
+      col: "sId",
+    }),
+    AgentConfigurationModel.count({
+      where: { workspaceId: workspace.id, agentId: null },
+    }),
+    frontSequelize.query<{ count: string }>(
+      `
+          SELECT COUNT(*) AS count
+          FROM agents AS agent
+          WHERE agent."workspaceId" = :workspaceId
+            AND NOT EXISTS (
+              SELECT 1
+              FROM agent_configurations AS configuration
+              WHERE configuration."workspaceId" = agent."workspaceId"
+                AND configuration."sId" = agent."sId"
+            )
+        `,
+      {
+        replacements: { workspaceId: workspace.id },
+        type: QueryTypes.SELECT,
+      }
+    ),
+  ]);
 
-  const identity = identitiesBySId.get(sId);
-  if (linkedId !== undefined && identity?.id !== linkedId) {
-    throw new Error(`Agent ${sId} has inconsistent identity links.`);
-  }
-
-  return identity ?? null;
+  return {
+    logicalAgentCount,
+    identitiesToCreate: 0,
+    versionsToAttach,
+    orphanIdentityCount: Number(count),
+  };
 }
 
 export async function backfillAgentIdentities({
   execute,
   logger,
   workspace,
+  batchSize = DEFAULT_BATCH_SIZE,
 }: {
   execute: boolean;
   logger: Logger;
   workspace: MigrationWorkspace;
+  batchSize?: number;
 }): Promise<AgentIdentityBackfillStats> {
-  // Load each indexed workspace slice once, then validate and group it in memory to avoid
-  // per-agent reads before the writes below.
-  const [configurations, identities] = await Promise.all([
-    AgentConfigurationModel.findAll({
-      where: { workspaceId: workspace.id },
-      attributes: ["agentId", "sId"],
-    }),
-    AgentModel.findAll({
-      where: { workspaceId: workspace.id },
-      attributes: ["id", "sId"],
-    }),
-  ]);
-
-  const configurationsBySId = new Map<string, AgentConfigurationModel[]>();
-  for (const configuration of configurations) {
-    const versions = configurationsBySId.get(configuration.sId) ?? [];
-    versions.push(configuration);
-    configurationsBySId.set(configuration.sId, versions);
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error("batchSize must be a positive integer");
   }
 
-  const identitiesById = new Map(identities.map((agent) => [agent.id, agent]));
-  const identitiesBySId = new Map(
-    identities.map((agent) => [agent.sId, agent])
-  );
-  const stats: AgentIdentityBackfillStats = {
-    logicalAgentCount: configurationsBySId.size,
-    identitiesToCreate: 0,
-    versionsToAttach: 0,
-    orphanIdentityCount: identities.filter(
-      ({ sId }) => !configurationsBySId.has(sId)
-    ).length,
-  };
+  await validateIdentityLinks(workspace);
+  const stats = await getBackfillStats(workspace);
 
-  await concurrentExecutor(
-    [...configurationsBySId],
-    async ([sId, versions]) => {
-      const currentIdentity = resolveIdentity(
-        sId,
-        versions,
-        identitiesById,
-        identitiesBySId
-      );
-      const versionsToAttach = versions.filter(
-        ({ agentId }) => agentId === null
-      ).length;
-      stats.identitiesToCreate += currentIdentity ? 0 : 1;
-      stats.versionsToAttach += versionsToAttach;
+  let batch = 0;
+  let lastAgentId = "";
+  let totalUpdated = 0;
+  for (;;) {
+    const rows = await frontSequelize.query<{ sId: string }>(SELECT_BATCH_SQL, {
+      replacements: { workspaceId: workspace.id, lastAgentId, batchSize },
+      type: QueryTypes.SELECT,
+    });
+    if (rows.length === 0) {
+      break;
+    }
 
-      if (!execute || versionsToAttach === 0) {
-        return;
+    const agentIds = rows.map(({ sId }) => sId);
+    lastAgentId = agentIds[agentIds.length - 1];
+    const existingIdentities = await AgentModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        sId: { [Op.in]: agentIds },
+      },
+      attributes: ["sId"],
+    });
+    const existingAgentIds = new Set(existingIdentities.map(({ sId }) => sId));
+    const missingAgentIds = agentIds.filter(
+      (agentId) => !existingAgentIds.has(agentId)
+    );
+    stats.identitiesToCreate += missingAgentIds.length;
+
+    if (!execute) {
+      continue;
+    }
+
+    const updated = await withTransaction(async (transaction) => {
+      if (missingAgentIds.length > 0) {
+        await AgentModel.bulkCreate(
+          missingAgentIds.map((sId) => ({ sId, workspaceId: workspace.id })),
+          { ignoreDuplicates: true, transaction }
+        );
       }
 
-      await withTransaction(async (transaction) => {
-        const [identity] = await AgentModel.findOrCreate({
-          where: { sId, workspaceId: workspace.id },
-          defaults: { sId, workspaceId: workspace.id },
-          transaction,
-        });
-        await AgentConfigurationModel.update(
-          { agentId: identity.id },
-          {
-            where: {
-              sId,
-              workspaceId: workspace.id,
-              [Op.and]: literal('"agentId" IS NULL'),
-            },
-            transaction,
-          }
-        );
+      // A joined update attaches all versions in the batch without changing their updatedAt.
+      const [, updatedCount] = await frontSequelize.query(UPDATE_BATCH_SQL, {
+        replacements: { workspaceId: workspace.id, agentIds },
+        transaction,
+        type: QueryTypes.UPDATE,
       });
-    },
-    { concurrency: 4 }
-  );
+      return updatedCount;
+    });
+
+    batch += 1;
+    totalUpdated += updated;
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        batch,
+        agentCount: agentIds.length,
+        updated,
+        totalUpdated,
+      },
+      "Backfilled agent identity batch"
+    );
+  }
 
   if (execute) {
     const missingIdentityCount = await AgentConfigurationModel.count({
-      where: {
-        workspaceId: workspace.id,
-        [Op.and]: literal('"agentId" IS NULL'),
-      },
+      where: { workspaceId: workspace.id, agentId: null },
     });
     if (missingIdentityCount > 0) {
       throw new Error(
@@ -145,7 +198,7 @@ export async function backfillAgentIdentities({
   }
 
   logger.info(
-    { workspaceId: workspace.sId, execute, ...stats },
+    { workspaceId: workspace.sId, execute, batch, totalUpdated, ...stats },
     "Agent identity backfill completed for workspace"
   );
   return stats;
@@ -153,11 +206,23 @@ export async function backfillAgentIdentities({
 
 if (process.argv[1]?.endsWith("20260828_backfill_agent_identities.ts")) {
   makeScript(
-    { wId: { type: "string", required: false } },
-    async ({ execute, wId }, logger) => {
+    {
+      wId: { type: "string", required: false },
+      batchSize: {
+        type: "number",
+        default: DEFAULT_BATCH_SIZE,
+        description: "Maximum number of agents updated per transaction",
+      },
+    },
+    async ({ execute, wId, batchSize }, logger) => {
       await runOnAllWorkspaces(
         async (workspace) => {
-          await backfillAgentIdentities({ execute, logger, workspace });
+          await backfillAgentIdentities({
+            execute,
+            logger,
+            workspace,
+            batchSize,
+          });
         },
         { concurrency: 4, wId }
       );

--- a/front/migrations/20260828_backfill_agent_identities.ts
+++ b/front/migrations/20260828_backfill_agent_identities.ts
@@ -106,6 +106,11 @@ async function getBackfillStats(
   };
 }
 
+/**
+ * Backfills the stable numeric identity shared by every version of an agent. Each batch first
+ * creates missing rows in `agents`, then uses their generated IDs to fill
+ * `agent_configurations.agentId` for all matching versions.
+ */
 export async function backfillAgentIdentities({
   execute,
   logger,


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31330.

The original backfill loads every agent version and opens one transaction per logical agent. This becomes slow for workspaces with many agents, including reruns where most rows are already attached.

This change scans each workspace once to collect distinct logical agents with at least one version missing an identity, keeps only those short sIds in memory, then processes configurable write batches of 1,000. Each batch bulk-creates missing identities and attaches every version with one joined update. Dry-run reporting, idempotency, link validation, and the final completeness check remain in place.

## Risks

Blast radius: the one-time agent identity backfill script.

Risk: standard.

## Deploy Plan

- Deploy front.
- Run the backfill in dry-run mode for target workspaces and inspect the counts.
- Execute it with the default batch size of 1,000, lowering --batchSize if needed.
- Verify that no agent configuration is missing agentId before #31331.

## Tests

- [x] NODE_ENV=test npm test -- migrations/20260828_backfill_agent_identities.test.ts