### PR TITLE
[front] sidebar: top expand button with crossfade

### DIFF
--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -6,7 +6,6 @@ import {
 } from "@app/components/navigation/NavigationSidebar";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useUser } from "@app/lib/swr/user";
-import { classNames } from "@app/lib/utils";
 import type { SubscriptionType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -110,7 +109,13 @@ export function Navigation({
               isNavigationBarOpen ? "w-80" : "w-0"
             )}
           >
-            <div className="flex-1 bg-app-background inset-y-0 z-0 flex w-80 flex-col">
+            <div
+              className={cn(
+                "flex-1 bg-app-background inset-y-0 z-0 flex w-80 flex-col",
+                "transition-opacity duration-150 ease-out motion-reduce:transition-none",
+                !isNavigationBarOpen && "opacity-0"
+              )}
+            >
               <NavigationSidebar
                 owner={owner}
                 subscription={subscription}
@@ -123,11 +128,8 @@ export function Navigation({
           </div>
 
           <div
-            // center handle vertically (top at 50% + translate half the handle height)
-            className={classNames(
-              "fixed z-40 hidden lg:top-1/2 lg:flex lg:-translate-y-1/2",
-              isNavigationBarOpen ? "lg:ml-80" : ""
-            )}
+            // aligned with the sidebar collapse button (pt-2 + h-8 row)
+            className="fixed left-0 top-[var(--banner-height)] z-40 hidden px-0.5 pt-2 lg:flex"
           >
             <ToggleNavigationSidebarButton
               isNavigationBarOpened={isNavigationBarOpen}

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -17,8 +17,9 @@ import type { SubscriptionType } from "@app/types/plan";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin, isManager } from "@app/types/user";
 import {
-  CollapseButton,
+  Button,
   cn,
+  Icon,
   LayoutLeft,
   NavigationList,
   NavigationListCompactLabel,
@@ -220,15 +221,30 @@ export const ToggleNavigationSidebarButton = React.forwardRef<
     toggleNavigationBarVisibility(!isNavigationBarOpened);
   }, [isNavigationBarOpened, toggleNavigationBarVisibility]);
 
-  if (isNavigationBarOpened || isFullScreen) {
+  if (isFullScreen) {
     return null;
   }
 
+  // Stays mounted while the sidebar is open so it can crossfade: it fades in
+  // once the sidebar has finished sliding away, and fades out immediately on
+  // expand.
   return (
-    <div ref={ref} onClick={handleClick} className="lg:top-1/2 lg:flex lg:w-5">
-      <CollapseButton
-        direction={isNavigationBarOpened ? "left" : "right"}
-        variant="light"
+    <div
+      ref={ref}
+      className={cn(
+        "transition-opacity duration-150 ease-out motion-reduce:transition-none lg:flex",
+        isNavigationBarOpened ? "pointer-events-none opacity-0" : "delay-150"
+      )}
+      aria-hidden={isNavigationBarOpened}
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        // Element icon to render at the pill's 20px instead of sm's 16px.
+        icon={<Icon visual={LayoutLeft} size="sm" />}
+        onClick={handleClick}
+        aria-label="Open navigation"
+        tabIndex={isNavigationBarOpened ? -1 : 0}
       />
     </div>
   );

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -54,7 +54,10 @@ function AppContentInnerWrapper({
     <div
       className={cn(
         "my-2 mr-2 rounded-xl flex-1 bg-panel-background border border-border overflow-hidden h-panel",
-        !isNavigationBarOpen && !isFullScreen && "ml-5",
+        // Keeps the gutter in sync with the sidebar's width animation.
+        "transition-[margin-left] duration-150 ease-out motion-reduce:transition-none",
+        // ml-9 = expand button in Navigation.tsx: px-0.5 (2px) + w-8 (32px) + 2px.
+        !isNavigationBarOpen && !isFullScreen && "ml-9",
         isFullScreen && "ml-2"
       )}
       style={{


### PR DESCRIPTION
When the sidebar is collapsed, the reopen control is now the same LayoutLeft button as the collapse pill, at the same top position, instead of the chevron centered on the left edge. Collapsing fades the sidebar content out while it slides and fades the button in after; expanding crossfades them back. The content panel gutter animates with the width instead of jumping.