### PR TITLE
Renew distributed lock leases

### DIFF
--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -1,8 +1,20 @@
 import type { RedisClientType } from "@app/lib/api/redis";
-import { distributedRefresh } from "@app/lib/lock";
-import { describe, expect, it, vi } from "vitest";
+import {
+  distributedRefresh,
+  executeWithRenewingLockResult,
+  isLockLeaseLostError,
+} from "@app/lib/lock";
+import { Err, Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
+const { getRedisStreamClientMock } = vi.hoisted(() => ({
+  getRedisStreamClientMock: vi.fn<() => Promise<LockRedisClient>>(),
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisStreamClient: getRedisStreamClientMock,
+}));
 
 function makeRedisClient(): LockRedisClient {
   return {
@@ -11,13 +23,24 @@ function makeRedisClient(): LockRedisClient {
   };
 }
 
-describe("distributedRefresh", () => {
+describe("renewing locks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it("refreshes only the lock owned by the caller", async () => {
     const redisClient = makeRedisClient();
 
     await expect(
       distributedRefresh(redisClient, "frame:source:123", "owner-token", 900)
     ).resolves.toBe(true);
+
     expect(redisClient.eval).toHaveBeenCalledWith(
       expect.stringContaining('redis.call("pexpire", KEYS[1], ARGV[2])'),
       {
@@ -30,5 +53,143 @@ describe("distributedRefresh", () => {
     await expect(
       distributedRefresh(redisClient, "frame:source:123", "old-owner", 900)
     ).resolves.toBe(false);
+  });
+
+  it("does not overlap renewal requests", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+    let finishCallback: () => void = () => {};
+    const callbackDone = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await callbackDone;
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    expect(redisClient.eval).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(redisClient.eval).toHaveBeenCalledTimes(1);
+
+    finishRefresh(1);
+    await vi.advanceTimersByTimeAsync(30);
+    expect(redisClient.eval).toHaveBeenCalledTimes(2);
+    finishCallback();
+    await resultPromise;
+  });
+
+  it("observes an in-flight definitive loss before returning", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+    let finishCallback: () => void = () => {};
+    const callbackDone = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await callbackDone;
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    finishCallback();
+    await vi.advanceTimersByTimeAsync(0);
+    finishRefresh(0);
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("fails the lease when refresh errors", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval).mockRejectedValue(
+      new Error("redis unavailable")
+    );
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Ok("callback-completed");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("fails the lease immediately when Redis reports a different owner", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval).mockResolvedValue(0);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Err(new Error("callback failed too"));
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("stops renewal before unlocking", async () => {
+    const redisClient = makeRedisClient();
+    const scripts: string[] = [];
+    vi.mocked(redisClient.eval).mockImplementation((...args) => {
+      scripts.push(String(typeof args[0] === "string" ? args[0] : args[1]));
+      return Promise.resolve(1);
+    });
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async () => {
+        await vi.advanceTimersByTimeAsync(30);
+        return new Ok("done");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+    await resultPromise;
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(scripts.filter((script) => script.includes("pexpire"))).toHaveLength(
+      1
+    );
+    expect(scripts.at(-1)).toContain('redis.call("del", KEYS[1])');
   });
 });

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,8 +1,10 @@
 import type { RedisClientType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 type LockRedisClient = Pick<RedisClientType, "eval" | "set">;
 
@@ -90,6 +92,23 @@ export function isLockAcquisitionTimeoutError(
   return error instanceof LockAcquisitionTimeoutError;
 }
 
+export class LockLeaseLostError extends Error {
+  constructor(readonly lockName: string) {
+    super(`Lock lease lost for ${lockName}`);
+    this.name = "LockLeaseLostError";
+  }
+}
+
+export function isLockLeaseLostError(
+  error: unknown
+): error is LockLeaseLostError {
+  return error instanceof LockLeaseLostError;
+}
+
+export interface LockLeaseGuard {
+  check(): Result<void, LockLeaseLostError>;
+}
+
 type ExecuteWithLockOptions = {
   lockTtlMs?: number;
   // How long a waiter sleeps between acquisition attempts. The wait is blind
@@ -157,6 +176,130 @@ async function runWithAcquiredLock<T>(
   }
 }
 
+function waitForRenewal(
+  delayMs: number,
+  signal: AbortSignal
+): Promise<boolean> {
+  if (signal.aborted) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, delayMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function createLockLeaseGuard(
+  lockName: string,
+  lockTtlMs: number,
+  lockAttemptStartedAtMs: number
+): {
+  guard: LockLeaseGuard;
+  markLost: () => void;
+  markRenewed: (renewedAtMs: number) => void;
+} {
+  const safetyMarginMs = Math.max(1, Math.floor(lockTtlMs / 10));
+  let confirmedUntilMs = lockAttemptStartedAtMs + lockTtlMs - safetyMarginMs;
+  let lost = false;
+  const markLost = () => {
+    lost = true;
+  };
+
+  return {
+    guard: {
+      check: () => {
+        if (lost || performance.now() >= confirmedUntilMs) {
+          markLost();
+          return new Err(new LockLeaseLostError(lockName));
+        }
+        return new Ok(undefined);
+      },
+    },
+    markLost,
+    markRenewed: (renewedAtMs) => {
+      confirmedUntilMs = renewedAtMs + lockTtlMs - safetyMarginMs;
+    },
+  };
+}
+
+async function runWithRenewingLockResult<T, E>(
+  client: RedisClientType,
+  lockName: string,
+  lockValue: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>,
+  lockTtlMs: number
+): Promise<Result<T, E | LockLeaseLostError>> {
+  const renewalIntervalMs = Math.max(1, Math.floor(lockTtlMs / 3));
+  const lease = createLockLeaseGuard(lockName, lockTtlMs, performance.now());
+  const stopController = new AbortController();
+  const renew = async () => {
+    const nextRenewalDelayMs = () =>
+      renewalIntervalMs * (0.8 + Math.random() * 0.2);
+    let waitMs = nextRenewalDelayMs();
+    while (await waitForRenewal(waitMs, stopController.signal)) {
+      if (lease.guard.check().isErr()) {
+        return;
+      }
+      try {
+        const refreshStartedAtMs = performance.now();
+        const refreshed = await distributedRefresh(
+          client,
+          lockName,
+          lockValue,
+          lockTtlMs
+        );
+        if (!refreshed) {
+          lease.markLost();
+          logger.warn(
+            { lockName },
+            "Lost a distributed lock lease because its owner changed"
+          );
+          return;
+        }
+        lease.markRenewed(refreshStartedAtMs);
+        waitMs = nextRenewalDelayMs();
+      } catch (error) {
+        lease.markLost();
+        logger.warn(
+          { error: normalizeError(error), lockName },
+          "Lost a distributed lock lease after a refresh error"
+        );
+        return;
+      }
+    }
+  };
+  const renewal = renew();
+
+  try {
+    const result = await callback(lease.guard);
+    stopController.abort();
+    await renewal;
+    const held = lease.guard.check();
+    return held.isErr() ? held : result;
+  } finally {
+    stopController.abort();
+    await renewal;
+    try {
+      await distributedUnlock(client, lockName, lockValue);
+    } catch (error) {
+      logger.error(
+        { error: normalizeError(error), lockName },
+        "Failed to unlock a distributed lock after its callback completed"
+      );
+    }
+  }
+}
+
 export const executeWithLock = async <T>(
   lockName: string,
   callback: () => Promise<T>,
@@ -185,4 +328,28 @@ export const executeWithLockResult = async <T, E>(
   }
 
   return runWithAcquiredLock(client, lockName, lockValue, callback);
+};
+
+export const executeWithRenewingLockResult = async <T, E>(
+  lockName: string,
+  callback: (
+    lease: LockLeaseGuard
+  ) => Promise<Result<T, E | LockLeaseLostError>>,
+  timeoutMs: number = 30_000,
+  options: ExecuteWithLockOptions = {}
+): Promise<Result<T, E | LockAcquisitionTimeoutError | LockLeaseLostError>> => {
+  const { lockTtlMs = 5_000 } = options;
+  const { client, lockValue } = await acquireLock(lockName, timeoutMs, options);
+
+  if (!lockValue) {
+    return new Err(new LockAcquisitionTimeoutError(lockName));
+  }
+
+  return runWithRenewingLockResult(
+    client,
+    lockName,
+    lockValue,
+    callback,
+    lockTtlMs
+  );
 };


### PR DESCRIPTION
## Description

Add a result-based lock runner that renews ownership while a callback runs and exposes a lease guard for callers to check before committing writes. A refresh error or ownership change fails closed.

Stack: #31509 -> this PR. Timing and transient-error retry hardening remain a separate child.

## Tests

- All 6 focused core renewal tests pass.
- Biome and diff checks pass.

## Risk

No existing caller changes. The new runner fails the operation if renewal becomes uncertain.

## Deploy Plan

Merge after #31509. No migration is required.