### PR TITLE
Expose Frames v2 use rights endpoint

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -1,17 +1,34 @@
 // Legacy Frame publishing runs esbuild, whose TextEncoder invariant requires Node rather than jsdom.
 // @vitest-environment node
 
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
-import { getConversationFilesBasePath } from "@app/types/mount_path";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
 
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
@@ -55,6 +72,28 @@ function requestFrameRegister(
       "content-type": "application/json",
     },
     body: JSON.stringify({ manifestPath }),
+  });
+}
+
+function requestFrameShare(
+  workspaceId: string,
+  token: string,
+  sourceDirectoryPath: string,
+  {
+    emails = [],
+    shareScope = "workspace_and_emails",
+  }: {
+    emails?: string[];
+    shareScope?: "emails_only" | "public" | "workspace_and_emails";
+  } = {}
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/share`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ emails, shareScope, sourceDirectoryPath }),
   });
 }
 
@@ -140,6 +179,7 @@ async function setupLegacyFrame() {
 
 beforeEach(() => {
   fileStorageMock.reset();
+  mockEmitAuditLogEvent.mockClear();
 });
 
 describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
@@ -183,6 +223,123 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.useCaseMetadata?.activePublicationId).toBe(
       published.publicationId
     );
+  });
+
+  it("configures Frame use rights through the sandbox token", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const publishResponse = await requestFramePublish(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(publishResponse.status).toBe(200);
+    const user = context.auth.getNonNullableUser();
+    const sourceDirectoryPath = context.manifestPath.replace(
+      `/${FRAME_MANIFEST_FILE}`,
+      ""
+    );
+
+    const response = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      sourceDirectoryPath,
+      { emails: [user.email] }
+    );
+
+    const shared = await response.json();
+    expect(response.status, JSON.stringify(shared)).toBe(200);
+    expect(shared).toMatchObject({
+      emails: [user.email],
+      frameId: context.frame.sId,
+      shareScope: "workspace_and_emails",
+      sourceDirectoryPath,
+    });
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.email_grant_added",
+        metadata: expect.objectContaining({ emails: user.email }),
+      })
+    );
+  });
+
+  it("preserves existing rights when allowlist validation fails", async () => {
+    const context = await setup();
+    assert(context.frame);
+    const publishResponse = await requestFramePublish(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+    expect(publishResponse.status).toBe(200);
+    const published = await publishResponse.json();
+    await context.frame.setShareScope(context.auth, "emails_only");
+    fileStorageMock.setObject(
+      getFramePublicationUiBundlePath({
+        workspaceId: context.workspace.sId,
+        frameId: context.frame.sId,
+        publicationId: published.publicationId,
+      }),
+      'useFile("fil_ZZZZZZZZZZ");'
+    );
+
+    const response = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath.replace(`/${FRAME_MANIFEST_FILE}`, ""),
+      {
+        emails: [context.auth.getNonNullableUser().email],
+        shareScope: "workspace_and_emails",
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await context.frame.getShareScope()).toBe("emails_only");
+    expect(await context.frame.listActiveSharingGrants()).toEqual([]);
+  });
+
+  it("requires write access to the Frame source folder", async () => {
+    const context = await setup();
+    const pod = await SpaceFactory.project(context.workspace);
+    const { globalGroup } = await GroupFactory.defaults(context.workspace);
+    await SpaceFactory.attachGroup(pod, globalGroup, "project_viewer");
+    await ConversationModel.update(
+      { spaceId: pod.id },
+      { where: { id: context.conversation.id } }
+    );
+    await FileFactory.create(context.auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(manifest),
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+      mountFilePath: `${getPodFilesBasePath({
+        workspaceId: context.workspace.sId,
+        podId: pod.sId,
+      })}Status/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const response = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      `pod-${pod.sId}/Status`,
+      { shareScope: "emails_only" }
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("refuses sharing without the feature flag", async () => {
+    const context = await createSandboxTokenTestContext();
+
+    const response = await requestFrameShare(
+      context.workspace.sId,
+      context.token,
+      `conversation-${context.conversation.sId}/Status`
+    );
+
+    expect(response.status).toBe(403);
   });
 
   it("publishes a legacy Frame through its existing publication flow", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -18,6 +18,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import register from "./register";
+import share from "./share";
 
 const FramePublishRequestSchema = z.object({
   manifestPath: z.string().min(1),
@@ -70,6 +71,7 @@ const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
 app.route("/register", register);
+app.route("/share", share);
 
 /**
  * @ignoreswagger

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/share.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/share.ts
@@ -1,0 +1,122 @@
+import {
+  FrameSharingError,
+  type ShareFrameV2FromSourceError,
+  type ShareFrameV2FromSourceResult,
+  shareFrameV2FromSource,
+} from "@app/lib/api/frames/share_from_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { fileShareScopeSchema, MAX_EMAILS_PER_INVITE } from "@app/types/files";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameShareRequestSchema = z.object({
+  emails: z.array(z.string().email()).max(MAX_EMAILS_PER_INVITE).default([]),
+  shareScope: fileShareScopeSchema.exclude(["workspace"]),
+  sourceDirectoryPath: z.string().min(1),
+});
+
+function frameShareErrorStatus(
+  error: ShareFrameV2FromSourceError
+): 400 | 403 | 409 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+  if (error instanceof FrameSharingError) {
+    switch (error.code) {
+      case "conflict":
+        return 409;
+      case "internal":
+        return 500;
+      case "invalid_source":
+        return 400;
+      case "unauthorized":
+        return 403;
+      default:
+        return assertNever(error);
+    }
+  }
+  return 500;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameShareRequestSchema),
+  async (ctx): HandlerResult<ShareFrameV2FromSourceResult> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot share Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { emails, shareScope, sourceDirectoryPath } = ctx.req.valid("json");
+    const shared = await shareFrameV2FromSource(auth, {
+      conversation: conversation.toJSON(),
+      emails,
+      shareScope,
+      sourceDirectoryPath,
+    });
+    if (shared.isErr()) {
+      const status = frameShareErrorStatus(shared.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: shared.error.message,
+          },
+        },
+        shared.error
+      );
+    }
+
+    return ctx.json(shared.value, 200);
+  }
+);
+
+export default app;


### PR DESCRIPTION
## Description

Expose the source-authorized Frames v2 use-rights operation through the feature-gated sandbox endpoint.

Stacked on #31508. The reusable sharing primitives are in #31506.

## Tests

- Frames sandbox endpoint suite: 9 tests passed, including scope and grant updates, atomic allowlist failure, source write access, and feature gating

## Risk

Feature-gated. Frames v1 keeps its existing endpoints and behavior.

## Deploy Plan

Merge after #31508, then standard deploy.