### PR TITLE
Expose Frames v2 cloning endpoint

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/clone.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/clone.ts
@@ -1,0 +1,123 @@
+import {
+  type CloneFrameV2SourceError,
+  type CloneFrameV2SourceResult,
+  cloneFrameV2Source,
+  isFrameSourceCloneError,
+} from "@app/lib/api/frames/clone_source";
+import { isFramePublicationError } from "@app/lib/api/frames/publication_storage";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameCloneRequestSchema = z.object({
+  destinationDirectoryPath: z.string().min(1),
+  sourceDirectoryPath: z.string().min(1),
+});
+
+function frameCloneErrorStatus(
+  error: CloneFrameV2SourceError
+): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (isFrameSourceCloneError(error)) {
+    return 400;
+  }
+  if (isFramePublicationError(error)) {
+    return error.code === "unauthorized" ? 403 : 400;
+  }
+  const code = error.code;
+  switch (code) {
+    case "internal":
+    case "reconcile_failed":
+    case "sandbox_unavailable":
+      return 500;
+    case "build_failed":
+    case "invalid_contract":
+    case "invalid_path":
+    case "not_found":
+    case "publish_conflict":
+    case "reconcile_blocked":
+    case "schema_extraction_failed":
+      return 400;
+    default:
+      return assertNever(code);
+  }
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameCloneRequestSchema),
+  async (ctx): HandlerResult<CloneFrameV2SourceResult> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot clone Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { destinationDirectoryPath, sourceDirectoryPath } =
+      ctx.req.valid("json");
+    const cloned = await cloneFrameV2Source(auth, {
+      conversation: conversation.toJSON(),
+      destinationDirectoryPath,
+      sourceDirectoryPath,
+    });
+    if (cloned.isErr()) {
+      const status = frameCloneErrorStatus(cloned.error);
+      return apiError(ctx, {
+        status_code: status,
+        api_error: {
+          type:
+            status === 500 ? "internal_server_error" : "invalid_request_error",
+          message: cloned.error.message,
+        },
+      });
+    }
+
+    return ctx.json(cloned.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -3,6 +3,7 @@
 
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -124,6 +125,22 @@ function requestFrameShare(
   );
 }
 
