### PR TITLE
Move Frames within one mount

### DIFF
--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -422,7 +422,7 @@ async function moveGCSMountFile({
   return new Ok(undefined);
 }
 
-async function emitGCSMountFileMovedAuditLog(
+export async function emitGCSMountFileMovedAuditLog(
   auth: Authenticator,
   scope: GCSMountPoint,
   {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -1,0 +1,350 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const emitMovedAuditLog = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@app/lib/api/files/gcs_mount/files")
+  >()),
+  emitGCSMountFileMovedAuditLog: emitMovedAuditLog,
+}));
+
+vi.mock("@app/lib/lock", async (importActual) => ({
+  ...(await importActual<typeof import("@app/lib/lock")>()),
+  executeWithLockResult: async <T>(_name: string, cb: () => Promise<T>) => cb(),
+}));
+
+import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import assert from "assert";
+
+const manifest = JSON.stringify({ version: 1, name: "Status" });
+
+async function setup() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const sourceMountDirectory = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const sourceObjects = [
+    `${sourceMountDirectory}/${FRAME_MANIFEST_FILE}`,
+    `${sourceMountDirectory}/index.tsx`,
+  ];
+  const objectSizes = new Map<string, string>();
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(manifest),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: {
+      activePublicationId: "publication-1",
+      conversationId: conversation.sId,
+    },
+    mountFilePath: sourceObjects[0],
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+  fileStorageMock.setObject(sourceObjects[0], manifest);
+  fileStorageMock.setObject(sourceObjects[1], "ui source");
+  fileStorageMock.setFileExists(
+    (filePath) => fileStorageMock.getObject(filePath) !== undefined
+  );
+  const listedObjects = [...sourceObjects];
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    listedObjects
+      .filter(
+        (name) =>
+          name.startsWith(prefix) &&
+          fileStorageMock.getObject(name) !== undefined
+      )
+      .map((name) => ({
+        name,
+        metadata: {
+          contentType: "text/plain",
+          size: objectSizes.get(name) ?? "10",
+        },
+      }))
+  );
+  return {
+    auth,
+    conversation,
+    frame,
+    listedObjects,
+    objectSizes,
+    sourceDirectoryPath,
+    sourceMountDirectory,
+    sourceObjects,
+    workspace,
+  };
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  emitMovedAuditLog.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("moveFrameV2Source", () => {
+  it("moves the folder while preserving the Frame identity and publication", async () => {
+    const c = await setup();
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Archive/Renamed`;
+    const destinationMountDirectory = c.sourceMountDirectory.replace(
+      "/Status",
+      "/Archive/Renamed"
+    );
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value).toEqual({
+      destinationDirectoryPath,
+      frameId: c.frame.sId,
+      sourceDeletionFailed: false,
+    });
+    const reloaded = await FileResource.fetchById(c.auth, c.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${destinationMountDirectory}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: c.conversation.sId,
+    });
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBeUndefined();
+    expect(
+      fileStorageMock.getObject(
+        `${destinationMountDirectory}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBe(manifest);
+    expect(emitMovedAuditLog).toHaveBeenCalledOnce();
+  });
+
+  it("rejects cross-mount moves before looking up a Frame", async () => {
+    const c = await setup();
+    const lookup = vi.spyOn(FileResource, "fetchByMountFilePaths");
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath: "pod-pod_123/Status",
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("requires an empty, nonexistent destination", async () => {
+    const c = await setup();
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Taken`;
+    const destinationObject = c.sourceObjects[0].replace("/Status/", "/Taken/");
+    c.listedObjects.push(destinationObject);
+    fileStorageMock.setObject(destinationObject, "occupied");
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    expect((await c.frame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      c.sourceObjects[0]
+    );
+  });
+
+  it("copies hidden, processed, and placeholder objects", async () => {
+    const c = await setup();
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Archive`;
+    const destinationMountDirectory = c.sourceMountDirectory.replace(
+      "/Status",
+      "/Archive"
+    );
+    const additionalObjects = [
+      `${c.sourceMountDirectory}/.cache/state.json`,
+      `${c.sourceMountDirectory}/report.processed.txt`,
+      `${c.sourceMountDirectory}/empty/`,
+    ];
+    for (const objectPath of additionalObjects) {
+      c.listedObjects.push(objectPath);
+      fileStorageMock.setObject(objectPath, objectPath);
+    }
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    for (const objectPath of additionalObjects) {
+      expect(
+        fileStorageMock.getObject(
+          objectPath.replace(c.sourceMountDirectory, destinationMountDirectory)
+        )
+      ).toBe(objectPath);
+    }
+  });
+
+  it("rejects a destination containing only hidden objects", async () => {
+    const c = await setup();
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Taken`;
+    const hiddenDestinationObject = c.sourceObjects[0].replace(
+      "/Status/manifest.json",
+      "/Taken/.cache/state.json"
+    );
+    c.listedObjects.push(hiddenDestinationObject);
+    fileStorageMock.setObject(hiddenDestinationObject, "occupied");
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    expect((await c.frame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      c.sourceObjects[0]
+    );
+  });
+
+  it("counts hidden objects toward the source size limit", async () => {
+    const c = await setup();
+    const oversizedHiddenObject = `${c.sourceMountDirectory}/.cache/large.bin`;
+    c.listedObjects.push(oversizedHiddenObject);
+    c.objectSizes.set(oversizedHiddenObject, String(101 * 1024 * 1024));
+    fileStorageMock.setObject(oversizedHiddenObject, "");
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath: `conversation-${c.conversation.sId}/Oversized`,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect((await c.frame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      c.sourceObjects[0]
+    );
+  });
+
+  it("rejects a source containing a nested registered Frame", async () => {
+    const c = await setup();
+    const nestedManifestPath = `${c.sourceMountDirectory}/Nested/${FRAME_MANIFEST_FILE}`;
+    const nestedFrame = await FileFactory.create(c.auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(manifest),
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: c.conversation.sId },
+      mountFilePath: nestedManifestPath,
+    });
+    await nestedFrame.markFrameV2AsReadyFromMount(c.auth);
+    c.listedObjects.push(nestedManifestPath);
+    fileStorageMock.setObject(nestedManifestPath, manifest);
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath: `conversation-${c.conversation.sId}/ParentMoved`,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    expect((await nestedFrame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      nestedManifestPath
+    );
+    expect((await c.frame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      c.sourceObjects[0]
+    );
+    expect(
+      fileStorageMock.getObject(
+        c.sourceObjects[0].replace("/Status/", "/ParentMoved/")
+      )
+    ).toBeUndefined();
+  });
+
+  it("returns a typed copy failure while the source identity stays authoritative", async () => {
+    const c = await setup();
+    fileStorageMock.setCopyFileFails((source) =>
+      source.endsWith(FRAME_MANIFEST_FILE)
+    );
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath: `conversation-${c.conversation.sId}/CopyFail`,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "copy_failed",
+    });
+    expect((await c.frame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      c.sourceObjects[0]
+    );
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBe(manifest);
+  });
+
+  it("returns a typed commit failure without deleting the source", async () => {
+    const c = await setup();
+    vi.spyOn(FileResource.prototype, "updateMount").mockRejectedValueOnce(
+      new Error("database unavailable")
+    );
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath: `conversation-${c.conversation.sId}/CommitFail`,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "commit_failed",
+    });
+    expect((await c.frame.fetchFreshFrameV2(c.auth))?.mountFilePath).toBe(
+      c.sourceObjects[0]
+    );
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBe(manifest);
+  });
+
+  it("reports source cleanup failure after committing the destination", async () => {
+    const c = await setup();
+    fileStorageMock.setOnDeleteByPrefix(() => {
+      throw new Error("delete failed");
+    });
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Moved`;
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value.sourceDeletionFailed).toBe(true);
+    expect(
+      (await c.frame.fetchFreshFrameV2(c.auth))?.toScopedPath(c.auth)
+    ).toBe(`${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`);
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBe(manifest);
+  });
+});

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -1,0 +1,385 @@
+import path from "node:path";
+
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
+import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { UniqueConstraintError } from "sequelize";
+
+const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
+const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
+const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
+
+type FrameSourceOwner = {
+  useCase: FileUseCase;
+  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
+};
+
+export class FrameSourceMoveError extends Error {
+  constructor(
+    readonly code:
+      | "commit_failed"
+      | "conflict"
+      | "copy_failed"
+      | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceMoveError";
+  }
+}
+
+export function isFrameSourceMoveError(
+  error: unknown
+): error is FrameSourceMoveError {
+  return error instanceof FrameSourceMoveError;
+}
+
+export type MoveFrameV2SourceError = DustFileSystemError | FrameSourceMoveError;
+
+type FrameSourceMove = {
+  destinationDirectoryPath: string;
+  frameId: string;
+  sourceDeletionFailed: boolean;
+};
+
+function moveError(code: FrameSourceMoveError["code"], message: string) {
+  return new Err(new FrameSourceMoveError(code, message));
+}
+
+function sourceOwnerFromPath(path: string): FrameSourceOwner | null {
+  const parsed = parseScopedPrefix(path);
+  const slash = path.indexOf("/");
+  if (!parsed || slash < 0 || slash === path.length - 1) {
+    return null;
+  }
+
+  switch (parsed.kind) {
+    case "conversation":
+      return {
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parsed.id },
+      };
+    case "pod":
+      return {
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: parsed.id },
+      };
+    case "user":
+      return null;
+  }
+}
+
+function isSameOwner(a: FrameSourceOwner, b: FrameSourceOwner): boolean {
+  return (
+    a.useCase === b.useCase &&
+    a.useCaseMetadata.conversationId === b.useCaseMetadata.conversationId &&
+    a.useCaseMetadata.spaceId === b.useCaseMetadata.spaceId
+  );
+}
+
+/**
+ * Move a registered Frames v2 source folder within one GCS mount.
+ *
+ * This intentionally uses a non-transactional copy, DB update, then source delete sequence.
+ * A typed copy/commit failure can leave destination objects behind; until the DB update succeeds,
+ * the source FileResource path remains authoritative. Once committed, source cleanup is best-effort.
+ */
+export async function moveFrameV2Source(
+  auth: Authenticator,
+  {
+    conversation,
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    destinationDirectoryPath: string;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<FrameSourceMove, MoveFrameV2SourceError>> {
+  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  const destination = DustFileSystem.normalizeScopedPath(
+    destinationDirectoryPath
+  );
+  if (!source || !destination) {
+    return moveError(
+      "invalid_source",
+      "Frame source and destination must be scoped paths."
+    );
+  }
+  if (source === destination || destination.startsWith(`${source}/`)) {
+    return moveError(
+      "invalid_source",
+      "Frame source and destination must be different, non-nested folders."
+    );
+  }
+
+  // Reject cross-mount requests before resolving a filesystem or looking up a FileResource.
+  const sourceOwner = sourceOwnerFromPath(source);
+  const destinationOwner = sourceOwnerFromPath(destination);
+  if (
+    !sourceOwner ||
+    !destinationOwner ||
+    !isSameOwner(sourceOwner, destinationOwner)
+  ) {
+    return moveError(
+      "invalid_source",
+      "Frame source and destination must use the same conversation or Pod mount."
+    );
+  }
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [source, destination],
+  });
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return moveError(
+      "invalid_source",
+      "Frames v2 source moves do not support database-backed mounts."
+    );
+  }
+  for (const scopedPath of [source, destination]) {
+    const access = dustFs.checkWriteAccess(scopedPath);
+    if (access.isErr()) {
+      return access;
+    }
+  }
+
+  const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
+  const destinationManifestPath = path.posix.join(
+    destination,
+    FRAME_MANIFEST_FILE
+  );
+  const sourceMountPath = dustFs.toMountFilePath(sourceManifestPath);
+  const destinationMountPath = dustFs.toMountFilePath(destinationManifestPath);
+  if (!sourceMountPath || !destinationMountPath) {
+    return moveError("invalid_source", "Invalid Frame source or destination.");
+  }
+
+  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+    sourceMountPath,
+  ]);
+  if (!frame?.isFrameV2) {
+    return moveError(
+      "invalid_source",
+      `No registered Frame found at ${sourceManifestPath}.`
+    );
+  }
+
+  const locked = await withFramePublishLock<
+    FrameSourceMove,
+    MoveFrameV2SourceError
+  >(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame || freshFrame.toScopedPath(auth) !== sourceManifestPath) {
+      return moveError(
+        "conflict",
+        "The Frame source changed while it was being moved; retry from its current path."
+      );
+    }
+
+    const [registeredDestination] = await FileResource.fetchByMountFilePaths(
+      auth,
+      [destinationMountPath]
+    );
+    if (registeredDestination) {
+      return moveError(
+        "conflict",
+        "A registered file already uses the destination path."
+      );
+    }
+
+    const bucket = getPrivateUploadBucket();
+    const sourceMountPrefix = `${path.posix.dirname(sourceMountPath)}/`;
+    const destinationMountPrefix = `${path.posix.dirname(destinationMountPath)}/`;
+    const destinationExists = await dustFs.exists(destination);
+    if (destinationExists.isErr()) {
+      return destinationExists;
+    }
+    let destinationObjects;
+    try {
+      destinationObjects = await bucket.getFiles({
+        prefix: destinationMountPrefix,
+        maxResults: 1,
+      });
+    } catch (error) {
+      return moveError(
+        "copy_failed",
+        `Failed to inspect the Frame destination; the source remains authoritative: ${normalizeError(error).message}`
+      );
+    }
+    if (destinationExists.value || destinationObjects.length > 0) {
+      return moveError(
+        "conflict",
+        "A file or folder already exists at the destination."
+      );
+    }
+
+    let sourceObjects;
+    try {
+      sourceObjects = await bucket.getFiles({
+        prefix: sourceMountPrefix,
+        maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+      });
+    } catch (error) {
+      return moveError(
+        "copy_failed",
+        `Failed to inspect the Frame source; the source remains authoritative: ${normalizeError(error).message}`
+      );
+    }
+    if (sourceObjects.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+      return moveError(
+        "invalid_source",
+        "Frame source exceeds the move size or file count limit."
+      );
+    }
+    let sourceSizeBytes = 0;
+    for (const sourceObject of sourceObjects) {
+      const sizeBytes = Number(sourceObject.metadata.size);
+      if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+        return moveError(
+          "invalid_source",
+          `Frame source object has invalid size metadata: ${sourceObject.name}`
+        );
+      }
+      sourceSizeBytes += sizeBytes;
+    }
+    if (sourceSizeBytes > MAX_FRAME_SOURCE_BYTES) {
+      return moveError(
+        "invalid_source",
+        "Frame source exceeds the move size or file count limit."
+      );
+    }
+    if (!sourceObjects.some((entry) => entry.name === sourceMountPath)) {
+      return moveError(
+        "invalid_source",
+        `Frame manifest not found in source folder: ${sourceManifestPath}`
+      );
+    }
+    const registeredSourceFiles = await FileResource.fetchByMountFilePaths(
+      auth,
+      sourceObjects.map((entry) => entry.name)
+    );
+    if (registeredSourceFiles.some((file) => file.id !== freshFrame.id)) {
+      return moveError(
+        "conflict",
+        "Move nested registered files separately before moving this Frame."
+      );
+    }
+
+    const copyResults = await concurrentExecutor(
+      sourceObjects,
+      async (entry) => {
+        if (!entry.name.startsWith(sourceMountPrefix)) {
+          return new Err(
+            new Error(`Invalid Frame source object path: ${entry.name}`)
+          );
+        }
+        const relativePath = entry.name.slice(sourceMountPrefix.length);
+        try {
+          await bucket.copyFile(
+            entry.name,
+            `${destinationMountPrefix}${relativePath}`
+          );
+          return new Ok(undefined);
+        } catch (error) {
+          return new Err(normalizeError(error));
+        }
+      },
+      { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+    );
+    const copyFailure = copyResults.find((result) => result.isErr());
+    if (copyFailure?.isErr()) {
+      return moveError(
+        "copy_failed",
+        `Failed to copy the Frame source; the source remains authoritative and partial destination objects may remain: ${copyFailure.error.message}`
+      );
+    }
+
+    try {
+      await freshFrame.updateMount({
+        destFileName: FRAME_MANIFEST_FILE,
+        destMountFilePath: destinationMountPath,
+        destUseCase: freshFrame.useCase,
+        destUseCaseMetadata: freshFrame.useCaseMetadata ?? undefined,
+      });
+    } catch (error) {
+      const normalized = normalizeError(error);
+      return moveError(
+        error instanceof UniqueConstraintError ? "conflict" : "commit_failed",
+        error instanceof UniqueConstraintError
+          ? "A registered file already uses the destination path."
+          : `Failed to commit the Frame source move; the source remains authoritative and destination objects may remain: ${normalized.message}`
+      );
+    }
+
+    let sourceDeletionFailed = false;
+    try {
+      await bucket.deleteByPrefix(sourceMountPrefix);
+    } catch (error) {
+      sourceDeletionFailed = true;
+      logger.warn(
+        {
+          destinationDirectoryPath: destination,
+          error: normalizeError(error),
+          frameId: frame.sId,
+          sourceDirectoryPath: source,
+        },
+        "Frame source moved but the old folder could not be removed"
+      );
+    }
+
+    const destinationScope: GCSMountPoint =
+      destinationOwner.useCase === "conversation"
+        ? {
+            useCase: "conversation",
+            conversationId:
+              destinationOwner.useCaseMetadata.conversationId ?? "",
+          }
+        : {
+            useCase: "pod",
+            podId: destinationOwner.useCaseMetadata.spaceId ?? "",
+          };
+    const scopedPrefix = source.split("/", 1)[0];
+    const parentRelativePath = path.posix.dirname(
+      path.posix.relative(scopedPrefix, destination)
+    );
+    void emitGCSMountFileMovedAuditLog(auth, destinationScope, {
+      relativeFilePath: path.posix.relative(scopedPrefix, source),
+      parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
+    });
+
+    return new Ok({
+      destinationDirectoryPath: destination,
+      frameId: frame.sId,
+      sourceDeletionFailed,
+    });
+  });
+
+  if (locked.isErr()) {
+    return isLockAcquisitionTimeoutError(locked.error)
+      ? moveError(
+          "conflict",
+          "Another Frame operation is in progress; retry the move."
+        )
+      : new Err(locked.error);
+  }
+  return locked;
+}

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -439,6 +439,10 @@ class FileStorageMock {
             new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
           );
         }
+        const content = this._objectStore.get(src) ?? this._contentForPath(src);
+        if (content !== null && content !== undefined) {
+          this._objectStore.set(dest, content);
+        }
         return Promise.resolve(undefined);
       }),
       // Mirrors real GCS compose: concatenates each source's stored content, in order,


### PR DESCRIPTION
## Description

- add the bounded backend operation for moving a registered Frames v2 source folder within the same conversation or Pod mount
- preserve the stable FileResource identity, publication metadata, sharing state, and source ownership metadata
- reject nested registered files and occupied destinations before copying
- raw-list at most 1,024 GCS objects / 100 MiB so hidden, processed, and placeholder objects are included
- copy objects, commit the FileResource path, best-effort delete the source, and emit the existing file.moved audit event

This is deliberately non-crash-safe. It does not include reservations, recovery, generation fencing, rollback, or renewable locks. The HTTP route is split into a child PR.

## Tests

Tested the move operation locally, including hidden objects, placeholders, size bounds, nested registered Frames, copy failures, commit failures, and source cleanup failures.

## Risk

The operation has no production caller until the child HTTP PR merges. Once called, a crash or typed failure can leave partial destination objects. The FileResource path remains authoritative.

## Deploy Plan

Standard deploy. No migration or backfill.