### PR TITLE
Renew long-lived distributed locks

### DIFF
--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -1,0 +1,276 @@
+import type { RedisClientType } from "@app/lib/api/redis";
+import {
+  distributedRefresh,
+  executeWithRenewingLockResult,
+  isLockLeaseLostError,
+} from "@app/lib/lock";
+import { Err, Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+const { getRedisStreamClientMock } = vi.hoisted(() => ({
+  getRedisStreamClientMock: vi.fn<() => Promise<LockRedisClient>>(),
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisStreamClient: getRedisStreamClientMock,
+}));
+
+function makeRedisClient(): LockRedisClient {
+  return {
+    eval: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("renewing locks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes only the lock owned by the caller", async () => {
+    const redisClient = makeRedisClient();
+
+    await expect(
+      distributedRefresh(redisClient, "frame:source:123", "owner-token", 900)
+    ).resolves.toBe(true);
+
+    expect(redisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call("pexpire", KEYS[1], ARGV[2])'),
+      {
+        keys: ["lock:frame:source:123"],
+        arguments: ["owner-token", "900"],
+      }
+    );
+
+    vi.mocked(redisClient.eval).mockResolvedValueOnce(0);
+    await expect(
+      distributedRefresh(redisClient, "frame:source:123", "old-owner", 900)
+    ).resolves.toBe(false);
+  });
+
+  it("measures the initial lease from the start of lock acquisition", async () => {
+    const redisClient = makeRedisClient();
+    let finishAcquisition: (value: string) => void = () => {};
+    const pendingAcquisition = new Promise<string>((resolve) => {
+      finishAcquisition = resolve;
+    });
+    vi.mocked(redisClient.set).mockImplementationOnce(() => pendingAcquisition);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(90);
+    finishAcquisition("OK");
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("does not overlap renewal requests", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+    let finishCallback: () => void = () => {};
+    const callbackDone = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await callbackDone;
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    expect(redisClient.eval).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(redisClient.eval).toHaveBeenCalledTimes(1);
+
+    finishRefresh(1);
+    await vi.advanceTimersByTimeAsync(30);
+    expect(redisClient.eval).toHaveBeenCalledTimes(2);
+    finishCallback();
+    await resultPromise;
+  });
+
+  it("observes an in-flight definitive loss before returning", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+    let finishCallback: () => void = () => {};
+    const callbackDone = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await callbackDone;
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    finishCallback();
+    await vi.advanceTimersByTimeAsync(0);
+    finishRefresh(0);
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("fails the lease after transient refresh errors exhaust its safe lifetime", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval).mockRejectedValue(
+      new Error("redis unavailable")
+    );
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(90);
+        const leaseResult = lease.check();
+        return leaseResult.isErr() ? leaseResult : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("keeps the lease after a transient refresh error recovers", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval)
+      .mockRejectedValueOnce(new Error("redis unavailable"))
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const result = await executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(60);
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    expect(result.isOk() && result.value).toBe("held");
+    expect(
+      vi
+        .mocked(redisClient.eval)
+        .mock.calls.filter(([script]) => String(script).includes("pexpire"))
+    ).toHaveLength(2);
+  });
+
+  it("fails the lease immediately when Redis reports a different owner", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval).mockResolvedValue(0);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Err(new Error("callback failed too"));
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("measures a renewed lease from refresh start, not a delayed response", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const result = await executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(30);
+        await vi.advanceTimersByTimeAsync(60);
+        finishRefresh(1);
+        await vi.advanceTimersByTimeAsync(22);
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("stops renewal before unlocking", async () => {
+    const redisClient = makeRedisClient();
+    const scripts: string[] = [];
+    vi.mocked(redisClient.eval).mockImplementation((...args) => {
+      scripts.push(String(typeof args[0] === "string" ? args[0] : args[1]));
+      return Promise.resolve(1);
+    });
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    await resultPromise;
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(scripts.filter((script) => script.includes("pexpire"))).toHaveLength(
+      1
+    );
+    expect(scripts.at(-1)).toContain('redis.call("del", KEYS[1])');
+  });
+});

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,13 +1,17 @@
 import type { RedisClientType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
 
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
 export async function distributedLock(
-  redisCli: RedisClientType,
+  redisCli: LockRedisClient,
   key: string,
   lockTtlMs: number = 5_000
 ): Promise<string | undefined> {
@@ -30,7 +34,7 @@ export async function distributedLock(
 }
 
 export async function distributedUnlock(
-  redisCli: RedisClientType,
+  redisCli: LockRedisClient,
   key: string,
   lockValue: string
 ): Promise<void> {
@@ -51,7 +55,31 @@ export async function distributedUnlock(
   });
 }
 
+export async function distributedRefresh(
+  redisCli: LockRedisClient,
+  key: string,
+  lockValue: string,
+  lockTtlMs: number
+): Promise<boolean> {
+  const lockKey = `lock:${key}`;
+  const luaScript = `
+    if redis.call("get", KEYS[1]) == ARGV[1] then
+      return redis.call("pexpire", KEYS[1], ARGV[2])
+    else
+      return 0
+    end
+  `;
+  const refreshed = await redisCli.eval(luaScript, {
+    keys: [lockKey],
+    arguments: [lockValue, String(lockTtlMs)],
+  });
+
+  return refreshed === 1;
+}
+
 const DEFAULT_RETRY_INTERVAL_MS = 100;
+const RENEWAL_RETRY_INITIAL_DELAY_MS = 250;
+const RENEWAL_RETRY_MAX_DELAY_MS = 30_000;
 
 export class LockAcquisitionTimeoutError extends Error {
   constructor(readonly lockName: string) {
@@ -64,6 +92,23 @@ export function isLockAcquisitionTimeoutError(
   error: unknown
 ): error is LockAcquisitionTimeoutError {
   return error instanceof LockAcquisitionTimeoutError;
+}
+
+export class LockLeaseLostError extends Error {
+  constructor(readonly lockName: string) {
+    super(`Lock lease lost for ${lockName}`);
+    this.name = "LockLeaseLostError";
+  }
+}
+
+export function isLockLeaseLostError(
+  error: unknown
+): error is LockLeaseLostError {
+  return error instanceof LockLeaseLostError;
+}
+
+export interface LockLeaseGuard {
+  check(): Result<void, LockLeaseLostError>;
 }
 
 type ExecuteWithLockOptions = {
@@ -88,13 +133,18 @@ async function acquireLock(
     retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS,
     traceAcquireResource,
   }: ExecuteWithLockOptions
-): Promise<{ client: RedisClientType; lockValue: string | undefined }> {
+): Promise<{
+  client: RedisClientType;
+  lockAttemptStartedAtMs: number | undefined;
+  lockValue: string | undefined;
+}> {
   const client = await getRedisStreamClient({ origin: "lock" });
 
   const acquire = async (): Promise<string | undefined> => {
     const startMs = Date.now();
     let acquired: string | undefined;
     while (Date.now() - startMs < timeoutMs) {
+      lockAttemptStartedAtMs = performance.now();
       // Try to acquire the lock
       acquired = await distributedLock(client, lockName, lockTtlMs);
       if (acquired) {
@@ -109,6 +159,8 @@ async function acquireLock(
     return acquired;
   };
 
+  let lockAttemptStartedAtMs: number | undefined;
+
   const lockValue = traceAcquireResource
     ? await tracer.trace(
         "lock.acquire",
@@ -117,7 +169,11 @@ async function acquireLock(
       )
     : await acquire();
 
-  return { client, lockValue };
+  return {
+    client,
+    lockAttemptStartedAtMs: lockValue ? lockAttemptStartedAtMs : undefined,
+    lockValue,
+  };
 }
 
 async function runWithAcquiredLock<T>(
@@ -130,6 +186,167 @@ async function runWithAcquiredLock<T>(
     return await callback();
   } finally {
     await distributedUnlock(client, lockName, lockValue);
+  }
+}
+
+function waitForRenewal(
+  delayMs: number,
+  signal: AbortSignal
+): Promise<boolean> {
+  if (signal.aborted) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, delayMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function createLockLeaseGuard(
+  lockName: string,
+  lockTtlMs: number,
+  lockAttemptStartedAtMs: number
+): {
+  guard: LockLeaseGuard;
+  markLost: () => void;
+  markRenewed: (renewedAtMs: number) => void;
+  remainingSafeLifetimeMs: () => number;
+} {
+  const safetyMarginMs = Math.max(1, Math.floor(lockTtlMs / 10));
+  let confirmedUntilMs = lockAttemptStartedAtMs + lockTtlMs - safetyMarginMs;
+  let lost = false;
+  const markLost = () => {
+    lost = true;
+  };
+
+  return {
+    guard: {
+      check: () => {
+        if (lost || performance.now() >= confirmedUntilMs) {
+          markLost();
+          return new Err(new LockLeaseLostError(lockName));
+        }
+        return new Ok(undefined);
+      },
+    },
+    markLost,
+    markRenewed: (renewedAtMs) => {
+      confirmedUntilMs = renewedAtMs + lockTtlMs - safetyMarginMs;
+    },
+    remainingSafeLifetimeMs: () => confirmedUntilMs - performance.now(),
+  };
+}
+
+async function runWithRenewingLockResult<T, E>(
+  client: RedisClientType,
+  lockName: string,
+  lockValue: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>,
+  lockTtlMs: number,
+  lockAttemptStartedAtMs: number
+): Promise<Result<T, E | LockLeaseLostError>> {
+  const renewalIntervalMs = Math.max(1, Math.floor(lockTtlMs / 3));
+  const renewalRetryInitialDelayMs = Math.min(
+    RENEWAL_RETRY_INITIAL_DELAY_MS,
+    renewalIntervalMs
+  );
+  const lease = createLockLeaseGuard(
+    lockName,
+    lockTtlMs,
+    lockAttemptStartedAtMs
+  );
+  const stopController = new AbortController();
+  const renew = async () => {
+    const nextRenewalDelayMs = () =>
+      renewalIntervalMs * (0.8 + Math.random() * 0.2);
+    let waitMs = nextRenewalDelayMs();
+    let retryDelayMs = renewalRetryInitialDelayMs;
+    let lastRefreshError: Error | undefined;
+    while (await waitForRenewal(waitMs, stopController.signal)) {
+      if (lease.guard.check().isErr()) {
+        if (lastRefreshError) {
+          logger.error(
+            { error: lastRefreshError, lockName },
+            "Lost a distributed lock lease after refresh errors"
+          );
+        }
+        return;
+      }
+      try {
+        const refreshStartedAtMs = performance.now();
+        const refreshed = await distributedRefresh(
+          client,
+          lockName,
+          lockValue,
+          lockTtlMs
+        );
+        if (!refreshed) {
+          lease.markLost();
+          logger.warn(
+            { lockName },
+            "Lost a distributed lock lease because its owner changed"
+          );
+          return;
+        }
+        lease.markRenewed(refreshStartedAtMs);
+        if (lastRefreshError) {
+          logger.info({ lockName }, "Recovered distributed lock lease renewal");
+        }
+        lastRefreshError = undefined;
+        retryDelayMs = renewalRetryInitialDelayMs;
+        waitMs = nextRenewalDelayMs();
+      } catch (error) {
+        const refreshError = normalizeError(error);
+        if (!lastRefreshError) {
+          logger.warn(
+            { error: refreshError, lockName },
+            "Failed to refresh a distributed lock lease; retrying"
+          );
+        }
+        lastRefreshError = refreshError;
+        const remainingSafeLifetimeMs = lease.remainingSafeLifetimeMs();
+        if (remainingSafeLifetimeMs <= 0) {
+          lease.markLost();
+          logger.error(
+            { error: refreshError, lockName },
+            "Lost a distributed lock lease after refresh errors"
+          );
+          return;
+        }
+        waitMs = Math.min(retryDelayMs, remainingSafeLifetimeMs);
+        retryDelayMs = Math.min(retryDelayMs * 2, RENEWAL_RETRY_MAX_DELAY_MS);
+      }
+    }
+  };
+  const renewal = renew();
+
+  try {
+    const result = await callback(lease.guard);
+    stopController.abort();
+    await renewal;
+    const held = lease.guard.check();
+    return held.isErr() ? held : result;
+  } finally {
+    stopController.abort();
+    await renewal;
+    try {
+      await distributedUnlock(client, lockName, lockValue);
+    } catch (error) {
+      logger.error(
+        { error: normalizeError(error), lockName },
+        "Failed to unlock a distributed lock after its callback completed"
+      );
+    }
   }
 }
 
@@ -161,4 +378,33 @@ export const executeWithLockResult = async <T, E>(
   }
 
   return runWithAcquiredLock(client, lockName, lockValue, callback);
+};
+
+export const executeWithRenewingLockResult = async <T, E>(
+  lockName: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>,
+  timeoutMs: number = 30_000,
+  options: ExecuteWithLockOptions = {}
+): Promise<Result<T, E | LockAcquisitionTimeoutError | LockLeaseLostError>> => {
+  const { lockTtlMs = 5_000 } = options;
+  const { client, lockAttemptStartedAtMs, lockValue } = await acquireLock(
+    lockName,
+    timeoutMs,
+    options
+  );
+
+  if (!lockValue || lockAttemptStartedAtMs === undefined) {
+    return new Err(new LockAcquisitionTimeoutError(lockName));
+  }
+
+  return runWithRenewingLockResult(
+    client,
+    lockName,
+    lockValue,
+    callback,
+    lockTtlMs,
+    lockAttemptStartedAtMs
+  );
 };


### PR DESCRIPTION
## Description

Add owner-token-based lease renewal to the shared Redis lock abstraction. Renewal extends only the caller-owned lock, tracks a conservative monotonic deadline, retries bounded transient refresh failures, and exposes a guard that fails when ownership can no longer be proven.

This PR contains only generic lock infrastructure. Frame adoption is a separate hardening tip.

## Tests

- focused shared lock tests
- Front typecheck
- Biome and pre-commit checks
- exact final tree previously passed the full Front CI suite

## Risk

Low. Existing non-renewing lock callers retain their current behavior. Renewal is opt-in.

## Deploy Plan

Deploy normally. No migration or backfill.