### PR TITLE
Keep Frames v2 out of legacy deletion

### DIFF
--- a/front/lib/api/poke/plugins/files/delete_frame.test.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.test.ts
@@ -5,7 +5,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -81,5 +81,31 @@ describe("deleteFramePlugin", () => {
         },
       })
     );
+  });
+
+  it("leaves Frames v2 deletion to the package-aware flow", async () => {
+    const {
+      authenticator: auth,
+      user,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const frame = await ProjectFileFactory.create(auth, user, pod, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "ready",
+    });
+
+    expect(deleteFramePlugin.isApplicableTo(auth, frame)).toBe(false);
+    const result = await deleteFramePlugin.execute(auth, frame, {
+      confirmation: "DELETE",
+    });
+
+    expect(result.isErr()).toBe(true);
+    await expect(
+      FileResource.fetchById(auth, frame.sId)
+    ).resolves.not.toBeNull();
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/poke/plugins/files/delete_frame.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.ts
@@ -82,7 +82,7 @@ export const deleteFramePlugin = createPlugin({
     requiredRoles: ["engineering", "support"],
   },
   execute: async (auth, file, args) => {
-    if (!file?.isInteractiveContent) {
+    if (!file?.isInteractiveContent || file.isFrameV2) {
       return new Err(new Error("Frame not found."));
     }
     if (args.confirmation !== "DELETE") {
@@ -117,5 +117,6 @@ export const deleteFramePlugin = createPlugin({
       value: `Frame "${frameName}" was permanently deleted.`,
     });
   },
-  isApplicableTo: (auth, file) => file?.isInteractiveContent === true,
+  isApplicableTo: (_auth, file) =>
+    file?.isInteractiveContent === true && !file.isFrameV2,
 });


### PR DESCRIPTION
## Description

Hide Frames v2 from the legacy admin deletion plugin. Frames v2 own source packages and runtime state, so the legacy FileResource-only path is unsafe.

This independent replacement slice comes from #31402.

## Tests

- Both focused plugin tests pass.
- Biome and diff checks pass.

## Risk

Support users must use the package-aware deletion API for Frames v2. Legacy Frames remain available in the plugin.

## Deploy Plan

Deploy normally. No ordering dependency or migration.