### PR TITLE
Move Frames across same-runtime mounts

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,8 +9,9 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FramePublishRequest, FramePublishResponse,
-    FrameRegisterRequest, FrameRegisterResponse, MCPServerView, SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FrameMoveRequest, FrameMoveResponse, FramePublishRequest,
+    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, MCPServerView,
+    SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -151,6 +152,22 @@ impl DustApiClient {
         self.post(
             "sandbox/frames/register",
             &FrameRegisterRequest { manifest_path },
+        )
+        .await
+    }
+
+    pub async fn move_frame(
+        &self,
+        source_directory_path: &str,
+        destination_directory_path: &str,
+    ) -> anyhow::Result<FrameMoveResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/move",
+            &FrameMoveRequest {
+                source_directory_path,
+                destination_directory_path,
+            },
+            POLL_MAX_DURATION,
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -15,6 +15,13 @@ pub struct FrameRegisterRequest<'a> {
     pub manifest_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMoveRequest<'a> {
+    pub source_directory_path: &'a str,
+    pub destination_directory_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -32,6 +39,14 @@ pub struct FrameRegisterResponse {
     pub frame_id: String,
     pub manifest_path: String,
     pub created: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMoveResponse {
+    pub frame_id: String,
+    pub destination_directory_path: String,
+    pub source_deletion_failed: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,4 +1,5 @@
 mod create;
+mod move_frame;
 mod publish;
 mod register;
 
@@ -8,6 +9,7 @@ use anyhow::{bail, Context};
 use clap::Subcommand;
 
 pub use create::run as cmd_frame_create;
+pub use move_frame::run as cmd_frame_move;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
 
@@ -30,6 +32,13 @@ pub enum FrameCommand {
     Register {
         /// Absolute /files/.../manifest.json path
         manifest: PathBuf,
+    },
+    /// Move a registered Frame folder while preserving its identity and state
+    Move {
+        /// Existing Frame folder under /files
+        source: PathBuf,
+        /// New Frame folder path under /files
+        destination: PathBuf,
     },
     /// Build and publish a Frame from its current source
     Publish {

--- a/cli/dust-sandbox/src/commands/frame/move_frame.rs
+++ b/cli/dust-sandbox/src/commands/frame/move_frame.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_path};
+
+pub async fn run(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(source)?;
+    let destination_directory_path = scoped_path(destination)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .move_frame(&source_directory_path, &destination_directory_path)
+        .await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
-pub use frame::{cmd_frame_create, cmd_frame_publish, cmd_frame_register};
+pub use frame::{cmd_frame_create, cmd_frame_move, cmd_frame_publish, cmd_frame_register};
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -139,6 +139,10 @@ async fn run() -> anyhow::Result<()> {
             commands::frame::FrameCommand::Register { manifest } => {
                 commands::cmd_frame_register(&manifest).await?
             }
+            commands::frame::FrameCommand::Move {
+                source,
+                destination,
+            } => commands::cmd_frame_move(&source, &destination).await?,
             commands::frame::FrameCommand::Publish { source } => {
                 commands::cmd_frame_publish(&source).await?
             }
@@ -490,6 +494,38 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected publish"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_move_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "move",
+            "/files/conversation-conv_123/Status",
+            "/files/pod-vlt_123/Status",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Move {
+                        source,
+                        destination,
+                    },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+                assert_eq!(
+                    destination,
+                    std::path::PathBuf::from("/files/pod-vlt_123/Status")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected move"),
             _ => panic!("expected frame"),
         }
     }

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -58,6 +58,22 @@ function requestFrameRegister(
   });
 }
 
+function requestFrameMove(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string,
+  destinationDirectoryPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/move`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourceDirectoryPath, destinationDirectoryPath }),
+  });
+}
+
 async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -82,18 +98,24 @@ async function setup({ registered = true }: { registered?: boolean } = {}) {
     [`${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifest],
     [`${mountDirectoryPath}/index.tsx`, uiSource],
   ]);
+  for (const [filePath, content] of sourceByPath) {
+    fileStorageMock.setObject(filePath, content);
+  }
   fileStorageMock.setFileContent((path) => sourceByPath.get(path) ?? null);
   fileStorageMock.setFilesByPrefix((prefix) =>
     prefix === `${mountDirectoryPath}/`
-      ? [...sourceByPath.entries()].map(([name, content]) => ({
-          name,
-          metadata: {
-            contentType: name.endsWith(".tsx")
-              ? "text/typescript"
-              : "application/json",
-            size: String(Buffer.byteLength(content)),
-          },
-        }))
+      ? [...sourceByPath.entries()]
+          .filter(([name]) => fileStorageMock.getObject(name) !== undefined)
+          .map(([name, content], index) => ({
+            name,
+            metadata: {
+              contentType: name.endsWith(".tsx")
+                ? "text/typescript"
+                : "application/json",
+              generation: String(index + 1),
+              size: String(Buffer.byteLength(content)),
+            },
+          }))
       : null
   );
 
@@ -183,6 +205,52 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.useCaseMetadata?.activePublicationId).toBe(
       published.publicationId
     );
