### PR TITLE
Register Frames through authorized filesystems

### DIFF
--- a/front/lib/api/frames/register_from_source.ts
+++ b/front/lib/api/frames/register_from_source.ts
@@ -4,6 +4,7 @@ import { DustFileSystem } from "@app/lib/api/file_system";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import {
   FRAME_MANIFEST_FILE,
   parseFrameManifest,
@@ -45,14 +46,14 @@ export type RegisterFrameV2FromSourceError =
   | DustFileSystemError
   | FramePublicationError;
 
-/** Register the manifest already present on the invoking conversation's mounted GCS filesystem. */
-export async function registerFrameV2FromSource(
+/** Register a Frames v2 manifest through an already authorized GCS filesystem. */
+export async function registerFrameV2FromSourceUsingFileSystem(
   auth: Authenticator,
   {
-    conversation,
+    dustFs,
     manifestPath,
   }: {
-    conversation: ConversationWithoutContentType;
+    dustFs: DustFileSystem;
     manifestPath: string;
   }
 ): Promise<
@@ -71,11 +72,6 @@ export async function registerFrameV2FromSource(
     );
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
-  if (fsResult.isErr()) {
-    return new Err(fsResult.error);
-  }
-  const dustFs = fsResult.value;
   if (!dustFs.isGCSBacked()) {
     return registrationError(
       "Frames v2 registration does not yet support the database-backed filesystem."
@@ -135,18 +131,24 @@ export async function registerFrameV2FromSource(
     mount.kind === "pod" ? { spaceId: mount.id } : { conversationId: mount.id };
 
   try {
-    const frame = await FileResource.makeNew({
-      workspaceId: auth.getNonNullableWorkspace().id,
-      userId: auth.user()?.id ?? null,
-      contentType: frameV2ContentType,
-      fileName: FRAME_MANIFEST_FILE,
-      fileSize: manifestBuffer.length,
-      useCase,
-      useCaseMetadata,
-      mountFilePath,
-      fileSystemNodeId: null,
+    const frame = await withTransaction(async (transaction) => {
+      const created = await FileResource.makeNew(
+        {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          userId: auth.user()?.id ?? null,
+          contentType: frameV2ContentType,
+          fileName: FRAME_MANIFEST_FILE,
+          fileSize: manifestBuffer.length,
+          useCase,
+          useCaseMetadata,
+          mountFilePath,
+          fileSystemNodeId: null,
+        },
+        { transaction }
+      );
+      await created.markFrameV2AsReadyFromMount(auth, { transaction });
+      return created;
     });
-    await frame.markFrameV2AsReadyFromMount(auth);
     return new Ok({ frame, created: true });
   } catch (error) {
     if (!(error instanceof UniqueConstraintError)) {
@@ -160,4 +162,31 @@ export async function registerFrameV2FromSource(
     assert(concurrent.value, "Frame not found after mount path conflict");
     return new Ok({ frame: concurrent.value, created: false });
   }
+}
+
+/** Register the manifest already present on the invoking conversation's mounted GCS filesystem. */
+export async function registerFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { frame: FileResource; created: boolean },
+    RegisterFrameV2FromSourceError
+  >
+> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+
+  return registerFrameV2FromSourceUsingFileSystem(auth, {
+    dustFs: fsResult.value,
+    manifestPath,
+  });
 }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -164,14 +164,18 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   static async makeNew(
-    blob: Omit<CreationAttributes<FileModel>, "status" | "sId" | "version">
+    blob: Omit<CreationAttributes<FileModel>, "status" | "sId" | "version">,
+    { transaction }: { transaction?: Transaction } = {}
   ) {
-    const key = await FileResource.model.create({
-      ...blob,
-      fileName: sanitizeFileSystemName(blob.fileName),
-      status: "created",
-      version: 0,
-    });
+    const key = await FileResource.model.create(
+      {
+        ...blob,
+        fileName: sanitizeFileSystemName(blob.fileName),
+        status: "created",
+        version: 0,
+      },
+      { transaction }
+    );
 
     return new this(FileResource.model, key.get());
   }
@@ -770,17 +774,20 @@ export class FileResource extends BaseResource<FileModel> {
    * Mark a Frames v2 manifest that already exists at its mount path as ready.
    * Unlike markAsReady(), this must not copy from the canonical upload path.
    */
-  async markFrameV2AsReadyFromMount(auth: Authenticator) {
+  async markFrameV2AsReadyFromMount(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
     assert(this.isFrameV2, "Only Frames v2 can be adopted from a mount path");
     assert(this.mountFilePath, "A mounted Frames v2 manifest requires a path");
 
-    await this.ensureShareableFrame(auth);
+    await this.ensureShareableFrame(auth, { transaction });
 
     if (this.status === "ready") {
       return;
     }
 
-    return this.update({ status: "ready" });
+    return this.update({ status: "ready" }, transaction);
   }
 
   get isReady(): boolean {
@@ -807,7 +814,10 @@ export class FileResource extends BaseResource<FileModel> {
     return isFrameContentType(this.contentType);
   }
 
-  async ensureShareableFrame(auth: Authenticator): Promise<void> {
+  async ensureShareableFrame(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
     if (!this.isShareableFrame) {
       return;
     }
@@ -829,6 +839,7 @@ export class FileResource extends BaseResource<FileModel> {
         sharedAt: new Date(),
         token: crypto.randomUUID(),
       },
+      transaction,
     });
   }
 


### PR DESCRIPTION
## Description

Make Frames v2 registration atomic and reusable with an already-authorized filesystem. The existing registration path delegates to the new primitive without changing its contract.

## Tests

- Frame source registration suite: 2 passed

## Risk

Low. Existing registration behavior is preserved and creation now commits with the ready and sharing records.

## Deploy Plan

Standard deploy.