### PR TITLE
Enabled workspace analytics for analyst global agent

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -128,6 +128,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "most active. Admin-only.",
     schema: getTopAgentsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top agents",
       done: "Retrieved top agents",
@@ -145,6 +146,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "are, rank members by usage, or find your top contributors. Admin-only.",
     schema: getTopUsersSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top users",
       done: "Retrieved top users",
@@ -165,6 +167,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "based on historical message data and may not reflect current agent tags. Admin-only.",
     schema: getTopAgentTagsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top agent tags",
       done: "Retrieved top agent tags",
@@ -185,6 +188,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "models may appear. Admin-only.",
     schema: getTopModelsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top models",
       done: "Retrieved top models",
@@ -201,6 +205,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "does. Admin-only.",
     schema: getAgentDetailsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving agent details",
       done: "Retrieved agent details",
@@ -217,6 +222,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "to answer which skills are used most. Admin-only.",
     schema: getTopSkillsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top skills",
       done: "Retrieved top skills",
@@ -235,6 +241,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "rely on. Admin-only.",
     schema: getTopToolsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top tools",
       done: "Retrieved top tools",
@@ -257,6 +264,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "tag, or model. Admin-only.",
     schema: getSourceBreakdownSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving source breakdown",
       done: "Retrieved source breakdown",
@@ -279,6 +287,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "drive spend. Admin-only.",
     schema: getCreditUsageSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Estimating credit usage",
       done: "Estimated credit usage",
@@ -302,6 +311,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "agent, user, tag, or model. Admin-only.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Estimating credit trend",
       done: "Estimated credit trend",
@@ -319,6 +329,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "day. Combine with filters to narrow. Chart the result. Admin-only.",
     schema: getUsageTimeseriesSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving usage time series",
       done: "Retrieved usage time series",

--- a/front/lib/api/actions/servers/workspace_management/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_management/metadata.ts
@@ -183,6 +183,7 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
       "whether they are published, and who can edit them.",
     schema: listAgentsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Listing agents",
       done: "Listed agents",
@@ -198,6 +199,7 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
       "instructions. Use this to inspect what an agent actually does.",
     schema: getAgentDetailsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving agent details",
       done: "Retrieved agent details",
@@ -212,6 +214,7 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
       "and who can reach them.",
     schema: listSkillsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Listing skills",
       done: "Listed skills",
@@ -227,6 +230,7 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
       "instructions private, so those come back empty.",
     schema: getSkillSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving skill",
       done: "Retrieved skill",
@@ -241,6 +245,7 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
       "Admin and manager only.",
     schema: listWorkspaceMembersSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Listing workspace members",
       done: "Workspace members listed",

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -3,6 +3,7 @@ import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { _getAnalystGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/analyst";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -100,6 +101,79 @@ describe("resolveSkillMCPServers", () => {
         }),
       ])
     );
+  });
+
+  it("eagerly exposes workspace analytics tools to Analyst", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+    const agentConfiguration = _getAnalystGlobalAgent({
+      auth: authenticator,
+    });
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      authenticator,
+      {
+        workspace,
+        conversation,
+        agentConfig: agentConfiguration,
+      }
+    );
+    const { userMessage } = await ConversationFactory.createUserMessage({
+      auth: authenticator,
+      workspace,
+      conversation,
+      content: "Which agents are used most?",
+      // The agent message factory sits at rank 0.
+      rank: 1,
+    });
+
+    const skillBuckets = await SkillResource.listForAgentLoop(authenticator, {
+      agentConfiguration,
+      conversation,
+    });
+    expect(
+      skillBuckets.systemSkills.some(
+        (skill) => skill.sId === "workspace-analytics"
+      )
+    ).toBe(true);
+
+    const { skillServers, systemSkillServers } = await resolveSkillMCPServers(
+      authenticator,
+      {
+        agentConfiguration,
+        conversation,
+      }
+    );
+    const serverToolsAndInstructions = await tryListMCPTools(
+      authenticator,
+      {
+        agentConfiguration,
+        agentMessage,
+        userMessage,
+        clientSideActionConfigurations: [],
+        conversation,
+      },
+      {
+        jitServers: [],
+        skillServers,
+        systemSkillServers,
+      }
+    );
+
+    const workspaceAnalyticsTools = serverToolsAndInstructions
+      .filter(({ serverName }) =>
+        ["workspace_analytics", "workspace_management"].includes(serverName)
+      )
+      .flatMap(({ tools }) => tools);
+
+    expect(workspaceAnalyticsTools.length).toBeGreaterThan(0);
+    expect(workspaceAnalyticsTools.every((tool) => tool.eager)).toBe(true);
   });
 
   it("exposes one set of company data tools when Discover Knowledge and Go Deep are enabled", async () => {

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -176,6 +176,28 @@ describe("resolveSkillMCPServers", () => {
     expect(workspaceAnalyticsTools.every((tool) => tool.eager)).toBe(true);
   });
 
+  it("does not auto-equip workspace analytics on other agents", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+
+    const { systemSkills, enabledSkills, equippedSkills } =
+      await SkillResource.listForAgentLoop(authenticator, {
+        agentConfiguration,
+        conversation,
+      });
+    const isWorkspaceAnalytics = (skill: SkillResource) =>
+      skill.sId === "workspace-analytics";
+
+    expect(systemSkills.some(isWorkspaceAnalytics)).toBe(false);
+    expect(enabledSkills.some(isWorkspaceAnalytics)).toBe(false);
+    expect(equippedSkills.some(isWorkspaceAnalytics)).toBe(false);
+  });
+
   it("exposes one set of company data tools when Discover Knowledge and Go Deep are enabled", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -75,6 +75,6 @@ export const workspaceAnalyticsSkill = {
     return agentConfiguration.scope === "global" &&
       agentConfiguration.sId === GLOBAL_AGENTS_SID.ANALYST
       ? "enabled"
-      : "equipped";
+      : undefined;
   },
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/api/actions/servers/workspace_management/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
 
 export const workspaceAnalyticsSkill = {
@@ -69,5 +70,11 @@ export const workspaceAnalyticsSkill = {
       return true;
     }
     return !isWorkspaceAnalyticsEnabled(auth.getNonNullableWorkspace());
+  },
+  getAutoEnabledOrEquippedForAgentLoop: ({ agentConfiguration }) => {
+    return agentConfiguration.scope === "global" &&
+      agentConfiguration.sId === GLOBAL_AGENTS_SID.ANALYST
+      ? "enabled"
+      : "equipped";
   },
 } as const satisfies GlobalSkillDefinition;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR enables the workspace analytics skill on global agent `@.analyst` while still keeping it available as a regular standalone skill that can be pinned in the input bar.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
