### PR TITLE
Renew Frame publication operation locks

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -11,8 +11,13 @@ import { getRedisStreamClient } from "@app/lib/api/redis";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import type { Authenticator } from "@app/lib/auth";
-import { LockAcquisitionTimeoutError } from "@app/lib/lock";
+import {
+  isLockLeaseLostError,
+  LockAcquisitionTimeoutError,
+  LockLeaseLostError,
+} from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import {
   computeSandboxFunctionBundleSha256,
   SandboxFunctionResource,
@@ -594,6 +599,101 @@ describe("activateFramePublication", () => {
     );
   });
 
+  it("does not start activation when the lease is already lost", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    const leaseError = new LockLeaseLostError(
+      getFramePublishLockName(frame.sId)
+    );
+    const lease = {
+      check: vi.fn().mockReturnValue(new Err(leaseError)),
+    };
+    const setActivePublication = vi.spyOn(frame, "setActiveFramePublication");
+
+    const activated = await activateFramePublication(auth, {
+      frame,
+      lease,
+      publicationId: stored.value.publicationId,
+    });
+
+    expect(activated.isErr() && isLockLeaseLostError(activated.error)).toBe(
+      true
+    );
+    expect(setActivePublication).not.toHaveBeenCalled();
+  });
+
+  it("rolls back activation when the lease is lost before commit", async () => {
+    const { auth, frame } = await setupFrame();
+    const stored = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts,
+      manifest: manifestWithFunction,
+      sourceFiles: sourceFilesWithFunction,
+      uiBundleCode,
+    });
+    expect(stored.isOk()).toBe(true);
+    if (stored.isErr()) {
+      return;
+    }
+    const leaseError = new LockLeaseLostError(
+      getFramePublishLockName(frame.sId)
+    );
+    const lease = {
+      check: vi
+        .fn()
+        .mockReturnValueOnce(new Ok(undefined))
+        .mockReturnValueOnce(new Err(leaseError)),
+    };
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+
+    await expect(
+      frontSequelize.transaction(
+        { transaction: parentTransaction },
+        async () => {
+          const activated = await activateFramePublication(auth, {
+            frame,
+            lease,
+            publicationId: stored.value.publicationId,
+          });
+          throw activated.isErr()
+            ? activated.error
+            : new Error("Expected the activation lease to be lost.");
+        }
+      )
+    ).rejects.toMatchObject({ name: "LockLeaseLostError" });
+
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.activePublicationId).toBeUndefined();
+    expect(
+      await FileResource.shareableFileModel.count({
+        where: { fileId: frame.id, workspaceId: frame.workspaceId },
+      })
+    ).toBe(0);
+    expect(
+      await FileResource.authorizedFileAccessModel.count({
+        where: { workspaceId: frame.workspaceId },
+      })
+    ).toBe(0);
+    expect(
+      await SandboxFunctionResource.listByFramePublication(auth, {
+        frame,
+        publicationId: stored.value.publicationId,
+      })
+    ).toHaveLength(0);
+  });
+
   it("keeps the active publication when validation fails", async () => {
     const { auth, frame } = await setupFrame();
     const stored = await storeFramePublication(auth, {
@@ -618,9 +718,11 @@ describe("activateFramePublication", () => {
       publicationId: "b8c2b796-534a-4ad2-a5ad-071da692ca0b",
     });
 
-    expect(activation.isErr() && activation.error.code).toBe(
-      "publication_not_found"
-    );
+    expect(
+      activation.isErr() && "code" in activation.error
+        ? activation.error.code
+        : undefined
+    ).toBe("publication_not_found");
     const reloaded = await FileResource.fetchById(auth, frame.sId);
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
@@ -699,9 +801,9 @@ describe("activateFramePublication", () => {
       publicationId: stored.value.publicationId,
     });
 
-    expect(result.isErr() && result.error.code).toBe(
-      "invalid_function_artifact"
-    );
+    expect(
+      result.isErr() && "code" in result.error ? result.error.code : undefined
+    ).toBe("invalid_function_artifact");
     expect(frame.useCaseMetadata?.activePublicationId).toBeUndefined();
   });
 
@@ -1052,5 +1154,45 @@ describe("publishFramePublication", () => {
       deletion.isErr() ? deletion.error.message : undefined
     ).toBe(true);
     await expect(FileResource.fetchById(auth, frame.sId)).resolves.toBeNull();
+  });
+
+  it("preserves the Frame when its deletion lease is lost", async () => {
+    const { auth, frame } = await setupFrame({ ready: true });
+    const onDeleteByPrefix = vi.fn();
+    fileStorageMock.setOnDeleteByPrefix(onDeleteByPrefix);
+    const redisEval = vi.mocked(
+      redisMock.streamClient.eval as (...args: unknown[]) => Promise<number>
+    );
+    redisEval.mockResolvedValueOnce(0).mockResolvedValue(1);
+    const deleteSandbox = vi
+      .spyOn(FrameSandboxAdapter, "deleteSandbox")
+      .mockImplementation(
+        async (
+          _auth,
+          _frame,
+          { afterSandboxCleanup, beforeSandboxCleanup } = {}
+        ) => {
+          expect(beforeSandboxCleanup?.().isOk()).toBe(true);
+          await vi.advanceTimersByTimeAsync(200_000);
+          return afterSandboxCleanup?.() ?? new Ok(undefined);
+        }
+      );
+    vi.useFakeTimers();
+
+    try {
+      const deletion = await frame.delete(auth);
+
+      expect(deletion.isErr() && isLockLeaseLostError(deletion.error)).toBe(
+        true
+      );
+      await expect(
+        FileResource.fetchById(auth, frame.sId)
+      ).resolves.not.toBeNull();
+      expect(onDeleteByPrefix).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      deleteSandbox.mockRestore();
+      redisEval.mockResolvedValue(1);
+    }
   });
 });

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -15,7 +15,11 @@ import {
   getPrivateUploadBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
-import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
+import type { LockLeaseGuard, LockLeaseLostError } from "@app/lib/lock";
+import {
+  isLockAcquisitionTimeoutError,
+  isLockLeaseLostError,
+} from "@app/lib/lock";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FramePublicationFunctionDefinition } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -456,12 +460,14 @@ export async function activateFramePublication(
   auth: Authenticator,
   {
     frame,
+    lease,
     publicationId,
   }: {
     frame: FileResource;
+    lease?: LockLeaseGuard;
     publicationId: string;
   }
-): Promise<Result<void, FramePublicationError>> {
+): Promise<Result<void, FramePublicationError | LockLeaseLostError>> {
   const descriptor = await loadFramePublicationDescriptor(auth, {
     frame,
     publicationId,
@@ -522,21 +528,40 @@ export async function activateFramePublication(
   }
   const shareScope = await frame.getShareScope();
 
-  await withTransaction(async (transaction) => {
-    // Updating the Frame first serializes concurrent activations. None of the
-    // new publication state becomes visible until the transaction commits.
-    await frame.setActiveFramePublication(publicationId, transaction);
-    await frame.persistAuthorizedFileAccess(allowlist.value, { transaction });
-    await SandboxFunctionResource.createForFramePublication(
-      auth,
-      {
-        frame,
-        functions: functionDefinitions.value,
-        publicationId,
-      },
-      transaction
-    );
-  });
+  try {
+    await withTransaction(async (transaction) => {
+      const heldBeforeActivation = lease?.check();
+      if (heldBeforeActivation?.isErr()) {
+        throw heldBeforeActivation.error;
+      }
+
+      // Updating the Frame first serializes concurrent activations. None of the
+      // new publication state becomes visible until the transaction commits.
+      await frame.setActiveFramePublication(publicationId, transaction);
+      await frame.persistAuthorizedFileAccess(allowlist.value, {
+        transaction,
+      });
+      await SandboxFunctionResource.createForFramePublication(
+        auth,
+        {
+          frame,
+          functions: functionDefinitions.value,
+          publicationId,
+        },
+        transaction
+      );
+
+      const heldBeforeCommit = lease?.check();
+      if (heldBeforeCommit?.isErr()) {
+        throw heldBeforeCommit.error;
+      }
+    });
+  } catch (error) {
+    if (isLockLeaseLostError(error)) {
+      return new Err(error);
+    }
+    throw error;
+  }
 
   emitFrameAuthorizedFilesUpdatedAuditLog(
     auth,
@@ -589,7 +614,7 @@ export async function publishFramePublication(
   const publication = await withFramePublishLock<
     { publicationId: string },
     FramePublicationError | SandboxFunctionError
-  >(frame.sId, async () => {
+  >(frame.sId, async (lease) => {
     const storedPublication = await storeFramePublication(auth, {
       frame,
       functionArtifacts,
@@ -601,6 +626,10 @@ export async function publishFramePublication(
       return storedPublication;
     }
 
+    const heldBeforeReconciliation = lease.check();
+    if (heldBeforeReconciliation.isErr()) {
+      return heldBeforeReconciliation;
+    }
     const reconciliation = await reconcileFramePublicationDatabases(auth, {
       frame,
       manifest,
@@ -610,8 +639,13 @@ export async function publishFramePublication(
       return reconciliation;
     }
 
+    const heldBeforeActivation = lease.check();
+    if (heldBeforeActivation.isErr()) {
+      return heldBeforeActivation;
+    }
     const activation = await activateFramePublication(auth, {
       frame,
+      lease,
       publicationId: storedPublication.value.publicationId,
     });
     if (activation.isErr()) {
@@ -622,7 +656,7 @@ export async function publishFramePublication(
   });
   if (publication.isErr()) {
     const error = publication.error;
-    if (isLockAcquisitionTimeoutError(error)) {
+    if (isLockAcquisitionTimeoutError(error) || isLockLeaseLostError(error)) {
       return new Err(
         new SandboxFunctionError(
           "publish_conflict",

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -35,6 +35,7 @@ import {
   getUpsertQueueBucket,
 } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import type { LockLeaseGuard } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -640,11 +641,21 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   private async deleteAfterSandboxCleanup(
-    auth: Authenticator
+    auth: Authenticator,
+    lease?: LockLeaseGuard
   ): Promise<Result<undefined, Error>> {
     try {
+      const checkLease = () => {
+        const held = lease?.check();
+        if (held?.isErr()) {
+          throw held.error;
+        }
+      };
+
       if (this.isFrameV2) {
+        checkLease();
         await this.deleteFrameFunctions(auth);
+        checkLease();
         await getPrivateUploadBucket().deleteByPrefix(
           getFrameBasePath({
             workspaceId: auth.getNonNullableWorkspace().sId,
@@ -654,35 +665,43 @@ export class FileResource extends BaseResource<FileModel> {
       }
 
       if (this.isReady) {
+        checkLease();
         await maybeDeleteCoreArtifactsForIndexedFile(auth, this);
 
         // Delete mount file copies if set.
+        checkLease();
         await this.deleteMountFileCopies();
 
+        checkLease();
         await this.getBucketForVersion("original")
           .file(this.getCloudStoragePath(auth, "original"))
           .delete();
 
         // Delete the processed file if it exists.
+        checkLease();
         await this.getBucketForVersion("processed")
           .file(this.getCloudStoragePath(auth, "processed"))
           .delete({ ignoreNotFound: true });
         // Delete the public file if it exists.
+        checkLease();
         await this.getBucketForVersion("public")
           .file(this.getCloudStoragePath(auth, "public"))
           .delete({ ignoreNotFound: true });
 
         // Delete sharing grants and access snapshots before shareable file (FK constraint).
+        checkLease();
         const shareableFile = await FileResource.shareableFileModel.findOne({
           where: { fileId: this.id, workspaceId: this.workspaceId },
         });
         if (shareableFile) {
+          checkLease();
           await SharingGrantModel.destroy({
             where: {
               shareableFileId: shareableFile.id,
               workspaceId: this.workspaceId,
             },
           });
+          checkLease();
           await FileResource.authorizedFileAccessModel.destroy({
             where: {
               shareableFileId: shareableFile.id,
@@ -692,6 +711,7 @@ export class FileResource extends BaseResource<FileModel> {
         }
 
         // Delete the shareable file record.
+        checkLease();
         await FileResource.shareableFileModel.destroy({
           where: {
             fileId: this.id,
@@ -700,6 +720,7 @@ export class FileResource extends BaseResource<FileModel> {
         });
       }
 
+      checkLease();
       await this.model.destroy({
         where: {
           id: this.id,
@@ -718,11 +739,16 @@ export class FileResource extends BaseResource<FileModel> {
       return this.deleteAfterSandboxCleanup(auth);
     }
 
-    return withFramePublishLock(this.sId, () =>
-      FrameSandboxAdapter.deleteSandbox(auth, this, {
-        afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth),
-      })
-    );
+    return withFramePublishLock(this.sId, async (lease) => {
+      const held = lease.check();
+      if (held.isErr()) {
+        return held;
+      }
+      return FrameSandboxAdapter.deleteSandbox(auth, this, {
+        afterSandboxCleanup: () => this.deleteAfterSandboxCleanup(auth, lease),
+        beforeSandboxCleanup: () => lease.check(),
+      });
+    });
   }
 
   get sId(): string {


### PR DESCRIPTION
## Description

Adopt renewable lease checks for Frame publication, activation, and deletion before durable state changes. The inherited #31516 primitive carries the lease guard through sandbox cleanup. This slice uses the publish-lock domain; the following slice adds the outer source lock for publication.

Stack: #31516 -> #31499 -> this PR. Retry/logging hardening #31551 is independent and is not inherited.

## Tests

- 88 focused publication and FileResource tests pass.
- Biome and diff checks pass.

## Risk

Publication or deletion now fails rather than committing after losing publish-lock ownership. Existing timeout errors remain typed.

## Deploy Plan

Merge after #31499. No migration is required.