+function requestFrameClone(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string,
+  destinationDirectoryPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/clone`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourceDirectoryPath, destinationDirectoryPath }),
+  });
+}
+
 async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -171,7 +188,57 @@ async function setup({ registered = true }: { registered?: boolean } = {}) {
       : null
   );
 
-  return { ...context, frame, manifestPath };
+  return { ...context, frame, manifestPath, mountDirectoryPath, sourceByPath };
+}
+
+function configureCloneStorage(
+  sourceDirectoryPath: string,
+  destinationDirectoryPath: string,
+  sourceByPath: Map<string, string>,
+  {
+    destinationByPath = new Map<string, string>(),
+    sourceSizeByPath = new Map<string, number>(),
+  }: {
+    destinationByPath?: Map<string, string>;
+    sourceSizeByPath?: Map<string, number>;
+  } = {}
+) {
+  for (const [filePath, content] of [...sourceByPath, ...destinationByPath]) {
+    fileStorageMock.setObject(filePath, content);
+  }
+  fileStorageMock.setFileExists(
+    (filePath) =>
+      sourceByPath.has(filePath) ||
+      destinationByPath.has(filePath) ||
+      fileStorageMock.getObject(filePath) !== undefined
+  );
+  fileStorageMock.setFilesByPrefix((prefix) => {
+    let entries: Array<[string, string]>;
+    if (prefix === `${sourceDirectoryPath}/`) {
+      entries = [...sourceByPath];
+    } else if (prefix === `${destinationDirectoryPath}/`) {
+      const copiedEntries: Array<[string, string]> = [];
+      for (const [name, content] of sourceByPath) {
+        const destinationName = `${destinationDirectoryPath}/${name.slice(sourceDirectoryPath.length + 1)}`;
+        if (fileStorageMock.getObject(destinationName) !== undefined) {
+          copiedEntries.push([destinationName, content]);
+        }
+      }
+      entries = [...new Map([...destinationByPath, ...copiedEntries])];
+    } else {
+      return null;
+    }
+
+    return entries.map(([name, content]) => ({
+      name,
+      metadata: {
+        contentType: name.endsWith(".tsx")
+          ? "text/typescript"
+          : "application/json",
+        size: String(sourceSizeByPath.get(name) ?? Buffer.byteLength(content)),
+      },
+    }));
+  });
 }
 
 async function setupLegacyFrame() {
@@ -446,6 +513,121 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     );
 
     expect(response.status).toBe(403);
+  });
+
+  it("clones source into fresh Frame, publication, sharing, and runtime ownership", async () => {
+    const context = await setup();
+    assert(context.frame);
+    await context.frame.markFrameV2AsReadyFromMount(context.auth);
+    await context.frame.setShareScope(context.auth, "public");
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+    const destinationDirectoryPath = sourceDirectoryPath.replace(
+      "/Status",
+      "/Status Copy"
+    );
+    const destinationMountDirectoryPath = context.mountDirectoryPath.replace(
+      /Status$/,
+      "Status Copy"
+    );
+    const rawSourceByPath = new Map(context.sourceByPath);
+    rawSourceByPath.set(`${context.mountDirectoryPath}/.cache/data.json`, "{}");
+    rawSourceByPath.set(
+      `${context.mountDirectoryPath}/notes.processed.txt`,
+      "processed"
+    );
+    rawSourceByPath.set(`${context.mountDirectoryPath}/assets/`, "");
+    configureCloneStorage(
+      context.mountDirectoryPath,
+      destinationMountDirectoryPath,
+      rawSourceByPath
+    );
+
+    const response = await requestFrameClone(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      destinationDirectoryPath
+    );
+
+    const cloned = await response.json();
+    expect(response.status, JSON.stringify(cloned)).toBe(200);
+    expect(cloned.frameId).not.toBe(context.frame.sId);
+    const clonedFrame = await FileResource.fetchById(
+      context.auth,
+      cloned.frameId
+    );
+    assert(clonedFrame);
+    expect(clonedFrame.toScopedPath(context.auth)).toBe(
+      `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(clonedFrame.useCaseMetadata?.activePublicationId).toBe(
+      cloned.publicationId
+    );
+    expect(await clonedFrame.getShareScope()).toBe("workspace_and_emails");
+    expect((await clonedFrame.getShareInfo())?.shareUrl).not.toBe(
+      (await context.frame.getShareInfo())?.shareUrl
+    );
+    expect(
+      fileStorageMock.getObject(
+        `${destinationMountDirectoryPath}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBe(manifest);
+    expect(
+      fileStorageMock.getObject(`${destinationMountDirectoryPath}/index.tsx`)
+    ).toBe(uiSource);
+    expect(
+      fileStorageMock.getObject(
+        `${destinationMountDirectoryPath}/.cache/data.json`
+      )
+    ).toBe("{}");
+    expect(
+      fileStorageMock.getObject(
+        `${destinationMountDirectoryPath}/notes.processed.txt`
+      )
+    ).toBe("processed");
+    expect(
+      fileStorageMock.getObject(`${destinationMountDirectoryPath}/assets/`)
+    ).toBe("");
+    await expect(
+      FrameSandboxAdapter.fetchSandbox(context.auth, clonedFrame)
+    ).resolves.toBeNull();
+  });
+
+  it("bounds the raw source byte size before copying", async () => {
+    const context = await setup();
+    const destinationMountDirectoryPath = context.mountDirectoryPath.replace(
+      /Status$/,
+      "Too Large"
+    );
+    configureCloneStorage(
+      context.mountDirectoryPath,
+      destinationMountDirectoryPath,
+      context.sourceByPath,
+      {
+        sourceSizeByPath: new Map([
+          [`${context.mountDirectoryPath}/index.tsx`, 100 * 1024 * 1024],
+        ]),
+      }
+    );
+
+    const response = await requestFrameClone(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath.replace(`/${FRAME_MANIFEST_FILE}`, ""),
+      context.manifestPath
+        .replace("/Status/", "/Too Large/")
+        .replace(`/${FRAME_MANIFEST_FILE}`, "")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: "Frame source exceeds the copy size or file count limit.",
+      },
+    });
   });
 
   it("publishes a legacy Frame through its existing publication flow", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 
 import call from "./call";
 import callById from "./call_by_id";
+import clone from "./clone";
 import { frameSourceErrorStatus } from "./errors";
 import move from "./move";
 import register from "./register";
@@ -36,6 +37,7 @@ const app = sandboxApp();
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
 app.route("/call", call);
 app.route("/:frameId/call", callById);
+app.route("/clone", clone);
 app.route("/move", move);
 app.route("/register", register);
 app.route("/share", share);


### PR DESCRIPTION
## Description

Expose the clone service through the feature-gated internal sandbox endpoint.

The endpoint authenticates the sandbox execution token, resolves the invoking conversation, validates source and destination paths, enforces access through the clone service, and returns the new Frame and publication IDs. Typed filesystem, clone, publication, and sandbox failures are mapped to the existing API error contract.

This PR is stacked on #31553. CLI support follows in #31500; hardening tests and audit logging remain independent children.

## Tests

- Endpoint tests cover successful cloning, fresh runtime ownership, bounded source storage, and typed failures.
- Clone service tests.
- Front and Front API typechecks.
- Biome on changed files.

## Risk

Moderate but feature-gated. The endpoint creates a new Frame identity and first publication; it never mutates the source Frame.

## Deploy Plan

Merge after #31553. No migration is required.