### PR TITLE
feat(sandbox): bulk env-var create/delete across scopes (Computer admin backend)

### DIFF
--- a/front-api/routes/w/[wId]/sandbox/env-vars/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/bulk.test.ts
@@ -6,6 +6,42 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+// Parsed in assertions to keep the results strongly typed without an `as` cast.
+const PostBulkResultsSchema = z.object({
+  results: z.array(
+    z.object({
+      podId: z.string(),
+      success: z.boolean(),
+      created: z.boolean().optional(),
+      errorMessage: z.string().optional(),
+    })
+  ),
+});
+const DeleteBulkResultsSchema = z.object({
+  results: z.array(
+    z.object({
+      scopeId: z.string(),
+      success: z.boolean(),
+      errorMessage: z.string().optional(),
+    })
+  ),
+});
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
 
 async function setupTest({
   role = "admin",
@@ -35,6 +71,36 @@ async function setupTest({
 
 function getBulk(wId: string, query: string) {
   return honoApp.request(`/api/w/${wId}/sandbox/env-vars/bulk?${query}`);
+}
+
+function postBulk(wId: string, body: unknown) {
+  return honoApp.request(`/api/w/${wId}/sandbox/env-vars/bulk`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function deleteBulk(wId: string, body: unknown) {
+  return honoApp.request(`/api/w/${wId}/sandbox/env-vars/bulk`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedEnvVar(
+  auth: Parameters<typeof SandboxEnvVarResource.upsert>[0],
+  scope: Parameters<typeof SandboxEnvVarResource.upsert>[1],
+  name: string
+) {
+  const upsert = await SandboxEnvVarResource.upsert(auth, scope, {
+    name,
+    value: "value",
+  });
+  if (upsert.isErr()) {
+    throw upsert.error;
+  }
 }
 
 describe("GET /api/w/:wId/sandbox/env-vars/bulk", () => {
@@ -172,5 +238,333 @@ describe("GET /api/w/:wId/sandbox/env-vars/bulk", () => {
 
     const neitherResponse = await getBulk(workspace.sId, "");
     expect(neitherResponse.status).toBe(400);
+  });
+});
+
+describe("POST /api/w/:wId/sandbox/env-vars/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates one independently scoped row per pod", async () => {
+    const { workspace, auth, podA, podB } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      value: "super-secret-token",
+      podIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [
+        { podId: podA.sId, success: true, created: true },
+        { podId: podB.sId, success: true, created: true },
+      ],
+    });
+
+    for (const pod of [podA, podB]) {
+      const podVars = await SandboxEnvVarResource.listForScope(auth, {
+        kind: "pod",
+        pod,
+      });
+      expect(podVars.map((envVar) => envVar.envName)).toEqual([
+        "DST_API_TOKEN",
+      ]);
+    }
+
+    // The pod-scoped rows must not leak into the workspace scope.
+    const workspaceVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "workspace",
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    expect(workspaceVars).toHaveLength(0);
+
+    // One audit event per pod row, each identifying its pod.
+    for (const pod of [podA, podB]) {
+      expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "sandbox_env_var.created",
+          metadata: expect.objectContaining({ space_id: pod.sId }),
+        })
+      );
+    }
+  });
+
+  it("reports per-pod failures for unknown or non-project pods and still applies the rest", async () => {
+    const { workspace, auth, podA } = await setupTest();
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const response = await postBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      value: "super-secret-token",
+      podIds: [podA.sId, "spc_unknown", regularSpace.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const { results } = PostBulkResultsSchema.parse(await response.json());
+    expect(results).toEqual([
+      { podId: podA.sId, success: true, created: true },
+      {
+        podId: "spc_unknown",
+        success: false,
+        errorMessage: "Pod not found.",
+      },
+      {
+        podId: regularSpace.sId,
+        success: false,
+        errorMessage: "Pod not found.",
+      },
+    ]);
+
+    const podVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "pod",
+      pod: podA,
+    });
+    expect(podVars).toHaveLength(1);
+  });
+
+  it("validates the payload once and writes nothing on an invalid name", async () => {
+    const { workspace, auth, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      name: "bad-name",
+      value: "value",
+      podIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+
+    const podVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "pod",
+      pod: podA,
+    });
+    expect(podVars).toHaveLength(0);
+  });
+
+  it("returns created:false when replacing an existing pod row", async () => {
+    const { workspace, auth, podA, podB } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod: podA },
+      { name: "API_TOKEN", value: "initial-value" }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await postBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      value: "rotated-value",
+      podIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [
+        { podId: podA.sId, success: true, created: false },
+        { podId: podB.sId, success: true, created: true },
+      ],
+    });
+  });
+
+  it("creates https_secret rows with normalized allowed domains", async () => {
+    const { workspace, auth, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      name: "DSEC_API_TOKEN",
+      value: "super-secret-token",
+      kind: "https_secret",
+      allowedDomains: ["API.GitHub.COM"],
+      podIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [{ podId: podA.sId, success: true, created: true }],
+    });
+
+    const podVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "pod",
+      pod: podA,
+    });
+    expect(podVars).toHaveLength(1);
+    expect(podVars[0].kind).toBe("https_secret");
+    expect(podVars[0].allowedDomains).toEqual(["api.github.com"]);
+  });
+
+  it("rejects invalid allowed domains before any write", async () => {
+    const { workspace, auth, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      name: "DSEC_API_TOKEN",
+      value: "super-secret-token",
+      kind: "https_secret",
+      allowedDomains: ["127.0.0.1"],
+      podIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(400);
+    const podVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "pod",
+      pod: podA,
+    });
+    expect(podVars).toHaveLength(0);
+  });
+
+  it("rejects an empty podIds array", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      value: "value",
+      podIds: [],
+    });
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/w/:wId/sandbox/env-vars/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when the sandbox_functions flag is off", async () => {
+    const { workspace, podA } = await setupTest({
+      enableSandboxFunctions: false,
+    });
+
+    const response = await deleteBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      kind: "config",
+      includeWorkspace: false,
+      podIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("deletes the variable from the workspace and each pod that defines it", async () => {
+    const { workspace, auth, podA, podB } = await setupTest();
+    const workspaceScope = {
+      kind: "workspace" as const,
+      workspace: auth.getNonNullableWorkspace(),
+    };
+    await seedEnvVar(auth, workspaceScope, "API_TOKEN");
+    await seedEnvVar(auth, { kind: "pod", pod: podA }, "API_TOKEN");
+    await seedEnvVar(auth, { kind: "pod", pod: podB }, "API_TOKEN");
+
+    const response = await deleteBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      kind: "config",
+      includeWorkspace: true,
+      podIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [
+        { scopeId: "workspace", success: true },
+        { scopeId: podA.sId, success: true },
+        { scopeId: podB.sId, success: true },
+      ],
+    });
+
+    for (const scope of [
+      workspaceScope,
+      { kind: "pod" as const, pod: podA },
+      { kind: "pod" as const, pod: podB },
+    ]) {
+      expect(
+        await SandboxEnvVarResource.listForScope(auth, scope)
+      ).toHaveLength(0);
+    }
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "sandbox_env_var.deleted" })
+    );
+  });
+
+  it("removes a pod override while leaving the workspace baseline intact", async () => {
+    const { workspace, auth, podA } = await setupTest();
+    const workspaceScope = {
+      kind: "workspace" as const,
+      workspace: auth.getNonNullableWorkspace(),
+    };
+    await seedEnvVar(auth, workspaceScope, "API_TOKEN");
+    await seedEnvVar(auth, { kind: "pod", pod: podA }, "API_TOKEN");
+
+    const response = await deleteBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      kind: "config",
+      includeWorkspace: false,
+      podIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [{ scopeId: podA.sId, success: true }],
+    });
+
+    expect(
+      await SandboxEnvVarResource.listForScope(auth, { kind: "pod", pod: podA })
+    ).toHaveLength(0);
+    expect(
+      await SandboxEnvVarResource.listForScope(auth, workspaceScope)
+    ).toHaveLength(1);
+  });
+
+  it("reports no-op success for scopes that do not define the name", async () => {
+    const { workspace, podA } = await setupTest();
+
+    const response = await deleteBulk(workspace.sId, {
+      name: "DST_MISSING",
+      kind: "config",
+      includeWorkspace: true,
+      podIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [
+        { scopeId: "workspace", success: true },
+        { scopeId: podA.sId, success: true },
+      ],
+    });
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("reports pod-not-found for unknown or non-project pods", async () => {
+    const { workspace, auth, podA } = await setupTest();
+    const regularSpace = await SpaceFactory.regular(workspace);
+    await seedEnvVar(auth, { kind: "pod", pod: podA }, "API_TOKEN");
+
+    const response = await deleteBulk(workspace.sId, {
+      name: "DST_API_TOKEN",
+      kind: "config",
+      includeWorkspace: false,
+      podIds: [podA.sId, "spc_unknown", regularSpace.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const { results } = DeleteBulkResultsSchema.parse(await response.json());
+    expect(results).toEqual([
+      { scopeId: podA.sId, success: true },
+      {
+        scopeId: "spc_unknown",
+        success: false,
+        errorMessage: "Pod not found.",
+      },
+      {
+        scopeId: regularSpace.sId,
+        success: false,
+        errorMessage: "Pod not found.",
+      },
+    ]);
   });
 });

--- a/front-api/routes/w/[wId]/sandbox/env-vars/bulk.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/bulk.ts
@@ -1,17 +1,46 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
+  deleteSandboxEnvVarForScopes,
   parseSandboxAdminPodSelection,
   resolveSandboxAdminPods,
   SandboxAdminPodSelectionQuerySchema,
+  upsertSandboxEnvVarForPods,
 } from "@app/lib/api/sandbox/admin_pods";
+import {
+  normalizeAllowedDomainsForKind,
+  parseSandboxEnvVarNameForKind,
+  validateEnvVarValueForKind,
+} from "@app/lib/api/sandbox/env_vars";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
-import type { GetSandboxEnvVarsBulkResponseBody } from "@app/types/api/sandbox/env_vars";
+import type {
+  DeleteSandboxEnvVarsBulkResponseBody,
+  GetSandboxEnvVarsBulkResponseBody,
+  PostSandboxEnvVarsBulkResponseBody,
+} from "@app/types/api/sandbox/env_vars";
+import { SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { z } from "zod";
 
-// Mounted at /api/w/:wId/sandbox/env-vars/bulk. Multi-pod reads for the
-// central Computer admin page. The parent sub-app applies the
+const PostSandboxEnvVarsBulkBodySchema = z.object({
+  name: z.string(),
+  value: z.string(),
+  kind: z.enum(SANDBOX_ENV_VAR_KINDS).optional(),
+  allowedDomains: z.array(z.string()).nullable().optional(),
+  podIds: z.array(z.string()).min(1).max(100),
+});
+
+const DeleteSandboxEnvVarsBulkBodySchema = z.object({
+  name: z.string().min(1),
+  kind: z.enum(SANDBOX_ENV_VAR_KINDS),
+  includeWorkspace: z.boolean(),
+  podIds: z.array(z.string()).max(100),
+});
+
+// Mounted at /api/w/:wId/sandbox/env-vars/bulk. Multi-pod reads and writes for
+// the central Computer admin page. The parent sub-app applies the
 // workspace-admin + Computer gates; the multi-Pod feature is gated on the
 // Pod Functions (sandbox_functions) flag. Values are never returned
 // (write-only invariant).
@@ -43,6 +72,107 @@ app.get(
     return ctx.json({
       envVars: envVars.map((envVar) => envVar.toJSON()),
     });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", PostSandboxEnvVarsBulkBodySchema),
+  async (ctx): HandlerResult<PostSandboxEnvVarsBulkResponseBody> => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    // The payload is validated once, before any write; per-pod outcomes in
+    // the response only reflect per-pod conditions (unknown pod, cap, kind
+    // mismatch with an existing row).
+    const kind = body.kind ?? "config";
+    const parsedName = parseSandboxEnvVarNameForKind({
+      kind,
+      name: body.name,
+    });
+    const parsedValue = validateEnvVarValueForKind({
+      kind,
+      value: body.value,
+    });
+    if (parsedName.isErr() || parsedValue.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: [
+            parsedName.isErr() ? `name: ${parsedName.error}` : null,
+            parsedValue.isErr() ? `value: ${parsedValue.error}` : null,
+          ]
+            .filter((message) => message !== null)
+            .join("; "),
+        },
+      });
+    }
+
+    // `undefined` stays `undefined` (replace flows keep each pod row's
+    // stored domains); provided domains are normalized and rejected here if
+    // invalid, so the per-pod loop never fails on them.
+    const normalizedDomains = normalizeAllowedDomainsForKind({
+      kind,
+      allowedDomains: body.allowedDomains,
+      requiredForSecret: false,
+    });
+    if (normalizedDomains.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: normalizedDomains.error.message,
+        },
+      });
+    }
+
+    const results = await upsertSandboxEnvVarForPods(auth, {
+      podIds: [...new Set(body.podIds)],
+      name: parsedName.value,
+      value: body.value,
+      kind,
+      allowedDomains: normalizedDomains.value,
+      context: getAuditLogContext(auth),
+    });
+
+    return ctx.json({ results });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  validate("json", DeleteSandboxEnvVarsBulkBodySchema),
+  async (ctx): HandlerResult<DeleteSandboxEnvVarsBulkResponseBody> => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    // Rows are stored under the suffix; accept the prefixed wire name and
+    // strip it, rejecting a prefix that disagrees with the kind.
+    const parsedName = parseSandboxEnvVarNameForKind({
+      kind: body.kind,
+      name: body.name,
+    });
+    if (parsedName.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `name: ${parsedName.error}`,
+        },
+      });
+    }
+
+    const results = await deleteSandboxEnvVarForScopes(auth, {
+      name: parsedName.value,
+      includeWorkspace: body.includeWorkspace,
+      podIds: [...new Set(body.podIds)],
+      context: getAuditLogContext(auth),
+    });
+
+    return ctx.json({ results });
   }
 );
 

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -12,10 +12,13 @@ import {
 } from "@app/lib/api/sandbox/egress_policy";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ScopeMutationResult } from "@app/types/api/sandbox/egress_policy";
 import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
