### PR TITLE
Bind Pod renderer invocations to Frame identity

### DIFF
--- a/front/components/pod/PodFileTabContent.test.ts
+++ b/front/components/pod/PodFileTabContent.test.ts
@@ -1,0 +1,107 @@
+import { PodFileTabContent } from "@app/components/pod/PodFileTabContent";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import type { RichSpaceType } from "@app/types/api/spaces";
+import type { PodFileTab } from "@app/types/pod_file_tab";
+import { DEFAULT_POD_FILE_TAB_ICON } from "@app/types/pod_file_tab";
+import { cleanup, render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  functionReferenceKind: "legacy" | "v2" | null;
+  visualizationProps: { frameId?: string } | null;
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  functionReferenceKind: "v2",
+  visualizationProps: null,
+}));
+
+vi.mock("@app/components/pod/PodFrameVisualization", () => ({
+  PodFrameVisualization: (props: { frameId?: string }) => {
+    mocks.visualizationProps = props;
+    return "pod-frame-visualization";
+  },
+}));
+
+vi.mock("@app/hooks/usePodFrameRenderableContent", () => ({
+  usePodFrameRenderableContent: () => ({
+    fileContent: "frame bundle",
+    fileId: "fil_frame",
+    functionReferenceKind: mocks.functionReferenceKind,
+    isLoading: false,
+    isNotFound: false,
+  }),
+}));
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({ vizUrl: "https://viz.dust.tt" }),
+}));
+
+vi.mock("@app/lib/swr/files", () => ({
+  useFileMetadataFromPath: () => ({
+    metadata: { contentType: "application/vnd.dust.frame.v2+json" },
+    isFileMetadataLoading: false,
+    isFileMetadataNotFound: false,
+  }),
+}));
+
+const owner = LightWorkspaceFactory.build();
+const podInfo = {
+  archivedAt: null,
+  canRead: true,
+  canWrite: true,
+  categories: {},
+  createdAt: 0,
+  description: null,
+  frameTabs: [],
+  groupIds: [],
+  isAdminControlled: false,
+  isEditor: true,
+  isMember: true,
+  isRestricted: false,
+  kind: "project",
+  lastTodoAnalysisAt: null,
+  managementMode: "manual",
+  members: [],
+  name: "Project",
+  pinnedFramePath: null,
+  sId: "vlt_project",
+  tabsOrder: [],
+  todoGenerationEnabled: false,
+  updatedAt: 0,
+} satisfies RichSpaceType;
+const tab = {
+  icon: DEFAULT_POD_FILE_TAB_ICON,
+  path: "pod-vlt_project/App/App.tsx",
+  title: "App",
+} satisfies PodFileTab;
+
+afterEach(() => {
+  cleanup();
+  mocks.functionReferenceKind = "v2";
+  mocks.visualizationProps = null;
+});
+
+describe("PodFileTabContent", () => {
+  it("passes the stable identity only for a Frames v2 tab", () => {
+    const props = { owner, podInfo, tab };
+    const { rerender } = render(createElement(PodFileTabContent, props));
+
+    expect(mocks.visualizationProps?.frameId).toBe("fil_frame");
+
+    mocks.functionReferenceKind = "legacy";
+    rerender(createElement(PodFileTabContent, props));
+
+    expect(mocks.visualizationProps?.frameId).toBeUndefined();
+  });
+
+  it("fails closed when the path metadata is not a known Frame", () => {
+    mocks.functionReferenceKind = null;
+
+    render(createElement(PodFileTabContent, { owner, podInfo, tab }));
+
+    expect(screen.getByText(/no longer available/i)).not.toBeNull();
+    expect(mocks.visualizationProps).toBeNull();
+  });
+});

--- a/front/components/pod/PodFileTabContent.tsx
+++ b/front/components/pod/PodFileTabContent.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileMetadataFromPath } from "@app/lib/swr/files";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import {
-  isInteractiveContentType,
+  isFrameContentType,
   stripMimeParameters,
 } from "@app/types/files";
 import type { PodFileTab } from "@app/types/pod_file_tab";
