### PR TITLE
Measure renewable leases from request start

### DIFF
--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -55,6 +55,32 @@ describe("renewing locks", () => {
     ).resolves.toBe(false);
   });
 
+  it("measures the initial lease from the start of lock acquisition", async () => {
+    const redisClient = makeRedisClient();
+    let finishAcquisition: (value: string) => void = () => {};
+    const pendingAcquisition = new Promise<string>((resolve) => {
+      finishAcquisition = resolve;
+    });
+    vi.mocked(redisClient.set).mockImplementationOnce(() => pendingAcquisition);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const resultPromise = executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    await vi.advanceTimersByTimeAsync(90);
+    finishAcquisition("OK");
+    const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
   it("does not overlap renewal requests", async () => {
     const redisClient = makeRedisClient();
     let finishRefresh: (value: number) => void = () => {};
@@ -162,6 +188,34 @@ describe("renewing locks", () => {
       { lockTtlMs: 90 }
     );
     const result = await resultPromise;
+
+    expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("measures a renewed lease from refresh start, not a delayed response", async () => {
+    const redisClient = makeRedisClient();
+    let finishRefresh: (value: number) => void = () => {};
+    const pendingRefresh = new Promise<number>((resolve) => {
+      finishRefresh = resolve;
+    });
+    vi.mocked(redisClient.eval)
+      .mockImplementationOnce(() => pendingRefresh)
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const result = await executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(30);
+        await vi.advanceTimersByTimeAsync(60);
+        finishRefresh(1);
+        await vi.advanceTimersByTimeAsync(22);
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("unexpectedly-held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
 
     expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
   });

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -131,13 +131,19 @@ async function acquireLock(
     retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS,
     traceAcquireResource,
   }: ExecuteWithLockOptions
-): Promise<{ client: RedisClientType; lockValue: string | undefined }> {
+): Promise<{
+  client: RedisClientType;
+  lockAttemptStartedAtMs: number | undefined;
+  lockValue: string | undefined;
+}> {
   const client = await getRedisStreamClient({ origin: "lock" });
+  let lockAttemptStartedAtMs: number | undefined;
 
   const acquire = async (): Promise<string | undefined> => {
     const startMs = Date.now();
     let acquired: string | undefined;
     while (Date.now() - startMs < timeoutMs) {
+      lockAttemptStartedAtMs = performance.now();
       // Try to acquire the lock
       acquired = await distributedLock(client, lockName, lockTtlMs);
       if (acquired) {
@@ -160,7 +166,11 @@ async function acquireLock(
       )
     : await acquire();
 
-  return { client, lockValue };
+  return {
+    client,
+    lockAttemptStartedAtMs: lockValue ? lockAttemptStartedAtMs : undefined,
+    lockValue,
+  };
 }
 
 async function runWithAcquiredLock<T>(
@@ -237,10 +247,15 @@ async function runWithRenewingLockResult<T, E>(
   callback: (
     lease: LockLeaseGuard
   ) => Promise<Result<T, E | LockLeaseLostError>>,
-  lockTtlMs: number
+  lockTtlMs: number,
+  lockAttemptStartedAtMs: number
 ): Promise<Result<T, E | LockLeaseLostError>> {
   const renewalIntervalMs = Math.max(1, Math.floor(lockTtlMs / 3));
-  const lease = createLockLeaseGuard(lockName, lockTtlMs, performance.now());
+  const lease = createLockLeaseGuard(
+    lockName,
+    lockTtlMs,
+    lockAttemptStartedAtMs
+  );
   const stopController = new AbortController();
   const renew = async () => {
     const nextRenewalDelayMs = () =>
@@ -339,9 +354,13 @@ export const executeWithRenewingLockResult = async <T, E>(
   options: ExecuteWithLockOptions = {}
 ): Promise<Result<T, E | LockAcquisitionTimeoutError | LockLeaseLostError>> => {
   const { lockTtlMs = 5_000 } = options;
-  const { client, lockValue } = await acquireLock(lockName, timeoutMs, options);
+  const { client, lockAttemptStartedAtMs, lockValue } = await acquireLock(
+    lockName,
+    timeoutMs,
+    options
+  );
 
-  if (!lockValue) {
+  if (!lockValue || lockAttemptStartedAtMs === undefined) {
     return new Err(new LockAcquisitionTimeoutError(lockName));
   }
 
@@ -350,6 +369,7 @@ export const executeWithRenewingLockResult = async <T, E>(
     lockName,
     lockValue,
     callback,
-    lockTtlMs
+    lockTtlMs,
+    lockAttemptStartedAtMs
   );
 };


### PR DESCRIPTION
## Description\n\nMeasure renewable lease safety from the start of the successful acquisition request, not from its delayed response. The same request-start rule already used for refreshes now has direct regression coverage.\n\nMandatory lock correctness stack: #31509 -> #31512 -> this PR. Frame lock wrappers may build on this head. Transient refresh retries and recovery logging move to a separate late hardening tip.\n\n## Tests\n\n- Renewable lock suite: 8 tests passed, including delayed acquisition and delayed refresh responses\n- Biome and diff checks\n\n## Risk\n\nLow. A delayed Redis response can only shorten the locally trusted lifetime; it can no longer extend trust beyond the Redis TTL.\n\n## Deploy Plan\n\nMerge after #31512, before renewable Frame wrapper adoption.