### PR TITLE
[front] fix: preserve optional parameters in Fireworks tool schemas

### DIFF
--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
@@ -17,7 +17,11 @@ import type {
 } from "@app/lib/model_constructors/types/input/messages";
 import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isRecord, removeNulls } from "@app/types/shared/utils/general";
+import {
+  isRecord,
+  isStringArray,
+  removeNulls,
+} from "@app/types/shared/utils/general";
 import type {
   ChatCompletionMessageParam,
   ChatCompletionTool,
@@ -242,6 +246,9 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 export function toTool(tool: ToolSpecification): ChatCompletionTool {
   const properties = asRecord(tool.inputSchema.properties);
+  const required = isStringArray(tool.inputSchema.required)
+    ? tool.inputSchema.required
+    : [];
   return {
     type: "function",
     function: {
@@ -251,8 +258,7 @@ export function toTool(tool: ToolSpecification): ChatCompletionTool {
       parameters: {
         type: "object",
         properties,
-        // OpenAI strict mode requires every property to be listed as required.
-        required: Object.keys(properties),
+        required,
         additionalProperties: false,
       },
     },

--- a/front/lib/model_constructors/stream/clients/fireworks.test.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks.test.ts
@@ -1,9 +1,42 @@
 // @vitest-environment node
 
+import { DeepSeekDeepSeekV4Flash0731GlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/deepseek_deepseek_v4_flash_0731_global_fireworks";
 import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/z_ai_glm_five_dot_two_global_fireworks";
 import { describe, expect, it } from "vitest";
 
 describe("FireworksStream", () => {
+  it("preserves optional tool parameters for DeepSeek V4 Flash", () => {
+    const endpoint = new DeepSeekDeepSeekV4Flash0731GlobalFireworksStream({
+      FIREWORKS_API_KEY: "test",
+    });
+    const payload = endpoint.buildRequestPayload(
+      { conversation: { system: [], messages: [] } },
+      DeepSeekDeepSeekV4Flash0731GlobalFireworksStream.configSchema.parse({
+        tools: [
+          {
+            name: "search",
+            description: "Search for documents",
+            inputSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+                limit: { type: "number" },
+              },
+              required: ["query"],
+              additionalProperties: false,
+            },
+          },
+        ],
+      })
+    );
+
+    const tool = payload.tools?.[0];
+    if (tool?.type !== "function") {
+      throw new Error("Expected a function tool");
+    }
+    expect(tool.function.parameters?.required).toEqual(["query"]);
+  });
+
   it("includes names when replaying parallel tool results", () => {
     const endpoint = new ZAiGlmFiveDotTwoGlobalFireworksStream({
       FIREWORKS_API_KEY: "test",


### PR DESCRIPTION
## Description

When running DeepSeek V4 Flash, optional tool parameters are sent as `required` because the Fireworks converter adds every property to the `required` array.

This PR keeps the original `required` list instead. Fireworks uses standard JSON Schema semantics even with `strict: true`. Kimi K3 uses a different converter.

This was only observed on DeepSeek V4 Flash, although we send the same incorrect JSON Schema to other Fireworks models. The difference could be due to minor nuances in how each tool template works (maybe DSML works differently).

## Tests

- Added regression coverage for required and optional tool arguments.
- Live-tested on all Fireworks models.

## Risk

- Low.

## Deploy Plan

- Deploy front.
