### PR TITLE
Bind renderer invocations to Frame identity

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,6 +1,30 @@
-import { getFrameRuntimeAccess } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import {
+  getFrameRuntimeAccess,
+  VisualizationActionIframe,
+} from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clientFetch: vi.fn(),
+}));
+
+vi.mock("@app/hooks/conversations", () => ({
+  useVisualizationRetry: () => ({
+    canRetry: false,
+    handleVisualizationRetry: vi.fn(),
+  }),
+}));
+
+vi.mock("@app/hooks/useNotification", () => ({
+  useSendNotification: () => vi.fn(),
+}));
+
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: mocks.clientFetch,
+}));
 
 const user = {
   sId: "usr_123",
@@ -14,6 +38,11 @@ const scopedUserIdentity: ScopedWorkspaceUserIdentity = {
   workspaceId: "w_current",
   user,
 };
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe("getFrameRuntimeAccess", () => {
   it("enables access with an identity scoped to the Frame workspace", () => {
@@ -97,6 +126,62 @@ describe("getFrameRuntimeAccess", () => {
         isPodMember: false,
         user,
       },
+    });
+  });
+});
+
+describe("VisualizationActionIframe", () => {
+  it("routes a Frames v2 call through the rendered Frame identity", async () => {
+    mocks.clientFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          invocation: { functionId: "sfn_function", sId: "sfi_invocation" },
+          outcome: { status: "succeeded", result: { ok: true } },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const { container } = render(
+      createElement(VisualizationActionIframe, {
+        agentConfigurationId: null,
+        canInvokeFunctions: true,
+        conversationId: null,
+        frameId: "fil_frame",
+        scopedUserIdentity,
+        viewer: null,
+        visualization: {
+          code: "export default function Frame() {}",
+          complete: true,
+          identifier: "viz-fil_frame",
+        },
+        vizUrl: "https://viz.dust.tt",
+        workspaceId: "w_current",
+      })
+    );
+    const iframe = container.querySelector("iframe");
+    if (!iframe?.contentWindow) {
+      throw new Error("Expected the visualization iframe to be mounted.");
+    }
+    vi.spyOn(iframe.contentWindow, "postMessage").mockImplementation(() => {});
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframe.contentWindow,
+        data: {
+          command: "callFunction",
+          identifier: "viz-fil_frame",
+          messageUniqueId: "message-1",
+          params: { functionIdOrSlug: "list-comments" },
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(mocks.clientFetch).toHaveBeenCalledWith(
+        "/api/w/w_current/sandbox-functions/fil_frame%2Flist-comments/invocations",
+        expect.objectContaining({ method: "POST" })
+      );
     });
   });
 });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -10,11 +10,9 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
-import {
-  podFunctionScopeFromFramePath,
-  resolvePodFunctionReference,
-} from "@app/types/api/pod_function_reference";
+import type { FrameFunctionReferenceScope } from "@app/types/api/frame_function_reference";
+import { resolveFrameFunctionReference } from "@app/types/api/frame_function_reference";
+import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
@@ -398,7 +396,7 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
-  podFunctionScope,
+  functionReferenceScope,
   setCodeDrawerOpened,
   setContentHeight,
   setErrorMessage,
