### PR TITLE
Expose Frame cloning in dsbx

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -10,9 +10,10 @@ use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, FrameCallByIdRequest, FrameCallFromSourceRequest,
-    FrameCallResponse, FrameMoveRequest, FrameMoveResponse, FramePublishRequest,
-    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, FrameShareLinkResponse,
-    FrameValidateRequest, FrameValidateResponse, MCPServerView, SandboxServerViewsResponse,
+    FrameCallResponse, FrameCloneRequest, FrameCloneResponse, FrameMoveRequest, FrameMoveResponse,
+    FramePublishRequest, FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse,
+    FrameShareLinkResponse, FrameValidateRequest, FrameValidateResponse, MCPServerView,
+    SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -227,6 +228,22 @@ impl DustApiClient {
         self.get(
             "sandbox/frames/share",
             &[("sourceDirectoryPath", source_directory_path)],
+        )
+        .await
+    }
+
+    pub async fn clone_frame(
+        &self,
+        source_directory_path: &str,
+        destination_directory_path: &str,
+    ) -> anyhow::Result<FrameCloneResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/clone",
+            &FrameCloneRequest {
+                source_directory_path,
+                destination_directory_path,
+            },
+            POLL_MAX_DURATION,
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -53,6 +53,13 @@ pub struct FrameMoveRequest<'a> {
     pub destination_directory_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameCloneRequest<'a> {
+    pub source_directory_path: &'a str,
+    pub destination_directory_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -96,6 +103,15 @@ pub struct FrameShareLinkResponse {
     pub share_scope: String,
     pub share_url: String,
     pub source_directory_path: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameCloneResponse {
+    pub frame_id: String,
+    pub publication_id: String,
+    pub source_directory_path: String,
+    pub destination_directory_path: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/dust-sandbox/src/commands/frame/clone.rs
+++ b/cli/dust-sandbox/src/commands/frame/clone.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_new_path, scoped_path};
+
+pub async fn run(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let source_directory_path = scoped_path(source)?;
+    let destination_directory_path = scoped_new_path(destination)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .clone_frame(&source_directory_path, &destination_directory_path)
+        .await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,4 +1,5 @@
 mod call;
+mod clone;
 mod create;
 mod move_frame;
 mod publish;
@@ -12,6 +13,7 @@ use anyhow::{bail, Context};
 use clap::Subcommand;
 
 pub use call::run as cmd_frame_call;
+pub use clone::run as cmd_frame_clone;
 pub use create::run as cmd_frame_create;
 pub use move_frame::run as cmd_frame_move;
 pub use publish::run as cmd_frame_publish;
@@ -33,6 +35,13 @@ pub enum FrameCommand {
         /// JSON input passed to the function
         #[arg(long, value_name = "JSON")]
         input: Option<String>,
+    },
+    /// Clone a registered Frame into a fresh identity, publication, sharing record, and state
+    Clone {
+        /// Existing Frame folder under /files
+        source: PathBuf,
+        /// New Frame folder path under /files
+        destination: PathBuf,
     },
     /// Create and register a new Frame folder
     Create {

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -14,8 +14,8 @@ pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
 pub use frame::{
-    cmd_frame_call, cmd_frame_create, cmd_frame_move, cmd_frame_publish, cmd_frame_register,
-    cmd_frame_share_link, cmd_frame_validate,
+    cmd_frame_call, cmd_frame_clone, cmd_frame_create, cmd_frame_move, cmd_frame_publish,
+    cmd_frame_register, cmd_frame_share_link, cmd_frame_validate,
 };
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -136,6 +136,10 @@ async fn run() -> anyhow::Result<()> {
                 function_name,
                 input,
             } => commands::cmd_frame_call(&target, &function_name, input.as_deref()).await?,
+            commands::frame::FrameCommand::Clone {
+                source,
+                destination,
+            } => commands::cmd_frame_clone(&source, &destination).await?,
             commands::frame::FrameCommand::Create {
                 directory,
                 name,
@@ -646,5 +650,37 @@ mod tests {
             "/files/conversation-conv_123/Status",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn frame_clone_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "clone",
+            "/files/conversation-conv_123/Status",
+            "/files/pod-vlt_123/Status Copy",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Clone {
+                        source,
+                        destination,
+                    },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status")
+                );
+                assert_eq!(
+                    destination,
+                    std::path::PathBuf::from("/files/pod-vlt_123/Status Copy")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected clone"),
+            _ => panic!("expected frame"),
+        }
     }
 }

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -77,6 +77,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("This command is read-only");
     expect(instructions).not.toContain("--scope");
     expect(instructions).not.toContain("--email");
+    expect(instructions).toContain("dsbx frame clone");
     expect(instructions).toContain("package-like folder");
     expect(instructions).toContain("canonical Frame resource");
     expect(instructions).toContain("`index.tsx` by default");

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -78,6 +78,17 @@ This command is read-only. It never creates sharing state, changes the scope, or
 recipients. It returns the stable Frame ID, current share scope, and existing share URL. If no share
 link exists, ask the user to configure sharing in the Dust UI.
 
+## Clone a registered Frame
+
+Use the CLI instead of \`cp\` to copy source into a new Frame with a fresh identity, publication,
+sharing record, sandbox ownership, and empty database state:
+
+\`\`\`bash
+dsbx frame clone /files/<source-scope>/<frame-folder> /files/<destination-scope>/<new-folder>
+\`\`\`
+
+The destination must not exist. The source Frame and its sharing and database state are unchanged.
+
 ## Frames v2 source layout
 
 Keep one Frame and everything it owns in one folder:
@@ -386,8 +397,6 @@ dsbx frame publish /files/<scope>/<frame>.tsx
 Do not use the \`publish_interactive_content_file\` tool: the CLI replaces it under Frames v2.
 Other interactive-content tools remain available for Frame operations that the CLI does not cover
 yet. Use \`dsbx frame --help\` as the authority for available operations.
-
-Do not use \`cp\` to clone a registered Frame folder. Cloning is not supported yet.
 
 ## Editing
 


### PR DESCRIPTION
## Description

Add `dsbx frame clone <source> <destination>` and document it in the Frames v2 skill.

The source must be an existing registered Frame folder. The destination must not exist; the CLI validates it as a new scoped path before calling the endpoint from #31496. The result contains the fresh Frame and publication IDs.

This PR contains only CLI wiring, parser coverage, and skill instructions. Backend behavior remains in #31496.

## Tests

- Dust sandbox CLI test suite and clone parser coverage.
- Frames skill tests.
- Rust formatting and Biome checks.

## Risk

Low. The command is unavailable in production until a new dsbx version is shipped in the base image.

## Deploy Plan

Merge after #31496. Then release dsbx and bump the base image separately.