### PR TITLE
Expose canonical Frames v2 invocation event stream

### DIFF
--- a/front-api/lib/api/sse/frame_function_invocation_events.ts
+++ b/front-api/lib/api/sse/frame_function_invocation_events.ts
@@ -1,0 +1,50 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { streamEvents } from "@front-api/lib/api/sse/stream_events";
+import type { Context } from "hono";
+import { z } from "zod";
+
+export const FrameFunctionInvocationEventParamSchema = z.object({
+  frameId: z.string().min(1),
+  invocationId: z.string().min(1),
+});
+
+export async function streamFrameFunctionInvocationEventsForRoute(
+  ctx: Context,
+  auth: Authenticator,
+  {
+    frameId,
+    invocationId,
+    lastEventId,
+  }: {
+    frameId: string;
+    invocationId: string;
+    lastEventId: string | null;
+  }
+) {
+  const frame = await FileResource.fetchById(auth, frameId);
+  if (!frame?.isFrameV2 || !(await frame.canCurrentUserUseFrame(auth))) {
+    return ctx.notFound();
+  }
+
+  const invocation = await SandboxFunctionResource.fetchInvocationByFrameAndId(
+    auth,
+    { frame, invocationId }
+  );
+  if (!invocation) {
+    return ctx.notFound();
+  }
+
+  return streamEvents({
+    ctx,
+    iterator: (signal) =>
+      getSandboxFunctionInvocationEvents({
+        invocationId: invocation.sId,
+        lastEventId,
+        signal,
+      }),
+    writeDoneSentinel: true,
+  });
+}

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9407,6 +9407,61 @@
         }
       }
     },
+    "/api/w/{wId}/frames/{frameId}/invocations/{invocationId}/events": {
+      "get": {
+        "summary": "Stream Frames v2 function invocation events",
+        "description": "Authorizes through the stable Frame identity and redirects to the SSE service. The invocation's own publication is used, so a republish cannot break an existing stream.",
+        "tags": [
+          "Private Frames"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "frameId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "invocationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server-Sent Event stream.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateSandboxFunctionInvocationEvent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Frame use right or Frame-owned invocation not found."
+          }
+        }
+      }
+    },
     "/api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events": {
       "get": {
         "summary": "Stream sandbox function invocation events",
@@ -13443,6 +13498,12 @@
           },
           {
             "$ref": "#/components/schemas/PrivateSandboxFunctionInvocationErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateSandboxFunctionToolApproveExecutionEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateSandboxFunctionToolPersonalAuthRequiredEvent"
           }
         ]
       },
@@ -13566,6 +13627,140 @@
               }
             },
             "description": "A structured error describing why the invocation failed."
+          }
+        }
+      },
+      "PrivateSandboxFunctionToolApproveExecutionEvent": {
+        "type": "object",
+        "description": "Sent when a tool called by a sandbox function requires user approval.",
+        "required": [
+          "type",
+          "created",
+          "sandboxFunctionId",
+          "invocationId",
+          "actionId",
+          "inputs",
+          "metadata"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_approve_execution"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "sandboxFunctionId": {
+            "type": "string"
+          },
+          "invocationId": {
+            "type": "string"
+          },
+          "actionId": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "stake": {
+            "type": "string"
+          },
+          "isLastBlockingEventForStep": {
+            "type": "boolean"
+          },
+          "argumentsRequiringApproval": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "approvalArgsLabel": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateSandboxFunctionToolPersonalAuthRequiredEvent": {
+        "type": "object",
+        "description": "Sent when a tool called by a sandbox function requires personal OAuth authentication.",
+        "required": [
+          "type",
+          "created",
+          "sandboxFunctionId",
+          "invocationId",
+          "actionId",
+          "inputs",
+          "metadata",
+          "authError"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_personal_auth_required"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "sandboxFunctionId": {
+            "type": "string"
+          },
+          "invocationId": {
+            "type": "string"
+          },
+          "actionId": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "stake": {
+            "type": "string"
+          },
+          "isLastBlockingEventForStep": {
+            "type": "boolean"
+          },
+          "authError": {
+            "type": "object",
+            "required": [
+              "mcpServerId",
+              "provider",
+              "toolName",
+              "message"
+            ],
+            "properties": {
+              "mcpServerId": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "scope": {
+                "type": "string"
+              },
+              "toolName": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
           }
         }
       },

