### PR TITLE
Guard sandbox cleanup with renewable leases

### DIFF
--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -261,14 +261,16 @@ export class FrameSandboxAdapter {
     frame: FrameSandboxOwner,
     {
       afterSandboxCleanup,
+      beforeSandboxCleanup,
     }: {
       afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+      beforeSandboxCleanup?: () => Result<void, Error>;
     } = {}
   ): Promise<Result<undefined, Error>> {
     return SandboxResource.deleteByOwner(
       auth,
       this.toSandboxDeleteOwner(auth, frame),
-      { afterSandboxCleanup }
+      { afterSandboxCleanup, beforeSandboxCleanup }
     );
   }
 

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -52,6 +52,7 @@ import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sand
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import {
   SandboxModel,
   SandboxOwnerModel,
@@ -62,6 +63,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 import { encrypt } from "@app/types/shared/utils/encryption";
@@ -479,6 +481,74 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
       }),
     ]);
     expect([linkCount, sandboxCount]).toEqual([0, 0]);
+  });
+
+  it("rolls back sandbox rows when the lease is lost before commit", async () => {
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON()
+    );
+    const workspaceModelId = authenticator.getNonNullableWorkspace().id;
+    const leaseError = new Error("lease lost");
+    let leaseChecks = 0;
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+
+    await expect(
+      frontSequelize.transaction(
+        { transaction: parentTransaction },
+        async () => {
+          const result = await SandboxResource.deleteByOwner(
+            authenticator,
+            {
+              lockKey: conversationResource.sId,
+              fetchSandbox: () =>
+                ConversationSandboxAdapter.fetchSandbox(
+                  authenticator,
+                  conversationResource.toJSON()
+                ),
+              deleteSandbox: async (sandboxToDelete, transaction) => {
+                await SandboxOwnerModel.destroy({
+                  where: {
+                    conversationId: conversationResource.id,
+                    sandboxId: sandboxToDelete.id,
+                    workspaceId: workspaceModelId,
+                  },
+                  transaction,
+                });
+              },
+            },
+            {
+              beforeSandboxCleanup: () => {
+                leaseChecks += 1;
+                return leaseChecks === 3
+                  ? new Err(leaseError)
+                  : new Ok(undefined);
+              },
+            }
+          );
+          throw result.isErr()
+            ? result.error
+            : new Error("Expected the sandbox deletion lease to be lost.");
+        }
+      )
+    ).rejects.toBe(leaseError);
+
+    const [linkCount, sandboxCount] = await Promise.all([
+      SandboxOwnerModel.count({
+        where: {
+          conversationId: conversationResource.id,
+          sandboxId: sandbox.id,
+          workspaceId: workspaceModelId,
+        },
+      }),
+      SandboxModel.count({
+        where: { id: sandbox.id, workspaceId: workspaceModelId },
+      }),
+    ]);
+    expect(leaseChecks).toBe(3);
+    expect([linkCount, sandboxCount]).toEqual([1, 1]);
   });
 });
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -527,8 +527,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     owner: SandboxDeleteOwner,
     {
       afterSandboxCleanup,
+      beforeSandboxCleanup,
     }: {
       afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+      beforeSandboxCleanup?: () => Result<void, Error>;
     } = {}
   ): Promise<Result<undefined, Error>> {
     return this.withLifecycleLockWithOptionalProvider(
@@ -543,6 +545,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         if (sandbox.status !== "deleted") {
+          const heldBeforeProviderCleanup = beforeSandboxCleanup?.();
+          if (heldBeforeProviderCleanup?.isErr()) {
+            return heldBeforeProviderCleanup;
+          }
           const tracingOpts = {
             workspaceId: auth.getNonNullableWorkspace().sId,
           };
@@ -561,16 +567,34 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
         }
 
-        await withTransaction(async (transaction) => {
-          await owner.deleteSandbox(sandbox, transaction);
-          await SandboxModel.destroy({
-            where: {
-              id: sandbox.id,
-              workspaceId: auth.getNonNullableWorkspace().id,
-            },
-            transaction,
+        const heldBeforeDatabaseCleanup = beforeSandboxCleanup?.();
+        if (heldBeforeDatabaseCleanup?.isErr()) {
+          return heldBeforeDatabaseCleanup;
+        }
+        let leaseError: Error | undefined;
+        try {
+          await withTransaction(async (transaction) => {
+            await owner.deleteSandbox(sandbox, transaction);
+            await SandboxModel.destroy({
+              where: {
+                id: sandbox.id,
+                workspaceId: auth.getNonNullableWorkspace().id,
+              },
+              transaction,
+            });
+
+            const heldBeforeDatabaseCommit = beforeSandboxCleanup?.();
+            if (heldBeforeDatabaseCommit?.isErr()) {
+              leaseError = heldBeforeDatabaseCommit.error;
+              throw leaseError;
+            }
           });
-        });
+        } catch (error) {
+          if (leaseError && error === leaseError) {
+            return new Err(leaseError);
+          }
+          throw error;
+        }
 
         return afterSandboxCleanup?.() ?? new Ok(undefined);
       }


### PR DESCRIPTION
## Description

Add the generic pre-cleanup lease boundary required by Frame deletion: the callback is checked before provider destruction, before database cleanup, and again before transaction commit. A lost lease stops cleanup and rolls database changes back. FrameSandboxAdapter forwards the optional guard to the shared sandbox cleanup primitive.

Stack: #31509 -> #31512 -> #31514 -> #31489 -> this PR. Source-lock and publication adoption follow this shared cleanup primitive. Retry/logging hardening #31551 is an independent sibling.

## Tests

- Focused SandboxResource coverage proves lease loss before commit rolls back owner and sandbox rows.
- Frame sandbox adapter tests cover the forwarded callback contract.
- 53 focused tests pass.
- Biome and diff checks pass.

## Risk

Existing callers are unchanged because the guard is optional. Guarded cleanup now fails instead of committing after ownership is lost.

## Deploy Plan

Merge after #31489. No migration is required.