### PR TITLE
feat: close the user credit pool to non credit-priced plans

### DIFF
--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -251,7 +251,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
   });
 
   it("stores payload when a matched trigger includes payload", async () => {
-    const { workspace } = await createPublicApiMockRequest();
+    const { workspace } = await createPublicApiMockRequest({
+      plan: "creditPriced",
+    });
 
     const webhookSource = await createWebhookSourceAndTrigger(workspace, {
       includePayload: true,
@@ -270,7 +272,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
   });
 
   it("does not store payload when matched triggers do not include payload", async () => {
-    const { workspace } = await createPublicApiMockRequest();
+    const { workspace } = await createPublicApiMockRequest({
+      plan: "creditPriced",
+    });
 
     const webhookSource = await createWebhookSourceAndTrigger(workspace, {
       includePayload: false,
@@ -289,7 +293,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
   });
 
   it("stores payload when no triggers match if a trigger includes payload", async () => {
-    const { workspace } = await createPublicApiMockRequest();
+    const { workspace } = await createPublicApiMockRequest({
+      plan: "creditPriced",
+    });
 
     const webhookSource = await createWebhookSourceAndTrigger(workspace, {
       includePayload: true,
@@ -309,7 +315,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
   });
 
   it("does not store payload when no enabled triggers include payload", async () => {
-    const { workspace } = await createPublicApiMockRequest();
+    const { workspace } = await createPublicApiMockRequest({
+      plan: "creditPriced",
+    });
 
     const webhookSource = await createWebhookSourceAndTrigger(workspace, {
       includePayload: false,

--- a/front-api/routes/w/[wId]/me/analytics/automations/triggers/[tId]/breakdown.test.ts
+++ b/front-api/routes/w/[wId]/me/analytics/automations/triggers/[tId]/breakdown.test.ts
@@ -61,6 +61,7 @@ describe("POST /api/w/:wId/me/analytics/automations/triggers/:tId/breakdown", ()
       new Ok(BREAKDOWN)
     );
     const { workspace, auth } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       role: "user",
     });
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
@@ -74,6 +75,7 @@ describe("POST /api/w/:wId/me/analytics/automations/triggers/:tId/breakdown", ()
 
   it("returns 404 for a trigger edited by another member", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       role: "admin",
     });
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
@@ -96,7 +98,9 @@ describe("POST /api/w/:wId/me/analytics/automations/triggers/:tId/breakdown", ()
   });
 
   it("returns 404 for an unknown trigger", async () => {
-    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
 
     const response = await postBreakdownRequest(
       workspace.sId,

--- a/front-api/routes/w/[wId]/me/analytics/automations/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/me/analytics/automations/triggers/index.test.ts
@@ -45,6 +45,7 @@ describe("POST /api/w/:wId/me/analytics/automations/triggers", () => {
 
   it("returns the caller's own triggers", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       role: "user",
     });
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
@@ -74,6 +75,7 @@ describe("POST /api/w/:wId/me/analytics/automations/triggers", () => {
 
   it("applies filters and validates the request", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       role: "user",
     });
     const agent = await AgentConfigurationFactory.createTestAgent(auth);

--- a/front-api/routes/w/[wId]/me/triggers.test.ts
+++ b/front-api/routes/w/[wId]/me/triggers.test.ts
@@ -15,7 +15,9 @@ const EVERY_MONDAY_9AM = {
 
 describe("GET /api/w/:wId/me/triggers", () => {
   it("lists a trigger on a deprecated (model-only) global agent such as gemini-pro", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest();
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
+    });
 
     await TriggerFactory.schedule(auth, {
       name: "Weekly gemini digest",

--- a/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.test.ts
+++ b/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.test.ts
@@ -67,6 +67,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
 
   it("lets the editor move their own trigger back to their own pool", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });
@@ -92,6 +93,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
 
   it("rejects a member without the workspace pool permission", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });

--- a/front-api/routes/w/[wId]/triggers/[tId]/status.test.ts
+++ b/front-api/routes/w/[wId]/triggers/[tId]/status.test.ts
@@ -28,6 +28,7 @@ async function createOtherEditorAuth(workspace: WorkspaceType) {
 describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
   it("lets the editor enable their own disabled trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });
@@ -51,6 +52,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("lets an admin disable another member's enabled trigger, locking it", async () => {
     const { workspace } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "admin",
     });
@@ -72,6 +74,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("stores a plain disabled status when the editor pauses their own trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });
@@ -101,6 +104,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
     target,
   }) => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });
@@ -125,6 +129,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("lets an admin re-enable an admin-locked trigger", async () => {
     const { workspace } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "admin",
     });
@@ -146,6 +151,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("lets a manager disable and re-enable a trigger they own", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "manager",
     });
@@ -178,6 +184,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("lets a manager disable and lock another member's trigger", async () => {
     const { workspace } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "manager",
     });
@@ -199,6 +206,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("lets a manager re-enable an admin-locked trigger", async () => {
     const { workspace } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "manager",
     });
@@ -220,6 +228,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
 
   it("rejects a member who is neither admin nor editor", async () => {
     const { workspace } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });
@@ -249,6 +258,7 @@ describe("PATCH /api/w/:wId/triggers/:tId/status", () => {
     target,
   }) => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "admin",
     });

--- a/front-api/routes/w/[wId]/triggers/bulk-execution-mode.test.ts
+++ b/front-api/routes/w/[wId]/triggers/bulk-execution-mode.test.ts
@@ -16,6 +16,7 @@ async function setupTest({
   withWorkspacePoolGrant?: boolean;
 }) {
   const { workspace, user } = await createPrivateApiMockRequest({
+    plan: "creditPriced",
     method: "POST",
     role,
   });

--- a/front-api/routes/w/[wId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/triggers/index.test.ts
@@ -70,6 +70,7 @@ async function createScheduleTrigger(
 describe("POST /api/w/:wId/triggers (spaceId)", () => {
   it("creates a trigger scoped to an open pod", async () => {
     const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -99,6 +100,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
 
   it("creates a trigger scoped to a restricted pod the user is a member of", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -165,6 +167,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
 
   it("creates a trigger with no pod (backward compatible default)", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -207,6 +210,7 @@ describe("POST /api/w/:wId/triggers (spaceId)", () => {
 describe("PATCH /api/w/:wId/triggers (spaceId)", () => {
   it("updates an existing trigger to run inside a Pod", async () => {
     const { workspace, user, globalGroup } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -241,6 +245,7 @@ describe("PATCH /api/w/:wId/triggers (spaceId)", () => {
 
   it("rejects updating a trigger to a Pod the user is not a member of", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -281,6 +286,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
 
   it("rejects a non-admin editor re-enabling an admin-locked trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -302,6 +308,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
 
   it("rejects a non-admin editor re-enabling a relocating trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -375,6 +382,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
 
   it("lets an editor save other fields of a system-disabled trigger, status echoed unchanged", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -442,6 +450,7 @@ describe("PATCH /api/w/:wId/triggers (disabled_by_manager)", () => {
 
   it("lets a non-admin editor edit other fields of an admin-locked trigger", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "POST",
       role: "user",
     });
@@ -544,6 +553,7 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
 
   it("rejects an update to the workspace pool without the permission", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      plan: "creditPriced",
       method: "PATCH",
       role: "user",
     });
@@ -594,5 +604,40 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
     expect(response.status).toBe(204);
     const updated = await TriggerResource.fetchById(auth, trigger.sId);
     expect(updated?.executionMode).toBe("workspace_pool");
+  });
+  it("keeps a legacy plan user pool trigger editable when the pool is unchanged", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      configuration: { type: "cron", cron: "0 9 * * *", timezone: "UTC" },
+      executionMode: "workspace_pool",
+    });
+    await TriggerResource.update(auth, trigger.sId, {
+      executionMode: "user_pool",
+    });
+
+    const body = scheduleTriggerBody(null);
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...body.triggers[0],
+          sId: trigger.sId,
+          executionMode: "user_pool",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("user_pool");
+    expect(updated?.name).toBe(body.triggers[0].name);
   });
 });

--- a/front-api/routes/w/[wId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/triggers/index.ts
@@ -393,8 +393,6 @@ app.post(
         ? validatedTrigger.executionPerDayLimitOverride
         : null;
 
-      const executionMode = validatedTrigger.executionMode ?? "user_pool";
-
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,
         validatedTrigger.spaceId
@@ -421,7 +419,7 @@ app.post(
         editor: auth.getNonNullableUser().id,
         webhookSourceViewId,
         executionPerDayLimitOverride: executionPerDay,
-        executionMode,
+        executionMode: validatedTrigger.executionMode,
         origin: "user",
         spaceId: spaceIdRes.value,
       });

--- a/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
@@ -1,8 +1,13 @@
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
-import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import { useTriggerExecutionModes } from "@app/hooks/useTriggerExecutionModes";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
 import {
+  NO_TRIGGER_EXECUTION_MODE_AVAILABLE_MESSAGE,
+  TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES,
+} from "@app/types/assistant/triggers";
+import {
   Button,
+  ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -20,17 +25,26 @@ const POOL_OPTIONS: { value: TriggerExecutionMode; label: string }[] = [
 interface TriggerPoolSelectorProps {
   name: "schedule.executionMode" | "webhook.executionMode";
   isEditor: boolean;
+  currentExecutionMode: TriggerExecutionMode | null;
 }
 
 export function TriggerPoolSelector({
   name,
   isEditor,
+  currentExecutionMode,
 }: TriggerPoolSelectorProps) {
   const { control } = useFormContext<TriggerViewsSheetFormValues>();
   const { field } = useController({ control, name });
 
-  const { hasPermission } = useWorkspacePermissions();
-  const canSetPool = hasPermission("use_workspace_pool", "trigger");
+  const { canUseExecutionMode, hasAvailableExecutionMode } =
+    useTriggerExecutionModes({ currentExecutionMode });
+
+  let restriction: string | null = null;
+  if (!hasAvailableExecutionMode) {
+    restriction = NO_TRIGGER_EXECUTION_MODE_AVAILABLE_MESSAGE;
+  } else if (!canUseExecutionMode(field.value)) {
+    restriction = TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES[field.value];
+  }
 
   return (
     <div className="space-y-1">
@@ -45,7 +59,7 @@ export function TriggerPoolSelector({
             variant="outline"
             isSelect
             className="w-fit"
-            disabled={!isEditor || !canSetPool}
+            disabled={!isEditor || !hasAvailableExecutionMode}
             label={
               POOL_OPTIONS.find((option) => option.value === field.value)
                 ?.label ?? "Select"
@@ -58,12 +72,15 @@ export function TriggerPoolSelector({
             <DropdownMenuItem
               key={value}
               label={label}
-              disabled={!isEditor || !canSetPool}
+              disabled={!isEditor || !canUseExecutionMode(value)}
               onClick={() => field.onChange(value)}
             />
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
+      {restriction && (
+        <ContentMessage variant="info">{restriction}</ContentMessage>
+      )}
     </div>
   );
 }

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/components/agent_builder/triggers/webhook/webhookEditionFormSchema";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
+import { useCanUseSelectedExecutionMode } from "@app/hooks/useTriggerExecutionModes";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
@@ -110,6 +111,11 @@ export function TriggerViewsSheet({
     defaultValues,
     resolver: zodResolver(TriggerViewsSheetFormSchema),
     mode: "onSubmit",
+  });
+
+  const canUseSelectedExecutionMode = useCanUseSelectedExecutionMode({
+    control: form.control,
+    currentExecutionMode: editTrigger?.executionMode ?? null,
   });
 
   const handleSheetClose = useCallback(() => {
@@ -315,6 +321,7 @@ export function TriggerViewsSheet({
           rightButton={{
             label: "Save",
             variant: "primary",
+            disabled: !canUseSelectedExecutionMode,
             onClick: form.handleSubmit(handleFormSubmit),
           }}
         />

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
@@ -130,6 +130,7 @@ export function ScheduleEditionSheetContent({
         <ScheduleEditionMessageInput isEditor={isEditor} />
         <TriggerPoolSelector
           name="schedule.executionMode"
+          currentExecutionMode={trigger?.executionMode ?? null}
           isEditor={isEditor}
         />
         <Separator />

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -355,7 +355,11 @@ export function WebhookEditionSheetContent({
 
         <Separator />
 
-        <TriggerPoolSelector name="webhook.executionMode" isEditor={isEditor} />
+        <TriggerPoolSelector
+          name="webhook.executionMode"
+          currentExecutionMode={trigger?.executionMode ?? null}
+          isEditor={isEditor}
+        />
 
         <WebhookEditionExecutionLimit isEditor={isEditor} />
 

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -460,6 +460,7 @@ function TriggerEditView({
     isEditor,
     isOnSelectionPage,
     pageTitle,
+    canUseSelectedExecutionMode,
     handleScheduleSelect,
     handleWebhookSelect,
     handleCancel,
@@ -529,6 +530,7 @@ function TriggerEditView({
           <Button
             label="Save"
             variant="primary"
+            disabled={!canUseSelectedExecutionMode}
             onClick={form.handleSubmit(handleFormSubmit)}
           />
         </div>

--- a/front/components/assistant/details/useTriggerSheetState.ts
+++ b/front/components/assistant/details/useTriggerSheetState.ts
@@ -14,6 +14,7 @@ import {
   formValuesToWebhookTriggerData,
   getWebhookFormDefaultValues,
 } from "@app/components/agent_builder/triggers/webhook/webhookEditionFormSchema";
+import { useCanUseSelectedExecutionMode } from "@app/hooks/useTriggerExecutionModes";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import {
   useCreateTrigger,
@@ -259,6 +260,11 @@ export function useTriggerSheetState({
     setSelectedWebhookSourceView(null);
   }, [defaultValues, form, mode]);
 
+  const canUseSelectedExecutionMode = useCanUseSelectedExecutionMode({
+    control: form.control,
+    currentExecutionMode: editTrigger?.executionMode ?? null,
+  });
+
   const pageTitle = getPageTitle(
     currentPageId,
     editTrigger,
@@ -274,6 +280,7 @@ export function useTriggerSheetState({
     isEditor,
     isOnSelectionPage,
     pageTitle,
+    canUseSelectedExecutionMode,
     handleScheduleSelect,
     handleWebhookSelect,
     handleCancel,

--- a/front/components/workspace/analytics/automations/BulkTriggerPoolModal.tsx
+++ b/front/components/workspace/analytics/automations/BulkTriggerPoolModal.tsx
@@ -1,4 +1,5 @@
 import { POOL_OPTIONS } from "@app/components/workspace/analytics/automations/trigger_pool_options";
+import { useTriggerExecutionModes } from "@app/hooks/useTriggerExecutionModes";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
 import { isTriggerExecutionMode } from "@app/types/assistant/triggers";
 import {
@@ -52,6 +53,7 @@ function BulkTriggerPoolForm({
   triggerCount,
   onValidate,
 }: BulkTriggerPoolFormProps) {
+  const { canUseExecutionMode } = useTriggerExecutionModes();
   const [executionMode, setExecutionMode] =
     useState<TriggerExecutionMode>("workspace_pool");
   const [isSaving, setIsSaving] = useState(false);
@@ -95,6 +97,7 @@ function BulkTriggerPoolForm({
               value={value}
               id={`bulk-trigger-pool-${value}`}
               label={label}
+              disabled={!canUseExecutionMode(value)}
             />
           ))}
         </RadioGroup>
@@ -108,7 +111,7 @@ function BulkTriggerPoolForm({
         rightButtonProps={{
           label: "Validate",
           variant: "primary",
-          disabled: isSaving,
+          disabled: isSaving || !canUseExecutionMode(executionMode),
           onClick: handleValidate,
         }}
       />

--- a/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
+++ b/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
@@ -6,10 +6,12 @@ import {
   CreditsCell,
   EntityTooltipCard,
 } from "@app/components/workspace/analytics/creditsTableCells";
+import { useTriggerExecutionModes } from "@app/hooks/useTriggerExecutionModes";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import { TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES } from "@app/types/assistant/triggers";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Avatar,
@@ -225,6 +227,7 @@ export interface PoolRowFields {
 
 function PoolCell({ row }: { row: TriggerRowData & PoolRowFields }) {
   const { hasPermission } = useWorkspacePermissions();
+  const { canUseExecutionMode } = useTriggerExecutionModes();
   const isWorkspacePool = row.displayExecutionMode === "workspace_pool";
   const canSetPool = hasPermission("use_workspace_pool", "trigger");
 
@@ -245,6 +248,12 @@ function PoolCell({ row }: { row: TriggerRowData & PoolRowFields }) {
           <DropdownMenuItem
             key={value}
             label={label}
+            disabled={!canUseExecutionMode(value)}
+            tooltip={
+              canUseExecutionMode(value)
+                ? undefined
+                : TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES[value]
+            }
             onClick={() => row.onSetExecutionMode(value)}
           />
         ))}

--- a/front/hooks/useTriggerExecutionModes.ts
+++ b/front/hooks/useTriggerExecutionModes.ts
@@ -1,0 +1,60 @@
+import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import { availableTriggerExecutionModes } from "@app/types/assistant/triggers";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { Control } from "react-hook-form";
+import { useWatch } from "react-hook-form";
+
+export function useTriggerExecutionModes({
+  currentExecutionMode,
+}: {
+  currentExecutionMode?: TriggerExecutionMode | null;
+} = {}): {
+  canUseExecutionMode: (executionMode: TriggerExecutionMode) => boolean;
+  hasAvailableExecutionMode: boolean;
+} {
+  const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions();
+
+  const executionModes = availableTriggerExecutionModes({
+    isPlanCreditPriced: isCreditPricedPlan(subscription.plan),
+    hasLegacyTriggerLimits: hasFeature("legacy_trigger_limits"),
+    canUseWorkspacePool: hasPermission("use_workspace_pool", "trigger"),
+    currentExecutionMode,
+  });
+
+  return {
+    canUseExecutionMode: (executionMode) =>
+      executionModes.includes(executionMode),
+    hasAvailableExecutionMode: executionModes.length > 0,
+  };
+}
+
+export function useCanUseSelectedExecutionMode({
+  control,
+  currentExecutionMode,
+}: {
+  control: Control<TriggerViewsSheetFormValues>;
+  currentExecutionMode: TriggerExecutionMode | null;
+}): boolean {
+  const { canUseExecutionMode } = useTriggerExecutionModes({
+    currentExecutionMode,
+  });
+
+  const type = useWatch({ control, name: "type" });
+  const scheduleExecutionMode = useWatch({
+    control,
+    name: "schedule.executionMode",
+  });
+  const webhookExecutionMode = useWatch({
+    control,
+    name: "webhook.executionMode",
+  });
+
+  return canUseExecutionMode(
+    type === "schedule" ? scheduleExecutionMode : webhookExecutionMode
+  );
+}

--- a/front/lib/api/actions/servers/triggers_management/tools/index.ts
+++ b/front/lib/api/actions/servers/triggers_management/tools/index.ts
@@ -221,7 +221,6 @@ export function createTriggersManagementTools(
           editor: user.id,
           webhookSourceViewId: null,
           executionPerDayLimitOverride: null,
-          executionMode: "user_pool",
           origin: "agent",
           spaceId,
         });
@@ -604,7 +603,6 @@ export function createTriggersManagementTools(
           webhookSourceViewId: view.id,
           executionPerDayLimitOverride:
             DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT,
-          executionMode: "user_pool",
           origin: "agent",
           spaceId,
         });

--- a/front/lib/api/analytics/automations/triggers.test.ts
+++ b/front/lib/api/analytics/automations/triggers.test.ts
@@ -221,6 +221,7 @@ describe("fetchAutomationTriggers webhook source display", () => {
 
   it("shows the name for a webhook source in an accessible space", async () => {
     const { workspace, authenticator, globalSpace } = await createResourceTest({
+      plan: "creditPriced",
       role: "manager",
     });
     const agent =
@@ -253,6 +254,7 @@ describe("fetchAutomationTriggers webhook source display", () => {
 
   it("labels a webhook source in a space the caller can't access as restricted", async () => {
     const { workspace, authenticator } = await createResourceTest({
+      plan: "creditPriced",
       role: "manager",
     });
     const agent =

--- a/front/lib/api/analytics/automations/user_triggers.test.ts
+++ b/front/lib/api/analytics/automations/user_triggers.test.ts
@@ -67,7 +67,10 @@ describe("fetchUserAutomationTriggers", () => {
   });
 
   it("lists the triggers that never ran after the ones that consumed", async () => {
-    const { authenticator } = await createResourceTest({ role: "user" });
+    const { authenticator } = await createResourceTest({
+      plan: "creditPriced",
+      role: "user",
+    });
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
     const consuming = await scheduleTrigger(authenticator, {
@@ -106,6 +109,7 @@ describe("fetchUserAutomationTriggers", () => {
 
   it("leaves out the triggers of other members", async () => {
     const { authenticator, workspace } = await createResourceTest({
+      plan: "creditPriced",
       role: "user",
     });
     const agent =
@@ -150,7 +154,10 @@ describe("fetchUserAutomationTriggers", () => {
   });
 
   it("still lists the triggers when the consumption query fails", async () => {
-    const { authenticator } = await createResourceTest({ role: "user" });
+    const { authenticator } = await createResourceTest({
+      plan: "creditPriced",
+      role: "user",
+    });
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
     const trigger = await scheduleTrigger(authenticator, {
@@ -173,7 +180,10 @@ describe("fetchUserAutomationTriggers", () => {
   });
 
   it("filters agents in Elasticsearch and applies kind and name filters", async () => {
-    const { authenticator } = await createResourceTest({ role: "user" });
+    const { authenticator } = await createResourceTest({
+      plan: "creditPriced",
+      role: "user",
+    });
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
     const schedule = await scheduleTrigger(authenticator, {

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -972,6 +972,7 @@ describe("updateAgentConfigurationsScope", () => {
 
   it("disables triggers of non-editors when transitioning visible → hidden", async () => {
     const { authenticator, workspace, user } = await createResourceTest({
+      plan: "creditPriced",
       role: "admin",
     });
 

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -43,7 +43,7 @@ describe("createAgentMessages", () => {
 
   beforeEach(async () => {
     // Create workspace, user, spaces, and groups using the helper
-    const setup = await createResourceTest({});
+    const setup = await createResourceTest({ plan: "creditPriced" });
     workspace = setup.workspace;
     user = setup.user;
     auth = setup.authenticator;
@@ -1698,7 +1698,7 @@ describe("createUserMessage", () => {
   let conversation: ConversationType;
 
   beforeEach(async () => {
-    const setup = await createResourceTest({});
+    const setup = await createResourceTest({ plan: "creditPriced" });
     workspace = setup.workspace;
     auth = setup.authenticator;
 

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import * as temporalClient from "@app/temporal/triggers/schedule_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -22,6 +23,7 @@ describe("TriggerResource", () => {
         .mockResolvedValue(new Ok(undefined));
 
       const { workspace, authenticator } = await createResourceTest({
+        plan: "creditPriced",
         role: "admin",
       });
 
@@ -153,6 +155,7 @@ describe("TriggerResource", () => {
         .mockResolvedValue(new Ok(undefined));
 
       const { workspace, authenticator } = await createResourceTest({
+        plan: "creditPriced",
         role: "admin",
       });
 
@@ -315,6 +318,7 @@ describe("TriggerResource", () => {
         .mockResolvedValue(new Ok(undefined));
 
       const { workspace, authenticator } = await createResourceTest({
+        plan: "creditPriced",
         role: "admin",
       });
 
@@ -374,6 +378,7 @@ describe("TriggerResource", () => {
         .mockResolvedValue(new Ok(undefined));
 
       const { workspace, authenticator } = await createResourceTest({
+        plan: "creditPriced",
         role: "admin",
       });
 
@@ -430,7 +435,10 @@ describe("TriggerResource", () => {
         .spyOn(temporalClient, "createOrUpdateAgentSchedule")
         .mockResolvedValue(new Ok("workflow-id"));
 
-      const { authenticator } = await createResourceTest({ role: "admin" });
+      const { authenticator } = await createResourceTest({
+        plan: "creditPriced",
+        role: "admin",
+      });
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
         authenticator,
         { name: "Test Agent" }
@@ -458,7 +466,9 @@ describe("TriggerResource", () => {
     });
 
     it("counts zero for a workspace without triggers", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+      });
 
       expect(await TriggerResource.countForWorkspace(authenticator)).toEqual({
         enabled: 0,
@@ -467,9 +477,115 @@ describe("TriggerResource", () => {
       });
     });
   });
+  describe("legacy plans", () => {
+    it("refuses to create a trigger on the user pool", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      const result = await TriggerResource.makeNew(authenticator, {
+        workspaceId: workspace.id,
+        name: "Legacy user pool trigger",
+        kind: "schedule",
+        agentConfigurationId: agentConfig.sId,
+        editor: authenticator.getNonNullableUser().id,
+        customPrompt: null,
+        status: "disabled",
+        configuration: { cron: "0 9 * * 1", timezone: "UTC" },
+        origin: "user",
+        executionMode: "user_pool",
+      });
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("creates a trigger on the user pool with the legacy trigger limits flag", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      await FeatureFlagResource.enable(workspace, "legacy_trigger_limits");
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      const result = await TriggerResource.makeNew(authenticator, {
+        workspaceId: workspace.id,
+        name: "Legacy user pool trigger",
+        kind: "schedule",
+        agentConfigurationId: agentConfig.sId,
+        editor: authenticator.getNonNullableUser().id,
+        customPrompt: null,
+        status: "disabled",
+        configuration: { cron: "0 9 * * 1", timezone: "UTC" },
+        origin: "user",
+        executionMode: "user_pool",
+      });
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it("allows moving an existing user pool trigger to the workspace pool", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+      const trigger = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+      });
+      await TriggerResource.update(authenticator, trigger.sId, {
+        executionMode: "user_pool",
+      });
+      const userPoolTrigger = await TriggerResource.fetchById(
+        authenticator,
+        trigger.sId
+      );
+
+      const result = await userPoolTrigger?.setExecutionMode(
+        authenticator,
+        "workspace_pool"
+      );
+
+      expect(result?.isOk()).toBe(true);
+      const reloaded = await TriggerResource.fetchById(
+        authenticator,
+        trigger.sId
+      );
+      expect(reloaded?.executionMode).toBe("workspace_pool");
+    });
+
+    it("refuses to move an existing trigger back to the user pool", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+      const trigger = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+      });
+
+      const result = await trigger.setExecutionMode(authenticator, "user_pool");
+
+      expect(result.isErr()).toBe(true);
+      const reloaded = await TriggerResource.fetchById(
+        authenticator,
+        trigger.sId
+      );
+      expect(reloaded?.executionMode).toBe("workspace_pool");
+    });
+  });
+
   describe("setExecutionMode", () => {
     it("refuses the workspace pool without the governance grant", async () => {
-      const { authenticator } = await createResourceTest({ role: "user" });
+      const { authenticator } = await createResourceTest({
+        plan: "creditPriced",
+        role: "user",
+      });
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
         authenticator,
         { name: "Test Agent" }
@@ -522,7 +638,9 @@ describe("TriggerResource", () => {
     });
 
     it("lets an admin move a trigger to the workspace pool", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+      });
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
         authenticator,
         { name: "Test Agent" }
@@ -552,6 +670,7 @@ describe("TriggerResource", () => {
         .mockResolvedValue(new Ok("workflow-id"));
 
       const { workspace, authenticator } = await createResourceTest({
+        plan: "creditPriced",
         role: "admin",
       });
       const agentConfig = await AgentConfigurationFactory.createTestAgent(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -3,7 +3,7 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
@@ -31,7 +31,13 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
-import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
+import {
+  availableTriggerExecutionModes,
+  getTriggerStatusOwner,
+  NO_TRIGGER_EXECUTION_MODE_AVAILABLE_MESSAGE,
+  TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES,
+} from "@app/types/assistant/triggers";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -102,25 +108,24 @@ function emitBulkTriggerAuditLogEvents(
   );
 }
 
+async function availableExecutionModes(
+  auth: Authenticator
+): Promise<TriggerExecutionMode[]> {
+  return availableTriggerExecutionModes({
+    isPlanCreditPriced: isCreditPricedPlan(auth.getNonNullablePlan()),
+    hasLegacyTriggerLimits: await hasFeatureFlag(auth, "legacy_trigger_limits"),
+    canUseWorkspacePool: await auth.hasWorkspacePermission(
+      "use_workspace_pool",
+      "trigger"
+    ),
+  });
+}
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface TriggerResource extends ReadonlyAttributesType<TriggerModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-async function canUseExecutionMode(
-  auth: Authenticator,
-  executionMode: TriggerExecutionMode
-): Promise<boolean> {
-  switch (executionMode) {
-    case "user_pool":
-      return true;
-    case "workspace_pool":
-      return auth.hasWorkspacePermission("use_workspace_pool", "trigger");
-    default:
-      assertNever(executionMode);
-  }
-}
-
 export class TriggerResource extends BaseResource<TriggerModel> {
   static model: ModelStatic<TriggerModel> = TriggerModel;
 
@@ -133,20 +138,32 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
   static async makeNew(
     auth: Authenticator,
-    blob: CreationAttributes<TriggerModel>,
+    blob: Omit<CreationAttributes<TriggerModel>, "executionMode"> & {
+      executionMode?: TriggerExecutionMode;
+    },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<TriggerResource, Error>> {
-    if (!(await canUseExecutionMode(auth, blob.executionMode))) {
+    const executionModes = await availableExecutionModes(auth);
+    const executionMode = blob.executionMode ?? executionModes[0];
+    if (!executionMode) {
       return new Err(
         new TriggerExecutionModeForbiddenError(
-          "You don't have permission to charge this trigger to the workspace."
+          NO_TRIGGER_EXECUTION_MODE_AVAILABLE_MESSAGE
+        )
+      );
+    }
+    if (!executionModes.includes(executionMode)) {
+      return new Err(
+        new TriggerExecutionModeForbiddenError(
+          TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES[executionMode]
         )
       );
     }
 
-    const trigger = await TriggerModel.create(blob, {
-      transaction,
-    });
+    const trigger = await TriggerModel.create(
+      { ...blob, executionMode },
+      { transaction }
+    );
 
     const resource = new this(TriggerModel, trigger.get());
 
@@ -1026,7 +1043,9 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     executionMode: TriggerExecutionMode
   ): Promise<BulkTriggerUpdateOutcome> {
     const workspace = auth.getNonNullableWorkspace();
-    const canUseTargetMode = await canUseExecutionMode(auth, executionMode);
+    const canUseTargetMode = (await availableExecutionModes(auth)).includes(
+      executionMode
+    );
     const updatable = canUseTargetMode
       ? triggers.filter(
           (trigger) => auth.isManager() || trigger.isEditedBy(auth)
@@ -1271,7 +1290,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     executionMode: TriggerExecutionMode
   ): Promise<Result<undefined, Error>> {
     const isEditor = auth.isManager() || this.isEditedBy(auth);
-    if (!isEditor || !(await canUseExecutionMode(auth, executionMode))) {
+    if (!isEditor) {
       return new Err(
         new TriggerExecutionModeForbiddenError(
           "You don't have permission to change this trigger's pool."
@@ -1281,6 +1300,14 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
     if (this.executionMode === executionMode) {
       return new Ok(undefined);
+    }
+
+    if (!(await availableExecutionModes(auth)).includes(executionMode)) {
+      return new Err(
+        new TriggerExecutionModeForbiddenError(
+          TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES[executionMode]
+        )
+      );
     }
 
     const previousExecutionMode = this.executionMode;

--- a/front/scripts/seed/factories/seedTriggers.ts
+++ b/front/scripts/seed/factories/seedTriggers.ts
@@ -104,7 +104,6 @@ export async function seedTriggers(
         configuration: asset.configuration,
         webhookSourceViewId,
         origin: "user",
-        executionMode: "user_pool",
       });
 
       if (result.isErr()) {

--- a/front/tests/utils/TriggerFactory.ts
+++ b/front/tests/utils/TriggerFactory.ts
@@ -53,7 +53,7 @@ export class TriggerFactory {
       webhookSourceViewId: options.webhookSourceViewId ?? null,
       spaceId: options.spaceId ?? null,
       origin: "user",
-      executionMode: options.executionMode ?? "user_pool",
+      executionMode: options.executionMode,
     });
 
     if (result.isErr()) {
@@ -85,7 +85,7 @@ export class TriggerFactory {
       configuration: options.configuration,
       webhookSourceViewId: null,
       origin: "user",
-      executionMode: options.executionMode ?? "user_pool",
+      executionMode: options.executionMode,
     });
 
     if (result.isErr()) {

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -18,6 +18,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import { faker } from "@faker-js/faker";
 import { expect } from "vitest";
@@ -180,5 +181,20 @@ export class WorkspaceFactory {
     });
 
     return workspaceType;
+  }
+}
+
+export type TestWorkspacePlan = "basic" | "creditPriced";
+
+export async function workspaceForPlan(
+  plan: TestWorkspacePlan
+): Promise<WorkspaceType> {
+  switch (plan) {
+    case "basic":
+      return WorkspaceFactory.basic();
+    case "creditPriced":
+      return WorkspaceFactory.creditPriced();
+    default:
+      assertNever(plan);
   }
 }

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -2,7 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { TestWorkspacePlan } from "@app/tests/utils/WorkspaceFactory";
+import { workspaceForPlan } from "@app/tests/utils/WorkspaceFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import type { RequestMethod } from "node-mocks-http";
@@ -44,14 +45,16 @@ export const createPrivateApiMockRequest = async ({
   method = "GET",
   role = "user",
   isSuperUser = false,
+  plan = "basic",
   workspace: existingWorkspace,
 }: {
   method?: RequestMethod;
   role?: MembershipRoleType;
   isSuperUser?: boolean;
+  plan?: TestWorkspacePlan;
   workspace?: WorkspaceType;
 } = {}) => {
-  const workspace = existingWorkspace ?? (await WorkspaceFactory.basic());
+  const workspace = existingWorkspace ?? (await workspaceForPlan(plan));
   const user = await (isSuperUser
     ? UserFactory.superUser()
     : UserFactory.basic());

--- a/front/tests/utils/generic_public_api_tests.ts
+++ b/front/tests/utils/generic_public_api_tests.ts
@@ -2,7 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { Authenticator } from "@app/lib/auth";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { TestWorkspacePlan } from "@app/tests/utils/WorkspaceFactory";
+import { workspaceForPlan } from "@app/tests/utils/WorkspaceFactory";
 import type { RequestMethod } from "node-mocks-http";
 import { createMocks } from "node-mocks-http";
 
@@ -22,12 +23,14 @@ export const createPublicApiMockRequest = async ({
   systemKey = false,
   method = "GET",
   role = "builder",
+  plan = "basic",
 }: {
   systemKey?: boolean;
   method?: RequestMethod;
   role?: "user" | "builder" | "admin";
+  plan?: TestWorkspacePlan;
 } = {}) => {
-  const workspace = await WorkspaceFactory.basic();
+  const workspace = await workspaceForPlan(plan);
   const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
   let key;
   if (systemKey) {

--- a/front/tests/utils/generic_resource_tests.ts
+++ b/front/tests/utils/generic_resource_tests.ts
@@ -6,7 +6,11 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { TestWorkspacePlan } from "@app/tests/utils/WorkspaceFactory";
+import {
+  WorkspaceFactory,
+  workspaceForPlan,
+} from "@app/tests/utils/WorkspaceFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -17,10 +21,12 @@ export const createResourceTest: ({
   role,
   isSuperUser,
   isByok,
+  plan,
 }: {
   role?: MembershipRoleType;
   isSuperUser?: boolean;
   isByok?: boolean;
+  plan?: TestWorkspacePlan;
 }) => Promise<{
   workspace: LightWorkspaceType;
   user: UserResource;
@@ -35,14 +41,16 @@ export const createResourceTest: ({
   role = "user",
   isSuperUser = false,
   isByok = false,
+  plan = "basic",
 }: {
   role?: MembershipRoleType;
   isSuperUser?: boolean;
   isByok?: boolean;
+  plan?: TestWorkspacePlan;
 }) => {
   const workspace = isByok
     ? await WorkspaceFactory.byok()
-    : await WorkspaceFactory.basic();
+    : await workspaceForPlan(plan);
   const user: UserResource = await (isSuperUser
     ? UserFactory.superUser()
     : UserFactory.basic());

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -76,6 +76,45 @@ export function isTriggerExecutionMode(
   return (TRIGGER_EXECUTION_MODES as readonly string[]).includes(value);
 }
 
+export function availableTriggerExecutionModes({
+  isPlanCreditPriced,
+  hasLegacyTriggerLimits,
+  canUseWorkspacePool,
+  currentExecutionMode,
+}: {
+  isPlanCreditPriced: boolean;
+  hasLegacyTriggerLimits: boolean;
+  canUseWorkspacePool: boolean;
+  currentExecutionMode?: TriggerExecutionMode | null;
+}): TriggerExecutionMode[] {
+  const modes: TriggerExecutionMode[] = [];
+  if (
+    isPlanCreditPriced ||
+    hasLegacyTriggerLimits ||
+    currentExecutionMode === "user_pool"
+  ) {
+    modes.push("user_pool");
+  }
+  if (canUseWorkspacePool) {
+    modes.push("workspace_pool");
+  }
+  return modes;
+}
+
+export const NO_TRIGGER_EXECUTION_MODE_AVAILABLE_MESSAGE =
+  "Automations on your plan must be charged to the workspace credit pool, " +
+  "which you don't have permission to use. Ask a workspace admin for access.";
+
+export const TRIGGER_EXECUTION_MODE_UNAVAILABLE_MESSAGES: Record<
+  TriggerExecutionMode,
+  string
+> = {
+  user_pool:
+    "Your plan doesn't support charging automations to personal credits.",
+  workspace_pool:
+    "You don't have permission to charge automations to the workspace credit pool.",
+};
+
 export type BulkTriggerUpdateOutcome = {
   updatedCount: number;
   // Triggers the caller may not move (insufficient role or permission).

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -459,6 +459,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "tdraier",
   },
+  legacy_trigger_limits: {
+    description:
+      "Keep the legacy trigger limits: automations may still be charged to personal credits on a non credit-priced plan.",
+    stage: "self_serve",
+    owner: "adrsimon",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "ask_owner" | "self_serve";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -774,6 +774,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_mcp_actions_dashboard"
   | "labs_transcripts"
   | "legacy_dust_apps"
+  | "legacy_trigger_limits"
   | "netsuite_mcp"
   | "noop_model_feature"
   | "notion_private_integration"


### PR DESCRIPTION
## Description

Choosing user pool on new triggers should not be available in the legacy plan anymore. `availableTriggerExecutionModes` now decides which pools a caller may pick, from the plan, the `legacy_trigger_limits` flag and the `use_workspace_pool` grant, and both `TriggerResource` and the new `useTriggerExecutionModes` hook read from it.

A workspace with `legacy_trigger_limits` keeps the legacy trigger limits and can still charge automations to personal credits. Use it to hold back a legacy workspace that is not ready to move.

In the trigger sheets the selector disables the pools the user cannot pick and says why, and Save stays disabled while the selected pool is unavailable.

Existing `user_pool` triggers on legacy plans keep running and stay editable. They cannot move back once they leave.

## Tests

`trigger_resource.test.ts` covers the legacy-plan transitions: creation on `user_pool` refused, allowed again with `legacy_trigger_limits`, an existing `user_pool` trigger moving to the workspace pool, no move back. `front-api/routes/w/[wId]/triggers/index.test.ts` covers a legacy-plan PATCH that edits other fields while leaving the pool alone.

The `plan: "creditPriced"` additions elsewhere are tests that build a trigger through `TriggerFactory` and would otherwise fail. Each was added after it failed without it.

## Risk

On a non credit-priced workspace only admins hold `use_workspace_pool` by default, so managers and members cannot create any trigger. Enable `legacy_trigger_limits` on the workspace to unblock them.

The form still opens on personal credits, so a legacy-plan admin has to switch the pool before saving.

Existing legacy-plan `user_pool` triggers keep being charged as they are today. No migration moves them.

Revert to roll back, no schema change.

## Deploy Plan

Deploy `front`.