+import type { PodSandboxEnvVarBulkResult } from "@app/types/api/sandbox/env_vars";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import type { SandboxEnvVarKind } from "@app/types/sandbox/env_var";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -109,6 +112,64 @@ export async function resolveSandboxAdminPods(
 
   const spaces = await SpaceResource.fetchByIds(auth, selection.podIds);
   return spaces.filter((space) => space.isProject());
+}
+
+// Applies one validated env var independently to each pod: one pod-scoped
+// row per pod, each encrypted under its own pod key (existing upsert path,
+// which also emits the per-row audit events). Sequential on purpose — the
+// route schema bounds podIds at 100 and parallel upserts would only pressure
+// the connection pool.
+export async function upsertSandboxEnvVarForPods(
+  auth: Authenticator,
+  {
+    podIds,
+    name,
+    value,
+    kind,
+    allowedDomains,
+    context,
+  }: {
+    podIds: string[];
+    name: string;
+    value: string;
+    kind: SandboxEnvVarKind;
+    allowedDomains?: string[] | null;
+    context?: AuditLogContext;
+  }
+): Promise<PodSandboxEnvVarBulkResult[]> {
+  const spaces = await SpaceResource.fetchByIds(auth, podIds);
+  const spacesById = new Map(spaces.map((space) => [space.sId, space]));
+
+  const results: PodSandboxEnvVarBulkResult[] = [];
+  for (const podId of podIds) {
+    const pod = spacesById.get(podId);
+    if (!pod || !pod.isProject()) {
+      results.push({
+        podId,
+        success: false,
+        errorMessage: "Pod not found.",
+      });
+      continue;
+    }
+
+    const result = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      { name, value, kind, allowedDomains, context }
+    );
+    if (result.isErr()) {
+      results.push({
+        podId,
+        success: false,
+        errorMessage: result.error.message,
+      });
+      continue;
+    }
+
+    results.push({ podId, success: true, created: result.value.created });
+  }
+
+  return results;
 }
 
 // One egress-domain add/remove applied across the workspace policy and/or a
