### PR TITLE
Fence Frame deletion with source operations

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -8,8 +9,13 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import {
+  getFrameBasePath,
+  getFramePublicationUiBundlePath,
+} from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -27,6 +33,33 @@ vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
 
 function fileUrl(workspace: { sId: string }, fileId: string, query = "") {
   return `/api/w/${workspace.sId}/files/${fileId}${query}`;
+}
+
+async function createConversationFrame(
+  auth: Authenticator,
+  directoryName: string
+) {
+  const owner = auth.getNonNullableWorkspace();
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+  })}${directoryName}`;
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: 128,
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: { conversationId: conversation.sId },
+    mountFilePath: `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+
+  return { conversationId: conversation.sId, frame, sourceDirectoryPath };
 }
 
 describe("GET /api/w/:wId/files/:fileId", () => {
@@ -315,6 +348,7 @@ describe("GET /api/w/:wId/files/:fileId", () => {
 describe("DELETE /api/w/:wId/files/:fileId", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fileStorageMock.reset();
   });
 
   it("should allow manager to delete any file", async () => {
@@ -340,6 +374,72 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     });
 
     expect(response.status).toBe(204);
+  });
+
+  it("deletes a Frames v2 package", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "manager",
+    });
+    const { frame, sourceDirectoryPath } = await createConversationFrame(
+      auth,
+      "Status"
+    );
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setFileExists((path) => path.endsWith("/"));
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    const response = await honoApp.request(fileUrl(workspace, frame.sId), {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(204);
+    await expect(FileResource.fetchById(auth, frame.sId)).resolves.toBeNull();
+    expect(deletedPrefixes).toContain(`${sourceDirectoryPath}/`);
+    expect(deletedPrefixes).toContain(
+      getFrameBasePath({ workspaceId: workspace.sId, frameId: frame.sId })
+    );
+  });
+
+  it("rejects a Frame package containing another registered Frame", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "manager",
+    });
+    const {
+      conversationId,
+      frame: parent,
+      sourceDirectoryPath,
+    } = await createConversationFrame(auth, "Parent");
+    const child = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 128,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId },
+      mountFilePath: `${sourceDirectoryPath}/Child/${FRAME_MANIFEST_FILE}`,
+    });
+    await child.markFrameV2AsReadyFromMount(auth);
+    const deletedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) =>
+      deletedPrefixes.push(prefix)
+    );
+
+    const response = await honoApp.request(fileUrl(workspace, parent.sId), {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(
+      FileResource.fetchById(auth, parent.sId)
+    ).resolves.not.toBeNull();
+    await expect(
+      FileResource.fetchById(auth, child.sId)
+    ).resolves.not.toBeNull();
+    expect(deletedPrefixes).toEqual([]);
   });
 
   it("should allow file author with admin role to delete upload files", async () => {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1,3 +1,5 @@
+import { getFrameSourceLockName } from "@app/lib/api/frames/operation_lock";
+import { getRedisStreamClient } from "@app/lib/api/redis";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import { Authenticator } from "@app/lib/auth";
@@ -1806,6 +1808,42 @@ describe("FileResource", () => {
       true
     );
     expect(await FileResource.fetchById(auth, frame.sId)).toBeNull();
+  });
+
+  it("does not delete while another source operation holds the lock", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+    const frame = await createFrameWithFunction(auth, "frame-delete-locked", {
+      withSource: true,
+    });
+    const lockKey = `lock:${getFrameSourceLockName(frame.sId)}`;
+    const redisClient = await getRedisStreamClient({ origin: "lock" });
+    await redisClient.set(lockKey, "held-by-test", {
+      NX: true,
+      PX: 60_000,
+    });
+    vi.useFakeTimers();
+
+    try {
+      const deletionPromise = frame.delete(auth);
+      await vi.runAllTimersAsync();
+      const result = await deletionPromise;
+
+      expect(result.isErr() && result.error).toMatchObject({
+        name: "LockAcquisitionTimeoutError",
+      });
+      expect(await FileResource.fetchById(auth, frame.sId)).not.toBeNull();
+      expect(
+        await SandboxFunctionResource.listByFramePublication(auth, {
+          frame,
+          publicationId: "frame-delete-locked",
+        })
+      ).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+      await redisClient.del(lockKey);
+    }
   });
 
   it("rejects Frame deletion from another workspace", async () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -14,7 +14,10 @@ import {
   getProcessedContentType,
   hasProcessedVersion,
 } from "@app/lib/api/files/processing";
-import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import {
+  withFramePublishLock,
+  withFrameSourceLock,
+} from "@app/lib/api/frames/operation_lock";
 import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import { cleanupProjectFileFragments } from "@app/lib/api/projects/file_cleanup";
 import { requestDustProjectIncrementalSync } from "@app/lib/api/projects/request_incremental_sync";
@@ -809,6 +812,14 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   private async deleteFrameV2(
+    auth: Authenticator
+  ): Promise<Result<undefined, Error>> {
+    return withFrameSourceLock(this.sId, () =>
+      this.deleteFrameV2WithPublishLock(auth)
+    );
+  }
+
+  private async deleteFrameV2WithPublishLock(
     auth: Authenticator
   ): Promise<Result<undefined, Error>> {
     const owner = auth.getNonNullableWorkspace();


### PR DESCRIPTION
## Description

Acquire the Frame source lock before the existing publish lock during Frames v2 deletion. This serializes deletion with publish, move, and clone without moving lifecycle ownership out of `FileResource`.

Add resource and private endpoint coverage for lock conflicts, package deletion, and nested Frame rejection. The endpoint remains absent from Swagger.

## Tests

- `front/lib/resources/file_resource.test.ts`: 58 tests pass.
- `front-api/routes/w/[wId]/files/[fileId]`: 90 tests pass.

## Risk

Low. Lock acquisition can return the existing deletion error while another source operation is active. No schema or API contract change.

## Deploy Plan

Standard deploy.
