### PR TITLE
Add devcontainer and speed up setup.

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -19,6 +19,8 @@
     { "name": "front-spa", "port": 3011 },
     { "name": "core-api", "port": 3001 },
     { "name": "viz", "port": 3007 },
-    { "name": "temporal", "port": 7233 }
+    { "name": "qdrant", "port": 6333 },
+    { "name": "temporal", "port": 7233 },
+    { "name": "temporal-ui", "port": 8233 }
   ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,70 @@
+{
+  "name": "dust-dev",
+  "build": {
+    "dockerfile": "../dev/Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "remoteUser": "root",
+  "runArgs": [
+    "--init"
+  ],
+  "forwardPorts": [
+    3000,
+    3010,
+    3011,
+    3001,
+    3007,
+    6333,
+    7233,
+    8233
+  ],
+  "remoteEnv": {
+    "DUST_IN_CONTAINER": "1",
+    "OP_SERVICE_ACCOUNT_TOKEN": "${localEnv:OP_SERVICE_ACCOUNT_TOKEN}",
+    "OP_ENVIRONMENT_ID": "${localEnv:OP_ENVIRONMENT_ID}",
+    "GCP_SERVICE_ACCOUNT": "${localEnv:GCP_SERVICE_ACCOUNT}",
+    "DEV_WORKOS_USER_EMAIL": "${localEnv:DEV_WORKOS_USER_EMAIL}",
+    "DEV_WORKOS_USER_ID": "${localEnv:DEV_WORKOS_USER_ID}",
+    "DEV_WORKOS_USER_PASSWORD": "${localEnv:DEV_WORKOS_USER_PASSWORD}",
+    "SHELL": "/bin/zsh"
+  },
+  "mounts": [
+    "source=dust-dev-node-modules,target=/workspace/node_modules,type=volume",
+    "source=dust-dev-cargo-target,target=/workspace/core/target,type=volume",
+    "source=dust-dev-cargo-registry,target=/usr/local/cargo/registry,type=volume",
+    "source=dust-dev-cargo-git,target=/usr/local/cargo/git,type=volume",
+    "source=dust-dev-front-spa-vite,target=/workspace/front-spa/.vite,type=volume",
+    "source=dust-dev-front-api-cache,target=/workspace/front-api/.cache,type=volume",
+    "source=dust-dev-front-api-dist,target=/workspace/front-api/dist,type=volume",
+    "source=dust-dev-sparkle-dist,target=/workspace/sparkle/dist,type=volume",
+    "source=dust-dev-data,target=/var/lib/dust-dev,type=volume",
+    "source=dust-dev-gcloud-config,target=/root/.config/gcloud,type=volume",
+    "source=dust-dev-git-spice-config,target=/root/.config/git-spice,type=volume"
+  ],
+  "postCreateCommand": "bash dev/scripts/install.sh",
+  "postStartCommand": "DUST_OFFER_START_APPS=1 bash dev/scripts/infra.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "biomejs.biome",
+        "rust-lang.rust-analyzer",
+        "typescriptteam.native-preview",
+        "dbaeumer.vscode-eslint",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/bin/zsh",
+            "args": [
+              "-l"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -14,6 +14,8 @@
 # installed from the official tarball below.
 FROM ubuntu:24.04
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive \
     LEFTHOOK_EXCLUDE=front-lint-test-filenames,front-typecheck,front-circular,front-docs-check,connectors-lint-test-filenames,connectors-typecheck,lint-staged \
     DUST_IN_CONTAINER=1 \
@@ -35,6 +37,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     > /etc/apt/sources.list.d/pgdg.list \
   && apt-get update && apt-get install -y --no-install-recommends \
     git \
+    openssh-client \
     sudo \
     python3 \
     postgresql-16 \
@@ -54,12 +57,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     bash-completion \
     tmux \
     ffmpeg \
+    zsh \
   && rm -rf /var/lib/apt/lists/*
 
 # Node — official tarball, checksum-verified (same artifact the node:* images ship)
 ARG NODE_VERSION=24.16.0
 RUN set -eu \
-  && archive="node-v${NODE_VERSION}-linux-x64.tar.xz" \
+  && case "${TARGETARCH}" in \
+       amd64) node_arch="x64" ;; \
+       arm64) node_arch="arm64" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && archive="node-v${NODE_VERSION}-linux-${node_arch}.tar.xz" \
   && curl -fsSLo /tmp/node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" \
   && curl -fsSLo /tmp/node-shasums.txt "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" \
   && expected="$(awk -v archive="$archive" '$2 == archive { print $1 }' /tmp/node-shasums.txt)" \
@@ -84,11 +93,68 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   && install -m 0755 /usr/local/cargo/bin/bacon /usr/local/bin/bacon \
   && bacon --version
 
+# cargo-sweep — prune stale core/target artifacts on the persistent volume
+ARG CARGO_SWEEP_VERSION=0.8.0
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo install --locked --version "${CARGO_SWEEP_VERSION}" cargo-sweep \
+  && install -m 0755 /usr/local/cargo/bin/cargo-sweep /usr/local/bin/cargo-sweep \
+  && cargo sweep --version
+
 # mprocs — prebuilt binary to /usr/local/bin (same PATH reason as bacon/temporal)
 ARG MPROCS_VERSION=0.9.6
-RUN curl -fsSL "https://github.com/pvolok/mprocs/releases/download/v${MPROCS_VERSION}/mprocs-${MPROCS_VERSION}-linux-x86_64-musl.tar.gz" \
+RUN set -eu \
+  && case "${TARGETARCH}" in \
+       amd64) mprocs_arch="x86_64" ;; \
+       arm64) mprocs_arch="aarch64" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSL "https://github.com/pvolok/mprocs/releases/download/v${MPROCS_VERSION}/mprocs-${MPROCS_VERSION}-linux-${mprocs_arch}-musl.tar.gz" \
     | tar -xz -C /usr/local/bin \
   && mprocs --version
+
+# git-spice — stacked-branch CLI (`gs` / `git-spice`); 0.31.x satisfies >= 0.30.0
+ARG GIT_SPICE_VERSION=0.31.2
+RUN set -eu \
+  && case "${TARGETARCH}" in \
+       amd64) git_spice_arch="x86_64"; git_spice_sha256="4fbaffe8b6f69d1effce3bc3050083748ee8765b71fd928a966ad480b2d5d4f0" ;; \
+       arm64) git_spice_arch="aarch64"; git_spice_sha256="47492e167fa55a934e615e8e850345d8bb4c42ec6c03158896df7e5bec6559f8" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && archive="git-spice.Linux-${git_spice_arch}.tar.gz" \
+  && curl -fsSLo /tmp/git-spice.tar.gz \
+      "https://github.com/abhinav/git-spice/releases/download/v${GIT_SPICE_VERSION}/${archive}" \
+  && echo "${git_spice_sha256}  /tmp/git-spice.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/git-spice.tar.gz -C /usr/local/bin git-spice \
+  && rm /tmp/git-spice.tar.gz \
+  && chmod 0755 /usr/local/bin/git-spice \
+  && ln -s git-spice /usr/local/bin/gs \
+  && git-spice version
+
+# Interactive shell tools. Pin Oh My Zsh to a commit and verify the Starship
+# archive so rebuilding the image is deterministic.
+ARG OH_MY_ZSH_COMMIT=a5ecff7560b2e26f612032c632a12c75a3048bd0
+RUN git init /root/.oh-my-zsh \
+  && git -C /root/.oh-my-zsh remote add origin https://github.com/ohmyzsh/ohmyzsh.git \
+  && git -C /root/.oh-my-zsh fetch --depth=1 origin "${OH_MY_ZSH_COMMIT}" \
+  && git -C /root/.oh-my-zsh checkout --detach FETCH_HEAD \
+  && rm -rf /root/.oh-my-zsh/.git
+
+ARG STARSHIP_VERSION=1.26.0
+RUN set -eu \
+  && case "${TARGETARCH}" in \
+       amd64) starship_arch="x86_64"; starship_sha256="b7c232b0e8249d8e55a40beb79c5c43a7d370f3f9408bd215deb0170daeaadf3" ;; \
+       arm64) starship_arch="aarch64"; starship_sha256="dc30189378d2f2e287384e8a692d3f95ad1df64cf0e8c36aa9201516028aed6b" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSLo /tmp/starship.tar.gz \
+      "https://github.com/starship/starship/releases/download/v${STARSHIP_VERSION}/starship-${starship_arch}-unknown-linux-musl.tar.gz" \
+  && echo "${starship_sha256}  /tmp/starship.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/starship.tar.gz -C /usr/local/bin starship \
+  && rm /tmp/starship.tar.gz \
+  && starship --version
+
+COPY dev/starship.toml /root/.config/starship.toml
 
 # Temporal dev server
 RUN curl -sSf https://temporal.download/cli.sh | sh \
@@ -96,13 +162,31 @@ RUN curl -sSf https://temporal.download/cli.sh | sh \
   && temporal --version
 
 # Qdrant
-RUN mkdir -p /opt/qdrant \
-  && curl -fsSL https://github.com/qdrant/qdrant/releases/download/v1.18.3/qdrant-x86_64-unknown-linux-gnu.tar.gz \
-    | tar -xz -C /opt/qdrant --strip-components=1
+# The tarball has `qdrant` at the archive root. `--strip-components=1` treats
+# that filename as a path component and extracts nothing.
+ARG QDRANT_VERSION=1.18.3
+RUN set -eu \
+  && case "${TARGETARCH}" in \
+       amd64) qdrant_target="x86_64-unknown-linux-gnu"; qdrant_sha256="60663a254cf421dba4db45710872895cd3a714fe1e6978f7927923b5cfae4718" ;; \
+       arm64) qdrant_target="aarch64-unknown-linux-musl"; qdrant_sha256="1e738b45f90935c383b4076c30f377f390964cb5962b5bff24439812d157dc24" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSLo /tmp/qdrant.tar.gz \
+      "https://github.com/qdrant/qdrant/releases/download/v${QDRANT_VERSION}/qdrant-${qdrant_target}.tar.gz" \
+  && echo "${qdrant_sha256}  /tmp/qdrant.tar.gz" | sha256sum -c - \
+  && mkdir -p /opt/qdrant \
+  && tar -xzf /tmp/qdrant.tar.gz -C /opt/qdrant \
+  && rm /tmp/qdrant.tar.gz
 
 # Elasticsearch 8.x + ICU plugin
 ARG ES_VERSION=8.11.3
-RUN curl -fsSL "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz" \
+RUN set -eu \
+  && case "${TARGETARCH}" in \
+       amd64) es_arch="x86_64" ;; \
+       arm64) es_arch="aarch64" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSL "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-${es_arch}.tar.gz" \
     | tar -xz -C /opt \
   && mv "/opt/elasticsearch-${ES_VERSION}" /opt/es \
   && /opt/es/bin/elasticsearch-plugin install --batch analysis-icu \
@@ -113,11 +197,33 @@ RUN curl -fsSL "https://artifacts.elastic.co/downloads/elasticsearch/elasticsear
 
 # 1Password CLI beta — `op environment read` requires >= 2.33.0-beta.02 (stable apt pkg lacks it)
 ARG OP_CLI_VERSION=2.39.1-beta.01
-RUN curl -sSfLo /tmp/op.zip \
-      "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_CLI_VERSION}/op_linux_amd64_v${OP_CLI_VERSION}.zip" \
+RUN set -eu \
+  && case "${TARGETARCH}" in \
+       amd64) op_arch="amd64" ;; \
+       arm64) op_arch="arm64" ;; \
+       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+     esac \
+  && curl -sSfLo /tmp/op.zip \
+      "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_CLI_VERSION}/op_linux_${op_arch}_v${OP_CLI_VERSION}.zip" \
   && unzip -q /tmp/op.zip -d /usr/local/bin \
   && rm /tmp/op.zip \
   && op --version
+
+# Google Cloud SDK — gcloud + GKE plugin + kubectl (dust-us / dust-eu aliases)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    > /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
+    google-cloud-cli \
+    google-cloud-cli-gke-gcloud-auth-plugin \
+    kubectl \
+  && rm -rf /var/lib/apt/lists/* \
+  && gcloud version \
+  && gke-gcloud-auth-plugin --version \
+  && kubectl version --client
 
 # Postgres dev user (databases are created at agent start by init-databases.sh)
 RUN service postgresql start \
@@ -126,7 +232,7 @@ RUN service postgresql start \
   && sudo -u postgres psql -c "ALTER USER dev WITH SUPERUSER;" \
   && service postgresql stop
 
-RUN mkdir -p /tmp/dust-infra /opt/temporal /root/.config/mprocs \
+RUN mkdir -p /tmp/dust-infra /opt/temporal /var/lib/dust-dev /root/.config/mprocs \
   && printf '%s\n' \
     '# Sourced via BASH_ENV until infra.sh materializes 1Password + local-dev env.' \
     'return 0 2>/dev/null || true' \
@@ -151,6 +257,23 @@ RUN mkdir -p /tmp/dust-infra /opt/temporal /root/.config/mprocs \
     '  # shellcheck disable=SC1091' \
     '  . ~/.bashrc' \
     'fi' \
-    > /root/.bash_profile
+    > /root/.bash_profile \
+  && printf '%s\n' \
+    '# Dust shared dev container — refreshed by materialize_dev_environment at runtime.' \
+    'export SHELL=/bin/zsh' \
+    '' \
+    'if [ -f /tmp/dust-shell-env.sh ]; then' \
+    '  # shellcheck disable=SC1091' \
+    '  . /tmp/dust-shell-env.sh' \
+    'fi' \
+    '' \
+    'if [ -f /workspace/dev/zshrc ]; then' \
+    '  # shellcheck disable=SC1091' \
+    '  . /workspace/dev/zshrc' \
+    'fi' \
+    > /root/.zshrc \
+  && chsh -s /bin/zsh root
+
+ENV SHELL=/bin/zsh
 
 WORKDIR /workspace

--- a/dev/README.md
+++ b/dev/README.md
@@ -2,13 +2,24 @@
 
 Agent-agnostic Dockerfile + scripts used by:
 
+- **Cursor / VS Code Dev Containers** via [`.devcontainer/devcontainer.json`](../.devcontainer/devcontainer.json)
 - **Cursor Cloud Agents** via thin adapter [`.cursor/environment.json`](../.cursor/environment.json)
-- **Laptop** via `bash dev/scripts/docker-run.sh`
+- **Laptop CLI** via `bash dev/scripts/docker-run.sh`
 - **Other AI agents** by calling the same scripts (`install` → `infra` / `up`)
 
 Mac-native workflows stay separate: `tools/start-mprocs.sh` (mprocs + Docker Compose) and `tools/dev.sh` (process-compose).
 
-## Quick start (laptop)
+## Quick start (Dev Containers)
+
+Export the same host secrets as for `docker-run.sh`, open [`dust.code-workspace`](../dust.code-workspace) (single-root), then **Dev Containers: Reopen in Container** (or **Open Workspace in Container...**).
+
+On create: `install.sh`. On each start: `infra.sh`. Apps/mprocs are not auto-started — in a container terminal run:
+
+```bash
+bash dev/scripts/apps.sh
+```
+
+## Quick start (laptop CLI)
 
 ```bash
 export OP_SERVICE_ACCOUNT_TOKEN=...   # 1Password service account
@@ -17,12 +28,44 @@ bash dev/scripts/docker-run.sh        # build/start container → install → in
 bash dev/scripts/docker-run.sh --shell
 ```
 
+Local builds use Docker's native architecture (`linux/arm64` on Apple Silicon,
+`linux/amd64` on Intel) by default. Set `DUST_DEV_PLATFORM=linux/amd64` or
+`DUST_DEV_PLATFORM=linux/arm64` to override it. When switching architecture,
+rebuild and reset the named volumes because `node_modules` and Rust build
+artifacts contain architecture-specific binaries:
+
+```bash
+bash dev/scripts/docker-run.sh --build --reset-volumes
+```
+
+## Persistent data
+
+Postgres, Redis, Elasticsearch, Temporal and Qdrant all keep their state under
+`DUST_DATA_ROOT` (`/var/lib/dust-dev`), backed by the single `dust-dev-data`
+volume. `init-data-dirs.sh` creates the per-service subdirectories and, on an
+empty volume, `initdb`s a fresh Postgres cluster. `infra.sh` then recreates
+databases, Elasticsearch indices, and the Qdrant collection. Without the
+volume this state lives in the container layer and is lost on every rebuild.
+
+`core/target` is a separate named volume (`dust-dev-cargo-target`). Cargo
+leaves old incremental and dep artifacts behind on rebuilds; `infra.sh` runs
+`cargo-sweep` on start to drop unused files older than 14 days, artifacts from
+uninstalled toolchains, and anything over 12GiB. Override with
+`DUST_CARGO_SWEEP_DAYS` / `DUST_CARGO_SWEEP_MAXSIZE`.
+
+`--reset-volumes` drops that data too: the next `infra.sh` starts from a
+pristine cluster (schema, indices, collection) with no local workspaces or
+documents.
+
 ## Scripts
 
 | Script | Role |
 |--------|------|
 | `install.sh` | `npm install` + lefthook |
 | `infra.sh` | Postgres/Redis/Qdrant/ES/Temporal + Chrome managed policies + materialize 1Password + migrations |
+| `sweep-cargo-target.sh` | Prune stale `core/target` artifacts on the Cargo volume (14d / 12GiB cap) |
+| `init-data-dirs.sh` | Create `DUST_DATA_ROOT` dirs; `initdb` a fresh Postgres cluster if empty |
+| `init-qdrant-collections.sh` | Create the Qdrant embedding collection (idempotent) |
 | `apps.sh` | Wait for infra, optional WorkOS seed, mprocs |
 | `up.sh` | `install?` → `infra` → `apps` (serial entry for laptop / non-Cursor agents) |
 | `refresh-op-env.sh` | Re-fetch 1Password Environment into `/tmp` for all shells |
@@ -31,7 +74,7 @@ bash dev/scripts/docker-run.sh --shell
 ## Secrets
 
 - **Runtime / host-injected:** `OP_SERVICE_ACCOUNT_TOKEN`, `DEV_WORKOS_*`, `GCP_SERVICE_ACCOUNT` (already in process env; not re-exported).
-- **1Password Environment:** materialized once to `/tmp/dust-op-environment.env`, loaded via `BASH_ENV=/tmp/dust-shell-env.sh` and `dev/bashrc`.
+- **1Password Environment:** materialized once to `/tmp/dust-op-environment.env`, loaded via `BASH_ENV=/tmp/dust-shell-env.sh` for non-interactive bash (infra/mprocs) and via `/root/.zshrc` / `dev/zshrc` for interactive terminals.
 - **Local overrides:** `dev/scripts/env.sh` → `apply_local_overrides` forces in-container DB/API URLs after OP load.
 
 ## Infra models

--- a/dev/bashrc
+++ b/dev/bashrc
@@ -12,7 +12,7 @@ if [ -f /tmp/dust-shell-env.sh ]; then
   source /tmp/dust-shell-env.sh
 fi
 
-export SHELL=/bin/bash
+export SHELL=/bin/zsh
 export LANG="${LANG:-C.UTF-8}"
 export LC_ALL="${LC_ALL:-C.UTF-8}"
 export TERM="${TERM:-xterm-256color}"
@@ -51,6 +51,11 @@ alias l='ls -CF'
 # Repo helper when /workspace is mounted.
 if [ -d /workspace/.git ]; then
   alias cdust='cd /workspace'
+fi
+
+if [ -f /workspace/dev/interactive-aliases.sh ]; then
+  # shellcheck disable=SC1091
+  . /workspace/dev/interactive-aliases.sh
 fi
 
 if [ -f /etc/bash_completion ]; then

--- a/dev/interactive-aliases.sh
+++ b/dev/interactive-aliases.sh
@@ -1,0 +1,48 @@
+# Interactive-only aliases for the Dust shared dev container.
+# Sourced from dev/bashrc and dev/zshrc — not from BASH_ENV.
+
+alias dust-us='gcloud config configurations activate us-central1 && gcloud container clusters get-credentials dust-kube --region us-central1'
+alias dust-eu='gcloud config configurations activate europe-west1 && gcloud container clusters get-credentials dust-kube --region europe-west1'
+
+alias gs='git-spice'
+
+k8s_ssh () {
+  if [ -z "$1" ]; then
+    echo "Usage: k8s_ssh <pod_name>"
+    return
+  fi
+
+  # can specify shell using a second argument, default to bash
+  local k8s_shell="bash"
+  if [ -n "$2" ]; then
+    k8s_shell="$2"
+  fi
+
+  kubectl exec -it "$(kubectl get pods | grep "$1" | grep "Running" | awk 'NR==1{print $1}')" -- "$k8s_shell"
+}
+
+k8s_cp () {
+  # k8s_cp <pod_name> <local_file> <remote_file>
+  if [ -z "$3" ]; then
+    echo "Usage: k8s_cp <pod_name> <local_file> <remote_file>"
+    return
+  fi
+  if kubectl cp "$2" "$(kubectl get pods | grep "$1" | awk 'NR==1{print $1}')":"$3"; then
+    echo "Copied $2 to $1:$3"
+  else
+    echo "Failed to copy $2 to $1:$3"
+  fi
+}
+
+k8s_cp_from () {
+  # k8s_cp_from <pod_name> <remote_file> <local_file>
+  if [ -z "$3" ]; then
+    echo "Usage: k8s_cp_from <pod_name> <remote_file> <local_file>"
+    return
+  fi
+  if kubectl cp "$(kubectl get pods | grep "$1" | awk 'NR==1{print $1}')":"$2" "$3"; then
+    echo "Copied $1:$2 to $3"
+  else
+    echo "Failed to copy $1:$2 to $3"
+  fi
+}

--- a/dev/scripts/common.sh
+++ b/dev/scripts/common.sh
@@ -98,6 +98,31 @@ ensure_elasticsearch_create_index_built() {
   fi
 }
 
+qdrant_create_collection_bin() {
+  echo "${DUST_REPO_ROOT}/core/target/debug/qdrant_create_collection"
+}
+
+ensure_qdrant_create_collection_built() {
+  local bin
+  bin="$(qdrant_create_collection_bin)"
+  if [ -x "$bin" ]; then
+    return 0
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    log "cargo not found on PATH; rebuild dev/Dockerfile or source dev/scripts/env.sh"
+    return 1
+  fi
+  log "Building qdrant_create_collection (core)..."
+  (
+    cd "${DUST_REPO_ROOT}/core"
+    cargo build --bin qdrant_create_collection
+  )
+  if [ ! -x "$bin" ]; then
+    log "qdrant_create_collection binary missing after cargo build"
+    return 1
+  fi
+}
+
 write_gcp_service_account_file() {
   if [ -n "${GCP_SERVICE_ACCOUNT:-}" ]; then
     printf '%s' "$GCP_SERVICE_ACCOUNT" >"${SERVICE_ACCOUNT:-/tmp/dust-dev-sa.json}"
@@ -177,15 +202,16 @@ export_local_dev_infra() {
   apply_local_overrides
 }
 
-# Install /root shell rc so interactive login shells get secrets + colored PS1.
-# Interactive bash does NOT load BASH_ENV — only non-interactive bash does — so
-# /root/.bashrc must source the materialized env directly.
+# Install /root shell rc so interactive login shells get secrets + prompt.
+# Interactive bash does NOT load BASH_ENV — only non-interactive bash does.
+# zsh never loads BASH_ENV. Both rc files source the materialized env directly.
+# Infra scripts stay bash; only interactive terminals are zsh.
 write_root_shell_rc() {
   cat >/root/.bashrc <<EOF
 # Dust shared dev container — kept in sync by materialize_dev_environment.
 export BASH_ENV=${DUST_SHELL_ENV_FILE}
 
-# Interactive shells skip BASH_ENV; load materialized 1Password + local overrides here.
+# Interactive bash skips BASH_ENV; load materialized 1Password + local overrides here.
 if [ -f ${DUST_SHELL_ENV_FILE} ]; then
   # shellcheck disable=SC1091
   . ${DUST_SHELL_ENV_FILE}
@@ -199,10 +225,25 @@ EOF
 
   # Prefer bash_profile for login shells that skip .profile.
   cat >/root/.bash_profile <<'EOF'
-# Dust shared dev container login shell.
+# Dust shared dev container login shell (bash).
 if [ -f ~/.bashrc ]; then
   # shellcheck disable=SC1091
   . ~/.bashrc
+fi
+EOF
+
+  cat >/root/.zshrc <<EOF
+# Dust shared dev container — kept in sync by materialize_dev_environment.
+export SHELL=/bin/zsh
+
+if [ -f ${DUST_SHELL_ENV_FILE} ]; then
+  # shellcheck disable=SC1091
+  . ${DUST_SHELL_ENV_FILE}
+fi
+
+if [ -f /workspace/dev/zshrc ]; then
+  # shellcheck disable=SC1091
+  . /workspace/dev/zshrc
 fi
 EOF
 }

--- a/dev/scripts/docker-run.sh
+++ b/dev/scripts/docker-run.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 # Run the Dust shared dev container locally (laptop) or attach to it.
 #
-# Binds the repo for live edits but overlays node_modules and core/target so
-# container npm install / cargo builds do not touch your Mac copies.
-#
-# Default: gitignored host dirs under dev/docker-volumes/ (not in the image).
-# Alternative: DUST_DEV_VOLUME_MODE=docker for opaque Docker named volumes.
+# Binds the repo for live edits but overlays node_modules and core/target with
+# named Docker volumes so container npm install / cargo builds stay on the
+# Linux VM disk (persist across relaunch, not visible on the Mac checkout).
 #
 # Usage (from repo root):
 #   bash dev/scripts/docker-run.sh                 # start container + up.sh (infra + mprocs)
@@ -26,12 +24,55 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 IMAGE_NAME="${DUST_DEV_IMAGE:-dust-dev}"
 CONTAINER_NAME="${DUST_DEV_CONTAINER:-dust-dev}"
-PLATFORM="${DUST_DEV_PLATFORM:-linux/amd64}"
-VOLUME_MODE="${DUST_DEV_VOLUME_MODE:-host}"
 VOLUME_PREFIX="${DUST_DEV_VOLUME_PREFIX:-dust-dev}"
-HOST_VOLUME_ROOT="${DUST_DEV_HOST_VOLUME_ROOT:-$REPO_ROOT/dev/docker-volumes}"
-NODE_MODULES_VOLUME="${VOLUME_PREFIX}-node-modules"
-CARGO_TARGET_VOLUME="${VOLUME_PREFIX}-cargo-target"
+
+# Build for Docker's native architecture by default. Set DUST_DEV_PLATFORM
+# (for example linux/amd64) to opt into a different platform explicitly.
+if [ -n "${DUST_DEV_PLATFORM:-}" ]; then
+  PLATFORM="$DUST_DEV_PLATFORM"
+else
+  docker_arch="$(docker info --format '{{.Architecture}}')"
+  case "$docker_arch" in
+    amd64|x86_64) PLATFORM="linux/amd64" ;;
+    arm64|aarch64) PLATFORM="linux/arm64" ;;
+    *)
+      echo "Unsupported Docker architecture: ${docker_arch}" >&2
+      exit 1
+      ;;
+  esac
+fi
+case "$PLATFORM" in
+  linux/amd64|linux/arm64) ;;
+  *)
+    echo "Unsupported DUST_DEV_PLATFORM: ${PLATFORM}" >&2
+    echo "Supported values: linux/amd64, linux/arm64" >&2
+    exit 1
+    ;;
+esac
+
+# Dependency trees, build outputs and dev-server caches, as `volume:target`
+# pairs. These are rewritten constantly and only ever read from inside the
+# container, so they stay on the Linux VM disk instead of the virtiofs repo
+# bind (where per-file latency dominates). Keep in sync with
+# .devcontainer/devcontainer.json.
+DEV_VOLUMES=(
+  "${VOLUME_PREFIX}-node-modules:/workspace/node_modules"
+  "${VOLUME_PREFIX}-cargo-target:/workspace/core/target"
+  # Only the caches under CARGO_HOME: /usr/local/cargo/bin holds the rustup
+  # shims, so a volume there would shadow toolchain upgrades from the image.
+  "${VOLUME_PREFIX}-cargo-registry:/usr/local/cargo/registry"
+  "${VOLUME_PREFIX}-cargo-git:/usr/local/cargo/git"
+  "${VOLUME_PREFIX}-front-spa-vite:/workspace/front-spa/.vite"
+  "${VOLUME_PREFIX}-front-api-cache:/workspace/front-api/.cache"
+  "${VOLUME_PREFIX}-front-api-dist:/workspace/front-api/dist"
+  "${VOLUME_PREFIX}-sparkle-dist:/workspace/sparkle/dist"
+  # Postgres/Redis/Elasticsearch/Temporal/Qdrant state, relocated under one root
+  # by init-data-dirs.sh — otherwise it lives in the container layer and is lost
+  # on every rebuild.
+  "${VOLUME_PREFIX}-data:/var/lib/dust-dev"
+  "${VOLUME_PREFIX}-gcloud-config:/root/.config/gcloud"
+  "${VOLUME_PREFIX}-git-spice-config:/root/.config/git-spice"
+)
 
 BUILD=0
 RESET_VOLUMES=0
@@ -81,7 +122,7 @@ exec_interactive() {
   exec docker exec -it \
     -e TERM="${TERM:-xterm-256color}" \
     -e COLORTERM="${COLORTERM:-truecolor}" \
-    -e SHELL=/bin/bash \
+    -e SHELL=/bin/zsh \
     -e LANG=C.UTF-8 \
     -e LC_ALL=C.UTF-8 \
     -e DUST_IN_CONTAINER=1 \
@@ -104,7 +145,7 @@ ensure_container_running() {
     --name "$CONTAINER_NAME" \
     -e TERM="${TERM:-xterm-256color}" \
     -e COLORTERM="${COLORTERM:-truecolor}" \
-    -e SHELL=/bin/bash \
+    -e SHELL=/bin/zsh \
     -e LANG=C.UTF-8 \
     -e LC_ALL=C.UTF-8 \
     -e DUST_IN_CONTAINER=1 \
@@ -113,7 +154,9 @@ ensure_container_running() {
     -p 3011:3011 \
     -p 3001:3001 \
     -p 3007:3007 \
+    -p 6333:6333 \
     -p 7233:7233 \
+    -p 8233:8233 \
     -v "$REPO_ROOT:/workspace" \
     "${VOLUME_ARGS[@]}" \
     "${ENV_ARGS[@]}" \
@@ -137,13 +180,21 @@ if [ "$SHELL_ONLY" = 1 ]; then
     exit 1
   fi
   collect_env_args
-  # -i: interactive shells skip BASH_ENV, so bashrc must run (colored PS1 + op env).
-  # -l: load profile/bash_profile so /root/.bashrc is reached consistently.
-  exec_interactive bash -il
+  # Interactive zsh reads ~/.zshrc (not BASH_ENV). Login (-l) also reads .zprofile.
+  exec_interactive zsh -il
 fi
 
-if [ "$BUILD" = 1 ] || ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
-  echo "Building ${IMAGE_NAME} from dev/Dockerfile..."
+IMAGE_PLATFORM=""
+if docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+  IMAGE_PLATFORM="$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$IMAGE_NAME")"
+fi
+if [ "$BUILD" = 1 ] || [ -z "$IMAGE_PLATFORM" ] || [ "$IMAGE_PLATFORM" != "$PLATFORM" ]; then
+  if [ -n "$IMAGE_PLATFORM" ] && [ "$IMAGE_PLATFORM" != "$PLATFORM" ]; then
+    echo "Rebuilding ${IMAGE_NAME}: existing image is ${IMAGE_PLATFORM}, requested ${PLATFORM}."
+    BUILD=1
+  else
+    echo "Building ${IMAGE_NAME} for ${PLATFORM} from dev/Dockerfile..."
+  fi
   docker build --platform "$PLATFORM" -f "$REPO_ROOT/dev/Dockerfile" -t "$IMAGE_NAME" "$REPO_ROOT"
 fi
 
@@ -152,45 +203,35 @@ if [ "$BUILD" = 1 ] && docker container inspect "$CONTAINER_NAME" >/dev/null 2>&
   docker rm -f "$CONTAINER_NAME" >/dev/null
 fi
 
+if docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+  container_image="$(docker container inspect --format '{{.Image}}' "$CONTAINER_NAME")"
+  container_platform="$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$container_image")"
+  if [ "$container_platform" != "$PLATFORM" ]; then
+    echo "Removing ${CONTAINER_NAME}: existing container is ${container_platform}, requested ${PLATFORM}."
+    docker rm -f "$CONTAINER_NAME" >/dev/null
+  fi
+fi
+
 if [ "$RESET_VOLUMES" = 1 ] && docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
   echo "Removing container ${CONTAINER_NAME} before resetting volumes..."
   docker rm -f "$CONTAINER_NAME" >/dev/null
 fi
 
 VOLUME_ARGS=()
-case "$VOLUME_MODE" in
-  host)
-    NODE_MODULES_MOUNT="$HOST_VOLUME_ROOT/node_modules"
-    CARGO_TARGET_MOUNT="$HOST_VOLUME_ROOT/core-target"
-    if [ "$RESET_VOLUMES" = 1 ]; then
-      echo "Resetting host dev volumes under ${HOST_VOLUME_ROOT}..."
-      rm -rf "$NODE_MODULES_MOUNT" "$CARGO_TARGET_MOUNT"
-    fi
-    mkdir -p "$NODE_MODULES_MOUNT" "$CARGO_TARGET_MOUNT"
-    VOLUME_ARGS+=(
-      -v "$NODE_MODULES_MOUNT:/workspace/node_modules"
-      -v "$CARGO_TARGET_MOUNT:/workspace/core/target"
-    )
-    echo "Using host-isolated deps: ${NODE_MODULES_MOUNT}"
-    ;;
-  docker)
-    if [ "$RESET_VOLUMES" = 1 ]; then
-      echo "Removing Docker volumes ${NODE_MODULES_VOLUME} and ${CARGO_TARGET_VOLUME}..."
-      docker volume rm "$NODE_MODULES_VOLUME" "$CARGO_TARGET_VOLUME" >/dev/null 2>&1 || true
-    fi
-    docker volume create "$NODE_MODULES_VOLUME" >/dev/null
-    docker volume create "$CARGO_TARGET_VOLUME" >/dev/null
-    VOLUME_ARGS+=(
-      -v "$NODE_MODULES_VOLUME:/workspace/node_modules"
-      -v "$CARGO_TARGET_VOLUME:/workspace/core/target"
-    )
-    echo "Using Docker volumes: ${NODE_MODULES_VOLUME}, ${CARGO_TARGET_VOLUME}"
-    ;;
-  *)
-    echo "Unknown DUST_DEV_VOLUME_MODE=${VOLUME_MODE} (expected host or docker)" >&2
-    exit 1
-    ;;
-esac
+VOLUME_NAMES=()
+for spec in "${DEV_VOLUMES[@]}"; do
+  VOLUME_NAMES+=("${spec%%:*}")
+  VOLUME_ARGS+=(-v "$spec")
+done
+
+if [ "$RESET_VOLUMES" = 1 ]; then
+  echo "Removing Docker volumes: ${VOLUME_NAMES[*]}..."
+  docker volume rm "${VOLUME_NAMES[@]}" >/dev/null 2>&1 || true
+fi
+for name in "${VOLUME_NAMES[@]}"; do
+  docker volume create "$name" >/dev/null
+done
+echo "Using Docker volumes: ${VOLUME_NAMES[*]}"
 
 collect_env_args
 

--- a/dev/scripts/ensure-temporal.sh
+++ b/dev/scripts/ensure-temporal.sh
@@ -25,12 +25,12 @@ temporal_port_open() {
 }
 
 start_temporal_dev_server() {
-  mkdir -p /opt/temporal "${DUST_INFRA_LOG_DIR}"
+  mkdir -p "$(dirname "$DUST_TEMPORAL_DB_FILE")" "${DUST_INFRA_LOG_DIR}"
   log "Starting Temporal dev server on ${LOCAL_TEMPORAL_ADDRESS} (${TEMPORAL_BIN})..."
   nohup "$TEMPORAL_BIN" server start-dev \
     --ip 0.0.0.0 \
     --port "${TEMPORAL_PORT}" \
-    --db-filename /opt/temporal/dev.db \
+    --db-filename "$DUST_TEMPORAL_DB_FILE" \
     >>"${DUST_INFRA_LOG_DIR}/temporal.log" 2>&1 &
 }
 

--- a/dev/scripts/env.sh
+++ b/dev/scripts/env.sh
@@ -8,10 +8,26 @@
 
 export DUST_REPO_ROOT="${DUST_REPO_ROOT:-/workspace}"
 export DUST_IN_CONTAINER="${DUST_IN_CONTAINER:-1}"
+export DUST_APPS_PROMPT_FILE="${DUST_APPS_PROMPT_FILE:-/tmp/dust-infra/start-apps.prompt}"
+# Persistent core/target volume: keep recent artifacts, drop the rest.
+export DUST_CARGO_SWEEP_DAYS="${DUST_CARGO_SWEEP_DAYS:-14}"
+export DUST_CARGO_SWEEP_MAXSIZE="${DUST_CARGO_SWEEP_MAXSIZE:-12GiB}"
 
 # 1Password Environment id for shared cloud-agent / container secrets (not a credential).
 # Cloud agents get it injected as a runtime secret; this default serves local docker runs.
 export OP_ENVIRONMENT_ID="${OP_ENVIRONMENT_ID:-r6iqd3y67zqlbsxnotrj6bm25q}"  # pragma: allowlist secret
+
+# Every stateful service writes under this single root so one Docker volume
+# survives image rebuilds and container re-creation. Paths are wired up by
+# init-data-dirs.sh; keep in sync with .devcontainer/devcontainer.json.
+export DUST_DATA_ROOT="${DUST_DATA_ROOT:-/var/lib/dust-dev}"
+export DUST_POSTGRES_DATA_ROOT="${DUST_POSTGRES_DATA_ROOT:-${DUST_DATA_ROOT}/postgres}"
+export DUST_REDIS_DATA_DIR="${DUST_REDIS_DATA_DIR:-${DUST_DATA_ROOT}/redis}"
+export DUST_ELASTICSEARCH_DATA_DIR="${DUST_ELASTICSEARCH_DATA_DIR:-${DUST_DATA_ROOT}/elasticsearch/data}"
+export DUST_TEMPORAL_DB_FILE="${DUST_TEMPORAL_DB_FILE:-${DUST_DATA_ROOT}/temporal/dev.db}"
+# Qdrant has no CLI flags for these; it reads QDRANT__* overrides from the env.
+export QDRANT__STORAGE__STORAGE_PATH="${QDRANT__STORAGE__STORAGE_PATH:-${DUST_DATA_ROOT}/qdrant/storage}"
+export QDRANT__STORAGE__SNAPSHOTS_PATH="${QDRANT__STORAGE__SNAPSHOTS_PATH:-${DUST_DATA_ROOT}/qdrant/snapshots}"
 
 export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
 export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
@@ -51,6 +67,9 @@ export REDIS_URI="${REDIS_URI:-redis://${REDIS_HOST}:${REDIS_PORT}}"
 export REDIS_CACHE_URI="${REDIS_CACHE_URI:-$REDIS_URI}"
 export ELASTICSEARCH_URL="${ELASTICSEARCH_URL:-http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}}"
 export QDRANT_CLUSTER_0_URL="${QDRANT_CLUSTER_0_URL:-http://${QDRANT_HTTP_HOST}:${QDRANT_GRPC_PORT}}"
+# QdrantClients::build() errors out when the key is unset, even though the local
+# single-node Qdrant runs without authentication.
+export QDRANT_CLUSTER_0_API_KEY="${QDRANT_CLUSTER_0_API_KEY:-dust-dev-local}"
 export QDRANT_USE_SHARDING="${QDRANT_USE_SHARDING:-false}"
 
 export CORE_API="${CORE_API:-http://localhost:3001}"
@@ -73,7 +92,7 @@ export BASH_ENV="${BASH_ENV:-/tmp/dust-shell-env.sh}"
 # container id, so health checks against localhost:3000 never reach front-api.
 export HOSTNAME="${DUST_DEV_BIND_HOST:-0.0.0.0}"
 
-export SHELL="${SHELL:-/bin/bash}"
+export SHELL="${SHELL:-/bin/zsh}"
 export LANG="${LANG:-C.UTF-8}"
 export LC_ALL="${LC_ALL:-C.UTF-8}"
 export TERM="${TERM:-xterm-256color}"

--- a/dev/scripts/infra.sh
+++ b/dev/scripts/infra.sh
@@ -13,8 +13,17 @@ source "${SCRIPT_DIR}/env.sh"
 install_mprocs_config
 install_chrome_policies
 rm -f "${DUST_INFRA_LOG_DIR}/infra.ready"
+rm -f "${DUST_APPS_PROMPT_FILE}"
+rmdir "${DUST_APPS_PROMPT_FILE}.claimed" 2>/dev/null || true
 
 ensure_node_path
+
+log "Sweeping stale Cargo target artifacts..."
+bash "${SCRIPT_DIR}/sweep-cargo-target.sh" \
+  >"${DUST_INFRA_LOG_DIR}/sweep-cargo-target.log" 2>&1 || {
+  log "Cargo target sweep failed (non-fatal); see ${DUST_INFRA_LOG_DIR}/sweep-cargo-target.log"
+}
+
 ensure_client_built || {
   log "Installing workspace deps once before migrations..."
   bash "${SCRIPT_DIR}/install.sh" || exit 1
@@ -27,6 +36,31 @@ start_bg() {
   log "Starting $name..."
   "$@" >"${DUST_INFRA_LOG_DIR}/${name}.log" 2>&1 &
 }
+
+# Qdrant binds its ports a moment after launch. Without this gate infra.ready
+# can land first and workers started by apps.sh hit connection refused.
+wait_for_qdrant() {
+  local attempt=0
+  local max_attempts=60
+  local url="http://${QDRANT_HTTP_HOST}:${QDRANT_HTTP_PORT}/readyz"
+
+  until curl -sf "$url" >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -gt "$max_attempts" ]; then
+      log "Qdrant did not become ready on ${QDRANT_HTTP_HOST}:${QDRANT_HTTP_PORT}"
+      tail -30 "${DUST_INFRA_LOG_DIR}/qdrant.log" 2>/dev/null
+      return 1
+    fi
+    if [ "$attempt" -eq 1 ] || [ $((attempt % 15)) -eq 0 ]; then
+      log "Waiting for Qdrant on ${QDRANT_HTTP_HOST}:${QDRANT_HTTP_PORT} (${attempt}s)..."
+    fi
+    sleep 1
+  done
+  log "Qdrant is ready on ${QDRANT_HTTP_HOST}:${QDRANT_HTTP_PORT}"
+}
+
+log "Preparing data directories under ${DUST_DATA_ROOT}..."
+bash "${SCRIPT_DIR}/init-data-dirs.sh" || exit 1
 
 # --- Postgres ---
 if ! pgrep -x postgres >/dev/null 2>&1; then
@@ -42,12 +76,17 @@ fi
 # --- Redis ---
 if ! redis-cli ping >/dev/null 2>&1; then
   log "Starting redis..."
-  sudo redis-server /etc/redis/redis.conf --daemonize yes
+  sudo redis-server /etc/redis/redis.conf --daemonize yes --dir "$DUST_REDIS_DATA_DIR"
 fi
 
 # --- Qdrant ---
+# Unlike the other services here, Qdrant has no daemon mode and stays in the
+# foreground, so a plain `&` leaves it in this script's session and it dies with
+# the exec that ran infra.sh. Detach it into its own session instead.
 if ! pgrep -x qdrant >/dev/null 2>&1; then
-  start_bg qdrant bash -lc "cd /opt/qdrant && ./qdrant"
+  log "Starting qdrant..."
+  setsid nohup bash -lc "cd /opt/qdrant && exec ./qdrant" \
+    </dev/null >"${DUST_INFRA_LOG_DIR}/qdrant.log" 2>&1 &
 fi
 
 # --- Elasticsearch ---
@@ -56,10 +95,11 @@ if ! curl -sf "http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}" >/dev/null 2>
     groupadd -r elasticsearch 2>/dev/null || true
     useradd -r -g elasticsearch -d /opt/es -s /usr/sbin/nologin elasticsearch 2>/dev/null || true
   fi
-  mkdir -p /opt/es/data /opt/es/logs
-  chown -R elasticsearch:elasticsearch /opt/es
+  mkdir -p "$DUST_ELASTICSEARCH_DATA_DIR" /opt/es/logs
+  chown -R elasticsearch:elasticsearch /opt/es "$DUST_ELASTICSEARCH_DATA_DIR"
+  # sudo drops the env, so path.data has to be interpolated into the command.
   start_bg elasticsearch sudo -u elasticsearch bash -lc \
-    'ES_JAVA_OPTS="-Xms512m -Xmx512m" /opt/es/bin/elasticsearch -d -p /tmp/es.pid -E discovery.type=single-node -E xpack.security.enabled=false -E bootstrap.memory_lock=false -E path.data=/opt/es/data -E path.logs=/opt/es/logs'
+    "ES_JAVA_OPTS=\"-Xms512m -Xmx512m\" /opt/es/bin/elasticsearch -d -p /tmp/es.pid -E discovery.type=single-node -E xpack.security.enabled=false -E bootstrap.memory_lock=false -E path.data=${DUST_ELASTICSEARCH_DATA_DIR} -E path.logs=/opt/es/logs"
 fi
 
 # --- Temporal (start + namespaces + search attributes; single call) ---
@@ -92,6 +132,19 @@ bash "${SCRIPT_DIR}/setup-dev-db.sh" \
   exit 1
 }
 
+wait_for_qdrant || exit 1
+
+log "Ensuring Qdrant collections..."
+bash "${SCRIPT_DIR}/init-qdrant-collections.sh" 2>&1 | tee "${DUST_INFRA_LOG_DIR}/init-qdrant.log"
+qdrant_init_status=${PIPESTATUS[0]}
+if [ "$qdrant_init_status" -ne 0 ]; then
+  log "Qdrant collection init failed; see ${DUST_INFRA_LOG_DIR}/init-qdrant.log"
+  exit 1
+fi
+
 log "Infra ready. App services: bash dev/scripts/apps.sh (or up.sh)."
 log "Infra logs: ${DUST_INFRA_LOG_DIR}/"
 date -u +%Y-%m-%dT%H:%M:%SZ >"${DUST_INFRA_LOG_DIR}/infra.ready"
+if [ "${DUST_OFFER_START_APPS:-0}" = "1" ]; then
+  touch "${DUST_APPS_PROMPT_FILE}"
+fi

--- a/dev/scripts/init-data-dirs.sh
+++ b/dev/scripts/init-data-dirs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Point Postgres/Redis/Elasticsearch/Temporal/Qdrant at ${DUST_DATA_ROOT} so a
+# single Docker volume keeps their state across image rebuilds. First run on an
+# empty volume is a fresh cluster; infra.sh then recreates DBs, indices, and
+# the Qdrant collection. Everything else (ports, users, configs) stays in the
+# image.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=init-data-dirs
+# shellcheck source=dev/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=dev/scripts/env.sh
+source "$(dirname "$0")/env.sh"
+
+PG_VERSION="$(ls /etc/postgresql 2>/dev/null | sort -rn | head -1)"
+
+stop_postgres() {
+  if pgrep -x postgres >/dev/null 2>&1; then
+    log "Stopping Postgres..."
+    sudo pg_ctlcluster "$PG_VERSION" main stop || true
+  fi
+}
+
+ensure_postgres() {
+  if [ -z "$PG_VERSION" ]; then
+    log "Postgres not installed; skipping"
+    return 0
+  fi
+
+  local conf="/etc/postgresql/${PG_VERSION}/main/postgresql.conf"
+  local target="${DUST_POSTGRES_DATA_ROOT}/${PG_VERSION}/main"
+  local current initdb
+  current="$(awk -F"'" '/^data_directory/ {print $2}' "$conf")"
+  initdb="/usr/lib/postgresql/${PG_VERSION}/bin/initdb"
+
+  mkdir -p "$DUST_POSTGRES_DATA_ROOT"
+  chown postgres:postgres "$DUST_POSTGRES_DATA_ROOT"
+
+  if [ "$current" != "$target" ]; then
+    log "Pointing Postgres at ${target}"
+    stop_postgres
+    sed -i "s|^data_directory = .*|data_directory = '${target}'|" "$conf"
+  fi
+
+  if [ ! -f "${target}/PG_VERSION" ]; then
+    stop_postgres
+    log "Initializing a fresh Postgres cluster at ${target}"
+    rm -rf "$target"
+    sudo -u postgres mkdir -p "$target"
+    sudo -u postgres "$initdb" -D "$target"
+  fi
+
+  chown -R postgres:postgres "$DUST_POSTGRES_DATA_ROOT"
+  chmod 0700 "$target"
+}
+
+ensure_redis() {
+  mkdir -p "$DUST_REDIS_DATA_DIR"
+  if id redis >/dev/null 2>&1; then
+    chown -R redis:redis "$DUST_REDIS_DATA_DIR"
+  fi
+}
+
+ensure_elasticsearch() {
+  mkdir -p "$DUST_ELASTICSEARCH_DATA_DIR"
+  if id elasticsearch >/dev/null 2>&1; then
+    chown -R elasticsearch:elasticsearch "$(dirname "$DUST_ELASTICSEARCH_DATA_DIR")"
+  fi
+}
+
+ensure_temporal() {
+  mkdir -p "$(dirname "$DUST_TEMPORAL_DB_FILE")"
+}
+
+ensure_qdrant() {
+  mkdir -p "$QDRANT__STORAGE__STORAGE_PATH" "$QDRANT__STORAGE__SNAPSHOTS_PATH"
+}
+
+mkdir -p "$DUST_DATA_ROOT"
+
+ensure_postgres
+ensure_redis
+ensure_elasticsearch
+ensure_temporal
+ensure_qdrant
+
+log "Data directories ready under ${DUST_DATA_ROOT}"

--- a/dev/scripts/init-databases.sh
+++ b/dev/scripts/init-databases.sh
@@ -11,6 +11,20 @@ admin_uri="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
 
 log "Waiting for Postgres at ${POSTGRES_HOST}:${POSTGRES_PORT}..."
 for _ in $(seq 1 60); do
+  if sudo -u postgres psql -tc "select 1" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='dev'" | grep -q 1; then
+  log "Creating Postgres role dev"
+  sudo -u postgres psql -v ON_ERROR_STOP=1 -c "CREATE USER dev WITH PASSWORD 'dev' SUPERUSER;"
+else
+  sudo -u postgres psql -c "ALTER USER dev WITH SUPERUSER;" >/dev/null
+fi
+
+for _ in $(seq 1 30); do
   if PGPASSWORD=dev psql "$admin_uri" -tc "select 1" >/dev/null 2>&1; then
     break
   fi

--- a/dev/scripts/init-qdrant-collections.sh
+++ b/dev/scripts/init-qdrant-collections.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Idempotent local Qdrant collection bootstrap (mirrors dust-hive initQdrant).
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=init-qdrant
+# shellcheck source=dev/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=dev/scripts/env.sh
+source "$(dirname "$0")/env.sh"
+
+export_local_dev_infra
+
+ensure_qdrant_create_collection_built
+
+QDRANT_HTTP_URL="http://${QDRANT_HTTP_HOST}:${QDRANT_HTTP_PORT}"
+
+wait_for_qdrant() {
+  log "Waiting for Qdrant at ${QDRANT_HTTP_URL}..."
+  for _ in $(seq 1 60); do
+    if curl -sf "${QDRANT_HTTP_URL}/readyz" >/dev/null 2>&1; then
+      log "Qdrant is ready"
+      return 0
+    fi
+    sleep 1
+  done
+  log "Qdrant did not become ready in time"
+  return 1
+}
+
+collection_exists() {
+  curl -sf -H "api-key: ${QDRANT_CLUSTER_0_API_KEY:-}" \
+    "${QDRANT_HTTP_URL}/collections/$1" >/dev/null 2>&1
+}
+
+ensure_collection() {
+  local provider="$1"
+  local model="$2"
+  # DustQdrantClient::collection_prefix() is hardcoded to "c" in core.
+  local name="c_${provider}_${model}"
+  local output_file status
+
+  if collection_exists "$name"; then
+    log "${name} already exists"
+    return 0
+  fi
+
+  log "Creating ${name}..."
+  output_file="$(mktemp)"
+  trap 'rm -f "$output_file"' RETURN
+
+  # create_collection.rs prompts through utils::confirm and has no
+  # --skip-confirmation flag like elasticsearch_create_index does.
+  status=0
+  (
+    cd "${DUST_REPO_ROOT}/core"
+    set -o pipefail
+    printf 'y\n' | "$(qdrant_create_collection_bin)" \
+      --cluster cluster-0 \
+      --provider "$provider" \
+      --model "$model" 2>&1 | tee "$output_file"
+  ) || status=$?
+
+  if [ "$status" -eq 0 ]; then
+    return 0
+  fi
+  if grep -qi 'already exists' "$output_file"; then
+    log "${name} already exists"
+    return 0
+  fi
+  log "Failed to create ${name}"
+  return 1
+}
+
+wait_for_qdrant
+
+# Keep in sync with x/henry/dust-hive/src/lib/init.ts (initQdrant).
+ensure_collection openai text-embedding-3-large-1536
+
+log "Qdrant collections ready"

--- a/dev/scripts/sweep-cargo-target.sh
+++ b/dev/scripts/sweep-cargo-target.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Bound the persistent core/target volume. Cargo leaves old deps and incremental
+# files behind on rebuilds; this keeps recent artifacts (so the volume still
+# speeds up bacon / rust-analyzer) and drops the rest.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=sweep-cargo-target
+# shellcheck source=dev/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=dev/scripts/env.sh
+source "$(dirname "$0")/env.sh"
+
+TARGET_DIR="${DUST_REPO_ROOT}/core/target"
+CORE_DIR="${DUST_REPO_ROOT}/core"
+DAYS="${DUST_CARGO_SWEEP_DAYS:-14}"
+MAXSIZE="${DUST_CARGO_SWEEP_MAXSIZE:-12GiB}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+  log "No ${TARGET_DIR}; skipping"
+  exit 0
+fi
+
+if ! command -v cargo-sweep >/dev/null 2>&1; then
+  log "cargo-sweep not installed; rebuild the dev image"
+  exit 0
+fi
+
+if pgrep -x cargo >/dev/null 2>&1 || pgrep -x rustc >/dev/null 2>&1 || pgrep -x bacon >/dev/null 2>&1; then
+  log "Cargo is compiling; skipping sweep so we don't delete in-flight artifacts"
+  exit 0
+fi
+
+size_before="$(du -sh "$TARGET_DIR" 2>/dev/null | awk '{print $1}')"
+log "Sweeping ${TARGET_DIR} (${size_before:-?}) — unused >${DAYS}d, cap ${MAXSIZE}, current toolchain only"
+
+run_sweep() {
+  (
+    cd "$CORE_DIR"
+    cargo-sweep sweep "$@"
+  )
+}
+
+# Criteria are mutually exclusive; run them in order from "keep current
+# toolchain" to "drop old unused files" to "hard size cap".
+run_sweep --installed
+run_sweep --time "$DAYS"
+run_sweep --maxsize "$MAXSIZE"
+
+size_after="$(du -sh "$TARGET_DIR" 2>/dev/null | awk '{print $1}')"
+log "Cargo target after sweep: ${size_after:-?}"

--- a/dev/starship.toml
+++ b/dev/starship.toml
@@ -1,0 +1,196 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+[](surface0)\
+$os\
+$username\
+[](bg:peach fg:surface0)\
+$directory\
+[](fg:peach bg:green)\
+$git_branch\
+$git_status\
+[](fg:green bg:teal)\
+$c\
+$rust\
+$golang\
+$nodejs\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+$gcloud\
+[ ](fg:teal)\
+$line_break$character"""
+
+palette = 'catppuccin_mocha'
+
+[palettes.gruvbox_dark]
+color_fg0 = '#fbf1c7'
+color_bg1 = '#3c3836'
+color_bg3 = '#665c54'
+color_blue = '#458588'
+color_aqua = '#689d6a'
+color_green = '#98971a'
+color_orange = '#d65d0e'
+color_purple = '#b16286'
+color_red = '#cc241d'
+color_yellow = '#d79921'
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+orange = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
+
+[os]
+disabled = false
+style = "bg:surface0 fg:text"
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = ""
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+Arch = "󰣇"
+Artix = "󰣇"
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+
+[username]
+show_always = true
+style_user = "bg:surface0 fg:text"
+style_root = "bg:surface0 fg:text"
+format = '[ $user ]($style)'
+
+[directory]
+style = "fg:mantle bg:peach"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = "󰝚 "
+"Pictures" = " "
+"Developer" = "󰲋 "
+
+[git_branch]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol $branch ](fg:base bg:green)]($style)'
+truncation_length = 14
+truncation_symbol = "…"
+
+
+[git_status]
+style = "bg:teal"
+format = '[[($all_status$ahead_behind )](fg:base bg:green)]($style)'
+
+[nodejs]
+disabled = true
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[c]
+symbol = " "
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[php]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[java]
+symbol = " "
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[python]
+symbol = ""
+style = "bg:teal"
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
+
+[docker_context]
+symbol = ""
+style = "bg:mantle"
+format = '[[ $symbol( $context) ](fg:#83a598 bg:color_bg3)]($style)'
+
+[time]
+disabled = true
+time_format = "%R"
+style = "bg:peach"
+format = '[[  $time ](fg:mantle bg:purple)]($style)'
+
+[line_break]
+disabled = false
+
+[character]
+disabled = false
+success_symbol = '[](bold fg:green)'
+error_symbol = '[](bold fg:red)'
+vimcmd_symbol = '[](bold fg:creen)'
+vimcmd_replace_one_symbol = '[](bold fg:purple)'
+vimcmd_replace_symbol = '[](bold fg:purple)'
+vimcmd_visual_symbol = '[](bold fg:lavender)'
+
+[gcloud]
+symbol = '☁️ '
+style = "bg:teal"
+format = '[[ $symbol($region) ](fg:base bg:teal)]($style)'

--- a/dev/zshrc
+++ b/dev/zshrc
@@ -1,0 +1,115 @@
+# Interactive zsh defaults for the Dust shared dev container.
+# Secret env is loaded by /root/.zshrc (zsh does not use BASH_ENV).
+
+[[ -o interactive ]] || return
+
+# Belt-and-suspenders if this file is sourced without going through /root/.zshrc.
+if [[ -f /tmp/dust-shell-env.sh ]]; then
+  # shellcheck disable=SC1091
+  source /tmp/dust-shell-env.sh
+fi
+
+export SHELL=/bin/zsh
+export LANG="${LANG:-C.UTF-8}"
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+export TERM="${TERM:-xterm-256color}"
+export COLORTERM="${COLORTERM:-truecolor}"
+export FORCE_COLOR="${FORCE_COLOR:-1}"
+export CLICOLOR="${CLICOLOR:-1}"
+export CLICOLOR_FORCE="${CLICOLOR_FORCE:-1}"
+
+# Cursor cloud-agent terminals replace image PATH; restore Rust/Qdrant tool locations.
+for _dev_bin_dir in /usr/local/cargo/bin /opt/qdrant; do
+  if [[ -d "${_dev_bin_dir}" ]]; then
+    case ":${PATH}:" in
+      *":${_dev_bin_dir}:"*) ;;
+      *) export PATH="${_dev_bin_dir}:${PATH}" ;;
+    esac
+  fi
+done
+unset _dev_bin_dir
+
+# Match the local interactive shell setup. Starship initializes below and
+# replaces the robbyrussell prompt, while the theme still supplies the rest of
+# its Oh My Zsh behavior.
+export ZSH="${HOME}/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+plugins=(git virtualenv gcloud)
+
+if [[ -r "${ZSH}/oh-my-zsh.sh" ]]; then
+  source "${ZSH}/oh-my-zsh.sh"
+fi
+
+HISTFILE="${HOME}/.zsh_history"
+HISTSIZE=10000
+SAVEHIST=20000
+setopt HIST_IGNORE_DUPS HIST_IGNORE_SPACE SHARE_HISTORY
+
+if [[ -x /usr/bin/dircolors ]]; then
+  eval "$(dircolors -b)"
+  alias ls='ls --color=auto'
+  alias grep='grep --color=auto'
+fi
+
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+if [[ -d /workspace/.git ]]; then
+  alias cdust='cd /workspace'
+fi
+
+if [[ -f /workspace/dev/interactive-aliases.sh ]]; then
+  # shellcheck disable=SC1091
+  source /workspace/dev/interactive-aliases.sh
+fi
+
+# Oh My Zsh's gcloud plugin sources the apt-installed completion.zsh.inc.
+# git-spice emits a zsh wrapper around its native completion command.
+if (( $+commands[git-spice] )); then
+  eval "$(git-spice shell completion zsh)"
+fi
+
+if [[ -f /workspace/dev/starship.toml ]]; then
+  export STARSHIP_CONFIG=/workspace/dev/starship.toml
+elif [[ -f "${HOME}/.config/starship.toml" ]]; then
+  export STARSHIP_CONFIG="${HOME}/.config/starship.toml"
+fi
+
+if (( $+commands[starship] )); then
+  eval "$(starship init zsh)"
+fi
+
+# Dev Container lifecycle commands do not have an interactive stdin. infra.sh
+# leaves this one-shot marker after postStartCommand completes, and the next
+# interactive prompt offers to launch mprocs.
+_dust_offer_start_apps() {
+  local marker="${DUST_APPS_PROMPT_FILE:-/tmp/dust-infra/start-apps.prompt}"
+  local claim="${marker}.claimed"
+  local reply=""
+
+  [[ -t 0 && -t 1 && -f "$marker" ]] || return
+  mkdir "$claim" 2>/dev/null || return
+  rm -f "$marker"
+
+  if pgrep -f 'mprocs .*mprocs.yaml' >/dev/null 2>&1; then
+    rmdir "$claim" 2>/dev/null
+    return
+  fi
+
+  if ! read "reply?Would you like to start the Dust apps? [Y/n] "; then
+    echo
+    rmdir "$claim" 2>/dev/null
+    return
+  fi
+  echo
+
+  if [[ -z "$reply" || "$reply" == [Yy]* ]]; then
+    bash /workspace/dev/scripts/apps.sh
+  fi
+
+  rmdir "$claim" 2>/dev/null
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _dust_offer_start_apps

--- a/dust.code-workspace
+++ b/dust.code-workspace
@@ -1,158 +1,73 @@
 {
   "folders": [
     {
-      "name": "sdks",
-      "path": "sdks/js",
-      "settings": {
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true
-        }
-      }
-    },
-    {
-      "name": "front",
-      "path": "front",
-      "settings": {
-        "typescript.preferences.useLabelDetailsInCompletion": true,
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true,
-          "**/.next": true,
-          "**/workers-build": true
-        }
-      }
-    },
-    {
-      "name": "front-api",
-      "path": "front-api",
-      "settings": {
-        "typescript.preferences.useLabelDetailsInCompletion": true,
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true
-        }
-      }
-    },
-    {
-      "name": "front-spa",
-      "path": "front-spa",
-      "settings": {
-        "typescript.preferences.useLabelDetailsInCompletion": true,
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true,
-          "**/.next": true,
-          "**/workers-build": true
-        }
-      }
-    },
-    {
-      "name": "connectors",
-      "path": "connectors",
-      "settings": {
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true
-        }
-      }
-    },
-    {
-      "name": "extension",
-      "path": "extension",
-      "settings": {
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true
-        }
-      }
-    },
-    {
-      "name": "firebase-functions",
-      "path": "firebase-functions",
-      "settings": {
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true
-        }
-      }
-    },
-    {
-      "name": "sparkle",
-      "path": "sparkle",
-      "settings": {
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "editor.defaultFormatter": "biomejs.biome",
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/dist": true
-        }
-      }
-    },
-    {
-      "name": "viz",
-      "path": "viz",
-      "settings": {
-        "typescript.preferences.includePackageJsonAutoImports": "off",
-        "typescript.experimental.useTsgo": true,
-        "files.exclude": {
-          "**/node_modules": true,
-          "**/.next": true,
-          "**/dist": true
-        }
-      }
+      "path": "."
     }
   ],
   "settings": {
     // TypeScript Native (tsgo) settings
     // Enable TypeScript Native - requires "TypeScript (Native Preview)" extension
     "typescript.experimental.useTsgo": true,
-
     // TypeScript preferences (work with both tsserver and tsgo)
     "typescript.preferences.useAliasesForRenames": true,
     "typescript.preferences.includePackageJsonAutoImports": "off",
+    "typescript.preferences.useLabelDetailsInCompletion": true,
     "typescript.disableAutomaticTypeAcquisition": true,
-
-    // File exclusions for better performance
-    "search.exclude": {
-      "**/node_modules": true,
-      "**/dist": true,
-      "**/build": true,
-      "**/out": true,
-      "**/target": true
-    },
+    // Hide build artifacts + rarely-opened packages (formerly omitted from multi-root)
     "files.exclude": {
       "**/node_modules": true,
       "**/dist": true,
       "**/build": true,
       "**/out": true,
-      "**/target": true
+      "**/target": true,
+      "**/.next": true,
+      "**/workers-build": true,
+      "**/storybook-static": true,
+      "dev/docker-volumes": true,
+      "cli": true,
+      "core": true,
+      "design_docs": true,
+      "dockerfiles": true,
+      "egress-proxy": true,
+      "marketing": true,
+      "preview-proxy": true,
+      "prodbox": true,
+      "sandbox": true,
+      "scripts": true,
+      "temporal": true,
+      "tools": true,
+      "x": true
+    },
+    "search.exclude": {
+      "**/node_modules": true,
+      "**/dist": true,
+      "**/build": true,
+      "**/out": true,
+      "**/target": true,
+      "**/.next": true,
+      "**/workers-build": true,
+      "**/storybook-static": true,
+      "dev/docker-volumes": true
+    },
+    "files.watcherExclude": {
+      "**/node_modules/**": true,
+      "**/dist/**": true,
+      "**/build/**": true,
+      "**/out/**": true,
+      "**/target/**": true,
+      "**/.next/**": true,
+      "**/workers-build/**": true,
+      "**/storybook-static/**": true,
+      "**/dev/docker-volumes/**": true,
+      "**/.git/objects/**": true,
+      "**/.git/subtree-cache/**": true
     },
     "files.autoSave": "onFocusChange",
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "biomejs.biome",
+    // Single-root layout: the Biome extension resolves the config against "/"
+    // instead of the workspace folder, so point it at the file explicitly.
+    "biome.configurationPath": "biome.editor.json",
     "editor.codeActionsOnSave": {
       "source.fixAll.biome": "explicit",
       "source.organizeImports.biome": "explicit"

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -279,7 +279,11 @@ export default defineConfig(({ mode }) => {
     : "treemap";
 
   return {
-    cacheDir: path.resolve(__dirname, ".vite"),
+    // Scoped per app: `dev:app` and `dev:poke` run concurrently from this same
+    // config. A shared cache dir makes each server treat the other's metadata
+    // as stale and re-optimize over it, which 504s the other's in-flight dep
+    // chunks and forces a full page reload.
+    cacheDir: path.resolve(__dirname, `.vite/${appName}`),
     base: basePath,
     root: path.resolve(__dirname, "."),
     publicDir: path.resolve(__dirname, "../front/public"),

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -211,7 +211,8 @@ export function PodConversationsTab({
                   podInfo.archivedAt && "text-muted-foreground"
                 )}
               >
-                {podInfo.name} - {greeting}
+                {podInfo.name}{" "}
+                <span className="text-muted-foreground">- {greeting}</span>
               </h2>
               {podInfo.archivedAt && (
                 <Chip size="xs" color="warning" label="Archived" />

--- a/front/poke/temporal/worker.ts
+++ b/front/poke/temporal/worker.ts
@@ -5,16 +5,18 @@ import {
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import * as activities from "@app/poke/temporal/activities";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
 const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runPokeWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "poke",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/activation_scheduler/worker.ts
+++ b/front/temporal/activation_scheduler/worker.ts
@@ -5,9 +5,11 @@ import {
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/activation_scheduler/activities";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runActivationSchedulerWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "activation_scheduler",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/agent_inactivity/worker.ts
+++ b/front/temporal/agent_inactivity/worker.ts
@@ -6,9 +6,11 @@ import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/agent_inactivity/activities";
 import { launchArchiveInactiveAgentsSchedule } from "@app/temporal/agent_inactivity/client";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -18,7 +20,7 @@ const MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS = 2;
 export async function runAgentInactivityWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "agent_inactivity",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -32,7 +32,10 @@ import {
   SCHEDULES_QUEUE_NAME,
 } from "@app/temporal/agent_loop/config";
 import { instrumentationSinks } from "@app/temporal/agent_loop/sinks";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { WorkerName } from "@app/temporal/worker_registry";
 import { isDevelopment } from "@app/types/shared/env";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -43,7 +46,6 @@ import {
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,
 } from "@temporalio/interceptors-opentelemetry/lib/worker";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 // Must match front-agent-loop-worker's terminationGracePeriodSeconds.
@@ -96,7 +98,7 @@ async function runAgentLoopWorkerForQueue({
 
   const spanExporter = new NoopSpanExporter();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName,
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -5,9 +5,11 @@ import {
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/analytics_queue/activities";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import { QUEUE_NAME } from "./config";
 
@@ -19,7 +21,7 @@ const MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS = 16;
 export async function runAnalyticsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "analytics_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/bundle_helper.ts
+++ b/front/temporal/bundle_helper.ts
@@ -1,10 +1,31 @@
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { Worker } from "@temporalio/worker";
 import { readFileSync } from "fs";
 import path from "path";
 
 import type { WorkerName } from "./worker_registry";
+
+// Webpack is per Worker.create(workflowsPath). Running those in parallel
+// re-walks the same graph ~30 times and saturates disk. Queue creates in
+// dev; worker.run() still overlaps once each bundle is ready.
+let workflowBundleQueue: Promise<void> = Promise.resolve();
+
+export function createTemporalWorker(
+  ...args: Parameters<typeof Worker.create>
+): ReturnType<typeof Worker.create> {
+  if (!isDevelopment() || process.env.USE_TEMPORAL_BUNDLES === "true") {
+    return Worker.create(...args);
+  }
+
+  const worker = workflowBundleQueue.then(() => Worker.create(...args));
+  workflowBundleQueue = worker.then(
+    () => undefined,
+    () => undefined
+  );
+  return worker;
+}
 
 /**
  * Returns the workflow configuration for a worker.

--- a/front/temporal/conversation_fork_queue/worker.ts
+++ b/front/temporal/conversation_fork_queue/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/conversation_fork_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runConversationForkQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "conversation_fork_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/credit_alerts/worker.ts
+++ b/front/temporal/credit_alerts/worker.ts
@@ -4,11 +4,13 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/credit_alerts/activities";
 import { launchSpendLimitExpirationSchedule } from "@app/temporal/credit_alerts/client";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -18,7 +20,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runCreditAlertsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "credit_alerts",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/data_retention/worker.ts
+++ b/front/temporal/data_retention/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/data_retention/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runDataRetentionWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "data_retention",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/es_indexation/worker.ts
+++ b/front/temporal/es_indexation/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/es_indexation/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runESIndexationQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "es_indexation_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/hard_delete/worker.ts
+++ b/front/temporal/hard_delete/worker.ts
@@ -4,11 +4,13 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/hard_delete/activities";
 import { launchHardDeleteSchedule } from "@app/temporal/hard_delete/client";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runHardDeleteWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "hard_delete",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/invitations/worker.ts
+++ b/front/temporal/invitations/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/invitations/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runInvitationsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "invitations",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/labs/transcripts/worker.ts
+++ b/front/temporal/labs/transcripts/worker.ts
@@ -1,10 +1,12 @@
 import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/labs/transcripts/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { TRANSCRIPTS_QUEUE_NAME } from "./config";
 
@@ -13,7 +15,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runLabsTranscriptsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "labs",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/mentions_count_queue/worker.ts
+++ b/front/temporal/mentions_count_queue/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/mentions_count_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runMentionsCountWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "mentions_count",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/mentions_queue/worker.ts
+++ b/front/temporal/mentions_queue/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/mentions_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runMentionsQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "mentions_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/metronome_events_queue/worker.ts
+++ b/front/temporal/metronome_events_queue/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/metronome_events_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runMetronomeEventsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "metronome_events_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/notifications_queue/worker.ts
+++ b/front/temporal/notifications_queue/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/notifications_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runNotificationsQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "notifications_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/production_checks/worker.ts
+++ b/front/temporal/production_checks/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/production_checks/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runProductionChecksWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "production_checks",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/project_task/worker.ts
+++ b/front/temporal/project_task/worker.ts
@@ -5,10 +5,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/project_task/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import { QUEUE_NAME } from "./config";
 
@@ -22,7 +24,7 @@ export async function runProjectTaskWorker() {
     serviceName: "dust-project-todo",
   });
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "project_task",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/reinforcement/worker.ts
+++ b/front/temporal/reinforcement/worker.ts
@@ -9,7 +9,10 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/reinforcement/activities";
 import { isDevelopment } from "@app/types/shared/env";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -19,7 +22,6 @@ import {
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,
 } from "@temporalio/interceptors-opentelemetry/lib/worker";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -35,7 +37,7 @@ export async function runReinforcementWorker() {
 
   const spanExporter = new NoopSpanExporter();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "reinforcement",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/relocation/worker.ts
+++ b/front/temporal/relocation/worker.ts
@@ -1,7 +1,10 @@
 import { config } from "@app/lib/api/regions/config";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as connectorsDestinationActivities from "@app/temporal/relocation/activities/destination_region/connectors/sql";
 import * as coreDestinationActivities from "@app/temporal/relocation/activities/destination_region/core";
 import * as frontDestinationActivities from "@app/temporal/relocation/activities/destination_region/front";
@@ -11,7 +14,6 @@ import * as frontSourceActivities from "@app/temporal/relocation/activities/sour
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
 import { getTemporalRelocationWorkerConnection } from "@app/temporal/relocation/temporal";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
@@ -22,7 +24,7 @@ export async function runRelocationWorker() {
 
   const { connection, namespace } =
     await getTemporalRelocationWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "relocation",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/remote_tools/worker.ts
+++ b/front/temporal/remote_tools/worker.ts
@@ -4,11 +4,13 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/remote_tools/activities";
 import { QUEUE_NAME } from "@app/temporal/remote_tools/config";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runRemoteToolsSyncWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "remote_tools_sync",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/sandbox_functions/worker.ts
+++ b/front/temporal/sandbox_functions/worker.ts
@@ -4,13 +4,15 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import { markSandboxFunctionInvocationFailedActivity } from "@app/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed";
 import { runSandboxFunctionInvocationActivity } from "@app/temporal/sandbox_functions/activities/run_sandbox_function_invocation";
 import { runSandboxFunctionToolActivity } from "@app/temporal/sandbox_functions/activities/run_sandbox_function_tool";
 import { QUEUE_NAME } from "@app/temporal/sandbox_functions/config";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
@@ -19,7 +21,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runSandboxFunctionsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "sandbox_functions",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/sandbox_reaper/worker.ts
+++ b/front/temporal/sandbox_reaper/worker.ts
@@ -4,12 +4,14 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as reaperActivities from "@app/temporal/sandbox_reaper/activities";
 import { launchSandboxReaperSchedule } from "@app/temporal/sandbox_reaper/client";
 import * as killRequesterActivities from "@app/temporal/sandbox_reaper/kill_requester/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -18,7 +20,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runSandboxReaperWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "sandbox_reaper",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/scrub_workspace/worker.ts
+++ b/front/temporal/scrub_workspace/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/scrub_workspace/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runScrubWorkspaceQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "scrub_workspace_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/triggers/worker.ts
+++ b/front/temporal/triggers/worker.ts
@@ -4,9 +4,11 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import * as activities from "./activities";
@@ -18,7 +20,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runAgentTriggerWorker() {
   const { connection, namespace } = await getTemporalAgentWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "agent_schedule",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/triggers_garbage_collect/worker.ts
+++ b/front/temporal/triggers_garbage_collect/worker.ts
@@ -4,9 +4,11 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import * as activities from "./activities";
 import { QUEUE_NAME } from "./config";
@@ -17,7 +19,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runAgentTriggerWebhookWorker() {
   const { connection, namespace } = await getTemporalAgentWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "agent_trigger_webhook",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/upsert_queue/worker.ts
+++ b/front/temporal/upsert_queue/worker.ts
@@ -1,10 +1,12 @@
 import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/upsert_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -14,7 +16,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runUpsertQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "upsert_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/upsert_tables/worker.ts
+++ b/front/temporal/upsert_tables/worker.ts
@@ -1,10 +1,12 @@
 import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/upsert_tables/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
@@ -15,7 +17,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 export async function runUpsertTableQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "upsert_table_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -1,10 +1,12 @@
 import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/usage_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
@@ -14,7 +16,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runUpdateWorkspaceUsageWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "update_workspace_usage",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/front/temporal/workos_events_queue/worker.ts
+++ b/front/temporal/workos_events_queue/worker.ts
@@ -4,10 +4,12 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/workos_events_queue/activities";
 import type { Context } from "@temporalio/activity";
-import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
@@ -16,7 +18,7 @@ const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runWorkOSEventsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const worker = await createTemporalWorker({
     ...getWorkflowConfig({
       workerName: "workos_events_queue",
       getWorkflowsPath: () => require.resolve("./workflows"),

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -5,7 +5,8 @@
     "node": ">=24.16.0"
   },
   "scripts": {
-    "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
+    "build": "npm run clean:dist && npm run tailwind && npm run build:esm && npm run build:cjs",
+    "clean:dist": "mkdir -p dist && find dist -mindepth 1 -delete",
     "tailwind": "npx @tailwindcss/cli -i ./src/styles/tailwind.css -o dist/sparkle.css",
     "build:esm": "npm run copy:esm && tsgo && tsc-alias",
     "copy:esm": "copyfiles -u 1 src/**/*.css src/**/*.svg src/**/*.png src/**/*.json dist/esm",

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -112,6 +112,7 @@ procs:
       echo "Waiting for sparkle to compile..."
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
+      bash ../tools/wait-for-front-api-ready.sh
       npm run dev:app
 
   front-poke:
@@ -122,6 +123,7 @@ procs:
       echo "Waiting for sparkle to compile..."
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
+      bash ../tools/wait-for-front-api-ready.sh
       npm run dev:poke
 
   marketing-site:

--- a/tools/wait-for-front-api-ready.sh
+++ b/tools/wait-for-front-api-ready.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Block until the Hono front-api health endpoint is ready.
+set -euo pipefail
+
+HEALTH_URL="${DUST_FRONT_API:-http://127.0.0.1:3000}/api/healthz"
+
+echo "Waiting for front-api at ${HEALTH_URL}..."
+attempt=0
+until curl -sf "$HEALTH_URL" >/dev/null; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -eq 30 ] || [ $((attempt % 30)) -eq 0 ]; then
+    echo "Still waiting for front-api (${attempt}s)... check the front-api-hono proc"
+  fi
+  sleep 1
+done
+
+echo "front-api ready."

--- a/tools/wait-for-front-api.sh
+++ b/tools/wait-for-front-api.sh
@@ -3,20 +3,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-HEALTH_URL="${DUST_FRONT_API:-http://127.0.0.1:3000}/api/healthz"
-
 bash "${ROOT}/tools/wait-for-temporal.sh"
+bash "${ROOT}/tools/wait-for-front-api-ready.sh"
 
-echo "Waiting for front-api at ${HEALTH_URL}..."
-attempt=0
-until curl -sf "$HEALTH_URL" >/dev/null; do
-  attempt=$((attempt + 1))
-  if [ "$attempt" -eq 30 ] || [ $((attempt % 30)) -eq 0 ]; then
-    echo "Still waiting for front-api (${attempt}s)... check the front-api-hono proc"
-  fi
-  sleep 1
-done
-
-echo "front-api ready. Starting front-workers."
+echo "Starting front-workers."
 cd "${ROOT}/front"
 exec ./admin/dev_worker.sh


### PR DESCRIPTION
## Description

I add a multi-architecture Dev Container workflow for Dust and make the shared development image faster and more reproducible:

- `.devcontainer/devcontainer.json` opens the repo with zsh, pinned and checksummed tooling, persistent Docker volumes, forwarded services, and install/infra lifecycle hooks.
- `dev/scripts/docker-run.sh` selects the native Docker architecture, isolates dependency/build/cache volumes, and supports reset/rebuild.
- Development startup now serializes Temporal workflow bundling, scopes Vite caches per app, and adds git-spice, Google Cloud, Kubernetes, and shell tooling.
- The Pod conversation header de-emphasizes the greeting.

## Tests

Automated CI has passed `lint`, `tsgo`, `react-doctor`, CodeQL, and GitGuardian checks. Build and test shards were still running when this description was generated. No dedicated unit tests were added.

## Risk

Low. The Temporal wrapper preserves direct `Worker.create` behavior outside development and when `USE_TEMPORAL_BUNDLES=true`. The main risk is dev image build or startup regressions across amd64/arm64, or stale named volumes after an architecture switch; `--reset-volumes` handles the latter. Rollback is a single revert.

## Deploy Plan

Deploy `front`. No SQL migrations or infrastructure changes. The Dev Container and Docker tooling take effect when developers rebuild locally; production needs only the normal front deployment.
