### PR TITLE
Order project Frame source deletion

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -1019,7 +1019,9 @@ describe("publishFramePublication", () => {
     });
     await activationStarted.promise;
 
-    const deletionPromise = frame.delete(auth);
+    const deletionPromise = frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
     const redisSet = vi.mocked(
       redisMock.streamClient.set as (
         key: string,

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -12,6 +12,8 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("removeFileFromProject", () => {
@@ -115,6 +117,138 @@ describe("removeFileFromProject", () => {
     expect(frAfter).toBeTruthy();
     expect(frAfter!.spaceId).toBeNull();
     expect(frAfter!.expiredReason).toBe("file_deleted");
+  });
+
+  it("preserves orphaned and referenced Frame fragments on source failure and cleans them on retry", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 123,
+      status: "ready",
+    });
+    const referenced = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(referenced).toBeTruthy();
+    const orphan = await ContentFragmentModel.create({
+      workspaceId: workspace.id,
+      spaceId: project.id,
+      fileId: file.id,
+      title: "Old Frame fragment",
+      contentType: "text/plain",
+      sourceUrl: null,
+      textBytes: null,
+      userId: user.id,
+      userContextUsername: null,
+      userContextFullName: null,
+      userContextEmail: null,
+      userContextProfilePictureUrl: null,
+      nodeId: null,
+      nodeDataSourceViewId: null,
+      nodeType: null,
+      version: "superseded",
+      expiredReason: null,
+      sId: generateRandomModelSId(),
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 999,
+      conversationId: conversation.id,
+      parentId: null,
+      contentFragmentId: referenced!.id,
+      workspaceId: workspace.id,
+    });
+
+    const failed = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+      deleteFrameSource: async () => new Err(new Error("source unavailable")),
+    });
+    expect(failed.isErr()).toBe(true);
+    await expect(
+      FileModel.findOne({ where: { id: file.id, workspaceId: workspace.id } })
+    ).resolves.not.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: orphan.id, workspaceId: workspace.id },
+      })
+    ).resolves.not.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: referenced!.id, workspaceId: workspace.id },
+      })
+    ).resolves.not.toBeNull();
+
+    const retried = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+      deleteFrameSource: async () => new Ok(undefined),
+    });
+    expect(retried.isOk()).toBe(true);
+    await expect(
+      FileModel.findOne({ where: { id: file.id, workspaceId: workspace.id } })
+    ).resolves.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: orphan.id, workspaceId: workspace.id },
+      })
+    ).resolves.toBeNull();
+    const referencedAfter = await ContentFragmentModel.findOne({
+      where: { id: referenced!.id, workspaceId: workspace.id },
+    });
+    expect(referencedAfter?.spaceId).toBeNull();
+    expect(referencedAfter?.expiredReason).toBe("file_deleted");
+  });
+
+  it("rejects Frames v2 before mutating project fragments without package deletion", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 123,
+      status: "ready",
+    });
+    const fragment = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(fragment).toBeTruthy();
+
+    const result = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    await expect(
+      FileModel.findOne({ where: { id: file.id, workspaceId: workspace.id } })
+    ).resolves.not.toBeNull();
+    await expect(
+      ContentFragmentModel.findOne({
+        where: { id: fragment!.id, workspaceId: workspace.id },
+      })
+    ).resolves.not.toBeNull();
   });
 });
 

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -20,6 +20,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { FrameV2SourceDeletion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -43,6 +44,7 @@ import {
 } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Op } from "sequelize";
 import { z } from "zod";
