### PR TITLE
Expose Frame moves in dsbx

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -10,9 +10,9 @@ use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, FrameCallByIdRequest, FrameCallFromSourceRequest,
-    FrameCallResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
-    FrameRegisterResponse, FrameShareLinkResponse, FrameValidateRequest, FrameValidateResponse,
-    MCPServerView, SandboxServerViewsResponse,
+    FrameCallResponse, FrameMoveRequest, FrameMoveResponse, FramePublishRequest,
+    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, FrameShareLinkResponse,
+    FrameValidateRequest, FrameValidateResponse, MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -199,6 +199,22 @@ impl DustApiClient {
         self.post_with_timeout(
             "sandbox/frames/validate",
             &FrameValidateRequest { manifest_path },
+            POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn move_frame(
+        &self,
+        source_directory_path: &str,
+        destination_directory_path: &str,
+    ) -> anyhow::Result<FrameMoveResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/move",
+            &FrameMoveRequest {
+                source_directory_path,
+                destination_directory_path,
+            },
             POLL_MAX_DURATION,
         )
         .await

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -46,6 +46,13 @@ pub struct FrameValidateRequest<'a> {
     pub manifest_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMoveRequest<'a> {
+    pub source_directory_path: &'a str,
+    pub destination_directory_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -72,6 +79,14 @@ pub struct FrameValidateResponse {
     pub manifest_path: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMoveResponse {
+    pub frame_id: String,
+    pub destination_directory_path: String,
+    pub source_deletion_failed: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,5 +1,6 @@
 mod call;
 mod create;
+mod move_frame;
 mod publish;
 mod register;
 mod share_link;
@@ -12,6 +13,7 @@ use clap::Subcommand;
 
 pub use call::run as cmd_frame_call;
 pub use create::run as cmd_frame_create;
+pub use move_frame::run as cmd_frame_move;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
 pub use share_link::run as cmd_frame_share_link;
@@ -48,6 +50,13 @@ pub enum FrameCommand {
         /// Absolute /files/.../manifest.json path
         manifest: PathBuf,
     },
+    /// Move a registered Frame folder while preserving its identity and state
+    Move {
+        /// Existing Frame folder under /files
+        source: PathBuf,
+        /// New Frame folder path under /files
+        destination: PathBuf,
+    },
     /// Retrieve the existing share link for a registered Frame
     ShareLink {
         /// Existing Frame folder under /files
@@ -69,6 +78,10 @@ fn scoped_path(path: &Path) -> anyhow::Result<String> {
     scoped_path_under(path, Path::new(FILES_ROOT))
 }
 
+fn scoped_new_path(path: &Path) -> anyhow::Result<String> {
+    scoped_new_path_under(path, Path::new(FILES_ROOT))
+}
+
 fn validate_scoped_path(path: &Path) -> anyhow::Result<()> {
     let relative = path
         .strip_prefix(FILES_ROOT)
@@ -88,6 +101,30 @@ fn scoped_path_under(path: &Path, files_root: &Path) -> anyhow::Result<String> {
         .with_context(|| format!("path must be under /files: {}", path.display()))?;
 
     validate_relative_scoped_path(relative)
+}
+
+fn scoped_new_path_under(path: &Path, files_root: &Path) -> anyhow::Result<String> {
+    if path.symlink_metadata().is_ok() {
+        bail!("destination must not exist: {}", path.display());
+    }
+
+    let canonical_root = files_root
+        .canonicalize()
+        .with_context(|| format!("failed to resolve {}", files_root.display()))?;
+    let parent = path
+        .parent()
+        .context("destination must have an existing parent under /files")?;
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("destination parent must exist: {}", parent.display()))?;
+    let relative_parent = canonical_parent
+        .strip_prefix(&canonical_root)
+        .with_context(|| format!("path must be under /files: {}", path.display()))?;
+    let name = path
+        .file_name()
+        .context("destination must identify a folder under /files")?;
+
+    validate_relative_scoped_path(&relative_parent.join(name))
 }
 
 fn validate_relative_scoped_path(relative: &Path) -> anyhow::Result<String> {
@@ -166,6 +203,32 @@ mod tests {
             )
             .expect("valid alias path"),
             "conversation-conv_123/Status/manifest.json"
+        );
+        assert_eq!(
+            scoped_new_path_under(&files_root.join("conversation/NewFrame"), &files_root)
+                .expect("valid new path through alias"),
+            "conversation-conv_123/NewFrame"
+        );
+    }
+
+    #[test]
+    fn accepts_only_missing_destinations_with_existing_scoped_parents() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let files_root = temp.path().join("files");
+        let parent = files_root.join("conversation-conv_123");
+        let destination = parent.join("NewFrame");
+        fs::create_dir_all(&parent).expect("create parent");
+
+        assert_eq!(
+            scoped_new_path_under(&destination, &files_root).expect("valid new path"),
+            "conversation-conv_123/NewFrame"
+        );
+
+        fs::create_dir(&destination).expect("create destination");
+        assert!(scoped_new_path_under(&destination, &files_root).is_err());
+        assert!(
+            scoped_new_path_under(&files_root.join("missing-parent/NewFrame"), &files_root)
+                .is_err()
         );
     }
 

--- a/cli/dust-sandbox/src/commands/frame/move_frame.rs
+++ b/cli/dust-sandbox/src/commands/frame/move_frame.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_new_path, scoped_path};
+
+pub async fn run(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(source)?;
+    let destination_directory_path = scoped_new_path(destination)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .move_frame(&source_directory_path, &destination_directory_path)
+        .await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -14,8 +14,8 @@ pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
 pub use frame::{
-    cmd_frame_call, cmd_frame_create, cmd_frame_publish, cmd_frame_register, cmd_frame_share_link,
-    cmd_frame_validate,
+    cmd_frame_call, cmd_frame_create, cmd_frame_move, cmd_frame_publish, cmd_frame_register,
+    cmd_frame_share_link, cmd_frame_validate,
 };
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -144,6 +144,10 @@ async fn run() -> anyhow::Result<()> {
             commands::frame::FrameCommand::Register { manifest } => {
                 commands::cmd_frame_register(&manifest).await?
             }
+            commands::frame::FrameCommand::Move {
+                source,
+                destination,
+            } => commands::cmd_frame_move(&source, &destination).await?,
             commands::frame::FrameCommand::ShareLink { directory } => {
                 commands::cmd_frame_share_link(&directory).await?
             }
@@ -559,6 +563,38 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected validate"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_move_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "move",
+            "/files/conversation-conv_123/Status",
+            "/files/pod-vlt_123/Status",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Move {
+                        source,
+                        destination,
+                    },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+                assert_eq!(
+                    destination,
+                    std::path::PathBuf::from("/files/pod-vlt_123/Status")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected move"),
             _ => panic!("expected frame"),
         }
     }

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -63,6 +63,8 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame publish");
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
+    expect(instructions).toContain("dsbx frame move");
+    expect(instructions).toContain("registered Frame folder with raw");
     expect(instructions).toContain("dsbx frame share-link");
     expect(instructions).toContain("dsbx frame call");
     expect(instructions).toContain("stable Frame ID");

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -53,6 +53,18 @@ dsbx frame register /files/<scope>/<frame-folder>/manifest.json
 Registration validates the manifest and assigns its stable Frame identity. Repeating the command
 for the same manifest path returns the same Frame. Registration does not publish the source.
 
+## Move a registered Frame
+
+Use the CLI instead of \`mv\` so the Frame keeps its identity, active publication, sharing, and
+database state while its source folder moves:
+
+\`\`\`bash
+dsbx frame move /files/<scope>/<source-folder> /files/<scope>/<destination-folder>
+\`\`\`
+
+Source and destination must stay in the same conversation or Pod mount.
+Do not move a registered Frame folder with raw filesystem commands.
+
 ## Retrieve a registered Frame's share link
 
 Frame sharing and use rights are configured by the user in the Dust UI. Agents must not change
@@ -375,8 +387,7 @@ Do not use the \`publish_interactive_content_file\` tool: the CLI replaces it un
 Other interactive-content tools remain available for Frame operations that the CLI does not cover
 yet. Use \`dsbx frame --help\` as the authority for available operations.
 
-Do not use \`mv\` or \`cp\` on a registered Frame folder: move and clone are not supported in this
-initial scope.
+Do not use \`cp\` to clone a registered Frame folder. Cloning is not supported yet.
 
 ## Editing
 


### PR DESCRIPTION
## Description

Add `dsbx frame move SOURCE DESTINATION` and document that registered Frame folders must move through dsbx instead of raw `mv`.

The command forwards the internal move request and reports its typed response, including `sourceDeletionFailed`. This terminal child contains only the Rust CLI and Frames skill surfaces.

## Tests

Tested all 403 dsbx unit tests and the local forwarder E2E. Added CLI parsing and Frames skill instruction coverage.

## Risk

Additive terminal CLI and skill surface. Backend errors are reported unchanged. This branch should merge late because the shared dsbx command registry and Frames skill files also receive clone and share commands.

## Deploy Plan

Merge after #31494. Rebase serially if another CLI surface lands first, then use the standard deploy.
