### PR TITLE
feat(workspace-analytics): move get_usage_timeseries onto the consumption index

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2598,35 +2598,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_source_breakdown": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_agent_tags": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_agents": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
     "get_top_entities_by_credits": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_top_models": {
+    "get_top_entities_by_execution_count": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_top_skills": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_tools": {
-      "freeUsage": true,
-      "toolCostCategory": "basic",
-    },
-    "get_top_users": {
+    "get_top_entities_by_message_count": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
@@ -3457,14 +3437,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_agent_details": "never_ask",
     "get_credit_timeseries": "never_ask",
     "get_credit_usage": "never_ask",
-    "get_source_breakdown": "never_ask",
-    "get_top_agent_tags": "never_ask",
-    "get_top_agents": "never_ask",
     "get_top_entities_by_credits": "never_ask",
-    "get_top_models": "never_ask",
-    "get_top_skills": "never_ask",
-    "get_top_tools": "never_ask",
-    "get_top_users": "never_ask",
+    "get_top_entities_by_execution_count": "never_ask",
+    "get_top_entities_by_message_count": "never_ask",
     "get_usage_timeseries": "never_ask",
   },
   "workspace_management": {

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2590,11 +2590,11 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_credit_timeseries": {
+    "get_consumption_overview": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
-    "get_credit_usage": {
+    "get_credit_timeseries": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
@@ -3435,8 +3435,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "workspace_analytics": {
     "get_agent_details": "never_ask",
+    "get_consumption_overview": "never_ask",
     "get_credit_timeseries": "never_ask",
-    "get_credit_usage": "never_ask",
     "get_top_entities_by_credits": "never_ask",
     "get_top_entities_by_execution_count": "never_ask",
     "get_top_entities_by_message_count": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1079,19 +1079,7 @@ const QUERIES: LabeledQuery[] = [
     maxRank: 2,
   },
   {
-    query: "show me the top 10 most active agents this month",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
     query: "who are the most active users this month",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
-    query: "rank workspace members by messages sent",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
-    query: "rank member groups by message volume",
     expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
@@ -1103,10 +1091,6 @@ const QUERIES: LabeledQuery[] = [
     query: "which models did the workspace use most this month",
     expected: "workspace_analytics.get_top_entities_by_message_count",
     maxRank: 5,
-  },
-  {
-    query: "list the agent tags",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query:

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1102,12 +1102,8 @@ const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_agent_details",
   },
   {
-    query: "how many AWU credits did the workspace consume this month",
-    expected: "workspace_analytics.get_credit_usage",
-  },
-  {
     query: "break down credit spending by agent",
-    expected: "workspace_analytics.get_credit_usage",
+    expected: "workspace_analytics.get_top_entities_by_credits",
   },
   {
     query: "which skills are executed most in the workspace",
@@ -1136,6 +1132,10 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "rank credit spend by tool",
     expected: "workspace_analytics.get_top_entities_by_credits",
+  },
+  {
+    query: "how many credits did the workspace consume this month",
+    expected: "workspace_analytics.get_consumption_overview",
   },
   {
     query: "show the credit spending trend over the last 30 days",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1075,24 +1075,38 @@ const QUERIES: LabeledQuery[] = [
   // --- workspace_analytics ---
   {
     query: "which agents are used most in the workspace",
-    expected: "workspace_analytics.get_top_agents",
-    maxRank: 2, // get_top_tools collides on "most used"
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+    maxRank: 2,
   },
   {
     query: "show me the top 10 most active agents this month",
-    expected: "workspace_analytics.get_top_agents",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query: "who are the most active users this month",
-    expected: "workspace_analytics.get_top_users",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query: "rank workspace members by messages sent",
-    expected: "workspace_analytics.get_top_users",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+  },
+  {
+    query: "rank member groups by message volume",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+  },
+  {
+    query: "where do workspace messages come from - slack, api, or browser",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+    maxRank: 10,
+  },
+  {
+    query: "which models did the workspace use most this month",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
+    maxRank: 5,
   },
   {
     query: "list the agent tags",
-    expected: "workspace_analytics.get_top_agent_tags",
+    expected: "workspace_analytics.get_top_entities_by_message_count",
   },
   {
     query:
@@ -1104,30 +1118,24 @@ const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_agent_details",
   },
   {
-    query: "which skills are executed most in the workspace",
-    expected: "workspace_analytics.get_top_skills",
-  },
-  {
-    query: "what are the top MCP tools used by agents",
-    expected: "workspace_analytics.get_top_tools",
-  },
-  {
-    query: "where do workspace messages come from - slack, api, or browser",
-    expected: "workspace_analytics.get_source_breakdown",
-    maxRank: 10,
-  },
-  {
-    query: "which models did the workspace use most this month",
-    expected: "workspace_analytics.get_top_models",
-    maxRank: 5,
-  },
-  {
     query: "how many AWU credits did the workspace consume this month",
     expected: "workspace_analytics.get_credit_usage",
   },
   {
     query: "break down credit spending by agent",
     expected: "workspace_analytics.get_credit_usage",
+  },
+  {
+    query: "which skills are executed most in the workspace",
+    expected: "workspace_analytics.get_top_entities_by_execution_count",
+  },
+  {
+    query: "what are the top MCP tools used by agents",
+    expected: "workspace_analytics.get_top_entities_by_execution_count",
+  },
+  {
+    query: "how many times did each integration run",
+    expected: "workspace_analytics.get_top_entities_by_execution_count",
   },
   {
     query: "which agents cost the most credits this month",
@@ -1139,6 +1147,10 @@ const QUERIES: LabeledQuery[] = [
   },
   {
     query: "attribute credit spend to our API keys",
+    expected: "workspace_analytics.get_top_entities_by_credits",
+  },
+  {
+    query: "rank credit spend by tool",
     expected: "workspace_analytics.get_top_entities_by_credits",
   },
   {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -6,8 +6,8 @@ import {
   MAX_CREDIT_GROUPS,
   MAX_RESULTS,
   timeWindowSchemaShape,
-  usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { CONSUMPTION_ACTIVITY_METRICS } from "@app/lib/api/analytics/consumption/activity_timeseries";
 import { ConsumptionPeriodSchema } from "@app/lib/api/analytics/consumption/schema";
 import {
   CONSUMPTION_INVOCATION_DIMENSIONS,
@@ -62,21 +62,18 @@ const getCreditTimeseriesSchema = {
 
 const getUsageTimeseriesSchema = {
   ...timeWindowSchemaShape,
-  ...usageFilterSchema,
+  ...consumptionFilterSchema,
   metric: z
-    .enum(["messages", "skills", "tools"])
+    .enum(CONSUMPTION_ACTIVITY_METRICS)
     .optional()
     .describe(
       "What to plot over time. 'messages' (default): messages, conversations " +
-        "and active users. 'skills'/'tools': executions and unique users."
+        "and active users. 'tools'/'skills': executions and active users."
     ),
   granularity: z
-    .enum(["day", "week"])
+    .enum(["day", "week", "month"])
     .optional()
-    .describe(
-      "Bucket granularity (default day). Only applies to the messages metric; " +
-        "skills and tools are always daily."
-    ),
+    .describe("Bucket granularity (default day)."),
 };
 
 export const GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME =
@@ -228,7 +225,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "days). Plot message volume (messages, conversations, active users), " +
       "skill executions, or tool calls over time. Use this for any activity " +
       "or usage trend — it is a single call, do not call other tools once per " +
-      "day. Combine with filters to narrow. Chart the result. Admin-only.",
+      "day. Combine with filters to narrow. Chart the result.",
     schema: getUsageTimeseriesSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -12,6 +12,7 @@ import { ConsumptionPeriodSchema } from "@app/lib/api/analytics/consumption/sche
 import {
   CONSUMPTION_INVOCATION_DIMENSIONS,
   CONSUMPTION_MESSAGE_DIMENSIONS,
+  CONSUMPTION_SCOPE_DIMENSIONS,
   CONSUMPTION_TOP_DIMENSIONS,
 } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
@@ -34,18 +35,17 @@ const getConsumptionOverviewSchema = {
 
 const getCreditTimeseriesSchema = {
   ...timeWindowSchemaShape,
-  ...usageFilterSchema,
+  ...consumptionFilterSchema,
   granularity: z
     .enum(["day", "week", "month"])
     .optional()
     .describe("Bucket granularity for the credit trend (default day)."),
   breakdownBy: z
-    .enum(["agent", "user", "model"])
+    .enum(CONSUMPTION_SCOPE_DIMENSIONS)
     .optional()
     .describe(
-      "Split each bucket into the top agents, users or models by credits, " +
-        "plus an 'other' series for the rest. Omit for a single total-credits " +
-        "trend."
+      "Split each bucket by this dimension — its top groups plus an 'others' " +
+        "series for the rest. Omit for a single total-credits trend."
     ),
   breakdownLimit: z
     .number()
@@ -56,7 +56,7 @@ const getCreditTimeseriesSchema = {
     .describe(
       `Number of top groups to break out when breakdownBy is set ` +
         `(default ${DEFAULT_CREDIT_GROUPS}, max ${MAX_CREDIT_GROUPS}); the ` +
-        `remainder is folded into 'other'.`
+        `remainder is folded into 'others'.`
     ),
 };
 
@@ -205,24 +205,18 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_credit_timeseries",
     description:
-      "Return estimated credit consumption as a time series over a window " +
-      "(defaults to the last 30 days), bucketed by day, week, or month. Set " +
-      "breakdownBy to split each " +
-      "bucket into the top agents, users or models plus an 'other' series (a " +
-      "stacked trend). Use this for credit/spend TRENDS over time. Use " +
-      `${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} for a single window's total ` +
-      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute it. ` +
-      "These figures are ESTIMATES. Always tell the user they are " +
-      "approximate " +
-      "and point them to the workspace Usage page for exact, billed credit " +
-      "amounts. Chart the result. Optionally filter by source (context_origin), " +
-      "agent, user, tag, or model. Admin-only.",
+      "Return credit consumption as a time series over a window (defaults to " +
+      "the last 30 days), bucketed by day, week or month. Use this to answer " +
+      "'is credit spend trending up or down' or 'which week had the highest " +
+      `spend'. For a single window use ${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} ` +
+      `for the total and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} for the ` +
+      "breakdown. Chart the result.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Estimating credit trend",
-      done: "Estimated credit trend",
+      running: "Retrieving credit trend",
+      done: "Retrieved credit trend",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -155,8 +155,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top by message count",
-      done: "Retrieved top by message count",
+      running: "Retrieving top entities by message count",
+      done: "Retrieved top entities by message count",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -176,8 +176,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top by execution count",
-      done: "Retrieved top by execution count",
+      running: "Retrieving top entities by execution count",
+      done: "Retrieved top entities by execution count",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -26,27 +26,9 @@ const getAgentDetailsSchema = {
     ),
 };
 
-const getCreditUsageSchema = {
+const getConsumptionOverviewSchema = {
   ...timeWindowSchemaShape,
-  ...usageFilterSchema,
-  groupBy: z
-    .enum(["agent", "user", "model", "none"])
-    .optional()
-    .describe(
-      "Break the estimated credits down by top 'agent', 'user' or 'model' " +
-        "(the model that answered the message), or 'none' (default) for the " +
-        "workspace total only."
-    ),
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS)
-    .optional()
-    .describe(
-      `When grouping, the maximum number of rows to return ` +
-        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
-    ),
+  ...consumptionFilterSchema,
 };
 
 const getCreditTimeseriesSchema = {
@@ -100,6 +82,8 @@ export const GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME =
   "get_top_entities_by_message_count" as const;
 export const GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME =
   "get_top_entities_by_execution_count" as const;
+export const GET_CONSUMPTION_OVERVIEW_TOOL_NAME =
+  "get_consumption_overview" as const;
 
 const rankingLimitSchema = z
   .number()
@@ -200,24 +184,21 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     freeUsage: true,
   },
   {
-    name: "get_credit_usage",
+    name: GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
     description:
-      "Estimate AWU credit consumption over a time window (defaults to the " +
-      "current calendar month), optionally broken down by the top agents, " +
-      "users or models. Credits combine model compute and tool usage, " +
-      "mirroring how billing computes them. IMPORTANT: these figures are " +
-      "ESTIMATES derived from usage logs — always tell the user they are " +
-      "approximate and point them to the workspace Usage page for exact, " +
-      "billed credit amounts. Optionally filter by source (context_origin), " +
-      "agent, user, tag, or model — e.g. filter by tag to attribute credits " +
-      "to all agents with a given tag, or group by model to see which models " +
-      "drive spend. Admin-only.",
-    schema: getCreditUsageSchema,
+      "Summarize the workspace's headline figures for a time window " +
+      "(defaults to the current calendar month): total credits consumed, " +
+      "messages, active and total members, and the top agent. Use this to " +
+      "answer 'how are we doing this month' or 'how many credits did we " +
+      `consume' in one call, and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to ` +
+      "attribute that total. For the credit cap and how much of it is left, " +
+      "point the admin at the workspace Usage page.",
+    schema: getConsumptionOverviewSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Estimating credit usage",
-      done: "Estimated credit usage",
+      running: "Retrieving consumption overview",
+      done: "Retrieved consumption overview",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -225,14 +206,15 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_credit_timeseries",
     description:
-      "Return estimated AWU credit consumption as a time series over a window " +
+      "Return estimated credit consumption as a time series over a window " +
       "(defaults to the last 30 days), bucketed by day, week, or month. Set " +
       "breakdownBy to split each " +
       "bucket into the top agents, users or models plus an 'other' series (a " +
-      "stacked trend). Use this for credit/spend TRENDS over time; use " +
-      "get_credit_usage for a single window's totals and top " +
-      "agent/user/model attribution. IMPORTANT: " +
-      "these figures are ESTIMATES — always tell the user they are approximate " +
+      "stacked trend). Use this for credit/spend TRENDS over time. Use " +
+      `${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} for a single window's total ` +
+      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute it. ` +
+      "These figures are ESTIMATES. Always tell the user they are " +
+      "approximate " +
       "and point them to the workspace Usage page for exact, billed credit " +
       "amounts. Chart the result. Optionally filter by source (context_origin), " +
       "agent, user, tag, or model. Admin-only.",
@@ -269,10 +251,11 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     description:
       "Rank the workspace's credit consumption by entity " +
       "over a time window (defaults to the current calendar month). Use " +
-      "this to answer 'which agent costs the most' or 'which " +
-      "conversation was most expensive', or to attribute credit spend by " +
-      "API key, tag, or model. Figures are billed credits. Rows may " +
-      "overlap, so don't sum them for a workspace total.",
+      "this to break credit spending down by agent, or to answer 'which " +
+      "agent costs the most' or 'which conversation was most expensive', " +
+      "or to attribute credit spend by API key, tag, or model. Figures " +
+      "are billed credits. Rows may overlap, so don't sum them for a " +
+      "workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -8,6 +8,7 @@ import {
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { ConsumptionPeriodSchema } from "@app/lib/api/analytics/consumption/schema";
 import {
   CONSUMPTION_INVOCATION_DIMENSIONS,
   CONSUMPTION_MESSAGE_DIMENSIONS,
@@ -27,7 +28,7 @@ const getAgentDetailsSchema = {
 };
 
 const getConsumptionOverviewSchema = {
-  ...timeWindowSchemaShape,
+  ...ConsumptionPeriodSchema.shape,
   ...consumptionFilterSchema,
 };
 
@@ -186,13 +187,11 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
     description:
-      "Summarize the workspace's headline figures for a time window " +
-      "(defaults to the current calendar month): total credits consumed, " +
-      "messages, active and total members, and the top agent. Use this to " +
-      "answer 'how are we doing this month' or 'how many credits did we " +
-      `consume' in one call, and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to ` +
-      "attribute that total. For the credit cap and how much of it is left, " +
-      "point the admin at the workspace Usage page.",
+      "Summarize the workspace's headline figures for the current billing " +
+      "cycle, or the last N days: total credits consumed, messages, active " +
+      "and total members, and the top agent. Use this to answer 'how are we " +
+      "doing this cycle' or 'how many credits did we consume' in one call, " +
+      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute that total.`,
     schema: getConsumptionOverviewSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -8,41 +8,15 @@ import {
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
-import { CONSUMPTION_TOP_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
+import {
+  CONSUMPTION_INVOCATION_DIMENSIONS,
+  CONSUMPTION_MESSAGE_DIMENSIONS,
+  CONSUMPTION_TOP_DIMENSIONS,
+} from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
 export const GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME =
   "get_top_entities_by_credits" as const;
-
-const topListSchema = (entityPlural: string) => ({
-  ...timeWindowSchemaShape,
-  ...usageFilterSchema,
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS)
-    .optional()
-    .describe(
-      `Maximum number of ${entityPlural} to return ` +
-        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
-    ),
-});
-
-const getTopAgentsSchema = topListSchema("agents");
-const getTopUsersSchema = topListSchema("users");
-const getTopSkillsSchema = topListSchema("skills");
-const getTopToolsSchema = topListSchema("tools");
-const getTopAgentTagsSchema = topListSchema("agent tags");
-const getTopModelsSchema = topListSchema("models");
-
-const getSourceBreakdownSchema = {
-  ...timeWindowSchemaShape,
-  agentIds: usageFilterSchema.agentIds,
-  userIds: usageFilterSchema.userIds,
-  agentTagIds: usageFilterSchema.agentTagIds,
-  modelIds: usageFilterSchema.modelIds,
-};
 
 const getAgentDetailsSchema = {
   agentId: z
@@ -122,99 +96,88 @@ const getUsageTimeseriesSchema = {
     ),
 };
 
+export const GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME =
+  "get_top_entities_by_message_count" as const;
+export const GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME =
+  "get_top_entities_by_execution_count" as const;
+
+const rankingLimitSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(MAX_RESULTS)
+  .optional()
+  .describe(
+    `Maximum number of rows to return ` +
+      `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
+  );
+
+const GROUP_BY_DESCRIPTION = "What to group results by.";
+
 const getTopEntitiesByCreditsSchema = {
-  dimension: z
-    .enum(CONSUMPTION_TOP_DIMENSIONS)
-    .describe("What to group results by."),
+  dimension: z.enum(CONSUMPTION_TOP_DIMENSIONS).describe(GROUP_BY_DESCRIPTION),
   ...timeWindowSchemaShape,
   ...consumptionFilterSchema,
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_RESULTS)
-    .optional()
-    .describe(
-      `Maximum number of rows to return ` +
-        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
-    ),
+  limit: rankingLimitSchema,
+};
+
+const getTopEntitiesByMessageCountSchema = {
+  dimension: z
+    .enum(CONSUMPTION_MESSAGE_DIMENSIONS)
+    .describe(GROUP_BY_DESCRIPTION),
+  ...timeWindowSchemaShape,
+  ...consumptionFilterSchema,
+  limit: rankingLimitSchema,
+};
+
+const getTopEntitiesByExecutionCountSchema = {
+  dimension: z
+    .enum(CONSUMPTION_INVOCATION_DIMENSIONS)
+    .describe(GROUP_BY_DESCRIPTION),
+  ...timeWindowSchemaShape,
+  ...consumptionFilterSchema,
+  limit: rankingLimitSchema,
 };
 
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
-    name: "get_top_agents",
+    name: GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME,
     description:
-      "Return the workspace's most-used and most active agents over a time " +
-      "window (defaults to the current calendar month), ranked by message " +
-      "count, with unique user count for each. Each row includes the agent's " +
-      "id. Use this to answer which agents are most popular, most used, or " +
-      "most active. Admin-only.",
-    schema: getTopAgentsSchema,
+      "Rank the workspace's entities by message volume over a " +
+      "time window (defaults to the current calendar month). Use this to " +
+      "answer 'which user is most active this month', 'which agent is " +
+      "used most', 'where do our messages come from, by source', or " +
+      "'list the agent tags, most-used tags first'. Every value it " +
+      "returns, including tag ids, can be fed back in as a filter on " +
+      `any of these tools. Use ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} ` +
+      "to rank by cost.",
+    schema: getTopEntitiesByMessageCountSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top agents",
-      done: "Retrieved top agents",
+      running: "Retrieving top by message count",
+      done: "Retrieved top by message count",
     },
     toolCostCategory: "basic",
     freeUsage: true,
   },
   {
-    name: "get_top_users",
+    name: GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME,
     description:
-      "Return the workspace's most active users and members over a time " +
-      "window (defaults to the current calendar month), ranked by number of " +
-      "messages sent, with the count of distinct agents each used. Each row " +
-      "includes the user's id. Use this to answer who the most active users " +
-      "are, rank members by usage, or find your top contributors. Admin-only.",
-    schema: getTopUsersSchema,
+      "Rank the workspace's skills, or its MCP tools and integrations, by how " +
+      "many times they were executed over a time window (defaults to the " +
+      "current calendar month). Use this to answer 'which are the top " +
+      "tools agents used most' or 'which skill runs most often'. One " +
+      "run attributed to several skills counts for each, so skill rows " +
+      "overlap. Use " +
+      `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to rank the same ` +
+      "entities by cost instead.",
+    schema: getTopEntitiesByExecutionCountSchema,
     stake: "never_ask",
     eager: true,
     displayLabels: {
-      running: "Retrieving top users",
-      done: "Retrieved top users",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_agent_tags",
-    description:
-      "List the agent tags applied across the workspace over a time window " +
-      "(defaults to the current calendar month), ranked by message volume, " +
-      "with the number of distinct agents bearing each tag. Each row includes " +
-      "the tag's id. Use this to enumerate which agent tags exist and obtain " +
-      "their ids, then supply those ids as the agentTagIds filter on the " +
-      "other analytics tools. Because an agent can bear several tags, per-tag " +
-      "counts overlap and may exceed the workspace total. Tags are fetched " +
-      "based on historical message data and may not reflect current agent tags. Admin-only.",
-    schema: getTopAgentTagsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top agent tags",
-      done: "Retrieved top agent tags",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_models",
-    description:
-      "List which LLM models (Claude, GPT, Gemini, ...) answered messages over " +
-      "a time window (defaults to the current calendar month), ranked by " +
-      "message volume, with each model's provider and its distinct agent and " +
-      "user counts. Use this to answer which model is used most, and to " +
-      "discover the model ids to pass as the modelIds filter of the other " +
-      "analytics tools; for credits per model use get_credit_usage with " +
-      "groupBy 'model'. Models come from historical message data, so retired " +
-      "models may appear. Admin-only.",
-    schema: getTopModelsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top models",
-      done: "Retrieved top models",
+      running: "Retrieving top by execution count",
+      done: "Retrieved top by execution count",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -232,65 +195,6 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     displayLabels: {
       running: "Retrieving agent details",
       done: "Retrieved agent details",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_skills",
-    description:
-      "Return the workspace's most-used skills over a time window (defaults " +
-      "to the current calendar month), ranked by execution count. Optionally " +
-      "filter by source (context_origin), agent, user, tag, or model. Use this " +
-      "to answer which skills are executed or used most. Admin-only.",
-    schema: getTopSkillsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top skills",
-      done: "Retrieved top skills",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_top_tools",
-    description:
-      "Return the workspace's most-used MCP tools and integrations over a " +
-      "time window (defaults to the current calendar month), ranked by " +
-      "execution count. Shows which MCP server tools are called most. Optionally " +
-      "filter by source (context_origin), agent, user, tag, or model. Use this " +
-      "to answer which tools are used most or which integrations agents " +
-      "rely on. Admin-only.",
-    schema: getTopToolsSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving top tools",
-      done: "Retrieved top tools",
-    },
-    toolCostCategory: "basic",
-    freeUsage: true,
-  },
-  {
-    name: "get_source_breakdown",
-    description:
-      "Return the workspace's message volume broken down by source — where " +
-      "messages originate (Conversation, Slack, API, Trigger, extension, and " +
-      "more) — over a time window (defaults to the current calendar month), " +
-      "most used first. Sources are labeled and merged exactly as the " +
-      "workspace Usage page's source chart, so the values line up with the " +
-      "dashboard. Use this to discover and compare which channels or " +
-      "integrations drive usage (including programmatic ones like API and " +
-      "triggers) — the source filter on the other tools only narrows to one " +
-      "source, this enumerates them all. Optionally filter by agent, user, " +
-      "tag, or model. Admin-only.",
-    schema: getSourceBreakdownSchema,
-    stake: "never_ask",
-    eager: true,
-    displayLabels: {
-      running: "Retrieving source breakdown",
-      done: "Retrieved source breakdown",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -365,9 +269,10 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     description:
       "Rank the workspace's credit consumption by entity " +
       "over a time window (defaults to the current calendar month). Use " +
-      "this to answer 'which agent is most expensive', or to attribute " +
-      "credit spend by API key, tag, or model. Figures are billed " +
-      "credits. Rows may overlap, so don't sum them for a workspace total.",
+      "this to answer 'which agent costs the most' or 'which " +
+      "conversation was most expensive', or to attribute credit spend by " +
+      "API key, tag, or model. Figures are billed credits. Rows may " +
+      "overlap, so don't sum them for a workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.test.ts
@@ -1,6 +1,7 @@
 import {
   MAX_QUERY_WINDOW_DAYS,
   resolveTimeWindow,
+  toConsumptionPeriod,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -105,5 +106,20 @@ describe("resolveTimeWindow", () => {
         expect(r.value.label).toBe("the last 30 days");
       }
     });
+  });
+});
+
+describe("toConsumptionPeriod", () => {
+  it("nudges the inclusive endDate forward one millisecond so the last instant is not dropped by a half-open query", () => {
+    const r = resolveTimeWindow({
+      startDate: "2026-01-01",
+      endDate: "2026-01-31",
+    });
+    expect(r.isOk()).toBe(true);
+    if (r.isOk()) {
+      const period = toConsumptionPeriod(r.value);
+      expect(period.startDate).toBe(r.value.startDate);
+      expect(period.endDate).toBe("2026-02-01T00:00:00.000Z");
+    }
   });
 });

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -149,26 +149,19 @@ export type ConsumptionFilterInput = z.input<
   typeof consumptionFilterInputSchema
 >;
 
-export type ConsumptionScope = {
-  filter: ConsumptionScopeFilter;
-  agentTagIds: string[];
-};
-
 export function toConsumptionScope(
   input: ConsumptionFilterInput
-): ConsumptionScope {
+): ConsumptionScopeFilter {
   return {
-    filter: {
-      sources: input.sources,
-      agents: input.agentIds,
-      users: input.userIds,
-      models: input.modelIds,
-      api_keys: input.apiKeyNames,
-      groups: input.groupIds,
-      tools: input.toolNames,
-      skills: input.skillIds,
-    },
-    agentTagIds: input.agentTagIds ?? [],
+    sources: input.sources,
+    agents: input.agentIds,
+    users: input.userIds,
+    models: input.modelIds,
+    api_keys: input.apiKeyNames,
+    groups: input.groupIds,
+    tools: input.toolNames,
+    skills: input.skillIds,
+    tags: input.agentTagIds,
   };
 }
 

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -62,43 +62,6 @@ export const timeWindowSchemaShape = {
 
 const timeWindowInputSchema = z.object(timeWindowSchemaShape);
 
-// Shared filter fragment for message-based usage tools.
-export const usageFilterSchema = {
-  source: z
-    .string()
-    .optional()
-    .describe(
-      "Filter to a single message origin (context_origin) — the source a " +
-        "message came from. Many origins exist (channels, integrations, " +
-        "triggers, and more); do not assume a fixed short list. Use 'unknown' " +
-        "to match messages with no recorded origin."
-    ),
-  agentIds: z
-    .array(z.string())
-    .optional()
-    .describe("Restrict to messages from these agent sIds."),
-  userIds: z
-    .array(z.string())
-    .optional()
-    .describe("Restrict to messages from these user sIds."),
-  agentTagIds: z
-    .array(z.string())
-    .optional()
-    .describe(
-      "Restrict to messages from agents carrying any of these agent tag sIds"
-    ),
-  modelIds: z
-    .array(z.string())
-    .optional()
-    .describe(
-      "Restrict to messages answered by these models, identified by their " +
-        "model id (e.g. 'claude-sonnet-4-5')."
-    ),
-};
-
-// Filters for the consumption-index tools. Every key narrows the same scope the
-// workspace Analytics page filters on. The legacy `usageFilterSchema` above stays
-// until the tools still reading the old index are gone.
 export const consumptionFilterSchema = {
   sources: z
     .array(z.string())
@@ -167,7 +130,7 @@ export function toConsumptionScope(
 
 // `resolveTimeWindow` reports an inclusive end instant, because the legacy index
 // is queried with `lte`. The consumption index uses a half-open range, so its
-// bound is the following millisecond. Goes away with the last legacy tool.
+// bound is the following millisecond.
 export function toConsumptionPeriod(
   window: ResolvedTimeWindow
 ): ConsumptionPeriod {

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -85,15 +85,14 @@ export const usageFilterSchema = {
     .array(z.string())
     .optional()
     .describe(
-      "Restrict to messages from agents carrying any of these agent tag " +
-        "sIds, as returned by get_top_agent_tags."
+      "Restrict to messages from agents carrying any of these agent tag sIds"
     ),
   modelIds: z
     .array(z.string())
     .optional()
     .describe(
       "Restrict to messages answered by these models, identified by their " +
-        "model id (e.g. 'claude-sonnet-4-5'), as returned by get_top_models."
+        "model id (e.g. 'claude-sonnet-4-5')."
     ),
 };
 
@@ -185,7 +184,7 @@ export function toConsumptionPeriod(
   };
 }
 
-type TimeWindowInput = z.input<typeof timeWindowInputSchema>;
+export type TimeWindowInput = z.input<typeof timeWindowInputSchema>;
 
 export type ResolvedTimeWindow = {
   startDate: string;

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -25,7 +25,7 @@ function createTestExtra(auth: Authenticator, runContext?: unknown) {
 describe("workspace_analytics tools", () => {
   it.each([
     "get_agent_details",
-    "get_credit_usage",
+    "get_consumption_overview",
     "get_credit_timeseries",
     "get_usage_timeseries",
     "get_top_entities_by_credits",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -24,18 +24,13 @@ function createTestExtra(auth: Authenticator, runContext?: unknown) {
 
 describe("workspace_analytics tools", () => {
   it.each([
-    "get_top_agents",
-    "get_top_users",
-    "get_top_agent_tags",
-    "get_top_models",
     "get_agent_details",
-    "get_top_skills",
-    "get_top_tools",
-    "get_source_breakdown",
     "get_credit_usage",
     "get_credit_timeseries",
     "get_usage_timeseries",
     "get_top_entities_by_credits",
+    "get_top_entities_by_message_count",
+    "get_top_entities_by_execution_count",
   ])("%s refuses callers below manager", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   ToolHandlerResult,
   ToolHandlers,
@@ -6,7 +7,11 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceManagerGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
-import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type {
+  ConsumptionFilterInput,
+  ResolvedTimeWindow,
+  TimeWindowInput,
+} from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import {
   DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
@@ -14,6 +19,10 @@ import {
   toConsumptionPeriod,
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type {
+  ConsumptionTopDimension,
+  ConsumptionTopRankBy,
+} from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
@@ -21,28 +30,13 @@ import {
 } from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
-  fetchContextOriginBreakdown,
-  toLabeledSources,
-} from "@app/lib/api/assistant/observability/context_origin";
-import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
   fetchCreditUsage,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  fetchAvailableSkills,
-  fetchSkillUsageMetrics,
-} from "@app/lib/api/assistant/observability/skill_usage";
-import {
-  fetchAvailableTools,
-  fetchToolUsageMetrics,
-  resolveServerDisplayNames,
-} from "@app/lib/api/assistant/observability/tool_usage";
-import { fetchTopAgentTags } from "@app/lib/api/assistant/observability/top_agent_tags";
-import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
-import { fetchTopModels } from "@app/lib/api/assistant/observability/top_models";
-import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
+import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
@@ -118,286 +112,94 @@ function renderExecutionSeries<
   ]);
 }
 
+async function renderRanking(
+  auth: Authenticator,
+  {
+    dimension,
+    rankBy,
+    limit,
+    input,
+  }: {
+    dimension: ConsumptionTopDimension;
+    rankBy: ConsumptionTopRankBy;
+    limit: number | undefined;
+    input: TimeWindowInput & ConsumptionFilterInput;
+  }
+): Promise<ToolHandlerResult> {
+  const window = resolveTimeWindow(input);
+  if (window.isErr()) {
+    return new Err(new MCPError(window.error, { tracked: false }));
+  }
+  const { filter, agentTagIds } = toConsumptionScope(input);
+
+  const result = await fetchConsumptionTopGroups(auth, {
+    dimension,
+    period: toConsumptionPeriod(window.value),
+    limit: limit ?? DEFAULT_RESULTS,
+    filter,
+    agentTagIds,
+    rankBy,
+    includePreviousCredits: false,
+    includeTotalCount: false,
+  });
+
+  if (result.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to rank ${dimension} by ${rankBy}: ${result.error.message}`
+      )
+    );
+  }
+
+  const { label, timezone: tz } = window.value;
+  const { totalCredits } = result.value;
+  const groups =
+    dimension === "tool"
+      ? result.value.groups.filter(
+          (group) => group.key !== SKILL_MANAGEMENT_SERVER_NAME
+        )
+      : result.value.groups;
+  const skillManagementCredits =
+    dimension === "tool"
+      ? (result.value.groups.find(
+          (group) => group.key === SKILL_MANAGEMENT_SERVER_NAME
+        )?.credits ?? 0)
+      : 0;
+
+  if (groups.length === 0) {
+    const noun = rankBy === "credits" ? "consumption" : "activity";
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `No ${dimension} ${noun} recorded for ${label} (${tz}).`,
+      },
+    ]);
+  }
+
+  const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
+  const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
+  const lines = rows.map(
+    (row, index) =>
+      `${index + 1}. ${row.name} [${row.key}] — ` +
+      `${row.credits.toFixed(2)} credits, ` +
+      `${row.count} ${unit}${pluralize(row.count)} ` +
+      `(${row.avgCredits.toFixed(4)} per ${unit})`
+  );
+
+  return new Ok([
+    {
+      type: "text" as const,
+      text:
+        `Top ${dimension} for ${label} (${tz}), ` +
+        `${rankBy === "credits" ? "most expensive" : `most ${unit}s`} first:\n` +
+        `${lines.join("\n")}\n\n` +
+        `Credits over the whole window, every row included: ` +
+        `${(totalCredits - skillManagementCredits).toFixed(2)}.`,
+    },
+  ]);
+}
+
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
-  get_top_agents: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopAgents(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top agents: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No agent activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map(
-      (agent, index) =>
-        `${index + 1}. ${agent.name} [${agent.agentId}] — ` +
-        `${agent.messageCount} messages, ${agent.userCount} users`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top agents for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_users: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopUsers(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top users: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No user activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map(
-      (user, index) =>
-        `${index + 1}. ${user.name} [${user.userId}] — ` +
-        `${user.messageCount} messages, ${user.agentCount} agents`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top users for ${label} (${tz}), most active first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_agent_tags: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopAgentTags(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top tags: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No agent tag activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map(
-      (tag, index) =>
-        `${index + 1}. ${tag.name} [${tag.tagId}] — ` +
-        `${tag.messageCount} messages, ${tag.agentCount} agents`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top agent tags for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_models: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const result = await fetchTopModels(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      contextOrigin: source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve top models: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-
-    if (result.value.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No model activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = result.value.map((model, index) => {
-      const provider = model.providerId ? ` (${model.providerId})` : "";
-      return (
-        `${index + 1}. ${model.name}${provider} [${model.modelId}] — ` +
-        `${model.messageCount} messages, ${model.agentCount} agents, ` +
-        `${model.userCount} users`
-      );
-    });
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top models for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
   get_agent_details: async ({ agentId }, { auth }) => {
     const deniedError = workspaceManagerGuard(auth);
     if (deniedError) {
@@ -451,216 +253,6 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
           `- Tools: ${toolNames || "none"}\n\n` +
           "Instructions (full system prompt):\n" +
           `${agent.instructions ?? "(no instructions)"}`,
-      },
-    ]);
-  },
-
-  get_top_skills: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    const result = await fetchAvailableSkills(baseQuery);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve skill usage: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const skills = result.value.slice(0, limit ?? DEFAULT_RESULTS);
-
-    if (skills.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No skill usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const lines = skills.map(
-      (skill, index) =>
-        `${index + 1}. ${skill.skillName} — ${skill.totalExecutions} executions`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Most-used skills for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_top_tools: async (
-    {
-      limit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    const result = await fetchAvailableTools(baseQuery);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(`Failed to retrieve tool usage: ${result.error.message}`)
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const top = result.value.slice(0, limit ?? DEFAULT_RESULTS);
-
-    if (top.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No tool usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const displayNames = await resolveServerDisplayNames(
-      auth,
-      top.map((tool) => tool.serverName)
-    );
-
-    const lines = top.map((tool, index) => {
-      const displayName = displayNames.get(tool.serverName) ?? tool.displayName;
-      const name =
-        displayName === tool.serverName
-          ? displayName
-          : `${displayName} [${tool.serverName}]`;
-      return `${index + 1}. ${name} — ${tool.totalExecutions} executions`;
-    });
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Most-used tools for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
-      },
-    ]);
-  },
-
-  get_source_breakdown: async (
-    {
-      period,
-      startDate,
-      endDate,
-      timezone,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
-    const deniedError = workspaceManagerGuard(auth);
-    if (deniedError) {
-      return new Err(deniedError);
-    }
-
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    });
-
-    const result = await fetchContextOriginBreakdown(baseQuery);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to retrieve source breakdown: ${result.error.message}`
-        )
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const sources = toLabeledSources(result.value);
-
-    if (sources.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No source activity recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const total = sources.reduce((sum, source) => sum + source.count, 0);
-    const lines = sources.map((source, index) => {
-      const percent = total > 0 ? Math.round((source.count / total) * 100) : 0;
-      return `${index + 1}. ${source.label} — ${source.count} messages (${percent}%)`;
-    });
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Message sources for ${label} (${tz}), most used first:\n` +
-          lines.join("\n"),
       },
     ]);
   },
@@ -982,6 +574,28 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         return assertNever(selectedMetric);
     }
   },
+  get_top_entities_by_message_count: async (
+    { dimension, limit, ...input },
+    { auth }
+  ) => {
+    const denied = workspaceManagerGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+    return renderRanking(auth, { dimension, rankBy: "count", limit, input });
+  },
+
+  get_top_entities_by_execution_count: async (
+    { dimension, limit, ...input },
+    { auth }
+  ) => {
+    const denied = workspaceManagerGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+    return renderRanking(auth, { dimension, rankBy: "count", limit, input });
+  },
+
   get_top_entities_by_credits: async (
     { dimension, limit, ...input },
     { auth }
@@ -990,64 +604,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     if (deniedError) {
       return new Err(deniedError);
     }
-
-    const window = resolveTimeWindow(input);
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-    const { filter, agentTagIds } = toConsumptionScope(input);
-
-    const result = await fetchConsumptionTopGroups(auth, {
-      dimension,
-      period: toConsumptionPeriod(window.value),
-      limit: limit ?? DEFAULT_RESULTS,
-      filter,
-      agentTagIds,
-      // A single window has no vs-previous column to fill, and the lookup is a
-      // second round trip.
-      includePreviousCredits: false,
-    });
-
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to rank ${dimension} by credits: ${result.error.message}`
-        )
-      );
-    }
-
-    const { label, timezone: tz } = window.value;
-    const { groups, totalCredits } = result.value;
-
-    if (groups.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No ${dimension} consumption recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
-    const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
-    const lines = rows.map(
-      (row, index) =>
-        `${index + 1}. ${row.name} [${row.key}] — ` +
-        `${row.credits.toFixed(2)} credits, ` +
-        `${row.count} ${unit}${pluralize(row.count)} ` +
-        `(${row.avgCredits.toFixed(4)} per ${unit})`
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `Top ${dimension} by credits for ${label} (${tz}), most expensive ` +
-          `first:\n${lines.join("\n")}\n\n` +
-          `Credits over the whole window, every row included: ` +
-          `${totalCredits.toFixed(2)}.`,
-      },
-    ]);
+    return renderRanking(auth, { dimension, rankBy: "credits", limit, input });
   },
 };
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -45,6 +45,7 @@ import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messag
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -238,19 +239,16 @@ async function renderRanking(
   return new Ok([{ type: "text" as const, text }]);
 }
 
-function dayOf(timestampMs: number): string {
-  return new Date(timestampMs).toISOString().slice(0, 10);
-}
-
 function formatCreditLine(
   point: ConsumptionTimeseriesPoint,
-  groups: ConsumptionTimeseriesGroup[]
+  groups: ConsumptionTimeseriesGroup[],
+  tz: string
 ): string {
   const parts = groups.map(
     ({ groupKey, name }) =>
       `${name}: ${(point.values[groupKey] ?? 0).toFixed(2)}`
   );
-  return `${dayOf(point.timestamp)} — ${parts.join(", ")}`;
+  return `${formatDateFromMillis(point.timestamp, tz)} — ${parts.join(", ")}`;
 }
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
@@ -413,7 +411,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       ]);
     }
 
-    const lines = active.map((point) => formatCreditLine(point, groups));
+    const lines = active.map((point) => formatCreditLine(point, groups, tz));
 
     return new Ok([
       {

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -130,7 +130,7 @@ async function renderRanking(
 
   const result = await fetchConsumptionTopGroups(auth, {
     dimension,
-    period: window.value,
+    period: toConsumptionPeriod(window.value),
     limit: limit ?? DEFAULT_RESULTS,
     filter,
     rankBy,
@@ -316,7 +316,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const filter = toConsumptionScope(input);
 
     const result = await fetchConsumptionTimeseries(auth, {
-      period: window.value,
+      period: toConsumptionPeriod(window.value),
       granularity,
       mode: "daily",
       breakdownBy,
@@ -376,7 +376,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const filter = toConsumptionScope(input);
 
     const result = await fetchConsumptionActivityTimeseries(auth, {
-      period: window.value,
+      period: toConsumptionPeriod(window.value),
       granularity,
       metric,
       filter,

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -375,7 +375,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
-    const { filter, agentTagIds } = toConsumptionScope(input);
+    const filter = toConsumptionScope(input);
 
     const result = await fetchConsumptionTimeseries(auth, {
       period: toConsumptionPeriod(window.value),
@@ -384,7 +384,6 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       breakdownBy,
       breakdownCount: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
       filter,
-      agentTagIds,
       timezone: window.value.timezone,
     });
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -20,6 +20,7 @@ import {
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRankBy,
@@ -196,14 +197,13 @@ async function renderRanking(
   if (window.isErr()) {
     return new Err(new MCPError(window.error, { tracked: false }));
   }
-  const { filter, agentTagIds } = toConsumptionScope(input);
+  const filter = toConsumptionScope(input);
 
   const result = await fetchConsumptionTopGroups(auth, {
     dimension,
     period: toConsumptionPeriod(window.value),
     limit: limit ?? DEFAULT_RESULTS,
     filter,
-    agentTagIds,
     rankBy,
     includePreviousCredits: false,
     includeTotalCount: false,
@@ -301,17 +301,12 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow(input);
-    if (window.isErr()) {
-      return new Err(new MCPError(window.error, { tracked: false }));
-    }
-    const { filter, agentTagIds } = toConsumptionScope(input);
+    const filter = toConsumptionScope(input);
+    const periodInput = toConsumptionPeriodInput(input);
 
     const result = await fetchConsumptionOverview(auth, {
-      period: toConsumptionPeriod(window.value),
+      periodInput,
       filter,
-      agentTagIds,
-      withCreditCap: false,
     });
 
     if (result.isErr()) {
@@ -322,24 +317,33 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       );
     }
 
-    const { label, timezone: tz } = window.value;
     const overview = result.value;
+    const label =
+      periodInput.kind === "cycle"
+        ? "the current billing cycle"
+        : `the last ${periodInput.days} days`;
     const topAgent = overview.topAgent
       ? `${overview.topAgent.name} [${overview.topAgent.agentId}] ` +
         `(${overview.topAgent.credits.toFixed(2)} credits)`
       : "none";
+    const creditCapLine = overview.creditUsage
+      ? `\n- Credit cap: ${overview.creditUsage.status.usedPercentage}% of ` +
+        `${overview.creditUsage.capCredits} used, resets ` +
+        `${overview.creditUsage.status.resetAt}`
+      : "";
 
     return new Ok([
       {
         type: "text" as const,
         text:
-          `Workspace consumption for ${label} (${tz}):\n` +
+          `Workspace consumption for ${label}:\n` +
           `- Credits consumed: ${overview.totalCredits.toFixed(2)}\n` +
           `- Messages: ${overview.messageCount ?? 0}\n` +
           `- Active members: ${overview.members.active} of ` +
           `${overview.members.total}\n` +
           `- Top agent by credits: ${topAgent}\n` +
-          `- Last recorded consumption: ${overview.lastRecordAt ?? "none"}`,
+          `- Last recorded consumption: ${overview.lastRecordAt ?? "none"}` +
+          creditCapLine,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -19,6 +19,7 @@ import {
   toConsumptionPeriod,
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRankBy,
@@ -37,7 +38,6 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
-  fetchCreditUsage,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
@@ -295,84 +295,51 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     ]);
   },
 
-  get_credit_usage: async (
-    {
-      limit,
-      groupBy,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
-    { auth }
-  ) => {
+  get_consumption_overview: async (input, { auth }) => {
     const deniedError = workspaceManagerGuard(auth);
     if (deniedError) {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = resolveTimeWindow(input);
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
+    const { filter, agentTagIds } = toConsumptionScope(input);
 
-    const selectedGroupBy = groupBy ?? "none";
-    const result = await fetchCreditUsage(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      groupBy: selectedGroupBy,
-      contextOrigin: source,
-      agentIds,
-      userIds,
+    const result = await fetchConsumptionOverview(auth, {
+      period: toConsumptionPeriod(window.value),
+      filter,
       agentTagIds,
-      modelIds,
+      withCreditCap: false,
     });
 
     if (result.isErr()) {
       return new Err(
-        new MCPError(`Failed to estimate credit usage: ${result.error.message}`)
+        new MCPError(
+          `Failed to retrieve the consumption overview: ${result.error.message}`
+        )
       );
     }
 
     const { label, timezone: tz } = window.value;
-    const { totalCredits, rows } = result.value;
-
-    if (totalCredits === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No credit usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-
-    const header =
-      `Estimated credit usage for ${label} (${tz}): ${totalCredits} credits. ` +
-      "These are estimates — point the user to the workspace Usage page for " +
-      "exact billed credits.";
-
-    if (selectedGroupBy === "none" || rows.length === 0) {
-      return new Ok([{ type: "text" as const, text: header }]);
-    }
-
-    const lines = rows.map(
-      (row, index) =>
-        `${index + 1}. ${row.name} [${row.groupKey}] — ` +
-        `${row.totalCredits} credits`
-    );
+    const overview = result.value;
+    const topAgent = overview.topAgent
+      ? `${overview.topAgent.name} [${overview.topAgent.agentId}] ` +
+        `(${overview.topAgent.credits.toFixed(2)} credits)`
+      : "none";
 
     return new Ok([
       {
         type: "text" as const,
         text:
-          `${header}\nTop ${selectedGroupBy}s by estimated credits:\n` +
-          lines.join("\n"),
+          `Workspace consumption for ${label} (${tz}):\n` +
+          `- Credits consumed: ${overview.totalCredits.toFixed(2)}\n` +
+          `- Messages: ${overview.messageCount ?? 0}\n` +
+          `- Active members: ${overview.members.active} of ` +
+          `${overview.members.total}\n` +
+          `- Top agent by credits: ${topAgent}\n` +
+          `- Last recorded consumption: ${overview.lastRecordAt ?? "none"}`,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -28,6 +28,11 @@ import type {
 } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import type {
+  ConsumptionTimeseriesGroup,
+  ConsumptionTimeseriesPoint,
+} from "@app/lib/api/analytics/consumption/timeseries";
+import { fetchConsumptionTimeseries } from "@app/lib/api/analytics/consumption/timeseries";
+import type {
   ConsumptionTopGroup,
   ResolvedConsumptionGroup,
 } from "@app/lib/api/analytics/consumption/top";
@@ -36,10 +41,6 @@ import {
   resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import {
-  fetchCreditTimeseries,
-  fetchCreditTimeseriesBreakdown,
-} from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
@@ -237,6 +238,21 @@ async function renderRanking(
   return new Ok([{ type: "text" as const, text }]);
 }
 
+function dayOf(timestampMs: number): string {
+  return new Date(timestampMs).toISOString().slice(0, 10);
+}
+
+function formatCreditLine(
+  point: ConsumptionTimeseriesPoint,
+  groups: ConsumptionTimeseriesGroup[]
+): string {
+  const parts = groups.map(
+    ({ groupKey, name }) =>
+      `${name}: ${(point.values[groupKey] ?? 0).toFixed(2)}`
+  );
+  return `${dayOf(point.timestamp)} — ${parts.join(", ")}`;
+}
+
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   get_agent_details: async ({ agentId }, { auth }) => {
     const deniedError = workspaceManagerGuard(auth);
@@ -349,20 +365,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_credit_timeseries: async (
-    {
-      granularity,
-      breakdownBy,
-      breakdownLimit,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
+    { granularity = "day", breakdownBy, breakdownLimit, ...input },
     { auth }
   ) => {
     const deniedError = workspaceManagerGuard(auth);
@@ -370,116 +373,53 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow(
-      { period, startDate, endDate, timezone },
-      "last_30_days"
-    );
+    const window = resolveTimeWindow(input, "last_30_days");
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
+    const { filter, agentTagIds } = toConsumptionScope(input);
 
-    const { label, timezone: tz } = window.value;
-    const interval = granularity ?? "day";
-    const estimateNote =
-      "These are estimates — point the user to the workspace Usage page for " +
-      "exact billed credits";
-
-    if (breakdownBy) {
-      const result = await fetchCreditTimeseriesBreakdown(auth, {
-        startDate: window.value.startDate,
-        endDate: window.value.endDate,
-        granularity: interval,
-        timezone: window.value.timezone,
-        breakdownBy,
-        limit: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
-        contextOrigin: source,
-        agentIds,
-        userIds,
-        agentTagIds,
-        modelIds,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to estimate credit trend: ${result.error.message}`
-          )
-        );
-      }
-
-      const { groups, points } = result.value;
-      if (
-        groups.length === 0 ||
-        points.every((point) => point.totalCredits === 0)
-      ) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `No credit usage recorded for ${label} (${tz}).`,
-          },
-        ]);
-      }
-
-      const series = [...groups.map((group) => group.name), "Other"].join(", ");
-      const lines = points.map((point) => {
-        const parts = groups.map(
-          (group, index) => `${group.name} ${point.groupCredits[index]}`
-        );
-        parts.push(`Other ${point.otherCredits}`);
-        return `${point.date}: ${parts.join(", ")} (total ${point.totalCredits})`;
-      });
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text:
-            `Estimated credit usage per ${interval} for ${label} (${tz}), top ` +
-            `${groups.length} ${breakdownBy}s plus 'other'. ${estimateNote}.\n` +
-            `Series: ${series}\n` +
-            lines.join("\n"),
-        },
-      ]);
-    }
-
-    const result = await fetchCreditTimeseries(auth, {
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      granularity: interval,
-      timezone: window.value.timezone,
-      contextOrigin: source,
-      agentIds,
-      userIds,
+    const result = await fetchConsumptionTimeseries(auth, {
+      period: toConsumptionPeriod(window.value),
+      granularity,
+      mode: "daily",
+      breakdownBy,
+      breakdownCount: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
+      filter,
       agentTagIds,
-      modelIds,
+      timezone: window.value.timezone,
     });
 
     if (result.isErr()) {
       return new Err(
-        new MCPError(`Failed to estimate credit trend: ${result.error.message}`)
+        new MCPError(
+          `Failed to retrieve the credit trend: ${result.error.message}`
+        )
       );
     }
 
-    const points = result.value;
+    const { label, timezone: tz } = window.value;
+    const { groups, points } = result.value;
+    const active = points.filter((point) =>
+      Object.values(point.values).some((value) => value > 0)
+    );
 
-    if (points.every((point) => point.totalCredits === 0)) {
+    if (active.length === 0) {
       return new Ok([
         {
           type: "text" as const,
-          text: `No credit usage recorded for ${label} (${tz}).`,
+          text: `No credit consumption recorded for ${label} (${tz}).`,
         },
       ]);
     }
 
-    const lines = points.map(
-      (point) => `${point.date}: ${point.totalCredits} credits`
-    );
+    const lines = active.map((point) => formatCreditLine(point, groups));
 
     return new Ok([
       {
         type: "text" as const,
         text:
-          `Estimated credit usage per ${interval} for ${label} (${tz}). ` +
-          `${estimateNote}:\n` +
+          `Credits per ${granularity} for ${label} (${tz}):\n` +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -22,8 +22,13 @@ import {
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRankBy,
+  ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_TOP_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionTopGroup,
+  ResolvedConsumptionGroup,
+} from "@app/lib/api/analytics/consumption/top";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -112,6 +117,67 @@ function renderExecutionSeries<
   ]);
 }
 
+function excludeSkillManagement(
+  dimension: ConsumptionTopDimension,
+  groups: ConsumptionTopGroup[]
+): { groups: ConsumptionTopGroup[]; skillManagementCredits: number } {
+  if (dimension !== "tool") {
+    return { groups, skillManagementCredits: 0 };
+  }
+  const skillManagementGroup = groups.find(
+    (group) => group.key === SKILL_MANAGEMENT_SERVER_NAME
+  );
+  return {
+    groups: groups.filter((group) => group !== skillManagementGroup),
+    skillManagementCredits: skillManagementGroup?.credits ?? 0,
+  };
+}
+
+function formatRankingText({
+  dimension,
+  label,
+  tz,
+  rankBy,
+  unit,
+  rows,
+  totalCredits,
+}: {
+  dimension: ConsumptionTopDimension;
+  label: string;
+  tz: string;
+  rankBy: ConsumptionTopRankBy;
+  unit: ConsumptionTopUnit;
+  rows: ResolvedConsumptionGroup[];
+  totalCredits: number;
+}): string {
+  const metricLabel = rankBy === "credits" ? "credits" : `${unit}s`;
+
+  if (rows.length === 0) {
+    return `No ${dimension} ${metricLabel} recorded for ${label} (${tz}).`;
+  }
+
+  const lines = rows.map(
+    (row, index) =>
+      `${index + 1}. ${row.name} [${row.key}] — ` +
+      `${row.credits.toFixed(2)} credits, ` +
+      `${row.count} ${unit}${pluralize(row.count)} ` +
+      `(${row.avgCredits.toFixed(2)} per ${unit})`
+  );
+
+  // e.g.:
+  // Top agents for July 2026 (UTC), by credits, highest first:
+  // 1. Support Bot [agentXYZ] — 152.30 credits, 42 messages (3.62 per message)
+  // 2. Sales Bot [agentABC] — 98.10 credits, 12 messages (8.18 per message)
+  //
+  // Credits over the whole window, every row included: 250.40.
+  return (
+    `Top ${dimension}s for ${label} (${tz}), by ${metricLabel}, highest first:\n` +
+    `${lines.join("\n")}\n\n` +
+    `Credits over the whole window, every row included: ` +
+    `${totalCredits.toFixed(2)}.`
+  );
+}
+
 async function renderRanking(
   auth: Authenticator,
   {
@@ -151,52 +217,24 @@ async function renderRanking(
     );
   }
 
-  const { label, timezone: tz } = window.value;
-  const { totalCredits } = result.value;
-  const groups =
-    dimension === "tool"
-      ? result.value.groups.filter(
-          (group) => group.key !== SKILL_MANAGEMENT_SERVER_NAME
-        )
-      : result.value.groups;
-  const skillManagementCredits =
-    dimension === "tool"
-      ? (result.value.groups.find(
-          (group) => group.key === SKILL_MANAGEMENT_SERVER_NAME
-        )?.credits ?? 0)
-      : 0;
-
-  if (groups.length === 0) {
-    const noun = rankBy === "credits" ? "consumption" : "activity";
-    return new Ok([
-      {
-        type: "text" as const,
-        text: `No ${dimension} ${noun} recorded for ${label} (${tz}).`,
-      },
-    ]);
-  }
-
-  const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
-  const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
-  const lines = rows.map(
-    (row, index) =>
-      `${index + 1}. ${row.name} [${row.key}] — ` +
-      `${row.credits.toFixed(2)} credits, ` +
-      `${row.count} ${unit}${pluralize(row.count)} ` +
-      `(${row.avgCredits.toFixed(4)} per ${unit})`
+  const { groups, skillManagementCredits } = excludeSkillManagement(
+    dimension,
+    result.value.groups
   );
+  const rows = await resolveConsumptionGroupLabels(auth, dimension, groups);
 
-  return new Ok([
-    {
-      type: "text" as const,
-      text:
-        `Top ${dimension} for ${label} (${tz}), ` +
-        `${rankBy === "credits" ? "most expensive" : `most ${unit}s`} first:\n` +
-        `${lines.join("\n")}\n\n` +
-        `Credits over the whole window, every row included: ` +
-        `${(totalCredits - skillManagementCredits).toFixed(2)}.`,
-    },
-  ]);
+  const { label, timezone: tz } = window.value;
+  const text = formatRankingText({
+    dimension,
+    label,
+    tz,
+    rankBy,
+    unit: CONSUMPTION_TOP_DIMENSION_UNIT[dimension],
+    rows,
+    totalCredits: result.value.totalCredits - skillManagementCredits,
+  });
+
+  return new Ok([{ type: "text" as const, text }]);
 }
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
@@ -578,9 +616,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     { dimension, limit, ...input },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
     return renderRanking(auth, { dimension, rankBy: "count", limit, input });
   },
@@ -589,9 +627,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     { dimension, limit, ...input },
     { auth }
   ) => {
-    const denied = workspaceManagerGuard(auth);
-    if (denied) {
-      return new Err(denied);
+    const deniedError = workspaceManagerGuard(auth);
+    if (deniedError) {
+      return new Err(deniedError);
     }
     return renderRanking(auth, { dimension, rankBy: "count", limit, input });
   },

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -9,7 +9,6 @@ import { workspaceManagerGuard } from "@app/lib/actions/mcp_internal_actions/uti
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import type {
   ConsumptionFilterInput,
-  ResolvedTimeWindow,
   TimeWindowInput,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import {
@@ -19,6 +18,8 @@ import {
   toConsumptionPeriod,
   toConsumptionScope,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type { ConsumptionActivityTimeseries } from "@app/lib/api/analytics/consumption/activity_timeseries";
+import { fetchConsumptionActivityTimeseries } from "@app/lib/api/analytics/consumption/activity_timeseries";
 import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
 import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
 import type {
@@ -41,84 +42,10 @@ import {
   resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
-import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pluralize } from "@app/types/shared/utils/string_utils";
-import moment from "moment-timezone";
-
-function scopedBaseQuery(
-  auth: Authenticator,
-  window: ResolvedTimeWindow,
-  {
-    source,
-    agentIds,
-    userIds,
-    agentTagIds,
-    modelIds,
-  }: {
-    source?: string;
-    agentIds?: string[];
-    userIds?: string[];
-    agentTagIds?: string[];
-    modelIds?: string[];
-  }
-) {
-  return buildAgentAnalyticsBaseQuery({
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    startDate: window.startDate,
-    endDate: window.endDate,
-    contextOrigin: source,
-    agentIds,
-    userIds,
-    agentTagIds,
-    modelIds,
-  });
-}
-
-function renderExecutionSeries<
-  T extends { date: string; executionCount: number; uniqueUsers: number },
->(
-  result: Result<T[], Error>,
-  metricLabel: string,
-  windowLabel: string,
-  tz: string
-): ToolHandlerResult {
-  if (result.isErr()) {
-    return new Err(
-      new MCPError(
-        `Failed to retrieve usage time series: ${result.error.message}`
-      )
-    );
-  }
-  if (result.value.length === 0) {
-    return new Ok([
-      {
-        type: "text" as const,
-        text: `No ${metricLabel} usage recorded for ${windowLabel} (${tz}).`,
-      },
-    ]);
-  }
-  const lines = result.value.map(
-    (point) =>
-      `${point.date}: ${point.executionCount} executions, ` +
-      `${point.uniqueUsers} unique users`
-  );
-  return new Ok([
-    {
-      type: "text" as const,
-      text:
-        `${metricLabel} usage per day for ${windowLabel} (${tz}):\n` +
-        lines.join("\n"),
-    },
-  ]);
-}
 
 function excludeSkillManagement(
   dimension: ConsumptionTopDimension,
@@ -203,7 +130,7 @@ async function renderRanking(
 
   const result = await fetchConsumptionTopGroups(auth, {
     dimension,
-    period: toConsumptionPeriod(window.value),
+    period: window.value,
     limit: limit ?? DEFAULT_RESULTS,
     filter,
     rankBy,
@@ -249,6 +176,17 @@ function formatCreditLine(
       `${name}: ${(point.values[groupKey] ?? 0).toFixed(2)}`
   );
   return `${formatDateFromMillis(point.timestamp, tz)} — ${parts.join(", ")}`;
+}
+
+function formatActivityLine(
+  point: ConsumptionTimeseriesPoint,
+  series: ConsumptionActivityTimeseries["series"],
+  tz: string
+): string {
+  const parts = series.map(
+    ({ key, name }) => `${point.values[key] ?? 0} ${name.toLowerCase()}`
+  );
+  return `${formatDateFromMillis(point.timestamp, tz)}: ${parts.join(", ")}`;
 }
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
@@ -378,7 +316,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const filter = toConsumptionScope(input);
 
     const result = await fetchConsumptionTimeseries(auth, {
-      period: toConsumptionPeriod(window.value),
+      period: window.value,
       granularity,
       mode: "daily",
       breakdownBy,
@@ -423,19 +361,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_usage_timeseries: async (
-    {
-      metric,
-      granularity,
-      period,
-      startDate,
-      endDate,
-      timezone,
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
-    },
+    { metric = "messages", granularity = "day", ...input },
     { auth }
   ) => {
     const deniedError = workspaceManagerGuard(auth);
@@ -443,82 +369,55 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(deniedError);
     }
 
-    const window = resolveTimeWindow(
-      { period, startDate, endDate, timezone },
-      "last_30_days"
-    );
+    const window = resolveTimeWindow(input, "last_30_days");
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
+    const filter = toConsumptionScope(input);
 
-    const baseQuery = scopedBaseQuery(auth, window.value, {
-      source,
-      agentIds,
-      userIds,
-      agentTagIds,
-      modelIds,
+    const result = await fetchConsumptionActivityTimeseries(auth, {
+      period: window.value,
+      granularity,
+      metric,
+      filter,
+      timezone: window.value.timezone,
     });
-    const { label, timezone: tz } = window.value;
-    const selectedMetric = metric ?? "messages";
 
-    switch (selectedMetric) {
-      case "messages": {
-        const interval = granularity ?? "day";
-        const result = await fetchMessageMetrics(
-          baseQuery,
-          interval,
-          ["conversations", "activeUsers"],
-          tz
-        );
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to retrieve usage time series: ${result.error.message}`
-            )
-          );
-        }
-        if (result.value.length === 0) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `No messages usage recorded for ${label} (${tz}).`,
-            },
-          ]);
-        }
-        const lines = result.value.map((point) => {
-          const date = moment.tz(point.timestamp, tz).format("YYYY-MM-DD");
-          return (
-            `${date}: ${point.count} messages, ` +
-            `${point.conversations} conversations, ` +
-            `${point.activeUsers} active users`
-          );
-        });
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              `messages usage per ${interval} for ${label} (${tz}):\n` +
-              lines.join("\n"),
-          },
-        ]);
-      }
-      case "skills":
-        return renderExecutionSeries(
-          await fetchSkillUsageMetrics(baseQuery, null, tz),
-          "skills",
-          label,
-          tz
-        );
-      case "tools":
-        return renderExecutionSeries(
-          await fetchToolUsageMetrics(baseQuery, null, tz),
-          "tools",
-          label,
-          tz
-        );
-      default:
-        return assertNever(selectedMetric);
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to retrieve the usage time series: ${result.error.message}`
+        )
+      );
     }
+
+    const { label, timezone: tz } = window.value;
+    const series = result.value;
+    const active = series.points.filter((point) =>
+      Object.values(point.values).some((value) => value > 0)
+    );
+
+    if (active.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No ${metric} activity recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = active.map((point) =>
+      formatActivityLine(point, series.series, tz)
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `${metric} per ${granularity} for ${label} (${tz}):\n` +
+          lines.join("\n"),
+      },
+    ]);
   },
   get_top_entities_by_message_count: async (
     { dimension, limit, ...input },

--- a/front/lib/api/analytics/consumption/activity_timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/activity_timeseries.test.ts
@@ -1,0 +1,138 @@
+import { fetchConsumptionActivityTimeseries } from "@app/lib/api/analytics/consumption/activity_timeseries";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+
+const PERIOD: ConsumptionPeriod = {
+  startDate: "2026-07-01T00:00:00.000Z",
+  endDate: "2026-07-03T00:00:00.000Z",
+};
+
+const BUCKET_MS = 1782950400000;
+
+function mockBuckets(buckets: unknown[]) {
+  const response: estypes.SearchResponse<never> = {
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0, skipped: 0 },
+    hits: { hits: [] },
+    aggregations: { by_date: { buckets } },
+  };
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(new Ok(response));
+}
+
+async function setup() {
+  const workspace = await WorkspaceFactory.basic();
+  return Authenticator.internalAdminForWorkspace(workspace.sId);
+}
+
+function lastOptions() {
+  const calls = vi.mocked(searchConsumptionAnalytics).mock.calls;
+  return calls[calls.length - 1][1];
+}
+
+describe("fetchConsumptionActivityTimeseries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("counts distinct messages rather than documents", async () => {
+    const auth = await setup();
+    mockBuckets([
+      {
+        key: BUCKET_MS,
+        doc_count: 40,
+        messages: { value: 7 },
+        conversations: { value: 3 },
+        activeUsers: { value: 2 },
+      },
+    ]);
+
+    const result = await fetchConsumptionActivityTimeseries(auth, {
+      period: PERIOD,
+      granularity: "day",
+      metric: "messages",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.points[0].values).toEqual({
+        messages: 7,
+        conversations: 3,
+        activeUsers: 2,
+      });
+    }
+  });
+
+  it("counts tool executions from the tool documents only", async () => {
+    const auth = await setup();
+    mockBuckets([
+      {
+        key: BUCKET_MS,
+        doc_count: 40,
+        executions: { doc_count: 12, activeUsers: { value: 4 } },
+      },
+    ]);
+
+    const result = await fetchConsumptionActivityTimeseries(auth, {
+      period: PERIOD,
+      granularity: "day",
+      metric: "tools",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.points[0].values).toEqual({
+        executions: 12,
+        activeUsers: 4,
+      });
+    }
+  });
+
+  it("counts a skill execution only where a skill is attributed", async () => {
+    const auth = await setup();
+    mockBuckets([]);
+
+    await fetchConsumptionActivityTimeseries(auth, {
+      period: PERIOD,
+      granularity: "day",
+      metric: "skills",
+    });
+
+    expect(
+      lastOptions()?.aggregations?.by_date?.aggs?.executions?.filter
+    ).toMatchObject({
+      bool: {
+        filter: [
+          { term: { consumption_type: "tool" } },
+          { exists: { field: "tool.attributed_skill_ids" } },
+        ],
+      },
+    });
+  });
+
+  it("buckets in the caller's timezone", async () => {
+    const auth = await setup();
+    mockBuckets([]);
+
+    await fetchConsumptionActivityTimeseries(auth, {
+      period: PERIOD,
+      granularity: "day",
+      metric: "messages",
+      timezone: "Europe/Paris",
+    });
+
+    expect(lastOptions()?.aggregations?.by_date?.date_histogram).toMatchObject({
+      time_zone: "Europe/Paris",
+    });
+  });
+});

--- a/front/lib/api/analytics/consumption/activity_timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/activity_timeseries.test.ts
@@ -98,6 +98,36 @@ describe("fetchConsumptionActivityTimeseries", () => {
     }
   });
 
+  it("counts one skill execution per attributed skill, not per document", async () => {
+    const auth = await setup();
+    mockBuckets([
+      {
+        key: BUCKET_MS,
+        doc_count: 40,
+        // One tool call attributed to two skills: one document, two executions.
+        executions: {
+          doc_count: 1,
+          count: { value: 2 },
+          activeUsers: { value: 1 },
+        },
+      },
+    ]);
+
+    const result = await fetchConsumptionActivityTimeseries(auth, {
+      period: PERIOD,
+      granularity: "day",
+      metric: "skills",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.points[0].values).toEqual({
+        executions: 2,
+        activeUsers: 1,
+      });
+    }
+  });
+
   it("counts a skill execution only where a skill is attributed", async () => {
     const auth = await setup();
     mockBuckets([]);

--- a/front/lib/api/analytics/consumption/activity_timeseries.ts
+++ b/front/lib/api/analytics/consumption/activity_timeseries.ts
@@ -111,7 +111,14 @@ function metricSubAggs(
               ],
             },
           },
-          aggs: { activeUsers: cardinality(CONSUMPTION_DIMENSION_FIELDS.user) },
+          aggs: {
+            activeUsers: cardinality(CONSUMPTION_DIMENSION_FIELDS.user),
+            // A tool call attributed to several skills is one document but
+            // several executions, one per skill — value_count over doc_count.
+            count: {
+              value_count: { field: CONSUMPTION_DIMENSION_FIELDS.skill },
+            },
+          },
         },
       };
     default:
@@ -126,6 +133,7 @@ type ActivityBucket = {
   activeUsers?: estypes.AggregationsCardinalityAggregate;
   executions?: estypes.AggregationsSingleBucketAggregateBase & {
     activeUsers?: estypes.AggregationsCardinalityAggregate;
+    count?: estypes.AggregationsValueCountAggregate;
   };
 };
 
@@ -145,9 +153,13 @@ function valuesFromBucket(
         activeUsers: Math.round(bucket.activeUsers?.value ?? 0),
       };
     case "tools":
-    case "skills":
       return {
         executions: bucket.executions?.doc_count ?? 0,
+        activeUsers: Math.round(bucket.executions?.activeUsers?.value ?? 0),
+      };
+    case "skills":
+      return {
+        executions: Math.round(bucket.executions?.count?.value ?? 0),
         activeUsers: Math.round(bucket.executions?.activeUsers?.value ?? 0),
       };
     default:

--- a/front/lib/api/analytics/consumption/activity_timeseries.ts
+++ b/front/lib/api/analytics/consumption/activity_timeseries.ts
@@ -1,0 +1,216 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import {
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CONVERSATION_ID_FIELD,
+  uniqueMessagesCardinalityAgg,
+} from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionGranularity,
+  ConsumptionTimeseriesPoint,
+} from "@app/lib/api/analytics/consumption/timeseries";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { estypes } from "@elastic/elasticsearch";
+
+/**
+ * Activity over time, counted rather than summed: how many messages, how many
+ * people, how many tool calls.
+ *
+ * A message spans several consumption documents — one per LLM step, one per tool
+ * call — so a bucket's doc count is not a message count and every message metric
+ * dedupes by `agent_message_id`.
+ */
+
+export const CONSUMPTION_ACTIVITY_METRICS = [
+  "messages",
+  "tools",
+  "skills",
+] as const;
+
+export type ConsumptionActivityMetric =
+  (typeof CONSUMPTION_ACTIVITY_METRICS)[number];
+
+export type ConsumptionActivityTimeseries = {
+  period: ConsumptionPeriod;
+  granularity: ConsumptionGranularity;
+  metric: ConsumptionActivityMetric;
+  series: { key: string; name: string }[];
+  points: ConsumptionTimeseriesPoint[];
+};
+
+const TOOL_DOCUMENTS: estypes.QueryDslQueryContainer = {
+  term: { consumption_type: "tool" },
+};
+
+const SERIES_BY_METRIC: Record<
+  ConsumptionActivityMetric,
+  { key: string; name: string }[]
+> = {
+  messages: [
+    { key: "messages", name: "Messages" },
+    { key: "conversations", name: "Conversations" },
+    { key: "activeUsers", name: "Active users" },
+  ],
+  tools: [
+    { key: "executions", name: "Tool calls" },
+    { key: "activeUsers", name: "Active users" },
+  ],
+  skills: [
+    { key: "executions", name: "Skill executions" },
+    { key: "activeUsers", name: "Active users" },
+  ],
+};
+
+function cardinality(field: string): estypes.AggregationsAggregationContainer {
+  return {
+    cardinality: {
+      field,
+      precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+    },
+  };
+}
+
+// Tool and skill executions only exist on tool documents, so they hang off a
+// filter sub-aggregation rather than the date bucket itself.
+function metricSubAggs(
+  metric: ConsumptionActivityMetric
+): Record<string, estypes.AggregationsAggregationContainer> {
+  switch (metric) {
+    case "messages":
+      return {
+        messages: uniqueMessagesCardinalityAgg(),
+        conversations: cardinality(CONVERSATION_ID_FIELD),
+        activeUsers: cardinality(CONSUMPTION_DIMENSION_FIELDS.user),
+      };
+    case "tools":
+      return {
+        executions: {
+          filter: TOOL_DOCUMENTS,
+          aggs: { activeUsers: cardinality(CONSUMPTION_DIMENSION_FIELDS.user) },
+        },
+      };
+    case "skills":
+      return {
+        executions: {
+          filter: {
+            bool: {
+              filter: [
+                TOOL_DOCUMENTS,
+                { exists: { field: CONSUMPTION_DIMENSION_FIELDS.skill } },
+              ],
+            },
+          },
+          aggs: { activeUsers: cardinality(CONSUMPTION_DIMENSION_FIELDS.user) },
+        },
+      };
+    default:
+      return assertNever(metric);
+  }
+}
+
+type ActivityBucket = {
+  key: number;
+  messages?: estypes.AggregationsCardinalityAggregate;
+  conversations?: estypes.AggregationsCardinalityAggregate;
+  activeUsers?: estypes.AggregationsCardinalityAggregate;
+  executions?: estypes.AggregationsSingleBucketAggregateBase & {
+    activeUsers?: estypes.AggregationsCardinalityAggregate;
+  };
+};
+
+type ActivityAggs = {
+  by_date?: estypes.AggregationsMultiBucketAggregateBase<ActivityBucket>;
+};
+
+function valuesFromBucket(
+  metric: ConsumptionActivityMetric,
+  bucket: ActivityBucket
+): Record<string, number> {
+  switch (metric) {
+    case "messages":
+      return {
+        messages: Math.round(bucket.messages?.value ?? 0),
+        conversations: Math.round(bucket.conversations?.value ?? 0),
+        activeUsers: Math.round(bucket.activeUsers?.value ?? 0),
+      };
+    case "tools":
+    case "skills":
+      return {
+        executions: bucket.executions?.doc_count ?? 0,
+        activeUsers: Math.round(bucket.executions?.activeUsers?.value ?? 0),
+      };
+    default:
+      return assertNever(metric);
+  }
+}
+
+export async function fetchConsumptionActivityTimeseries(
+  auth: Authenticator,
+  {
+    period,
+    granularity,
+    metric,
+    filter,
+    timezone = "UTC",
+  }: {
+    period: ConsumptionPeriod;
+    granularity: ConsumptionGranularity;
+    metric: ConsumptionActivityMetric;
+    filter?: ConsumptionScopeFilter;
+    timezone?: string;
+  }
+): Promise<Result<ConsumptionActivityTimeseries, ElasticsearchError>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter,
+  });
+
+  const result = await searchConsumptionAnalytics<never, ActivityAggs>(query, {
+    aggregations: {
+      by_date: {
+        date_histogram: {
+          field: COMPLETED_AT_FIELD,
+          calendar_interval: granularity,
+          time_zone: timezone,
+          min_doc_count: 0,
+          extended_bounds: {
+            min: new Date(period.startDate).getTime(),
+            max: new Date(period.endDate).getTime() - 1,
+          },
+        },
+        aggs: metricSubAggs(metric),
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  return new Ok({
+    period,
+    granularity,
+    metric,
+    series: SERIES_BY_METRIC[metric],
+    points: bucketsToArray<ActivityBucket>(
+      result.value.aggregations?.by_date?.buckets
+    ).map((bucket) => ({
+      timestamp: bucket.key,
+      values: valuesFromBucket(metric, bucket),
+    })),
+  });
+}

--- a/front/lib/api/analytics/consumption/overview.test.ts
+++ b/front/lib/api/analytics/consumption/overview.test.ts
@@ -33,9 +33,13 @@ describe("fetchConsumptionOverview", () => {
     );
 
     const result = await fetchConsumptionOverview(auth, {
-      periodInput: { kind: "days", days: 7 },
+      period: {
+        startDate: "2026-08-21T00:00:00.000Z",
+        endDate: "2026-08-28T00:00:00.000Z",
+      },
       filter: { agents: ["agent-1"] },
       includeWorkspaceContext: false,
+      withCreditCap: false,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/analytics/consumption/overview.test.ts
+++ b/front/lib/api/analytics/consumption/overview.test.ts
@@ -33,13 +33,9 @@ describe("fetchConsumptionOverview", () => {
     );
 
     const result = await fetchConsumptionOverview(auth, {
-      period: {
-        startDate: "2026-08-21T00:00:00.000Z",
-        endDate: "2026-08-28T00:00:00.000Z",
-      },
+      periodInput: { kind: "days", days: 7 },
       filter: { agents: ["agent-1"] },
       includeWorkspaceContext: false,
-      withCreditCap: false,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -1,12 +1,9 @@
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
-import type {
-  ConsumptionPeriod,
-  ConsumptionPeriodInput,
-} from "@app/lib/api/analytics/consumption/period";
-import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
+  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   COMPLETED_AT_FIELD,
@@ -79,13 +76,8 @@ function lastRecordAtFromAgg(
 }
 
 async function fetchPoolCapCredits(
-  auth: Authenticator,
-  periodInput: ConsumptionPeriodInput
+  auth: Authenticator
 ): Promise<number | null> {
-  if (periodInput.kind !== "cycle") {
-    return null;
-  }
-
   const poolResult = await getAwuPoolSummary(auth);
   if (poolResult.isErr()) {
     return null;
@@ -144,29 +136,38 @@ async function topAgentFromAgg(
 export async function fetchConsumptionOverview(
   auth: Authenticator,
   {
-    periodInput,
+    period,
     filter,
+    agentTagIds,
     includeWorkspaceContext = true,
+    withCreditCap,
   }: {
-    periodInput: ConsumptionPeriodInput;
+    period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
+    agentTagIds?: string[];
     includeWorkspaceContext?: boolean;
+    withCreditCap: boolean;
   }
 ): Promise<Result<ConsumptionOverview, ElasticsearchError>> {
   const workspace = auth.getNonNullableWorkspace();
-  const period = await resolveConsumptionPeriod(auth, periodInput);
 
   const query = buildConsumptionScopeQuery({
     auth: auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
+    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const [searchResult, totalMembers, capCredits] = await Promise.all([
     searchConsumptionAnalytics<never, OverviewAggs>(query, {
       aggregations: {
-        active_members: { cardinality: { field: "user.id" } },
+        active_members: {
+          cardinality: {
+            field: CONSUMPTION_DIMENSION_FIELDS.user,
+            precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+          },
+        },
         message_count: {
           cardinality: {
             field: AGENT_MESSAGE_ID_FIELD,
@@ -191,8 +192,8 @@ export async function fetchConsumptionOverview(
     includeWorkspaceContext
       ? MembershipResource.countActiveMembersForWorkspace({ workspace })
       : Promise.resolve(0),
-    includeWorkspaceContext
-      ? fetchPoolCapCredits(auth, periodInput)
+    includeWorkspaceContext && withCreditCap
+      ? fetchPoolCapCredits(auth)
       : Promise.resolve(null),
   ]);
 

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -1,9 +1,12 @@
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
-import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type {
+  ConsumptionPeriod,
+  ConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/period";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
-  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   COMPLETED_AT_FIELD,
@@ -76,8 +79,13 @@ function lastRecordAtFromAgg(
 }
 
 async function fetchPoolCapCredits(
-  auth: Authenticator
+  auth: Authenticator,
+  periodInput: ConsumptionPeriodInput
 ): Promise<number | null> {
+  if (periodInput.kind !== "cycle") {
+    return null;
+  }
+
   const poolResult = await getAwuPoolSummary(auth);
   if (poolResult.isErr()) {
     return null;
@@ -136,27 +144,23 @@ async function topAgentFromAgg(
 export async function fetchConsumptionOverview(
   auth: Authenticator,
   {
-    period,
+    periodInput,
     filter,
-    agentTagIds,
     includeWorkspaceContext = true,
-    withCreditCap,
   }: {
-    period: ConsumptionPeriod;
+    periodInput: ConsumptionPeriodInput;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     includeWorkspaceContext?: boolean;
-    withCreditCap: boolean;
   }
 ): Promise<Result<ConsumptionOverview, ElasticsearchError>> {
   const workspace = auth.getNonNullableWorkspace();
+  const period = await resolveConsumptionPeriod(auth, periodInput);
 
   const query = buildConsumptionScopeQuery({
     auth: auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const [searchResult, totalMembers, capCredits] = await Promise.all([
@@ -192,8 +196,8 @@ export async function fetchConsumptionOverview(
     includeWorkspaceContext
       ? MembershipResource.countActiveMembersForWorkspace({ workspace })
       : Promise.resolve(0),
-    includeWorkspaceContext && withCreditCap
-      ? fetchPoolCapCredits(auth)
+    includeWorkspaceContext
+      ? fetchPoolCapCredits(auth, periodInput)
       : Promise.resolve(null),
   ]);
 

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -1,4 +1,10 @@
-import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import {
+  buildConsumptionScopeQuery,
+  CONSUMPTION_INVOCATION_DIMENSIONS,
+  CONSUMPTION_MESSAGE_DIMENSIONS,
+  CONSUMPTION_TOP_DIMENSION_UNIT,
+  CONSUMPTION_TOP_DIMENSIONS,
+} from "@app/lib/api/analytics/consumption/scope";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
@@ -74,5 +80,25 @@ describe("buildConsumptionScopeQuery", () => {
     });
 
     expect(query.bool?.filter).toHaveLength(2);
+  });
+});
+
+describe("the top dimensions split by ranking unit", () => {
+  it("covers every top dimension exactly once", () => {
+    expect(
+      [
+        ...CONSUMPTION_MESSAGE_DIMENSIONS,
+        ...CONSUMPTION_INVOCATION_DIMENSIONS,
+      ].sort()
+    ).toEqual([...CONSUMPTION_TOP_DIMENSIONS].sort());
+  });
+
+  it("files each dimension under its own unit", () => {
+    for (const dimension of CONSUMPTION_MESSAGE_DIMENSIONS) {
+      expect(CONSUMPTION_TOP_DIMENSION_UNIT[dimension]).toBe("message");
+    }
+    for (const dimension of CONSUMPTION_INVOCATION_DIMENSIONS) {
+      expect(CONSUMPTION_TOP_DIMENSION_UNIT[dimension]).toBe("invocation");
+    }
   });
 });

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -122,6 +122,24 @@ export const CONSUMPTION_TOP_DIMENSION_UNIT: Record<
   reasoning_effort: "message",
 };
 
+export const CONSUMPTION_TOP_RANK_BY = ["credits", "count"] as const;
+
+export type ConsumptionTopRankBy = (typeof CONSUMPTION_TOP_RANK_BY)[number];
+
+export const CONSUMPTION_MESSAGE_DIMENSIONS = [
+  "agent",
+  "user",
+  "api_key",
+  "group",
+  "model",
+  "source",
+  "conversation",
+  "tag",
+  "reasoning_effort",
+] as const;
+
+export const CONSUMPTION_INVOCATION_DIMENSIONS = ["tool", "skill"] as const;
+
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 
 export type ConsumptionMetric = (typeof CONSUMPTION_METRICS)[number];

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -200,12 +200,6 @@ function termFilter(
   ];
 }
 
-export function agentTagIdsFilter(
-  agentTagIds: string[]
-): estypes.QueryDslQueryContainer[] {
-  return termFilter(AGENT_TAG_IDS_FIELD, agentTagIds);
-}
-
 /**
  * Workspace-scoped query over a half-open [startDate, endDate) window.
  */
@@ -236,6 +230,7 @@ export function buildConsumptionScopeQuery({
       )
     );
   }
+  filters.push(...termFilter(AGENT_TAG_IDS_FIELD, filter.tags));
 
   return { bool: { filter: [...filters, ...extraFilters] } };
 }

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -7,6 +7,7 @@ import type {
   ConsumptionScopeFilter,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
+  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
@@ -54,6 +55,7 @@ export type ConsumptionTimeseries = {
   granularity: ConsumptionGranularity;
   mode: ConsumptionTimeseriesMode;
   metric: ConsumptionMetric;
+  timezone: string;
   breakdownBy: ConsumptionBreakdownDimension | null;
   // In rank order, highest consumption first, with "others" last when present.
   groups: ConsumptionTimeseriesGroup[];
@@ -67,6 +69,7 @@ type ConsumptionTimeseriesScope = {
   granularity: ConsumptionGranularity;
   mode: ConsumptionTimeseriesMode;
   metric: ConsumptionMetric;
+  timezone: string;
 };
 
 type DateBucket = {
@@ -102,6 +105,8 @@ export async function fetchConsumptionTimeseries(
     breakdownBy,
     breakdownCount = DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
     filter,
+    agentTagIds,
+    timezone = "UTC",
   }: {
     period: ConsumptionPeriod;
     granularity: ConsumptionGranularity;
@@ -110,6 +115,8 @@ export async function fetchConsumptionTimeseries(
     breakdownBy?: ConsumptionBreakdownDimension | null;
     breakdownCount?: number;
     filter?: ConsumptionScopeFilter;
+    agentTagIds?: string[];
+    timezone?: string;
   }
 ): Promise<Result<ConsumptionTimeseries, ElasticsearchError>> {
   const query = buildConsumptionScopeQuery({
@@ -117,8 +124,9 @@ export async function fetchConsumptionTimeseries(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
+    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
-  const scope = { period, granularity, mode, metric };
+  const scope = { period, granularity, mode, metric, timezone };
 
   if (!breakdownBy) {
     return fetchTimeseries(query, scope);
@@ -138,6 +146,7 @@ async function fetchTimeseries(
   const bucketsResult = await fetchMetricTimeseries(query, {
     period: scope.period,
     granularity: scope.granularity,
+    timezone: scope.timezone,
     metric: scope.metric,
     breakdown: null,
   });
@@ -189,6 +198,7 @@ async function fetchTimeseriesBreakdown(
   const bucketsResult = await fetchMetricTimeseries(query, {
     period: scope.period,
     granularity: scope.granularity,
+    timezone: scope.timezone,
     metric: scope.metric,
     breakdown: { field, groupKeys: topDimensionKeys },
   });
@@ -231,11 +241,13 @@ async function fetchMetricTimeseries(
   {
     period,
     granularity,
+    timezone,
     metric,
     breakdown,
   }: {
     period: ConsumptionPeriod;
     granularity: ConsumptionGranularity;
+    timezone: string;
     metric: ConsumptionMetric;
     breakdown: ConsumptionBreakdown | null;
   }
@@ -248,7 +260,7 @@ async function fetchMetricTimeseries(
           date_histogram: {
             field: COMPLETED_AT_FIELD,
             calendar_interval: granularity,
-            time_zone: "UTC",
+            time_zone: timezone,
             min_doc_count: 0,
             extended_bounds: {
               min: new Date(period.startDate).getTime(),

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -7,7 +7,6 @@ import type {
   ConsumptionScopeFilter,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
@@ -105,7 +104,6 @@ export async function fetchConsumptionTimeseries(
     breakdownBy,
     breakdownCount = DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
     filter,
-    agentTagIds,
     timezone = "UTC",
   }: {
     period: ConsumptionPeriod;
@@ -115,7 +113,6 @@ export async function fetchConsumptionTimeseries(
     breakdownBy?: ConsumptionBreakdownDimension | null;
     breakdownCount?: number;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     timezone?: string;
   }
 ): Promise<Result<ConsumptionTimeseries, ElasticsearchError>> {
@@ -124,7 +121,6 @@ export async function fetchConsumptionTimeseries(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
   const scope = { period, granularity, mode, metric, timezone };
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -878,10 +878,44 @@ describe("consumption top rankings", () => {
   });
 });
 
-// The two options the analytics tools rely on and the page never sets.
 describe("fetchConsumptionTopGroups options", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      name: "credits sort on the credit sum",
+      dimension: "agent" as const,
+      rankBy: "credits" as const,
+      order: { credit_micro: "desc" },
+    },
+    {
+      name: "a message dimension counted sorts on distinct messages",
+      dimension: "agent" as const,
+      rankBy: "count" as const,
+      order: { messages: "desc" },
+    },
+    {
+      name: "an invocation dimension counted sorts on the bucket's own docs",
+      dimension: "tool" as const,
+      rankBy: "count" as const,
+      order: { _count: "desc" },
+    },
+  ])("$name", async ({ dimension, rankBy, order }) => {
+    const { auth } = await setup();
+    mockAggs({ buckets: [], totalMicro: 0 });
+
+    await fetchConsumptionTopGroupBuckets(auth, {
+      dimension,
+      period: PERIOD,
+      limit: 5,
+      rankBy,
+      includePreviousCredits: false,
+    });
+
+    const [, options] = lastSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({ order });
   });
 
   it("skips the previous-period search when the caller opts out", async () => {

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -935,7 +935,7 @@ describe("fetchConsumptionTopGroups options", () => {
     expect(vi.mocked(searchConsumptionAnalytics)).toHaveBeenCalledTimes(1);
   });
 
-  it("scopes on agentTagIds, which no filter key covers", async () => {
+  it("scopes on the tags filter key", async () => {
     const { auth } = await setup();
     mockAggs({ buckets: [], totalMicro: 0 });
 
@@ -943,7 +943,7 @@ describe("fetchConsumptionTopGroups options", () => {
       dimension: "agent",
       period: PERIOD,
       limit: 5,
-      agentTagIds: ["tag_1"],
+      filter: { tags: ["tag_1"] },
       includePreviousCredits: false,
     });
 

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -34,7 +34,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 import chunk from "lodash/chunk";
 
-type ConsumptionTopGroup = {
+export type ConsumptionTopGroup = {
   key: string;
   credits: number;
   // Distinct messages, or tool invocations, per the ranking's unit.

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,11 +5,11 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeFilter,
   ConsumptionTopDimension,
+  ConsumptionTopRankBy,
   ConsumptionTopSortOrder,
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  AGENT_MESSAGE_ID_FIELD,
   agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
@@ -17,6 +17,7 @@ import {
   CONSUMPTION_TOP_DIMENSION_FIELDS,
   CONSUMPTION_TOP_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
+  uniqueMessagesCardinalityAgg,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -75,7 +76,7 @@ function subAggs(unit: ConsumptionTopUnit) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
     ...(unit === "message"
-      ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
+      ? { [MESSAGES_AGG]: uniqueMessagesCardinalityAgg() }
       : {}),
   };
 }
@@ -183,18 +184,41 @@ async function resolveConsumptionTopSearchFilter(
   );
 }
 
+function rankingOrder(
+  dimension: ConsumptionTopDimension,
+  rankBy: ConsumptionTopRankBy,
+  sortOrder: ConsumptionTopSortOrder
+): Record<string, ConsumptionTopSortOrder> {
+  if (rankBy === "credits") {
+    return { [CREDIT_AGG]: sortOrder };
+  }
+
+  switch (CONSUMPTION_TOP_DIMENSION_UNIT[dimension]) {
+    case "message":
+      return { [MESSAGES_AGG]: sortOrder };
+    case "invocation":
+      return { _count: sortOrder };
+    default:
+      return assertNever(CONSUMPTION_TOP_DIMENSION_UNIT[dimension]);
+  }
+}
+
 function buildConsumptionTopAggregations({
   dimension,
   bucketCount,
   excludedKeys,
   searchFilter,
   sortOrder,
+  rankBy,
+  includeTotalCount,
 }: {
   dimension: ConsumptionTopDimension;
   bucketCount: number;
   excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
   sortOrder: ConsumptionTopSortOrder;
+  rankBy: ConsumptionTopRankBy;
+  includeTotalCount: boolean;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_TOP_DIMENSION_FIELDS[dimension];
@@ -204,17 +228,21 @@ function buildConsumptionTopAggregations({
       terms: {
         field: dimensionField,
         size: bucketCount,
-        order: { [CREDIT_AGG]: sortOrder },
+        order: rankingOrder(dimension, rankBy, sortOrder),
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
       aggs: subAggs(unit),
     },
-    [TOTAL_COUNT_AGG]: {
-      cardinality: {
-        field: dimensionField,
-        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-      },
-    },
+    ...(includeTotalCount
+      ? {
+          [TOTAL_COUNT_AGG]: {
+            cardinality: {
+              field: dimensionField,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
+      : {}),
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
   const rankingRootAggregations = searchFilter
@@ -317,7 +345,9 @@ export async function fetchConsumptionTopGroups(
     filter,
     agentTagIds,
     sortOrder = "desc",
+    rankBy = "credits",
     includePreviousCredits = true,
+    includeTotalCount = true,
   }: {
     dimension: ConsumptionTopDimension;
     period: ConsumptionPeriod;
@@ -327,7 +357,9 @@ export async function fetchConsumptionTopGroups(
     filter?: ConsumptionScopeFilter;
     agentTagIds?: string[];
     sortOrder?: ConsumptionTopSortOrder;
+    rankBy?: ConsumptionTopRankBy;
     includePreviousCredits?: boolean;
+    includeTotalCount?: boolean;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const searchFilter = await resolveConsumptionTopSearchFilter(auth, {
@@ -364,6 +396,8 @@ export async function fetchConsumptionTopGroups(
       excludedKeys: rankedGroups.map((group) => group.key),
       searchFilter,
       sortOrder,
+      rankBy,
+      includeTotalCount,
     });
     const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
       aggregations,

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -10,7 +10,6 @@ import type {
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  agentTagIdsFilter,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
@@ -273,13 +272,11 @@ async function fetchConsumptionPreviousCredits(
     dimension,
     previousPeriod,
     filter,
-    agentTagIds,
     keys,
   }: {
     dimension: ConsumptionTopDimension;
     previousPeriod: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     keys: string[];
   }
 ): Promise<Result<Map<string, number>, ElasticsearchError>> {
@@ -292,7 +289,6 @@ async function fetchConsumptionPreviousCredits(
     startDate: previousPeriod.startDate,
     endDate: previousPeriod.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const result = await searchConsumptionAnalytics<never, PreviousCreditsAggs>(
@@ -343,7 +339,6 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
-    agentTagIds,
     sortOrder = "desc",
     rankBy = "credits",
     includePreviousCredits = true,
@@ -355,7 +350,6 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    agentTagIds?: string[];
     sortOrder?: ConsumptionTopSortOrder;
     rankBy?: ConsumptionTopRankBy;
     includePreviousCredits?: boolean;
@@ -372,7 +366,6 @@ export async function fetchConsumptionTopGroups(
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
-    extraFilters: agentTagIdsFilter(agentTagIds ?? []),
   });
 
   const requestedBucketCount = offset + limit;
@@ -437,7 +430,6 @@ export async function fetchConsumptionTopGroups(
     dimension,
     previousPeriod: previousConsumptionPeriod(period),
     filter,
-    agentTagIds,
     keys: includePreviousCredits ? pagedGroups.map((group) => group.key) : [],
   });
   // The prior-period lookup only feeds the vs-prev display column: a failure

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -46,9 +46,13 @@ export const workspaceAnalyticsSkill = {
     "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
     "call returns the top groups plus an 'other' series. Do not make one " +
     "filtered call per agent, user or model.\n" +
-    "- To scope any tool to specific models, call get_top_models first to get " +
-    "the exact model ids in use, then pass them as modelIds — never guess a " +
-    "model id from its display name.\n" +
+    "- For volume rather than spend — who is most active, which agents or " +
+    "models get used most, where messages come from — call " +
+    "get_top_entities_by_message_count with that dimension, and " +
+    "get_top_entities_by_execution_count for how often tools and skills ran.\n" +
+    "- The rankings return each row's id. Feed those ids back in as filters " +
+    "(agentIds, userIds, modelIds, agentTagIds, sources, ...) to narrow any " +
+    "other call — never guess an id from a display name.\n" +
     `- To inventory what EXISTS rather than what is used — which agents or ` +
     `skills the workspace has, whether they are published or discoverable, ` +
     `which ones nobody uses — call ${LIST_AGENTS_TOOL_NAME} or ` +
@@ -61,7 +65,7 @@ export const workspaceAnalyticsSkill = {
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 6,
+  version: 7,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -35,13 +35,14 @@ export const workspaceAnalyticsSkill = {
     "call: get_credit_timeseries for credit/spend trends, or " +
     "get_usage_timeseries for activity, skill, or tool trends. They return the " +
     "whole series bucketed by day/week/month in one call.\n" +
-    "- Never build a trend by calling a snapshot tool (get_credit_usage, " +
-    "get_top_*) once per day or in parallel per period — it is slower and " +
-    "unnecessary, the timeseries tools already bucket over time.\n" +
+    "- Never build a trend by calling a snapshot tool once per day or in " +
+    "parallel per period — it is slower and unnecessary, the timeseries " +
+    "tools already bucket over time.\n" +
     "- To attribute spend — which agents, users, models, tools, skills, " +
     "sources, API keys, groups, tags or conversations cost the most — call " +
-    "get_top_entities_by_credits with that dimension. Use get_credit_usage " +
-    "only for a single window's total credits.\n" +
+    "get_top_entities_by_credits with that dimension. Use " +
+    "get_consumption_overview for a window's totals: credits, messages, " +
+    "active members and the top agent in one call.\n" +
     "- For a credit trend split by agent, user or model (e.g. 'how did each " +
     "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
     "call returns the top groups plus an 'other' series. Do not make one " +
@@ -65,7 +66,7 @@ export const workspaceAnalyticsSkill = {
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 7,
+  version: 8,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -66,7 +66,7 @@ export const workspaceAnalyticsSkill = {
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 8,
+  version: 9,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {

--- a/front/types/api/analytics/consumption.ts
+++ b/front/types/api/analytics/consumption.ts
@@ -31,6 +31,7 @@ export const CONSUMPTION_SCOPE_FILTER_KEYS = [
   "tools",
   "skills",
   "sources",
+  "tags",
 ] as const;
 
 export type ConsumptionScopeFilterKey =


### PR DESCRIPTION
Last of the stack — on #31303, itself on #31300, #31290 and #31273. Review those first; this diff is against #31303's branch.

## Description

`get_usage_timeseries` is the last reader of `front.agent_message_analytics` in `workspace_analytics`; re-pointed at the consumption index, same name.

With no legacy tool left, two pieces of scaffolding go:

- `usageFilterSchema`, which existed only because the old tools took a singular `source` over `context_origin`.
- `toConsumptionPeriod`, the +1ms conversion from the old inclusive `lte` bound. `get_credit_timeseries` (#31303) and the ranking/overview tools switch to the raw resolved window at their call sites.

`workspace_analytics` now runs entirely on the consumption index: six tools, and `get_agent_details` which only ever read Postgres.

## Tests

- `activity_timeseries.test.ts`: distinct messages rather than documents, tool executions counted from tool documents only, a skill execution requiring an attributed skill, and bucketing in the caller's timezone.
- Review fix: date labels used a bare UTC slice instead of `formatDateFromMillis`, same timezone bug as #31303.

## Risk

Medium. The tool changes index, and message counts become billed messages only — the consumption indexer skips failed and unbilled messages. Caller is `@analyst` only.

## Deploy Plan

Merge after #31303. Last of five: credits ranking → count rankings → overview → credit timeseries → usage timeseries.
