### PR TITLE
[front] analytics: clarify empty search results copy

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -622,7 +622,7 @@ function TriggersTableBody({
     return (
       <div className="text-sm text-muted-foreground">
         {search.trim()
-          ? `No match for "${search.trim()}".`
+          ? `No results for "${search.trim()}". Only items with usage data appear here.`
           : "No automation ran over this period."}
       </div>
     );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -684,7 +684,9 @@ export function ConsumptionAttributionRowsView({
       <div>
         {rows.length === 0 ? (
           <div className="text-sm text-muted-foreground">
-            {search.trim() ? `No match for "${search.trim()}".` : emptyMessage}
+            {search.trim()
+              ? `No results for "${search.trim()}". Only items with usage data appear here.`
+              : emptyMessage}
           </div>
         ) : (
           <div className="overflow-x-auto">


### PR DESCRIPTION
Analytics data comes from Elasticsearch and only indexes items with usage data, so searching for an agent with no usage returns nothing, which reads as a bug. The empty state now says so: `No results for "support". Only items with usage data appear here.` instead of `No match for "support".`

Applied to the consumption attribution table and the automations triggers table, which behave the same way.