### PR TITLE
Admin governance: Remove the unused keyAuth from Authenticator.fromKey

### DIFF
--- a/front-api/middlewares/public_api_auth.ts
+++ b/front-api/middlewares/public_api_auth.ts
@@ -176,13 +176,12 @@ export const publicApiAuth = createMiddleware<PublicApiCtx>(
       return apiError(ctx, keyRes.error);
     }
 
-    const keyAndWorkspaceAuth = await Authenticator.fromKey(
+    let workspaceAuth = await Authenticator.fromKey(
       keyRes.value,
       wId,
       getGroupIdsFromHeaders(headers),
       getRoleFromHeaders(headers)
     );
-    let { workspaceAuth } = keyAndWorkspaceAuth;
 
     const workspaceError = validateWorkspaceFromAuth(workspaceAuth);
     if (workspaceError) {

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -328,10 +328,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     }
     // The permission set is resolved once at Authenticator construction, so build the request auth
     // after the grants above for its snapshot to include them.
-    const { workspaceAuth: auth } = await Authenticator.fromKey(
-      key,
-      workspace.sId
-    );
+    const auth = await Authenticator.fromKey(key, workspace.sId);
 
     const importWithAvailability = async ({
       availability,
@@ -391,10 +388,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     }
     // The permission set is resolved once at Authenticator construction, so build the request auth
     // after the grants above for its snapshot to include them.
-    const { workspaceAuth: auth } = await Authenticator.fromKey(
-      key,
-      workspace.sId
-    );
+    const auth = await Authenticator.fromKey(key, workspace.sId);
 
     const result = await importSkillsFromFiles(auth, {
       uploadedFiles: [
@@ -434,10 +428,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     });
     // The permission set is resolved once at Authenticator construction, so build the request auth
     // after the grant above for its snapshot to include the create/skill capability.
-    const { workspaceAuth: auth } = await Authenticator.fromKey(
-      key,
-      workspace.sId
-    );
+    const auth = await Authenticator.fromKey(key, workspace.sId);
     const firstEditor = await UserFactory.basic();
     const secondEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, firstEditor, {

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -537,10 +537,7 @@ describe("retryAgentMessage", () => {
 
   it("should use the actor api key for rate limiting", async () => {
     const systemKey = await KeyFactory.system(globalGroup);
-    const { workspaceAuth: systemKeyAuth } = await Authenticator.fromKey(
-      systemKey,
-      workspace.sId
-    );
+    const systemKeyAuth = await Authenticator.fromKey(systemKey, workspace.sId);
 
     const rateLimiterSpy = vi
       .spyOn(rateLimiterModule, "rateLimiter")
@@ -2579,10 +2576,7 @@ describe("postUserMessage", () => {
       expect(await projectSpace.isOpen(auth)).toBe(false);
 
       const apiKey = await KeyFactory.regular(globalGroup);
-      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
-        apiKey,
-        workspace.sId
-      );
+      const apiKeyAuth = await Authenticator.fromKey(apiKey, workspace.sId);
 
       expect(apiKeyAuth.user()).toBeNull();
       const restrictedPod = await SpaceResource.fetchById(
@@ -2626,10 +2620,7 @@ describe("postUserMessage", () => {
       );
 
       const apiKey = await KeyFactory.regular(globalGroup);
-      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
-        apiKey,
-        workspace.sId
-      );
+      const apiKeyAuth = await Authenticator.fromKey(apiKey, workspace.sId);
 
       expect(apiKeyAuth.user()).toBeNull();
       const openPod = await SpaceResource.fetchById(
@@ -2672,10 +2663,7 @@ describe("postUserMessage", () => {
       );
 
       const apiKey = await KeyFactory.regular(globalGroup);
-      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
-        apiKey,
-        workspace.sId
-      );
+      const apiKeyAuth = await Authenticator.fromKey(apiKey, workspace.sId);
 
       expect(apiKeyAuth.user()).toBeNull();
       const openPod = await SpaceResource.fetchById(
@@ -2805,10 +2793,7 @@ describe("postUserMessage", () => {
       expect(updateResult.isOk()).toBe(true);
 
       const apiKey = await KeyFactory.regular(globalGroup);
-      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
-        apiKey,
-        workspace.sId
-      );
+      const apiKeyAuth = await Authenticator.fromKey(apiKey, workspace.sId);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversationResource,
@@ -3677,10 +3662,7 @@ describe("editUserMessage", () => {
     // A key has no `auth.user()` either, so the author check used to compare
     // null against null and let this through.
     const systemKey = await KeyFactory.system(globalGroup);
-    const { workspaceAuth: keyAuth } = await Authenticator.fromKey(
-      systemKey,
-      workspace.sId
-    );
+    const keyAuth = await Authenticator.fromKey(systemKey, workspace.sId);
 
     const result = await editUserMessage(keyAuth, {
       conversationResource,

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -408,10 +408,7 @@ describe("computeAuthorizedFileAccess", () => {
       [globalGroup]
     );
 
-    const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
-      key,
-      workspace.sId
-    );
+    const apiKeyAuth = await Authenticator.fromKey(key, workspace.sId);
     expect(apiKeyAuth.user()).toBeNull();
 
     const conversation = await ConversationFactory.create(userAuth, {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -910,16 +910,14 @@ export class Authenticator {
    *                                   possible with a system key).
    * @param requestedRole optional role to assign the auth in place of the key role (only possible
    *                               with a system key).
-   * @returns Promise<{ workspaceAuth: Authenticator }>
+   * @returns Promise<Authenticator>
    */
   static async fromKey(
     key: KeyResource,
     wId: string,
     requestedGroupIds?: string[],
     requestedRole?: RoleType
-  ): Promise<{
-    workspaceAuth: Authenticator;
-  }> {
+  ): Promise<Authenticator> {
     const [workspace, keyWorkspace] = await Promise.all([
       WorkspaceResource.fetchById(wId),
       WorkspaceResource.fetchByModelId(key.workspaceId),
@@ -985,18 +983,16 @@ export class Authenticator {
         : { workspace, groupModelIds: workspaceGroupModelIds }
     );
 
-    return {
-      workspaceAuth: new Authenticator({
-        authMethod: key.isSystem ? "system_api_key" : "api_key",
-        groupModelIds: workspaceGroupModelIds,
-        key: key.toAuthJSON(),
-        role,
-        subscription: workspaceSubscription,
-        workspace,
-        providersHealth: workspaceProvidersHealth,
-        permissions,
-      }),
-    };
+    return new Authenticator({
+      authMethod: key.isSystem ? "system_api_key" : "api_key",
+      groupModelIds: workspaceGroupModelIds,
+      key: key.toAuthJSON(),
+      role,
+      subscription: workspaceSubscription,
+      workspace,
+      providersHealth: workspaceProvidersHealth,
+      permissions,
+    });
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -900,8 +900,9 @@ export class Authenticator {
   }
 
   /**
-   * Returns two Authenticators, one for the workspace associated with the key and one for the
-   * workspace provided as an argument.
+   * Returns an Authenticator for the workspace provided as an argument, authenticated with the
+   * given API key. The key does not have to belong to that workspace: when it does not, it
+   * confers no groups and no role there.
    *
    * @param key Key the API key
    * @param wId the target workspaceId
@@ -909,7 +910,7 @@ export class Authenticator {
    *                                   possible with a system key).
    * @param requestedRole optional role to assign the auth in place of the key role (only possible
    *                               with a system key).
-   * @returns Promise<{ workspaceAuth: Authenticator, keyAuth: Authenticator }>
+   * @returns Promise<{ workspaceAuth: Authenticator }>
    */
   static async fromKey(
     key: KeyResource,
@@ -918,7 +919,6 @@ export class Authenticator {
     requestedRole?: RoleType
   ): Promise<{
     workspaceAuth: Authenticator;
-    keyAuth: Authenticator;
   }> {
     const [workspace, keyWorkspace] = await Promise.all([
       WorkspaceResource.fetchById(wId),
@@ -944,49 +944,21 @@ export class Authenticator {
     let keyGroups: GroupResource[] = [];
     let requestedGroups: GroupResource[] = [];
     let workspaceSubscription: SubscriptionResource | null = null;
-    let keySubscription: SubscriptionResource | null = null;
 
     if (workspace) {
       const lightWorkspace = renderLightWorkspaceType({ workspace });
-      const lightKeyWorkspace = renderLightWorkspaceType({
-        workspace: keyWorkspace,
-      });
       if (requestedGroupIds && key.isSystem) {
-        [requestedGroups, keySubscription, workspaceSubscription] =
-          await Promise.all([
-            GroupResource.listGroupsWithSystemKey(key, requestedGroupIds),
-            SubscriptionResource.fetchActiveByWorkspaceModelId(
-              lightKeyWorkspace.id
-            ),
-            // We need to fetch the subscription separately as requested groups
-            // might not include the global group which is used to fetch the
-            // subscription in fetchRoleGroupsAndSubscription.
-            isKeyWorkspace
-              ? null
-              : SubscriptionResource.fetchActiveByWorkspaceModelId(
-                  lightWorkspace.id
-                ),
-          ]);
+        [requestedGroups, workspaceSubscription] = await Promise.all([
+          GroupResource.listGroupsWithSystemKey(key, requestedGroupIds),
+          // Fetched separately: the requested groups might not include the global group, which is
+          // what fetchRoleGroupsAndSubscription uses to resolve the subscription.
+          SubscriptionResource.fetchActiveByWorkspaceModelId(lightWorkspace.id),
+        ]);
       } else {
-        [keyGroups, keySubscription, workspaceSubscription] = await Promise.all(
-          [
-            GroupResource.listWorkspaceGroupsFromKey(key),
-            SubscriptionResource.fetchActiveByWorkspaceModelId(
-              lightKeyWorkspace.id
-            ),
-            isKeyWorkspace
-              ? null
-              : SubscriptionResource.fetchActiveByWorkspaceModelId(
-                  lightWorkspace.id
-                ),
-          ]
-        );
-      }
-
-      // When the key workspace is the target workspace, both subscriptions
-      // are identical - reuse the one we already fetched.
-      if (isKeyWorkspace) {
-        workspaceSubscription = keySubscription;
+        [keyGroups, workspaceSubscription] = await Promise.all([
+          GroupResource.listWorkspaceGroupsFromKey(key),
+          SubscriptionResource.fetchActiveByWorkspaceModelId(lightWorkspace.id),
+        ]);
       }
     }
     const allGroups = requestedGroupIds ? requestedGroups : keyGroups;
@@ -1000,37 +972,18 @@ export class Authenticator {
     const workspaceGroupModelIds = isKeyWorkspace
       ? allGroups.map((g) => g.id)
       : [];
-    const keyGroupModelIds = allGroups.map((g) => g.id);
 
     // `requestedGroupIds` replaces the key's own groups (the Slack bot acting as a user), so the
     // resolution goes through those groups instead of the key.
     const systemKey = !requestedGroupIds && isSystemKey(key) ? key : null;
 
-    let permissions: GroupPermissions;
-    let keyPermissions: GroupPermissions;
-    if (isKeyWorkspace) {
-      // Same workspace and same groups: both Authenticators share one resolution rather than
-      // running the same query twice. Safe to share the instance, GroupPermissions is immutable.
-      permissions = await this.resolvePermissions(
-        systemKey
-          ? { workspace, systemKey }
-          : { workspace, groupModelIds: workspaceGroupModelIds }
-      );
-      keyPermissions = permissions;
-    } else {
-      [permissions, keyPermissions] = await Promise.all([
-        // The target workspace is not the key's, so the key says nothing about it.
-        this.resolvePermissions({
-          workspace,
-          groupModelIds: workspaceGroupModelIds,
-        }),
-        this.resolvePermissions(
-          systemKey
-            ? { workspace: keyWorkspace, systemKey }
-            : { workspace: keyWorkspace, groupModelIds: keyGroupModelIds }
-        ),
-      ]);
-    }
+    // The target workspace is not necessarily the key's; when it is not, the key says nothing
+    // about it and `workspaceGroupModelIds` is empty.
+    const permissions = await this.resolvePermissions(
+      systemKey && isKeyWorkspace
+        ? { workspace, systemKey }
+        : { workspace, groupModelIds: workspaceGroupModelIds }
+    );
 
     return {
       workspaceAuth: new Authenticator({
@@ -1042,15 +995,6 @@ export class Authenticator {
         workspace,
         providersHealth: workspaceProvidersHealth,
         permissions,
-      }),
-      keyAuth: new Authenticator({
-        authMethod: key.isSystem ? "system_api_key" : "api_key",
-        groupModelIds: keyGroupModelIds,
-        key: key.toAuthJSON(),
-        role: "builder",
-        subscription: keySubscription,
-        workspace: keyWorkspace,
-        permissions: keyPermissions,
       }),
     };
   }

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -254,7 +254,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     const listForGroups = vi.spyOn(GroupPermissionResource, "listForGroups");
 
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+    const workspaceAuth = await Authenticator.fromKey(key, workspace.sId);
 
     // A system key holds every group of its workspace, so its grants are stated, not read.
     expect(listForGroups).not.toHaveBeenCalled();
@@ -287,10 +287,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     await GroupFactory.defaults(otherWorkspace);
 
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth } = await Authenticator.fromKey(
-      key,
-      otherWorkspace.sId
-    );
+    const workspaceAuth = await Authenticator.fromKey(key, otherWorkspace.sId);
 
     expect(workspaceAuth.getGrantedVerbs("space", 1234)).toEqual([]);
   });
@@ -309,7 +306,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     });
 
     const key = await KeyFactory.regular(globalGroup);
-    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+    const workspaceAuth = await Authenticator.fromKey(key, workspace.sId);
 
     expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
       "read",
@@ -349,7 +346,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     const listForGroups = vi.spyOn(GroupPermissionResource, "listForGroups");
 
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
+    const workspaceAuth = await Authenticator.fromKey(key, workspace.sId, [
       includedGroup.sId,
     ]);
 
@@ -379,7 +376,7 @@ describe("Authenticator.refresh permission resolution", () => {
     // A key auth has no user; its grant snapshot is resolved once at build time. The agent loop
     // freezes it at workflow start and refreshes it on every step.
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
+    const workspaceAuth = await Authenticator.fromKey(key, workspace.sId, [
       group.sId,
     ]);
     expect(workspaceAuth.getGrantedVerbs("agent", 42)).toEqual([]);

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -254,10 +254,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     const listForGroups = vi.spyOn(GroupPermissionResource, "listForGroups");
 
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth, keyAuth } = await Authenticator.fromKey(
-      key,
-      workspace.sId
-    );
+    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
 
     // A system key holds every group of its workspace, so its grants are stated, not read.
     expect(listForGroups).not.toHaveBeenCalled();
@@ -277,7 +274,6 @@ describe("Authenticator.fromKey permission resolution", () => {
       "write",
     ]);
     expect(workspaceAuth.getGrantedVerbs("space", 1234)).toContain("admin");
-    expect(keyAuth.getGrantedVerbs("space", 1234)).toContain("admin");
 
     // It survives the Temporal round trip the agent loop puts the auth through.
     const restored = await Authenticator.fromJSON(workspaceAuth.toJSON());
@@ -291,14 +287,12 @@ describe("Authenticator.fromKey permission resolution", () => {
     await GroupFactory.defaults(otherWorkspace);
 
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth, keyAuth } = await Authenticator.fromKey(
+    const { workspaceAuth } = await Authenticator.fromKey(
       key,
       otherWorkspace.sId
     );
 
     expect(workspaceAuth.getGrantedVerbs("space", 1234)).toEqual([]);
-    // The key's own workspace still gets the full set.
-    expect(keyAuth.getGrantedVerbs("space", 1234)).toContain("admin");
   });
 
   it("resolves grants for non-system keys", async () => {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1974,10 +1974,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     assert(updateResult.isOk(), "Failed to enable private conversation URLs");
 
     const apiKey = await KeyFactory.regular(globalGroup);
-    const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
-      apiKey,
-      workspace.sId
-    );
+    const apiKeyAuth = await Authenticator.fromKey(apiKey, workspace.sId);
 
     const conversation = await ConversationFactory.create(apiKeyAuth, {
       agentConfigurationId: agents[0].sId,

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -60,8 +60,7 @@ describe("SkillResource", () => {
       // role ("user") must be allowed here — there is no role distinction left to gate on.
       const key = await KeyFactory.readOnly(testContext.globalGroup);
 
-      const auth = (await Authenticator.fromKey(key, testContext.workspace.sId))
-        .workspaceAuth;
+      const auth = await Authenticator.fromKey(key, testContext.workspace.sId);
 
       expect(skill.canWrite(auth)).toBe(true);
       expect(skill.canAdministrate(auth)).toBe(true);

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2328,7 +2328,7 @@ describe("SpaceResource", () => {
       const second = await SpaceFactory.project(workspace);
 
       const key = await KeyFactory.system(systemGroup);
-      const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+      const workspaceAuth = await Authenticator.fromKey(key, workspace.sId);
 
       // A system key holds the type-wide space grant, so `isMember` is true on every project. The
       // enumeration has to agree rather than come back empty.

--- a/front/tests/utils/generic_public_api_tests.ts
+++ b/front/tests/utils/generic_public_api_tests.ts
@@ -51,7 +51,7 @@ export const createPublicApiMockRequest = async ({
   const auth = await Authenticator.fromKey(key, workspace.sId);
 
   return {
-    auth: auth.workspaceAuth,
+    auth,
     req,
     res,
     workspace,


### PR DESCRIPTION
## Description

`fromKey` returned two Authenticators: `workspaceAuth` for the target workspace, and `keyAuth` for the key's own workspace. `keyAuth` was added in #6648 (Aug 2024) for cross-workspace Dust app runs: the app runs endpoint used it to read the key workspace's providers and feature flags, and to check `app.canRead(keyAuth)`.

That went away in Jan 2026: https://github.com/dust-tt/dust/pull/20357 ("Remove ability to execute dust apps cross workspacee") rewrote every use in that endpoint to `auth`, and https://github.com/dust-tt/dust/pull/20360 dropped the `keyAuth` parameter from `withPublicAPIAuthentication` altogether. Since then nothing in production has read it — the only caller, `public_api_auth.ts`, destructures `workspaceAuth` and discards the rest. Two tests asserted on it.

Dropping it removes unnecessary work `fromKey` did on public API request.

This also removes one of the last `role: "builder"` references in production: `keyAuth` was hardcoded to the deprecated role.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
