### PR TITLE
Add renewable Frame lock wrappers

### DIFF
--- a/front/lib/api/frames/operation_lock.test.ts
+++ b/front/lib/api/frames/operation_lock.test.ts
@@ -1,0 +1,43 @@
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import type { RedisClientType } from "@app/lib/api/redis";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+const { getRedisStreamClientMock } = vi.hoisted(() => ({
+  getRedisStreamClientMock: vi.fn<() => Promise<LockRedisClient>>(),
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisStreamClient: getRedisStreamClientMock,
+}));
+
+function makeRedisClient(): LockRedisClient {
+  return {
+    eval: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("Frame operation locks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps zero-argument publish callbacks compatible", async () => {
+    getRedisStreamClientMock.mockResolvedValue(makeRedisClient());
+
+    const result = await withFramePublishLock(
+      "frame-123",
+      async () => new Ok("published")
+    );
+
+    expect(result.isOk() && result.value).toBe("published");
+  });
+});

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,8 +1,14 @@
-import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
-import { executeWithLockResult } from "@app/lib/lock";
+import type {
+  LockAcquisitionTimeoutError,
+  LockLeaseGuard,
+  LockLeaseLostError,
+} from "@app/lib/lock";
+import { executeWithRenewingLockResult } from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
+
+type FrameOperationLockError = LockAcquisitionTimeoutError | LockLeaseLostError;
 
 export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
@@ -10,9 +16,11 @@ export function getFramePublishLockName(frameId: string): string {
 
 export function withFramePublishLock<T, E>(
   frameId: string,
-  callback: () => Promise<Result<T, E>>
-): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
-  return executeWithLockResult(
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>
+): Promise<Result<T, E | FrameOperationLockError>> {
+  return executeWithRenewingLockResult(
     getFramePublishLockName(frameId),
     callback,
     30_000,

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockExecuteWithLock,
+  mockExecuteWithRenewingLockResult,
   mockGetSandboxImage,
   mockGetSandboxProvider,
   mockProviderCreate,
@@ -9,6 +10,7 @@ const {
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockExecuteWithLock: vi.fn(),
+  mockExecuteWithRenewingLockResult: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
   mockProviderCreate: vi.fn(),
@@ -31,6 +33,7 @@ vi.mock("@app/lib/api/sandbox/image", () => ({
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
   executeWithLockResult: mockExecuteWithLock,
+  executeWithRenewingLockResult: mockExecuteWithRenewingLockResult,
 }));
 
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -89,6 +92,10 @@ describe("FrameSandboxAdapter", () => {
           }
         }
       }
+    );
+    mockExecuteWithRenewingLockResult.mockImplementation(
+      async (key: string, fn: (lease: unknown) => Promise<unknown>) =>
+        mockExecuteWithLock(key, () => fn({ check: () => new Ok(undefined) }))
     );
     mockGetSandboxImage.mockReturnValue(
       new Ok({


### PR DESCRIPTION
## Description

Add renewable Frame publish-lock wrappers on top of #31514. The wrapper passes a lease guard to callers and maps acquisition/lease failures through typed Results.

Because importing Frame resources now reaches the renewable wrapper, this slice also completes the existing `FrameSandboxAdapter` test mock with `executeWithRenewingLockResult`; that is the earliest point where the mock becomes required.

Stack: #31509 -> #31512 -> #31514 -> this PR. Generic sandbox cleanup fencing follows in #31516. Retry/logging hardening #31551 remains an independent sibling from #31514.

## Tests

- Frame operation-lock test: 1 passed.
- Frame sandbox adapter tests: 4 passed.
- Biome and diff checks pass.

## Risk

No production caller changes in this slice. Existing zero-argument callbacks remain compatible.

## Deploy Plan

Merge after #31514. No migration is required.