### PR TITLE
Prepare atomic Frame sharing updates

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { checkFrameEmailGrantPermission } from "@app/lib/api/share/frame_sharing";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -89,43 +90,15 @@ app.post(
 
     const { emails: rawEmails } = ctx.req.valid("json");
 
-    const workspace = auth.getNonNullableWorkspace();
-
-    const externalSharingDisabledByPolicy =
-      workspace.sharingPolicy === "workspace_only";
-    const canInviteExternal =
-      !externalSharingDisabledByPolicy &&
-      (await auth.hasWorkspacePermission("invite", "frame"));
-
-    if (!canInviteExternal) {
-      const emails = rawEmails.map((e) => e.toLowerCase());
-      const users = await UserResource.fetchByEmails(emails);
-
-      const userIdToEmail = new Map(
-        users.map((u) => [u.id, u.email.toLowerCase()])
-      );
-
-      const { memberships } = await MembershipResource.getActiveMemberships({
-        users,
-        workspace,
+    const permission = await checkFrameEmailGrantPermission(auth, rawEmails);
+    if (permission.isErr()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: permission.error.message,
+        },
       });
-
-      const memberEmails = new Set(
-        memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
-      );
-
-      const hasNonMemberEmails = emails.some((e) => !memberEmails.has(e));
-      if (hasNonMemberEmails) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: externalSharingDisabledByPolicy
-              ? "Only workspace members can be invited when external sharing is disabled."
-              : "You do not have permission to invite people outside the workspace. Only workspace members can be invited.",
-          },
-        });
-      }
     }
 
     const grants = await file.addSharingGrants(auth, { emails: rawEmails });

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { checkFrameShareScopePermission } from "@app/lib/api/share/frame_sharing";
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import {
   buildShareFileResponse,
@@ -85,25 +86,15 @@ app.post(
 
     const { shareScope } = ctx.req.valid("json");
 
-    if (shareScope === "public") {
-      const workspace = auth.getNonNullableWorkspace();
-      const publicSharingAllowedByPolicy =
-        workspace.sharingPolicy === "all_scopes";
-      const canPublish =
-        publicSharingAllowedByPolicy &&
-        (await auth.hasWorkspacePermission("publish", "frame"));
-
-      if (!canPublish) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: publicSharingAllowedByPolicy
-              ? "You do not have permission to share this frame publicly."
-              : "Public sharing is disabled for this workspace.",
-          },
-        });
-      }
+    const permission = await checkFrameShareScopePermission(auth, shareScope);
+    if (permission.isErr()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: permission.error.message,
+        },
+      });
     }
 
     await file.setShareScope(auth, shareScope);

--- a/front/lib/api/share/frame_sharing.ts
+++ b/front/lib/api/share/frame_sharing.ts
@@ -1,6 +1,10 @@
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import { runOnRedis } from "@app/lib/api/redis";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { FileShareScope } from "@app/types/files";
@@ -24,6 +28,82 @@ export function getDefaultFrameShareScope(
     default:
       assertNever(sharingPolicy);
   }
