### PR TITLE
Audit successful Frame deletions

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -413,10 +413,15 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "frame.deleted",
+        context: { location: "internal" },
         metadata: {
           active_publication_id: "",
           source_path: `conversation-${conversationId}/Status`,
         },
+        targets: [
+          expect.objectContaining({ id: workspace.sId, type: "workspace" }),
+          { id: frame.sId, name: "Status", type: "frame" },
+        ],
       })
     );
   });
@@ -451,6 +456,7 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     });
 
     expect(response.status).toBe(400);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
     await expect(
       FileResource.fetchById(auth, parent.sId)
     ).resolves.not.toBeNull();

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -19,6 +19,16 @@ import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
 vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
   const mod =
     await importOriginal<typeof import("@app/lib/api/files/processing")>();
@@ -381,10 +391,8 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
       method: "DELETE",
       role: "manager",
     });
-    const { frame, sourceDirectoryPath } = await createConversationFrame(
-      auth,
-      "Status"
-    );
+    const { conversationId, frame, sourceDirectoryPath } =
+      await createConversationFrame(auth, "Status");
     const deletedPrefixes: string[] = [];
     fileStorageMock.setFileExists((path) => path.endsWith("/"));
     fileStorageMock.setOnDeleteByPrefix((prefix) =>
@@ -400,6 +408,16 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     expect(deletedPrefixes).toContain(`${sourceDirectoryPath}/`);
     expect(deletedPrefixes).toContain(
       getFrameBasePath({ workspaceId: workspace.sId, frameId: frame.sId })
+    );
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledOnce();
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.deleted",
+        metadata: {
+          active_publication_id: "",
+          source_path: `conversation-${conversationId}/Status`,
+        },
+      })
     );
   });
 

--- a/front/admin/audit_log_schemas/frame.deleted.json
+++ b/front/admin/audit_log_schemas/frame.deleted.json
@@ -1,0 +1,11 @@
+{
+  "action": "frame.deleted",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "active_publication_id": "string",
+    "source_path": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.deleted": 2,
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -176,6 +176,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.deleted",
   "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -2,7 +2,11 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 import path from "node:path";
-
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
 import {
   SCOPED_PREFIX_CONVERSATION,
@@ -933,10 +937,27 @@ export class FileResource extends BaseResource<FileModel> {
         }
       );
       if (deleteResult.isOk()) {
+        const activePublicationId =
+          frame.useCaseMetadata?.activePublicationId ?? "";
+        void emitAuditLogEvent({
+          auth,
+          action: "frame.deleted",
+          targets: [
+            buildAuditLogTarget("workspace", owner),
+            buildAuditLogTarget("frame", {
+              sId: frame.sId,
+              name: path.posix.basename(sourceDirectory),
+            }),
+          ],
+          context: getAuditLogContext(auth),
+          metadata: {
+            active_publication_id: activePublicationId,
+            source_path: sourceDirectory,
+          },
+        });
         logger.info(
           {
-            activePublicationId:
-              frame.useCaseMetadata?.activePublicationId ?? "",
+            activePublicationId,
             frameId: frame.sId,
             source: "api",
             sourceDirectoryPath: sourceDirectory,


### PR DESCRIPTION
## Description

- Emit `frame.deleted` after a Frames v2 package is fully deleted.
- Record the workspace, Frame, scoped source path, and active publication.
- Add and register the WorkOS audit schema as version 2.

This stays in `FileResource`, which owns the complete Frame deletion lifecycle. It is stacked on #31504.

## Tests

- `front`: audit schema tests and `FileResource` tests.
- `front-api`: file endpoint tests, including the emitted audit event.
- `front` and `front-api`: `tsgo --noEmit`.
- Biome on changed files.

## Risk

Low. Audit delivery is fire-and-forget and only runs after successful deletion. Deletion behavior is unchanged.

## Deploy Plan

Merge #31504 first, then deploy normally. The WorkOS `frame.deleted` schema version 2 is already registered.