### PR TITLE
feat(sandbox): bulk env-var read across scopes (Computer admin backend)

### DIFF
--- a/front-api/routes/w/[wId]/sandbox/env-vars/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/bulk.test.ts
@@ -1,0 +1,176 @@
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function setupTest({
+  role = "admin",
+  disableComputerFeature = false,
+  enableSandboxFunctions = true,
+}: {
+  role?: MembershipRoleType;
+  disableComputerFeature?: boolean;
+  enableSandboxFunctions?: boolean;
+} = {}) {
+  const { workspace, auth, user, ...rest } = await createPrivateApiMockRequest({
+    role,
+  });
+
+  if (enableSandboxFunctions) {
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  }
+  if (disableComputerFeature) {
+    await FeatureFlagFactory.basic(auth, "disable_computer_feature");
+  }
+
+  const podA = await SpaceFactory.project(workspace, user.id);
+  const podB = await SpaceFactory.project(workspace, user.id);
+
+  return { workspace, auth, user, podA, podB, ...rest };
+}
+
+function getBulk(wId: string, query: string) {
+  return honoApp.request(`/api/w/${wId}/sandbox/env-vars/bulk?${query}`);
+}
+
+describe("GET /api/w/:wId/sandbox/env-vars/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const { workspace, podA } = await setupTest({ role: "user" });
+
+    const response = await getBulk(workspace.sId, `podIds=${podA.sId}`);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "workspace_auth_error" },
+    });
+  });
+
+  it("returns 403 when Computer is disabled", async () => {
+    const { workspace, podA } = await setupTest({
+      disableComputerFeature: true,
+    });
+
+    const response = await getBulk(workspace.sId, `podIds=${podA.sId}`);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "feature_flag_not_found" },
+    });
+  });
+
+  it("returns the selected pods' env vars flat, without workspace rows", async () => {
+    const { workspace, auth, podA, podB } = await setupTest();
+
+    for (const [scope, name] of [
+      [
+        {
+          kind: "workspace" as const,
+          workspace: auth.getNonNullableWorkspace(),
+        },
+        "WORKSPACE_TOKEN",
+      ],
+      [{ kind: "pod" as const, pod: podA }, "A_TOKEN"],
+      [{ kind: "pod" as const, pod: podB }, "B_TOKEN"],
+    ] as const) {
+      const upsert = await SandboxEnvVarResource.upsert(auth, scope, {
+        name,
+        value: "value",
+      });
+      if (upsert.isErr()) {
+        throw upsert.error;
+      }
+    }
+
+    const response = await getBulk(
+      workspace.sId,
+      `podIds=${podA.sId},${podB.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    // toMatchObject on an array also pins its length; ordered by name.
+    expect(await response.json()).toMatchObject({
+      envVars: [
+        { name: "DST_A_TOKEN", spaceId: podA.sId },
+        { name: "DST_B_TOKEN", spaceId: podB.sId },
+      ],
+    });
+  });
+
+  it("supports repeated podIds params and drops unknown ids", async () => {
+    const { workspace, auth, podA } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod: podA },
+      { name: "A_TOKEN", value: "value" }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await getBulk(
+      workspace.sId,
+      `podIds=${podA.sId}&podIds=spc_unknown`
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      envVars: [{ name: "DST_A_TOKEN", spaceId: podA.sId }],
+    });
+  });
+
+  it("resolves scope=all-pods to every live pod, excluding archived ones", async () => {
+    const { workspace, auth, podA, podB } = await setupTest();
+    await ProjectMetadataResource.makeNew(auth, podA, { description: null });
+    await ProjectMetadataResource.makeNew(auth, podB, { description: null });
+    const archivedPod = await SpaceFactory.project(workspace);
+    const archivedMetadata = await ProjectMetadataResource.makeNew(
+      auth,
+      archivedPod,
+      { description: null }
+    );
+    await archivedMetadata.archive();
+
+    for (const [pod, name] of [
+      [podA, "A_TOKEN"],
+      [archivedPod, "ARCHIVED_TOKEN"],
+    ] as const) {
+      const upsert = await SandboxEnvVarResource.upsert(
+        auth,
+        { kind: "pod", pod },
+        { name, value: "value" }
+      );
+      if (upsert.isErr()) {
+        throw upsert.error;
+      }
+    }
+
+    const response = await getBulk(workspace.sId, "scope=all-pods");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      envVars: [{ name: "DST_A_TOKEN", spaceId: podA.sId }],
+    });
+  });
+
+  it("rejects providing both scope and podIds, or neither", async () => {
+    const { workspace, podA } = await setupTest();
+
+    const bothResponse = await getBulk(
+      workspace.sId,
+      `scope=all-pods&podIds=${podA.sId}`
+    );
+    expect(bothResponse.status).toBe(400);
+
+    const neitherResponse = await getBulk(workspace.sId, "");
+    expect(neitherResponse.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/sandbox/env-vars/bulk.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/bulk.ts
@@ -1,0 +1,49 @@
+import {
+  parseSandboxAdminPodSelection,
+  resolveSandboxAdminPods,
+  SandboxAdminPodSelectionQuerySchema,
+} from "@app/lib/api/sandbox/admin_pods";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import type { GetSandboxEnvVarsBulkResponseBody } from "@app/types/api/sandbox/env_vars";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+
+// Mounted at /api/w/:wId/sandbox/env-vars/bulk. Multi-pod reads for the
+// central Computer admin page. The parent sub-app applies the
+// workspace-admin + Computer gates; the multi-Pod feature is gated on the
+// Pod Functions (sandbox_functions) flag. Values are never returned
+// (write-only invariant).
+const app = workspaceApp();
+
+app.use("*", withFeatureFlag("sandbox_functions"));
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("query", SandboxAdminPodSelectionQuerySchema),
+  async (ctx): HandlerResult<GetSandboxEnvVarsBulkResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const selection = parseSandboxAdminPodSelection(ctx.req.valid("query"));
+    if (selection.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: selection.error.message,
+        },
+      });
+    }
+
+    const pods = await resolveSandboxAdminPods(auth, selection.value);
+    const envVars = await SandboxEnvVarResource.listForPods(auth, pods);
+
+    return ctx.json({
+      envVars: envVars.map((envVar) => envVar.toJSON()),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/index.ts
@@ -15,6 +15,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import envVarId from "./[id]";
+import bulk from "./bulk";
 
 const PostWorkspaceSandboxEnvVarBodySchema = z.object({
   name: z.string(),
@@ -102,6 +103,7 @@ app.post(
   }
 );
 
+app.route("/bulk", bulk);
 app.route("/:id", envVarId);
 
 export default app;

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -12,7 +12,7 @@ import {
 } from "@app/lib/api/sandbox/egress_policy";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ScopeMutationResult } from "@app/types/api/sandbox/egress_policy";
 import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
@@ -86,6 +86,29 @@ export async function listPodsWithEgressPolicy(
       .filter((pod) => configured.has(pod.sId))
       .sort((a, b) => a.name.localeCompare(b.name))
   );
+}
+
+// Resolves a pod selection to project spaces, admin surfaces only (the
+// caller must have verified the admin role). Ids that do not resolve to a
+// project space in this workspace are silently dropped: these reads back a
+// live comparison view, and a Pod deleted between listing and query should
+// vanish from the comparison, not fail it.
+export async function resolveSandboxAdminPods(
+  auth: Authenticator,
+  selection: SandboxAdminPodSelection
+): Promise<SpaceResource[]> {
+  if (selection.kind === "all-pods") {
+    const projectSpaces = await listNonArchivedProjectSpacesAsAdmin(auth);
+    if (projectSpaces.isErr()) {
+      // Unreachable behind ensureIsAdmin(); throwing surfaces a plumbing bug
+      // as a 500 rather than silently returning no pods.
+      throw projectSpaces.error;
+    }
+    return projectSpaces.value;
+  }
+
+  const spaces = await SpaceResource.fetchByIds(auth, selection.podIds);
+  return spaces.filter((space) => space.isProject());
 }
 
 // One egress-domain add/remove applied across the workspace policy and/or a

--- a/front/lib/resources/sandbox_env_var_resource.ts
+++ b/front/lib/resources/sandbox_env_var_resource.ts
@@ -38,7 +38,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import { randomBytes } from "crypto";
 import type { Attributes, Includeable, Transaction } from "sequelize";
-import { UniqueConstraintError } from "sequelize";
+import { Op, UniqueConstraintError } from "sequelize";
 
 export type DeleteSandboxEnvVarResponseBody = {
   success: true;
@@ -270,6 +270,32 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
     scope: SandboxEnvVarScope
   ): Promise<SandboxEnvVarResource[]> {
     return this.baseFetch(auth, scope);
+  }
+
+  // Multi-pod read for the admin comparison view: one query across the given
+  // pods' scopes instead of one per pod. Values stay encrypted and are never
+  // exposed on this path, so no scope key is involved.
+  static async listForPods(
+    auth: Authenticator,
+    pods: SpaceResource[]
+  ): Promise<SandboxEnvVarResource[]> {
+    if (pods.length === 0) {
+      return [];
+    }
+    for (const pod of pods) {
+      this.assertScope(auth, { kind: "pod", pod });
+    }
+
+    const rows = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: { [Op.in]: pods.map((pod) => pod.id) },
+      },
+      include: USER_JOIN_INCLUDES,
+      order: [["name", "ASC"]],
+    });
+
+    return rows.map((row) => this.fromRow(row));
   }
 
   static async fetchByName(

--- a/front/types/api/sandbox/env_vars.ts
+++ b/front/types/api/sandbox/env_vars.ts
@@ -8,3 +8,8 @@ export type PostSandboxEnvVarsResponseBody = {
   envVar: SandboxEnvVarType;
   created: boolean;
 };
+
+// Flat across the requested pods; each row carries its pod via `spaceId`.
+export type GetSandboxEnvVarsBulkResponseBody = {
+  envVars: SandboxEnvVarType[];
+};


### PR DESCRIPTION
## Description

First PR of the env-var ("Computer API keys") phase — the **read** half of the scope-aware env-var server contract, ported from `central-computer-admin` onto current main. The write half (POST/DELETE) stacks on top in a follow-up; the SWR hooks + UI land with their consumers after that. Reuses the scope scaffolding already on main from the egress work (`SandboxAdminPodSelection`).

- **Bulk GET** `front-api/.../sandbox/env-vars/bulk.ts` — reads the selected Pods' env vars flat (values never returned; write-only invariant). Mounted before `/:id`; inherits the workspace-admin + Computer gates from the sandbox sub-app and is additionally gated on `sandbox_functions`.
- **`admin_pods.ts`** — `resolveSandboxAdminPods` (resolves a Pod selection / `scope=all-pods` to project spaces, admin-only, drops archived/unknown).
- **`sandbox_env_var_resource.ts`** — `listForPods` (one `spaceId IN` query, no N+1).
- **Types** — `GetSandboxEnvVarsBulkResponseBody`.

## Tests

`bulk.test.ts` GET coverage (admin/Computer gates, flat pod read, repeated/unknown `podIds`, `scope=all-pods` excluding archived, scope+podIds validation). Runs in CI (local vitest is gated). `tsc` clean (front + front-api).

## Risk

Very low. Additive read-only route + helpers, no behavior change to existing single-scope env-var paths. Behind admin + Computer + `sandbox_functions` gates. Safe to roll back.

## Deploy Plan

Standard front / front-api deploy. No migration.