@@ -416,7 +414,7 @@ function useVisualizationDataHandler({
     Result<PostSandboxFunctionInvocationResponseBody, SandboxFunctionCallError>
   >;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
-  podFunctionScope: PodFunctionScope | null;
+  functionReferenceScope: FrameFunctionReferenceScope;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
   setContentHeight: (v: SetStateAction<number>) => void;
@@ -486,11 +484,11 @@ function useVisualizationDataHandler({
 
       switch (data.command) {
         case "callFunction": {
-          // A Frame in an app folder may name its own functions by bare slug; qualify it here, the
-          // only layer that both knows which Frame is calling and is trusted about it.
-          const referenceRes = resolvePodFunctionReference(
+          // Qualify bare function names in the trusted host. Frames v2 bind to stable identity;
+          // legacy Frames keep their existing Pod app-folder resolution.
+          const referenceRes = resolveFrameFunctionReference(
             data.params.functionIdOrSlug,
-            podFunctionScope
+            functionReferenceScope
           );
           if (referenceRes.isErr()) {
             sendErrorToIframe(
@@ -613,7 +611,7 @@ function useVisualizationDataHandler({
     downloadFileFromBlob,
     getFileBlob,
     onEditText,
-    podFunctionScope,
+    functionReferenceScope,
     setContentHeight,
     setErrorMessage,
     setCodeDrawerOpened,
@@ -666,6 +664,8 @@ export interface VisualizationActionIframeProps {
    * bare name; without it, relative references are refused.
    */
   framePath?: string | null;
+  /** Stable identity of a Frames v2 resource. Omit for legacy Frames and raw visualizations. */
+  frameId?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
@@ -695,6 +695,13 @@ export const VisualizationActionIframe = forwardRef<
   const podFunctionScope = useMemo(
     () => podFunctionScopeFromFramePath(props.framePath),
     [props.framePath]
+  );
+  const functionReferenceScope = useMemo<FrameFunctionReferenceScope>(
+    () =>
+      props.frameId
+        ? { kind: "v2", frameId: props.frameId }
+        : { kind: "legacy", podFunctionScope },
+    [podFunctionScope, props.frameId]
   );
 
   // In-flight sandbox function invocations. Each entry mounts a
@@ -937,7 +944,7 @@ export const VisualizationActionIframe = forwardRef<
     createSandboxFunctionInvocation,
     getFileBlob,
     onEditText,
-    podFunctionScope,
+    functionReferenceScope,
     setCodeDrawerOpened,
     setContentHeight,
     setErrorMessage,

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -485,6 +485,7 @@ export function FrameRenderer({
               conversationId={conversation?.sId ?? null}
               spaceId={frameSpaceId ?? undefined}
               framePath={framePath}
+              frameId={renderMode === "v2" ? fileId : undefined}
               isInDrawer={true}
               isEditable={renderMode === "legacy"}
               onEditText={renderMode === "legacy" ? handleEditText : undefined}

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   iframeProps: null as {
     canInvokeFunctions: boolean;
+    frameId?: string;
     scopedUserIdentity?: ScopedWorkspaceUserIdentity;
     viewer: unknown;
   } | null,
@@ -25,6 +26,7 @@ vi.mock(
   () => ({
     VisualizationActionIframe: (props: {
       canInvokeFunctions: boolean;
+      frameId?: string;
       scopedUserIdentity?: ScopedWorkspaceUserIdentity;
       viewer: unknown;
     }) => {
@@ -144,7 +146,8 @@ describe("PublicFrameRenderer", () => {
 
     render(
       createElement(PublicFrameRenderer, {
-        fileId: "file_123",
+        fileId: "fil_frame",
+        frameId: "fil_frame",
         hideHeader: true,
         shareToken: "share-token",
         workspaceId: "w_current",
@@ -154,6 +157,7 @@ describe("PublicFrameRenderer", () => {
 
     expect(mocks.iframeProps).toMatchObject({
       canInvokeFunctions: true,
+      frameId: "fil_frame",
       scopedUserIdentity: {
         workspaceId: "w_current",
         isPodMember: true,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -16,6 +16,7 @@ import { useCookies } from "react-cookie";
 
 interface PublicFrameRendererProps {
   fileId: string;
+  frameId?: string;
   fileName?: string;
   hideHeader?: boolean;
   logoUrl?: string | null;
@@ -62,6 +63,7 @@ export function getPublicFrameUserIdentity(
 
 export function PublicFrameRenderer({
   fileId,
+  frameId,
   fileName,
   hideHeader = false,
   logoUrl,
@@ -161,6 +163,7 @@ export function PublicFrameRenderer({
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
             framePath={framePath}
+            frameId={frameId}
             isInDrawer
           />
         </div>

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.test.ts
@@ -1,0 +1,81 @@
+import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  frameMetadata: {
+    contentType: string;
+    fileName: string;
+    sId: string;
+  };
+  rendererProps: { fileId: string; frameId?: string } | null;
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  frameMetadata: {
+    contentType: "application/vnd.dust.frame.v2+json",
+    fileName: "app.frame.json",
+    sId: "fil_frame",
+  },
+  rendererProps: null,
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/PublicFrameRenderer",
+  () => ({
+    PublicFrameRenderer: (props: { fileId: string; frameId?: string }) => {
+      mocks.rendererProps = props;
+      return "public-frame-renderer";
+    },
+  })
+);
+
+vi.mock("@app/lib/swr/frames", () => ({
+  usePublicFrame: () => ({
+    error: null,
+    frameMetadata: mocks.frameMetadata,
+    isFrameLoading: false,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.frameMetadata = {
+    contentType: frameV2ContentType,
+    fileName: "app.frame.json",
+    sId: "fil_frame",
+  };
+  mocks.rendererProps = null;
+});
+
+describe("PublicInteractiveContentContainer", () => {
+  it("passes the stable identity only for Frames v2", () => {
+    const props = {
+      shareToken: "share-token",
+      workspaceId: "w_current",
+      vizUrl: "https://viz.dust.tt",
+    };
+    const { rerender } = render(
+      createElement(PublicInteractiveContentContainer, props)
+    );
+
+    expect(mocks.rendererProps).toMatchObject({
+      fileId: "fil_frame",
+      frameId: "fil_frame",
+    });
+
+    mocks.frameMetadata = {
+      contentType: frameContentType,
+      fileName: "legacy.tsx",
+      sId: "fil_legacy",
+    };
+    rerender(createElement(PublicInteractiveContentContainer, props));
+
+    expect(mocks.rendererProps).toEqual(
+      expect.objectContaining({ fileId: "fil_legacy" })
+    );
+    expect(mocks.rendererProps?.frameId).toBeUndefined();
+  });
+});

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -56,6 +56,11 @@ export function PublicInteractiveContentContainer({
         return (
           <PublicFrameRenderer
             fileId={frameMetadata.sId}
+            frameId={
+              frameMetadata.contentType === frameV2ContentType
+                ? frameMetadata.sId
+                : undefined
+            }
             fileName={frameMetadata.fileName}
             shareToken={shareToken}
             workspaceId={workspaceId}


### PR DESCRIPTION
## Description

Pass the stable Frames v2 identity through conversation and public renderers, then bind `callFunction` messages to that identity in the trusted iframe host. Legacy Frames keep Pod-relative resolution.

This is a focused renderer child replacing part of #31401. No visual or Sparkle property changes.

## Tests

- Front Vitest: 3 files, 14 tests passed
- `git diff --check`

## Risk

Low and feature-gated. Raw visualizations and legacy Frames do not receive a Frame id. Rollback is reverting this PR.

## Deploy Plan

Merge after the Frame function reference base. Deploy normally.