@@ -295,6 +356,92 @@ export async function bulkUpdateEgressDomain(
         context,
       });
     }
+  }
+
+  return results;
+}
+
+// Deletes one env var (by suffix, the stored `name` column) from the selected
+// scopes: the workspace row and/or each pod's row. A scope that does not
+// define the name is a no-op success (idempotent removal). The resource's
+// delete emits the per-row sandbox_env_var.deleted event. Sequential for the
+// same reasons as the other bulk helpers.
+export async function deleteSandboxEnvVarForScopes(
+  auth: Authenticator,
+  {
+    name,
+    includeWorkspace,
+    podIds,
+    context,
+  }: {
+    name: string;
+    includeWorkspace: boolean;
+    podIds: string[];
+    context?: AuditLogContext;
+  }
+): Promise<ScopeMutationResult[]> {
+  const results: ScopeMutationResult[] = [];
+
+  if (includeWorkspace) {
+    const envVar = await SandboxEnvVarResource.fetchByName(
+      auth,
+      { kind: "workspace", workspace: auth.getNonNullableWorkspace() },
+      name
+    );
+    if (!envVar) {
+      results.push({ scopeId: SANDBOX_WORKSPACE_SCOPE_ID, success: true });
+    } else {
+      const deleted = await envVar.delete(auth, { context });
+      results.push(
+        deleted.isErr()
+          ? {
+              scopeId: SANDBOX_WORKSPACE_SCOPE_ID,
+              success: false,
+              errorMessage: deleted.error.message,
+            }
+          : { scopeId: SANDBOX_WORKSPACE_SCOPE_ID, success: true }
+      );
+    }
+  }
+
+  const spaces = await SpaceResource.fetchByIds(auth, podIds);
+  const podsById = new Map(
+    spaces.filter((space) => space.isProject()).map((pod) => [pod.sId, pod])
+  );
+  // One read for the name across every valid pod, then destroy per row (the
+  // resource emits the per-row audit event on delete).
+  const envVarByPodId = await SandboxEnvVarResource.fetchByNameForPods(
+    auth,
+    [...podsById.values()],
+    name
+  );
+
+  for (const podId of podIds) {
+    if (!podsById.has(podId)) {
+      results.push({
+        scopeId: podId,
+        success: false,
+        errorMessage: "Pod not found.",
+      });
+      continue;
+    }
+
+    const envVar = envVarByPodId.get(podId);
+    if (!envVar) {
+      results.push({ scopeId: podId, success: true });
+      continue;
+    }
+
+    const deleted = await envVar.delete(auth, { context });
+    results.push(
+      deleted.isErr()
+        ? {
+            scopeId: podId,
+            success: false,
+            errorMessage: deleted.error.message,
+          }
+        : { scopeId: podId, success: true }
+    );
   }
 
   return results;

--- a/front/lib/resources/sandbox_env_var_resource.ts
+++ b/front/lib/resources/sandbox_env_var_resource.ts
@@ -298,6 +298,38 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
     return rows.map((row) => this.fromRow(row));
   }
 
