### PR TITLE
Admin governance: Remove some builder role usage

### DIFF
--- a/front-api/routes/w/[wId]/members/search.test.ts
+++ b/front-api/routes/w/[wId]/members/search.test.ts
@@ -187,16 +187,16 @@ describe("GET /api/w/:wId/members/search", () => {
     );
   });
 
-  it("includes builders when filtering on the member role", async () => {
+  it("returns every member when filtering on the member role", async () => {
     const { workspace } = await setup();
 
-    const [member, builder] = await Promise.all([
+    const [member, otherMember] = await Promise.all([
       UserFactory.basic(),
       UserFactory.basic(),
     ]);
 
     await MembershipFactory.associate(workspace, member, { role: "user" });
-    await MembershipFactory.associate(workspace, builder, { role: "builder" });
+    await MembershipFactory.associate(workspace, otherMember, { role: "user" });
 
     const response = await honoApp.request(
       searchUrl(workspace.sId, { role: "user" })
@@ -206,7 +206,7 @@ describe("GET /api/w/:wId/members/search", () => {
     const data = await response.json();
     expect(data.total).toBe(2);
     expect(data.members.map((m: { sId: string }) => m.sId).sort()).toEqual(
-      [member.sId, builder.sId].sort()
+      [member.sId, otherMember.sId].sort()
     );
   });
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -306,14 +306,9 @@ async function resolveRoleFilterUserIds({
   workspace: LightWorkspaceType;
   role: ActiveRoleType;
 }): Promise<string[]> {
-  // `builder` is deprecated and surfaced to end users as a regular member, so
-  // filtering on `user` must include both.
-  const roles: ActiveRoleType[] =
-    role === "user" ? ["user", "builder"] : [role];
-
   const { memberships } = await MembershipResource.getActiveMemberships({
     workspace,
-    roles,
+    roles: [role],
   });
 
   // The query's filter make sure `user` is never null, so nothing

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2670,24 +2670,19 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Transitional — builder role deprecation, see
    * https://github.com/dust-tt/tasks/issues/9459.
    *
-   * Keeps a per-workspace "Builders" group (`regular_manual`) in sync with the `builder`
-   * role so that when the role is removed, the group can be granted the builders' governance
-   * capabilities (create agents / skills) and former builders keep their rights. Until then
-   * the role is the source of truth: the group is created lazily and manual edits may be
-   * undone by the sync. Once the role is removed, the sync goes away and the group becomes
-   * fully admin-managed.
+   * Maintains the per-workspace "Builders" group (`regular_manual`), which holds the governance
+   * capabilities (create agents / skills) that the `builder` role used to confer, so former
+   * builders kept their rights when the role was migrated away.
    *
-   * The group is deliberately independent from SCIM provisioning: provisioned
-   * "dust-builders" groups proved unreliable (drifted membership, stale groups after
-   * deprovisioning). Workspaces provisioning builders get both groups — IdP changes flow
-   * through role assignment, which keeps this group in sync automatically.
+   * The `builder` role is no longer the source of truth and no longer drives this sync — every
+   * builder membership has been migrated to `user`. The only remaining driver is the
+   * `dust-builders` SCIM provisioning group: both callers mirror an add/remove on that IdP group
+   * into this manual group, and neither creates it (`createIfMissing: false`). Once
+   * `dust-builders` is retired on the WorkOS side, this sync goes away and the group becomes
+   * fully admin-managed.
    *
    * Idempotent ensure-state semantics: after the call, the user's active membership in the
    * group matches `isBuilder`.
-   *
-   * Callers must invoke this after every membership write that can involve the builder role
-   * (role change, membership creation, revocation) — see the `lib/api/membership.ts`
-   * wrappers.
    */
   static async syncBuilderGroupMembership({
     workspace,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1039,9 +1039,8 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
-   * Caller of this method should call `ServerSideTracking.trackCreateMembership` and
-   * `GroupResource.syncBuilderGroupMembership` (builder role deprecation). Prefer
-   * `createAndTrackMembership` from `@app/lib/api/membership` which handles both.
+   * Caller of this method should call `ServerSideTracking.trackCreateMembership`. Prefer
+   * `createAndTrackMembership` from `@app/lib/api/membership` which handles it.
    */
   static async createMembership({
     user,
@@ -1275,9 +1274,8 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
-   * Caller of this method should call `ServerSideTracking.trackUpdateMembershipRole` and
-   * `GroupResource.syncBuilderGroupMembership` (builder role deprecation). Prefer
-   * `updateMembershipRoleAndTrack` from `@app/lib/api/membership` which handles both.
+   * Caller of this method should call `ServerSideTracking.trackUpdateMembershipRole`. Prefer
+   * `updateMembershipRoleAndTrack` from `@app/lib/api/membership` which handles it.
    */
   static async updateMembershipRole({
     user,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -190,12 +190,12 @@ export function isGlobalAgentWithFeedback(sId: GLOBAL_AGENTS_SID): boolean {
   return GLOBAL_AGENTS_WITH_FEEDBACK.has(sId);
 }
 
-const AGENT_IDS_RESTRICTED_TO_BUILDER = new Set<string>([
+const AGENT_IDS_WITHOUT_CONVERSATION_ACTIONS = new Set<string>([
   GLOBAL_AGENTS_SID.SIDEKICK,
 ]);
 
 export function canShowAgentConversationActions(agentId: string): boolean {
-  return !AGENT_IDS_RESTRICTED_TO_BUILDER.has(agentId);
+  return !AGENT_IDS_WITHOUT_CONVERSATION_ACTIONS.has(agentId);
 }
 
 export function getGlobalAgentAuthorName(agentId: string): string {

--- a/marketing/types/user.ts
+++ b/marketing/types/user.ts
@@ -1,4 +1,4 @@
-export type RoleType = "admin" | "builder" | "user" | "none";
+export type RoleType = "admin" | "manager" | "user" | "none";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9755

Follow-up to #31430 (builder role dropped from tests). Now that every builder membership has been migrated to `user`, a few leftovers in production code are unreachable or actively misleading. No observable behavior change.

Each commit stands alone:

  - **`a61eaecb` Drop builder from the member search role filter** — `resolveRoleFilterUserIds` expanded a `user` filter to `["user", "builder"]`. It only queries active memberships, none of which carry the role any more, so the expansion is dead. Its test asserted exactly that, so it now covers the member-role filter with two regular members rather than being deleted.
  - **`e2af3b35` Correct stale builder-sync documentation** — `createMembership` / `updateMembershipRole` still told callers to invoke `syncBuilderGroupMembership` after every membership write; that stopped being true when the role-driven call sites left `lib/api/membership.ts`, so following the instruction today is a no-op at best. The sync's own doc claimed the role was its source of truth — its only remaining driver is the `dust-builders` SCIM group. Docs only.
  - **`85edff79` Rename `AGENT_IDS_RESTRICTED_TO_BUILDER`** — gates `canShowAgentConversationActions` and never had anything to do with the role; the name just made it look like role logic. Now `AGENT_IDS_WITHOUT_CONVERSATION_ACTIONS`.
  - **`73faf0af` Fix the marketing `RoleType`** — listed the deprecated `builder` and was missing `manager` entirely, so it was wrong in both directions. Marketing only forwards `role` to PostHog.


## Tests

No new tests; this is dead-code and documentation cleanup.

## Risk

Low, safe to roll back (revert any commit independently, no migration or data change)

## Deploy Plan

deploy front
