### PR TITLE
Block legacy sharing mutations for Frames v2

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.test.ts
@@ -5,9 +5,10 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import type { WorkspaceSharingPolicy } from "@app/types/user";
 import { honoApp } from "@front-api/app";
+import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
@@ -95,6 +96,54 @@ describe("sharing grants endpoint", () => {
     const response = await getGrants(workspace, file.sId);
 
     expect(response.status).toBe(400);
+  });
+
+  it("rejects adding grants to Frames v2", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    const response = await postGrants(workspace, file.sId, {
+      emails: ["viewer@example.com"],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await file.listActiveSharingGrants()).toEqual([]);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects revoking grants from Frames v2", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "conversation",
+    });
+    const [grant] = await file.addSharingGrants(auth, {
+      emails: ["viewer@example.com"],
+    });
+    assert(grant);
+
+    const response = await deleteGrant(workspace, file.sId, {
+      grantId: grant.id,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await file.listActiveSharingGrants()).toHaveLength(1);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 
   it("should return empty grants list for a new frame", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -83,7 +83,9 @@ app.post(
     const auth = ctx.get("auth");
     const { fileId } = ctx.req.valid("param");
 
-    const file = await fetchShareableFile(ctx, auth, fileId);
+    const file = await fetchShareableFile(ctx, auth, fileId, {
+      rejectFrameV2: true,
+    });
     if (file instanceof Response) {
       return file;
     }
@@ -132,7 +134,9 @@ app.delete(
     const auth = ctx.get("auth");
     const { fileId } = ctx.req.valid("param");
 
-    const file = await fetchShareableFile(ctx, auth, fileId);
+    const file = await fetchShareableFile(ctx, auth, fileId, {
+      rejectFrameV2: true,
+    });
     if (file instanceof Response) {
       return file;
     }
@@ -174,7 +178,8 @@ app.delete(
 async function fetchShareableFile(
   ctx: Context,
   auth: Authenticator,
-  fileId: string
+  fileId: string,
+  { rejectFrameV2 = false }: { rejectFrameV2?: boolean } = {}
 ): Promise<FileResource | Response> {
   const file = await FileResource.fetchById(auth, fileId);
   if (!file) {
@@ -206,6 +211,16 @@ async function fetchShareableFile(
       api_error: {
         type: "invalid_request_error",
         message: "Only Frame files support sharing grants.",
+      },
+    });
+  }
+
+  if (rejectFrameV2 && file.isFrameV2) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Frames v2 sharing must be configured in the Dust UI.",
       },
     });
   }

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.test.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import { FileResource } from "@app/lib/resources/file_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -234,7 +234,7 @@ describe("share scope endpoint", () => {
       expect((await response.json()).scope).toBe("workspace_and_emails");
     });
 
-    it("lazily repairs a missing Frames v2 sharing record", async () => {
+    it("rejects Frames v2 scope mutations", async () => {
       const { auth, user, workspace } = await createPrivateApiMockRequest({
         method: "POST",
         role: "user",
@@ -246,18 +246,15 @@ describe("share scope endpoint", () => {
         status: "ready",
         useCase: "conversation",
       });
-      await FileResource.shareableFileModel.destroy({
-        where: { fileId: file.id, workspaceId: file.workspaceId },
-      });
-      expect(await file.getShareInfo()).toBeNull();
+      const initialScope = await file.getShareScope();
 
       const response = await postShare(workspace, file.sId, {
-        shareScope: "workspace_and_emails",
+        shareScope: "emails_only",
       });
 
-      expect(response.status).toBe(200);
-      expect((await response.json()).scope).toBe("workspace_and_emails");
-      expect(await file.getShareInfo()).not.toBeNull();
+      expect(response.status).toBe(400);
+      expect(await file.getShareScope()).toBe(initialScope);
+      expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -79,7 +79,9 @@ app.post(
     const auth = ctx.get("auth");
     const { fileId } = ctx.req.valid("param");
 
-    const file = await fetchShareableFile(ctx, auth, fileId);
+    const file = await fetchShareableFile(ctx, auth, fileId, {
+      rejectFrameV2: true,
+    });
     if (file instanceof Response) {
       return file;
     }
@@ -156,7 +158,8 @@ app.post(
 async function fetchShareableFile(
   ctx: Context,
   auth: Authenticator,
-  fileId: string
+  fileId: string,
+  { rejectFrameV2 = false }: { rejectFrameV2?: boolean } = {}
 ): Promise<FileResource | (Response & TypedResponse<APIErrorResponse>)> {
   const file = await FileResource.fetchById(auth, fileId);
   if (!file) {
@@ -188,6 +191,16 @@ async function fetchShareableFile(
       api_error: {
         type: "invalid_request_error",
         message: "Only Frame files can be shared publicly.",
+      },
+    });
+  }
+
+  if (rejectFrameV2 && file.isFrameV2) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Frames v2 sharing must be configured in the Dust UI.",
       },
     });
   }


### PR DESCRIPTION
## Description

Reject Frames v2 share-scope and email-grant mutations through the legacy generic FileResource routes. Frames v2 sharing is configured by users in the Dust UI, while agents can only retrieve existing links through the read-only flow merged in #31498.

Legacy read routes and Frames v1 mutation behavior are unchanged. The obsolete sandbox share-route change has been removed from this PR.

## Tests

- Legacy share scope and grant suites: 30 passed, including three Frames v2 rejection cases that preserve prior state
- Front-api `tsgo` passed
- Biome passed on all four changed files

## Risk

Low. This only rejects legacy mutation requests for Frames v2 and leaves the existing read paths intact.

## Deploy Plan

Standard deploy.
