### PR TITLE
feat: use spaces when creating api keys

### DIFF
--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -146,7 +146,35 @@ describe("POST /api/w/:wId/keys — space scoping", () => {
     );
   });
 
-  it("attaches both the member and the editor group of a restricted pod", async () => {
+  it("attaches only the member group of a restricted pod to a user key", async () => {
+    const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const pod = await SpaceFactory.project(workspace, undefined, {
+      name: "SecretPod",
+    });
+    const podGroups = await SpaceResource.listRegularAutoGroupsForSpaces(auth, [
+      pod,
+    ]);
+    expect(podGroups).toHaveLength(2);
+    const memberGroup = await pod.fetchManualMemberGroup(auth);
+
+    const res = await createKey(workspace, {
+      name: "pod-scoped-user-key",
+      space_ids: [pod.sId],
+      role: "user",
+    });
+
+    expect(res.status).toBe(201);
+    const { key } = await res.json();
+    // The editor group holds the space `admin` grant, which would let the key administrate the pod.
+    expect(key.groupIds.toSorted()).toEqual(
+      [globalGroup.id, memberGroup.id].toSorted()
+    );
+  });
+
+  it("attaches both the member and the editor group of a restricted pod to an admin key", async () => {
     const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
       role: "admin",
     });
@@ -160,8 +188,9 @@ describe("POST /api/w/:wId/keys — space scoping", () => {
     expect(podGroups).toHaveLength(2);
 
     const res = await createKey(workspace, {
-      name: "pod-scoped-key",
+      name: "pod-scoped-admin-key",
       space_ids: [pod.sId],
+      role: "admin",
     });
 
     expect(res.status).toBe(201);

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -1,7 +1,8 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
-import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -112,18 +113,107 @@ describe("POST /api/w/:wId/keys — role restrictions", () => {
   });
 });
 
-describe("POST /api/w/:wId/keys — group scoping", () => {
-  it("rejects scoping to a group not tied to a restricted space or pod", async () => {
-    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
-
-    // This group is not associated to any restricted space or pod, so it is
-    // not scopable — even for an admin.
-    const group = await GroupFactory.regularManual(workspace, "Backend");
-
-    const res = await honoApp.request(`/api/w/${workspace.sId}/keys`, {
+describe("POST /api/w/:wId/keys — space scoping", () => {
+  function createKey(workspace: { sId: string }, body: object) {
+    return honoApp.request(`/api/w/${workspace.sId}/keys`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "scoped-key", group_ids: [group.sId] }),
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("scopes the key to the groups of a restricted space", async () => {
+    const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+    const spaceGroups = await SpaceResource.listRegularAutoGroupsForSpaces(
+      auth,
+      [space]
+    );
+    expect(spaceGroups).toHaveLength(1);
+
+    const res = await createKey(workspace, {
+      name: "scoped-key",
+      space_ids: [space.sId],
+    });
+
+    expect(res.status).toBe(201);
+    const { key } = await res.json();
+    expect(key.groupIds.toSorted()).toEqual(
+      [globalGroup.id, spaceGroups[0].id].toSorted()
+    );
+  });
+
+  it("attaches both the member and the editor group of a restricted pod", async () => {
+    const { workspace, auth, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const pod = await SpaceFactory.project(workspace, undefined, {
+      name: "SecretPod",
+    });
+    const podGroups = await SpaceResource.listRegularAutoGroupsForSpaces(auth, [
+      pod,
+    ]);
+    expect(podGroups).toHaveLength(2);
+
+    const res = await createKey(workspace, {
+      name: "pod-scoped-key",
+      space_ids: [pod.sId],
+    });
+
+    expect(res.status).toBe(201);
+    const { key } = await res.json();
+    expect(key.groupIds.toSorted()).toEqual(
+      [globalGroup.id, ...podGroups.map((group) => group.id)].toSorted()
+    );
+  });
+
+  it("rejects scoping to an open space", async () => {
+    const { workspace, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    // Attaching the workspace global group as a viewer is what makes a space open.
+    const openSpace = await SpaceFactory.regular(workspace);
+    await SpaceFactory.attachGroup(openSpace, globalGroup, "project_viewer");
+
+    const res = await createKey(workspace, {
+      name: "open-space-key",
+      space_ids: [openSpace.sId],
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("rejects scoping to the global or the system space", async () => {
+    const { workspace, globalSpace, systemSpace } =
+      await createPrivateApiMockRequest({ role: "admin" });
+
+    for (const [index, space] of [globalSpace, systemSpace].entries()) {
+      const res = await createKey(workspace, {
+        name: `unique-kind-key-${index}`,
+        space_ids: [space.sId],
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error.type).toBe("workspace_auth_error");
+    }
+  });
+
+  it("rejects an unknown space id", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    // `fetchByIds` silently drops ids it cannot resolve, so an unknown id must not pass
+    // unnoticed alongside a valid one.
+    const res = await createKey(workspace, {
+      name: "unknown-space-key",
+      space_ids: [space.sId, "notaspaceid"],
     });
 
     expect(res.status).toBe(403);

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { listKeyScopableGroups } from "@app/lib/api/keys/scopable_groups";
 import {
   MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
   MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
@@ -33,6 +34,8 @@ const MAX_API_KEY_CREATION_PER_DAY = 30;
 const CreateKeyPostBodySchema = z.object({
   name: z.string(),
   space_ids: z.array(z.string()).optional(),
+  group_ids: z.array(z.string()).optional(),
+  group_id: z.string().optional(),
   monthly_cap_micro_usd: z.number().nullish(),
   // Per-key credit cap in AWU credits (credit-priced plans only). null/omitted
   // = unlimited.
@@ -72,6 +75,8 @@ app.post(
     const {
       name,
       space_ids,
+      group_ids,
+      group_id,
       monthly_cap_micro_usd,
       monthly_cap_awu_credits,
       role,
@@ -199,6 +204,38 @@ app.post(
           scopableSpaces
         ))
       );
+    }
+
+    const requestedGroupIds = [
+      ...new Set(group_ids ?? (group_id ? [group_id] : [])),
+    ].filter((groupId) => groupId !== globalGroup.sId);
+
+    if (requestedGroupIds.length > 0) {
+      const scopableGroupIds = new Set(
+        (await listKeyScopableGroups(auth)).map((group) => group.sId)
+      );
+      if (requestedGroupIds.some((groupId) => !scopableGroupIds.has(groupId))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "An API key can only be scoped to groups of restricted spaces or pods.",
+          },
+        });
+      }
+
+      const groupsRes = await GroupResource.fetchByIds(auth, requestedGroupIds);
+      if (groupsRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "group_not_found",
+            message: "Invalid group",
+          },
+        });
+      }
+      resolvedGroups.push(...groupsRes.value);
     }
 
     const rateLimitKey = `api_key_creation_${owner.sId}`;

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -1,24 +1,10 @@
-import {
-  buildAuditLogTarget,
-  emitAuditLogEvent,
-  getAuditLogContext,
-} from "@app/lib/api/audit/workos_audit";
-import { listKeyScopableGroups } from "@app/lib/api/keys/scopable_groups";
-import {
-  MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
-  MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
-  setApiKeySpendLimit,
-} from "@app/lib/api/keys/spend_limit";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import { createApiKey } from "@app/lib/api/keys/create";
 import { KeyResource } from "@app/lib/resources/key_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { rateLimiter } from "@app/lib/utils/rate_limiter";
-import logger from "@app/logger/logger";
 import type {
   GetKeysResponseBody,
   PostKeysResponseBody,
 } from "@app/types/api/keys";
-import { isCreditPricedPlan } from "@app/types/plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -28,8 +14,6 @@ import { z } from "zod";
 import keyId from "./[id]";
 import keyGroups from "./groups";
 import keySpaces from "./spaces";
-
-const MAX_API_KEY_CREATION_PER_DAY = 30;
 
 const CreateKeyPostBodySchema = z.object({
   name: z.string(),
@@ -70,7 +54,6 @@ app.post(
   async (ctx): HandlerResult<PostKeysResponseBody> => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const owner = auth.getNonNullableWorkspace();
 
     const {
       name,
@@ -81,260 +64,53 @@ app.post(
       monthly_cap_awu_credits,
       role,
     } = ctx.req.valid("json");
-    const trimmedName = name.trim();
-    const keyRole = role ?? "user";
 
-    if (trimmedName.length === 0) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "API key name cannot be empty.",
-        },
-      });
-    }
-
-    if (
-      monthly_cap_micro_usd !== null &&
-      monthly_cap_micro_usd !== undefined &&
-      monthly_cap_micro_usd < 0
-    ) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "monthly_cap_micro_usd must be greater than or equal to 0",
-        },
-      });
-    }
-
-    // Per-key credit cap: only valid on credit-priced plans and within range.
-    // Validated up front so we never create a key whose requested cap can't be
-    // applied.
-    if (
-      monthly_cap_awu_credits !== null &&
-      monthly_cap_awu_credits !== undefined
-    ) {
-      const plan = auth.subscription()?.plan;
-      if (!plan || !isCreditPricedPlan(plan)) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "Per-key credit spend limits are only available on credit-priced plans.",
-          },
-        });
-      }
-      if (
-        monthly_cap_awu_credits < MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS ||
-        monthly_cap_awu_credits > MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS
-      ) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              `monthly_cap_awu_credits must be between ` +
-              `${MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS} and ` +
-              `${MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS}.`,
-          },
-        });
-      }
-    }
-
-    const existingKey = await KeyResource.fetchByName(auth, {
-      name: trimmedName,
-      onlyActive: true,
-    });
-    if (existingKey) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "An API key with this name already exists in this workspace.",
-        },
-      });
-    }
-
-    // A key always carries the workspace global group, so it can reach everything every workspace
-    // member can reach; the spaces it is scoped to add to that.
-    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
-    if (globalGroupRes.isErr()) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "group_not_found",
-          message: "Global group not found",
-        },
-      });
-    }
-    const globalGroup = globalGroupRes.value;
-
-    const resolvedGroups: GroupResource[] = [globalGroup];
-    const requestedSpaceIds = [...new Set(space_ids ?? [])];
-
-    if (requestedSpaceIds.length > 0) {
-      const spaces = await SpaceResource.fetchByIds(auth, requestedSpaceIds);
-      const openSpaceModelIds = await SpaceResource.listOpenSpaceModelIds(
-        auth,
-        spaces
-      );
-      const scopableSpaces = spaces.filter(
-        (space) =>
-          (space.isRegular() || space.isProject()) &&
-          !openSpaceModelIds.has(space.id)
-      );
-
-      if (scopableSpaces.length !== requestedSpaceIds.length) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "An API key can only be scoped to restricted spaces or pods.",
-          },
-        });
-      }
-
-      resolvedGroups.push(
-        ...(await SpaceResource.listRegularAutoGroupsForSpaces(
-          auth,
-          scopableSpaces
-        ))
-      );
-    }
-
-    const additionalGroupIds = group_ids
-      ? group_ids.filter((gId) => gId !== globalGroup.sId)
-      : group_id && group_id !== globalGroup.sId
-        ? [group_id]
-        : [];
-
-    if (additionalGroupIds.length > 0) {
-      const scopableGroupIds = new Set(
-        (await listKeyScopableGroups(auth)).map((group) => group.sId)
-      );
-      const invalidGroupIds = additionalGroupIds.filter(
-        (gId) => !scopableGroupIds.has(gId)
-      );
-      if (invalidGroupIds.length > 0) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "An API key can only be scoped to groups of restricted spaces or pods.",
-          },
-        });
-      }
-
-      const groupsRes = await GroupResource.fetchByIds(
-        auth,
-        additionalGroupIds
-      );
-      if (groupsRes.isErr()) {
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "group_not_found",
-            message: "Invalid group",
-          },
-        });
-      }
-      resolvedGroups.push(...groupsRes.value);
-    }
-
-    const rateLimitKey = `api_key_creation_${owner.sId}`;
-    const remaining = await rateLimiter({
-      key: rateLimitKey,
-      maxPerTimeframe: MAX_API_KEY_CREATION_PER_DAY,
-      timeframeSeconds: 24 * 60 * 60, // 1 day
-      logger,
+    const keyRes = await createApiKey(auth, {
+      name,
+      spaceIds: space_ids ?? [],
+      groupIds: group_ids ?? (group_id ? [group_id] : []),
+      monthlyCapMicroUsd: monthly_cap_micro_usd ?? null,
+      monthlyCapAwuCredits: monthly_cap_awu_credits ?? null,
+      role: role ?? "user",
     });
 
-    if (remaining === 0) {
-      return apiError(ctx, {
-        status_code: 429,
-        api_error: {
-          type: "rate_limit_error",
-          message:
-            `You have reached the limit of ${MAX_API_KEY_CREATION_PER_DAY} API keys ` +
-            "creations per day. Please try again later.",
-        },
-      });
-    }
-
-    const key = await KeyResource.makeNew(
-      {
-        name: trimmedName,
-        status: "active",
-        userId: user.id,
-        workspaceId: owner.id,
-        isSystem: false,
-        role: keyRole,
-        monthlyCapMicroUsd: monthly_cap_micro_usd ?? null,
-      },
-      resolvedGroups
-    );
-
-    void emitAuditLogEvent({
-      auth,
-      action: "api_key.created",
-      targets: [
-        buildAuditLogTarget("workspace", owner),
-        buildAuditLogTarget("api_key", {
-          sId: String(key.id),
-          name: trimmedName,
-        }),
-      ],
-      context: getAuditLogContext(auth),
-      metadata: {
-        group_ids: resolvedGroups.map((g) => g.sId).join(","),
-        role: keyRole,
-      },
-    });
-
-    // Apply the per-key credit cap (persists the cap, creates the Metronome
-    // alert, reconciles state). Validated above, so only a Metronome failure
-    // can error here.
-    if (
-      monthly_cap_awu_credits !== null &&
-      monthly_cap_awu_credits !== undefined
-    ) {
-      const limitResult = await setApiKeySpendLimit(auth, {
-        keyModelId: key.id,
-        limit: { kind: "limited", awuCredits: monthly_cap_awu_credits },
-      });
-      if (limitResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: owner.sId,
-            keyName: trimmedName,
-            err: limitResult.error,
-          },
-          "[Keys] Failed to apply credit cap on newly created key"
-        );
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Key created but failed to set credit cap: ${limitResult.error.message}`,
-          },
-        });
+    if (keyRes.isErr()) {
+      const { code, message } = keyRes.error;
+      switch (code) {
+        case "invalid_request_error":
+        case "name_conflict":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: { type: "invalid_request_error", message },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: { type: "workspace_auth_error", message },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: { type: "group_not_found", message },
+          });
+        case "limit_reached":
+          return apiError(ctx, {
+            status_code: 429,
+            api_error: { type: "rate_limit_error", message },
+          });
+        case "metronome_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: { type: "internal_server_error", message },
+          });
+        default:
+          assertNever(code);
       }
     }
-
-    const created =
-      (await KeyResource.fetchByWorkspaceAndId({
-        workspace: owner,
-        id: key.id,
-      })) ?? key;
 
     return ctx.json(
       {
-        key: created.toJSON(user.id),
+        key: keyRes.value.toJSON(user.id),
       },
       201
     );

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -3,7 +3,6 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { listKeyScopableGroups } from "@app/lib/api/keys/scopable_groups";
 import {
   MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
   MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
@@ -11,6 +10,7 @@ import {
 } from "@app/lib/api/keys/spend_limit";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
@@ -26,13 +26,13 @@ import { z } from "zod";
 
 import keyId from "./[id]";
 import keyGroups from "./groups";
+import keySpaces from "./spaces";
 
 const MAX_API_KEY_CREATION_PER_DAY = 30;
 
 const CreateKeyPostBodySchema = z.object({
   name: z.string(),
-  group_id: z.string().optional(),
-  group_ids: z.array(z.string()).optional(),
+  space_ids: z.array(z.string()).optional(),
   monthly_cap_micro_usd: z.number().nullish(),
   // Per-key credit cap in AWU credits (credit-priced plans only). null/omitted
   // = unlimited.
@@ -71,8 +71,7 @@ app.post(
 
     const {
       name,
-      group_id,
-      group_ids,
+      space_ids,
       monthly_cap_micro_usd,
       monthly_cap_awu_credits,
       role,
@@ -154,7 +153,8 @@ app.post(
       });
     }
 
-    // Resolve groups: prefer group_ids (new), fall back to group_id (retro-compatibility).
+    // A key always carries the workspace global group, so it can reach everything every workspace
+    // member can reach; the spaces it is scoped to add to that.
     const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
     if (globalGroupRes.isErr()) {
       return apiError(ctx, {
@@ -168,46 +168,37 @@ app.post(
     const globalGroup = globalGroupRes.value;
 
     const resolvedGroups: GroupResource[] = [globalGroup];
+    const requestedSpaceIds = [...new Set(space_ids ?? [])];
 
-    const additionalGroupIds = group_ids
-      ? group_ids.filter((gId) => gId !== globalGroup.sId)
-      : group_id && group_id !== globalGroup.sId
-        ? [group_id]
-        : [];
+    if (requestedSpaceIds.length > 0) {
+      const spaces = await SpaceResource.fetchByIds(auth, requestedSpaceIds);
+      const openSpaceModelIds = await SpaceResource.listOpenSpaceModelIds(
+        auth,
+        spaces
+      );
+      const scopableSpaces = spaces.filter(
+        (space) =>
+          (space.isRegular() || space.isProject()) &&
+          !openSpaceModelIds.has(space.id)
+      );
 
-    if (additionalGroupIds.length > 0) {
-      // A key can only be scoped to groups of restricted spaces or pods.
-      const scopableGroupIds = new Set(
-        (await listKeyScopableGroups(auth)).map((group) => group.sId)
-      );
-      const invalidGroupIds = additionalGroupIds.filter(
-        (gId) => !scopableGroupIds.has(gId)
-      );
-      if (invalidGroupIds.length > 0) {
+      if (scopableSpaces.length !== requestedSpaceIds.length) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
             message:
-              "An API key can only be scoped to groups of restricted spaces or pods.",
+              "An API key can only be scoped to restricted spaces or pods.",
           },
         });
       }
 
-      const groupsRes = await GroupResource.fetchByIds(
-        auth,
-        additionalGroupIds
+      resolvedGroups.push(
+        ...(await SpaceResource.listRegularAutoGroupsForSpaces(
+          auth,
+          scopableSpaces
+        ))
       );
-      if (groupsRes.isErr()) {
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "group_not_found",
-            message: "Invalid group",
-          },
-        });
-      }
-      resolvedGroups.push(...groupsRes.value);
     }
 
     const rateLimitKey = `api_key_creation_${owner.sId}`;
@@ -306,6 +297,7 @@ app.post(
 );
 
 app.route("/groups", keyGroups);
+app.route("/spaces", keySpaces);
 app.route("/:id", keyId);
 
 export default app;

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -206,15 +206,20 @@ app.post(
       );
     }
 
-    const requestedGroupIds = [
-      ...new Set(group_ids ?? (group_id ? [group_id] : [])),
-    ].filter((groupId) => groupId !== globalGroup.sId);
+    const additionalGroupIds = group_ids
+      ? group_ids.filter((gId) => gId !== globalGroup.sId)
+      : group_id && group_id !== globalGroup.sId
+        ? [group_id]
+        : [];
 
-    if (requestedGroupIds.length > 0) {
+    if (additionalGroupIds.length > 0) {
       const scopableGroupIds = new Set(
         (await listKeyScopableGroups(auth)).map((group) => group.sId)
       );
-      if (requestedGroupIds.some((groupId) => !scopableGroupIds.has(groupId))) {
+      const invalidGroupIds = additionalGroupIds.filter(
+        (gId) => !scopableGroupIds.has(gId)
+      );
+      if (invalidGroupIds.length > 0) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {
@@ -225,7 +230,10 @@ app.post(
         });
       }
 
-      const groupsRes = await GroupResource.fetchByIds(auth, requestedGroupIds);
+      const groupsRes = await GroupResource.fetchByIds(
+        auth,
+        additionalGroupIds
+      );
       if (groupsRes.isErr()) {
         return apiError(ctx, {
           status_code: 404,

--- a/front-api/routes/w/[wId]/keys/spaces.ts
+++ b/front-api/routes/w/[wId]/keys/spaces.ts
@@ -1,0 +1,25 @@
+import { listKeyScopableSpaces } from "@app/lib/api/keys/scopable_spaces";
+import type { GetKeyScopableSpacesResponseBody } from "@app/types/api/keys";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/keys/spaces.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetKeyScopableSpacesResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const spaces = await listKeyScopableSpaces(auth);
+
+    return ctx.json({
+      spaces: spaces.map((space) => space.toJSON()),
+    });
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -16,6 +16,7 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { useKeys } from "@app/lib/swr/apps";
 import { useKeyScopableGroups } from "@app/lib/swr/groups";
+import { useKeyScopableSpaces } from "@app/lib/swr/spaces";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
@@ -127,6 +128,9 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
   const { groups, isGroupsError, isGroupsLoading } = useKeyScopableGroups({
     owner,
   });
+  const { spaces, isSpacesError, isSpacesLoading } = useKeyScopableSpaces({
+    owner,
+  });
   const isDataLoading = isKeysLoading || isGroupsLoading;
   const isDataError = !!isKeysError || isGroupsError;
 
@@ -143,13 +147,13 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
     useSubmitFunction(
       async ({
         name,
-        groups: selectedGroups,
+        spaceIds,
         monthlyCapMicroUsd,
         monthlyCapAwuCredits,
         role,
       }: {
         name: string;
-        groups: GroupType[];
+        spaceIds: string[];
         monthlyCapMicroUsd: number | null;
         monthlyCapAwuCredits: number | null;
         role: KeyRole;
@@ -161,7 +165,7 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
           },
           body: JSON.stringify({
             name,
-            group_ids: selectedGroups.map((g) => g.sId),
+            space_ids: spaceIds,
             monthly_cap_micro_usd: monthlyCapMicroUsd,
             monthly_cap_awu_credits: monthlyCapAwuCredits,
             role,
@@ -289,8 +293,8 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
             rel="noreferrer"
           />
           <NewAPIKeyDialog
-            groups={groups}
-            disabled={isGroupsLoading || isGroupsError}
+            spaces={spaces}
+            disabled={isSpacesLoading || isSpacesError}
             isGenerating={isGenerating}
             isRevoking={isRevoking}
             onCreate={handleGenerate}

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -7,11 +7,9 @@ import {
   monthlyCapCreditsSchema,
   monthlyCapDollarsSchema,
   parseCreditsString,
-  prettifyGroupName,
 } from "@app/components/workspace/api-keys/utils";
-import type { GroupType } from "@app/types/groups";
 import { GLOBAL_SPACE_NAME } from "@app/types/groups";
-import type { ModelId } from "@app/types/shared/model_id";
+import type { SpaceType } from "@app/types/space";
 import {
   Button,
   DropdownMenu,
@@ -43,20 +41,20 @@ const formSchema = z.object({
   name: z.string().min(1, "API key name is required"),
   monthlyCapDollars: monthlyCapDollarsSchema,
   monthlyCapCredits: monthlyCapCreditsSchema,
-  selectedGroupIds: z.array(z.number()),
+  selectedSpaceIds: z.array(z.string()),
   role: z.enum(KEY_ROLES),
 });
 
 type FormValues = z.infer<typeof formSchema>;
 
 interface NewAPIKeyDialogProps {
-  groups: GroupType[];
+  spaces: SpaceType[];
   disabled?: boolean;
   isGenerating: boolean;
   isRevoking: boolean;
   onCreate: (params: {
     name: string;
-    groups: GroupType[];
+    spaceIds: string[];
     monthlyCapMicroUsd: number | null;
     monthlyCapAwuCredits: number | null;
     role: KeyRole;
@@ -65,7 +63,7 @@ interface NewAPIKeyDialogProps {
 }
 
 export const NewAPIKeyDialog = ({
-  groups,
+  spaces,
   disabled,
   isGenerating,
   isRevoking,
@@ -82,7 +80,7 @@ export const NewAPIKeyDialog = ({
       name: "",
       monthlyCapDollars: "",
       monthlyCapCredits: "",
-      selectedGroupIds: [],
+      selectedSpaceIds: [],
       role: "user",
     },
   });
@@ -90,9 +88,9 @@ export const NewAPIKeyDialog = ({
   const { handleSubmit, reset, formState } = form;
 
   const {
-    field: { value: selectedGroupIds, onChange: setSelectedGroupIds },
-  } = useController<FormValues, "selectedGroupIds">({
-    name: "selectedGroupIds",
+    field: { value: selectedSpaceIds, onChange: setSelectedSpaceIds },
+  } = useController<FormValues, "selectedSpaceIds">({
+    name: "selectedSpaceIds",
     control: form.control,
   });
 
@@ -103,28 +101,32 @@ export const NewAPIKeyDialog = ({
     control: form.control,
   });
 
-  const removeGroupId = (groupId: ModelId) => {
-    setSelectedGroupIds(selectedGroupIds.filter((id) => id !== groupId));
+  const removeSpaceId = (spaceId: string) => {
+    setSelectedSpaceIds(selectedSpaceIds.filter((sId) => sId !== spaceId));
   };
 
-  const groupsById = useMemo(() => {
-    const map: Record<ModelId, GroupType> = {};
-    for (const g of groups) {
-      map[g.id] = g;
+  const spacesById = useMemo(() => {
+    const map: Record<string, SpaceType> = {};
+    for (const space of spaces) {
+      map[space.sId] = space;
     }
     return map;
-  }, [groups]);
+  }, [spaces]);
 
-  const nonGlobalGroups = useMemo(
+  const sortedSpaces = useMemo(
     () =>
-      groups
-        .filter((g) => g.kind !== "global")
-        .sort((a, b) =>
-          prettifyGroupName(a)
-            .toLowerCase()
-            .localeCompare(prettifyGroupName(b).toLowerCase())
-        ),
-    [groups]
+      [...spaces].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      ),
+    [spaces]
+  );
+
+  const matchingSpaces = useMemo(
+    () =>
+      sortedSpaces.filter((space) =>
+        space.name.toLowerCase().includes(spaceSearch.toLowerCase())
+      ),
+    [sortedSpaces, spaceSearch]
   );
 
   const handleClose = () => {
@@ -136,13 +138,9 @@ export const NewAPIKeyDialog = ({
     const dollars =
       data.monthlyCapDollars === "" ? null : parseFloat(data.monthlyCapDollars);
 
-    const selectedGroups = data.selectedGroupIds
-      .map((id) => groupsById[id])
-      .filter(Boolean);
-
     await onCreate({
       name: data.name,
-      groups: selectedGroups,
+      spaceIds: data.selectedSpaceIds,
       monthlyCapMicroUsd: dollarsToMicroUsd(dollars),
       monthlyCapAwuCredits: parseCreditsString(data.monthlyCapCredits),
       role: data.role,
@@ -204,32 +202,24 @@ export const NewAPIKeyDialog = ({
                         />
                       }
                     >
-                      {nonGlobalGroups.filter((g) =>
-                        prettifyGroupName(g)
-                          .toLowerCase()
-                          .includes(spaceSearch.toLowerCase())
-                      ).length === 0 && (
+                      {matchingSpaces.length === 0 && (
                         <div className="flex items-center justify-center py-4 text-sm">
                           No spaces found
                         </div>
                       )}
-                      {nonGlobalGroups
+                      {matchingSpaces
                         .filter(
-                          (g) =>
-                            !selectedGroupIds.includes(g.id) &&
-                            prettifyGroupName(g)
-                              .toLowerCase()
-                              .includes(spaceSearch.toLowerCase())
+                          (space) => !selectedSpaceIds.includes(space.sId)
                         )
-                        .map((group) => (
+                        .map((space) => (
                           <DropdownMenuItem
-                            key={group.id}
-                            label={prettifyGroupName(group)}
+                            key={space.sId}
+                            label={space.name}
                             onSelect={(e) => e.preventDefault()}
                             onClick={() =>
-                              setSelectedGroupIds([
-                                ...selectedGroupIds,
-                                group.id,
+                              setSelectedSpaceIds([
+                                ...selectedSpaceIds,
+                                space.sId,
                               ])
                             }
                           />
@@ -244,19 +234,19 @@ export const NewAPIKeyDialog = ({
                     variant="outline"
                     disabled
                   />
-                  {selectedGroupIds.map((gId) => {
-                    const group = groupsById[gId];
-                    if (!group) {
+                  {selectedSpaceIds.map((id) => {
+                    const space = spacesById[id];
+                    if (!space) {
                       return null;
                     }
                     return (
                       <Button
-                        key={gId}
-                        label={prettifyGroupName(group)}
+                        key={id}
+                        label={space.name}
                         icon={XClose}
                         size="xs"
                         variant="ghost"
-                        onClick={() => removeGroupId(gId)}
+                        onClick={() => removeSpaceId(id)}
                       />
                     );
                   })}

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -121,12 +121,19 @@ export const NewAPIKeyDialog = ({
     [spaces]
   );
 
+  const selectedSpaceIdSet = useMemo(
+    () => new Set(selectedSpaceIds),
+    [selectedSpaceIds]
+  );
+
   const matchingSpaces = useMemo(
     () =>
-      sortedSpaces.filter((space) =>
-        space.name.toLowerCase().includes(spaceSearch.toLowerCase())
+      sortedSpaces.filter(
+        (space) =>
+          !selectedSpaceIdSet.has(space.sId) &&
+          space.name.toLowerCase().includes(spaceSearch.toLowerCase())
       ),
-    [sortedSpaces, spaceSearch]
+    [sortedSpaces, spaceSearch, selectedSpaceIdSet]
   );
 
   const handleClose = () => {
@@ -207,23 +214,19 @@ export const NewAPIKeyDialog = ({
                           No spaces found
                         </div>
                       )}
-                      {matchingSpaces
-                        .filter(
-                          (space) => !selectedSpaceIds.includes(space.sId)
-                        )
-                        .map((space) => (
-                          <DropdownMenuItem
-                            key={space.sId}
-                            label={space.name}
-                            onSelect={(e) => e.preventDefault()}
-                            onClick={() =>
-                              setSelectedSpaceIds([
-                                ...selectedSpaceIds,
-                                space.sId,
-                              ])
-                            }
-                          />
-                        ))}
+                      {matchingSpaces.map((space) => (
+                        <DropdownMenuItem
+                          key={space.sId}
+                          label={space.name}
+                          onSelect={(e) => e.preventDefault()}
+                          onClick={() =>
+                            setSelectedSpaceIds([
+                              ...selectedSpaceIds,
+                              space.sId,
+                            ])
+                          }
+                        />
+                      ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>

--- a/front/lib/api/keys/create.ts
+++ b/front/lib/api/keys/create.ts
@@ -1,0 +1,275 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { listKeyScopableGroups } from "@app/lib/api/keys/scopable_groups";
+import {
+  MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS,
+  setApiKeySpendLimit,
+} from "@app/lib/api/keys/spend_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const MAX_API_KEY_CREATION_PER_DAY = 30;
+
+type CreateApiKeyErrorCode =
+  | "invalid_request_error"
+  | "name_conflict"
+  | "unauthorized"
+  | "group_not_found"
+  | "limit_reached"
+  | "metronome_error";
+
+/**
+ * A key always carries the workspace global group, so it can reach everything
+ * every workspace member can reach; in addition, it can access the spaces it
+ * is scoped to.
+ */
+async function resolveApiKeyGroups(
+  auth: Authenticator,
+  { spaceIds, groupIds }: { spaceIds: string[]; groupIds: string[] }
+): Promise<Result<GroupResource[], DustError<CreateApiKeyErrorCode>>> {
+  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+  if (globalGroupRes.isErr()) {
+    return new Err(new DustError("group_not_found", "Global group not found"));
+  }
+  const globalGroup = globalGroupRes.value;
+
+  const resolvedGroups: GroupResource[] = [globalGroup];
+
+  const requestedSpaceIds = [...new Set(spaceIds)];
+  if (requestedSpaceIds.length > 0) {
+    const spaces = await SpaceResource.fetchByIds(auth, requestedSpaceIds);
+    const openSpaceModelIds = await SpaceResource.listOpenSpaceModelIds(
+      auth,
+      spaces
+    );
+    const scopableSpaces = spaces.filter(
+      (space) =>
+        (space.isRegular() || space.isProject()) &&
+        !openSpaceModelIds.has(space.id)
+    );
+
+    if (scopableSpaces.length !== requestedSpaceIds.length) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "An API key can only be scoped to restricted spaces or pods."
+        )
+      );
+    }
+
+    resolvedGroups.push(
+      ...(await SpaceResource.listRegularAutoGroupsForSpaces(
+        auth,
+        scopableSpaces
+      ))
+    );
+  }
+
+  const additionalGroupIds = groupIds.filter((gId) => gId !== globalGroup.sId);
+  if (additionalGroupIds.length > 0) {
+    const scopableGroupIds = new Set(
+      (await listKeyScopableGroups(auth)).map((group) => group.sId)
+    );
+    const invalidGroupIds = additionalGroupIds.filter(
+      (gId) => !scopableGroupIds.has(gId)
+    );
+    if (invalidGroupIds.length > 0) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "An API key can only be scoped to groups of restricted spaces or pods."
+        )
+      );
+    }
+
+    const groupsRes = await GroupResource.fetchByIds(auth, additionalGroupIds);
+    if (groupsRes.isErr()) {
+      return new Err(new DustError("group_not_found", "Invalid group"));
+    }
+    resolvedGroups.push(...groupsRes.value);
+  }
+
+  return new Ok(resolvedGroups);
+}
+
+/**
+ * Create a non-system API key for the workspace: validates the name, the spend caps and the
+ * requested scope, resolves the groups the key carries, enforces the per-workspace creation rate
+ * limit, then persists the key, applies the per-key credit cap and emits the audit log event.
+ */
+export async function createApiKey(
+  auth: Authenticator,
+  {
+    name,
+    spaceIds,
+    groupIds,
+    monthlyCapMicroUsd,
+    monthlyCapAwuCredits,
+    role,
+  }: {
+    name: string;
+    spaceIds: string[];
+    groupIds: string[];
+    monthlyCapMicroUsd: number | null;
+    // Per-key credit cap in AWU credits (credit-priced plans only). null = unlimited.
+    monthlyCapAwuCredits: number | null;
+    role: "user" | "admin";
+  }
+): Promise<Result<KeyResource, DustError<CreateApiKeyErrorCode>>> {
+  const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
+
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    return new Err(
+      new DustError("invalid_request_error", "API key name cannot be empty.")
+    );
+  }
+
+  if (monthlyCapMicroUsd !== null && monthlyCapMicroUsd < 0) {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        "monthly_cap_micro_usd must be greater than or equal to 0"
+      )
+    );
+  }
+
+  // Per-key credit cap: only valid on credit-priced plans and within range. Validated up front so
+  // we never create a key whose requested cap can't be applied.
+  if (monthlyCapAwuCredits !== null) {
+    const plan = auth.subscription()?.plan;
+    if (!plan || !isCreditPricedPlan(plan)) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          "Per-key credit spend limits are only available on credit-priced plans."
+        )
+      );
+    }
+    if (
+      monthlyCapAwuCredits < MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS ||
+      monthlyCapAwuCredits > MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS
+    ) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          `monthly_cap_awu_credits must be between ` +
+            `${MIN_API_KEY_SPEND_LIMIT_AWU_CREDITS} and ` +
+            `${MAX_API_KEY_SPEND_LIMIT_AWU_CREDITS}.`
+        )
+      );
+    }
+  }
+
+  const existingKey = await KeyResource.fetchByName(auth, {
+    name: trimmedName,
+    onlyActive: true,
+  });
+  if (existingKey) {
+    return new Err(
+      new DustError(
+        "name_conflict",
+        "An API key with this name already exists in this workspace."
+      )
+    );
+  }
+
+  const groupsRes = await resolveApiKeyGroups(auth, { spaceIds, groupIds });
+  if (groupsRes.isErr()) {
+    return groupsRes;
+  }
+  const resolvedGroups = groupsRes.value;
+
+  const remaining = await rateLimiter({
+    key: `api_key_creation_${owner.sId}`,
+    maxPerTimeframe: MAX_API_KEY_CREATION_PER_DAY,
+    timeframeSeconds: 24 * 60 * 60, // 1 day
+    logger,
+  });
+  if (remaining === 0) {
+    return new Err(
+      new DustError(
+        "limit_reached",
+        `You have reached the limit of ${MAX_API_KEY_CREATION_PER_DAY} API keys ` +
+          "creations per day. Please try again later."
+      )
+    );
+  }
+
+  const key = await KeyResource.makeNew(
+    {
+      name: trimmedName,
+      status: "active",
+      userId: user.id,
+      workspaceId: owner.id,
+      isSystem: false,
+      role,
+      monthlyCapMicroUsd,
+    },
+    resolvedGroups
+  );
+
+  void emitAuditLogEvent({
+    auth,
+    action: "api_key.created",
+    targets: [
+      buildAuditLogTarget("workspace", owner),
+      buildAuditLogTarget("api_key", {
+        sId: String(key.id),
+        name: trimmedName,
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      group_ids: resolvedGroups.map((g) => g.sId).join(","),
+      role,
+    },
+  });
+
+  // Apply the per-key credit cap (persists the cap, creates the Metronome alert, reconciles
+  // state). Validated above, so only a Metronome failure can error here.
+  if (monthlyCapAwuCredits !== null) {
+    const limitResult = await setApiKeySpendLimit(auth, {
+      keyModelId: key.id,
+      limit: { kind: "limited", awuCredits: monthlyCapAwuCredits },
+    });
+    if (limitResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: owner.sId,
+          keyName: trimmedName,
+          err: limitResult.error,
+        },
+        "[Keys] Failed to apply credit cap on newly created key"
+      );
+      return new Err(
+        new DustError(
+          "metronome_error",
+          `Key created but failed to set credit cap: ${limitResult.error.message}`
+        )
+      );
+    }
+  }
+
+  // Re-read so the returned key reflects the persisted cap (`setApiKeySpendLimit` updates its own
+  // resource instance).
+  const created = await KeyResource.fetchByWorkspaceAndId({
+    workspace: owner,
+    id: key.id,
+  });
+
+  return new Ok(created ?? key);
+}

--- a/front/lib/api/keys/create.ts
+++ b/front/lib/api/keys/create.ts
@@ -37,7 +37,11 @@ type CreateApiKeyErrorCode =
  */
 async function resolveApiKeyGroups(
   auth: Authenticator,
-  { spaceIds, groupIds }: { spaceIds: string[]; groupIds: string[] }
+  {
+    spaceIds,
+    groupIds,
+    role,
+  }: { spaceIds: string[]; groupIds: string[]; role: "user" | "admin" }
 ): Promise<Result<GroupResource[], DustError<CreateApiKeyErrorCode>>> {
   const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
   if (globalGroupRes.isErr()) {
@@ -72,7 +76,10 @@ async function resolveApiKeyGroups(
     resolvedGroups.push(
       ...(await SpaceResource.listRegularAutoGroupsForSpaces(
         auth,
-        scopableSpaces
+        scopableSpaces,
+        {
+          includeEditors: role === "admin",
+        }
       ))
     );
   }
@@ -187,7 +194,11 @@ export async function createApiKey(
     );
   }
 
-  const groupsRes = await resolveApiKeyGroups(auth, { spaceIds, groupIds });
+  const groupsRes = await resolveApiKeyGroups(auth, {
+    spaceIds,
+    groupIds,
+    role,
+  });
   if (groupsRes.isErr()) {
     return groupsRes;
   }

--- a/front/lib/api/keys/scopable_spaces.ts
+++ b/front/lib/api/keys/scopable_spaces.ts
@@ -1,0 +1,23 @@
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+/**
+ * The spaces a new API key may be scoped to: the workspace's restricted spaces — both regular
+ * (spaces) and project (pods).
+ *
+ * A key's groups are derived from the spaces it is scoped to, so scoping is expressed in spaces
+ * rather than in groups. Open spaces are readable through the workspace global group that every key
+ * carries, so they are not meaningful to scope to.
+ */
+export async function listKeyScopableSpaces(
+  auth: Authenticator
+): Promise<SpaceResource[]> {
+  const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
+    includeProjectSpaces: true,
+    includeOpen: false,
+  });
+
+  // `includeOpen: false` leaves the non-scopable unique kinds (system, global) in the result;
+  // narrow to the regular/project spaces we actually care about.
+  return spaces.filter((space) => space.isRegular() || space.isProject());
+}

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -335,11 +335,34 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       transaction?: Transaction;
     }
   ): Promise<GroupResource[]> {
+    return this.listRegularAutoGroupsForResources(auth, {
+      resourceType,
+      resourceIds: [resourceId],
+      transaction,
+    });
+  }
+
+  static async listRegularAutoGroupsForResources(
+    auth: Authenticator,
+    {
+      resourceType,
+      resourceIds,
+      transaction,
+    }: {
+      resourceType: GroupPermissionResourceType;
+      resourceIds: number[];
+      transaction?: Transaction;
+    }
+  ): Promise<GroupResource[]> {
+    if (resourceIds.length === 0) {
+      return [];
+    }
+
     const grants = await GroupPermissionModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         resourceType,
-        resourceId,
+        resourceId: [...new Set(resourceIds)],
       },
       transaction,
     });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1731,12 +1731,35 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // `spaces`, as a flat deduped union, in two queries rather than two per space.
   static async listRegularAutoGroupsForSpaces(
     auth: Authenticator,
-    spaces: SpaceResource[]
+    spaces: SpaceResource[],
+    { includeEditors = true }: { includeEditors?: boolean } = {}
   ): Promise<GroupResource[]> {
-    return GroupPermissionResource.listRegularAutoGroupsForResources(auth, {
-      resourceType: "space",
-      resourceIds: spaces.map((space) => space.id),
-    });
+    const autoGroups =
+      await GroupPermissionResource.listRegularAutoGroupsForResources(auth, {
+        resourceType: "space",
+        resourceIds: spaces.map((space) => space.id),
+      });
+
+    if (includeEditors) {
+      return autoGroups;
+    }
+
+    // Only projects have an editor group.
+    const editorGroupsByGrant =
+      await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+        grants: spaces
+          .filter((space) => space.isProject())
+          .map((space) => ({
+            grantType: SPACE_EDITOR_GRANT_TYPE,
+            resourceType: "space",
+            resourceId: space.id,
+          })),
+      });
+
+    const editorGroupIds = new Set(
+      [...editorGroupsByGrant.values()].map((group) => group.sId)
+    );
+    return autoGroups.filter((group) => !editorGroupIds.has(group.sId));
   }
 
   // The groups that make up this space's membership: its member group and, for projects, its editor

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1713,8 +1713,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   // The space's auto-created (regular_auto) groups: its manual member group and, for projects, its
   // editor group. Resolved from `group_permissions`, filtered to regular_auto groups (a grant's
-  // type alone cannot tell a regular_auto group from the global group). Empty in group management
-  // mode, where the space's groups are provisioned (IdP-owned) rather than auto-created.
+  // type alone cannot tell a regular_auto group from the global group). Present in group management
+  // mode too: that mode adds the provisioned groups' grants on top of these rather than replacing
+  // them (see `updatePermissions`).
   async fetchRegularAutoGroups(
     auth: Authenticator,
     transaction?: Transaction
@@ -1723,6 +1724,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       resourceType: "space",
       resourceId: this.id,
       transaction,
+    });
+  }
+
+  // The batched counterpart of `fetchRegularAutoGroups`: the regular_auto groups of every space in
+  // `spaces`, as a flat deduped union, in two queries rather than two per space.
+  static async listRegularAutoGroupsForSpaces(
+    auth: Authenticator,
+    spaces: SpaceResource[]
+  ): Promise<GroupResource[]> {
+    return GroupPermissionResource.listRegularAutoGroupsForResources(auth, {
+      resourceType: "space",
+      resourceIds: spaces.map((space) => space.id),
     });
   }
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -18,6 +18,7 @@ import type {
   GetSpaceDataSourceViewsResponseBody,
 } from "@app/types/api/data_source_view";
 import type { PostSpaceDataSourceResponseBody } from "@app/types/api/data_sources";
+import type { GetKeyScopableSpacesResponseBody } from "@app/types/api/keys";
 import type { SpacesLookupResponseBody } from "@app/types/api/projects/list";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type {
@@ -197,6 +198,31 @@ export function useSpacesAsAdmin({
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,
+  };
+}
+
+// The spaces a new API key may be scoped to: the workspace's restricted spaces and pods. Admin
+// only — the endpoint that serves it is behind `ensureIsAdmin()`.
+export function useKeyScopableSpaces({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const spacesFetcher: Fetcher<GetKeyScopableSpacesResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/keys/spaces`,
+    spacesFetcher,
+    { disabled }
+  );
+
+  return {
+    spaces: data?.spaces ?? emptyArray(),
+    isSpacesLoading: !error && !data && !disabled,
+    isSpacesError: !!error,
   };
 }
 

--- a/front/types/api/keys.ts
+++ b/front/types/api/keys.ts
@@ -1,5 +1,6 @@
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
+import type { SpaceType } from "@app/types/space";
 
 export type GetKeysResponseBody = {
   keys: KeyType[];
@@ -9,6 +10,10 @@ export type GetKeysResponseBody = {
 // member of). Served by GET /api/w/:wId/keys/groups.
 export type GetKeyScopableGroupsResponseBody = {
   groups: GroupType[];
+};
+
+export type GetKeyScopableSpacesResponseBody = {
+  spaces: SpaceType[];
 };
 
 export type PostKeysResponseBody = {


### PR DESCRIPTION
## Description

This PR lets API keys be scoped to restricted spaces and pods instead of selecting groups directly.

When a space used manual management mode, we previously displayed the provisioned and regular_manual groups the space relied on, which was wrong. Resolving through the space first means the key is always linked to the space's regular_auto groups.

It also ensures regular_auto groups are always reached through their space rather than fetched directly, which is needed for the follow-up permission refactor of group_resource.

## Tests

Added tests.

## Risks
Low.

## Deploy Plan

Standard deployment.
