### PR TITLE
Add Frame source operation locks

### DIFF
--- a/front/lib/api/frames/operation_lock.test.ts
+++ b/front/lib/api/frames/operation_lock.test.ts
@@ -1,0 +1,57 @@
+import {
+  getFramePublishLockName,
+  getFrameSourceLockName,
+  withFrameSourceLock,
+} from "@app/lib/api/frames/operation_lock";
+import type { RedisClientType } from "@app/lib/api/redis";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+const { getRedisStreamClientMock } = vi.hoisted(() => ({
+  getRedisStreamClientMock: vi.fn<() => Promise<LockRedisClient>>(),
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisStreamClient: getRedisStreamClientMock,
+}));
+
+function makeRedisClient(): LockRedisClient {
+  return {
+    eval: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("Frame operation locks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses a distinct source-operation lock namespace", async () => {
+    const redis = makeRedisClient();
+    getRedisStreamClientMock.mockResolvedValue(redis);
+
+    const result = await withFrameSourceLock(
+      "frame-123",
+      async () => new Ok("moved")
+    );
+
+    expect(result.isOk() && result.value).toBe("moved");
+    expect(getFrameSourceLockName("frame-123")).toBe("frame:source:frame-123");
+    expect(getFrameSourceLockName("frame-123")).not.toBe(
+      getFramePublishLockName("frame-123")
+    );
+    expect(redis.set).toHaveBeenCalledWith(
+      "lock:frame:source:frame-123",
+      expect.any(String),
+      expect.objectContaining({ PX: 10 * 60_000 })
+    );
+  });
+});

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -3,9 +3,14 @@ import { executeWithLockResult } from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
+const FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS = 30_000;
 
 export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
+}
+
+export function getFrameSourceLockName(frameId: string): string {
+  return `frame:source:${frameId}`;
 }
 
 export function withFramePublishLock<T, E>(
@@ -15,7 +20,19 @@ export function withFramePublishLock<T, E>(
   return executeWithLockResult(
     getFramePublishLockName(frameId),
     callback,
-    30_000,
+    FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS,
+    { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
+  );
+}
+
+export function withFrameSourceLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
+  return executeWithLockResult(
+    getFrameSourceLockName(frameId),
+    callback,
+    FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS,
     { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
   );
 }


### PR DESCRIPTION
## Description

Add a distinct distributed lock namespace, `frame:source:<frameId>`, for operations that read or mutate a Frames v2 source package.

A Frame identity is stable while its source path can change. Publishing concurrently with a move, clone, delete, or conversion could otherwise validate one path and then act on another. Callers acquire the source lock, re-fetch the Frame identity under that lock, and only then inspect or mutate its source. If publication is also involved, the existing `frame:publish` lock is acquired inside the source lock.

This PR only adds the fixed-lock primitive; it does not add call sites or acquire a `file:edit` lock.

The 10-minute TTL is a crash-expiry ceiling, not the expected lock duration. The lock is released immediately when the callback completes. A contender waits at most 30 seconds before returning a conflict. The conservative TTL prevents a slow build or GCS operation from outliving the lease, while ensuring a crashed process cannot leave a permanent lock.

## Tests

- Added focused coverage for the distinct source namespace and 10-minute TTL.
- Focused operation-lock test, Biome, and full `front` typecheck pass.

## Risk

Low. This adds an unused lock primitive. Later call sites can temporarily reject concurrent source operations, but successful operations release the lock immediately.

## Deploy Plan

Deploy normally. No migration or coordinated rollout is required.
