### PR TITLE
Expose linked file metadata on path HEAD

### DIFF
--- a/front-api/middlewares/cors.test.ts
+++ b/front-api/middlewares/cors.test.ts
@@ -1,5 +1,8 @@
 import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+} from "@app/types/files";
 import { cors } from "@front-api/middlewares/cors";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
@@ -20,16 +23,19 @@ function getExposedHeaders(response: Response): string[] {
 }
 
 describe("cors middleware", () => {
-  it("exposes the linked file id header on cross-origin responses", async () => {
+  it("exposes linked file metadata headers on cross-origin responses", async () => {
     const response = await createApp().request("/", {
       headers: { Origin: APP_ORIGIN },
     });
 
     expect(response.status).toBe(200);
     expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+    expect(getExposedHeaders(response)).toContain(
+      DUST_FILE_CONTENT_TYPE_HEADER
+    );
   });
 
-  it("exposes the linked file id header on preflight responses", async () => {
+  it("exposes linked file metadata headers on preflight responses", async () => {
     const response = await createApp().request("/", {
       method: "OPTIONS",
       headers: { Origin: APP_ORIGIN },
@@ -37,6 +43,9 @@ describe("cors middleware", () => {
 
     expect(response.status).toBe(200);
     expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+    expect(getExposedHeaders(response)).toContain(
+      DUST_FILE_CONTENT_TYPE_HEADER
+    );
   });
 
   it("allows the frame share token header on preflight requests", async () => {

--- a/front-api/middlewares/cors.ts
+++ b/front-api/middlewares/cors.ts
@@ -4,7 +4,10 @@ import {
   isAllowedOrigin,
 } from "@app/config/cors";
 import logger from "@app/logger/logger";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+} from "@app/types/files";
 import { isDevelopment } from "@app/types/shared/env";
 import type { MiddlewareHandler } from "hono";
 
@@ -14,6 +17,7 @@ const EXPOSE_HEADERS = [
   "WWW-Authenticate",
   "mcp-session-id",
   "mcp-protocol-version",
+  DUST_FILE_CONTENT_TYPE_HEADER,
   DUST_FILE_ID_HEADER,
 ].join(", ");
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -4,7 +4,11 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { DUST_FILE_ID_HEADER, frameContentType } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+  frameV2ContentType,
+} from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -259,16 +263,16 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
     expect(fileStorageMock.readStreamCalls).toHaveLength(0);
   });
 
-  it("returns the linked file id header when a FileResource exists", async () => {
+  it("returns linked FileResource metadata without replacing raw metadata", async () => {
     const { workspace, auth, conversation } = await setup();
 
     setExistingFiles(["/files/frame.tsx"], {
-      contentType: frameContentType,
+      contentType: "text/plain",
       size: "2048",
     });
 
     const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
-      contentType: frameContentType,
+      contentType: frameV2ContentType,
       fileName: "frame.tsx",
       fileSize: 2048,
       status: "ready",
@@ -290,8 +294,11 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe(frameContentType);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
     expect(response.headers.get(DUST_FILE_ID_HEADER)).toBe(file.sId);
+    expect(response.headers.get(DUST_FILE_CONTENT_TYPE_HEADER)).toBe(
+      frameV2ContentType
+    );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -14,6 +14,7 @@ import {
 import { requestDustProjectIncrementalSyncForScopedPath } from "@app/lib/api/projects/request_incremental_sync";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
   DUST_FILE_ID_HEADER,
   getFileFormat,
   normalizeMimeType,
@@ -161,6 +162,7 @@ async function handleHeadRequest(
   };
   if (linkedFileResource) {
     headers[DUST_FILE_ID_HEADER] = linkedFileResource.sId;
+    headers[DUST_FILE_CONTENT_TYPE_HEADER] = linkedFileResource.contentType;
   }
 
   return new Response(null, {

--- a/front/lib/swr/files.test.ts
+++ b/front/lib/swr/files.test.ts
@@ -1,9 +1,14 @@
 import {
+  fetchFileHeadMetadataFromPath,
   fetchFileIdFromPath,
   getFilePathContentApiPath,
 } from "@app/lib/swr/files";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+  frameV2ContentType,
+} from "@app/types/files";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClientFetch = vi.fn();
@@ -27,13 +32,42 @@ describe("file path API", () => {
   });
 });
 
-describe("fetchFileIdFromPath", () => {
-  it("fetches the linked file id with HEAD", async () => {
+describe("file path HEAD metadata", () => {
+  it("fetches linked file metadata with HEAD", async () => {
     mockClientFetch.mockResolvedValue(
       new Response(null, {
         status: 200,
         headers: {
+          [DUST_FILE_CONTENT_TYPE_HEADER]: frameV2ContentType,
           [DUST_FILE_ID_HEADER]: "fil_frame",
+          "Content-Type": "text/plain",
+        },
+      })
+    );
+
+    await expect(
+      fetchFileHeadMetadataFromPath({
+        owner,
+        filePath: "conversation-c1/frame.tsx",
+      })
+    ).resolves.toEqual({
+      fileId: "fil_frame",
+      contentType: frameV2ContentType,
+    });
+    expect(mockClientFetch).toHaveBeenCalledWith(
+      "/api/w/w_test_ws/files/path/conversation-c1/frame.tsx?metadata=1",
+      { method: "HEAD" }
+    );
+  });
+
+  it("keeps the file-id-only helper backward compatible", async () => {
+    mockClientFetch.mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: {
+          [DUST_FILE_CONTENT_TYPE_HEADER]: frameV2ContentType,
+          [DUST_FILE_ID_HEADER]: "fil_frame",
+          "Content-Type": "text/plain",
         },
       })
     );
@@ -44,10 +78,6 @@ describe("fetchFileIdFromPath", () => {
         filePath: "conversation-c1/frame.tsx",
       })
     ).resolves.toBe("fil_frame");
-    expect(mockClientFetch).toHaveBeenCalledWith(
-      "/api/w/w_test_ws/files/path/conversation-c1/frame.tsx?metadata=1",
-      { method: "HEAD" }
-    );
   });
 
   it("returns null for a missing path", async () => {

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -20,7 +20,10 @@ import type {
   FileTypeWithMetadata,
   SharingGrantType,
 } from "@app/types/files";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_CONTENT_TYPE_HEADER,
+  DUST_FILE_ID_HEADER,
+} from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -72,13 +75,18 @@ function getFilePathMetadataApiPath(
   return `${getFilePathContentApiPath(owner, canonicalPath)}?metadata=1`;
 }
 
-export async function fetchFileIdFromPath({
+export interface FilePathHeadMetadata {
+  fileId: string | null;
+  contentType: string | null;
+}
+
+export async function fetchFileHeadMetadataFromPath({
   owner,
   filePath,
 }: {
   owner: LightWorkspaceType;
   filePath: string;
-}): Promise<string | null> {
+}): Promise<FilePathHeadMetadata | null> {
   const response = await clientFetch(
     getFilePathMetadataApiPath(owner, filePath),
     { method: "HEAD" }
@@ -90,13 +98,27 @@ export async function fetchFileIdFromPath({
     throw new Error(`Failed to fetch file metadata (HTTP ${response.status}).`);
   }
 
-  return response.headers.get(DUST_FILE_ID_HEADER);
+  return {
+    fileId: response.headers.get(DUST_FILE_ID_HEADER),
+    contentType: response.headers.get(DUST_FILE_CONTENT_TYPE_HEADER),
+  };
+}
+
+export async function fetchFileIdFromPath({
+  owner,
+  filePath,
+}: {
+  owner: LightWorkspaceType;
+  filePath: string;
+}): Promise<string | null> {
+  const metadata = await fetchFileHeadMetadataFromPath({ owner, filePath });
+  return metadata?.fileId ?? null;
 }
 
 /**
- * Resolve the FileResource sId linked to a canonical scoped path.
- * Returns null when the path exists but has no linked FileResource, or when
- * the path is not found.
+ * Resolve the FileResource sId and content type linked to a canonical scoped path.
+ * The id is null when the path exists but has no linked FileResource, or when
+ * the path is not found; callers can use `isFileIdNotFound` to distinguish loading.
  */
 export function useFileIdFromPath({
   owner,
@@ -111,15 +133,15 @@ export function useFileIdFromPath({
   const swrKey =
     disabled || path === null
       ? null
-      : (`file-id-from-path:${owner.sId}:${path}` as const);
+      : (`file-head-metadata-from-path:${owner.sId}:${path}` as const);
 
   const { data, error } = useSWRWithDefaults(
     swrKey,
-    async (): Promise<string | null> => {
+    async (): Promise<FilePathHeadMetadata | null> => {
       if (path === null) {
         return null;
       }
-      return fetchFileIdFromPath({ owner, filePath: path });
+      return fetchFileHeadMetadataFromPath({ owner, filePath: path });
     },
     { disabled: swrKey === null }
   );
@@ -127,9 +149,11 @@ export function useFileIdFromPath({
   const isLoading = swrKey !== null && !error && data === undefined;
 
   return {
-    fileId: data ?? null,
+    fileId: data?.fileId ?? null,
+    fileContentType: data?.contentType ?? null,
     isFileIdLoading: isLoading,
-    isFileIdNotFound: swrKey !== null && !isLoading && data === null,
+    isFileIdNotFound:
+      swrKey !== null && !isLoading && (data === null || data?.fileId === null),
     fileIdError: error ? normalizeError(error) : null,
   };
 }

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -10,6 +10,7 @@ const uniq = <T>(arr: T[]): T[] => Array.from(new Set(arr));
 
 export const TABLE_PREFIX = "TABLE:";
 export const DUST_FILE_ID_HEADER = "X-Dust-File-Id";
+export const DUST_FILE_CONTENT_TYPE_HEADER = "X-Dust-File-Content-Type";
 
 export type FileStatus = "created" | "failed" | "ready";
 


### PR DESCRIPTION
## Description

Return the linked FileResource MIME type from the existing path HEAD request through a dedicated CORS-exposed Dust header. Keep the mounted object's raw `Content-Type` unchanged and extend the existing SWR metadata lookup without adding a second request.

This is a metadata foundation replacing part of #31401. The private API change is additive and backward compatible.

## Tests

- Front Vitest: 1 file, 6 tests passed
- Front API Vitest: 2 files, 29 tests passed
- `git diff --check`

## Risk

Low. Existing file-id consumers and raw content metadata remain unchanged. Rollback is reverting this PR.

## Deploy Plan

Merge after the Frame function reference base. Deploy normally before the Pod renderer child.