@@ -513,12 +515,70 @@ export async function addContentNodeToProject(
  * - If some fragments are referenced by messages, we keep them but detach them from the space
  *   and mark them expired so conversation rendering can display an appropriate placeholder.
  */
+async function cleanupProjectFileFragments(
+  auth: Authenticator,
+  {
+    file,
+    space,
+  }: {
+    file: FileResource;
+    space: SpaceResource;
+  }
+): Promise<void> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const projectFragmentModelIds = await ContentFragmentModel.findAll({
+    attributes: ["id"],
+    where: {
+      workspaceId,
+      spaceId: space.id,
+      fileId: file.id,
+    },
+  }).then((rows) => rows.map((r) => r.id));
+  if (projectFragmentModelIds.length === 0) {
+    return;
+  }
+
+  const messagesReferencing = await MessageModel.findAll({
+    attributes: ["contentFragmentId"],
+    where: {
+      workspaceId,
+      contentFragmentId: { [Op.in]: projectFragmentModelIds },
+    },
+  });
+  const referencedModelIds = new Set(
+    removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
+  );
+  const orphanModelIds = projectFragmentModelIds.filter(
+    (id) => !referencedModelIds.has(id)
+  );
+
+  if (orphanModelIds.length > 0) {
+    await ContentFragmentModel.destroy({
+      where: { workspaceId, id: { [Op.in]: orphanModelIds } },
+    });
+  }
+
+  if (referencedModelIds.size > 0) {
+    await ContentFragmentModel.update(
+      { spaceId: null, expiredReason: "file_deleted" },
+      {
+        where: {
+          workspaceId,
+          id: { [Op.in]: Array.from(referencedModelIds) },
+        },
+      }
+    );
+  }
+}
+
 export async function removeFileFromProject(
   auth: Authenticator,
   {
+    deleteFrameSource,
     space,
     fileId,
   }: {
+    deleteFrameSource?: FrameV2SourceDeletion;
     space: SpaceResource;
     fileId: string; // file sId
   }
@@ -528,56 +588,42 @@ export async function removeFileFromProject(
     return new Err(new Error("File not found."));
   }
 
-  // Best-effort cleanup of the project content fragments for this file.
-  const workspaceId = auth.getNonNullableWorkspace().id;
-  const projectFragmentIds = await ContentFragmentModel.findAll({
-    attributes: ["id"],
-    where: {
-      workspaceId,
-      spaceId: space.id,
-      fileId: file.id,
-    },
-  }).then((rows) => rows.map((r) => r.id));
-
-  if (projectFragmentIds.length > 0) {
-    const messagesReferencing = await MessageModel.findAll({
-      attributes: ["contentFragmentId"],
-      where: {
-        workspaceId,
-        contentFragmentId: {
-          [Op.in]: projectFragmentIds,
-        },
-      },
-    });
-
-    const referencedIds = new Set(
-      removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
+  if (file.isFrameV2 && !deleteFrameSource) {
+    return new Err(
+      new Error(
+        "Frames v2 must be deleted through the package-aware Frame deletion flow."
+      )
     );
-    const orphanIds = projectFragmentIds.filter((id) => !referencedIds.has(id));
-
-    if (orphanIds.length > 0) {
-      await ContentFragmentModel.destroy({
-        where: {
-          workspaceId,
-          id: { [Op.in]: orphanIds },
-        },
-      });
-    }
-
-    if (referencedIds.size > 0) {
-      await ContentFragmentModel.update(
-        { spaceId: null, expiredReason: "file_deleted" },
-        {
-          where: {
-            workspaceId,
-            id: { [Op.in]: Array.from(referencedIds) },
-          },
-        }
-      );
-    }
   }
 
-  const deleteRes = await file.delete(auth);
+  const deleteSourceAndFragments: FrameV2SourceDeletion | undefined =
+    deleteFrameSource
+      ? async () => {
+          const sourceResult = await deleteFrameSource();
+          if (sourceResult.isErr()) {
+            return sourceResult;
+          }
+          try {
+            await cleanupProjectFileFragments(auth, {
+              file,
+              space,
+            });
+            return new Ok(undefined);
+          } catch (error) {
+            return new Err(normalizeError(error));
+          }
+        }
+      : undefined;
+
+  // Legacy project files have no separately-owned source package, so preserve their existing
+  // cleanup order. Frames v2 run this only after their retryable source deletion succeeds.
+  if (!deleteFrameSource) {
+    await cleanupProjectFileFragments(auth, { file, space });
+  }
+
+  const deleteRes = await file.delete(auth, {
+    deleteFrameSource: deleteSourceAndFragments,
+  });
   if (deleteRes.isErr()) {
     return new Err(deleteRes.error);
   }

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -31,6 +31,7 @@ import {
   isUnverifiableFrameFileRefsShareError,
   sandboxFunctionContentType,
 } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1780,7 +1781,15 @@ describe("FileResource", () => {
       })
     ).toHaveLength(1);
 
-    const result = await frame.delete(auth);
+    const direct = await frame.delete(auth);
+    expect(direct.isErr() && direct.error.message).toBe(
+      "Frames v2 must be deleted through the package-aware Frame deletion flow."
+    );
+    expect(await FileResource.fetchById(auth, frame.sId)).not.toBeNull();
+
+    const result = await frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
 
     expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
       true

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -124,6 +124,8 @@ import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_mod
 
 export type FileVersion = "processed" | "original" | "public";
 
+export type FrameV2SourceDeletion = () => Promise<Result<void, Error>>;
+
 const FRAME_CONTENT_TYPES = new Set([
   frameContentType,
   frameSlideshowContentType,
@@ -659,18 +661,23 @@ export class FileResource extends BaseResource<FileModel> {
         // Delete mount file copies if set.
         await this.deleteMountFileCopies();
 
-        await this.getBucketForVersion("original")
-          .file(this.getCloudStoragePath(auth, "original"))
-          .delete();
+        // Frames v2 are contentless identities: their source lives at mountFilePath and their
+        // published/runtime data lives under the Frame prefix deleted above. They never own the
+        // canonical original/processed/public FileResource objects.
+        if (!this.isFrameV2) {
+          await this.getBucketForVersion("original")
+            .file(this.getCloudStoragePath(auth, "original"))
+            .delete();
 
-        // Delete the processed file if it exists.
-        await this.getBucketForVersion("processed")
-          .file(this.getCloudStoragePath(auth, "processed"))
-          .delete({ ignoreNotFound: true });
-        // Delete the public file if it exists.
-        await this.getBucketForVersion("public")
-          .file(this.getCloudStoragePath(auth, "public"))
-          .delete({ ignoreNotFound: true });
+          // Delete the processed file if it exists.
+          await this.getBucketForVersion("processed")
+            .file(this.getCloudStoragePath(auth, "processed"))
+            .delete({ ignoreNotFound: true });
+          // Delete the public file if it exists.
+          await this.getBucketForVersion("public")
+            .file(this.getCloudStoragePath(auth, "public"))
+            .delete({ ignoreNotFound: true });
+        }
 
         // Delete sharing grants and access snapshots before shareable file (FK constraint).
         const shareableFile = await FileResource.shareableFileModel.findOne({
@@ -713,16 +720,36 @@ export class FileResource extends BaseResource<FileModel> {
     }
   }
 
-  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+  async delete(
+    auth: Authenticator,
+    {
+      deleteFrameSource,
+    }: {
+      transaction?: Transaction;
+      deleteFrameSource?: FrameV2SourceDeletion;
+    } = {}
+  ): Promise<Result<undefined, Error>> {
     if (!this.isFrameV2) {
       return this.deleteAfterSandboxCleanup(auth);
     }
 
-    return withFramePublishLock(this.sId, () =>
-      FrameSandboxAdapter.deleteSandbox(auth, this, {
+    if (!deleteFrameSource) {
+      return new Err(
+        new Error(
+          "Frames v2 must be deleted through the package-aware Frame deletion flow."
+        )
+      );
+    }
+
+    return withFramePublishLock(this.sId, async () => {
+      const sourceResult = await deleteFrameSource();
+      if (sourceResult.isErr()) {
+        return sourceResult;
+      }
+      return FrameSandboxAdapter.deleteSandbox(auth, this, {
         afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
-      })
-    );
+      });
+    });
   }
 
   get sId(): string {

--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -186,7 +186,9 @@ describe("FrameSandboxAdapter", () => {
       deletedPrefixes.push(prefix)
     );
 
-    const deleteResult = await frame.delete(auth);
+    const deleteResult = await frame.delete(auth, {
+      deleteFrameSource: async () => new Ok(undefined),
+    });
 
     expect(
       deleteResult.isOk(),
@@ -266,7 +268,9 @@ describe("FrameSandboxAdapter", () => {
 
     try {
       mockExecuteWithLock.mockClear();
-      const deletionPromise = frame.delete(auth);
+      const deletionPromise = frame.delete(auth, {
+        deleteFrameSource: async () => new Ok(undefined),
+      });
       await deletionReachedFunctionCleanup.promise;
       expect(await FrameSandboxAdapter.fetchSandbox(auth, frame)).toBeNull();
 


### PR DESCRIPTION
## Description

Teach project-file removal to delete a Frames v2 source package before removing its FileResource and conversation fragments. Legacy project-file deletion keeps its existing behavior.

Stack: #31502 -> this PR.

## Tests

- All 7 focused project-context tests pass.
- Biome and diff checks pass.

## Risk

Frames v2 project deletion now requires the package-aware callback introduced by #31502. A failed source deletion leaves project metadata and fragments intact for retry.

## Deploy Plan

Merge after #31502. No migration is required.