### PR TITLE
Fence Frame publication with source operations

### DIFF
--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment node
 
+import { getFrameSourceLockName } from "@app/lib/api/frames/operation_lock";
 import {
   publishFrameFromSource,
   publishFrameV2FromSource,
 } from "@app/lib/api/frames/publish_from_source";
+import { getRedisStreamClient } from "@app/lib/api/redis";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -23,7 +25,7 @@ import {
   getPodFilesBasePath,
 } from "@app/types/mount_path";
 import assert from "assert";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const manifest = JSON.stringify({
   version: 1,
@@ -239,6 +241,66 @@ describe("publishFrameV2FromSource", () => {
       code: "invalid_source",
     });
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("revalidates the Frame source path after acquiring the source lock", async () => {
+    const { auth, conversation, frame, manifestPath, workspace } =
+      await setup();
+    const staleFrame = await FileResource.fetchById(auth, frame.sId);
+    assert(staleFrame);
+    const movedManifestPath = `${getConversationFilesBasePath({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+    })}Moved/${FRAME_MANIFEST_FILE}`;
+    await frame.updateMount({
+      destFileName: FRAME_MANIFEST_FILE,
+      destMountFilePath: movedManifestPath,
+      destUseCase: "conversation",
+      destUseCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame: staleFrame,
+      manifestPath,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("does not write when another source operation holds the lock", async () => {
+    const { auth, conversation, frame, manifestPath } = await setup();
+    const lockKey = `lock:${getFrameSourceLockName(frame.sId)}`;
+    const redisClient = await getRedisStreamClient({ origin: "lock" });
+    await redisClient.set(lockKey, "held-by-test", {
+      NX: true,
+      PX: 60_000,
+    });
+    vi.useFakeTimers();
+
+    try {
+      const publicationPromise = publishFrameV2FromSource(auth, {
+        conversation,
+        frame,
+        manifestPath,
+      });
+      await vi.runAllTimersAsync();
+      const published = await publicationPromise;
+
+      expect(published.isErr() && published.error).toMatchObject({
+        code: "publish_conflict",
+        message:
+          "Another source operation is in progress for this Frame; retry shortly.",
+      });
+      expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+      expect(fileStorageMock.writeStreamCalls).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+      await redisClient.del(lockKey);
+    }
   });
 
   it("rejects publication from a read-only Pod", async () => {

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -3,13 +3,15 @@ import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
-import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import type { PublishFrameError } from "@app/lib/api/viz/publish_frame";
 import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
@@ -148,7 +150,7 @@ export async function publishFrameFromSource(
  * Publish a Frames v2 FileResource from its current source folder. The FileResource path is the
  * authority: callers cannot point a Frame identity at a different manifest or source tree.
  */
-export async function publishFrameV2FromSource(
+async function publishFrameV2FromSourceWithSourceLockHeld(
   auth: Authenticator,
   {
     conversation,
@@ -165,13 +167,6 @@ export async function publishFrameV2FromSource(
     FramePublicationError | SandboxFunctionError
   >
 > {
-  if (!frame.isFrameV2) {
-    return frameError(
-      "invalid_frame",
-      `File '${frame.sId}' is not a Frames v2 manifest.`
-    );
-  }
-
   const canonicalManifestPath = frame.toScopedPath(auth);
   if (
     !canonicalManifestPath ||
@@ -323,4 +318,58 @@ export async function publishFrameV2FromSource(
     manifest: manifestResult.value,
     sourceFiles,
   });
+}
+
+export async function publishFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  if (!frame.isFrameV2) {
+    return frameError(
+      "invalid_frame",
+      `File '${frame.sId}' is not a Frames v2 manifest.`
+    );
+  }
+
+  const publication = await withFrameSourceLock(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame) {
+      return frameError(
+        "invalid_frame",
+        `Frame '${frame.sId}' no longer exists.`
+      );
+    }
+
+    return publishFrameV2FromSourceWithSourceLockHeld(auth, {
+      conversation,
+      frame: freshFrame,
+      manifestPath,
+    });
+  });
+  if (publication.isErr()) {
+    if (isLockAcquisitionTimeoutError(publication.error)) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          "Another source operation is in progress for this Frame; retry shortly."
+        )
+      );
+    }
+    return new Err(publication.error);
+  }
+
+  return publication;
 }


### PR DESCRIPTION
## Description

Acquire the fixed Frame source lock around Frames v2 publication and re-fetch the Frame identity after acquisition. This serializes publication with source lifecycle operations and keeps the source lock outside the existing publish lock. Callers that also hold `file:edit` acquire it first.

## Tests

Added contention coverage proving a blocked publish performs no storage writes, plus coverage for canonical path revalidation after lock acquisition. Tested locally with the focused operation-lock and publish-from-source suites.

## Risk

A publish waits up to 30 seconds for an active source operation, then returns typed `publish_conflict`. Fixed locks expire after 10 minutes if the process dies.

## Deploy Plan

Standard deploy.