### PR TITLE
fix: invalidate relocation caches before resume

### DIFF
--- a/front/scripts/relocation/cache.test.ts
+++ b/front/scripts/relocation/cache.test.ts
@@ -1,0 +1,37 @@
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { invalidateRelocatedWorkspaceCaches } from "./cache";
+
+describe("invalidateRelocatedWorkspaceCaches", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("invalidates the workspace and subscription caches", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const invalidateWorkspaceCache = vi
+      .spyOn(WorkspaceResource, "invalidateCache")
+      .mockResolvedValue();
+    const invalidateSubscriptionCache = vi
+      .spyOn(SubscriptionResource, "invalidateSubscriptionCache")
+      .mockResolvedValue();
+
+    await invalidateRelocatedWorkspaceCaches(workspace.sId);
+
+    expect(invalidateWorkspaceCache).toHaveBeenCalledExactlyOnceWith(
+      workspace.sId
+    );
+    expect(invalidateSubscriptionCache).toHaveBeenCalledExactlyOnceWith(
+      workspace.id
+    );
+  });
+
+  it("fails when the relocated workspace is missing", async () => {
+    await expect(
+      invalidateRelocatedWorkspaceCaches("missing-workspace")
+    ).rejects.toThrow("Workspace not found: missing-workspace");
+  });
+});

--- a/front/scripts/relocation/cache.ts
+++ b/front/scripts/relocation/cache.ts
@@ -1,0 +1,19 @@
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+
+export async function invalidateRelocatedWorkspaceCaches(
+  workspaceId: string
+): Promise<void> {
+  const [workspaceModelId] = await WorkspaceResource.fetchModelIdsByIds([
+    workspaceId,
+  ]);
+
+  if (!workspaceModelId) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+
+  await Promise.all([
+    WorkspaceResource.invalidateCache(workspaceId),
+    SubscriptionResource.invalidateSubscriptionCache(workspaceModelId),
+  ]);
+}

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -22,6 +22,7 @@ import { computeWorkspaceStatistics } from "@app/lib/api/workspace_statistics";
 import { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { invalidateRelocatedWorkspaceCaches } from "@app/scripts/relocation/cache";
 import { launchWorkspaceRelocationWorkflow } from "@app/temporal/relocation/client";
 import type { CellType } from "@app/types/cell";
 import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
@@ -94,6 +95,15 @@ makeScript(
     if (sourceCell === destinationCell) {
       logger.error("Source and destination cells must be different.");
       return;
+    }
+
+    // Relocation writes directly to the destination database, bypassing the
+    // Resource mutation paths that normally invalidate these caches. Clear
+    // them before building the authenticator so it cannot retain the
+    // synthetic FREE subscription produced while the copy was incomplete.
+    if (execute && step === "resume-in-destination") {
+      assertCurrentCell(destinationCell);
+      await invalidateRelocatedWorkspaceCaches(workspaceId);
     }
 
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes workspace relocation occasionally loading a stale subscription and treating the workspace as FREE.
When resuming in the destination cell, we now clear the workspace and subscription caches before creating the authenticator, ensuring it loads the relocated data from the destination database. As this write goes through the raw SQL queries, it currently by passes most of the resource logic. Only those two are required, as others are not loaded until workspace is resumed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