@@ -32,7 +32,7 @@ export function PodFileTabContent({
 
   const isFrame =
     !!metadata?.contentType &&
-    isInteractiveContentType(stripMimeParameters(metadata.contentType));
+    isFrameContentType(stripMimeParameters(metadata.contentType));
 
   // Frames still load via the processed renderable bundle; other previewable
   // files reuse the shared file preview stack (including markdown edit).
@@ -83,7 +83,7 @@ function PodFileTabVisualization({
   framePath: string;
   vizUrl: string | null;
 }) {
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, functionReferenceKind, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath,
@@ -97,7 +97,13 @@ function PodFileTabVisualization({
     );
   }
 
-  if (isNotFound || !fileId || !fileContent || !vizUrl) {
+  if (
+    isNotFound ||
+    !fileId ||
+    !fileContent ||
+    !functionReferenceKind ||
+    !vizUrl
+  ) {
     return (
       <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
         This frame is no longer available in the Pod files.
@@ -114,6 +120,7 @@ function PodFileTabVisualization({
           fileContent={fileContent}
           vizUrl={vizUrl}
           identifier={`viz-frame-tab-${fileId}`}
+          frameId={functionReferenceKind === "v2" ? fileId : undefined}
           isPodEditor={podInfo.isEditor}
           isPodMember={podInfo.isMember}
           framePath={framePath}

--- a/front/components/pod/PodFileTabContent.tsx
+++ b/front/components/pod/PodFileTabContent.tsx
@@ -4,10 +4,7 @@ import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableCo
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileMetadataFromPath } from "@app/lib/swr/files";
 import type { RichSpaceType } from "@app/types/api/spaces";
-import {
-  isFrameContentType,
-  stripMimeParameters,
-} from "@app/types/files";
+import { isFrameContentType, stripMimeParameters } from "@app/types/files";
 import type { PodFileTab } from "@app/types/pod_file_tab";
 import type { WorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -8,6 +8,7 @@ interface PodFrameVisualizationProps {
   fileContent: string;
   vizUrl: string;
   identifier: string;
+  frameId?: string;
   isPodEditor?: boolean;
   isPodMember?: boolean;
   /** Scoped path of the Frame, so one inside an app folder can call its functions by bare name. */
@@ -24,6 +25,7 @@ export function PodFrameVisualization({
   fileContent,
   vizUrl,
   identifier,
+  frameId,
   isPodEditor,
   isPodMember,
   framePath,
@@ -43,6 +45,7 @@ export function PodFrameVisualization({
       conversationId={null}
       spaceId={spaceId}
       framePath={framePath}
+      frameId={frameId}
       isInDrawer={true}
       isPodEditor={isPodEditor}
       isPodMember={isPodMember}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -143,7 +143,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     isEditor: podInfo.isEditor,
   });
 
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, functionReferenceKind, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: pinnedFramePath,
@@ -192,7 +192,13 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     );
   }
 
-  if (isNotFound || !fileId || !fileContent || !vizUrl) {
+  if (
+    isNotFound ||
+    !fileId ||
+    !fileContent ||
+    !functionReferenceKind ||
+    !vizUrl
+  ) {
     return null;
   }
 
@@ -202,6 +208,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     fileContent,
     vizUrl,
     identifier: `viz-banner-${fileId}`,
+    frameId: functionReferenceKind === "v2" ? fileId : undefined,
     isPodEditor: podInfo.isEditor,
     isPodMember: podInfo.isMember,
     framePath: pinnedFramePath,

--- a/front/hooks/usePodFrameRenderableContent.test.ts
+++ b/front/hooks/usePodFrameRenderableContent.test.ts
@@ -1,0 +1,53 @@
+import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  fileContentType: string | null;
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  fileContentType: "application/vnd.dust.frame.v2+json",
+}));
+
+vi.mock("@app/lib/swr/files", () => ({
+  useFileContent: () => ({
+    error: null,
+    fileContent: "frame bundle",
+    isFileContentLoading: false,
+  }),
+  useFileIdFromPath: () => ({
+    fileContentType: mocks.fileContentType,
+    fileId: "fil_frame",
+    fileIdError: null,
+    isFileIdLoading: false,
+    isFileIdNotFound: false,
+  }),
+}));
+
+const owner = LightWorkspaceFactory.build();
+
+afterEach(() => {
+  mocks.fileContentType = frameV2ContentType;
+});
+
+describe("usePodFrameRenderableContent", () => {
+  it.each([
+    [frameV2ContentType, "v2"],
+    [frameContentType, "legacy"],
+    ["text/plain", null],
+  ])("classifies %s from the linked FileResource header", (contentType, kind) => {
+    mocks.fileContentType = contentType;
+
+    const { result } = renderHook(() =>
+      usePodFrameRenderableContent({
+        owner,
+        framePath: "pod-vlt_project/App/App.tsx",
+      })
+    );
+
+    expect(result.current.functionReferenceKind).toBe(kind);
+  });
+});

--- a/front/hooks/usePodFrameRenderableContent.ts
+++ b/front/hooks/usePodFrameRenderableContent.ts
@@ -1,4 +1,5 @@
 import { useFileContent, useFileIdFromPath } from "@app/lib/swr/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -20,12 +21,17 @@ export function usePodFrameRenderableContent({
 }) {
   const isDisabled = disabled || !framePath;
 
-  const { fileId, isFileIdLoading, isFileIdNotFound, fileIdError } =
-    useFileIdFromPath({
-      owner,
-      filePath: framePath,
-      disabled: isDisabled,
-    });
+  const {
+    fileId,
+    fileContentType,
+    isFileIdLoading,
+    isFileIdNotFound,
+    fileIdError,
+  } = useFileIdFromPath({
+    owner,
+    filePath: framePath,
+    disabled: isDisabled,
+  });
 
   const {
     fileContent,
@@ -36,10 +42,10 @@ export function usePodFrameRenderableContent({
     owner,
     config: { disabled: isDisabled || !fileId },
   });
-
   return {
     fileId,
     fileContent: fileContent ?? null,
+    functionReferenceKind: getFrameFunctionReferenceKind(fileContentType),
     isLoading:
       !isDisabled && (isFileIdLoading || (!!fileId && isFileContentLoading)),
     isNotFound: isFileIdNotFound,


### PR DESCRIPTION
## Description

Classify Pod tabs and pinned Frames from trusted linked FileResource metadata, fail closed for unknown content, and pass the stable identity only for Frames v2. Legacy Pod Frames keep their existing app-folder function resolution.

This focused Pod renderer child replaces part of #31401. No visual or Sparkle property changes.

## Tests

- Front Vitest: 2 files, 5 tests passed
- `git diff --check`

## Risk

Low and feature-gated. Missing or unknown Frame metadata now fails closed. Rollback is reverting this PR.

## Deploy Plan

Merge after the linked file metadata PR. Deploy normally.
