### PR TITLE
Enforce Frame database publication contracts

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -1,19 +1,22 @@
 import type { Changes, SQLQueryBindings, Statement } from "bun:sqlite";
 import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import { z } from "zod";
 
 import { podEnv } from "./context.ts";
 
 /**
  * Frame and Pod state databases.
  *
- * `db(name)` returns a cached Drizzle instance over the sandbox owner's live SQLite
- * database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. Databases are
- * created by `dsbx db reconcile` (the db_reconcile tool), never here: the file
- * is opened must-exist so a typo'd name errors clearly instead of minting an
- * empty database. Functions that never call `db()` pay nothing.
+ * `db(name)` returns a cached Drizzle instance over the sandbox owner's live
+ * SQLite database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. Pod names
+ * may be prefixed; Frame names are unprefixed and must be declared by the
+ * selected immutable publication. Databases are created by reconciliation,
+ * never here: the file is opened must-exist so a typo'd name errors clearly
+ * instead of minting an empty database. Functions that never call `db()` pay
+ * nothing.
  *
  * `name` is the app-relative name the function's source writes, and the app
  * prefix comes from the environment ({@link POD_DATABASE_PREFIX_ENV}) rather
@@ -59,6 +62,10 @@ export const POD_SPACE_ID_ENV = "SPACE_ID";
 /** Sandbox-global env var carrying the Frame sId for Frame-owned sandboxes. */
 export const FRAME_ID_ENV = "FRAME_ID";
 
+/** Exact immutable publication descriptor selected for a Frame invocation. */
+export const FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV =
+  "DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH";
+
 /**
  * Env var carrying the per-database size quota in bytes, required. Like the
  * databases directory, the value is owned by front (1 GiB in production) and
@@ -92,6 +99,16 @@ export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
 
 /** Valid database names (also the manifest/publish contract). */
 export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+export const SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION = 1;
+
+const framePublicationDatabaseContractSchema = z.object({
+  schemaVersion: z.literal(SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION),
+  manifest: z.object({
+    databases: z.array(
+      z.object({ name: z.string().regex(POD_DATABASE_NAME_REGEX) })
+    ),
+  }),
+});
 
 export class PodDatabaseError extends Error {
   constructor(message: string) {
@@ -120,6 +137,33 @@ export class PodDatabasesUnavailableError extends PodDatabaseError {
         `Frame sandbox.`
     );
     this.name = "PodDatabasesUnavailableError";
+  }
+}
+
+export class FramePublicationDescriptorError extends PodDatabaseError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FramePublicationDescriptorError";
+  }
+}
+
+export class FrameDatabaseNotDeclaredError extends PodDatabaseError {
+  constructor(dbName: string) {
+    super(
+      `Frame database "${dbName}" is not declared in this publication. ` +
+        `Declare it in manifest.json and publish the Frame again.`
+    );
+    this.name = "FrameDatabaseNotDeclaredError";
+  }
+}
+
+export class FrameDatabaseUnavailableError extends PodDatabaseError {
+  constructor(dbName: string, path: string) {
+    super(
+      `Frame database "${dbName}" is declared but unavailable (no database ` +
+        `file at ${path}). Publish the Frame again to reconcile its state.`
+    );
+    this.name = "FrameDatabaseUnavailableError";
   }
 }
 
@@ -369,14 +413,80 @@ function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
 // One instance per resolved database file path, opened lazily on first db().
 const instances = new Map<string, PodDatabase>();
 