+  // One query for a single name across the given pods, keyed by pod id for the
+  // caller. Backs the multi-pod bulk delete without an N+1 fetch per pod.
+  static async fetchByNameForPods(
+    auth: Authenticator,
+    pods: SpaceResource[],
+    name: string
+  ): Promise<Map<string, SandboxEnvVarResource>> {
+    if (pods.length === 0) {
+      return new Map();
+    }
+    for (const pod of pods) {
+      this.assertScope(auth, { kind: "pod", pod });
+    }
+
+    const rows = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: { [Op.in]: pods.map((pod) => pod.id) },
+        name,
+      },
+    });
+
+    const podIdByModelId = new Map(pods.map((pod) => [pod.id, pod.sId]));
+    return new Map(
+      rows.flatMap((row) => {
+        const podId =
+          row.spaceId !== null ? podIdByModelId.get(row.spaceId) : undefined;
+        return podId ? [[podId, this.fromRow(row)] as const] : [];
+      })
+    );
+  }
+
   static async fetchByName(
     auth: Authenticator,
     scope: SandboxEnvVarScope,

--- a/front/types/api/sandbox/env_vars.ts
+++ b/front/types/api/sandbox/env_vars.ts
@@ -1,3 +1,4 @@
+import type { ScopeMutationResult } from "@app/types/api/sandbox/egress_policy";
 import type { SandboxEnvVarType } from "@app/types/sandbox/env_var";
 
 export type GetSandboxEnvVarsResponseBody = {
@@ -12,4 +13,23 @@ export type PostSandboxEnvVarsResponseBody = {
 // Flat across the requested pods; each row carries its pod via `spaceId`.
 export type GetSandboxEnvVarsBulkResponseBody = {
   envVars: SandboxEnvVarType[];
+};
+
+export type PodSandboxEnvVarBulkResult = {
+  podId: string;
+  success: boolean;
+  // Set on success: whether the row was created (vs replaced).
+  created?: boolean;
+  // Set on failure.
+  errorMessage?: string;
+};
+
+export type PostSandboxEnvVarsBulkResponseBody = {
+  results: PodSandboxEnvVarBulkResult[];
+};
+
+// Delete reports per scope (workspace and/or pods), unlike the pods-only
+// upsert, since a variable can be removed from the workspace baseline too.
+export type DeleteSandboxEnvVarsBulkResponseBody = {
+  results: ScopeMutationResult[];
 };


### PR DESCRIPTION
## Description

Second PR of the env-var ("Computer API keys") phase — the **write** half of the scope-aware env-var server contract, stacked on the read PR (`31478`). SWR hooks + UI land with their consumers after this.

- **Bulk POST** `…/sandbox/env-vars/bulk.ts` — applies one validated env var independently to each Pod (one pod-scoped row per Pod, each encrypted under its own Pod key; payload validated once before any write; per-Pod results for unknown/non-project Pods).
- **Bulk DELETE** — removes one env var (by suffix) from the selected scopes (workspace and/or each Pod); a scope that doesn't define it is a no-op success (idempotent).
- **`admin_pods.ts`** — `upsertSandboxEnvVarForPods`, `deleteSandboxEnvVarForScopes`. Per-scope results; sequential (podIds bounded at 100) to avoid connection-pool pressure; each write goes through the existing resource upsert/delete, so per-row encryption and audit events (`sandbox_env_var.created`/`.deleted`) are unchanged.
- **`sandbox_env_var_resource.ts`** — `fetchByNameForPods` (batched, backs the multi-Pod delete without an N+1).
- **Types** — `Post/DeleteSandboxEnvVarsBulkResponseBody` + `PodSandboxEnvVarBulkResult`.

## Tests

`bulk.test.ts` POST + DELETE coverage (per-Pod create, per-Pod failures, validate-once, replace `created:false`, https_secret normalization, invalid-domain rejection, empty podIds; delete across scopes, pod-override delete, no-op success, pod-not-found, `sandbox_functions` gate). Runs in CI (local vitest is gated). `tsc` clean (front + front-api).

## Risk

Very low. Additive write paths on the same bulk route, no behavior change to existing single-scope env-var paths. Behind admin + Computer + `sandbox_functions` gates; write-only invariant preserved (values never returned). Safe to roll back.

## Deploy Plan

Standard front / front-api deploy. No migration. Merge after `31478`.
