### PR TITLE
Resolve Frame function references by renderer kind

### DIFF
--- a/front/types/api/frame_function_reference.test.ts
+++ b/front/types/api/frame_function_reference.test.ts
@@ -1,0 +1,59 @@
+import {
+  getFrameFunctionReferenceKind,
+  resolveFrameFunctionReference,
+} from "@app/types/api/frame_function_reference";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+describe("resolveFrameFunctionReference", () => {
+  it("qualifies a Frames v2 function with the stable Frame identity", () => {
+    const result = resolveFrameFunctionReference("list-comments", {
+      kind: "v2",
+      frameId: "file_123",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe("file_123/list-comments");
+  });
+
+  it("rejects cross-Frame references from Frames v2", () => {
+    const result = resolveFrameFunctionReference("file_other/list-comments", {
+      kind: "v2",
+      frameId: "file_123",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("keeps legacy Pod-relative resolution unchanged", () => {
+    const result = resolveFrameFunctionReference("list-comments", {
+      kind: "legacy",
+      podFunctionScope: { podId: "pod_123", appPrefix: "comments" },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe(
+      "pod_123/comments__list-comments"
+    );
+  });
+});
+
+describe("getFrameFunctionReferenceKind", () => {
+  it("classifies only known Frame MIME types", () => {
+    expect(getFrameFunctionReferenceKind(frameV2ContentType)).toBe("v2");
+    expect(getFrameFunctionReferenceKind(frameContentType)).toBe("legacy");
+    expect(getFrameFunctionReferenceKind(frameSlideshowContentType)).toBe(
+      "legacy"
+    );
+  });
+
+  it("does not treat absent or unknown metadata as legacy", () => {
+    expect(getFrameFunctionReferenceKind(null)).toBeNull();
+    expect(getFrameFunctionReferenceKind(undefined)).toBeNull();
+    expect(getFrameFunctionReferenceKind("text/plain")).toBeNull();
+  });
+});

--- a/front/types/api/frame_function_reference.ts
+++ b/front/types/api/frame_function_reference.ts
@@ -1,0 +1,50 @@
+import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
+import {
+  isRelativePodFunctionReference,
+  resolvePodFunctionReference,
+} from "@app/types/api/pod_function_reference";
+import { frameV2ContentType, isInteractiveContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type FrameFunctionReferenceScope =
+  | { kind: "v2"; frameId: string }
+  | { kind: "legacy"; podFunctionScope: PodFunctionScope | null };
+
+export type FrameFunctionReferenceKind = FrameFunctionReferenceScope["kind"];
+
+/** Classify only known Frame MIME types. Missing metadata must never imply a legacy Frame. */
+export function getFrameFunctionReferenceKind(
+  contentType: string | null | undefined
+): FrameFunctionReferenceKind | null {
+  if (contentType === frameV2ContentType) {
+    return "v2";
+  }
+  if (contentType && isInteractiveContentType(contentType)) {
+    return "legacy";
+  }
+  return null;
+}
+
+/** Resolve the function reference emitted by a Frame against that Frame's trusted host identity. */
+export function resolveFrameFunctionReference(
+  reference: string,
+  scope: FrameFunctionReferenceScope
+): Result<string, Error> {
+  switch (scope.kind) {
+    case "v2":
+      if (!isRelativePodFunctionReference(reference)) {
+        return new Err(
+          new Error(
+            `'${reference}' is not a Frames v2 function name: expected a bare manifest function name.`
+          )
+        );
+      }
+      return new Ok(`${scope.frameId}/${reference}`);
+    case "legacy":
+      return resolvePodFunctionReference(reference, scope.podFunctionScope);
+    default:
+      return assertNever(scope);
+  }
+}


### PR DESCRIPTION
## Description

Classify renderer function references by Frame kind. Frames v2 qualify bare manifest function names with the stable Frame id, while legacy Frames keep Pod-relative resolution.

This is the shared base for the renderer replacements of #31401. No visual or Sparkle property changes.

## Tests

- Front Vitest: 1 file, 5 tests passed
- `git diff --check`

## Risk

Low. This adds a typed resolver and tests without changing a renderer call site. Rollback is reverting this PR.

## Deploy Plan

Deploy normally. Merge before its renderer children.
