### PR TITLE
[front] fix: remove model selection counter from Manage Agents

### DIFF
--- a/front/components/assistant/ModelsFilterMenu.tsx
+++ b/front/components/assistant/ModelsFilterMenu.tsx
@@ -99,8 +99,6 @@ export function ModelsFilterMenu({
           icon={CpuChip01}
           label={isCompact ? undefined : "Models"}
           tooltip={isCompact ? "Models" : undefined}
-          counterValue={selectedModels.length.toString()}
-          isCounter={selectedModels.length > 0}
         />
       </DropdownMenuTrigger>
       <ModelPickerContent


### PR DESCRIPTION
## Description

This PR removes the counter shown in the model selector when adding models to the selection.

The selection is already shown as removable chips, so the count on the filter button is redundant.
This prevents some level of layout shift when updating the selection (the counter stretches the trigger's size, and the dropdown is left aligned so it moves in its entirety even if the model name remains the same).

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
