### PR TITLE
[front] Fix Pod group cleanup during deletion

### DIFF
--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -860,13 +860,15 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   // Every grant held by one group, across resource types and instances.
   static async listForGroup(
     auth: Authenticator,
-    group: GroupResource
+    group: GroupResource,
+    transaction?: Transaction
   ): Promise<GroupPermissionResource[]> {
     const rows = await GroupPermissionModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         groupId: group.id,
       },
+      transaction,
     });
 
     return rows.map((row) => new this(GroupPermissionModel, row.get()));

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -185,6 +185,7 @@ describe("SpaceResource", () => {
         expect.objectContaining({ id: regularGroup.id }),
         transaction
       );
+      listForGroupSpy.mockRestore();
     });
 
     it("should delete pod-scoped sandbox env vars but keep workspace-scoped ones when hard deleting a space", async () => {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -22,10 +22,11 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxEnvVarFactory } from "@app/tests/utils/SandboxEnvVarFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("SpaceResource", () => {
   describe("updatePermissions", () => {
@@ -166,6 +167,24 @@ describe("SpaceResource", () => {
           },
         })
       ).resolves.toBe(0);
+    });
+
+    it("checks remaining group grants in the deletion transaction", async () => {
+      const transaction = getNamespace("test-namespace")?.get("transaction");
+      expect(transaction).toBeDefined();
+      const listForGroupSpy = vi.spyOn(GroupPermissionResource, "listForGroup");
+
+      const deleteResult = await regularSpace.delete(adminAuth, {
+        hardDelete: false,
+        transaction,
+      });
+
+      expect(deleteResult.isOk()).toBe(true);
+      expect(listForGroupSpy).toHaveBeenCalledWith(
+        adminAuth,
+        expect.objectContaining({ id: regularGroup.id }),
+        transaction
+      );
     });
 
     it("should delete pod-scoped sandbox env vars but keep workspace-scoped ones when hard deleting a space", async () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -824,7 +824,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       async (group) => {
         // Ensure the group is not associated with any other space. The grants for this space were
         // just cleared above, so any remaining space grant means the group is used elsewhere.
-        const grants = await GroupPermissionResource.listForGroup(auth, group);
+        const grants = await GroupPermissionResource.listForGroup(
+          auth,
+          group,
+          transaction
+        );
         const hasSpaceGrant = grants.some(
           (grant) => grant.resourceType === "space"
         );


### PR DESCRIPTION
**Issue**: Trying to recreate a deleted pod (re-using same name) was failing with "Error: Space with that name already exists". I reproed it multiple times, and then multiple times verified that it worked after the fix.

## Description

- Propagate the Space deletion transaction to the remaining group-grants lookup.
- Ensure a permanently deleted Pod's auto-group is removed, allowing the Pod name to be reused.
- Keep archive behavior unchanged.

Fixes dust-tt/tasks#10245.

Existing orphaned groups created before this fix still require targeted cleanup.

## Tests

- NODE_ENV=test npm run test -- lib/resources/space_resource.test.ts lib/resources/group_permission_resource.test.ts lib/api/spaces.test.ts: 163 passed.
- Regression test confirmed failing before the fix and passing after it.
- Pre-commit Biome and front-typecheck hooks passed.
- Full front suite: 9,033 passed and 6 unrelated Frames tests failed. The same six failures reproduce on unchanged origin/main because sandbox-function fixtures omit the required spaceId.

## Risk

Low. The transaction parameter is optional for existing callers and is only supplied by the Space deletion path. The change can be rolled back by reverting these commits.

## Deploy Plan

Deploy front normally. Clean up the existing orphaned auto-group for the affected EQT workspace separately so the historical Pod name can be reused.