+  });
+
+  it("moves a registered Frame folder while preserving its identity", async () => {
+    const context = await setup();
+    assert(context.frame);
+    fileStorageMock.setFileExists(() => false);
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const destinationDirectoryPath = sourceDirectoryPath.replace(
+      "/Status",
+      "/Renamed"
+    );
+
+    const response = await requestFrameMove(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      destinationDirectoryPath
+    );
+
+    const moved = await response.json();
+    expect(response.status, JSON.stringify(moved)).toBe(200);
+    expect(moved).toEqual({
+      destinationDirectoryPath,
+      frameId: context.frame.sId,
+      sourceDeletionFailed: false,
+    });
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.toScopedPath(context.auth)).toBe(
+      `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+  });
+
+  it("refuses Frame moves without the feature flag", async () => {
+    const context = await createSandboxTokenTestContext();
+
+    const response = await requestFrameMove(
+      context.workspace.sId,
+      context.token,
+      `conversation-${context.conversation.sId}/Status`,
+      `conversation-${context.conversation.sId}/Renamed`
+    );
+
+    expect(response.status).toBe(403);
   });
 
   it("publishes a legacy Frame through its existing publication flow", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -16,7 +16,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
+import move from "./move";
 import register from "./register";
 
 const FramePublishRequestSchema = z.object({
@@ -69,6 +69,7 @@ function frameErrorStatus(error: PublishFrameFromSourceError): 400 | 403 | 500 {
 const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
+app.route("/move", move);
 app.route("/register", register);
 
 /**

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/move.ts
@@ -1,0 +1,115 @@
+import {
+  isFrameSourceMoveError,
+  type MoveFrameV2SourceError,
+  moveFrameV2Source,
+} from "@app/lib/api/frames/move_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameMoveRequestSchema = z.object({
+  destinationDirectoryPath: z.string().min(1),
+  sourceDirectoryPath: z.string().min(1),
+});
+
+type FrameMoveResponse = {
+  destinationDirectoryPath: string;
+  frameId: string;
+  sourceDeletionFailed: boolean;
+};
+
+function frameMoveErrorStatus(error: MoveFrameV2SourceError): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFrameSourceMoveError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (error instanceof SandboxFunctionError) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  return 500;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameMoveRequestSchema),
+  async (ctx): HandlerResult<FrameMoveResponse> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot move Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { destinationDirectoryPath, sourceDirectoryPath } =
+      ctx.req.valid("json");
+    const moved = await moveFrameV2Source(auth, {
+      conversation: conversation.toJSON(),
+      destinationDirectoryPath,
+      sourceDirectoryPath,
+    });
+    if (moved.isErr()) {
+      const status = frameMoveErrorStatus(moved.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: moved.error.message,
+          },
+        },
+        moved.error
+      );
+    }
+
+    return ctx.json(moved.value, 200);
+  }
+);
+
+export default app;

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -422,7 +422,7 @@ async function moveGCSMountFile({
   return new Ok(undefined);
 }
 
-async function emitGCSMountFileMovedAuditLog(
+export async function emitGCSMountFileMovedAuditLog(
   auth: Authenticator,
   scope: GCSMountPoint,
   {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -2,6 +2,19 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { emitGCSMountFileMovedAuditLogMock } = vi.hoisted(() => ({
+  emitGCSMountFileMovedAuditLogMock: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/files/gcs_mount/files")>();
+  return {
+    ...actual,
+    emitGCSMountFileMovedAuditLog: emitGCSMountFileMovedAuditLogMock,
+  };
+});
+
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
   return {
@@ -27,6 +40,7 @@ const manifest = JSON.stringify({
   name: "Status",
   description: "Show the current status.",
 });
+const moveIdMetadataKey = "dust_frame_source_move_id";
 
 async function setup() {
   const { authenticator: auth, workspace } = await createResourceTest({
@@ -97,6 +111,7 @@ async function setup() {
 
 beforeEach(() => {
   fileStorageMock.reset();
+  emitGCSMountFileMovedAuditLogMock.mockClear();
   vi.restoreAllMocks();
 });
 
@@ -104,7 +119,7 @@ describe("moveFrameV2Source", () => {
   it("moves within one scope without replacing identity, publication, or sharing", async () => {
     const context = await setup();
     const beforeShare = await context.frame.getShareInfo();
-    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Renamed`;
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Archive/Renamed`;
 
     const moved = await moveFrameV2Source(context.auth, {
       conversation: context.conversation,
@@ -130,13 +145,24 @@ describe("moveFrameV2Source", () => {
       `${getConversationFilesBasePath({
         workspaceId: context.workspace.sId,
         conversationId: context.conversation.sId,
-      })}Renamed/${FRAME_MANIFEST_FILE}`
+      })}Archive/Renamed/${FRAME_MANIFEST_FILE}`
     );
     expect(reloaded?.useCaseMetadata).toEqual({
       activePublicationId: "publication-1",
       conversationId: context.conversation.sId,
     });
     await expect(reloaded?.getShareInfo()).resolves.toEqual(beforeShare);
+    expect(emitGCSMountFileMovedAuditLogMock).toHaveBeenCalledWith(
+      context.auth,
+      {
+        conversationId: context.conversation.sId,
+        useCase: "conversation",
+      },
+      {
+        parentRelativePath: "Archive",
+        relativeFilePath: "Status",
+      }
+    );
   });
 
   it("does not move a registered Frame whose source manifest is missing", async () => {
@@ -198,6 +224,68 @@ describe("moveFrameV2Source", () => {
       `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
     );
   });
+
+  it("moves within another conversation when the caller can access its mount", async () => {
+    const context = await setup();
+    const otherConversation = await ConversationFactory.create(context.auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const otherSourceDirectoryPath = `conversation-${otherConversation.sId}/Status`;
+    const otherSourceGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: otherConversation.sId,
+    })}Status`;
+    const otherSourceManifestPath = `${otherSourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const otherSourceUiPath = `${otherSourceGcsDirectoryPath}/index.tsx`;
+    const otherFrame = await FileFactory.create(context.auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(manifest),
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: otherConversation.sId },
+      mountFilePath: otherSourceManifestPath,
+    });
+    await otherFrame.markFrameV2AsReadyFromMount(context.auth);
+    fileStorageMock.setObject(otherSourceManifestPath, manifest);
+    fileStorageMock.setObject(otherSourceUiPath, "ui source");
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix === `${otherSourceGcsDirectoryPath}/`
+        ? [
+            {
+              name: otherSourceManifestPath,
+              metadata: {
+                contentType: frameV2ContentType,
+                generation: "3",
+                size: String(Buffer.byteLength(manifest)),
+              },
+            },
+            {
+              name: otherSourceUiPath,
+              metadata: {
+                contentType: "text/typescript",
+                generation: "4",
+                size: "9",
+              },
+            },
+          ].filter(({ name }) => fileStorageMock.getObject(name) !== undefined)
+        : null
+    );
+    const destinationDirectoryPath = `conversation-${otherConversation.sId}/Renamed`;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: otherSourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value).toMatchObject({
+      destinationDirectoryPath,
+      frameId: otherFrame.sId,
+    });
+  });
   it("does not overwrite a destination object created during the move", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/Collision`;
@@ -249,7 +337,15 @@ describe("moveFrameV2Source", () => {
     );
   });
 
-  it("does not adopt a matching destination object created during the move", async () => {
+  it.each([
+    { label: "missing", metadata: undefined },
+    {
+      label: "different",
+      metadata: { [moveIdMetadataKey]: "another-operation" },
+    },
+  ])("does not adopt same-byte destination objects with a $label ownership marker", async ({
+    metadata,
+  }) => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/MatchingCollision`;
     const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
@@ -257,13 +353,14 @@ describe("moveFrameV2Source", () => {
       conversationId: context.conversation.sId,
     })}MatchingCollision`;
     const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
-    fileStorageMock.setObject(destinationManifestPath, manifest);
+    fileStorageMock.setObject(destinationManifestPath, manifest, metadata);
     fileStorageMock.setFileMetadata((filePath) =>
       filePath === destinationManifestPath
         ? {
             contentType: frameV2ContentType,
             generation: "3",
             md5Hash: "manifest",
+            metadata,
             size: String(Buffer.byteLength(manifest)),
           }
         : null
@@ -280,6 +377,37 @@ describe("moveFrameV2Source", () => {
     expect(fileStorageMock.deleteCalls).not.toContainEqual(
       expect.objectContaining({ filePath: destinationManifestPath })
     );
+  });
+
+  it("claims a marker-owned generation after a committed copy response is lost", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Ambiguous`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Ambiguous`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    let lostResponse = false;
+    fileStorageMock.setCopyFileCommitsThenFails(
+      (_sourcePath, destinationPath) => {
+        if (!lostResponse && destinationPath === destinationManifestPath) {
+          lostResponse = true;
+          return true;
+        }
+        return false;
+      }
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(lostResponse).toBe(true);
+    expect(fileStorageMock.metadataCalls).toContain(destinationManifestPath);
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
   });
 
   it("does not move over a destination-only object created during the move", async () => {
@@ -495,6 +623,7 @@ describe("moveFrameV2Source", () => {
     expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
     expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toEqual({
       destinationMountFilePath,
+      operationId: expect.stringMatching(/^[0-9a-f-]{36}$/),
       sourceMountFilePath: `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
     });
     expect(fileStorageMock.deleteCalls).toEqual(
@@ -528,11 +657,14 @@ describe("moveFrameV2Source", () => {
         conversationId: context.conversation.sId,
         pendingFrameSourceMove: {
           destinationMountFilePath,
+          operationId: "move-recovery",
           sourceMountFilePath,
         },
       },
     });
-    fileStorageMock.setObject(destinationManifestPath, manifest);
+    fileStorageMock.setObject(destinationManifestPath, manifest, {
+      [moveIdMetadataKey]: "move-recovery",
+    });
     fileStorageMock.setFilesByPrefix((prefix) => {
       if (prefix === `${context.sourceGcsDirectoryPath}/`) {
         return [
@@ -564,10 +696,11 @@ describe("moveFrameV2Source", () => {
               contentType: frameV2ContentType,
               generation: "3",
               md5Hash: "manifest",
+              metadata: { [moveIdMetadataKey]: "move-recovery" },
               size: String(Buffer.byteLength(manifest)),
             },
           },
-        ];
+        ].filter(({ name }) => fileStorageMock.getObject(name) !== undefined);
       }
       return null;
     });
@@ -592,9 +725,12 @@ describe("moveFrameV2Source", () => {
     });
 
     expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
-    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
-    expect(fileStorageMock.deleteCalls).not.toContainEqual(
-      expect.objectContaining({ filePath: destinationManifestPath })
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
+    expect(fileStorageMock.deleteCalls).toContainEqual(
+      expect.objectContaining({
+        filePath: destinationManifestPath,
+        options: { ifGenerationMatch: "3", ignoreNotFound: true },
+      })
     );
 
     const reserved = await FileResource.fetchById(
@@ -604,6 +740,7 @@ describe("moveFrameV2Source", () => {
     expect(reserved?.mountFilePath).toBe(destinationMountFilePath);
     expect(reserved?.useCaseMetadata?.pendingFrameSourceMove).toEqual({
       destinationMountFilePath,
+      operationId: "move-recovery",
       sourceMountFilePath,
     });
 
@@ -641,10 +778,19 @@ describe("moveFrameV2Source", () => {
         conversationId: context.conversation.sId,
         pendingFrameSourceMove: {
           destinationMountFilePath,
+          operationId: "move-interrupted",
           sourceMountFilePath,
         },
       },
     });
+    fileStorageMock.setObject(destinationMountFilePath, manifest, {
+      [moveIdMetadataKey]: "move-interrupted",
+    });
+    fileStorageMock.setObject(
+      `${destinationGcsDirectoryPath}/index.tsx`,
+      "ui source",
+      { [moveIdMetadataKey]: "move-interrupted" }
+    );
     fileStorageMock.setFilesByPrefix((prefix) => {
       const isSource = prefix === `${context.sourceGcsDirectoryPath}/`;
       const isDestination = prefix === `${destinationGcsDirectoryPath}/`;
@@ -659,8 +805,11 @@ describe("moveFrameV2Source", () => {
           name: `${directoryPath}/${FRAME_MANIFEST_FILE}`,
           metadata: {
             contentType: frameV2ContentType,
-            generation: isSource ? "1" : "2",
+            generation: isSource ? "1" : "3",
             md5Hash: "manifest",
+            metadata: isSource
+              ? undefined
+              : { [moveIdMetadataKey]: "move-interrupted" },
             size: String(Buffer.byteLength(manifest)),
           },
         },
@@ -668,8 +817,11 @@ describe("moveFrameV2Source", () => {
           name: `${directoryPath}/index.tsx`,
           metadata: {
             contentType: "text/typescript",
-            generation: "2",
+            generation: isSource ? "2" : "4",
             md5Hash: "ui",
+            metadata: isSource
+              ? undefined
+              : { [moveIdMetadataKey]: "move-interrupted" },
             size: "1",
           },
         },

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -1,0 +1,712 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    executeWithLock: async <T>(_key: string, callback: () => Promise<T>) =>
+      callback(),
+  };
+});
+
+import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import assert from "assert";
+
+const manifest = JSON.stringify({
+  version: 1,
+  name: "Status",
+  description: "Show the current status.",
+});
+
+async function setup() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(manifest),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: {
+      activePublicationId: "publication-1",
+      conversationId: conversation.sId,
+    },
+    mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+
+  const sourceManifestPath = `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+  const sourceUiPath = `${sourceGcsDirectoryPath}/index.tsx`;
+  fileStorageMock.setObject(sourceManifestPath, manifest);
+  fileStorageMock.setObject(sourceUiPath, "ui source");
+  fileStorageMock.setFileExists(() => false);
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    prefix === `${sourceGcsDirectoryPath}/`
+      ? [
+          {
+            name: sourceManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: sourceUiPath,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ].filter(({ name }) => fileStorageMock.getObject(name) !== undefined)
+      : null
+  );
+
+  return {
+    auth,
+    conversation,
+    frame,
+    sourceDirectoryPath,
+    sourceGcsDirectoryPath,
+    workspace,
+  };
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  vi.restoreAllMocks();
+});
+
+describe("moveFrameV2Source", () => {
+  it("moves within one scope without replacing identity, publication, or sharing", async () => {
+    const context = await setup();
+    const beforeShare = await context.frame.getShareInfo();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Renamed`;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value).toEqual({
+      destinationDirectoryPath,
+      frameId: context.frame.sId,
+      sourceDeletionFailed: false,
+    });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded).toMatchObject({
+      sId: context.frame.sId,
+      useCase: "conversation",
+    });
+    expect(reloaded?.mountFilePath).toBe(
+      `${getConversationFilesBasePath({
+        workspaceId: context.workspace.sId,
+        conversationId: context.conversation.sId,
+      })}Renamed/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: context.conversation.sId,
+    });
+    await expect(reloaded?.getShareInfo()).resolves.toEqual(beforeShare);
+  });
+
+  it("does not move a registered Frame whose source manifest is missing", async () => {
+    const context = await setup();
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix === `${context.sourceGcsDirectoryPath}/`
+        ? [
+            {
+              name: sourceUiPath,
+              metadata: {
+                contentType: "text/typescript",
+                generation: "2",
+                md5Hash: "ui",
+                size: "1",
+              },
+            },
+          ]
+        : null
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `conversation-${context.conversation.sId}/MissingManifest`,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+  });
+
+  it("rejects cross-mount moves before looking up a Frame", async () => {
+    const context = await setup();
+    const fetchFrames = vi.spyOn(FileResource, "fetchByMountFilePaths");
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: "pod-pod_123/Status",
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(fetchFrames).not.toHaveBeenCalled();
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+  });
+  it("does not overwrite a destination object created during the move", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Collision`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Collision`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setObject(destinationManifestPath, "raw destination");
+    fileStorageMock.setFileMetadata((filePath) =>
+      filePath === destinationManifestPath
+        ? {
+            contentType: frameV2ContentType,
+            generation: "1",
+            md5Hash: "raw",
+            size: "15",
+          }
+        : null
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(
+      "raw destination"
+    );
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
+    );
+    expect(fileStorageMock.deleteCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          options: expect.objectContaining({
+            ifGenerationMatch: expect.any(String),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("does not adopt a matching destination object created during the move", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/MatchingCollision`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}MatchingCollision`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setObject(destinationManifestPath, manifest);
+    fileStorageMock.setFileMetadata((filePath) =>
+      filePath === destinationManifestPath
+        ? {
+            contentType: frameV2ContentType,
+            generation: "3",
+            md5Hash: "manifest",
+            size: String(Buffer.byteLength(manifest)),
+          }
+        : null
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
+    );
+  });
+
+  it("does not move over a destination-only object created during the move", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/UnexpectedCollision`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}UnexpectedCollision`;
+    const destinationExtraPath = `${destinationGcsDirectoryPath}/extra.ts`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    let destinationListings = 0;
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix === `${context.sourceGcsDirectoryPath}/`) {
+        return [
+          {
+            name: sourceManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: sourceUiPath,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ];
+      }
+      if (prefix === `${destinationGcsDirectoryPath}/`) {
+        destinationListings++;
+        return destinationListings === 1
+          ? []
+          : [
+              {
+                name: destinationExtraPath,
+                metadata: {
+                  contentType: "text/typescript",
+                  generation: "3",
+                  md5Hash: "extra",
+                  size: "1",
+                },
+              },
+            ];
+      }
+      return null;
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationExtraPath })
+    );
+  });
+
+  it("copies pinned source generations and preserves concurrent edits", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Edited`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Edited`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    const newSourcePath = `${context.sourceGcsDirectoryPath}/new.ts`;
+    let sourceListings = 0;
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix !== `${context.sourceGcsDirectoryPath}/`) {
+        return null;
+      }
+      sourceListings++;
+      if (sourceListings === 1) {
+        const snapshot = [
+          {
+            name: sourceManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: sourceUiPath,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ];
+        fileStorageMock.setObject(sourceUiPath, "edited ui");
+        fileStorageMock.setObject(newSourcePath, "new source");
+        return snapshot;
+      }
+      return [sourceManifestPath, sourceUiPath, newSourcePath]
+        .filter((filePath) => fileStorageMock.getObject(filePath) !== undefined)
+        .map((filePath) => ({ name: filePath, metadata: {} }));
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value.sourceDeletionFailed).toBe(true);
+    expect(
+      fileStorageMock.getObject(`${destinationGcsDirectoryPath}/index.tsx`)
+    ).toBe("ui source");
+    expect(fileStorageMock.getObject(sourceUiPath)).toBe("edited ui");
+    expect(fileStorageMock.getObject(newSourcePath)).toBe("new source");
+    expect(fileStorageMock.getObject(sourceManifestPath)).toBeUndefined();
+  });
+
+  it("does not delete a destination generation overwritten after copy", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Overwritten`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Overwritten`;
+    const destinationUiPath = `${destinationGcsDirectoryPath}/index.tsx`;
+    fileStorageMock.setAfterCopyFile((_sourcePath, destinationPath) => {
+      if (destinationPath === destinationUiPath) {
+        fileStorageMock.setObject(
+          destinationPath,
+          "concurrent destination edit"
+        );
+      }
+    });
+    const updateMount = FileResource.prototype.updateMount;
+    let updateMountCalls = 0;
+    vi.spyOn(FileResource.prototype, "updateMount").mockImplementation(
+      function (this: FileResource, args) {
+        updateMountCalls++;
+        if (updateMountCalls === 2) {
+          return Promise.reject(
+            new Error("Simulated final Frame update failure")
+          );
+        }
+        return updateMount.call(this, args);
+      }
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    expect(fileStorageMock.getObject(destinationUiPath)).toBe(
+      "concurrent destination edit"
+    );
+    expect(fileStorageMock.deleteCalls).toContainEqual(
+      expect.objectContaining({
+        filePath: destinationUiPath,
+        options: expect.objectContaining({
+          ifGenerationMatch: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it("keeps the recovery reservation when exact-generation cleanup fails", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Retry`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Retry`;
+    const destinationMountFilePath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    fileStorageMock.setCopyFileFails((sourcePath) =>
+      sourcePath.endsWith(`/${FRAME_MANIFEST_FILE}`)
+    );
+    fileStorageMock.setDeleteFails((filePath) =>
+      filePath.endsWith("/index.tsx")
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toEqual({
+      destinationMountFilePath,
+      sourceMountFilePath: `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    expect(fileStorageMock.deleteCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filePath: `${destinationGcsDirectoryPath}/index.tsx`,
+          options: expect.objectContaining({
+            ifGenerationMatch: expect.any(String),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("keeps matching recovery objects reserved until a retry succeeds", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/RecoveryRollback`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}RecoveryRollback`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const destinationMountFilePath = destinationManifestPath;
+    const sourceMountFilePath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    await context.frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: destinationMountFilePath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: {
+        activePublicationId: "publication-1",
+        conversationId: context.conversation.sId,
+        pendingFrameSourceMove: {
+          destinationMountFilePath,
+          sourceMountFilePath,
+        },
+      },
+    });
+    fileStorageMock.setObject(destinationManifestPath, manifest);
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix === `${context.sourceGcsDirectoryPath}/`) {
+        return [
+          {
+            name: sourceMountFilePath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "1",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: `${context.sourceGcsDirectoryPath}/index.tsx`,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ].filter(({ name }) => fileStorageMock.getObject(name) !== undefined);
+      }
+      if (prefix === `${destinationGcsDirectoryPath}/`) {
+        return [
+          {
+            name: destinationManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              generation: "3",
+              md5Hash: "manifest",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+        ];
+      }
+      return null;
+    });
+    const updateMount = FileResource.prototype.updateMount;
+    let updateMountCalls = 0;
+    vi.spyOn(FileResource.prototype, "updateMount").mockImplementation(
+      function (this: FileResource, args) {
+        updateMountCalls++;
+        if (updateMountCalls === 1) {
+          return Promise.reject(
+            new Error("Simulated final Frame update failure")
+          );
+        }
+        return updateMount.call(this, args);
+      }
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
+    );
+
+    const reserved = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reserved?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reserved?.useCaseMetadata?.pendingFrameSourceMove).toEqual({
+      destinationMountFilePath,
+      sourceMountFilePath,
+    });
+
+    const retried = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(retried.isOk(), retried.isErr() ? retried.error.message : undefined);
+    expect(retried.value.sourceDeletionFailed).toBe(false);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
+  });
+
+  it("resumes an interrupted move from its destination reservation", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Recovered`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Recovered`;
+    const destinationMountFilePath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceMountFilePath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    await context.frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: destinationMountFilePath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: {
+        activePublicationId: "publication-1",
+        conversationId: context.conversation.sId,
+        pendingFrameSourceMove: {
+          destinationMountFilePath,
+          sourceMountFilePath,
+        },
+      },
+    });
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      const isSource = prefix === `${context.sourceGcsDirectoryPath}/`;
+      const isDestination = prefix === `${destinationGcsDirectoryPath}/`;
+      if (!isSource && !isDestination) {
+        return null;
+      }
+      const directoryPath = isSource
+        ? context.sourceGcsDirectoryPath
+        : destinationGcsDirectoryPath;
+      return [
+        {
+          name: `${directoryPath}/${FRAME_MANIFEST_FILE}`,
+          metadata: {
+            contentType: frameV2ContentType,
+            generation: isSource ? "1" : "2",
+            md5Hash: "manifest",
+            size: String(Buffer.byteLength(manifest)),
+          },
+        },
+        {
+          name: `${directoryPath}/index.tsx`,
+          metadata: {
+            contentType: "text/typescript",
+            generation: "2",
+            md5Hash: "ui",
+            size: "1",
+          },
+        },
+      ].filter(
+        ({ name }) => !isSource || fileStorageMock.getObject(name) !== undefined
+      );
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: context.conversation.sId,
+    });
+  });
+
+  it("rejects moving a Frame inside its own source folder", async () => {
+    const context = await setup();
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `${context.sourceDirectoryPath}/Nested`,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+});

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -2,12 +2,22 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { emitGCSMountFileMovedAuditLogMock, lockLeaseCheckMock } = vi.hoisted(
-  () => ({
+const {
+  emitGCSMountFileMovedAuditLogMock,
+  lockLeaseCheckMock,
+  sandboxLifecycleAfterCallbackMock,
+  sandboxLifecycleBeforeCallbackMock,
+  sandboxLifecycleLockTails,
+} = vi.hoisted(() => {
+  const sandboxLifecycleLockTails = new Map<string, Promise<void>>();
+  return {
     emitGCSMountFileMovedAuditLogMock: vi.fn(),
     lockLeaseCheckMock: vi.fn(),
-  })
-);
+    sandboxLifecycleAfterCallbackMock: vi.fn(),
+    sandboxLifecycleBeforeCallbackMock: vi.fn(),
+    sandboxLifecycleLockTails,
+  };
+});
 
 vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => {
   const actual =
@@ -21,9 +31,33 @@ vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => {
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
   const executeImmediately = async <T>(
-    _key: string,
+    key: string,
     callback: () => Promise<T>
-  ) => callback();
+  ) => {
+    if (!key.startsWith("sandbox:lifecycle:")) {
+      return callback();
+    }
+
+    const previous = sandboxLifecycleLockTails.get(key) ?? Promise.resolve();
+    let release: () => void = () => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    sandboxLifecycleLockTails.set(key, tail);
+    await previous;
+    try {
+      await sandboxLifecycleBeforeCallbackMock(key);
+      const result = await callback();
+      await sandboxLifecycleAfterCallbackMock(key);
+      return result;
+    } finally {
+      release();
+      if (sandboxLifecycleLockTails.get(key) === tail) {
+        sandboxLifecycleLockTails.delete(key);
+      }
+    }
+  };
   const executeRenewingImmediately = async <T>(
     _key: string,
     callback: (lease: {
@@ -46,6 +80,7 @@ vi.mock("@app/lib/lock", async (importActual) => {
 import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
 import { Authenticator } from "@app/lib/auth";
 import { LockLeaseLostError } from "@app/lib/lock";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -181,6 +216,11 @@ async function setup({
 
 beforeEach(() => {
   fileStorageMock.reset();
+  sandboxLifecycleLockTails.clear();
+  sandboxLifecycleBeforeCallbackMock.mockReset();
+  sandboxLifecycleBeforeCallbackMock.mockResolvedValue(undefined);
+  sandboxLifecycleAfterCallbackMock.mockReset();
+  sandboxLifecycleAfterCallbackMock.mockResolvedValue(undefined);
   emitGCSMountFileMovedAuditLogMock.mockClear();
   vi.restoreAllMocks();
   leaseCheckCount = 0;
@@ -380,6 +420,103 @@ describe("moveFrameV2Source", () => {
       context.auth,
       { useCase: "pod", podId: context.runtimeSpace.sId },
       { parentRelativePath: "", relativeFilePath: "Status" }
+    );
+  });
+
+  it("serializes conversation scope changes with final eligibility and update", async () => {
+    const context = await setup({ withRuntimePod: true });
+    assert(context.runtimeSpace);
+    const nextRuntimeSpace = await SpaceFactory.project(
+      context.workspace,
+      context.user.id
+    );
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      context.user.sId,
+      context.workspace.sId
+    );
+    assert(auth);
+    const destinationDirectoryPath = `pod-${context.runtimeSpace.sId}/Status`;
+    const destinationGcsDirectoryPath = `${getPodFilesBasePath({
+      workspaceId: context.workspace.sId,
+      podId: context.runtimeSpace.sId,
+    })}Status`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+
+    let releaseTransition: () => void = () => undefined;
+    const allowTransition = new Promise<void>((resolve) => {
+      releaseTransition = resolve;
+    });
+    let markTransitionEntered: () => void = () => undefined;
+    const transitionEntered = new Promise<void>((resolve) => {
+      markTransitionEntered = resolve;
+    });
+    const transition = ConversationSandboxAdapter.withScopeTransition(
+      auth,
+      context.conversation,
+      {
+        prepare: async () => {
+          markTransitionEntered();
+          await allowTransition;
+          return new Ok(undefined);
+        },
+        commit: async (freshConversation) => {
+          await freshConversation.updateSpaceId(auth, nextRuntimeSpace);
+          return new Ok(undefined);
+        },
+      }
+    );
+    await transitionEntered;
+
+    let markCopyCompleted: () => void = () => undefined;
+    const copyCompleted = new Promise<void>((resolve) => {
+      markCopyCompleted = resolve;
+    });
+    fileStorageMock.setAfterCopyFile((_sourcePath, destinationPath) => {
+      if (destinationPath === destinationManifestPath) {
+        markCopyCompleted();
+      }
+    });
+    const move = moveFrameV2Source(auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    await copyCompleted;
+    releaseTransition();
+    const transitionResult = await transition;
+    assert(
+      transitionResult.isOk(),
+      transitionResult.isErr() ? transitionResult.error.message : undefined
+    );
+
+    const moved = await move;
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "conflict",
+      message:
+        "The Frame runtime scope changed while its source was being moved.",
+    });
+    const reloaded = await FileResource.fetchById(auth, context.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: context.conversation.sId,
+    });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
+    expect(
+      fileStorageMock.getObject(`${destinationGcsDirectoryPath}/index.tsx`)
+    ).toBeUndefined();
+    expect(fileStorageMock.deleteCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filePath: destinationManifestPath,
+          options: expect.objectContaining({
+            ifGenerationMatch: expect.any(String),
+          }),
+        }),
+      ])
     );
   });
 
@@ -1242,6 +1379,64 @@ describe("moveFrameV2Source", () => {
     );
     expect(reloaded?.mountFilePath).toBe(destinationManifestPath);
     expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
+  });
+
+  it("reconciles a lifecycle unlock failure after the Frame update commits", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/UnlockLost`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}UnlockLost`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    sandboxLifecycleAfterCallbackMock.mockRejectedValueOnce(
+      new Error("Simulated lifecycle unlock failure")
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationManifestPath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+  });
+
+  it("cleans up after a lifecycle lock acquisition failure", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/LockTimeout`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}LockTimeout`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    sandboxLifecycleBeforeCallbackMock.mockRejectedValueOnce(
+      new Error("Simulated lifecycle lock timeout")
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
   });
 
   it("keeps the recovery reservation when exact-generation cleanup fails", async () => {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -2,9 +2,12 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { emitGCSMountFileMovedAuditLogMock } = vi.hoisted(() => ({
-  emitGCSMountFileMovedAuditLogMock: vi.fn(),
-}));
+const { emitGCSMountFileMovedAuditLogMock, lockLeaseCheckMock } = vi.hoisted(
+  () => ({
+    emitGCSMountFileMovedAuditLogMock: vi.fn(),
+    lockLeaseCheckMock: vi.fn(),
+  })
+);
 
 vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => {
   const actual =
@@ -17,14 +20,31 @@ vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => {
 
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
+  const executeImmediately = async <T>(
+    _key: string,
+    callback: () => Promise<T>
+  ) => callback();
+  const executeRenewingImmediately = async <T>(
+    _key: string,
+    callback: (lease: {
+      check: () => ReturnType<typeof lockLeaseCheckMock>;
+    }) => Promise<T>
+  ) => {
+    const lease = { check: () => lockLeaseCheckMock() };
+    const result = await callback(lease);
+    const held = lease.check();
+    return held.isErr() ? held : result;
+  };
   return {
     ...actual,
-    executeWithLock: async <T>(_key: string, callback: () => Promise<T>) =>
-      callback(),
+    executeWithLock: executeImmediately,
+    executeWithLockResult: executeImmediately,
+    executeWithRenewingLockResult: executeRenewingImmediately,
   };
 });
 
 import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import { LockLeaseLostError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -33,6 +53,7 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { frameV2ContentType } from "@app/types/files";
 import { getConversationFilesBasePath } from "@app/types/mount_path";
+import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 
 const manifest = JSON.stringify({
@@ -41,6 +62,8 @@ const manifest = JSON.stringify({
   description: "Show the current status.",
 });
 const moveIdMetadataKey = "dust_frame_source_move_id";
+let leaseCheckCount = 0;
+let loseLeaseAtCheck = Number.POSITIVE_INFINITY;
 
 async function setup() {
   const { authenticator: auth, workspace } = await createResourceTest({
@@ -113,6 +136,15 @@ beforeEach(() => {
   fileStorageMock.reset();
   emitGCSMountFileMovedAuditLogMock.mockClear();
   vi.restoreAllMocks();
+  leaseCheckCount = 0;
+  loseLeaseAtCheck = Number.POSITIVE_INFINITY;
+  lockLeaseCheckMock.mockReset();
+  lockLeaseCheckMock.mockImplementation(() => {
+    leaseCheckCount++;
+    return leaseCheckCount >= loseLeaseAtCheck
+      ? new Err(new LockLeaseLostError("frame-test"))
+      : new Ok(undefined);
+  });
 });
 
 describe("moveFrameV2Source", () => {
@@ -163,6 +195,108 @@ describe("moveFrameV2Source", () => {
         relativeFilePath: "Status",
       }
     );
+  });
+
+  it("does not reserve a destination after its composite lease is lost", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/LeaseLostBeforeReservation`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}LeaseLostBeforeReservation`;
+    loseLeaseAtCheck = 1;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "publish_conflict",
+    });
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(
+      `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(
+      fileStorageMock.getObject(
+        `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBeUndefined();
+  });
+
+  it("preserves copied objects and the reservation when its lease is lost before commit", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/LeaseLostBeforeCommit`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}LeaseLostBeforeCommit`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    loseLeaseAtCheck = 3;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "publish_conflict",
+    });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(
+      fileStorageMock.getObject(`${destinationGcsDirectoryPath}/index.tsx`)
+    ).toBe("ui source");
+    expect(
+      fileStorageMock.getObject(
+        `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBe(manifest);
+    const reserved = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reserved?.mountFilePath).toBe(destinationManifestPath);
+    expect(reserved?.useCaseMetadata?.pendingFrameSourceMove).toBeDefined();
+    expect(fileStorageMock.deleteCalls).toEqual([]);
+  });
+
+  it("reports source leftovers when its lease is lost after destination commit", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/LeaseLostAfterCommit`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}LeaseLostAfterCommit`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    loseLeaseAtCheck = 5;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value.sourceDeletionFailed).toBe(true);
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(
+      fileStorageMock.getObject(
+        `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBe(manifest);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationManifestPath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
+    expect(fileStorageMock.deleteCalls).toEqual([]);
   });
 
   it("does not move a registered Frame whose source manifest is missing", async () => {
@@ -397,6 +531,17 @@ describe("moveFrameV2Source", () => {
         return false;
       }
     );
+    fileStorageMock.setFileMetadata((filePath) =>
+      filePath === destinationManifestPath
+        ? {
+            contentType: frameV2ContentType,
+            generation:
+              fileStorageMock.getObjectGeneration(filePath) ?? "missing",
+            md5Hash: "manifest",
+            size: String(Buffer.byteLength(manifest)),
+          }
+        : null
+    );
 
     const moved = await moveFrameV2Source(context.auth, {
       conversation: context.conversation,
@@ -408,6 +553,297 @@ describe("moveFrameV2Source", () => {
     expect(lostResponse).toBe(true);
     expect(fileStorageMock.metadataCalls).toContain(destinationManifestPath);
     expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+  });
+
+  it("claims a matching committed generation after a final network error", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/NetworkAmbiguous`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}NetworkAmbiguous`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    let lostResponse = false;
+    fileStorageMock.setCopyFileCommitsThenErrors(
+      (_sourcePath, destinationPath) => {
+        if (!lostResponse && destinationPath === destinationManifestPath) {
+          lostResponse = true;
+          return new Error("Simulated final network error after commit");
+        }
+        return null;
+      }
+    );
+    fileStorageMock.setFileMetadata((filePath) =>
+      filePath === destinationManifestPath
+        ? {
+            contentType: frameV2ContentType,
+            generation:
+              fileStorageMock.getObjectGeneration(filePath) ?? "missing",
+            md5Hash: "manifest",
+            size: String(Buffer.byteLength(manifest)),
+          }
+        : null
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(lostResponse).toBe(true);
+    expect(fileStorageMock.metadataCalls).toContain(destinationManifestPath);
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+  });
+
+  it("preserves the initial reservation when copy ownership cannot be determined", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/UnknownCopy`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}UnknownCopy`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const destinationMountFilePath = destinationManifestPath;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    const updateMount = vi.spyOn(FileResource.prototype, "updateMount");
+    fileStorageMock.setCopyFileFails((sourcePath) =>
+      sourcePath.endsWith(`/${FRAME_MANIFEST_FILE}`)
+    );
+    fileStorageMock.setFileMetadataFails(
+      (filePath) => filePath === destinationManifestPath
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
+    const reservationMetadata = updateMount.mock.calls
+      .map(([args]) => args.destUseCaseMetadata?.pendingFrameSourceMove)
+      .find((pendingMove) => pendingMove !== undefined);
+    const reserved = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reservationMetadata).toBeDefined();
+    expect(reserved?.mountFilePath).toBe(destinationMountFilePath);
+    expect(reserved?.useCaseMetadata?.pendingFrameSourceMove).toEqual(
+      reservationMetadata
+    );
+    expect(fileStorageMock.getObject(sourceManifestPath)).toBe(manifest);
+    expect(fileStorageMock.getObject(sourceUiPath)).toBe("ui source");
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
+    expect(
+      fileStorageMock.getObject(`${destinationGcsDirectoryPath}/index.tsx`)
+    ).toBeUndefined();
+  });
+
+  it("does not adopt a stale copy after its pinned source generation changes", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/EditedRecovery`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}EditedRecovery`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const operationId = "edited-source-recovery";
+    await context.frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: destinationManifestPath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: {
+        ...context.frame.useCaseMetadata,
+        pendingFrameSourceMove: {
+          destinationMountFilePath: destinationManifestPath,
+          operationId,
+          sourceMountFilePath: sourceManifestPath,
+        },
+      },
+    });
+    fileStorageMock.setObject(destinationManifestPath, "stale copy", {
+      [moveIdMetadataKey]: operationId,
+    });
+    const destinationGeneration = fileStorageMock.getObjectGeneration(
+      destinationManifestPath
+    );
+    let sourceListed = false;
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix === `${context.sourceGcsDirectoryPath}/`) {
+        if (!sourceListed) {
+          sourceListed = true;
+          fileStorageMock.setObject(sourceManifestPath, "edited source");
+        }
+        return [
+          {
+            name: sourceManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              crc32c: "same-crc",
+              generation: "1",
+              size: String(Buffer.byteLength(manifest)),
+            },
+          },
+          {
+            name: sourceUiPath,
+            metadata: {
+              contentType: "text/typescript",
+              generation: "2",
+              md5Hash: "ui",
+              size: "1",
+            },
+          },
+        ];
+      }
+      if (prefix === `${destinationGcsDirectoryPath}/`) {
+        return [
+          {
+            name: destinationManifestPath,
+            metadata: {
+              contentType: frameV2ContentType,
+              crc32c: "same-crc",
+              generation: destinationGeneration,
+              metadata: { [moveIdMetadataKey]: operationId },
+            },
+          },
+        ];
+      }
+      return null;
+    });
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({ code: "conflict" });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(
+      "stale copy"
+    );
+    expect(fileStorageMock.getObject(sourceManifestPath)).toBe("edited source");
+    expect(fileStorageMock.deleteCalls).not.toContainEqual(
+      expect.objectContaining({ filePath: destinationManifestPath })
+    );
+    const reserved = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reserved?.useCaseMetadata?.pendingFrameSourceMove).toMatchObject({
+      operationId,
+    });
+  });
+
+  it("fences delayed cleanup with a fresh destination attempt generation", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/AttemptFence`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}AttemptFence`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const destinationUiPath = `${destinationGcsDirectoryPath}/index.tsx`;
+    const updateMount = FileResource.prototype.updateMount;
+    let updateMountCalls = 0;
+    vi.spyOn(FileResource.prototype, "updateMount").mockImplementation(
+      function (this: FileResource, args) {
+        updateMountCalls++;
+        if (updateMountCalls === 2) {
+          return Promise.reject(
+            new Error("Simulated uncommitted final Frame update")
+          );
+        }
+        return updateMount.call(this, args);
+      }
+    );
+    let releaseDelayedDelete: () => void = () => {};
+    let reportDelayedDeleteStarted: () => void = () => {};
+    const delayedDelete = new Promise<void>((resolve) => {
+      releaseDelayedDelete = resolve;
+    });
+    const delayedDeleteStarted = new Promise<void>((resolve) => {
+      reportDelayedDeleteStarted = resolve;
+    });
+    fileStorageMock.setDeleteFails(
+      (filePath) => filePath === destinationManifestPath
+    );
+    fileStorageMock.setBeforeDelete(async (filePath) => {
+      if (filePath === destinationUiPath) {
+        reportDelayedDeleteStarted();
+        await delayedDelete;
+      }
+    });
+
+    let oldMoveSettled = false;
+    const oldMovePromise = moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+    void oldMovePromise.then(() => {
+      oldMoveSettled = true;
+    });
+
+    await delayedDeleteStarted;
+    await Promise.resolve();
+    expect(oldMoveSettled).toBe(false);
+    const oldManifestGeneration = fileStorageMock.getObjectGeneration(
+      destinationManifestPath
+    );
+    const oldUiGeneration =
+      fileStorageMock.getObjectGeneration(destinationUiPath);
+
+    let freshAttemptCopyCount = 0;
+    let reportFreshAttemptCopied: () => void = () => {};
+    const freshAttemptCopied = new Promise<void>((resolve) => {
+      reportFreshAttemptCopied = resolve;
+    });
+    fileStorageMock.setAfterCopyFile((_sourcePath, destinationPath) => {
+      if (
+        destinationPath === destinationManifestPath ||
+        destinationPath === destinationUiPath
+      ) {
+        freshAttemptCopyCount++;
+        if (freshAttemptCopyCount === 2) {
+          reportFreshAttemptCopied();
+        }
+      }
+    });
+    const retriedPromise = moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    await freshAttemptCopied;
+    releaseDelayedDelete();
+    const [retried, oldMove] = await Promise.all([
+      retriedPromise,
+      oldMovePromise,
+    ]);
+
+    assert(retried.isOk(), retried.isErr() ? retried.error.message : undefined);
+    expect(
+      fileStorageMock.getObjectGeneration(destinationManifestPath)
+    ).not.toBe(oldManifestGeneration);
+    expect(fileStorageMock.getObjectGeneration(destinationUiPath)).not.toBe(
+      oldUiGeneration
+    );
+    expect(oldMove.isErr() && oldMove.error).toMatchObject({
+      code: "internal",
+    });
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(fileStorageMock.getObject(destinationUiPath)).toBe("ui source");
+    expect(fileStorageMock.getObject(sourceManifestPath)).toBeUndefined();
+    expect(fileStorageMock.getObject(sourceUiPath)).toBeUndefined();
   });
 
   it("does not move over a destination-only object created during the move", async () => {
@@ -594,6 +1030,54 @@ describe("moveFrameV2Source", () => {
     );
   });
 
+  it("reconciles a final Frame update whose committed response was lost", async () => {
+    const context = await setup();
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/CommittedUpdate`;
+    const destinationGcsDirectoryPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}CommittedUpdate`;
+    const destinationManifestPath = `${destinationGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const destinationUiPath = `${destinationGcsDirectoryPath}/index.tsx`;
+    const sourceManifestPath = `${context.sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
+    const updateMount = FileResource.prototype.updateMount;
+    let updateMountCalls = 0;
+    vi.spyOn(FileResource.prototype, "updateMount").mockImplementation(
+      async function (this: FileResource, args) {
+        updateMountCalls++;
+        const result = await updateMount.call(this, args);
+        if (updateMountCalls === 2) {
+          throw new Error("Simulated lost final update response");
+        }
+        return result;
+      }
+    );
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(fileStorageMock.getObject(destinationManifestPath)).toBe(manifest);
+    expect(fileStorageMock.getObject(destinationUiPath)).toBe("ui source");
+    expect(fileStorageMock.getObject(sourceManifestPath)).toBeUndefined();
+    expect(fileStorageMock.getObject(sourceUiPath)).toBeUndefined();
+    expect(
+      fileStorageMock.deleteCalls.filter(({ filePath }) =>
+        filePath.startsWith(`${destinationGcsDirectoryPath}/`)
+      )
+    ).toEqual([]);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded?.mountFilePath).toBe(destinationManifestPath);
+    expect(reloaded?.useCaseMetadata?.pendingFrameSourceMove).toBeUndefined();
+  });
+
   it("keeps the recovery reservation when exact-generation cleanup fails", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/Retry`;
@@ -665,6 +1149,8 @@ describe("moveFrameV2Source", () => {
     fileStorageMock.setObject(destinationManifestPath, manifest, {
       [moveIdMetadataKey]: "move-recovery",
     });
+    const preexistingDestinationGeneration =
+      fileStorageMock.getObjectGeneration(destinationManifestPath);
     fileStorageMock.setFilesByPrefix((prefix) => {
       if (prefix === `${context.sourceGcsDirectoryPath}/`) {
         return [
@@ -694,7 +1180,7 @@ describe("moveFrameV2Source", () => {
             name: destinationManifestPath,
             metadata: {
               contentType: frameV2ContentType,
-              generation: "3",
+              generation: preexistingDestinationGeneration,
               md5Hash: "manifest",
               metadata: { [moveIdMetadataKey]: "move-recovery" },
               size: String(Buffer.byteLength(manifest)),
@@ -726,11 +1212,15 @@ describe("moveFrameV2Source", () => {
 
     expect(moved.isErr() && moved.error).toMatchObject({ code: "internal" });
     expect(fileStorageMock.getObject(destinationManifestPath)).toBeUndefined();
-    expect(fileStorageMock.deleteCalls).toContainEqual(
-      expect.objectContaining({
-        filePath: destinationManifestPath,
-        options: { ifGenerationMatch: "3", ignoreNotFound: true },
-      })
+    const destinationCleanup = fileStorageMock.deleteCalls.find(
+      ({ filePath }) => filePath === destinationManifestPath
+    );
+    expect(destinationCleanup?.options).toEqual({
+      ifGenerationMatch: expect.any(String),
+      ignoreNotFound: true,
+    });
+    expect(destinationCleanup?.options?.ifGenerationMatch).not.toBe(
+      preexistingDestinationGeneration
     );
 
     const reserved = await FileResource.fetchById(

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -44,15 +44,20 @@ vi.mock("@app/lib/lock", async (importActual) => {
 });
 
 import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import { Authenticator } from "@app/lib/auth";
 import { LockLeaseLostError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { frameV2ContentType } from "@app/types/files";
-import { getConversationFilesBasePath } from "@app/types/mount_path";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 
@@ -65,40 +70,79 @@ const moveIdMetadataKey = "dust_frame_source_move_id";
 let leaseCheckCount = 0;
 let loseLeaseAtCheck = Number.POSITIVE_INFINITY;
 
-async function setup() {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
+async function setup({
+  sourceMount = "conversation",
+  withRuntimePod = false,
+}: {
+  sourceMount?: "conversation" | "pod";
+  withRuntimePod?: boolean;
+} = {}) {
+  const {
+    authenticator: initialAuth,
+    globalGroup,
+    user,
+    workspace,
+  } = await createResourceTest({ role: "admin" });
+  const runtimeSpace =
+    withRuntimePod || sourceMount === "pod"
+      ? await SpaceFactory.project(workspace, user.id)
+      : null;
+  const auth = runtimeSpace
+    ? await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId)
+    : initialAuth;
+  assert(auth);
   const conversation = await ConversationFactory.create(auth, {
     agentConfigurationId: "test-agent",
     messagesCreatedAt: [],
+    spaceId: runtimeSpace?.id,
   });
-  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
-  const sourceGcsDirectoryPath = `${getConversationFilesBasePath({
-    workspaceId: workspace.sId,
-    conversationId: conversation.sId,
-  })}Status`;
+  const source =
+    sourceMount === "conversation"
+      ? {
+          directoryPath: `conversation-${conversation.sId}/Status`,
+          gcsDirectoryPath: `${getConversationFilesBasePath({
+            workspaceId: workspace.sId,
+            conversationId: conversation.sId,
+          })}Status`,
+          useCase: "conversation" as const,
+          useCaseMetadata: {
+            activePublicationId: "publication-1",
+            conversationId: conversation.sId,
+          },
+        }
+      : (() => {
+          assert(runtimeSpace);
+          return {
+            directoryPath: `pod-${runtimeSpace.sId}/Status`,
+            gcsDirectoryPath: `${getPodFilesBasePath({
+              workspaceId: workspace.sId,
+              podId: runtimeSpace.sId,
+            })}Status`,
+            useCase: "project_context" as const,
+            useCaseMetadata: {
+              activePublicationId: "publication-1",
+              spaceId: runtimeSpace.sId,
+            },
+          };
+        })();
   const frame = await FileFactory.create(auth, null, {
     contentType: frameV2ContentType,
     fileName: FRAME_MANIFEST_FILE,
     fileSize: Buffer.byteLength(manifest),
     status: "created",
-    useCase: "conversation",
-    useCaseMetadata: {
-      activePublicationId: "publication-1",
-      conversationId: conversation.sId,
-    },
-    mountFilePath: `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    useCase: source.useCase,
+    useCaseMetadata: source.useCaseMetadata,
+    mountFilePath: `${source.gcsDirectoryPath}/${FRAME_MANIFEST_FILE}`,
   });
   await frame.markFrameV2AsReadyFromMount(auth);
 
-  const sourceManifestPath = `${sourceGcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
-  const sourceUiPath = `${sourceGcsDirectoryPath}/index.tsx`;
+  const sourceManifestPath = `${source.gcsDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+  const sourceUiPath = `${source.gcsDirectoryPath}/index.tsx`;
   fileStorageMock.setObject(sourceManifestPath, manifest);
   fileStorageMock.setObject(sourceUiPath, "ui source");
   fileStorageMock.setFileExists(() => false);
   fileStorageMock.setFilesByPrefix((prefix) =>
-    prefix === `${sourceGcsDirectoryPath}/`
+    prefix === `${source.gcsDirectoryPath}/`
       ? [
           {
             name: sourceManifestPath,
@@ -126,8 +170,11 @@ async function setup() {
     auth,
     conversation,
     frame,
-    sourceDirectoryPath,
-    sourceGcsDirectoryPath,
+    globalGroup,
+    runtimeSpace,
+    sourceDirectoryPath: source.directoryPath,
+    sourceGcsDirectoryPath: source.gcsDirectoryPath,
+    user,
     workspace,
   };
 }
@@ -299,6 +346,74 @@ describe("moveFrameV2Source", () => {
     expect(fileStorageMock.deleteCalls).toEqual([]);
   });
 
+  it("moves from a conversation mount to its runtime Pod", async () => {
+    const context = await setup({ withRuntimePod: true });
+    assert(context.runtimeSpace);
+    const destinationDirectoryPath = `pod-${context.runtimeSpace.sId}/Status`;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded).toMatchObject({
+      sId: context.frame.sId,
+      useCase: "project_context",
+    });
+    expect(reloaded?.mountFilePath).toBe(
+      `${getPodFilesBasePath({
+        workspaceId: context.workspace.sId,
+        podId: context.runtimeSpace.sId,
+      })}Status/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      spaceId: context.runtimeSpace.sId,
+    });
+    expect(emitGCSMountFileMovedAuditLogMock).toHaveBeenCalledWith(
+      context.auth,
+      { useCase: "pod", podId: context.runtimeSpace.sId },
+      { parentRelativePath: "", relativeFilePath: "Status" }
+    );
+  });
+
+  it("moves from a Pod mount to a conversation in that runtime", async () => {
+    const context = await setup({ sourceMount: "pod" });
+    const destinationDirectoryPath = `conversation-${context.conversation.sId}/Status`;
+
+    const moved = await moveFrameV2Source(context.auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(reloaded).toMatchObject({
+      sId: context.frame.sId,
+      useCase: "conversation",
+    });
+    expect(reloaded?.mountFilePath).toBe(
+      `${getConversationFilesBasePath({
+        workspaceId: context.workspace.sId,
+        conversationId: context.conversation.sId,
+      })}Status/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: context.conversation.sId,
+    });
+  });
+
   it("does not move a registered Frame whose source manifest is missing", async () => {
     const context = await setup();
     const sourceUiPath = `${context.sourceGcsDirectoryPath}/index.tsx`;
@@ -336,20 +451,37 @@ describe("moveFrameV2Source", () => {
     );
   });
 
-  it("rejects cross-mount moves before looking up a Frame", async () => {
+  it("rejects moves to a different runtime before any mutation", async () => {
     const context = await setup();
+    const destinationPod = await SpaceFactory.project(
+      context.workspace,
+      context.user.id
+    );
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      context.user.sId,
+      context.workspace.sId
+    );
+    assert(auth);
     const fetchFrames = vi.spyOn(FileResource, "fetchByMountFilePaths");
+    const updateMount = vi.spyOn(FileResource.prototype, "updateMount");
+    const copyFile = vi.fn();
+    fileStorageMock.setAfterCopyFile(copyFile);
 
-    const moved = await moveFrameV2Source(context.auth, {
+    const moved = await moveFrameV2Source(auth, {
       conversation: context.conversation,
-      destinationDirectoryPath: "pod-pod_123/Status",
+      destinationDirectoryPath: `pod-${destinationPod.sId}/Status`,
       sourceDirectoryPath: context.sourceDirectoryPath,
     });
 
     expect(moved.isErr() && moved.error).toMatchObject({
       code: "invalid_source",
+      message:
+        "Frame source and destination must resolve to the same runtime space.",
     });
     expect(fetchFrames).not.toHaveBeenCalled();
+    expect(updateMount).not.toHaveBeenCalled();
+    expect(copyFile).not.toHaveBeenCalled();
+    expect(fileStorageMock.deleteCalls).toEqual([]);
     const reloaded = await FileResource.fetchById(
       context.auth,
       context.frame.sId
@@ -420,6 +552,40 @@ describe("moveFrameV2Source", () => {
       frameId: otherFrame.sId,
     });
   });
+
+  it("requires destination write access before any mutation", async () => {
+    const context = await setup();
+    const destinationPod = await SpaceFactory.project(context.workspace);
+    await SpaceFactory.attachGroup(
+      destinationPod,
+      context.globalGroup,
+      "project_viewer"
+    );
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      context.user.sId,
+      context.workspace.sId
+    );
+    assert(auth);
+    const fetchFrames = vi.spyOn(FileResource, "fetchByMountFilePaths");
+    const updateMount = vi.spyOn(FileResource.prototype, "updateMount");
+    const copyFile = vi.fn();
+    fileStorageMock.setAfterCopyFile(copyFile);
+
+    const moved = await moveFrameV2Source(auth, {
+      conversation: context.conversation,
+      destinationDirectoryPath: `pod-${destinationPod.sId}/Status`,
+      sourceDirectoryPath: context.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "unauthorized",
+    });
+    expect(fetchFrames).not.toHaveBeenCalled();
+    expect(updateMount).not.toHaveBeenCalled();
+    expect(copyFile).not.toHaveBeenCalled();
+    expect(fileStorageMock.deleteCalls).toEqual([]);
+  });
+
   it("does not overwrite a destination object created during the move", async () => {
     const context = await setup();
     const destinationDirectoryPath = `conversation-${context.conversation.sId}/Collision`;

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -15,7 +15,11 @@ import {
   GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
-import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
+import {
+  isGCSNotFoundError,
+  isGCSPreconditionFailedError,
+} from "@app/lib/file_storage/types";
+import type { LockLeaseGuard } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FrameGoneError } from "@app/lib/resources/frame_sandbox_adapter";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -32,6 +36,9 @@ import type { File, FileMetadata } from "@google-cloud/storage";
 import { UniqueConstraintError } from "sequelize";
 
 const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
+const FRAME_SOURCE_MOVE_COPY_MAX_ATTEMPTS = 3;
+const FRAME_SOURCE_MOVE_ATTEMPT_ID_METADATA_KEY =
+  "dust_frame_source_move_attempt_id";
 const FRAME_SOURCE_MOVE_ID_METADATA_KEY = "dust_frame_source_move_id";
 
 type FrameSourceOwner = {
@@ -154,6 +161,27 @@ function isDestinationOwnedByMove(file: File, operationId: string): boolean {
   );
 }
 
+function isSameGCSObject(source: File, destination: File): boolean {
+  const sourceMd5 = metadataValue(source.metadata, "md5Hash");
+  const destinationMd5 = metadataValue(destination.metadata, "md5Hash");
+  if (sourceMd5 && destinationMd5) {
+    return sourceMd5 === destinationMd5;
+  }
+
+  const sourceCrc32c = metadataValue(source.metadata, "crc32c");
+  const destinationCrc32c = metadataValue(destination.metadata, "crc32c");
+  const sourceSize = metadataValue(source.metadata, "size");
+  const destinationSize = metadataValue(destination.metadata, "size");
+  return Boolean(
+    sourceCrc32c &&
+      destinationCrc32c &&
+      sourceSize &&
+      destinationSize &&
+      sourceCrc32c === destinationCrc32c &&
+      sourceSize === destinationSize
+  );
+}
+
 type GCSObjectGeneration = { filePath: string; generation: string };
 type FrameSourceCopy = {
   destinationObjects: GCSObjectGeneration[];
@@ -164,6 +192,7 @@ type FrameSourceCopyFailure = {
   destinationObjects: GCSObjectGeneration[];
   error: FrameSourceMoveError;
   hasPreexistingDestinationObjects: boolean;
+  preserveReservation: boolean;
 };
 
 async function cleanupDestinationObjects(
@@ -171,16 +200,26 @@ async function cleanupDestinationObjects(
 ): Promise<boolean> {
   const bucket = getPrivateUploadBucket();
   try {
-    await concurrentExecutor(
+    const deletionResults = await concurrentExecutor(
       objects,
-      ({ filePath, generation }) =>
-        bucket.delete(filePath, {
-          ignoreNotFound: true,
-          ifGenerationMatch: generation,
-        }),
+      async ({ filePath, generation }) => {
+        try {
+          await bucket.delete(filePath, {
+            ignoreNotFound: true,
+            ifGenerationMatch: generation,
+          });
+          return true;
+        } catch (error) {
+          logger.error(
+            { error: normalizeError(error), filePath, generation },
+            "Failed to clean up a Frame move destination object"
+          );
+          return false;
+        }
+      },
       { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
     );
-    return true;
+    return deletionResults.every(Boolean);
   } catch (error) {
     logger.error(
       { error: normalizeError(error) },
@@ -196,15 +235,28 @@ async function deleteCopiedSourceObjects(
 ): Promise<boolean> {
   const bucket = getPrivateUploadBucket();
   try {
-    await concurrentExecutor(
+    const deletionResults = await concurrentExecutor(
       objects,
-      ({ filePath, generation }) =>
-        bucket.delete(filePath, {
-          ignoreNotFound: true,
-          ifGenerationMatch: generation,
-        }),
+      async ({ filePath, generation }) => {
+        try {
+          await bucket.delete(filePath, {
+            ignoreNotFound: true,
+            ifGenerationMatch: generation,
+          });
+          return true;
+        } catch (error) {
+          logger.warn(
+            { error: normalizeError(error), filePath, generation },
+            "Failed to delete a copied Frame source object generation"
+          );
+          return false;
+        }
+      },
       { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
     );
+    if (!deletionResults.every(Boolean)) {
+      return false;
+    }
     const remaining = await bucket.getFiles({
       prefix: sourceMountPrefix,
       maxResults: 1,
@@ -220,11 +272,13 @@ async function deleteCopiedSourceObjects(
 }
 
 async function copyFrameSourceAsNew({
+  attemptId,
   destinationMountPrefix,
   operationId,
   sourceManifestPath,
   sourceMountPrefix,
 }: {
+  attemptId: string;
   destinationMountPrefix: string;
   operationId: string;
   sourceManifestPath: string;
@@ -249,6 +303,7 @@ async function copyFrameSourceAsNew({
         "Frame source folder is empty or no longer exists."
       ),
       hasPreexistingDestinationObjects: destinationFiles.length > 0,
+      preserveReservation: false,
     });
   }
   if (!sourceFiles.some((file) => file.name === sourceManifestPath)) {
@@ -259,6 +314,7 @@ async function copyFrameSourceAsNew({
         "Frame source manifest is missing."
       ),
       hasPreexistingDestinationObjects: destinationFiles.length > 0,
+      preserveReservation: false,
     });
   }
   const totalSourceSize = sourceFiles.reduce(
@@ -276,6 +332,7 @@ async function copyFrameSourceAsNew({
         "Frame source exceeds the move size limit."
       ),
       hasPreexistingDestinationObjects: destinationFiles.length > 0,
+      preserveReservation: false,
     });
   }
   if (destinationFiles.length > MAX_FRAME_SOURCE_FILE_COUNT) {
@@ -286,6 +343,7 @@ async function copyFrameSourceAsNew({
         "Frame destination exceeds the move file count limit."
       ),
       hasPreexistingDestinationObjects: true,
+      preserveReservation: false,
     });
   }
 
@@ -304,6 +362,7 @@ async function copyFrameSourceAsNew({
         `Destination file already exists: ${unexpectedDestination.name.slice(destinationMountPrefix.length)}`
       ),
       hasPreexistingDestinationObjects: true,
+      preserveReservation: false,
     });
   }
 
@@ -317,6 +376,8 @@ async function copyFrameSourceAsNew({
     sourceFiles,
     async (sourceFile) => {
       let hasPreexistingDestinationObject = false;
+      let ownedDestinationObject: GCSObjectGeneration | null = null;
+      let preserveReservation = false;
       try {
         const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
         const destinationPath = `${destinationMountPrefix}${relativePath}`;
@@ -331,66 +392,166 @@ async function copyFrameSourceAsNew({
           );
         }
         let destinationFile = destinationByRelativePath.get(relativePath);
-        let ownedDestinationObject: GCSObjectGeneration | null = null;
         hasPreexistingDestinationObject = Boolean(destinationFile);
-
-        if (!destinationFile) {
+        let copyAttempts = 0;
+        let lastCopyError: unknown = null;
+        const refreshDestination = async (): Promise<File | undefined> => {
+          const refreshedDestination = bucket.file(destinationPath);
           try {
-            const copied = await bucket.copyFile(
-              sourceFile.name,
-              destinationPath,
-              undefined,
-              {
-                destinationGenerationMatch:
-                  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-                destinationMetadata: {
-                  ...sourceFile.metadata.metadata,
-                  [FRAME_SOURCE_MOVE_ID_METADATA_KEY]: operationId,
-                },
-                sourceGeneration,
-              }
-            );
-            destinationFile = copied.destinationFile;
-            ownedDestinationObject = {
-              filePath: destinationPath,
-              generation: copied.destinationGeneration,
-            };
-          } catch (error) {
-            if (!isGCSPreconditionFailedError(error)) {
-              throw error;
-            }
+            const [metadata] = await refreshedDestination.getMetadata();
+            refreshedDestination.metadata = metadata;
             hasPreexistingDestinationObject = true;
-            destinationFile = bucket.file(destinationPath);
-            const [metadata] = await destinationFile.getMetadata();
-            destinationFile.metadata = metadata;
+            return refreshedDestination;
+          } catch (metadataError) {
+            if (isGCSNotFoundError(metadataError)) {
+              return undefined;
+            }
+            preserveReservation = true;
+            throw new FrameSourceMoveError(
+              "internal",
+              `Failed to determine whether the Frame destination copy succeeded: ${normalizeError(metadataError).message}`
+            );
           }
-        }
+        };
+        const copyMetadata = {
+          ...sourceFile.metadata.metadata,
+          [FRAME_SOURCE_MOVE_ATTEMPT_ID_METADATA_KEY]: attemptId,
+          [FRAME_SOURCE_MOVE_ID_METADATA_KEY]: operationId,
+        };
 
-        if (!ownedDestinationObject) {
+        while (!ownedDestinationObject) {
+          if (!destinationFile) {
+            if (copyAttempts >= FRAME_SOURCE_MOVE_COPY_MAX_ATTEMPTS) {
+              throw (
+                lastCopyError ??
+                new FrameSourceMoveError(
+                  "internal",
+                  `Frame destination copy retry limit reached: ${relativePath}`
+                )
+              );
+            }
+            copyAttempts++;
+            try {
+              const copied = await bucket.copyFile(
+                sourceFile.name,
+                destinationPath,
+                undefined,
+                {
+                  destinationGenerationMatch:
+                    GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+                  destinationMetadata: copyMetadata,
+                  sourceGeneration,
+                }
+              );
+              ownedDestinationObject = {
+                filePath: destinationPath,
+                generation: copied.destinationGeneration,
+              };
+              continue;
+            } catch (error) {
+              lastCopyError = error;
+              destinationFile = await refreshDestination();
+              if (!destinationFile && !isGCSPreconditionFailedError(error)) {
+                throw error;
+              }
+              continue;
+            }
+          }
+
           if (!isDestinationOwnedByMove(destinationFile, operationId)) {
             throw new FrameSourceMoveError(
               "conflict",
               `Destination file already exists: ${relativePath}`
             );
           }
-          const destinationGeneration = metadataValue(
+          const observedDestinationGeneration = metadataValue(
             destinationFile.metadata,
             "generation"
           );
-          if (!destinationGeneration) {
+          if (!observedDestinationGeneration) {
+            preserveReservation = true;
             throw new FrameSourceMoveError(
               "internal",
               `Destination generation is missing: ${relativePath}`
             );
           }
-          ownedDestinationObject = {
-            filePath: destinationPath,
-            generation: destinationGeneration,
-          };
+          const destinationMatchesSource = isSameGCSObject(
+            sourceFile,
+            destinationFile
+          );
+          if (
+            destinationMatchesSource &&
+            destinationFile.metadata.metadata?.[
+              FRAME_SOURCE_MOVE_ATTEMPT_ID_METADATA_KEY
+            ] === attemptId
+          ) {
+            ownedDestinationObject = {
+              filePath: destinationPath,
+              generation: observedDestinationGeneration,
+            };
+            continue;
+          }
+
+          if (!destinationMatchesSource) {
+            try {
+              const liveSource = bucket.file(sourceFile.name);
+              const [liveSourceMetadata] = await liveSource.getMetadata();
+              if (
+                metadataValue(liveSourceMetadata, "generation") !==
+                sourceGeneration
+              ) {
+                preserveReservation = true;
+                throw new FrameSourceMoveError(
+                  "conflict",
+                  `Frame source changed before its stale destination could be refreshed: ${relativePath}`
+                );
+              }
+            } catch (error) {
+              if (error instanceof FrameSourceMoveError) {
+                throw error;
+              }
+              preserveReservation = true;
+              throw new FrameSourceMoveError(
+                "internal",
+                `Failed to verify the current Frame source generation: ${normalizeError(error).message}`
+              );
+            }
+          }
+
+          if (copyAttempts >= FRAME_SOURCE_MOVE_COPY_MAX_ATTEMPTS) {
+            preserveReservation = true;
+            throw new FrameSourceMoveError(
+              "internal",
+              `Frame destination recopy retry limit reached: ${relativePath}`
+            );
+          }
+          copyAttempts++;
+          try {
+            const copied = await bucket.copyFile(
+              sourceFile.name,
+              destinationPath,
+              undefined,
+              {
+                destinationGenerationMatch: observedDestinationGeneration,
+                destinationMetadata: copyMetadata,
+                sourceGeneration,
+              }
+            );
+            ownedDestinationObject = {
+              filePath: destinationPath,
+              generation: copied.destinationGeneration,
+            };
+          } catch (error) {
+            lastCopyError = error;
+            destinationFile = await refreshDestination();
+            if (!destinationFile && !isGCSPreconditionFailedError(error)) {
+              throw error;
+            }
+          }
         }
 
         return new Ok<{
-          destination: GCSObjectGeneration | null;
+          destination: GCSObjectGeneration;
           hasPreexistingDestinationObject: boolean;
           source: GCSObjectGeneration;
         }>({
@@ -411,6 +572,7 @@ async function copyFrameSourceAsNew({
                   `Failed to copy the Frame source: ${normalizeError(error).message}`
                 ),
           hasPreexistingDestinationObject,
+          preserveReservation,
         });
       }
     },
@@ -419,8 +581,8 @@ async function copyFrameSourceAsNew({
   const copiedObjects = copyResults
     .filter((result) => result.isOk())
     .map((result) => result.value);
-  const destinationObjects = copiedObjects.flatMap(({ destination }) =>
-    destination ? [destination] : []
+  const destinationObjects = copiedObjects.map(
+    ({ destination }) => destination
   );
   const hasPreexistingDestinationObjects =
     destinationFiles.length > 0 ||
@@ -435,6 +597,9 @@ async function copyFrameSourceAsNew({
       destinationObjects,
       error: failedCopy.error.error,
       hasPreexistingDestinationObjects,
+      preserveReservation: copyResults.some(
+        (result) => result.isErr() && result.error.preserveReservation
+      ),
     });
   }
   return new Ok({
@@ -443,6 +608,12 @@ async function copyFrameSourceAsNew({
     sourceObjects: copiedObjects.map(({ source }) => source),
   });
 }
+
+type FrameSourceMove = {
+  destinationDirectoryPath: string;
+  frameId: string;
+  sourceDeletionFailed: boolean;
+};
 
 /** Move a registered Frame folder while retaining its stable FileResource identity. */
 export async function moveFrameV2Source(
@@ -456,16 +627,7 @@ export async function moveFrameV2Source(
     destinationDirectoryPath: string;
     sourceDirectoryPath: string;
   }
-): Promise<
-  Result<
-    {
-      destinationDirectoryPath: string;
-      frameId: string;
-      sourceDeletionFailed: boolean;
-    },
-    MoveFrameV2SourceError
-  >
-> {
+): Promise<Result<FrameSourceMove, MoveFrameV2SourceError>> {
   const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
   const destination = DustFileSystem.normalizeScopedPath(
     destinationDirectoryPath
@@ -560,7 +722,8 @@ export async function moveFrameV2Source(
     return invalidSource(`No registered Frame found at ${sourceManifestPath}.`);
   }
 
-  return withFrameSourceAndPublishLock(frame.sId, async () => {
+  let committedMove: FrameSourceMove | null = null;
+  const runLockedMove = async (lease: LockLeaseGuard) => {
     const freshFrame = await frame.fetchFreshFrameV2(auth);
     if (!freshFrame) {
       return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
@@ -571,6 +734,7 @@ export async function moveFrameV2Source(
     });
     const isRecovery = reservation !== null;
     const operationId = reservation?.operationId ?? randomUUID();
+    const attemptId = randomUUID();
     if (!isRecovery) {
       const sourceCheck = assertFrameAtSource(
         auth,
@@ -642,6 +806,10 @@ export async function moveFrameV2Source(
       }
     };
 
+    const heldBeforeReservation = lease.check();
+    if (heldBeforeReservation.isErr()) {
+      return heldBeforeReservation;
+    }
     if (!isRecovery) {
       try {
         await freshFrame.updateMount({
@@ -674,12 +842,17 @@ export async function moveFrameV2Source(
       destinationMountPath
     )}/`;
     const copyResult = await copyFrameSourceAsNew({
+      attemptId,
       destinationMountPrefix,
       operationId,
       sourceManifestPath: sourceMountPath,
       sourceMountPrefix,
     });
     if (copyResult.isErr()) {
+      const heldBeforeCleanup = lease.check();
+      if (heldBeforeCleanup.isErr()) {
+        return heldBeforeCleanup;
+      }
       const cleaned = await cleanupDestinationObjects(
         copyResult.error.destinationObjects
       );
@@ -691,8 +864,15 @@ export async function moveFrameV2Source(
           )
         );
       }
-      if (isRecovery && copyResult.error.hasPreexistingDestinationObjects) {
+      if (
+        copyResult.error.preserveReservation ||
+        (isRecovery && copyResult.error.hasPreexistingDestinationObjects)
+      ) {
         return new Err(copyResult.error.error);
+      }
+      const heldBeforeRestore = lease.check();
+      if (heldBeforeRestore.isErr()) {
+        return heldBeforeRestore;
       }
       const restored = await restoreSourceReservation();
       return restored
@@ -707,19 +887,24 @@ export async function moveFrameV2Source(
 
     const updateFrame = async (
       currentFrame: FileResource
-    ): Promise<Result<void, FrameSourceMoveError>> => {
-      if (
-        !getMatchingPendingMove(currentFrame, {
-          destinationMountFilePath: destinationMountPath,
-          sourceMountFilePath: sourceMountPath,
-        })
-      ) {
-        return new Err(
-          new FrameSourceMoveError(
-            "conflict",
-            "The Frame source changed while it was being moved; retry from its current path."
-          )
-        );
+    ): Promise<
+      Result<
+        void,
+        { error: FrameSourceMoveError; preserveDestinationObjects: boolean }
+      >
+    > => {
+      const currentReservation = getMatchingPendingMove(currentFrame, {
+        destinationMountFilePath: destinationMountPath,
+        sourceMountFilePath: sourceMountPath,
+      });
+      if (currentReservation?.operationId !== operationId) {
+        return new Err({
+          error: new FrameSourceMoveError(
+            "internal",
+            "The Frame source changed while its destination update was being committed."
+          ),
+          preserveDestinationObjects: true,
+        });
       }
       try {
         await currentFrame.updateMount({
@@ -732,31 +917,83 @@ export async function moveFrameV2Source(
         });
         return new Ok(undefined);
       } catch (error) {
-        return new Err(
-          new FrameSourceMoveError(
-            "internal",
-            `Failed to update the Frame source location: ${normalizeError(error).message}`
-          )
+        const updateError = new FrameSourceMoveError(
+          "internal",
+          `Failed to update the Frame source location: ${normalizeError(error).message}`
         );
+        let reconciledFrame: FileResource | null = null;
+        try {
+          reconciledFrame = await currentFrame.fetchFreshFrameV2(auth);
+        } catch (reconciliationError) {
+          logger.error(
+            {
+              error: normalizeError(reconciliationError),
+              frameId: currentFrame.sId,
+            },
+            "Failed to reconcile a Frame destination update"
+          );
+        }
+        if (
+          reconciledFrame?.mountFilePath === destinationMountPath &&
+          !reconciledFrame.useCaseMetadata?.pendingFrameSourceMove
+        ) {
+          return new Ok(undefined);
+        }
+        const reconciledReservation = reconciledFrame
+          ? getMatchingPendingMove(reconciledFrame, {
+              destinationMountFilePath: destinationMountPath,
+              sourceMountFilePath: sourceMountPath,
+            })
+          : null;
+        if (reconciledReservation?.operationId === operationId) {
+          return new Err({
+            error: updateError,
+            preserveDestinationObjects: false,
+          });
+        }
+        return new Err({
+          error: new FrameSourceMoveError(
+            "internal",
+            "The Frame destination update could not be reconciled; retry the move."
+          ),
+          preserveDestinationObjects: true,
+        });
       }
     };
 
+    const heldBeforeUpdate = lease.check();
+    if (heldBeforeUpdate.isErr()) {
+      return heldBeforeUpdate;
+    }
     const updateResult = await updateFrame(freshFrame);
 
     if (updateResult.isErr()) {
+      if (updateResult.error.preserveDestinationObjects) {
+        return new Err(updateResult.error.error);
+      }
+      const heldBeforeCleanup = lease.check();
+      if (heldBeforeCleanup.isErr()) {
+        return heldBeforeCleanup;
+      }
       const cleaned = await cleanupDestinationObjects(
         copyResult.value.destinationObjects
       );
-      const restored =
+      let restored = false;
+      if (
         cleaned &&
         (!isRecovery || !copyResult.value.hasPreexistingDestinationObjects)
-          ? await restoreSourceReservation()
-          : false;
+      ) {
+        const heldBeforeRestore = lease.check();
+        if (heldBeforeRestore.isErr()) {
+          return heldBeforeRestore;
+        }
+        restored = await restoreSourceReservation();
+      }
       if (!restored) {
         logger.error(
           {
             destinationDirectoryPath: destination,
-            err: updateResult.error,
+            err: updateResult.error.error,
             frameId: frame.sId,
             sourceDirectoryPath: source,
           },
@@ -769,13 +1006,16 @@ export async function moveFrameV2Source(
           )
         );
       }
-      return updateResult;
+      return new Err(updateResult.error.error);
     }
 
-    const sourceDeleted = await deleteCopiedSourceObjects(
-      copyResult.value.sourceObjects,
-      sourceMountPrefix
-    );
+    const heldBeforeSourceCleanup = lease.check();
+    const sourceDeleted = heldBeforeSourceCleanup.isOk()
+      ? await deleteCopiedSourceObjects(
+          copyResult.value.sourceObjects,
+          sourceMountPrefix
+        )
+      : false;
     const sourceDeletionFailed = !sourceDeleted;
     if (sourceDeletionFailed) {
       logger.warn(
@@ -814,10 +1054,17 @@ export async function moveFrameV2Source(
       parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
     });
 
-    return new Ok({
+    committedMove = {
       destinationDirectoryPath: destination,
       frameId: frame.sId,
       sourceDeletionFailed,
-    });
-  });
+    };
+    return new Ok(committedMove);
+  };
+  const lockedMove = await withFrameSourceAndPublishLock(
+    frame.sId,
+    runLockedMove
+  );
+
+  return committedMove ? new Ok(committedMove) : lockedMove;
 }

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -1,0 +1,808 @@
+import path from "node:path";
+
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
+import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
+import { withFrameSourceAndPublishLock } from "@app/lib/api/frames/operation_lock";
+import {
+  MAX_FRAME_SOURCE_BYTES,
+  MAX_FRAME_SOURCE_FILE_COUNT,
+} from "@app/lib/api/frames/source_limits";
+import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
+import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameGoneError } from "@app/lib/resources/frame_sandbox_adapter";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { File, FileMetadata } from "@google-cloud/storage";
+import { UniqueConstraintError } from "sequelize";
+
+const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
+
+type FrameSourceOwner = {
+  useCase: FileUseCase;
+  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
+};
+
+export class FrameSourceMoveError extends Error {
+  constructor(
+    readonly code: "conflict" | "internal" | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceMoveError";
+  }
+}
+
+export function isFrameSourceMoveError(
+  error: unknown
+): error is FrameSourceMoveError {
+  return error instanceof FrameSourceMoveError;
+}
+
+export type MoveFrameV2SourceError =
+  | DustFileSystemError
+  | FrameGoneError
+  | FrameSourceMoveError
+  | SandboxFunctionError;
+
+function invalidSource(message: string) {
+  return new Err(new FrameSourceMoveError("invalid_source", message));
+}
+
+function sourceOwnerFromPath(
+  scopedDirectoryPath: string
+): FrameSourceOwner | null {
+  const parsed = parseScopedPrefix(scopedDirectoryPath);
+  const slash = scopedDirectoryPath.indexOf("/");
+  if (
+    !parsed ||
+    slash < 0 ||
+    scopedDirectoryPath.slice(slash + 1).length === 0
+  ) {
+    return null;
+  }
+
+  switch (parsed.kind) {
+    case "conversation":
+      return {
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parsed.id },
+      };
+    case "pod":
+      return {
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: parsed.id },
+      };
+    case "user":
+      return null;
+    default:
+      return assertNever(parsed);
+  }
+}
+
+function metadataWithoutPendingMove(
+  metadata: FileUseCaseMetadata | null
+): FileUseCaseMetadata {
+  const { pendingFrameSourceMove: _pendingFrameSourceMove, ...stableMetadata } =
+    metadata ?? {};
+  return stableMetadata;
+}
+
+function hasMatchingPendingMove(
+  frame: FileResource,
+  {
+    destinationMountFilePath,
+    sourceMountFilePath,
+  }: {
+    destinationMountFilePath: string;
+    sourceMountFilePath: string;
+  }
+): boolean {
+  const pending = frame.useCaseMetadata?.pendingFrameSourceMove;
+  return (
+    frame.isFrameV2 &&
+    frame.mountFilePath === destinationMountFilePath &&
+    pending?.sourceMountFilePath === sourceMountFilePath &&
+    pending.destinationMountFilePath === destinationMountFilePath
+  );
+}
+
+function assertFrameAtSource(
+  auth: Authenticator,
+  frame: FileResource,
+  sourceManifestPath: string
+): Result<void, FrameSourceMoveError> {
+  if (!frame.isFrameV2 || frame.toScopedPath(auth) !== sourceManifestPath) {
+    return new Err(
+      new FrameSourceMoveError(
+        "conflict",
+        "The Frame source changed while it was being moved; retry from its current path."
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
+function metadataValue(metadata: FileMetadata, key: keyof FileMetadata) {
+  const value = metadata[key];
+  return value === undefined || value === null ? null : String(value);
+}
+
+function isSameGCSObject(source: File, destination: File): boolean {
+  const sourceMd5 = metadataValue(source.metadata, "md5Hash");
+  const destinationMd5 = metadataValue(destination.metadata, "md5Hash");
+  if (sourceMd5 && destinationMd5) {
+    return sourceMd5 === destinationMd5;
+  }
+
+  const sourceCrc32c = metadataValue(source.metadata, "crc32c");
+  const destinationCrc32c = metadataValue(destination.metadata, "crc32c");
+  return Boolean(
+    sourceCrc32c &&
+      destinationCrc32c &&
+      sourceCrc32c === destinationCrc32c &&
+      metadataValue(source.metadata, "size") ===
+        metadataValue(destination.metadata, "size")
+  );
+}
+
+type GCSObjectGeneration = { filePath: string; generation: string };
+type FrameSourceCopy = {
+  destinationObjects: GCSObjectGeneration[];
+  hasPreexistingDestinationObjects: boolean;
+  sourceObjects: GCSObjectGeneration[];
+};
+type FrameSourceCopyFailure = {
+  destinationObjects: GCSObjectGeneration[];
+  error: FrameSourceMoveError;
+  hasPreexistingDestinationObjects: boolean;
+};
+
+async function cleanupDestinationObjects(
+  objects: GCSObjectGeneration[]
+): Promise<boolean> {
+  const bucket = getPrivateUploadBucket();
+  try {
+    await concurrentExecutor(
+      objects,
+      ({ filePath, generation }) =>
+        bucket.delete(filePath, {
+          ignoreNotFound: true,
+          ifGenerationMatch: generation,
+        }),
+      { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+    );
+    return true;
+  } catch (error) {
+    logger.error(
+      { error: normalizeError(error) },
+      "Failed to clean up a Frame move destination"
+    );
+    return false;
+  }
+}
+
+async function deleteCopiedSourceObjects(
+  objects: GCSObjectGeneration[],
+  sourceMountPrefix: string
+): Promise<boolean> {
+  const bucket = getPrivateUploadBucket();
+  try {
+    await concurrentExecutor(
+      objects,
+      ({ filePath, generation }) =>
+        bucket.delete(filePath, {
+          ignoreNotFound: true,
+          ifGenerationMatch: generation,
+        }),
+      { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+    );
+    const remaining = await bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: 1,
+    });
+    return remaining.length === 0;
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), sourceMountPrefix },
+      "Failed to delete copied Frame source object generations"
+    );
+    return false;
+  }
+}
+
+async function copyFrameSourceAsNew({
+  allowMatchingDestinationObjects,
+  destinationMountPrefix,
+  sourceManifestPath,
+  sourceMountPrefix,
+}: {
+  allowMatchingDestinationObjects: boolean;
+  destinationMountPrefix: string;
+  sourceManifestPath: string;
+  sourceMountPrefix: string;
+}): Promise<Result<FrameSourceCopy, FrameSourceCopyFailure>> {
+  const bucket = getPrivateUploadBucket();
+  const [sourceFiles, destinationFiles] = await Promise.all([
+    bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    }),
+    bucket.getFiles({
+      prefix: destinationMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    }),
+  ]);
+  if (sourceFiles.length === 0) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source folder is empty or no longer exists."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  if (!sourceFiles.some((file) => file.name === sourceManifestPath)) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source manifest is missing."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  const totalSourceSize = sourceFiles.reduce(
+    (total, file) => total + Number(file.metadata.size ?? 0),
+    0
+  );
+  if (
+    sourceFiles.length > MAX_FRAME_SOURCE_FILE_COUNT ||
+    totalSourceSize > MAX_FRAME_SOURCE_BYTES
+  ) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source exceeds the move size limit."
+      ),
+      hasPreexistingDestinationObjects: destinationFiles.length > 0,
+    });
+  }
+  if (destinationFiles.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "conflict",
+        "Frame destination exceeds the move file count limit."
+      ),
+      hasPreexistingDestinationObjects: true,
+    });
+  }
+
+  const sourceRelativePaths = new Set(
+    sourceFiles.map((file) => file.name.slice(sourceMountPrefix.length))
+  );
+  const unexpectedDestination = destinationFiles.find(
+    (file) =>
+      !sourceRelativePaths.has(file.name.slice(destinationMountPrefix.length))
+  );
+  if (unexpectedDestination) {
+    return new Err({
+      destinationObjects: [],
+      error: new FrameSourceMoveError(
+        "conflict",
+        `Destination file already exists: ${unexpectedDestination.name.slice(destinationMountPrefix.length)}`
+      ),
+      hasPreexistingDestinationObjects: true,
+    });
+  }
+
+  const destinationByRelativePath = new Map(
+    destinationFiles.map((file) => [
+      file.name.slice(destinationMountPrefix.length),
+      file,
+    ])
+  );
+  const copyResults = await concurrentExecutor(
+    sourceFiles,
+    async (sourceFile) => {
+      let hasPreexistingDestinationObject = false;
+      try {
+        const relativePath = sourceFile.name.slice(sourceMountPrefix.length);
+        const destinationPath = `${destinationMountPrefix}${relativePath}`;
+        const sourceGeneration = metadataValue(
+          sourceFile.metadata,
+          "generation"
+        );
+        if (!sourceGeneration) {
+          throw new FrameSourceMoveError(
+            "internal",
+            `Source generation is missing: ${relativePath}`
+          );
+        }
+        let destinationFile = destinationByRelativePath.get(relativePath);
+        let ownedDestinationObject: GCSObjectGeneration | null = null;
+        hasPreexistingDestinationObject = Boolean(destinationFile);
+
+        if (!destinationFile) {
+          try {
+            const copied = await bucket.copyFile(
+              sourceFile.name,
+              destinationPath,
+              undefined,
+              {
+                destinationGenerationMatch:
+                  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+                sourceGeneration,
+              }
+            );
+            destinationFile = copied.destinationFile;
+            ownedDestinationObject = {
+              filePath: destinationPath,
+              generation: copied.destinationGeneration,
+            };
+          } catch (error) {
+            if (!isGCSPreconditionFailedError(error)) {
+              throw error;
+            }
+            if (!allowMatchingDestinationObjects) {
+              throw new FrameSourceMoveError(
+                "conflict",
+                `Destination file already exists: ${relativePath}`
+              );
+            }
+            hasPreexistingDestinationObject = true;
+            destinationFile = bucket.file(destinationPath);
+            const [metadata] = await destinationFile.getMetadata();
+            destinationFile.metadata = metadata;
+          }
+        }
+
+        if (
+          !ownedDestinationObject &&
+          (!allowMatchingDestinationObjects ||
+            !isSameGCSObject(sourceFile, destinationFile))
+        ) {
+          throw new FrameSourceMoveError(
+            "conflict",
+            `Destination file already exists: ${relativePath}`
+          );
+        }
+
+        return new Ok<{
+          destination: GCSObjectGeneration | null;
+          hasPreexistingDestinationObject: boolean;
+          source: GCSObjectGeneration;
+        }>({
+          destination: ownedDestinationObject,
+          hasPreexistingDestinationObject,
+          source: {
+            filePath: sourceFile.name,
+            generation: sourceGeneration,
+          },
+        });
+      } catch (error) {
+        return new Err({
+          error:
+            error instanceof FrameSourceMoveError
+              ? error
+              : new FrameSourceMoveError(
+                  "internal",
+                  `Failed to copy the Frame source: ${normalizeError(error).message}`
+                ),
+          hasPreexistingDestinationObject,
+        });
+      }
+    },
+    { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+  );
+  const copiedObjects = copyResults
+    .filter((result) => result.isOk())
+    .map((result) => result.value);
+  const destinationObjects = copiedObjects.flatMap(({ destination }) =>
+    destination ? [destination] : []
+  );
+  const hasPreexistingDestinationObjects =
+    destinationFiles.length > 0 ||
+    copyResults.some((result) =>
+      result.isOk()
+        ? result.value.hasPreexistingDestinationObject
+        : result.error.hasPreexistingDestinationObject
+    );
+  const failedCopy = copyResults.find((result) => result.isErr());
+  if (failedCopy?.isErr()) {
+    return new Err({
+      destinationObjects,
+      error: failedCopy.error.error,
+      hasPreexistingDestinationObjects,
+    });
+  }
+  return new Ok({
+    destinationObjects,
+    hasPreexistingDestinationObjects,
+    sourceObjects: copiedObjects.map(({ source }) => source),
+  });
+}
+
+/** Move a registered Frame folder while retaining its stable FileResource identity. */
+export async function moveFrameV2Source(
+  auth: Authenticator,
+  {
+    conversation,
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    destinationDirectoryPath: string;
+    sourceDirectoryPath: string;
+  }
+): Promise<
+  Result<
+    {
+      destinationDirectoryPath: string;
+      frameId: string;
+      sourceDeletionFailed: boolean;
+    },
+    MoveFrameV2SourceError
+  >
+> {
+  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  const destination = DustFileSystem.normalizeScopedPath(
+    destinationDirectoryPath
+  );
+  if (!source || !destination) {
+    return invalidSource("Frame source and destination must be scoped paths.");
+  }
+  if (source === destination) {
+    return invalidSource("Frame source and destination must be different.");
+  }
+  if (destination.startsWith(`${source}/`)) {
+    return invalidSource(
+      "A Frame cannot be moved inside its own source folder."
+    );
+  }
+
+  const sourceOwner = sourceOwnerFromPath(source);
+  const destinationOwner = sourceOwnerFromPath(destination);
+  if (!sourceOwner || !destinationOwner) {
+    return invalidSource(
+      "Frame source and destination must be folders in a conversation or Pod mount."
+    );
+  }
+  if (
+    sourceOwner.useCase !== destinationOwner.useCase ||
+    sourceOwner.useCaseMetadata.conversationId !==
+      destinationOwner.useCaseMetadata.conversationId ||
+    sourceOwner.useCaseMetadata.spaceId !==
+      destinationOwner.useCaseMetadata.spaceId
+  ) {
+    return invalidSource(
+      "Frame source and destination must use the same conversation or Pod mount."
+    );
+  }
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [source, destination],
+  });
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return invalidSource(
+      "Frames v2 source moves do not yet support the database-backed filesystem."
+    );
+  }
+  const sourceWriteAccess = dustFs.checkWriteAccess(source);
+  if (sourceWriteAccess.isErr()) {
+    return sourceWriteAccess;
+  }
+  const destinationWriteAccess = dustFs.checkWriteAccess(destination);
+  if (destinationWriteAccess.isErr()) {
+    return destinationWriteAccess;
+  }
+
+  const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
+  const destinationManifestPath = path.posix.join(
+    destination,
+    FRAME_MANIFEST_FILE
+  );
+  const sourceMountPath = dustFs.toMountFilePath(sourceManifestPath);
+  const destinationMountPath = dustFs.toMountFilePath(destinationManifestPath);
+  if (!sourceMountPath || !destinationMountPath) {
+    return invalidSource("Invalid Frame source or destination path.");
+  }
+
+  const candidateFrames = await FileResource.fetchByMountFilePaths(auth, [
+    sourceMountPath,
+    destinationMountPath,
+  ]);
+  const sourceFrame = candidateFrames.find(
+    (candidate) => candidate.mountFilePath === sourceMountPath
+  );
+  const destinationFrame = candidateFrames.find(
+    (candidate) => candidate.mountFilePath === destinationMountPath
+  );
+  const frame =
+    sourceFrame?.isFrameV2 === true
+      ? sourceFrame
+      : destinationFrame &&
+          hasMatchingPendingMove(destinationFrame, {
+            destinationMountFilePath: destinationMountPath,
+            sourceMountFilePath: sourceMountPath,
+          })
+        ? destinationFrame
+        : null;
+  if (!frame) {
+    return invalidSource(`No registered Frame found at ${sourceManifestPath}.`);
+  }
+
+  return withFrameSourceAndPublishLock(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame) {
+      return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
+    }
+    const isRecovery = hasMatchingPendingMove(freshFrame, {
+      destinationMountFilePath: destinationMountPath,
+      sourceMountFilePath: sourceMountPath,
+    });
+    if (!isRecovery) {
+      const sourceCheck = assertFrameAtSource(
+        auth,
+        freshFrame,
+        sourceManifestPath
+      );
+      if (sourceCheck.isErr()) {
+        return sourceCheck;
+      }
+    }
+
+    const [registeredDestination] = await FileResource.fetchByMountFilePaths(
+      auth,
+      [destinationMountPath]
+    );
+    if (registeredDestination && registeredDestination.sId !== freshFrame.sId) {
+      return new Err(
+        new FrameSourceMoveError(
+          "conflict",
+          "A registered file already uses the destination path."
+        )
+      );
+    }
+
+    if (!isRecovery) {
+      const destinationContents = await dustFs.list(destination, {
+        maxFiles: 1,
+      });
+      if (destinationContents.isErr()) {
+        return destinationContents;
+      }
+      const destinationFileExists = await dustFs.exists(destination);
+      if (destinationFileExists.isErr()) {
+        return destinationFileExists;
+      }
+      if (destinationFileExists.value || destinationContents.value.length > 0) {
+        return new Err(
+          new FrameSourceMoveError(
+            "conflict",
+            "A file or folder already exists at the destination."
+          )
+        );
+      }
+    }
+
+    const originalUseCase = freshFrame.useCase;
+    const originalMetadata = metadataWithoutPendingMove(
+      freshFrame.useCaseMetadata
+    );
+    const restoreSourceReservation = async (): Promise<boolean> => {
+      try {
+        await freshFrame.updateMount({
+          destFileName: FRAME_MANIFEST_FILE,
+          destMountFilePath: sourceMountPath,
+          destUseCase: originalUseCase,
+          destUseCaseMetadata: originalMetadata,
+        });
+        return true;
+      } catch (error) {
+        logger.error(
+          {
+            error: normalizeError(error),
+            frameId: frame.sId,
+            sourceMountPath,
+          },
+          "Failed to restore a Frame source reservation"
+        );
+        return false;
+      }
+    };
+
+    if (!isRecovery) {
+      try {
+        await freshFrame.updateMount({
+          destFileName: FRAME_MANIFEST_FILE,
+          destMountFilePath: destinationMountPath,
+          destUseCase: originalUseCase,
+          destUseCaseMetadata: {
+            ...originalMetadata,
+            pendingFrameSourceMove: {
+              destinationMountFilePath: destinationMountPath,
+              sourceMountFilePath: sourceMountPath,
+            },
+          },
+        });
+      } catch (error) {
+        return new Err(
+          new FrameSourceMoveError(
+            error instanceof UniqueConstraintError ? "conflict" : "internal",
+            error instanceof UniqueConstraintError
+              ? "A registered file already uses the destination path."
+              : `Failed to reserve the Frame destination: ${normalizeError(error).message}`
+          )
+        );
+      }
+    }
+
+    const sourceMountPrefix = `${path.posix.dirname(sourceMountPath)}/`;
+    const destinationMountPrefix = `${path.posix.dirname(
+      destinationMountPath
+    )}/`;
+    const copyResult = await copyFrameSourceAsNew({
+      allowMatchingDestinationObjects: isRecovery,
+      destinationMountPrefix,
+      sourceManifestPath: sourceMountPath,
+      sourceMountPrefix,
+    });
+    if (copyResult.isErr()) {
+      const cleaned = await cleanupDestinationObjects(
+        copyResult.error.destinationObjects
+      );
+      if (!cleaned) {
+        return new Err(
+          new FrameSourceMoveError(
+            "internal",
+            "The Frame source copy failed and its destination objects could not be cleaned up; retry the move."
+          )
+        );
+      }
+      if (isRecovery && copyResult.error.hasPreexistingDestinationObjects) {
+        return new Err(copyResult.error.error);
+      }
+      const restored = await restoreSourceReservation();
+      return restored
+        ? new Err(copyResult.error.error)
+        : new Err(
+            new FrameSourceMoveError(
+              "internal",
+              "The Frame source copy failed and its destination reservation could not be released."
+            )
+          );
+    }
+
+    const updateFrame = async (
+      currentFrame: FileResource
+    ): Promise<Result<void, FrameSourceMoveError>> => {
+      if (
+        !hasMatchingPendingMove(currentFrame, {
+          destinationMountFilePath: destinationMountPath,
+          sourceMountFilePath: sourceMountPath,
+        })
+      ) {
+        return new Err(
+          new FrameSourceMoveError(
+            "conflict",
+            "The Frame source changed while it was being moved; retry from its current path."
+          )
+        );
+      }
+      try {
+        await currentFrame.updateMount({
+          destFileName: FRAME_MANIFEST_FILE,
+          destMountFilePath: destinationMountPath,
+          destUseCase: originalUseCase,
+          destUseCaseMetadata: metadataWithoutPendingMove(
+            currentFrame.useCaseMetadata
+          ),
+        });
+        return new Ok(undefined);
+      } catch (error) {
+        return new Err(
+          new FrameSourceMoveError(
+            "internal",
+            `Failed to update the Frame source location: ${normalizeError(error).message}`
+          )
+        );
+      }
+    };
+
+    const updateResult = await updateFrame(freshFrame);
+
+    if (updateResult.isErr()) {
+      const cleaned = await cleanupDestinationObjects(
+        copyResult.value.destinationObjects
+      );
+      const restored =
+        cleaned &&
+        (!isRecovery || !copyResult.value.hasPreexistingDestinationObjects)
+          ? await restoreSourceReservation()
+          : false;
+      if (!restored) {
+        logger.error(
+          {
+            destinationDirectoryPath: destination,
+            err: updateResult.error,
+            frameId: frame.sId,
+            sourceDirectoryPath: source,
+          },
+          "Frame source move failed and could not be rolled back"
+        );
+        return new Err(
+          new FrameSourceMoveError(
+            "internal",
+            "The Frame source move failed and could not be rolled back."
+          )
+        );
+      }
+      return updateResult;
+    }
+
+    const sourceDeleted = await deleteCopiedSourceObjects(
+      copyResult.value.sourceObjects,
+      sourceMountPrefix
+    );
+    const sourceDeletionFailed = !sourceDeleted;
+    if (sourceDeletionFailed) {
+      logger.warn(
+        {
+          destinationDirectoryPath: destination,
+          frameId: frame.sId,
+          sourceDirectoryPath: source,
+        },
+        "Frame source moved but the old folder could not be removed"
+      );
+    }
+
+    const destinationScope: GCSMountPoint =
+      destinationOwner.useCase === "conversation"
+        ? {
+            useCase: "conversation",
+            conversationId:
+              destinationOwner.useCaseMetadata.conversationId ?? "",
+          }
+        : {
+            useCase: "pod",
+            podId: destinationOwner.useCaseMetadata.spaceId ?? "",
+          };
+    const destinationRelativePath = destination.slice(
+      destination.indexOf("/") + 1
+    );
+    const parentRelativePath = path.posix.dirname(destinationRelativePath);
+    void emitGCSMountFileMovedAuditLog(auth, destinationScope, {
+      relativeFilePath: destinationRelativePath,
+      parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
+    });
+
+    return new Ok({
+      destinationDirectoryPath: destination,
+      frameId: frame.sId,
+      sourceDeletionFailed,
+    });
+  });
+}

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -19,8 +19,10 @@ import {
   isGCSNotFoundError,
   isGCSPreconditionFailedError,
 } from "@app/lib/file_storage/types";
-import type { LockLeaseGuard } from "@app/lib/lock";
+import type { LockLeaseGuard, LockLeaseLostError } from "@app/lib/lock";
+import { isLockLeaseLostError } from "@app/lib/lock";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FrameGoneError } from "@app/lib/resources/frame_sandbox_adapter";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -124,6 +126,33 @@ async function resolveRuntimeSpaceId(
     return invalidSource(`Conversation ${conversationId} not found.`);
   }
   return new Ok(conversation.spaceSId);
+}
+
+async function withConversationOwnerLifecycleLocks<T>(
+  owners: FrameSourceOwner[],
+  fn: () => Promise<T>
+): Promise<T> {
+  const conversationIds = [
+    ...new Set(
+      owners.flatMap(({ useCase, useCaseMetadata }) =>
+        useCase === "conversation" && useCaseMetadata.conversationId
+          ? [useCaseMetadata.conversationId]
+          : []
+      )
+    ),
+  ].sort();
+
+  const acquireNext = (index: number): Promise<T> => {
+    const conversationId = conversationIds[index];
+    return conversationId
+      ? ConversationSandboxAdapter.withLifecycleLock(
+          { sId: conversationId },
+          () => acquireNext(index + 1)
+        )
+      : fn();
+  };
+
+  return acquireNext(0);
 }
 
 function frameMetadataAtDestination(
@@ -766,7 +795,11 @@ export async function moveFrameV2Source(
   }
 
   let committedMove: FrameSourceMove | null = null;
-  const runLockedMove = async (lease: LockLeaseGuard) => {
+  const runLockedMove = async (
+    lease: LockLeaseGuard
+  ): Promise<
+    Result<FrameSourceMove, MoveFrameV2SourceError | LockLeaseLostError>
+  > => {
     const freshFrame = await frame.fetchFreshFrameV2(auth);
     if (!freshFrame) {
       return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
@@ -928,14 +961,13 @@ export async function moveFrameV2Source(
           );
     }
 
+    type DestinationUpdateError = {
+      error: FrameSourceMoveError;
+      preserveDestinationObjects: boolean;
+    };
     const updateFrame = async (
       currentFrame: FileResource
-    ): Promise<
-      Result<
-        void,
-        { error: FrameSourceMoveError; preserveDestinationObjects: boolean }
-      >
-    > => {
+    ): Promise<Result<void, DestinationUpdateError>> => {
       const currentReservation = getMatchingPendingMove(currentFrame, {
         destinationMountFilePath: destinationMountPath,
         sourceMountFilePath: sourceMountPath,
@@ -961,57 +993,111 @@ export async function moveFrameV2Source(
         });
         return new Ok(undefined);
       } catch (error) {
-        const updateError = new FrameSourceMoveError(
-          "internal",
-          `Failed to update the Frame source location: ${normalizeError(error).message}`
-        );
-        let reconciledFrame: FileResource | null = null;
-        try {
-          reconciledFrame = await currentFrame.fetchFreshFrameV2(auth);
-        } catch (reconciliationError) {
-          logger.error(
-            {
-              error: normalizeError(reconciliationError),
-              frameId: currentFrame.sId,
-            },
-            "Failed to reconcile a Frame destination update"
-          );
-        }
-        if (
-          reconciledFrame?.mountFilePath === destinationMountPath &&
-          !reconciledFrame.useCaseMetadata?.pendingFrameSourceMove
-        ) {
-          return new Ok(undefined);
-        }
-        const reconciledReservation = reconciledFrame
-          ? getMatchingPendingMove(reconciledFrame, {
-              destinationMountFilePath: destinationMountPath,
-              sourceMountFilePath: sourceMountPath,
-            })
-          : null;
-        if (reconciledReservation?.operationId === operationId) {
-          return new Err({
-            error: updateError,
-            preserveDestinationObjects: false,
-          });
-        }
-        return new Err({
-          error: new FrameSourceMoveError(
+        return reconcileDestinationUpdate(
+          new FrameSourceMoveError(
             "internal",
-            "The Frame destination update could not be reconciled; retry the move."
-          ),
-          preserveDestinationObjects: true,
-        });
+            `Failed to update the Frame source location: ${normalizeError(error).message}`
+          )
+        );
       }
     };
 
-    const heldBeforeUpdate = lease.check();
-    if (heldBeforeUpdate.isErr()) {
-      return heldBeforeUpdate;
+    const reconcileDestinationUpdate = async (
+      updateError: FrameSourceMoveError
+    ): Promise<Result<void, DestinationUpdateError>> => {
+      let reconciledFrame: FileResource | null = null;
+      try {
+        reconciledFrame = await freshFrame.fetchFreshFrameV2(auth);
+      } catch (reconciliationError) {
+        logger.error(
+          {
+            error: normalizeError(reconciliationError),
+            frameId: freshFrame.sId,
+          },
+          "Failed to reconcile a Frame destination update"
+        );
+      }
+      if (
+        reconciledFrame?.mountFilePath === destinationMountPath &&
+        !reconciledFrame.useCaseMetadata?.pendingFrameSourceMove
+      ) {
+        return new Ok(undefined);
+      }
+      const reconciledReservation = reconciledFrame
+        ? getMatchingPendingMove(reconciledFrame, {
+            destinationMountFilePath: destinationMountPath,
+            sourceMountFilePath: sourceMountPath,
+          })
+        : null;
+      if (reconciledReservation?.operationId === operationId) {
+        return new Err({
+          error: updateError,
+          preserveDestinationObjects: false,
+        });
+      }
+      return new Err({
+        error: new FrameSourceMoveError(
+          "internal",
+          "The Frame destination update could not be reconciled; retry the move."
+        ),
+        preserveDestinationObjects: true,
+      });
+    };
+
+    let updateResult: Result<void, DestinationUpdateError | LockLeaseLostError>;
+    try {
+      updateResult = await withConversationOwnerLifecycleLocks(
+        [sourceOwner, destinationOwner],
+        async () => {
+          const [freshSourceRuntimeSpace, freshDestinationRuntimeSpace] =
+            await Promise.all([
+              resolveRuntimeSpaceId(auth, sourceOwner),
+              resolveRuntimeSpaceId(auth, destinationOwner),
+            ]);
+          if (freshSourceRuntimeSpace.isErr()) {
+            return new Err({
+              error: freshSourceRuntimeSpace.error,
+              preserveDestinationObjects: false,
+            });
+          }
+          if (freshDestinationRuntimeSpace.isErr()) {
+            return new Err({
+              error: freshDestinationRuntimeSpace.error,
+              preserveDestinationObjects: false,
+            });
+          }
+          if (
+            freshSourceRuntimeSpace.value !== freshDestinationRuntimeSpace.value
+          ) {
+            return new Err({
+              error: new FrameSourceMoveError(
+                "conflict",
+                "The Frame runtime scope changed while its source was being moved."
+              ),
+              preserveDestinationObjects: false,
+            });
+          }
+
+          const heldBeforeUpdate = lease.check();
+          if (heldBeforeUpdate.isErr()) {
+            return heldBeforeUpdate;
+          }
+          return updateFrame(freshFrame);
+        }
+      );
+    } catch (error) {
+      updateResult = await reconcileDestinationUpdate(
+        new FrameSourceMoveError(
+          "internal",
+          `Failed to serialize the Frame destination update: ${normalizeError(error).message}`
+        )
+      );
     }
-    const updateResult = await updateFrame(freshFrame);
 
     if (updateResult.isErr()) {
+      if (isLockLeaseLostError(updateResult.error)) {
+        return new Err(updateResult.error);
+      }
       if (updateResult.error.preserveDestinationObjects) {
         return new Err(updateResult.error.error);
       }

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
@@ -31,6 +32,7 @@ import type { File, FileMetadata } from "@google-cloud/storage";
 import { UniqueConstraintError } from "sequelize";
 
 const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
+const FRAME_SOURCE_MOVE_ID_METADATA_KEY = "dust_frame_source_move_id";
 
 type FrameSourceOwner = {
   useCase: FileUseCase;
@@ -102,7 +104,11 @@ function metadataWithoutPendingMove(
   return stableMetadata;
 }
 
-function hasMatchingPendingMove(
+type FrameSourceMoveReservation = NonNullable<
+  FileUseCaseMetadata["pendingFrameSourceMove"]
+>;
+
+function getMatchingPendingMove(
   frame: FileResource,
   {
     destinationMountFilePath,
@@ -111,14 +117,14 @@ function hasMatchingPendingMove(
     destinationMountFilePath: string;
     sourceMountFilePath: string;
   }
-): boolean {
+): FrameSourceMoveReservation | null {
   const pending = frame.useCaseMetadata?.pendingFrameSourceMove;
-  return (
-    frame.isFrameV2 &&
+  return frame.isFrameV2 &&
     frame.mountFilePath === destinationMountFilePath &&
     pending?.sourceMountFilePath === sourceMountFilePath &&
     pending.destinationMountFilePath === destinationMountFilePath
-  );
+    ? pending
+    : null;
 }
 
 function assertFrameAtSource(
@@ -142,21 +148,9 @@ function metadataValue(metadata: FileMetadata, key: keyof FileMetadata) {
   return value === undefined || value === null ? null : String(value);
 }
 
-function isSameGCSObject(source: File, destination: File): boolean {
-  const sourceMd5 = metadataValue(source.metadata, "md5Hash");
-  const destinationMd5 = metadataValue(destination.metadata, "md5Hash");
-  if (sourceMd5 && destinationMd5) {
-    return sourceMd5 === destinationMd5;
-  }
-
-  const sourceCrc32c = metadataValue(source.metadata, "crc32c");
-  const destinationCrc32c = metadataValue(destination.metadata, "crc32c");
-  return Boolean(
-    sourceCrc32c &&
-      destinationCrc32c &&
-      sourceCrc32c === destinationCrc32c &&
-      metadataValue(source.metadata, "size") ===
-        metadataValue(destination.metadata, "size")
+function isDestinationOwnedByMove(file: File, operationId: string): boolean {
+  return (
+    file.metadata.metadata?.[FRAME_SOURCE_MOVE_ID_METADATA_KEY] === operationId
   );
 }
 
@@ -226,13 +220,13 @@ async function deleteCopiedSourceObjects(
 }
 
 async function copyFrameSourceAsNew({
-  allowMatchingDestinationObjects,
   destinationMountPrefix,
+  operationId,
   sourceManifestPath,
   sourceMountPrefix,
 }: {
-  allowMatchingDestinationObjects: boolean;
   destinationMountPrefix: string;
+  operationId: string;
   sourceManifestPath: string;
   sourceMountPrefix: string;
 }): Promise<Result<FrameSourceCopy, FrameSourceCopyFailure>> {
@@ -349,6 +343,10 @@ async function copyFrameSourceAsNew({
               {
                 destinationGenerationMatch:
                   GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+                destinationMetadata: {
+                  ...sourceFile.metadata.metadata,
+                  [FRAME_SOURCE_MOVE_ID_METADATA_KEY]: operationId,
+                },
                 sourceGeneration,
               }
             );
@@ -361,12 +359,6 @@ async function copyFrameSourceAsNew({
             if (!isGCSPreconditionFailedError(error)) {
               throw error;
             }
-            if (!allowMatchingDestinationObjects) {
-              throw new FrameSourceMoveError(
-                "conflict",
-                `Destination file already exists: ${relativePath}`
-              );
-            }
             hasPreexistingDestinationObject = true;
             destinationFile = bucket.file(destinationPath);
             const [metadata] = await destinationFile.getMetadata();
@@ -374,15 +366,27 @@ async function copyFrameSourceAsNew({
           }
         }
 
-        if (
-          !ownedDestinationObject &&
-          (!allowMatchingDestinationObjects ||
-            !isSameGCSObject(sourceFile, destinationFile))
-        ) {
-          throw new FrameSourceMoveError(
-            "conflict",
-            `Destination file already exists: ${relativePath}`
+        if (!ownedDestinationObject) {
+          if (!isDestinationOwnedByMove(destinationFile, operationId)) {
+            throw new FrameSourceMoveError(
+              "conflict",
+              `Destination file already exists: ${relativePath}`
+            );
+          }
+          const destinationGeneration = metadataValue(
+            destinationFile.metadata,
+            "generation"
           );
+          if (!destinationGeneration) {
+            throw new FrameSourceMoveError(
+              "internal",
+              `Destination generation is missing: ${relativePath}`
+            );
+          }
+          ownedDestinationObject = {
+            filePath: destinationPath,
+            generation: destinationGeneration,
+          };
         }
 
         return new Ok<{
@@ -497,6 +501,8 @@ export async function moveFrameV2Source(
     );
   }
 
+  // The conversation is the sandbox invocation context. Explicitly requested
+  // mounts are still resolved through the authenticated agent-loop filesystem.
   const fsResult = await DustFileSystem.forAgentLoop(auth, {
     conversation,
     scopedPaths: [source, destination],
@@ -544,7 +550,7 @@ export async function moveFrameV2Source(
     sourceFrame?.isFrameV2 === true
       ? sourceFrame
       : destinationFrame &&
-          hasMatchingPendingMove(destinationFrame, {
+          getMatchingPendingMove(destinationFrame, {
             destinationMountFilePath: destinationMountPath,
             sourceMountFilePath: sourceMountPath,
           })
@@ -559,10 +565,12 @@ export async function moveFrameV2Source(
     if (!freshFrame) {
       return new Err(new FrameGoneError(`Frame ${frame.sId} not found.`));
     }
-    const isRecovery = hasMatchingPendingMove(freshFrame, {
+    const reservation = getMatchingPendingMove(freshFrame, {
       destinationMountFilePath: destinationMountPath,
       sourceMountFilePath: sourceMountPath,
     });
+    const isRecovery = reservation !== null;
+    const operationId = reservation?.operationId ?? randomUUID();
     if (!isRecovery) {
       const sourceCheck = assertFrameAtSource(
         auth,
@@ -644,6 +652,7 @@ export async function moveFrameV2Source(
             ...originalMetadata,
             pendingFrameSourceMove: {
               destinationMountFilePath: destinationMountPath,
+              operationId,
               sourceMountFilePath: sourceMountPath,
             },
           },
@@ -665,8 +674,8 @@ export async function moveFrameV2Source(
       destinationMountPath
     )}/`;
     const copyResult = await copyFrameSourceAsNew({
-      allowMatchingDestinationObjects: isRecovery,
       destinationMountPrefix,
+      operationId,
       sourceManifestPath: sourceMountPath,
       sourceMountPrefix,
     });
@@ -700,7 +709,7 @@ export async function moveFrameV2Source(
       currentFrame: FileResource
     ): Promise<Result<void, FrameSourceMoveError>> => {
       if (
-        !hasMatchingPendingMove(currentFrame, {
+        !getMatchingPendingMove(currentFrame, {
           destinationMountFilePath: destinationMountPath,
           sourceMountFilePath: sourceMountPath,
         })
@@ -790,12 +799,18 @@ export async function moveFrameV2Source(
             useCase: "pod",
             podId: destinationOwner.useCaseMetadata.spaceId ?? "",
           };
-    const destinationRelativePath = destination.slice(
-      destination.indexOf("/") + 1
+    const scopedPrefix =
+      sourceOwner.useCase === "conversation"
+        ? `conversation-${sourceOwner.useCaseMetadata.conversationId}`
+        : `pod-${sourceOwner.useCaseMetadata.spaceId}`;
+    const sourceRelativePath = path.posix.relative(scopedPrefix, source);
+    const destinationRelativePath = path.posix.relative(
+      scopedPrefix,
+      destination
     );
     const parentRelativePath = path.posix.dirname(destinationRelativePath);
     void emitGCSMountFileMovedAuditLog(auth, destinationScope, {
-      relativeFilePath: destinationRelativePath,
+      relativeFilePath: sourceRelativePath,
       parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
     });
 

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -20,6 +20,7 @@ import {
   isGCSPreconditionFailedError,
 } from "@app/lib/file_storage/types";
 import type { LockLeaseGuard } from "@app/lib/lock";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FrameGoneError } from "@app/lib/resources/frame_sandbox_adapter";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -101,6 +102,44 @@ function sourceOwnerFromPath(
     default:
       return assertNever(parsed);
   }
+}
+
+async function resolveRuntimeSpaceId(
+  auth: Authenticator,
+  sourceOwner: FrameSourceOwner
+): Promise<Result<string | null, FrameSourceMoveError>> {
+  const { conversationId, spaceId } = sourceOwner.useCaseMetadata;
+  if (spaceId) {
+    return new Ok(spaceId);
+  }
+  if (!conversationId) {
+    return invalidSource("Frame source has no conversation or Pod scope.");
+  }
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return invalidSource(`Conversation ${conversationId} not found.`);
+  }
+  return new Ok(conversation.spaceSId);
+}
+
+function frameMetadataAtDestination(
+  frame: FileResource,
+  destinationOwner: FrameSourceOwner
+): FileUseCaseMetadata {
+  const {
+    conversationId: _conversationId,
+    pendingFrameSourceMove: _pendingFrameSourceMove,
+    spaceId: _spaceId,
+    ...stableMetadata
+  } = frame.useCaseMetadata ?? {};
+  return {
+    ...stableMetadata,
+    ...destinationOwner.useCaseMetadata,
+  };
 }
 
 function metadataWithoutPendingMove(
@@ -651,18 +690,6 @@ export async function moveFrameV2Source(
       "Frame source and destination must be folders in a conversation or Pod mount."
     );
   }
-  if (
-    sourceOwner.useCase !== destinationOwner.useCase ||
-    sourceOwner.useCaseMetadata.conversationId !==
-      destinationOwner.useCaseMetadata.conversationId ||
-    sourceOwner.useCaseMetadata.spaceId !==
-      destinationOwner.useCaseMetadata.spaceId
-  ) {
-    return invalidSource(
-      "Frame source and destination must use the same conversation or Pod mount."
-    );
-  }
-
   // The conversation is the sandbox invocation context. Explicitly requested
   // mounts are still resolved through the authenticated agent-loop filesystem.
   const fsResult = await DustFileSystem.forAgentLoop(auth, {
@@ -685,6 +712,22 @@ export async function moveFrameV2Source(
   const destinationWriteAccess = dustFs.checkWriteAccess(destination);
   if (destinationWriteAccess.isErr()) {
     return destinationWriteAccess;
+  }
+
+  const [sourceRuntimeSpace, destinationRuntimeSpace] = await Promise.all([
+    resolveRuntimeSpaceId(auth, sourceOwner),
+    resolveRuntimeSpaceId(auth, destinationOwner),
+  ]);
+  if (sourceRuntimeSpace.isErr()) {
+    return sourceRuntimeSpace;
+  }
+  if (destinationRuntimeSpace.isErr()) {
+    return destinationRuntimeSpace;
+  }
+  if (sourceRuntimeSpace.value !== destinationRuntimeSpace.value) {
+    return invalidSource(
+      "Frame source and destination must resolve to the same runtime space."
+    );
   }
 
   const sourceManifestPath = path.posix.join(source, FRAME_MANIFEST_FILE);
@@ -910,9 +953,10 @@ export async function moveFrameV2Source(
         await currentFrame.updateMount({
           destFileName: FRAME_MANIFEST_FILE,
           destMountFilePath: destinationMountPath,
-          destUseCase: originalUseCase,
-          destUseCaseMetadata: metadataWithoutPendingMove(
-            currentFrame.useCaseMetadata
+          destUseCase: destinationOwner.useCase,
+          destUseCaseMetadata: frameMetadataAtDestination(
+            currentFrame,
+            destinationOwner
           ),
         });
         return new Ok(undefined);
@@ -1039,15 +1083,17 @@ export async function moveFrameV2Source(
             useCase: "pod",
             podId: destinationOwner.useCaseMetadata.spaceId ?? "",
           };
-    const scopedPrefix =
-      sourceOwner.useCase === "conversation"
-        ? `conversation-${sourceOwner.useCaseMetadata.conversationId}`
-        : `pod-${sourceOwner.useCaseMetadata.spaceId}`;
-    const sourceRelativePath = path.posix.relative(scopedPrefix, source);
+    const destinationScopedPrefix =
+      destinationOwner.useCase === "conversation"
+        ? `conversation-${destinationOwner.useCaseMetadata.conversationId}`
+        : `pod-${destinationOwner.useCaseMetadata.spaceId}`;
     const destinationRelativePath = path.posix.relative(
-      scopedPrefix,
+      destinationScopedPrefix,
       destination
     );
+    const sourceRelativePath = source.startsWith(`${destinationScopedPrefix}/`)
+      ? path.posix.relative(destinationScopedPrefix, source)
+      : destinationRelativePath;
     const parentRelativePath = path.posix.dirname(destinationRelativePath);
     void emitGCSMountFileMovedAuditLog(auth, destinationScope, {
       relativeFilePath: sourceRelativePath,

--- a/front/lib/api/frames/operation_lock.test.ts
+++ b/front/lib/api/frames/operation_lock.test.ts
@@ -1,0 +1,43 @@
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import type { RedisClientType } from "@app/lib/api/redis";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+const { getRedisStreamClientMock } = vi.hoisted(() => ({
+  getRedisStreamClientMock: vi.fn<() => Promise<LockRedisClient>>(),
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisStreamClient: getRedisStreamClientMock,
+}));
+
+function makeRedisClient(): LockRedisClient {
+  return {
+    eval: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("Frame operation locks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps zero-argument publish callbacks compatible", async () => {
+    getRedisStreamClientMock.mockResolvedValue(makeRedisClient());
+
+    const result = await withFramePublishLock(
+      "frame-123",
+      async () => new Ok("published")
+    );
+
+    expect(result.isOk() && result.value).toBe("published");
+  });
+});

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -55,10 +55,7 @@ async function withTypedFrameOperationLock<T, E>(
   );
   if (result.isErr()) {
     const error = result.error;
-    if (
-      isLockAcquisitionTimeoutError(error) ||
-      isLockLeaseLostError(error)
-    ) {
+    if (isLockAcquisitionTimeoutError(error) || isLockLeaseLostError(error)) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,8 +1,14 @@
-import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
-import { executeWithLockResult } from "@app/lib/lock";
+import type {
+  LockAcquisitionTimeoutError,
+  LockLeaseGuard,
+  LockLeaseLostError,
+} from "@app/lib/lock";
+import { executeWithRenewingLockResult } from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
+
+type FrameOperationLockError = LockAcquisitionTimeoutError | LockLeaseLostError;
 
 export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
@@ -10,9 +16,11 @@ export function getFramePublishLockName(frameId: string): string {
 
 export function withFramePublishLock<T, E>(
   frameId: string,
-  callback: () => Promise<Result<T, E>>
-): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
-  return executeWithLockResult(
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>
+): Promise<Result<T, E | FrameOperationLockError>> {
+  return executeWithRenewingLockResult(
     getFramePublishLockName(frameId),
     callback,
     30_000,

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,10 +1,16 @@
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type {
   LockAcquisitionTimeoutError,
   LockLeaseGuard,
   LockLeaseLostError,
 } from "@app/lib/lock";
-import { executeWithRenewingLockResult } from "@app/lib/lock";
+import {
+  executeWithRenewingLockResult,
+  isLockAcquisitionTimeoutError,
+  isLockLeaseLostError,
+} from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
 
@@ -12,6 +18,10 @@ type FrameOperationLockError = LockAcquisitionTimeoutError | LockLeaseLostError;
 
 export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
+}
+
+export function getFrameSourceLockName(frameId: string): string {
+  return `frame:source:${frameId}`;
 }
 
 export function withFramePublishLock<T, E>(
@@ -25,5 +35,67 @@ export function withFramePublishLock<T, E>(
     callback,
     30_000,
     { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
+  );
+}
+
+async function withTypedFrameOperationLock<T, E>(
+  lockName: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  const result = await executeWithRenewingLockResult(
+    lockName,
+    callback,
+    30_000,
+    {
+      lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS,
+      traceAcquireResource: "frame.source",
+    }
+  );
+  if (result.isErr()) {
+    const error = result.error;
+    if (
+      isLockAcquisitionTimeoutError(error) ||
+      isLockLeaseLostError(error)
+    ) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          "Another publication or source operation is in progress for this Frame; retry shortly."
+        )
+      );
+    }
+    return new Err(error);
+  }
+  return result;
+}
+
+export function withFrameSourceLock<T, E>(
+  frameId: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withTypedFrameOperationLock(getFrameSourceLockName(frameId), callback);
+}
+
+export function withFrameSourceAndPublishLock<T, E>(
+  frameId: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>
+): Promise<Result<T, E | SandboxFunctionError>> {
+  return withFrameSourceLock(frameId, (sourceLease) =>
+    withTypedFrameOperationLock(
+      getFramePublishLockName(frameId),
+      (publishLease) =>
+        callback({
+          check: () => {
+            const sourceHeld = sourceLease.check();
+            return sourceHeld.isErr() ? sourceHeld : publishLease.check();
+          },
+        })
+    )
   );
 }

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -17,6 +17,7 @@ import {
   LockLeaseLostError,
 } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import {
   computeSandboxFunctionBundleSha256,
   SandboxFunctionResource,
@@ -1153,5 +1154,45 @@ describe("publishFramePublication", () => {
       deletion.isErr() ? deletion.error.message : undefined
     ).toBe(true);
     await expect(FileResource.fetchById(auth, frame.sId)).resolves.toBeNull();
+  });
+
+  it("preserves the Frame when its deletion lease is lost", async () => {
+    const { auth, frame } = await setupFrame({ ready: true });
+    const onDeleteByPrefix = vi.fn();
+    fileStorageMock.setOnDeleteByPrefix(onDeleteByPrefix);
+    const redisEval = vi.mocked(
+      redisMock.streamClient.eval as (...args: unknown[]) => Promise<number>
+    );
+    redisEval.mockResolvedValueOnce(0).mockResolvedValue(1);
+    const deleteSandbox = vi
+      .spyOn(FrameSandboxAdapter, "deleteSandbox")
+      .mockImplementation(
+        async (
+          _auth,
+          _frame,
+          { afterSandboxCleanup, beforeSandboxCleanup } = {}
+        ) => {
+          expect(beforeSandboxCleanup?.().isOk()).toBe(true);
+          await vi.advanceTimersByTimeAsync(200_000);
+          return afterSandboxCleanup?.() ?? new Ok(undefined);
+        }
+      );
+    vi.useFakeTimers();
+
+    try {
+      const deletion = await frame.delete(auth);
+
+      expect(deletion.isErr() && isLockLeaseLostError(deletion.error)).toBe(
+        true
+      );
+      await expect(
+        FileResource.fetchById(auth, frame.sId)
+      ).resolves.not.toBeNull();
+      expect(onDeleteByPrefix).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      deleteSandbox.mockRestore();
+      redisEval.mockResolvedValue(1);
+    }
   });
 });

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -11,7 +11,11 @@ import { getRedisStreamClient } from "@app/lib/api/redis";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
-import { LockAcquisitionTimeoutError } from "@app/lib/lock";
+import {
+  isLockLeaseLostError,
+  LockAcquisitionTimeoutError,
+  LockLeaseLostError,
+} from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import {
   computeSandboxFunctionBundleSha256,
@@ -594,6 +598,101 @@ describe("activateFramePublication", () => {
     );
   });
 
+  it("does not start activation when the lease is already lost", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    const leaseError = new LockLeaseLostError(
+      getFramePublishLockName(frame.sId)
+    );
+    const lease = {
+      check: vi.fn().mockReturnValue(new Err(leaseError)),
+    };
+    const setActivePublication = vi.spyOn(frame, "setActiveFramePublication");
+
+    const activated = await activateFramePublication(auth, {
+      frame,
+      lease,
+      publicationId: stored.value.publicationId,
+    });
+
+    expect(activated.isErr() && isLockLeaseLostError(activated.error)).toBe(
+      true
+    );
+    expect(setActivePublication).not.toHaveBeenCalled();
+  });
+
+  it("rolls back activation when the lease is lost before commit", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    const leaseError = new LockLeaseLostError(
+      getFramePublishLockName(frame.sId)
+    );
+    const lease = {
+      check: vi
+        .fn()
+        .mockReturnValueOnce(new Ok(undefined))
+        .mockReturnValueOnce(new Err(leaseError)),
+    };
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+
+    await expect(
+      frontSequelize.transaction(
+        { transaction: parentTransaction },
+        async () => {
+          const activated = await activateFramePublication(auth, {
+            frame,
+            lease,
+            publicationId: stored.value.publicationId,
+          });
+          throw activated.isErr()
+            ? activated.error
+            : new Error("Expected the activation lease to be lost.");
+        }
+      )
+    ).rejects.toMatchObject({ name: "LockLeaseLostError" });
+
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBeUndefined();
+    expect(
+      await FileResource.shareableFileModel.count({
+        where: { fileId: frame.id, workspaceId: frame.workspaceId },
+      })
+    ).toBe(0);
+    expect(
+      await FileResource.authorizedFileAccessModel.count({
+        where: { workspaceId: frame.workspaceId },
+      })
+    ).toBe(0);
+    expect(
+      await SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: stored.value.publicationId,
+      })
+    ).toHaveLength(0);
+  });
+
   it("keeps the active publication when validation fails", async () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
@@ -618,9 +717,11 @@ describe("activateFramePublication", () => {
       publicationId: "b8c2b796-534a-4ad2-a5ad-071da692ca0b",
     });
 
-    expect(activation.isErr() && activation.error.code).toBe(
-      "publication_not_found"
-    );
+    expect(
+      activation.isErr() && "code" in activation.error
+        ? activation.error.code
+        : undefined
+    ).toBe("publication_not_found");
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
@@ -699,9 +800,9 @@ describe("activateFramePublication", () => {
       publicationId: stored.value.publicationId,
     });
 
-    expect(result.isErr() && result.error.code).toBe(
-      "invalid_function_artifact"
-    );
+    expect(
+      result.isErr() && "code" in result.error ? result.error.code : undefined
+    ).toBe("invalid_function_artifact");
     expect(frame.useCaseMetadata?.activePublicationId).toBeUndefined();
   });
 

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -15,7 +15,11 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
-import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
+import type { LockLeaseGuard, LockLeaseLostError } from "@app/lib/lock";
+import {
+  isLockAcquisitionTimeoutError,
+  isLockLeaseLostError,
+} from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -456,12 +460,14 @@ export async function activateFramePublication(
   auth: Authenticator,
   {
     frame,
+    lease,
     publicationId,
   }: {
     frame: FileResource;
+    lease?: LockLeaseGuard;
     publicationId: string;
   }
-): Promise<Result<void, FramePublicationError>> {
+): Promise<Result<void, FramePublicationError | LockLeaseLostError>> {
   const descriptor = await loadFramePublicationDescriptor(auth, {
     frame,
     publicationId,
@@ -522,21 +528,40 @@ export async function activateFramePublication(
   }
   const shareScope = await frame.getShareScope();
 
-  await withTransaction(async (transaction) => {
-    // Updating the Frame first serializes concurrent activations. None of the
-    // new publication state becomes visible until the transaction commits.
-    await frame.setActiveFramePublication(publicationId, transaction);
-    await frame.persistAuthorizedFileAccess(allowlist.value, { transaction });
-    await SandboxFunctionResource.createForFramePublication(
-      auth,
-      {
-        frame,
-        functions: functionDefinitions.value,
-        publicationId,
-      },
-      transaction
-    );
-  });
+  try {
+    await withTransaction(async (transaction) => {
+      const heldBeforeActivation = lease?.check();
+      if (heldBeforeActivation?.isErr()) {
+        throw heldBeforeActivation.error;
+      }
+
+      // Updating the Frame first serializes concurrent activations. None of the
+      // new publication state becomes visible until the transaction commits.
+      await frame.setActiveFramePublication(publicationId, transaction);
+      await frame.persistAuthorizedFileAccess(allowlist.value, {
+        transaction,
+      });
+      await SandboxFunctionResource.createForFramePublication(
+        auth,
+        {
+          frame,
+          functions: functionDefinitions.value,
+          publicationId,
+        },
+        transaction
+      );
+
+      const heldBeforeCommit = lease?.check();
+      if (heldBeforeCommit?.isErr()) {
+        throw heldBeforeCommit.error;
+      }
+    });
+  } catch (error) {
+    if (isLockLeaseLostError(error)) {
+      return new Err(error);
+    }
+    throw error;
+  }
 
   emitFrameAuthorizedFilesUpdatedAuditLog(
     auth,
@@ -589,7 +614,7 @@ export async function publishFramePublication(
   const publication = await withFramePublishLock<
     { publicationId: string },
     FramePublicationError | SandboxFunctionError
-  >(frame.sId, async () => {
+  >(frame.sId, async (lease) => {
     const storedPublication = await storeFramePublication(auth, {
       frame,
       functionArtifacts,
@@ -601,6 +626,10 @@ export async function publishFramePublication(
       return storedPublication;
     }
 
+    const heldBeforeReconciliation = lease.check();
+    if (heldBeforeReconciliation.isErr()) {
+      return heldBeforeReconciliation;
+    }
     const reconciliation = await reconcileFramePublicationDatabases(auth, {
       frame,
       manifest,
@@ -610,8 +639,13 @@ export async function publishFramePublication(
       return reconciliation;
     }
 
+    const heldBeforeActivation = lease.check();
+    if (heldBeforeActivation.isErr()) {
+      return heldBeforeActivation;
+    }
     const activation = await activateFramePublication(auth, {
       frame,
+      lease,
       publicationId: storedPublication.value.publicationId,
     });
     if (activation.isErr()) {
@@ -622,7 +656,7 @@ export async function publishFramePublication(
   });
   if (publication.isErr()) {
     const error = publication.error;
-    if (isLockAcquisitionTimeoutError(error)) {
+    if (isLockAcquisitionTimeoutError(error) || isLockLeaseLostError(error)) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 
+import path from "node:path";
+
 import {
   publishFrameFromSource,
   publishFrameV2FromSource,
@@ -182,6 +184,40 @@ describe("publishFrameFromSource", () => {
 });
 
 describe("publishFrameV2FromSource", () => {
+  it("fails closed while a partial source move is reserved", async () => {
+    const { auth, conversation, frame, gcsSourceDirectoryPath } = await setup();
+    const destinationManifestPath = `${path.posix.dirname(
+      gcsSourceDirectoryPath
+    )}/Moved/${FRAME_MANIFEST_FILE}`;
+    await frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: destinationManifestPath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: {
+        activePublicationId: "publication-1",
+        conversationId: conversation.sId,
+        pendingFrameSourceMove: {
+          destinationMountFilePath: destinationManifestPath,
+          operationId: "interrupted-move",
+          sourceMountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+        },
+      },
+    });
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame,
+      manifestPath: `conversation-${conversation.sId}/Moved/${FRAME_MANIFEST_FILE}`,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+      message: expect.stringContaining("source move is incomplete"),
+    });
+    expect(fileStorageMock.readStreamCalls).toHaveLength(0);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
   it("publishes artifacts without copying source and activates one publication", async () => {
     const {
       auth,

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -241,6 +241,34 @@ describe("publishFrameV2FromSource", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
+  it("revalidates the Frame source path after acquiring the source lock", async () => {
+    const { auth, conversation, frame, manifestPath, workspace } =
+      await setup();
+    const staleFrame = await FileResource.fetchById(auth, frame.sId);
+    assert(staleFrame);
+    const movedManifestPath = `${getConversationFilesBasePath({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+    })}Moved/${FRAME_MANIFEST_FILE}`;
+    await frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: movedManifestPath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame: staleFrame,
+      manifestPath,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
   it("rejects publication from a read-only Pod", async () => {
     const {
       authenticator: auth,

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -174,6 +174,12 @@ async function publishFrameV2FromSourceWithLockHeld(
       `File '${frame.sId}' is not a Frames v2 manifest.`
     );
   }
+  if (frame.useCaseMetadata?.pendingFrameSourceMove) {
+    return frameError(
+      "invalid_source",
+      `Frame '${frame.sId}' cannot be published while its source move is incomplete.`
+    );
+  }
 
   const canonicalManifestPath = frame.toScopedPath(auth);
   if (

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -3,8 +3,13 @@ import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import {
+  MAX_FRAME_SOURCE_BYTES,
+  MAX_FRAME_SOURCE_FILE_COUNT,
+} from "@app/lib/api/frames/source_limits";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import type { PublishFrameError } from "@app/lib/api/viz/publish_frame";
@@ -28,8 +33,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 const FRAME_SOURCE_READ_CONCURRENCY = 8;
-const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
-const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
 
 function frameError(code: FramePublicationError["code"], message: string) {
   return new Err(new FramePublicationError(code, message));
@@ -148,7 +151,7 @@ export async function publishFrameFromSource(
  * Publish a Frames v2 FileResource from its current source folder. The FileResource path is the
  * authority: callers cannot point a Frame identity at a different manifest or source tree.
  */
-export async function publishFrameV2FromSource(
+async function publishFrameV2FromSourceWithLockHeld(
   auth: Authenticator,
   {
     conversation,
@@ -322,5 +325,39 @@ export async function publishFrameV2FromSource(
     frame,
     manifest: manifestResult.value,
     sourceFiles,
+  });
+}
+
+export async function publishFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  return withFrameSourceLock(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame) {
+      return frameError(
+        "invalid_frame",
+        `Frame '${frame.sId}' no longer exists.`
+      );
+    }
+
+    return publishFrameV2FromSourceWithLockHeld(auth, {
+      conversation,
+      frame: freshFrame,
+      manifestPath,
+    });
   });
 }

--- a/front/lib/api/frames/source_limits.ts
+++ b/front/lib/api/frames/source_limits.ts
@@ -1,0 +1,2 @@
+export const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
+export const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -17,6 +17,7 @@ import type {
   Bucket,
   CopyOptions,
   File,
+  PreconditionOptions,
   SaveOptions,
 } from "@google-cloud/storage";
 import { RETRYABLE_ERR_FN_DEFAULT, Storage } from "@google-cloud/storage";
@@ -539,7 +540,7 @@ export class FileStorage {
       destinationMetadata,
       sourceGeneration,
     }: {
-      destinationGenerationMatch?: number;
+      destinationGenerationMatch?: PreconditionOptions["ifGenerationMatch"];
       destinationMetadata?: CopyOptions["metadata"];
       sourceGeneration?: string;
     } = {}

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -1,6 +1,9 @@
 import config from "@app/lib/file_storage/config";
 import type { GCSAPIError } from "@app/lib/file_storage/types";
-import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import {
+  isGCSNotFoundError,
+  isGCSPreconditionFailedError,
+} from "@app/lib/file_storage/types";
 import { setTimeoutAsync, withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AllSupportedFileContentType } from "@app/types/files";
@@ -52,6 +55,24 @@ type RawContentSaveOptions = Pick<
   SaveOptions,
   "preconditionOpts" | "resumable"
 >;
+
+export type FileCopyResult = {
+  destinationFile: File;
+  destinationGeneration: string;
+};
+
+function isCopyResponseWithGeneration(
+  response: unknown
+): response is { generation: string | number } {
+  if (
+    !response ||
+    typeof response !== "object" ||
+    !("generation" in response)
+  ) {
+    return false;
+  }
+  return isString(response.generation) || isNumber(response.generation);
+}
 
 function isRetryableGCSError(err: unknown): boolean {
   // ApiError only adds optional fields on top of Error, so a normalized Error
@@ -481,10 +502,13 @@ export class FileStorage {
 
   async delete(
     filePath: string,
-    { ignoreNotFound }: { ignoreNotFound?: boolean } = {}
+    {
+      ignoreNotFound,
+      ifGenerationMatch,
+    }: { ignoreNotFound?: boolean; ifGenerationMatch?: string } = {}
   ) {
     try {
-      return await this.file(filePath).delete();
+      return await this.file(filePath).delete({ ifGenerationMatch });
     } catch (err) {
       if (ignoreNotFound && isGCSNotFoundError(err)) {
         return;
@@ -505,8 +529,14 @@ export class FileStorage {
     srcPath: string,
     destPath: string,
     destinationStorage: FileStorage = this,
-    { sourceGeneration }: { sourceGeneration?: string } = {}
-  ): Promise<void> {
+    {
+      destinationGenerationMatch,
+      sourceGeneration,
+    }: {
+      destinationGenerationMatch?: number;
+      sourceGeneration?: string;
+    } = {}
+  ): Promise<FileCopyResult> {
     const destinationFile = destinationStorage.file(destPath);
     const sourceFile = sourceGeneration
       ? this.bucket.file(srcPath, { generation: sourceGeneration })
@@ -518,9 +548,29 @@ export class FileStorage {
       attempt++
     ) {
       try {
-        await sourceFile.copy(destinationFile);
-        return;
+        const [copiedFile, copyResponse] = await sourceFile.copy(
+          destinationFile,
+          {
+            preconditionOpts:
+              destinationGenerationMatch !== undefined
+                ? { ifGenerationMatch: destinationGenerationMatch }
+                : undefined,
+          }
+        );
+        if (!isCopyResponseWithGeneration(copyResponse)) {
+          throw new Error("GCS copy response is missing its generation.");
+        }
+        return {
+          destinationFile: copiedFile,
+          destinationGeneration: String(copyResponse.generation),
+        };
       } catch (err) {
+        // Preconditions are deterministic. In particular, a create-only copy
+        // must let its caller inspect the existing destination instead of
+        // retrying and potentially masking a concurrent writer.
+        if (isGCSPreconditionFailedError(err)) {
+          throw err;
+        }
         if (attempt === GCS_TRANSIENT_RETRY_MAX_ATTEMPTS) {
           throw err;
         }
@@ -544,6 +594,8 @@ export class FileStorage {
         await setTimeoutAsync(delayMs);
       }
     }
+
+    throw new Error("GCS copy retry loop exhausted unexpectedly.");
   }
 
   async deleteByPrefix(prefix: string): Promise<void> {

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -13,7 +13,12 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
-import type { Bucket, File, SaveOptions } from "@google-cloud/storage";
+import type {
+  Bucket,
+  CopyOptions,
+  File,
+  SaveOptions,
+} from "@google-cloud/storage";
 import { RETRYABLE_ERR_FN_DEFAULT, Storage } from "@google-cloud/storage";
 import type formidable from "formidable";
 import fs from "fs";
@@ -531,9 +536,11 @@ export class FileStorage {
     destinationStorage: FileStorage = this,
     {
       destinationGenerationMatch,
+      destinationMetadata,
       sourceGeneration,
     }: {
       destinationGenerationMatch?: number;
+      destinationMetadata?: CopyOptions["metadata"];
       sourceGeneration?: string;
     } = {}
   ): Promise<FileCopyResult> {
@@ -551,6 +558,7 @@ export class FileStorage {
         const [copiedFile, copyResponse] = await sourceFile.copy(
           destinationFile,
           {
+            metadata: destinationMetadata,
             preconditionOpts:
               destinationGenerationMatch !== undefined
                 ? { ifGenerationMatch: destinationGenerationMatch }

--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -1,0 +1,254 @@
+import type { RedisClientType } from "@app/lib/api/redis";
+import {
+  distributedRefresh,
+  executeWithRenewingLockResult,
+  isLockLeaseLostError,
+} from "@app/lib/lock";
+import { Err, Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+const { getRedisStreamClientMock } = vi.hoisted(() => ({
+  getRedisStreamClientMock: vi.fn<() => Promise<LockRedisClient>>(),
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisStreamClient: getRedisStreamClientMock,
+}));
+
+function makeRedisClient(): LockRedisClient {
+  return {
+    eval: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("renewing locks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes only the lock owned by the caller", async () => {
+    const redisClient = makeRedisClient();
+
+    await expect(
+      distributedRefresh(redisClient, "frame:source:123", "owner-token", 900)
+    ).resolves.toBe(true);
+
+    expect(redisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call("pexpire", KEYS[1], ARGV[2])'),
+      {
+        keys: ["lock:frame:source:123"],
+        arguments: ["owner-token", "900"],
+      }
+    );
+
+    vi.mocked(redisClient.eval).mockResolvedValueOnce(0);
+    await expect(
+      distributedRefresh(redisClient, "frame:source:123", "old-owner", 900)
+    ).resolves.toBe(false);
+  });
+
+  it("does not overlap renewal requests", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+    let finishCallback: () => void = () => {};
+    const callbackDone = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await callbackDone;
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    expect(redisClient.eval).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(redisClient.eval).toHaveBeenCalledTimes(1);
+
+    finishRefresh(1);
+    await vi.advanceTimersByTimeAsync(30);
+    expect(redisClient.eval).toHaveBeenCalledTimes(2);
+    finishCallback();
+    await resultPromise;
+  });
+
+  it("observes an in-flight definitive loss before returning", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+    let finishCallback: () => void = () => {};
+    const callbackDone = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await callbackDone;
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    finishCallback();
+    await vi.advanceTimersByTimeAsync(0);
+    finishRefresh(0);
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("fails the lease after transient refresh errors exhaust its safe lifetime", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval).mockImplementation((...args) =>
+      String(typeof args[0] === "string" ? args[0] : args[1]).includes(
+        "pexpire"
+      )
+        ? Promise.reject(new Error("redis unavailable"))
+        : Promise.resolve(1)
+    );
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(90);
+        const leaseResult = lease.check();
+        return leaseResult.isErr() ? leaseResult : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("keeps the lease after a transient refresh error recovers", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval)
+      .mockRejectedValueOnce(new Error("redis unavailable"))
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const result = await executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(60);
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    expect(result.isOk() && result.value).toBe("held");
+    expect(
+      vi
+        .mocked(redisClient.eval)
+        .mock.calls.filter(([script]) => String(script).includes("pexpire"))
+    ).toHaveLength(2);
+  });
+
+  it("fails the lease immediately when Redis reports a different owner", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval).mockResolvedValue(0);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Err(new Error("callback failed too"));
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("measures a renewed lease from refresh start, not a delayed response", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const result = await executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(30);
+        await vi.advanceTimersByTimeAsync(60);
+        finishRefresh(1);
+        await vi.advanceTimersByTimeAsync(22);
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("stops renewal before unlocking", async () => {
+    const redisClient = makeRedisClient();
+    const scripts: string[] = [];
+    vi.mocked(redisClient.eval).mockImplementation((...args) => {
+      scripts.push(String(typeof args[0] === "string" ? args[0] : args[1]));
+      return Promise.resolve(1);
+    });
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    await resultPromise;
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(scripts.filter((script) => script.includes("pexpire"))).toHaveLength(
+      1
+    );
+    expect(scripts.at(-1)).toContain('redis.call("del", KEYS[1])');
+  });
+});

--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -55,6 +55,32 @@ describe("renewing locks", () => {
     ).resolves.toBe(false);
   });
 
+  it("measures the initial lease from the start of lock acquisition", async () => {
+    const redisClient = makeRedisClient();
+    let finishAcquisition: (value: string) => void = () => {};
+    const pendingAcquisition = new Promise<string>((resolve) => {
+      finishAcquisition = resolve;
+    });
+    vi.mocked(redisClient.set).mockImplementationOnce(() => pendingAcquisition);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(90);
+    finishAcquisition("OK");
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
   it("does not overlap renewal requests", async () => {
     const redisClient = makeRedisClient();
     let finishRefresh: (value: number) => void = () => {};
@@ -128,12 +154,8 @@ describe("renewing locks", () => {
 
   it("fails the lease after transient refresh errors exhaust its safe lifetime", async () => {
     const redisClient = makeRedisClient();
-    vi.mocked(redisClient.eval).mockImplementation((...args) =>
-      String(typeof args[0] === "string" ? args[0] : args[1]).includes(
-        "pexpire"
-      )
-        ? Promise.reject(new Error("redis unavailable"))
-        : Promise.resolve(1)
+    vi.mocked(redisClient.eval).mockRejectedValue(
+      new Error("redis unavailable")
     );
     getRedisStreamClientMock.mockResolvedValue(redisClient);
 

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,13 +1,17 @@
 import type { RedisClientType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
 
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
 export async function distributedLock(
-  redisCli: RedisClientType,
+  redisCli: LockRedisClient,
   key: string,
   lockTtlMs: number = 5_000
 ): Promise<string | undefined> {
@@ -30,7 +34,7 @@ export async function distributedLock(
 }
 
 export async function distributedUnlock(
-  redisCli: RedisClientType,
+  redisCli: LockRedisClient,
   key: string,
   lockValue: string
 ): Promise<void> {
@@ -51,7 +55,31 @@ export async function distributedUnlock(
   });
 }
 
+export async function distributedRefresh(
+  redisCli: LockRedisClient,
+  key: string,
+  lockValue: string,
+  lockTtlMs: number
+): Promise<boolean> {
+  const lockKey = `lock:${key}`;
+  const luaScript = `
+    if redis.call("get", KEYS[1]) == ARGV[1] then
+      return redis.call("pexpire", KEYS[1], ARGV[2])
+    else
+      return 0
+    end
+  `;
+  const refreshed = await redisCli.eval(luaScript, {
+    keys: [lockKey],
+    arguments: [lockValue, String(lockTtlMs)],
+  });
+
+  return refreshed === 1;
+}
+
 const DEFAULT_RETRY_INTERVAL_MS = 100;
+const RENEWAL_RETRY_INITIAL_DELAY_MS = 250;
+const RENEWAL_RETRY_MAX_DELAY_MS = 30_000;
 
 export class LockAcquisitionTimeoutError extends Error {
   constructor(readonly lockName: string) {
@@ -64,6 +92,23 @@ export function isLockAcquisitionTimeoutError(
   error: unknown
 ): error is LockAcquisitionTimeoutError {
   return error instanceof LockAcquisitionTimeoutError;
+}
+
+export class LockLeaseLostError extends Error {
+  constructor(readonly lockName: string) {
+    super(`Lock lease lost for ${lockName}`);
+    this.name = "LockLeaseLostError";
+  }
+}
+
+export function isLockLeaseLostError(
+  error: unknown
+): error is LockLeaseLostError {
+  return error instanceof LockLeaseLostError;
+}
+
+export interface LockLeaseGuard {
+  check(): Result<void, LockLeaseLostError>;
 }
 
 type ExecuteWithLockOptions = {
@@ -133,6 +178,154 @@ async function runWithAcquiredLock<T>(
   }
 }
 
+function waitForRenewal(
+  delayMs: number,
+  signal: AbortSignal
+): Promise<boolean> {
+  if (signal.aborted) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, delayMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function createLockLeaseGuard(
+  lockName: string,
+  lockTtlMs: number
+): {
+  guard: LockLeaseGuard;
+  markLost: () => void;
+  markRenewed: (renewedAtMs: number) => void;
+  remainingSafeLifetimeMs: () => number;
+} {
+  const safetyMarginMs = Math.max(1, Math.floor(lockTtlMs / 10));
+  let confirmedUntilMs = Date.now() + lockTtlMs - safetyMarginMs;
+  let lost = false;
+  const markLost = () => {
+    lost = true;
+  };
+
+  return {
+    guard: {
+      check: () => {
+        if (lost || Date.now() >= confirmedUntilMs) {
+          markLost();
+          return new Err(new LockLeaseLostError(lockName));
+        }
+        return new Ok(undefined);
+      },
+    },
+    markLost,
+    markRenewed: (renewedAtMs) => {
+      confirmedUntilMs = renewedAtMs + lockTtlMs - safetyMarginMs;
+    },
+    remainingSafeLifetimeMs: () => confirmedUntilMs - Date.now(),
+  };
+}
+
+async function runWithRenewingLockResult<T, E>(
+  client: RedisClientType,
+  lockName: string,
+  lockValue: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>,
+  lockTtlMs: number
+): Promise<Result<T, E | LockLeaseLostError>> {
+  const renewalIntervalMs = Math.max(1, Math.floor(lockTtlMs / 3));
+  const renewalRetryInitialDelayMs = Math.min(
+    RENEWAL_RETRY_INITIAL_DELAY_MS,
+    renewalIntervalMs
+  );
+  const lease = createLockLeaseGuard(lockName, lockTtlMs);
+  const stopController = new AbortController();
+  const renew = async () => {
+    const nextRenewalDelayMs = () =>
+      renewalIntervalMs * (0.8 + Math.random() * 0.2);
+    let waitMs = nextRenewalDelayMs();
+    let retryDelayMs = renewalRetryInitialDelayMs;
+    let lastRefreshError: Error | undefined;
+    while (await waitForRenewal(waitMs, stopController.signal)) {
+      if (lease.guard.check().isErr()) {
+        if (lastRefreshError) {
+          logger.error(
+            { error: lastRefreshError, lockName },
+            "Lost a distributed lock lease after refresh errors"
+          );
+        }
+        return;
+      }
+      try {
+        const refreshStartedAtMs = Date.now();
+        const refreshed = await distributedRefresh(
+          client,
+          lockName,
+          lockValue,
+          lockTtlMs
+        );
+        if (!refreshed) {
+          lease.markLost();
+          logger.warn(
+            { lockName },
+            "Lost a distributed lock lease because its owner changed"
+          );
+          return;
+        }
+        lease.markRenewed(refreshStartedAtMs);
+        if (lastRefreshError) {
+          logger.info({ lockName }, "Recovered distributed lock lease renewal");
+        }
+        lastRefreshError = undefined;
+        retryDelayMs = renewalRetryInitialDelayMs;
+        waitMs = nextRenewalDelayMs();
+      } catch (error) {
+        const refreshError = normalizeError(error);
+        if (!lastRefreshError) {
+          logger.warn(
+            { error: refreshError, lockName },
+            "Failed to refresh a distributed lock lease; retrying"
+          );
+        }
+        lastRefreshError = refreshError;
+        const remainingSafeLifetimeMs = lease.remainingSafeLifetimeMs();
+        if (remainingSafeLifetimeMs <= 0) {
+          lease.markLost();
+          logger.error(
+            { error: refreshError, lockName },
+            "Lost a distributed lock lease after refresh errors"
+          );
+          return;
+        }
+        waitMs = Math.min(retryDelayMs, remainingSafeLifetimeMs);
+        retryDelayMs = Math.min(retryDelayMs * 2, RENEWAL_RETRY_MAX_DELAY_MS);
+      }
+    }
+  };
+  const renewal = renew();
+
+  try {
+    const result = await callback(lease.guard);
+    stopController.abort();
+    await renewal;
+    const held = lease.guard.check();
+    return held.isErr() ? held : result;
+  } finally {
+    stopController.abort();
+    await renewal;
+    await distributedUnlock(client, lockName, lockValue);
+  }
+}
+
 export const executeWithLock = async <T>(
   lockName: string,
   callback: () => Promise<T>,
@@ -161,4 +354,28 @@ export const executeWithLockResult = async <T, E>(
   }
 
   return runWithAcquiredLock(client, lockName, lockValue, callback);
+};
+
+export const executeWithRenewingLockResult = async <T, E>(
+  lockName: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>,
+  timeoutMs: number = 30_000,
+  options: ExecuteWithLockOptions = {}
+): Promise<Result<T, E | LockAcquisitionTimeoutError | LockLeaseLostError>> => {
+  const { lockTtlMs = 5_000 } = options;
+  const { client, lockValue } = await acquireLock(lockName, timeoutMs, options);
+
+  if (!lockValue) {
+    return new Err(new LockAcquisitionTimeoutError(lockName));
+  }
+
+  return runWithRenewingLockResult(
+    client,
+    lockName,
+    lockValue,
+    callback,
+    lockTtlMs
+  );
 };

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -133,13 +133,18 @@ async function acquireLock(
     retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS,
     traceAcquireResource,
   }: ExecuteWithLockOptions
-): Promise<{ client: RedisClientType; lockValue: string | undefined }> {
+): Promise<{
+  client: RedisClientType;
+  lockAttemptStartedAtMs: number | undefined;
+  lockValue: string | undefined;
+}> {
   const client = await getRedisStreamClient({ origin: "lock" });
 
   const acquire = async (): Promise<string | undefined> => {
     const startMs = Date.now();
     let acquired: string | undefined;
     while (Date.now() - startMs < timeoutMs) {
+      lockAttemptStartedAtMs = performance.now();
       // Try to acquire the lock
       acquired = await distributedLock(client, lockName, lockTtlMs);
       if (acquired) {
@@ -154,6 +159,8 @@ async function acquireLock(
     return acquired;
   };
 
+  let lockAttemptStartedAtMs: number | undefined;
+
   const lockValue = traceAcquireResource
     ? await tracer.trace(
         "lock.acquire",
@@ -162,7 +169,11 @@ async function acquireLock(
       )
     : await acquire();
 
-  return { client, lockValue };
+  return {
+    client,
+    lockAttemptStartedAtMs: lockValue ? lockAttemptStartedAtMs : undefined,
+    lockValue,
+  };
 }
 
 async function runWithAcquiredLock<T>(
@@ -201,7 +212,8 @@ function waitForRenewal(
 
 function createLockLeaseGuard(
   lockName: string,
-  lockTtlMs: number
+  lockTtlMs: number,
+  lockAttemptStartedAtMs: number
 ): {
   guard: LockLeaseGuard;
   markLost: () => void;
@@ -209,7 +221,7 @@ function createLockLeaseGuard(
   remainingSafeLifetimeMs: () => number;
 } {
   const safetyMarginMs = Math.max(1, Math.floor(lockTtlMs / 10));
-  let confirmedUntilMs = Date.now() + lockTtlMs - safetyMarginMs;
+  let confirmedUntilMs = lockAttemptStartedAtMs + lockTtlMs - safetyMarginMs;
   let lost = false;
   const markLost = () => {
     lost = true;
@@ -218,7 +230,7 @@ function createLockLeaseGuard(
   return {
     guard: {
       check: () => {
-        if (lost || Date.now() >= confirmedUntilMs) {
+        if (lost || performance.now() >= confirmedUntilMs) {
           markLost();
           return new Err(new LockLeaseLostError(lockName));
         }
@@ -229,7 +241,7 @@ function createLockLeaseGuard(
     markRenewed: (renewedAtMs) => {
       confirmedUntilMs = renewedAtMs + lockTtlMs - safetyMarginMs;
     },
-    remainingSafeLifetimeMs: () => confirmedUntilMs - Date.now(),
+    remainingSafeLifetimeMs: () => confirmedUntilMs - performance.now(),
   };
 }
 
@@ -240,14 +252,19 @@ async function runWithRenewingLockResult<T, E>(
   callback: (
     lease: LockLeaseGuard
   ) => Promise<Result<T, E | LockLeaseLostError>>,
-  lockTtlMs: number
+  lockTtlMs: number,
+  lockAttemptStartedAtMs: number
 ): Promise<Result<T, E | LockLeaseLostError>> {
   const renewalIntervalMs = Math.max(1, Math.floor(lockTtlMs / 3));
   const renewalRetryInitialDelayMs = Math.min(
     RENEWAL_RETRY_INITIAL_DELAY_MS,
     renewalIntervalMs
   );
-  const lease = createLockLeaseGuard(lockName, lockTtlMs);
+  const lease = createLockLeaseGuard(
+    lockName,
+    lockTtlMs,
+    lockAttemptStartedAtMs
+  );
   const stopController = new AbortController();
   const renew = async () => {
     const nextRenewalDelayMs = () =>
@@ -266,7 +283,7 @@ async function runWithRenewingLockResult<T, E>(
         return;
       }
       try {
-        const refreshStartedAtMs = Date.now();
+        const refreshStartedAtMs = performance.now();
         const refreshed = await distributedRefresh(
           client,
           lockName,
@@ -322,7 +339,14 @@ async function runWithRenewingLockResult<T, E>(
   } finally {
     stopController.abort();
     await renewal;
-    await distributedUnlock(client, lockName, lockValue);
+    try {
+      await distributedUnlock(client, lockName, lockValue);
+    } catch (error) {
+      logger.error(
+        { error: normalizeError(error), lockName },
+        "Failed to unlock a distributed lock after its callback completed"
+      );
+    }
   }
 }
 
@@ -365,9 +389,13 @@ export const executeWithRenewingLockResult = async <T, E>(
   options: ExecuteWithLockOptions = {}
 ): Promise<Result<T, E | LockAcquisitionTimeoutError | LockLeaseLostError>> => {
   const { lockTtlMs = 5_000 } = options;
-  const { client, lockValue } = await acquireLock(lockName, timeoutMs, options);
+  const { client, lockAttemptStartedAtMs, lockValue } = await acquireLock(
+    lockName,
+    timeoutMs,
+    options
+  );
 
-  if (!lockValue) {
+  if (!lockValue || lockAttemptStartedAtMs === undefined) {
     return new Err(new LockAcquisitionTimeoutError(lockName));
   }
 
@@ -376,6 +404,7 @@ export const executeWithRenewingLockResult = async <T, E>(
     lockName,
     lockValue,
     callback,
-    lockTtlMs
+    lockTtlMs,
+    lockAttemptStartedAtMs
   );
 };

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -150,6 +150,13 @@ export class ConversationSandboxAdapter {
     return this.fetchSandboxByConversation(auth, conversation);
   }
 
+  static async withLifecycleLock<T>(
+    conversation: Pick<ConversationSandboxOwner, "sId">,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    return SandboxResource.withLifecycleLockOnly(conversation.sId, fn);
+  }
+
   static async ensureSandboxActive(
     auth: Authenticator,
     conversation: ConversationSandboxOwner

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -35,6 +35,7 @@ import {
   getUpsertQueueBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import type { LockLeaseGuard } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -640,11 +641,21 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   private async deleteAfterSandboxCleanup(
-    auth: Authenticator
+    auth: Authenticator,
+    lease?: LockLeaseGuard
   ): Promise<Result<undefined, Error>> {
     try {
+      const checkLease = () => {
+        const held = lease?.check();
+        if (held?.isErr()) {
+          throw held.error;
+        }
+      };
+
       if (this.isFrameV2) {
+        checkLease();
         await this.deleteFrameFunctions(auth);
+        checkLease();
         await getPrivateUploadBucket().deleteByPrefix(
           getFrameBasePath({
             workspaceId: auth.getNonNullableWorkspace().sId,
@@ -654,35 +665,43 @@ export class FileResource extends BaseResource<FileModel> {
       }
 
       if (this.isReady) {
+        checkLease();
         await maybeDeleteCoreArtifactsForIndexedFile(auth, this);
 
         // Delete mount file copies if set.
+        checkLease();
         await this.deleteMountFileCopies();
 
+        checkLease();
         await this.getBucketForVersion("original")
           .file(this.getCloudStoragePath(auth, "original"))
           .delete();
 
         // Delete the processed file if it exists.
+        checkLease();
         await this.getBucketForVersion("processed")
           .file(this.getCloudStoragePath(auth, "processed"))
           .delete({ ignoreNotFound: true });
         // Delete the public file if it exists.
+        checkLease();
         await this.getBucketForVersion("public")
           .file(this.getCloudStoragePath(auth, "public"))
           .delete({ ignoreNotFound: true });
 
         // Delete sharing grants and access snapshots before shareable file (FK constraint).
+        checkLease();
         const shareableFile = await FileResource.shareableFileModel.findOne({
           where: { fileId: this.id, workspaceId: this.workspaceId },
         });
         if (shareableFile) {
+          checkLease();
           await SharingGrantModel.destroy({
             where: {
               shareableFileId: shareableFile.id,
               workspaceId: this.workspaceId,
             },
           });
+          checkLease();
           await FileResource.authorizedFileAccessModel.destroy({
             where: {
               shareableFileId: shareableFile.id,
@@ -692,6 +711,7 @@ export class FileResource extends BaseResource<FileModel> {
         }
 
         // Delete the shareable file record.
+        checkLease();
         await FileResource.shareableFileModel.destroy({
           where: {
             fileId: this.id,
@@ -700,6 +720,7 @@ export class FileResource extends BaseResource<FileModel> {
         });
       }
 
+      checkLease();
       await this.model.destroy({
         where: {
           id: this.id,
@@ -718,11 +739,16 @@ export class FileResource extends BaseResource<FileModel> {
       return this.deleteAfterSandboxCleanup(auth);
     }
 
-    return withFramePublishLock(this.sId, () =>
-      FrameSandboxAdapter.deleteSandbox(auth, this, {
-        afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
-      })
-    );
+    return withFramePublishLock(this.sId, async (lease) => {
+      const held = lease.check();
+      if (held.isErr()) {
+        return held;
+      }
+      return FrameSandboxAdapter.deleteSandbox(auth, this, {
+        afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth, lease),
+        beforeSandboxCleanup: () => lease.check(),
+      });
+    });
   }
 
   get sId(): string {

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockExecuteWithLock,
+  mockExecuteWithRenewingLockResult,
   mockGetSandboxImage,
   mockGetSandboxProvider,
   mockProviderCreate,
@@ -9,6 +10,7 @@ const {
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockExecuteWithLock: vi.fn(),
+  mockExecuteWithRenewingLockResult: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
   mockProviderCreate: vi.fn(),
@@ -31,6 +33,7 @@ vi.mock("@app/lib/api/sandbox/image", () => ({
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
   executeWithLockResult: mockExecuteWithLock,
+  executeWithRenewingLockResult: mockExecuteWithRenewingLockResult,
 }));
 
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -89,6 +92,10 @@ describe("FrameSandboxAdapter", () => {
           }
         }
       }
+    );
+    mockExecuteWithRenewingLockResult.mockImplementation(
+      async (key: string, fn: (lease: unknown) => Promise<unknown>) =>
+        mockExecuteWithLock(key, () => fn({ check: () => new Ok(undefined) }))
     );
     mockGetSandboxImage.mockReturnValue(
       new Ok({

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -261,14 +261,16 @@ export class FrameSandboxAdapter {
     frame: FrameSandboxOwner,
     {
       afterSandboxCleanup,
+      beforeSandboxCleanup,
     }: {
       afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+      beforeSandboxCleanup?: () => Result<void, Error>;
     } = {}
   ): Promise<Result<undefined, Error>> {
     return SandboxResource.deleteByOwner(
       auth,
       this.toSandboxDeleteOwner(auth, frame),
-      { afterSandboxCleanup }
+      { afterSandboxCleanup, beforeSandboxCleanup }
     );
   }
 

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -170,6 +170,38 @@ describe("SandboxResource.updateStatus", () => {
   });
 });
 
+describe("ConversationSandboxAdapter.withLifecycleLock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+  });
+
+  it("uses the conversation lifecycle key without touching its sandbox", async () => {
+    const callback = vi.fn().mockResolvedValue("done");
+
+    const result = await ConversationSandboxAdapter.withLifecycleLock(
+      { sId: "conversation_123" },
+      callback
+    );
+
+    expect(result).toBe("done");
+    expect(mockExecuteWithLock).toHaveBeenCalledWith(
+      "sandbox:lifecycle:conversation_123",
+      expect.any(Function),
+      undefined,
+      {
+        lockTtlMs: 5 * 60 * 1000,
+        retryIntervalMs: 25,
+        traceAcquireResource: "sandbox:lifecycle",
+      }
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+  });
+});
+
 describe("ConversationSandboxAdapter.withScopeTransition", () => {
   let authenticator: Authenticator;
   let conversationResource: ConversationResource;

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -52,6 +52,7 @@ import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sand
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import {
   SandboxModel,
   SandboxOwnerModel,
@@ -62,6 +63,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 import { encrypt } from "@app/types/shared/utils/encryption";
@@ -479,6 +481,74 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
       }),
     ]);
     expect([linkCount, sandboxCount]).toEqual([0, 0]);
+  });
+
+  it("rolls back sandbox rows when the lease is lost before commit", async () => {
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON()
+    );
+    const workspaceModelId = authenticator.getNonNullableWorkspace().id;
+    const leaseError = new Error("lease lost");
+    let leaseChecks = 0;
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+
+    await expect(
+      frontSequelize.transaction(
+        { transaction: parentTransaction },
+        async () => {
+          const result = await SandboxResource.deleteByOwner(
+            authenticator,
+            {
+              lockKey: conversationResource.sId,
+              fetchSandbox: () =>
+                ConversationSandboxAdapter.fetchSandbox(
+                  authenticator,
+                  conversationResource.toJSON()
+                ),
+              deleteSandbox: async (sandboxToDelete, transaction) => {
+                await SandboxOwnerModel.destroy({
+                  where: {
+                    conversationId: conversationResource.id,
+                    sandboxId: sandboxToDelete.id,
+                    workspaceId: workspaceModelId,
+                  },
+                  transaction,
+                });
+              },
+            },
+            {
+              beforeSandboxCleanup: () => {
+                leaseChecks += 1;
+                return leaseChecks === 3
+                  ? new Err(leaseError)
+                  : new Ok(undefined);
+              },
+            }
+          );
+          throw result.isErr()
+            ? result.error
+            : new Error("Expected the sandbox deletion lease to be lost.");
+        }
+      )
+    ).rejects.toBe(leaseError);
+
+    const [linkCount, sandboxCount] = await Promise.all([
+      SandboxOwnerModel.count({
+        where: {
+          conversationId: conversationResource.id,
+          sandboxId: sandbox.id,
+          workspaceId: workspaceModelId,
+        },
+      }),
+      SandboxModel.count({
+        where: { id: sandbox.id, workspaceId: workspaceModelId },
+      }),
+    ]);
+    expect(leaseChecks).toBe(3);
+    expect([linkCount, sandboxCount]).toEqual([1, 1]);
   });
 });
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -682,20 +682,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     lockKey: string,
     fn: (provider: SandboxProvider | null) => Promise<Result<T, Error>>
   ): Promise<Result<T, Error>> {
-    return executeWithLock(
-      `sandbox:lifecycle:${lockKey}`,
-      () => fn(getSandboxProvider() ?? null),
-      undefined,
-      {
-        traceAcquireResource: "sandbox:lifecycle",
-        lockTtlMs: SANDBOX_LIFECYCLE_LOCK_TTL_MS,
-        // Contended by concurrent invocations of the same pod: transitions
-        // hold this lock from milliseconds (status checks) to seconds
-        // (wake/create), and waiters on the fast side of that range should
-        // not lose in 100ms quanta.
-        retryIntervalMs: 25,
-      }
+    return this.withLifecycleLockOnly(lockKey, () =>
+      fn(getSandboxProvider() ?? null)
     );
+  }
+
+  /** Serialize a lock-only owner operation with sandbox lifecycle transitions. */
+  static async withLifecycleLockOnly<T>(
+    lockKey: string,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    return executeWithLock(`sandbox:lifecycle:${lockKey}`, fn, undefined, {
+      traceAcquireResource: "sandbox:lifecycle",
+      lockTtlMs: SANDBOX_LIFECYCLE_LOCK_TTL_MS,
+      // Contended by concurrent invocations of the same pod: transitions
+      // hold this lock from milliseconds (status checks) to seconds
+      // (wake/create), and waiters on the fast side of that range should
+      // not lose in 100ms quanta.
+      retryIntervalMs: 25,
+    });
   }
 
   // Owner env vars come either as a plain record or as a factory for owners

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -527,8 +527,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     owner: SandboxDeleteOwner,
     {
       afterSandboxCleanup,
+      beforeSandboxCleanup,
     }: {
       afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+      beforeSandboxCleanup?: () => Result<void, Error>;
     } = {}
   ): Promise<Result<undefined, Error>> {
     return this.withLifecycleLockWithOptionalProvider(
@@ -543,6 +545,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         if (sandbox.status !== "deleted") {
+          const heldBeforeProviderCleanup = beforeSandboxCleanup?.();
+          if (heldBeforeProviderCleanup?.isErr()) {
+            return heldBeforeProviderCleanup;
+          }
           const tracingOpts = {
             workspaceId: auth.getNonNullableWorkspace().sId,
           };
@@ -561,16 +567,34 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
         }
 
-        await withTransaction(async (transaction) => {
-          await owner.deleteSandbox(sandbox, transaction);
-          await SandboxModel.destroy({
-            where: {
-              id: sandbox.id,
-              workspaceId: auth.getNonNullableWorkspace().id,
-            },
-            transaction,
+        const heldBeforeDatabaseCleanup = beforeSandboxCleanup?.();
+        if (heldBeforeDatabaseCleanup?.isErr()) {
+          return heldBeforeDatabaseCleanup;
+        }
+        let leaseError: Error | undefined;
+        try {
+          await withTransaction(async (transaction) => {
+            await owner.deleteSandbox(sandbox, transaction);
+            await SandboxModel.destroy({
+              where: {
+                id: sandbox.id,
+                workspaceId: auth.getNonNullableWorkspace().id,
+              },
+              transaction,
+            });
+
+            const heldBeforeDatabaseCommit = beforeSandboxCleanup?.();
+            if (heldBeforeDatabaseCommit?.isErr()) {
+              leaseError = heldBeforeDatabaseCommit.error;
+              throw leaseError;
+            }
           });
-        });
+        } catch (error) {
+          if (leaseError && error === leaseError) {
+            return new Err(leaseError);
+          }
+          throw error;
+        }
 
         return afterSandboxCleanup?.() ?? new Ok(undefined);
       }

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -63,6 +63,8 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame publish");
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
+    expect(instructions).toContain("dsbx frame move");
+    expect(instructions).toContain("registered Frame folder with raw");
     expect(instructions).toContain("package-like folder");
     expect(instructions).toContain("canonical Frame resource");
     expect(instructions).toContain("`index.tsx` by default");

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -48,11 +48,11 @@ Use the CLI instead of \`mv\` so the Frame keeps its identity, active publicatio
 database state while its source folder moves:
 
 \`\`\`bash
-dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/<frame-folder>
+dsbx frame move /files/<scope>/<source-folder> /files/<scope>/<destination-folder>
 \`\`\`
 
-Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
-registered Frame folder with raw filesystem commands.
+Source and destination must stay in the same conversation or Pod mount.
+Do not move a registered Frame folder with raw filesystem commands.
 
 ## Frames v2 source layout
 

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -42,6 +42,18 @@ dsbx frame register /files/<scope>/<frame-folder>/manifest.json
 Registration validates the manifest and assigns its stable Frame identity. Repeating the command
 for the same manifest path returns the same Frame. Registration does not publish the source.
 
+## Move a registered Frame
+
+Use the CLI instead of \`mv\` so the Frame keeps its identity, active publication, sharing, and
+database state while its source folder moves:
+
+\`\`\`bash
+dsbx frame move /files/<source-scope>/<frame-folder> /files/<destination-scope>/<frame-folder>
+\`\`\`
+
+Moving to a different runtime scope safely refreshes the Frame-owned sandbox. Do not move a
+registered Frame folder with raw filesystem commands.
+
 ## Frames v2 source layout
 
 Keep one Frame and everything it owns in one folder:
@@ -321,7 +333,6 @@ Do not use the \`publish_interactive_content_file\` tool: the CLI replaces it un
 Other interactive-content tools remain available for Frame operations that the CLI does not cover
 yet. Use \`dsbx frame --help\` as the authority for available operations.
 
-Do not use \`mv\` or \`cp\` on a registered Frame folder: move and clone are not supported in this
-initial scope.
+Do not use \`cp\` to clone a registered Frame folder. Cloning is not supported yet.
 
 ${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}`;

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -23,6 +23,14 @@ interface MockFileMetadata {
   size: string;
   contentEncoding?: string;
   contentDisposition?: string;
+  crc32c?: string;
+  generation?: string;
+  md5Hash?: string;
+}
+
+interface DeleteCall {
+  filePath: string;
+  options: { ifGenerationMatch?: string; ignoreNotFound?: boolean } | undefined;
 }
 
 class MockGcsError extends Error {
@@ -60,6 +68,10 @@ class FileStorageMock {
   private _signedUploadUrlCalls: SignedUrlCall[] = [];
   private _metadataCalls: string[] = [];
   private _objectStore = new Map<string, string>();
+  private _objectGenerations = new Map<string, string>();
+  private _objectVersions = new Map<string, Map<string, string>>();
+  private _nextGeneration = 1;
+  private _deleteCalls: DeleteCall[] = [];
   private _fetchNotFoundPredicate: (filePath: string) => boolean = () => false;
   private _existsPredicate: (filePath: string) => boolean = () => true;
   private _saveShouldFail: (filePath: string) => boolean = () => false;
@@ -70,6 +82,8 @@ class FileStorageMock {
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
+  private _afterCopyFile: (src: string, dest: string) => void = () => {};
+  private _deleteShouldFail: (filePath: string) => boolean = () => false;
   private _filesByPrefix: (
     prefix: string
   ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
@@ -103,12 +117,20 @@ class FileStorageMock {
     return this._metadataCalls;
   }
 
+  get deleteCalls(): readonly DeleteCall[] {
+    return this._deleteCalls;
+  }
+
   /**
    * Controls what `file(path).exists()` resolves to, keyed by the GCS path.
    * Defaults to always-exists. Reset between tests via `reset()`.
    */
   setFileExists(predicate: (filePath: string) => boolean): void {
     this._existsPredicate = predicate;
+  }
+
+  setAfterCopyFile(callback: (src: string, dest: string) => void): void {
+    this._afterCopyFile = callback;
   }
 
   /**
@@ -154,6 +176,10 @@ class FileStorageMock {
    */
   setCopyFileFails(predicate: (src: string, dest: string) => boolean): void {
     this._copyFileShouldFail = predicate;
+  }
+
+  setDeleteFails(predicate: (filePath: string) => boolean): void {
+    this._deleteShouldFail = predicate;
   }
 
   /**
@@ -215,7 +241,12 @@ class FileStorageMock {
 
   // Seed the in-memory object store directly (no write path).
   setObject(filePath: string, content: string): void {
+    const generation = String(this._nextGeneration++);
     this._objectStore.set(filePath, content);
+    this._objectGenerations.set(filePath, generation);
+    const versions = this._objectVersions.get(filePath) ?? new Map();
+    versions.set(generation, content);
+    this._objectVersions.set(filePath, versions);
   }
 
   reset(): void {
@@ -225,7 +256,11 @@ class FileStorageMock {
     this._signedUrlCalls.length = 0;
     this._signedUploadUrlCalls.length = 0;
     this._metadataCalls.length = 0;
+    this._deleteCalls.length = 0;
     this._objectStore.clear();
+    this._objectGenerations.clear();
+    this._objectVersions.clear();
+    this._nextGeneration = 1;
     this._fetchNotFoundPredicate = () => false;
     this._existsPredicate = () => true;
     this._saveShouldFail = () => false;
@@ -233,6 +268,8 @@ class FileStorageMock {
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
+    this._afterCopyFile = () => {};
+    this._deleteShouldFail = () => false;
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
     this._deletedPrefixes.length = 0;
@@ -291,8 +328,24 @@ class FileStorageMock {
           }
           return stream;
         }),
-      delete: vi.fn().mockImplementation(() => {
-        this._objectStore.delete(filePath ?? "unknown");
+      delete: vi.fn().mockImplementation((options?: DeleteCall["options"]) => {
+        const path = filePath ?? "unknown";
+        this._deleteCalls.push({ filePath: path, options });
+        if (this._deleteShouldFail(path)) {
+          return Promise.reject(
+            new Error(`Simulated GCS delete failure: ${path}`)
+          );
+        }
+        if (
+          options?.ifGenerationMatch &&
+          this._objectGenerations.get(path) !== options.ifGenerationMatch
+        ) {
+          return Promise.reject(
+            new MockGcsError(412, `Object generation changed: ${path}`)
+          );
+        }
+        this._objectStore.delete(path);
+        this._objectGenerations.delete(path);
         return Promise.resolve(undefined);
       }),
       download: vi.fn().mockImplementation(() => {
@@ -308,6 +361,7 @@ class FileStorageMock {
         return Promise.resolve([
           this._metadataForPath(path) ?? {
             contentType: "text/plain",
+            generation: this._objectGenerations.get(path) ?? "1",
             size: "0",
           },
         ]);
@@ -433,14 +487,55 @@ class FileStorageMock {
         }
         return Promise.resolve(new Uint8Array());
       }),
-      copyFile: vi.fn((src: string, dest: string) => {
-        if (this._copyFileShouldFail(src, dest)) {
-          return Promise.reject(
-            new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
+      copyFile: vi.fn(
+        (
+          src: string,
+          dest: string,
+          _destinationStorage?: unknown,
+          options?: {
+            destinationGenerationMatch?: number;
+            sourceGeneration?: string;
+          }
+        ) => {
+          if (
+            options?.destinationGenerationMatch === 0 &&
+            this._objectStore.has(dest)
+          ) {
+            return Promise.reject(
+              new MockGcsError(412, `Object already exists: ${dest}`)
+            );
+          }
+          if (this._copyFileShouldFail(src, dest)) {
+            return Promise.reject(
+              new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
+            );
+          }
+          const versionedContent = options?.sourceGeneration
+            ? this._objectVersions.get(src)?.get(options.sourceGeneration)
+            : undefined;
+          if (options?.sourceGeneration && versionedContent === undefined) {
+            return Promise.reject(
+              new MockGcsError(
+                404,
+                `Source generation does not exist: ${src}@${options.sourceGeneration}`
+              )
+            );
+          }
+          this.setObject(
+            dest,
+            versionedContent ??
+              this._objectStore.get(src) ??
+              this._contentForPath(src) ??
+              ""
           );
+          const copiedGeneration = this._objectGenerations.get(dest);
+          this._afterCopyFile(src, dest);
+          return Promise.resolve({
+            destinationFile: this.createMockGCSFile(dest),
+            destinationGeneration: copiedGeneration,
+          });
         }
-        return Promise.resolve(undefined);
-      }),
+      ),
       // Mirrors real GCS compose: concatenates each source's stored content, in order,
       // into the destination object.
       composeFiles: vi.fn((sourcePaths: string[], destinationPath: string) => {
@@ -457,8 +552,23 @@ class FileStorageMock {
         });
         return Promise.resolve(undefined);
       }),
-      delete: vi.fn((filePath: string) => {
+      delete: vi.fn((filePath: string, options?: DeleteCall["options"]) => {
+        this._deleteCalls.push({ filePath, options });
+        if (this._deleteShouldFail(filePath)) {
+          return Promise.reject(
+            new Error(`Simulated GCS delete failure: ${filePath}`)
+          );
+        }
+        if (
+          options?.ifGenerationMatch &&
+          this._objectGenerations.get(filePath) !== options.ifGenerationMatch
+        ) {
+          return Promise.reject(
+            new MockGcsError(412, `Object generation changed: ${filePath}`)
+          );
+        }
         this._objectStore.delete(filePath);
+        this._objectGenerations.delete(filePath);
         return Promise.resolve(undefined);
       }),
       deleteByPrefix: vi.fn(async (prefix: string) => {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -1,4 +1,5 @@
 import { Ok } from "@app/types/shared/result";
+import type { PreconditionOptions } from "@google-cloud/storage";
 import { PassThrough, Readable } from "stream";
 import { vi } from "vitest";
 
@@ -81,15 +82,17 @@ class FileStorageMock {
   private _saveShouldFail: (filePath: string) => boolean = () => false;
   private _metadataForPath: (filePath: string) => MockFileMetadata | null =
     () => null;
+  private _metadataShouldFail: (filePath: string) => boolean = () => false;
   private _contentForPath: (filePath: string) => string | null = () => null;
   private _sortedFileVersions: (filePath: string) => MockFileVersion[] | null =
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
-  private _copyFileCommitsThenFails: (src: string, dest: string) => boolean =
-    () => false;
+  private _copyFileCommittedError: (src: string, dest: string) => Error | null =
+    () => null;
   private _afterCopyFile: (src: string, dest: string) => void = () => {};
   private _deleteShouldFail: (filePath: string) => boolean = () => false;
+  private _beforeDelete: (filePath: string) => Promise<void> = async () => {};
   private _filesByPrefix: (
     prefix: string
   ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
@@ -157,6 +160,10 @@ class FileStorageMock {
     this._metadataForPath = fn;
   }
 
+  setFileMetadataFails(predicate: (filePath: string) => boolean): void {
+    this._metadataShouldFail = predicate;
+  }
+
   /**
    * Controls what `file(path).createReadStream()` streams, keyed by the GCS path.
    * Return null to fall back to the default empty stream. Reset between tests via `reset()`.
@@ -189,11 +196,27 @@ class FileStorageMock {
   setCopyFileCommitsThenFails(
     predicate: (src: string, dest: string) => boolean
   ): void {
-    this._copyFileCommitsThenFails = predicate;
+    this._copyFileCommittedError = (src, dest) =>
+      predicate(src, dest)
+        ? new MockGcsError(
+            412,
+            `Copy committed but its response was lost: ${src} -> ${dest}`
+          )
+        : null;
+  }
+
+  setCopyFileCommitsThenErrors(
+    errorForCopy: (src: string, dest: string) => Error | null
+  ): void {
+    this._copyFileCommittedError = errorForCopy;
   }
 
   setDeleteFails(predicate: (filePath: string) => boolean): void {
     this._deleteShouldFail = predicate;
+  }
+
+  setBeforeDelete(callback: (filePath: string) => Promise<void>): void {
+    this._beforeDelete = callback;
   }
 
   /**
@@ -253,6 +276,10 @@ class FileStorageMock {
     return this._objectStore.get(filePath);
   }
 
+  getObjectGeneration(filePath: string): string | undefined {
+    return this._objectGenerations.get(filePath);
+  }
+
   // Seed the in-memory object store directly (no write path).
   setObject(
     filePath: string,
@@ -289,12 +316,14 @@ class FileStorageMock {
     this._existsPredicate = () => true;
     this._saveShouldFail = () => false;
     this._metadataForPath = () => null;
+    this._metadataShouldFail = () => false;
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
-    this._copyFileCommitsThenFails = () => false;
+    this._copyFileCommittedError = () => null;
     this._afterCopyFile = () => {};
     this._deleteShouldFail = () => false;
+    this._beforeDelete = async () => {};
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
     this._deletedPrefixes.length = 0;
@@ -353,27 +382,25 @@ class FileStorageMock {
           }
           return stream;
         }),
-      delete: vi.fn().mockImplementation((options?: DeleteCall["options"]) => {
-        const path = filePath ?? "unknown";
-        this._deleteCalls.push({ filePath: path, options });
-        if (this._deleteShouldFail(path)) {
-          return Promise.reject(
-            new Error(`Simulated GCS delete failure: ${path}`)
-          );
-        }
-        if (
-          options?.ifGenerationMatch &&
-          this._objectGenerations.get(path) !== options.ifGenerationMatch
-        ) {
-          return Promise.reject(
-            new MockGcsError(412, `Object generation changed: ${path}`)
-          );
-        }
-        this._objectStore.delete(path);
-        this._objectGenerations.delete(path);
-        this._objectCustomMetadata.delete(path);
-        return Promise.resolve(undefined);
-      }),
+      delete: vi
+        .fn()
+        .mockImplementation(async (options?: DeleteCall["options"]) => {
+          const path = filePath ?? "unknown";
+          this._deleteCalls.push({ filePath: path, options });
+          await this._beforeDelete(path);
+          if (this._deleteShouldFail(path)) {
+            throw new Error(`Simulated GCS delete failure: ${path}`);
+          }
+          if (
+            options?.ifGenerationMatch &&
+            this._objectGenerations.get(path) !== options.ifGenerationMatch
+          ) {
+            throw new MockGcsError(412, `Object generation changed: ${path}`);
+          }
+          this._objectStore.delete(path);
+          this._objectGenerations.delete(path);
+          this._objectCustomMetadata.delete(path);
+        }),
       download: vi.fn().mockImplementation(() => {
         const content = this._objectStore.get(filePath ?? "unknown") ?? "";
         return Promise.resolve([Buffer.from(content, "utf-8")]);
@@ -384,6 +411,11 @@ class FileStorageMock {
       getMetadata: vi.fn(() => {
         const path = filePath ?? "";
         this._metadataCalls.push(path);
+        if (this._metadataShouldFail(path)) {
+          return Promise.reject(
+            new Error(`Simulated GCS metadata failure: ${path}`)
+          );
+        }
         const configuredMetadata = this._metadataForPath(path);
         return Promise.resolve([
           configuredMetadata
@@ -532,7 +564,7 @@ class FileStorageMock {
           dest: string,
           _destinationStorage?: unknown,
           options?: {
-            destinationGenerationMatch?: number;
+            destinationGenerationMatch?: PreconditionOptions["ifGenerationMatch"];
             destinationMetadata?: ObjectCustomMetadata;
             sourceGeneration?: string;
           }
@@ -543,6 +575,16 @@ class FileStorageMock {
           ) {
             return Promise.reject(
               new MockGcsError(412, `Object already exists: ${dest}`)
+            );
+          }
+          if (
+            options?.destinationGenerationMatch !== undefined &&
+            options.destinationGenerationMatch !== 0 &&
+            this._objectGenerations.get(dest) !==
+              String(options.destinationGenerationMatch)
+          ) {
+            return Promise.reject(
+              new MockGcsError(412, `Object generation changed: ${dest}`)
             );
           }
           if (this._copyFileShouldFail(src, dest)) {
@@ -571,13 +613,9 @@ class FileStorageMock {
           );
           const copiedGeneration = this._objectGenerations.get(dest);
           this._afterCopyFile(src, dest);
-          if (this._copyFileCommitsThenFails(src, dest)) {
-            return Promise.reject(
-              new MockGcsError(
-                412,
-                `Copy committed but its response was lost: ${src} -> ${dest}`
-              )
-            );
+          const committedError = this._copyFileCommittedError(src, dest);
+          if (committedError) {
+            return Promise.reject(committedError);
           }
           return Promise.resolve({
             destinationFile: this.createMockGCSFile(dest),
@@ -602,26 +640,27 @@ class FileStorageMock {
         });
         return Promise.resolve(undefined);
       }),
-      delete: vi.fn((filePath: string, options?: DeleteCall["options"]) => {
-        this._deleteCalls.push({ filePath, options });
-        if (this._deleteShouldFail(filePath)) {
-          return Promise.reject(
-            new Error(`Simulated GCS delete failure: ${filePath}`)
-          );
+      delete: vi.fn(
+        async (filePath: string, options?: DeleteCall["options"]) => {
+          this._deleteCalls.push({ filePath, options });
+          await this._beforeDelete(filePath);
+          if (this._deleteShouldFail(filePath)) {
+            throw new Error(`Simulated GCS delete failure: ${filePath}`);
+          }
+          if (
+            options?.ifGenerationMatch &&
+            this._objectGenerations.get(filePath) !== options.ifGenerationMatch
+          ) {
+            throw new MockGcsError(
+              412,
+              `Object generation changed: ${filePath}`
+            );
+          }
+          this._objectStore.delete(filePath);
+          this._objectGenerations.delete(filePath);
+          this._objectCustomMetadata.delete(filePath);
         }
-        if (
-          options?.ifGenerationMatch &&
-          this._objectGenerations.get(filePath) !== options.ifGenerationMatch
-        ) {
-          return Promise.reject(
-            new MockGcsError(412, `Object generation changed: ${filePath}`)
-          );
-        }
-        this._objectStore.delete(filePath);
-        this._objectGenerations.delete(filePath);
-        this._objectCustomMetadata.delete(filePath);
-        return Promise.resolve(undefined);
-      }),
+      ),
       deleteByPrefix: vi.fn(async (prefix: string) => {
         this._deletedPrefixes.push(prefix);
         this._onDeleteByPrefix(prefix);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -26,7 +26,10 @@ interface MockFileMetadata {
   crc32c?: string;
   generation?: string;
   md5Hash?: string;
+  metadata?: ObjectCustomMetadata;
 }
+
+type ObjectCustomMetadata = Record<string, string | boolean | number | null>;
 
 interface DeleteCall {
   filePath: string;
@@ -69,6 +72,7 @@ class FileStorageMock {
   private _metadataCalls: string[] = [];
   private _objectStore = new Map<string, string>();
   private _objectGenerations = new Map<string, string>();
+  private _objectCustomMetadata = new Map<string, ObjectCustomMetadata>();
   private _objectVersions = new Map<string, Map<string, string>>();
   private _nextGeneration = 1;
   private _deleteCalls: DeleteCall[] = [];
@@ -82,6 +86,8 @@ class FileStorageMock {
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
+  private _copyFileCommitsThenFails: (src: string, dest: string) => boolean =
+    () => false;
   private _afterCopyFile: (src: string, dest: string) => void = () => {};
   private _deleteShouldFail: (filePath: string) => boolean = () => false;
   private _filesByPrefix: (
@@ -178,6 +184,14 @@ class FileStorageMock {
     this._copyFileShouldFail = predicate;
   }
 
+  // Simulates a committed first attempt whose response was lost. The real
+  // copy wrapper retries internally, then surfaces the create-only 412.
+  setCopyFileCommitsThenFails(
+    predicate: (src: string, dest: string) => boolean
+  ): void {
+    this._copyFileCommitsThenFails = predicate;
+  }
+
   setDeleteFails(predicate: (filePath: string) => boolean): void {
     this._deleteShouldFail = predicate;
   }
@@ -240,9 +254,18 @@ class FileStorageMock {
   }
 
   // Seed the in-memory object store directly (no write path).
-  setObject(filePath: string, content: string): void {
+  setObject(
+    filePath: string,
+    content: string,
+    metadata?: ObjectCustomMetadata
+  ): void {
     const generation = String(this._nextGeneration++);
     this._objectStore.set(filePath, content);
+    if (metadata) {
+      this._objectCustomMetadata.set(filePath, metadata);
+    } else {
+      this._objectCustomMetadata.delete(filePath);
+    }
     this._objectGenerations.set(filePath, generation);
     const versions = this._objectVersions.get(filePath) ?? new Map();
     versions.set(generation, content);
@@ -259,6 +282,7 @@ class FileStorageMock {
     this._deleteCalls.length = 0;
     this._objectStore.clear();
     this._objectGenerations.clear();
+    this._objectCustomMetadata.clear();
     this._objectVersions.clear();
     this._nextGeneration = 1;
     this._fetchNotFoundPredicate = () => false;
@@ -268,6 +292,7 @@ class FileStorageMock {
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
+    this._copyFileCommitsThenFails = () => false;
     this._afterCopyFile = () => {};
     this._deleteShouldFail = () => false;
     this._filesByPrefix = () => null;
@@ -346,6 +371,7 @@ class FileStorageMock {
         }
         this._objectStore.delete(path);
         this._objectGenerations.delete(path);
+        this._objectCustomMetadata.delete(path);
         return Promise.resolve(undefined);
       }),
       download: vi.fn().mockImplementation(() => {
@@ -358,12 +384,21 @@ class FileStorageMock {
       getMetadata: vi.fn(() => {
         const path = filePath ?? "";
         this._metadataCalls.push(path);
+        const configuredMetadata = this._metadataForPath(path);
         return Promise.resolve([
-          this._metadataForPath(path) ?? {
-            contentType: "text/plain",
-            generation: this._objectGenerations.get(path) ?? "1",
-            size: "0",
-          },
+          configuredMetadata
+            ? {
+                ...configuredMetadata,
+                metadata:
+                  configuredMetadata.metadata ??
+                  this._objectCustomMetadata.get(path),
+              }
+            : {
+                contentType: "text/plain",
+                generation: this._objectGenerations.get(path) ?? "1",
+                metadata: this._objectCustomMetadata.get(path),
+                size: "0",
+              },
         ]);
       }),
       getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
@@ -384,6 +419,7 @@ class FileStorageMock {
               contentType: opts?.contentType,
             });
             this._objectStore.set(path, content.toString());
+            this._objectCustomMetadata.delete(path);
             return Promise.resolve(undefined);
           }
         ),
@@ -418,6 +454,7 @@ class FileStorageMock {
             );
           }
           this._objectStore.set(args.filePath, args.buffer.toString());
+          this._objectCustomMetadata.delete(args.filePath);
           this._saveFileCalls.push({
             filePath: args.filePath,
             content: args.buffer,
@@ -429,6 +466,7 @@ class FileStorageMock {
       uploadRawContentToBucket: vi.fn(
         (args: { content: string; contentType: string; filePath: string }) => {
           this._objectStore.set(args.filePath, args.content);
+          this._objectCustomMetadata.delete(args.filePath);
           this._saveFileCalls.push({
             filePath: args.filePath,
             content: args.content,
@@ -450,6 +488,7 @@ class FileStorageMock {
             );
           }
           this._objectStore.set(args.filePath, args.content);
+          this._objectCustomMetadata.delete(args.filePath);
           this._saveFileCalls.push({
             filePath: args.filePath,
             content: args.content,
@@ -494,6 +533,7 @@ class FileStorageMock {
           _destinationStorage?: unknown,
           options?: {
             destinationGenerationMatch?: number;
+            destinationMetadata?: ObjectCustomMetadata;
             sourceGeneration?: string;
           }
         ) => {
@@ -526,10 +566,19 @@ class FileStorageMock {
             versionedContent ??
               this._objectStore.get(src) ??
               this._contentForPath(src) ??
-              ""
+              "",
+            options?.destinationMetadata
           );
           const copiedGeneration = this._objectGenerations.get(dest);
           this._afterCopyFile(src, dest);
+          if (this._copyFileCommitsThenFails(src, dest)) {
+            return Promise.reject(
+              new MockGcsError(
+                412,
+                `Copy committed but its response was lost: ${src} -> ${dest}`
+              )
+            );
+          }
           return Promise.resolve({
             destinationFile: this.createMockGCSFile(dest),
             destinationGeneration: copiedGeneration,
@@ -543,6 +592,7 @@ class FileStorageMock {
           .map((path) => this._objectStore.get(path) ?? "")
           .join("");
         this._objectStore.set(destinationPath, combined);
+        this._objectCustomMetadata.delete(destinationPath);
         this._saveFileCalls.push({
           filePath: destinationPath,
           content: combined,
@@ -569,6 +619,7 @@ class FileStorageMock {
         }
         this._objectStore.delete(filePath);
         this._objectGenerations.delete(filePath);
+        this._objectCustomMetadata.delete(filePath);
         return Promise.resolve(undefined);
       }),
       deleteByPrefix: vi.fn(async (prefix: string) => {
@@ -577,6 +628,7 @@ class FileStorageMock {
         for (const path of [...this._objectStore.keys()]) {
           if (path.startsWith(prefix)) {
             this._objectStore.delete(path);
+            this._objectCustomMetadata.delete(path);
           }
         }
       }),

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -63,6 +63,12 @@ export type FileUseCaseMetadata = {
   frameEntryRelPath?: string;
   // Immutable Frames v2 publication currently served by the Frame.
   activePublicationId?: string;
+  // Set only while a Frames v2 source move owns its destination mount path.
+  // Keeping this on the stable FileResource makes an interrupted move retryable.
+  pendingFrameSourceMove?: {
+    sourceMountFilePath: string;
+    destinationMountFilePath: string;
+  };
 };
 
 export function isConversationFileUseCase(

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -68,6 +68,7 @@ export type FileUseCaseMetadata = {
   pendingFrameSourceMove?: {
     sourceMountFilePath: string;
     destinationMountFilePath: string;
+    operationId: string;
   };
 };
 


### PR DESCRIPTION
## Description

Stacked on #31480.

Allows Frames v2 sources to move between conversation and Pod mounts only when both resolve to the same runtime space. Both owners are resolved and authorized before mutation. Immediately before the final FileResource update, conversation owners are locked by stable sId order using their existing sandbox lifecycle serialization and their runtime spaces are resolved again. GCS copy stays outside those locks. If eligibility changed, copied generations are cleaned and the reservation is restored.

Lifecycle lock acquisition and release errors use the same final Frame reconciliation as an ambiguous database update. A committed destination returns success, the exact pending reservation is cleanup-safe, and missing or foreign state preserves destination objects.

## Tests

- `npm test -- move_source.test.ts sandbox_resource.test.ts frame_sandbox_adapter.test.ts` (83 tests)
- `npm run tsgo -- --noEmit`
- `npx biome check front/lib/api/frames/move_source.ts front/lib/api/frames/move_source.test.ts front/lib/resources/conversation_sandbox_adapter.ts front/lib/resources/sandbox_resource.ts front/lib/resources/sandbox_resource.test.ts`
- `git diff --check`

## Risk

The move state machine is sensitive to partial GCS, database, and lock failures. This change preserves the renewable locks, operation and attempt fencing, pinned generations, exact-generation recovery, and post-commit reconciliation from #31480. It does not destroy conversation sandboxes or use FrameSandboxAdapter scope transitions. Rollback is a revert of this PR.

## Deploy Plan

Merge after #31480, then use the standard Front deployment. No migration or backfill is required. Monitor Frame move errors and audit events after deploy.