--- a/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.test.ts
@@ -1,0 +1,220 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_functions";
+import { frameV2ContentType } from "@app/types/files";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...mod,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+    getSandboxFunctionInvocationEvents: vi.fn(async function* () {}),
+  };
+});
+
+const inputSchema: JSONSchema = { type: "object" };
+const outputSchema: JSONSchema = { type: "object" };
+
+async function setupFrameInvocation({
+  enableFramesV2 = true,
+}: {
+  enableFramesV2?: boolean;
+} = {}) {
+  const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  if (enableFramesV2) {
+    await FeatureFlagFactory.basic(adminAuth, "frames_v2");
+  }
+  const space = await SpaceFactory.project(workspace);
+  const frame = await FileFactory.create(adminAuth, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 100,
+    status: "ready",
+    useCase: "project_context",
+    useCaseMetadata: {
+      spaceId: space.sId,
+      activePublicationId: "publication-1",
+    },
+  });
+  await frame.setShareScope(adminAuth, "workspace_and_emails");
+  await withTransaction((transaction) =>
+    SandboxFunctionResource.createForFramePublication(
+      adminAuth,
+      {
+        frame,
+        publicationId: "publication-1",
+        functions: [
+          {
+            name: "run-function",
+            description: "Run the Frame function.",
+            userIdentity: "optional",
+            executionMode: "durable",
+            defaultStake: "low",
+            bundleCode:
+              "export default { fetch: async () => Response.json({}) };",
+            inputSchema,
+            outputSchema,
+          },
+        ],
+      },
+      transaction
+    )
+  );
+  const sandboxFunction =
+    await SandboxFunctionResource.fetchByFramePublicationAndSlug(adminAuth, {
+      frame,
+      publicationId: "publication-1",
+      slug: "run-function",
+    });
+  if (!sandboxFunction) {
+    throw new Error("Expected the Frame function to exist.");
+  }
+
+  const { user } = await createPrivateApiMockRequest({
+    role: "user",
+    workspace,
+  });
+  const callerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const invocation = await SandboxFunctionInvocationResource.makeNew(
+    callerAuth,
+    { sandboxFunction, input: { message: "hello" } }
+  );
+
+  return {
+    adminAuth,
+    frame,
+    invocation,
+    sandboxFunction,
+    space,
+    workspace,
+  };
+}
+
+function getEvents({
+  workspaceId,
+  frameId,
+  invocationId,
+}: {
+  workspaceId: string;
+  frameId: string;
+  invocationId: string;
+}) {
+  return honoApp.request(
+    `/api/sse/w/${workspaceId}/frames/${frameId}/invocations/${invocationId}/events`
+  );
+}
+
+function mockEventStream(event: SandboxFunctionInvocationEvent) {
+  vi.mocked(getSandboxFunctionInvocationEvents).mockImplementation(
+    async function* () {
+      yield { eventId: "event-1", data: event };
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/sse/w/:wId/frames/:frameId/invocations/:invocationId/events", () => {
+  it("keeps an invocation streamable after the Frame republishes", async () => {
+    const { frame, invocation, sandboxFunction, workspace } =
+      await setupFrameInvocation();
+    await frame.setActiveFramePublication("publication-2");
+    mockEventStream({
+      type: "sandbox_function_invocation_result",
+      created: Date.now(),
+      invocationId: invocation.sId,
+      functionId: sandboxFunction.sId,
+      result: { ok: true },
+    });
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"result":{"ok":true}');
+    expect(getSandboxFunctionInvocationEvents).toHaveBeenCalledWith({
+      invocationId: invocation.sId,
+      lastEventId: null,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("does not stream an invocation owned by another Frame", async () => {
+    const { adminAuth, invocation, space, workspace } =
+      await setupFrameInvocation();
+    const otherFrame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: "other-manifest.json",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: {
+        spaceId: space.sId,
+        activePublicationId: "publication-1",
+      },
+    });
+    await otherFrame.setShareScope(adminAuth, "workspace_and_emails");
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: otherFrame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("rechecks Frame use rights", async () => {
+    const { adminAuth, frame, invocation, workspace } =
+      await setupFrameInvocation();
+    await frame.setShareScope(adminAuth, "emails_only");
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("is available only behind frames_v2", async () => {
+    const { frame, invocation, workspace } = await setupFrameInvocation({
+      enableFramesV2: false,
+    });
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(403);
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
@@ -1,0 +1,38 @@
+import {
+  FrameFunctionInvocationEventParamSchema,
+  streamFrameFunctionInvocationEventsForRoute,
+} from "@front-api/lib/api/sse/frame_function_invocation_events";
+import { SseQuerySchema } from "@front-api/lib/api/sse/stream_events";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { streamingTag } from "@front-api/middlewares/streaming";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+
+const app = workspaceApp();
+
+app.use("*", streamingTag);
+app.use(
+  "*",
+  withFeatureFlag("frames_v2", {
+    message: "Frames v2 are not enabled for this workspace.",
+  })
+);
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("param", FrameFunctionInvocationEventParamSchema),
+  validate("query", SseQuerySchema),
+  async (ctx) => {
+    const { frameId, invocationId } = ctx.req.valid("param");
+    const { lastEventId } = ctx.req.valid("query");
+
+    return streamFrameFunctionInvocationEventsForRoute(ctx, ctx.var.auth, {
+      frameId,
+      invocationId,
+      lastEventId,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/sse/w/[wId]/index.ts
+++ b/front-api/routes/sse/w/[wId]/index.ts
@@ -3,6 +3,7 @@ import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 
 import conversationEvents from "./assistant/conversations/[cId]/events";
 import messageEvents from "./assistant/conversations/[cId]/messages/[mId]/events";
+import frameFunctionInvocationEvents from "./frames/[frameId]/invocations/[invocationId]/events";
 import mcpRequests from "./mcp/requests";
 import sandboxFunctionInvocationEvents from "./sandbox-functions/[functionId]/invocations/[invocationId]/events";
 
@@ -16,6 +17,10 @@ app.use("*", workspaceAuth());
 
 app.route("/assistant/conversations/:cId/events", conversationEvents);
 app.route("/assistant/conversations/:cId/messages/:mId/events", messageEvents);
+app.route(
+  "/frames/:frameId/invocations/:invocationId/events",
+  frameFunctionInvocationEvents
+);
 app.route("/mcp/requests", mcpRequests);
 app.route(
   "/sandbox-functions/:functionId/invocations/:invocationId/events",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1724,6 +1724,8 @@
  *         - $ref: '#/components/schemas/PrivateSandboxFunctionInvocationCreatedEvent'
  *         - $ref: '#/components/schemas/PrivateSandboxFunctionInvocationResultEvent'
  *         - $ref: '#/components/schemas/PrivateSandboxFunctionInvocationErrorEvent'
+ *         - $ref: '#/components/schemas/PrivateSandboxFunctionToolApproveExecutionEvent'
+ *         - $ref: '#/components/schemas/PrivateSandboxFunctionToolPersonalAuthRequiredEvent'
  *     PrivateSandboxFunctionInvocationCreatedEvent:
  *       type: object
  *       required: [type, created, invocation]
@@ -1787,6 +1789,80 @@
  *             status:
  *               type: integer
  *           description: A structured error describing why the invocation failed.
+ *     PrivateSandboxFunctionToolApproveExecutionEvent:
+ *       type: object
+ *       description: Sent when a tool called by a sandbox function requires user approval.
+ *       required: [type, created, sandboxFunctionId, invocationId, actionId, inputs, metadata]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_approve_execution]
+ *         created:
+ *           type: integer
+ *         sandboxFunctionId:
+ *           type: string
+ *         invocationId:
+ *           type: string
+ *         actionId:
+ *           type: string
+ *         inputs:
+ *           type: object
+ *           additionalProperties: true
+ *         metadata:
+ *           type: object
+ *         userId:
+ *           type: string
+ *         stake:
+ *           type: string
+ *         isLastBlockingEventForStep:
+ *           type: boolean
+ *         argumentsRequiringApproval:
+ *           type: array
+ *           items:
+ *             type: string
+ *         approvalArgsLabel:
+ *           type: string
+ *     PrivateSandboxFunctionToolPersonalAuthRequiredEvent:
+ *       type: object
+ *       description: Sent when a tool called by a sandbox function requires personal OAuth authentication.
+ *       required: [type, created, sandboxFunctionId, invocationId, actionId, inputs, metadata, authError]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_personal_auth_required]
+ *         created:
+ *           type: integer
+ *         sandboxFunctionId:
+ *           type: string
+ *         invocationId:
+ *           type: string
+ *         actionId:
+ *           type: string
+ *         inputs:
+ *           type: object
+ *           additionalProperties: true
+ *         metadata:
+ *           type: object
+ *         userId:
+ *           type: string
+ *         stake:
+ *           type: string
+ *         isLastBlockingEventForStep:
+ *           type: boolean
+ *         authError:
+ *           type: object
+ *           required: [mcpServerId, provider, toolName, message]
+ *           properties:
+ *             mcpServerId:
+ *               type: string
+ *             provider:
+ *               type: string
+ *             scope:
+ *               type: string
+ *             toolName:
+ *               type: string
+ *             message:
+ *               type: string
  *     PrivateAgentMessageEvent:
  *       type: object
  *       description: Server-Sent Event for agent message streaming. Discriminated on the `type` field. Each event also includes a `step` integer.

--- a/front-api/routes/w/[wId]/frames/[frameId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/index.ts
@@ -1,9 +1,11 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import functions from "./functions";
+import invocations from "./invocations";
 
 const app = workspaceApp();
 
 app.route("/functions", functions);
+app.route("/invocations", invocations);
 
 export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
@@ -1,0 +1,44 @@
+import { redirectToSse } from "@front-api/lib/api/sse/redirect";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+const app = workspaceApp();
+
+/**
+ * @swagger
+ * /api/w/{wId}/frames/{frameId}/invocations/{invocationId}/events:
+ *   get:
+ *     summary: Stream Frames v2 function invocation events
+ *     description: Authorizes through the stable Frame identity and redirects to the SSE service. The invocation's own publication is used, so a republish cannot break an existing stream.
+ *     tags:
+ *       - Private Frames
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: frameId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: invocationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Server-Sent Event stream.
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateSandboxFunctionInvocationEvent'
+ *       404:
+ *         description: Frame use right or Frame-owned invocation not found.
+ */
+app.get("/", redirectToSse);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import events from "./events";
+
+const app = workspaceApp();
+
+app.route("/events", events);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import invocationId from "./[invocationId]";
+
+const app = workspaceApp();
+
+app.route("/:invocationId", invocationId);
+
+export default app;

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -590,6 +590,60 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     });
   }
 
+  /**
+   * Fetch an invocation through its stable Frame identity. The function row is resolved from the
+   * invocation itself rather than from the active publication, so an in-flight stream survives a
+   * republish or removal of the function from a later publication.
+   */
+  static async fetchInvocationByFrameAndId(
+    auth: Authenticator,
+    {
+      frame,
+      invocationId,
+    }: {
+      frame: FileResource;
+      invocationId: string;
+    }
+  ): Promise<SandboxFunctionInvocationResource | null> {
+    if (
+      !frame.isFrameV2 ||
+      !isResourceSId("sandbox_function_invocation", invocationId)
+    ) {
+      return null;
+    }
+    const invocationModelId = getResourceIdFromSId(invocationId);
+    if (invocationModelId === null) {
+      return null;
+    }
+
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      attributes: ["sandboxFunctionId"],
+      where: {
+        id: invocationModelId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: {
+        id: invocation.sandboxFunctionId,
+        fileId: frame.id,
+      },
+      includeFrameFunctions: true,
+    });
+    if (!sandboxFunction) {
+      return null;
+    }
+
+    return SandboxFunctionInvocationResource.fetchById(auth, {
+      sandboxFunction,
+      invocationId,
+    });
+  }
+
   static async listBySpace(
     auth: Authenticator,
     space: SpaceResource


### PR DESCRIPTION
## Description

Add the canonical Frames v2 invocation event stream keyed by stable Frame identity and invocation id. The stream rechecks current Frame use rights, resolves the invocation through its owning function row instead of the active publication, and therefore remains available after a Frame republishes.

The authenticated private route redirects to the SSE service, which repeats the feature gate and authorization checks. The private API is additive; legacy Frame and Pod Function event routes are unchanged. Swagger includes the approval and personal-auth event variants that the shared sandbox invocation stream can emit.

This PR is a true child of #31412 because both endpoints share the Frames route skeleton and API schemas. Its incremental diff contains only the SSE path.

## Tests

- Front API event tests: 6 files / 24 tests passed, including 4 canonical Frame SSE tests
- Front and Front API typechecks
- Swagger generation and strict validation
- Biome and git diff check

## Risk

Low and feature-gated. The endpoint is read-only and additive, fails closed when the Frame, current use right, or Frame-owned invocation is missing, and preserves Last-Event-ID replay through the existing stream helper. Rollback is reverting this PR.

## Deploy Plan

Merge and deploy after #31412. No migration or backfill. Enable the client switch only after both canonical POST and SSE server routes are available.