### PR TITLE
fix(conversation): avoid duplicate final answer in activity steps

### DIFF
--- a/front/lib/api/assistant/activity_steps.test.ts
+++ b/front/lib/api/assistant/activity_steps.test.ts
@@ -88,6 +88,50 @@ describe("renderAgentMessageContentView", () => {
     });
   });
 
+  it("does not repeat the final answer in the activity steps", async () => {
+    expect(
+      await render([
+        {
+          step: 0,
+          content: {
+            type: "reasoning",
+            value: {
+              reasoning: "I need the user to confirm the application",
+              metadata: "",
+              tokens: 0,
+              provider: "anthropic",
+            },
+          },
+        },
+        {
+          step: 0,
+          content: {
+            type: "text_content",
+            value: "Please confirm which application this is for.",
+          },
+        },
+        {
+          step: 1,
+          content: {
+            type: "text_content",
+            value: "Please confirm which application this is for.",
+          },
+        },
+      ])
+    ).toEqual({
+      content: "Please confirm which application this is for.",
+      chainOfThought: "I need the user to confirm the application",
+      activitySteps: [
+        {
+          type: "thinking",
+          content: "I need the user to confirm the application",
+          id: "reasoning-0-0",
+          step: 0,
+        },
+      ],
+    });
+  });
+
   it("extracts CoT from <thinking> delimiters when there is no native reasoning", async () => {
     expect(
       await render([

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -143,7 +143,14 @@ export async function renderAgentMessageContentView(
     messageId
   );
 
-  return { content, chainOfThought, activitySteps };
+  return {
+    content,
+    chainOfThought,
+    activitySteps: activitySteps.filter(
+      (step) =>
+        step.type !== "content" || step.content.trim() !== content?.trim()
+    ),
+  };
 }
 
 // Body = the last text fragment (final answer); chain of thought = native


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10241.

Prevent the final answer from appearing twice when an identical text fragment was already included in the Work timeline. The renderer now removes only content activity steps that match the final body after trimming, while preserving reasoning, actions, and distinct intermediate text.

## Tests

- Added a regression test for identical intermediate and final text.
- NODE_ENV=test npm test: 701 files passed, 9,048 tests passed.
- npx tsgo --noEmit.
- Targeted Biome check.
- Sparkle Storybook: 115 files passed, 439 tests passed.

## Risk

Low. The change only filters exact duplicate content from the rendered activity-step list. It is safe to roll back.

## Deploy Plan

Deploy through the standard front release process. No migration or configuration change is required.