### PR TITLE
[CONNECTORS] Add .feature (Gherkin) extension to GitHub supported files

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -71,6 +71,7 @@ const EXTENSION_WHITELIST = [
   ".avdl", // Apache Avro IDL definition
   ".lkml", // Looker LookML model/view files
   ".lookml", // Looker legacy dashboard files
+  ".feature", // Cucumber/Gherkin feature files (BDD tests)
 
   ".item", // Talend files, a data integration/ETL platform.
 


### PR DESCRIPTION
## Description

Add `.feature` (Cucumber/Gherkin) to the GitHub connector `EXTENSION_WHITELIST` so BDD test files (eg. Cypress feature files) are synced as code.

Fixes https://github.com/dust-tt/tasks/issues/10247

## Tests

N/A: one-line addition to a static extension whitelist. Local validation not run in the sandbox; delegated to PR CI. `.feature` files are plain-text Gherkin, no parsing dependency.

## Risk

Very low. Only widens the sync whitelist; safe to rollback by removing the line. Existing repos will pick up `.feature` files on next sync (a `github resync-repo-code` may be needed for existing repos).

## Deploy Plan

Standard connectors deploy. Then trigger `github resync-repo-code --connectorId=274877908489 --owner=honestica --repo=lifen-looker` for Lifen.
