### PR TITLE
Refresh owned distributed locks

### DIFF
--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -1,8 +1,6 @@
-import type { RedisClientType } from "@app/lib/api/redis";
+import type { LockRedisClient } from "@app/lib/lock";
 import { distributedRefresh } from "@app/lib/lock";
 import { describe, expect, it, vi } from "vitest";
-
-type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
 
 function makeRedisClient(): LockRedisClient {
   return {
@@ -18,6 +16,10 @@ describe("distributedRefresh", () => {
     await expect(
       distributedRefresh(redisClient, "frame:source:123", "owner-token", 900)
     ).resolves.toBe(true);
+    const luaScript = vi.mocked(redisClient.eval).mock.calls[0]?.[0];
+    expect(luaScript).toContain(
+      'if redis.call("get", KEYS[1]) == ARGV[1] then'
+    );
     expect(redisClient.eval).toHaveBeenCalledWith(
       expect.stringContaining('redis.call("pexpire", KEYS[1], ARGV[2])'),
       {

--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -1,0 +1,34 @@
+import type { RedisClientType } from "@app/lib/api/redis";
+import { distributedRefresh } from "@app/lib/lock";
+import { describe, expect, it, vi } from "vitest";
+
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+
+function makeRedisClient(): LockRedisClient {
+  return {
+    eval: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("distributedRefresh", () => {
+  it("refreshes only the lock owned by the caller", async () => {
+    const redisClient = makeRedisClient();
+
+    await expect(
+      distributedRefresh(redisClient, "frame:source:123", "owner-token", 900)
+    ).resolves.toBe(true);
+    expect(redisClient.eval).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call("pexpire", KEYS[1], ARGV[2])'),
+      {
+        keys: ["lock:frame:source:123"],
+        arguments: ["owner-token", "900"],
+      }
+    );
+
+    vi.mocked(redisClient.eval).mockResolvedValueOnce(0);
+    await expect(
+      distributedRefresh(redisClient, "frame:source:123", "old-owner", 900)
+    ).resolves.toBe(false);
+  });
+});

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -4,10 +4,12 @@ import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 
+type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
 export async function distributedLock(
-  redisCli: RedisClientType,
+  redisCli: LockRedisClient,
   key: string,
   lockTtlMs: number = 5_000
 ): Promise<string | undefined> {
@@ -30,7 +32,7 @@ export async function distributedLock(
 }
 
 export async function distributedUnlock(
-  redisCli: RedisClientType,
+  redisCli: LockRedisClient,
   key: string,
   lockValue: string
 ): Promise<void> {
@@ -49,6 +51,28 @@ export async function distributedUnlock(
     keys: [lockKey],
     arguments: [lockValue],
   });
+}
+
+export async function distributedRefresh(
+  redisCli: LockRedisClient,
+  key: string,
+  lockValue: string,
+  lockTtlMs: number
+): Promise<boolean> {
+  const lockKey = `lock:${key}`;
+  const luaScript = `
+    if redis.call("get", KEYS[1]) == ARGV[1] then
+      return redis.call("pexpire", KEYS[1], ARGV[2])
+    else
+      return 0
+    end
+  `;
+  const refreshed = await redisCli.eval(luaScript, {
+    keys: [lockKey],
+    arguments: [lockValue, String(lockTtlMs)],
+  });
+
+  return refreshed === 1;
 }
 
 const DEFAULT_RETRY_INTERVAL_MS = 100;

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -4,7 +4,7 @@ import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 
-type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+export type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
 
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.


### PR DESCRIPTION
## Description

Add the atomic Redis primitive needed to extend a distributed lock only while the caller still owns it. This is the first small replacement slice for #31484.

## Tests

- Focused ownership and stale-owner test passes.
- Biome and diff checks pass.

## Risk

No existing call path changes. This only exposes the refresh primitive.

## Deploy Plan

Deploy normally. No migration or ordering dependency.