+// Publication descriptors are immutable, so declarations can be cached by
+// their exact mounted path without mixing warm invocations across publications.
+const frameDatabaseDeclarations = new Map<string, ReadonlySet<string>>();
+
+function declaredFrameDatabases(frameId: string): ReadonlySet<string> {
+  const descriptorPath = podEnv(FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV);
+  if (!descriptorPath) {
+    throw new FramePublicationDescriptorError(
+      `${FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV} is not set for Frame ` +
+        `${frameId}: db() requires the selected publication descriptor.`
+    );
+  }
+
+  const cached = frameDatabaseDeclarations.get(descriptorPath);
+  if (cached) {
+    return cached;
+  }
+
+  let descriptorJson: unknown;
+  try {
+    descriptorJson = JSON.parse(readFileSync(descriptorPath, "utf8"));
+  } catch {
+    throw new FramePublicationDescriptorError(
+      `The Frame publication descriptor at ${descriptorPath} cannot be read ` +
+        `or is not valid JSON.`
+    );
+  }
+
+  const descriptor =
+    framePublicationDatabaseContractSchema.safeParse(descriptorJson);
+  if (!descriptor.success) {
+    throw new FramePublicationDescriptorError(
+      `The Frame publication descriptor at ${descriptorPath} has an invalid ` +
+        `database contract.`
+    );
+  }
+
+  const declarations = new Set(
+    descriptor.data.manifest.databases.map(({ name }) => name)
+  );
+  frameDatabaseDeclarations.set(descriptorPath, declarations);
+  return declarations;
+}
+
+/** Returns whether this invocation uses Frame-owned state. */
+function assertDatabaseOwnerCanUse(name: string): boolean {
+  const frameId = podEnv(FRAME_ID_ENV);
+  if (frameId) {
+    if (!declaredFrameDatabases(frameId).has(name)) {
+      throw new FrameDatabaseNotDeclaredError(name);
+    }
+    return true;
+  }
+
+  const spaceId = podEnv(POD_SPACE_ID_ENV);
+  if (!spaceId) {
+    throw new PodDatabasesUnavailableError();
+  }
+  return false;
+}
+
 /**
- * Get the sandbox owner's Drizzle handle for database `name`, where `name` is
- * the app's own name for it (`db("chat")`) and the app prefix is applied by
- * {@link resolveDatabasePath} from the environment.
+ * Get the sandbox owner's Drizzle handle for database `name`. Pod functions
+ * resolve app-relative names through {@link resolveDatabasePath}; Frame
+ * functions use unprefixed names declared by the selected publication.
  *
  * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
  * @throws PodDatabasesUnavailableError when both SPACE_ID and FRAME_ID are
  *   absent — this sandbox is owned by neither a Pod nor a Frame.
+ * @throws FramePublicationDescriptorError when a Frame invocation has no valid
+ *   selected publication descriptor.
+ * @throws FrameDatabaseNotDeclaredError when the selected Frame publication
+ *   does not declare `name`.
+ * @throws FrameDatabaseUnavailableError when declared state was not reconciled.
  * @throws PodDatabaseError when DUST_POD_DATABASES_DIR or
  *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
  *   in functions launched by `dsbx function run`.
@@ -388,14 +498,9 @@ export function db(name: string): PodDatabase {
   if (!POD_DATABASE_NAME_REGEX.test(name)) {
     throw new PodDatabaseInvalidNameError(name);
   }
-  const spaceId = podEnv(POD_SPACE_ID_ENV);
-  const frameId = podEnv(FRAME_ID_ENV);
-  if (
-    (spaceId === undefined || spaceId.length === 0) &&
-    (frameId === undefined || frameId.length === 0)
-  ) {
-    throw new PodDatabasesUnavailableError();
-  }
+  // Recheck before the instance cache: a warm worker may have opened this
+  // database for an older publication that declared it.
+  const isFrame = assertDatabaseOwnerCanUse(name);
   const path = resolveDatabasePath(podDatabasesDir(), name);
   const cached = instances.get(path);
   if (cached !== undefined) {
@@ -408,6 +513,9 @@ export function db(name: string): PodDatabase {
     sqlite = new PodSqliteDatabase(path, name, maxSizeBytes);
   } catch (err) {
     if (isSqliteErrorWithCode(err, "SQLITE_CANTOPEN")) {
+      if (isFrame) {
+        throw new FrameDatabaseUnavailableError(name, path);
+      }
       throw new PodDatabaseNotDeclaredError(name, path);
     }
     throw err;

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -1,11 +1,15 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   db,
   FRAME_ID_ENV,
+  FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV,
+  FrameDatabaseNotDeclaredError,
+  FrameDatabaseUnavailableError,
+  FramePublicationDescriptorError,
   POD_DATABASE_BUSY_TIMEOUT_MS,
   POD_DATABASE_MAX_SIZE_BYTES_ENV,
   POD_DATABASE_PREFIX_ENV,
@@ -17,6 +21,7 @@ import {
   PodDatabaseNotDeclaredError,
   PodDatabasesUnavailableError,
   runWithInvocationEnv,
+  SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION,
 } from "@dust/pod";
 import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
@@ -56,8 +61,29 @@ function uniqueName(prefix: string): string {
   return `${prefix}_${uniqueNameCounter}`;
 }
 
+function createFramePublicationDescriptor(
+  databaseNames: string[],
+  schemaVersion = SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION
+): string {
+  const descriptorPath = join(
+    databasesDir,
+    `${uniqueName("publication")}.json`
+  );
+  writeFileSync(
+    descriptorPath,
+    JSON.stringify({
+      schemaVersion,
+      manifest: {
+        databases: databaseNames.map((name) => ({ name })),
+      },
+    })
+  );
+  return descriptorPath;
+}
+
 let originalSpaceId: string | undefined;
 let originalFrameId: string | undefined;
+let originalFramePublicationDescriptorPath: string | undefined;
 
 beforeEach(() => {
   databasesDir = mkdtempSync(join(tmpdir(), "dust-pod-test-"));
@@ -69,6 +95,9 @@ beforeEach(() => {
   process.env[POD_SPACE_ID_ENV] = "spc_test_pod";
   originalFrameId = process.env[FRAME_ID_ENV];
   delete process.env[FRAME_ID_ENV];
+  originalFramePublicationDescriptorPath =
+    process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV];
+  delete process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV];
 });
 
 afterEach(() => {
@@ -84,6 +113,12 @@ afterEach(() => {
     delete process.env[FRAME_ID_ENV];
   } else {
     process.env[FRAME_ID_ENV] = originalFrameId;
+  }
+  if (originalFramePublicationDescriptorPath === undefined) {
+    delete process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV];
+  } else {
+    process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV] =
+      originalFramePublicationDescriptorPath;
   }
   rmSync(databasesDir, { recursive: true, force: true });
 });
@@ -110,6 +145,8 @@ describe("sandbox database owner guard", () => {
     createDatabaseFile(name);
     delete process.env[POD_SPACE_ID_ENV];
     process.env[FRAME_ID_ENV] = "fil_test_frame";
+    process.env[FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV] =
+      createFramePublicationDescriptor([name]);
 
     expect(() => db(name)).not.toThrow();
   });
@@ -118,6 +155,81 @@ describe("sandbox database owner guard", () => {
     delete process.env[POD_SPACE_ID_ENV];
     delete process.env[FRAME_ID_ENV];
     expect(() => db(uniqueName("guard"))).toThrow(PodDatabasesUnavailableError);
+  });
+});
+
+describe("Frame publication database contract", () => {
+  function frameInvocationEnv(descriptorPath?: string) {
+    return {
+      [POD_DATABASES_DIR_ENV]: databasesDir,
+      [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+      [FRAME_ID_ENV]: "fil_test_frame",
+      ...(descriptorPath
+        ? { [FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV]: descriptorPath }
+        : {}),
+    };
+  }
+
+  test("opens only databases declared by the selected publication", () => {
+    const declared = uniqueName("frame_db");
+    const undeclared = uniqueName("frame_db");
+    createDatabaseFile(declared);
+    createDatabaseFile(undeclared);
+    const descriptorPath = createFramePublicationDescriptor([declared]);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () =>
+        db(declared)
+      )
+    ).not.toThrow();
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () =>
+        db(undeclared)
+      )
+    ).toThrow(FrameDatabaseNotDeclaredError);
+  });
+
+  test("reports declared state that reconciliation has not created", () => {
+    const name = uniqueName("frame_db");
+    const descriptorPath = createFramePublicationDescriptor([name]);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(descriptorPath), () => db(name))
+    ).toThrow(FrameDatabaseUnavailableError);
+    expect(existsSync(join(databasesDir, `${name}.db`))).toBe(false);
+  });
+
+  test("requires a readable, supported publication descriptor", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(), () => db(name))
+    ).toThrow(FramePublicationDescriptorError);
+
+    const unsupported = createFramePublicationDescriptor(
+      [name],
+      SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION + 1
+    );
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(unsupported), () => db(name))
+    ).toThrow(FramePublicationDescriptorError);
+  });
+
+  test("rechecks declarations before returning a warm cached database", () => {
+    const name = uniqueName("frame_db");
+    createDatabaseFile(name);
+    const declaringPublication = createFramePublicationDescriptor([name]);
+    const removingPublication = createFramePublicationDescriptor([]);
+
+    runWithInvocationEnv(frameInvocationEnv(declaringPublication), () =>
+      db(name)
+    );
+    expect(() =>
+      runWithInvocationEnv(frameInvocationEnv(removingPublication), () =>
+        db(name)
+      )
+    ).toThrow(FrameDatabaseNotDeclaredError);
   });
 });
 
@@ -301,6 +413,7 @@ describe("app prefix resolution", () => {
     test("accepts a Frame-only invocation context", () => {
       const name = uniqueName("frame_context");
       createDatabaseOwnedBy(name, "frame");
+      const descriptorPath = createFramePublicationDescriptor([name]);
 
       expect(
         runWithInvocationEnv(
@@ -308,6 +421,7 @@ describe("app prefix resolution", () => {
             [POD_DATABASES_DIR_ENV]: databasesDir,
             [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
             [FRAME_ID_ENV]: "fil_test_frame",
+            [FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV]: descriptorPath,
             [POD_DATABASE_PREFIX_ENV]: "",
           },
           () => ownerOf(name)

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust/pod",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "private": true,
   "description": "Runtime library for code running in a Dust pod sandbox.",
   "type": "module",

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -5,6 +5,8 @@ import {
   getBaseMountPathForWorkspace,
   getConversationFilePath,
   getConversationFilesBasePath,
+  getFramePublicationDescriptorMountPoint,
+  getFramePublicationFunctionsMountPoint,
   getPodFilesBasePath,
   getPodSandboxFunctionsBasePath,
   getPodStateBasePath,
@@ -71,6 +73,17 @@ describe("mount_path helpers", () => {
         "w/ws1/pods/spc1/state/"
       );
     });
+  });
+
+  it("selects one immutable Frame publication", () => {
+    const identity = { frameId: "fil_123", publicationId: "pub_456" };
+
+    expect(getFramePublicationDescriptorMountPoint(identity)).toBe(
+      "/frames/fil_123/publications/pub_456/publication.json"
+    );
+    expect(getFramePublicationFunctionsMountPoint(identity)).toBe(
+      "/frames/fil_123/publications/pub_456/functions"
+    );
   });
 
   describe("scoped path classification", () => {

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -9,7 +9,7 @@ import path from "path";
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
 export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.3.1";
+export const POD_PACKAGE_VERSION = "0.3.2";
 export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
 
 let podPackageSrcDir: string | undefined;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.100",
+      tag: "0.8.101",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -678,7 +678,7 @@ describe("sandbox image registry", () => {
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.3.1" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.3.2" }),
       ])
     );
   });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.100";
+const DUST_BASE_IMAGE_VERSION = "0.8.101";
 const DSBX_CLI_VERSION = "0.1.52";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -836,6 +836,9 @@ describe("SandboxFunctionInvocationResource", () => {
       DUST_SANDBOX_TOKEN: "sbt-function-token",
       DUST_FUNCTION_WARM_ENABLED: "0",
     });
+    expect(opts?.envVars).not.toHaveProperty(
+      "DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH"
+    );
     expect(
       JSON.parse(opts?.envVars?.DUST_POD_USER_IDENTITY ?? "")
     ).toMatchObject({
@@ -906,6 +909,7 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     const execOptions = execSpy.mock.calls[0]?.[2];
     expect(execOptions?.envVars).toMatchObject({
+      DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH: `/frames/${frame.sId}/publications/${publicationId}/publication.json`,
       DUST_POD_DATABASES_DIR: "/pod-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_POD_DATABASE_PREFIX: "",

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -62,6 +62,7 @@ import type {
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
 import {
+  getFramePublicationDescriptorMountPoint,
   getFramePublicationFunctionsMountPoint,
   getPodSandboxFunctionsMountPoint,
   sandboxDatabaseExecEnvVars,
@@ -795,6 +796,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       );
 
       let functionsDirectory: string;
+      let databaseEnvVars: ReturnType<typeof sandboxDatabaseExecEnvVars>;
       if (frame) {
         if (!publicationId) {
           return new Err(
@@ -805,16 +807,21 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           frameId: frame.sId,
           publicationId,
         });
+        databaseEnvVars = sandboxDatabaseExecEnvVars({
+          framePublicationDescriptorPath:
+            getFramePublicationDescriptorMountPoint({
+              frameId: frame.sId,
+              publicationId,
+            }),
+        });
       } else {
         functionsDirectory = getPodSandboxFunctionsMountPoint(
           sandboxFunction.space.sId
         );
+        databaseEnvVars = sandboxDatabaseExecEnvVars({
+          databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
+        });
       }
-      const databaseEnvVars = frame
-        ? sandboxDatabaseExecEnvVars()
-        : sandboxDatabaseExecEnvVars({
-            databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
-          });
 
       const execStartedAtMs = Date.now();
       const execResult = await sandbox.exec(auth, command, {

--- a/front/types/api/frame_publication.ts
+++ b/front/types/api/frame_publication.ts
@@ -5,6 +5,7 @@ import {
   FrameManifestSchema,
   isSafeFrameRelativePath,
 } from "@app/types/api/frame_manifest";
+import { FRAME_PUBLICATION_FILE } from "@app/types/api/frame_storage";
 import { SANDBOX_FUNCTION_USER_IDENTITY_POLICIES } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -13,7 +14,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export const FRAME_PUBLICATION_FILE = "publication.json";
+export { FRAME_PUBLICATION_FILE };
 export const FRAME_PUBLICATION_SCHEMA_VERSION = 1;
 
 const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);

--- a/front/types/api/frame_storage.ts
+++ b/front/types/api/frame_storage.ts
@@ -2,6 +2,8 @@ import { FRAME_DATABASE_NAME_REGEX } from "@app/types/api/frame_manifest";
 
 const SAFE_FRAME_STORAGE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
+export const FRAME_PUBLICATION_FILE = "publication.json";
+
 function safeSegment(value: string, label: string): string {
   if (!SAFE_FRAME_STORAGE_SEGMENT.test(value)) {
     throw new Error(`Invalid ${label} for Frame storage.`);
@@ -74,7 +76,7 @@ export function getFramePublicationDescriptorPath(args: {
   frameId: string;
   publicationId: string;
 }): string {
-  return `${getFramePublicationBasePath(args)}publication.json`;
+  return `${getFramePublicationBasePath(args)}${FRAME_PUBLICATION_FILE}`;
 }
 
 export function getFramePublicationUiBundlePath(args: {

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -7,6 +7,7 @@
 //                     the same Pod.
 
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { FRAME_PUBLICATION_FILE } from "@app/types/api/frame_storage";
 import {
   LEGACY_PREFIX_CONVERSATION,
   LEGACY_PREFIX_PROJECT,
@@ -117,6 +118,17 @@ export function getFramePublicationFunctionsMountPoint({
   return `${getFramePublicationsMountPoint(frameId)}/${publicationId}/functions`;
 }
 
+/** Exact immutable publication descriptor selected for one Frame invocation. */
+export function getFramePublicationDescriptorMountPoint({
+  frameId,
+  publicationId,
+}: {
+  frameId: string;
+  publicationId: string;
+}): string {
+  return `${getFramePublicationsMountPoint(frameId)}/${publicationId}/${FRAME_PUBLICATION_FILE}`;
+}
+
 /**
  * Frame-owned SQLite uses the same isolated local runtime directories as Pod SQLite. A Frame has
  * its own sandbox, so the live files cannot overlap another Frame or a Pod; only its Litestream
@@ -155,18 +167,27 @@ const SANDBOX_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
  */
 export function sandboxDatabaseExecEnvVars({
   databasePrefix,
+  framePublicationDescriptorPath,
 }: {
   databasePrefix?: string | null;
+  framePublicationDescriptorPath?: string;
 } = {}): {
   DUST_POD_DATABASES_DIR: string;
   DUST_POD_DATABASE_MAX_SIZE_BYTES: string;
   DUST_POD_DATABASE_PREFIX: string;
+  DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH?: string;
 } {
   return {
     DUST_POD_DATABASES_DIR: SANDBOX_STATE_DATABASES_DIR,
     DUST_POD_DATABASE_MAX_SIZE_BYTES: String(SANDBOX_DATABASE_MAX_SIZE_BYTES),
     // Empty means unprefixed, which is what the shim reads an absent value as.
     DUST_POD_DATABASE_PREFIX: databasePrefix ?? "",
+    ...(framePublicationDescriptorPath
+      ? {
+          DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH:
+            framePublicationDescriptorPath,
+        }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Description

- Pass the selected immutable publication descriptor to each Frame function invocation.
- Make @dust/pod reject undeclared Frame databases, stale warm declarations, unsupported descriptors, and unreconciled state.
- Ship @dust/pod 0.3.2 in dust-base 0.8.101. Pod database behavior is unchanged.

## Tests

Added contract coverage for declared and undeclared databases, missing state, unsupported descriptors, and warm publication changes.

## Risk

Frame database access fails closed if the mounted publication descriptor is missing or invalid. Pod invocations do not receive the new environment variable.

## Deploy Plan

1. Build and release dust-base 0.8.101.
2. Deploy Front after the image is available.
3. Use /poke/kill to recycle older dust-base sandboxes so existing Frames pick up @dust/pod 0.3.2.