### PR TITLE
Expose poke port 3010 in Cursor/dev and fix ES index init under set -e

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -15,6 +15,7 @@
   ],
   "ports": [
     { "name": "front-api", "port": 3000 },
+    { "name": "front-poke", "port": 3010 },
     { "name": "front-spa", "port": 3011 },
     { "name": "core-api", "port": 3001 },
     { "name": "viz", "port": 3007 },

--- a/dev/scripts/docker-run.sh
+++ b/dev/scripts/docker-run.sh
@@ -109,6 +109,7 @@ ensure_container_running() {
     -e LC_ALL=C.UTF-8 \
     -e DUST_IN_CONTAINER=1 \
     -p 3000:3000 \
+    -p 3010:3010 \
     -p 3011:3011 \
     -p 3001:3001 \
     -p 3007:3007 \

--- a/dev/scripts/init-elasticsearch-indices.sh
+++ b/dev/scripts/init-elasticsearch-indices.sh
@@ -60,14 +60,16 @@ create_core_index() {
   binary="$(elasticsearch_create_index_bin)"
 
   log "Ensuring core.${index_name}_${index_version}..."
+  # Capture status under `set -e`: a bare `(...) ; status=$?` never runs status=$?
+  # when the subshell is non-zero (e.g. "already exists" → 2).
+  status=0
   (
     cd "${DUST_REPO_ROOT}/core"
     run_logged "$binary" \
       --index-name "$index_name" \
       --index-version "$index_version" \
       --skip-confirmation
-  )
-  status=$?
+  ) || status=$?
   if [ "$status" -eq 0 ]; then
     return 0
   fi
@@ -85,6 +87,9 @@ create_front_index() {
   local status
 
   log "Ensuring front.${index_name}_${index_version}..."
+  # Capture status under `set -e`: a bare `(...) ; status=$?` never runs status=$?
+  # when the subshell is non-zero (e.g. "already exists" → 2).
+  status=0
   (
     cd "${DUST_REPO_ROOT}/front"
     run_logged env PATH="${DUST_REPO_ROOT}/node_modules/.bin:${PATH}" \
@@ -93,8 +98,7 @@ create_front_index() {
       --index-version "$index_version" \
       --skip-confirmation \
       --execute
-  )
-  status=$?
+  ) || status=$?
   if [ "$status" -eq 0 ]; then
     return 0
   fi


### PR DESCRIPTION
## Description

Expose `front-poke` on port `3010` in Cursor Cloud and the local `docker-run.sh` environment. Fix Elasticsearch index initialization in `init-elasticsearch-indices.sh` so `set -e` does not abort before the script captures and handles the “already exists” status.

## Tests

Reviewed the shell control flow for both index creation paths. No automated tests cover these development scripts or Cursor configuration.

## Risk

Low. The changes affect development tooling only and have no production runtime impact. Rollback is a simple revert.

## Deploy Plan

No production deployment or SQL migration. Rebuild the shared development image and refresh the Cursor Cloud snapshot so the new port mapping and script behavior take effect.