+}
+
+export async function checkFrameShareScopePermission(
+  auth: Authenticator,
+  shareScope: FileShareScope
+): Promise<Result<void, DustError<"unauthorized">>> {
+  if (shareScope !== "public") {
+    return new Ok(undefined);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  if (workspace.sharingPolicy !== "all_scopes") {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        "Public sharing is disabled for this workspace."
+      )
+    );
+  }
+  if (!(await auth.hasWorkspacePermission("publish", "frame"))) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        "You do not have permission to share this frame publicly."
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+export async function checkFrameEmailGrantPermission(
+  auth: Authenticator,
+  rawEmails: string[]
+): Promise<Result<void, DustError<"unauthorized">>> {
+  if (rawEmails.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const externalSharingDisabledByPolicy =
+    workspace.sharingPolicy === "workspace_only";
+  const canInviteExternal =
+    !externalSharingDisabledByPolicy &&
+    (await auth.hasWorkspacePermission("invite", "frame"));
+  if (canInviteExternal) {
+    return new Ok(undefined);
+  }
+
+  const emails = rawEmails.map((email) => email.toLowerCase());
+  const users = await UserResource.fetchByEmails(emails);
+  const userModelIdToEmail = new Map(
+    users.map((user) => [user.id, user.email.toLowerCase()])
+  );
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace,
+  });
+  const memberEmails = new Set(
+    memberships
+      .map((membership) => userModelIdToEmail.get(membership.userId))
+      .filter((email): email is string => email !== undefined)
+  );
+
+  if (emails.some((email) => !memberEmails.has(email))) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        externalSharingDisabledByPolicy
+          ? "Only workspace members can be invited when external sharing is disabled."
+          : "You do not have permission to invite people outside the workspace. Only workspace members can be invited."
+      )
+    );
+  }
+
+  return new Ok(undefined);
 }
 
 const OTP_TTL_SECONDS = 15 * 60; // 15 minutes.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1724,7 +1724,8 @@ export class FileResource extends BaseResource<FileModel> {
 
   async setShareScope(
     auth: Authenticator,
-    scope: FileShareScope
+    scope: FileShareScope,
+    transaction?: Transaction
   ): Promise<void> {
     if (!this.isShareableFrame) {
       throw new Error("Only Frame files can be shared");
@@ -1737,6 +1738,7 @@ export class FileResource extends BaseResource<FileModel> {
     // Always update the existing ShareableFileModel record (never delete).
     const existingShare = await FileResource.shareableFileModel.findOne({
       where: { fileId: this.id, workspaceId: this.workspaceId },
+      transaction,
     });
 
     assert(
@@ -1744,11 +1746,14 @@ export class FileResource extends BaseResource<FileModel> {
       `ShareableFileModel record not found for file ${this.sId}`
     );
 
-    await existingShare.update({
-      shareScope: scope,
-      sharedBy: user.id,
-      sharedAt: new Date(),
-    });
+    await existingShare.update(
+      {
+        shareScope: scope,
+        sharedBy: user.id,
+        sharedAt: new Date(),
+      },
+      { transaction }
+    );
   }
 
   async getShareInfo(): Promise<{
@@ -2329,8 +2334,103 @@ export class FileResource extends BaseResource<FileModel> {
 
   // Sharing grants logic.
 
-  private async getShareableFileId(): Promise<ModelId> {
-    return (await this.getShareableFile()).id;
+  private async getShareableFileId(
+    transaction?: Transaction
+  ): Promise<ModelId> {
+    return (await this.getShareableFile(transaction)).id;
+  }
+
+  async addSharingGrantsAndGetCreatedEmails(
+    auth: Authenticator,
+    { emails }: { emails: string[] },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<string[]> {
+    assert(
+      this.isShareableFrame,
+      "addSharingGrantsAndGetCreatedEmails requires a Frame file"
+    );
+    const user = auth.getNonNullableUser();
+    const shareableFileId = await this.getShareableFileId(transaction);
+
+    const normalizedEmails = [
+      ...new Set(emails.map((email) => email.toLowerCase().trim())),
+    ];
+    const existingGrants = await SharingGrantModel.findAll({
+      where: {
+        workspaceId: this.workspaceId,
+        shareableFileId,
+        email: { [Op.in]: normalizedEmails },
+        revokedAt: null,
+      },
+      transaction,
+    });
+    const existingEmails = new Set(existingGrants.map((grant) => grant.email));
+    const createdEmails = normalizedEmails.filter(
+      (email) => !existingEmails.has(email)
+    );
+
+    if (createdEmails.length === 0) {
+      return [];
+    }
+
+    await SharingGrantModel.bulkCreate(
+      createdEmails.map((email) => ({
+        workspaceId: this.workspaceId,
+        shareableFileId,
+        email,
+        grantedBy: user.id,
+        grantedAt: new Date(),
+      })),
+      { transaction }
+    );
+
+    const sendNotifications = async () => {
+      const shareInfo = await this.getShareInfo();
+      if (!shareInfo) {
+        return;
+      }
+      const frameUrl = shareInfo.shareUrl;
+      const shareToken = frameUrl.split("/").at(-1) ?? "";
+
+      for (const email of createdEmails) {
+        void sendFrameSharedEmail({
+          to: email,
+          sharedByName: user.toJSON().fullName,
+          frameUrl,
+          shareToken,
+        }).catch((error) => {
+          logger.info(
+            {
+              email,
+              error: normalizeError(error),
+              fileId: this.sId,
+              workspaceId: this.workspaceId,
+            },
+            "Failed to send sharing notification email"
+          );
+        });
+      }
+    };
+    const scheduleNotifications = () => {
+      void sendNotifications().catch((error) => {
+        logger.error(
+          {
+            error: normalizeError(error),
+            fileId: this.sId,
+            workspaceId: this.workspaceId,
+          },
+          "Failed to send Frame sharing notifications"
+        );
+      });
+    };
+
+    if (transaction) {
+      transaction.afterCommit(scheduleNotifications);
+    } else {
+      scheduleNotifications();
+    }
+
+    return createdEmails;
   }
 
   async addSharingGrants(
@@ -2339,67 +2439,7 @@ export class FileResource extends BaseResource<FileModel> {
   ): Promise<SharingGrantType[]> {
     assert(this.isShareableFrame, "addSharingGrants requires a Frame file");
     await this.ensureShareableFrame(auth);
-    const user = auth.getNonNullableUser();
-    const shareableFileId = await this.getShareableFileId();
-
-    const normalizedEmails = emails.map((e) => e.toLowerCase().trim());
-
-    // Find existing active grants for these emails.
-    const existingGrants = await SharingGrantModel.findAll({
-      where: {
-        workspaceId: this.workspaceId,
-        shareableFileId,
-        email: { [Op.in]: normalizedEmails },
-        revokedAt: null,
-      },
-    });
-
-    const existingEmails = new Set(existingGrants.map((g) => g.email));
-
-    const newEmails = normalizedEmails.filter((e) => !existingEmails.has(e));
-
-    if (newEmails.length > 0) {
-      await SharingGrantModel.bulkCreate(
-        newEmails.map((email) => ({
-          workspaceId: this.workspaceId,
-          shareableFileId,
-          email,
-          grantedBy: user.id,
-          grantedAt: new Date(),
-        }))
-      );
-
-      const shareInfo = await this.getShareInfo();
-      if (shareInfo) {
-        const sharedByName = user.toJSON().fullName;
-        const frameUrl = shareInfo.shareUrl;
-        const shareToken = frameUrl.split("/").at(-1) ?? "";
-
-        // Fire-and-forget: don't block grant creation on email delivery.
-        // TODO: Consider moving email delivery to a dedicated worker/queue  to avoid unbounded
-        // parallelism and improve reliability/retry handling.
-        void Promise.all(
-          newEmails.map((email) =>
-            sendFrameSharedEmail({
-              to: email,
-              sharedByName,
-              frameUrl,
-              shareToken,
-            }).catch(() => {
-              // Silently ignore, email failures should not affect grant creation.
-              logger.info(
-                {
-                  email,
-                  fileId: this.sId,
-                  workspaceId: this.workspaceId,
-                },
-                "Failed to send sharing notification email"
-              );
-            })
-          )
-        );
-      }
-    }
+    await this.addSharingGrantsAndGetCreatedEmails(auth, { emails });
 
     return this.listActiveSharingGrants();
   }


### PR DESCRIPTION
## Description

Centralize Frame sharing permission checks and add transaction-aware scope and email-grant updates. Legacy routes keep the same behavior while the source-authorized Frames v2 flow can reuse these primitives.

## Tests

- `front-api` share scope and grant suites: 28 tests passed

## Risk

Low. Existing routes retain their request and response contracts.

## Deploy Plan

Standard deploy.