### PR TITLE
[admin governance] migrate remaining builder role

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -601,7 +601,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       MembershipResource.roleCacheKeyResolver(params)
   );
 
-  private static invalidateRoleCache = async (params: {
+  static invalidateRoleCache = async (params: {
     userModelId: ModelId;
     workspaceModelId: ModelId;
   }) => {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -601,7 +601,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       MembershipResource.roleCacheKeyResolver(params)
   );
 
-  static invalidateRoleCache = async (params: {
+  private static invalidateRoleCache = async (params: {
     userModelId: ModelId;
     workspaceModelId: ModelId;
   }) => {

--- a/front/migrations/20260831_migrate_remaining_builder_role_to_user.ts
+++ b/front/migrations/20260831_migrate_remaining_builder_role_to_user.ts
@@ -1,0 +1,62 @@
+import { Op } from "sequelize";
+
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { makeScript } from "@app/scripts/helpers";
+
+/**
+ * The previous migration only handled currently-active `builder` memberships.
+ * This script flips the remaining rows: not-yet-started ones (`startAt` in the
+ * future) and already-ended ones (`endAt` in the past).
+ *
+ * None of these rows are currently active, so their cached role is never
+ * `builder` and no cache invalidation is needed.
+ */
+
+makeScript({}, async ({ execute }, logger) => {
+  const now = new Date();
+
+  const where = {
+    role: "builder" as const,
+    [Op.or]: [{ startAt: { [Op.gt]: now } }, { endAt: { [Op.lt]: now } }],
+  };
+
+  const builderMemberships = await MembershipModel.findAll({
+    attributes: ["id", "userId", "workspaceId", "startAt", "endAt"],
+    where,
+  });
+
+  if (builderMemberships.length === 0) {
+    logger.info("No remaining builder memberships to migrate.");
+    return;
+  }
+
+  if (!execute) {
+    for (const m of builderMemberships) {
+      logger.info(
+        {
+          membershipId: m.id,
+          userModelId: m.userId,
+          workspaceModelId: m.workspaceId,
+          startAt: m.startAt,
+          endAt: m.endAt,
+        },
+        "Would flip builder -> user (DB only)"
+      );
+    }
+    logger.info(
+      { total: builderMemberships.length },
+      "Remaining builder -> user migration dry run complete"
+    );
+    return;
+  }
+
+  const [migrated] = await MembershipModel.update(
+    { role: "user" },
+    { where: { id: { [Op.in]: builderMemberships.map((m) => m.id) } } }
+  );
+
+  logger.info(
+    { migrated, total: builderMemberships.length },
+    "Remaining builder -> user migration complete"
+  );
+});

--- a/front/migrations/20260831_migrate_remaining_builder_role_to_user.ts
+++ b/front/migrations/20260831_migrate_remaining_builder_role_to_user.ts
@@ -41,7 +41,10 @@ makeScript({}, async ({ execute }, logger) => {
       return;
     }
 
-    const [migrated] = await MembershipModel.update({ role: "user" }, { where });
+    const [migrated] = await MembershipModel.update(
+      { role: "user" },
+      { where }
+    );
     if (migrated > 0) {
       totalMigrated += migrated;
       logger.info(

--- a/front/migrations/20260831_migrate_remaining_builder_role_to_user.ts
+++ b/front/migrations/20260831_migrate_remaining_builder_role_to_user.ts
@@ -2,61 +2,63 @@ import { Op } from "sequelize";
 
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 
 /**
  * The previous migration only handled currently-active `builder` memberships.
  * This script flips the remaining rows: not-yet-started ones (`startAt` in the
  * future) and already-ended ones (`endAt` in the past).
- *
- * None of these rows are currently active, so their cached role is never
- * `builder` and no cache invalidation is needed.
  */
 
 makeScript({}, async ({ execute }, logger) => {
+  // Single cutoff for the whole run, so the not-yet-started / already-ended
+  // classification stays stable across workspaces regardless of sweep duration.
   const now = new Date();
 
-  const where = {
-    role: "builder" as const,
-    [Op.or]: [{ startAt: { [Op.gt]: now } }, { endAt: { [Op.lt]: now } }],
-  };
+  let totalMatched = 0;
+  let totalMigrated = 0;
 
-  const builderMemberships = await MembershipModel.findAll({
-    attributes: ["id", "userId", "workspaceId", "startAt", "endAt"],
-    where,
-  });
+  await runOnAllWorkspaces(async (workspace) => {
+    const where = {
+      workspaceId: workspace.id,
+      role: "builder" as const,
+      [Op.or]: [{ startAt: { [Op.gt]: now } }, { endAt: { [Op.lt]: now } }],
+    };
 
-  if (builderMemberships.length === 0) {
-    logger.info("No remaining builder memberships to migrate.");
-    return;
-  }
+    if (!execute) {
+      const matched = await MembershipModel.count({ where });
+      if (matched > 0) {
+        totalMatched += matched;
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            workspaceModelId: workspace.id,
+            matched,
+          },
+          "Would flip builder -> user (DB only)"
+        );
+      }
+      return;
+    }
 
-  if (!execute) {
-    for (const m of builderMemberships) {
+    const [migrated] = await MembershipModel.update({ role: "user" }, { where });
+    if (migrated > 0) {
+      totalMigrated += migrated;
       logger.info(
         {
-          membershipId: m.id,
-          userModelId: m.userId,
-          workspaceModelId: m.workspaceId,
-          startAt: m.startAt,
-          endAt: m.endAt,
+          workspaceId: workspace.sId,
+          workspaceModelId: workspace.id,
+          migrated,
         },
-        "Would flip builder -> user (DB only)"
+        "Flipped builder -> user (DB only)"
       );
     }
-    logger.info(
-      { total: builderMemberships.length },
-      "Remaining builder -> user migration dry run complete"
-    );
-    return;
-  }
-
-  const [migrated] = await MembershipModel.update(
-    { role: "user" },
-    { where: { id: { [Op.in]: builderMemberships.map((m) => m.id) } } }
-  );
+  });
 
   logger.info(
-    { migrated, total: builderMemberships.length },
-    "Remaining builder -> user migration complete"
+    execute ? { totalMigrated } : { totalMatched },
+    execute
+      ? "Remaining builder -> user migration complete"
+      : "Remaining builder -> user migration dry run complete"
   );
 });


### PR DESCRIPTION
## Description
This PR is to migrate the remaining builder role users.

- My previous script skipped the users with the future date of startAt. I will re-run the previous one for the users who started between my migration and today (since they need to invalidate the cache)
- The new script is updating all the past and future builders to users (from what I understood, the future users don't need to update workOS role)

It's around 6,700 users in US and 2,700 in EU.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
