### PR TITLE
[front] workspace analytics: eager flag on billed-credits tool

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -370,6 +370,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "credits. Rows may overlap, so don't sum them for a workspace total.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
+    eager: true,
     displayLabels: {
       running: "Retrieving top consumers",
       done: "Retrieved top consumers",


### PR DESCRIPTION
Fixes the front test suite on main, red since 14:11 UTC.

#31273 added the `get_top_entities_by_credits` tool and #31453 made all workspace analytics tools eager for Analyst, with a test asserting every exposed tool is eager. Both were green on their own branch, but #31273 merged 10 minutes before #31453, whose branch did not have the new tool: on main the assertion fails (`eagerly exposes workspace analytics tools to Analyst`, shard 6).

This adds `eager: true` to the new tool, like the 11 other workspace analytics tools.