### PR TITLE
Bind Pod sheet invocations to Frame identity

### DIFF
--- a/front/components/pod/files/PodFrameSheet.test.ts
+++ b/front/components/pod/files/PodFrameSheet.test.ts
@@ -1,0 +1,131 @@
+import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { cleanup, render } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface Mocks {
+  iframeProps: { frameId?: string } | null;
+  metadataCalls: { disabled?: boolean; fileId: string | null }[];
+}
+
+const mocks = vi.hoisted<Mocks>(() => ({
+  iframeProps: null,
+  metadataCalls: [],
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe",
+  async () => {
+    const { forwardRef } = await import("react");
+    return {
+      AuthenticatedVisualizationActionIframe: forwardRef<
+        HTMLIFrameElement,
+        { frameId?: string }
+      >(function AuthenticatedVisualizationActionIframe(props, _ref) {
+        mocks.iframeProps = props;
+        return "frame-iframe";
+      }),
+    };
+  }
+);
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/ExportContentDropdown",
+  () => ({ ExportContentDropdown: () => null })
+);
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet",
+  () => ({ ShareFrameSheet: () => null })
+);
+
+vi.mock("@app/components/pod/files/PinPodBannerButton", () => ({
+  PinPodBannerButton: () => null,
+}));
+
+vi.mock("@app/components/pod/files/PodFrameTabButton", () => ({
+  PodFrameTabButton: () => null,
+}));
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({ vizUrl: "https://viz.dust.tt" }),
+  useFeatureFlags: () => ({ hasFeature: () => false }),
+}));
+
+vi.mock("@app/lib/swr/files", () => ({
+  useFileContent: () => ({ fileContent: "frame bundle" }),
+  useFileMetadata: (args: { disabled?: boolean; fileId: string | null }) => {
+    mocks.metadataCalls.push(args);
+    return {
+      fileMetadata: {
+        contentType: "application/vnd.dust.frame.v2+json",
+        fileName: "app.frame.json",
+        useCaseMetadata: { spaceId: "vlt_project" },
+      },
+      isFileMetadataError: null,
+      isFileMetadataLoading: false,
+    };
+  },
+}));
+
+vi.mock("@dust-tt/sparkle", async () => {
+  const { createElement } = await import("react");
+  const Container = ({ children }: PropsWithChildren) =>
+    createElement("div", null, children);
+  const Sheet = ({ children, open }: PropsWithChildren<{ open?: boolean }>) =>
+    open ? createElement("div", null, children) : null;
+  const Empty = () => null;
+
+  return {
+    Button: Empty,
+    Maximize01: Empty,
+    Minimize01: Empty,
+    Sheet,
+    SheetClose: Container,
+    SheetContent: Container,
+    SheetHeader: Container,
+    SheetTitle: Container,
+    Spinner: Empty,
+    XClose: Empty,
+    cn: (...classes: Array<string | false | null | undefined>) =>
+      classes.filter(Boolean).join(" "),
+  };
+});
+
+const owner = LightWorkspaceFactory.build();
+
+afterEach(() => {
+  cleanup();
+  mocks.iframeProps = null;
+  mocks.metadataCalls = [];
+});
+
+describe("PodFrameSheet", () => {
+  it("loads metadata only while open and forwards the Frames v2 identity", () => {
+    const props = {
+      fileId: "fil_frame",
+      fileName: "app.frame.json",
+      framePath: "pod-vlt_project/App/app.frame.json",
+      frameTabs: [],
+      isArchived: false,
+      isEditor: true,
+      isMember: true,
+      isOpen: false,
+      onClose: vi.fn(),
+      owner,
+      pinnedFramePath: null,
+      podId: "vlt_project",
+    };
+    const { rerender } = render(createElement(PodFrameSheet, props));
+
+    expect(mocks.metadataCalls.at(-1)).toMatchObject({ disabled: true });
+    expect(mocks.iframeProps).toBeNull();
+
+    rerender(createElement(PodFrameSheet, { ...props, isOpen: true }));
+
+    expect(mocks.metadataCalls.at(-1)).toMatchObject({ disabled: false });
+    expect(mocks.iframeProps?.frameId).toBe("fil_frame");
+  });
+});

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -5,6 +5,7 @@ import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton
 import { PodFrameTabButton } from "@app/components/pod/files/PodFrameTabButton";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -65,10 +66,15 @@ export function PodFrameSheet({
     config: { disabled: !isOpen || !fileId },
   });
 
-  const { fileMetadata, isFileMetadataLoading } = useFileMetadata({
-    fileId,
-    owner,
-  });
+  const { fileMetadata, isFileMetadataLoading, isFileMetadataError } =
+    useFileMetadata({
+      fileId,
+      owner,
+      disabled: !isOpen || !fileId,
+    });
+  const functionReferenceKind = getFrameFunctionReferenceKind(
+    fileMetadata?.contentType
+  );
 
   useEffect(() => {
     if (!isOpen) {
@@ -141,7 +147,15 @@ export function PodFrameSheet({
           </div>
         </SheetHeader>
         <div className="flex-1 overflow-hidden">
-          {isFileMetadataLoading || !fileContent ? (
+          {isFileMetadataLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : isFileMetadataError || !fileMetadata || !functionReferenceKind ? (
+            <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+              This frame is no longer available in the Pod files.
+            </div>
+          ) : !fileContent ? (
             <div className="flex h-full items-center justify-center">
               <Spinner />
             </div>
@@ -164,6 +178,7 @@ export function PodFrameSheet({
                 conversationId={null}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 framePath={framePath}
+                frameId={functionReferenceKind === "v2" ? fileId : undefined}
                 isInDrawer={true}
                 isPodEditor={isEditor}
                 isPodMember={isMember}

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -380,29 +380,33 @@ export function useFileMetadata({
   fileId,
   owner,
   cacheKey,
+  disabled = false,
 }: {
   fileId: string | null;
   owner: LightWorkspaceType;
   cacheKey?: string | null;
+  disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const fileMetadataFetcher: Fetcher<FileTypeWithMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
-  const swrKey = fileId
-    ? cacheKey
-      ? `/api/w/${owner.sId}/files/${fileId}/metadata?v=${cacheKey}`
-      : `/api/w/${owner.sId}/files/${fileId}/metadata`
-    : null;
+  const swrKey =
+    !disabled && fileId
+      ? cacheKey
+        ? `/api/w/${owner.sId}/files/${fileId}/metadata?v=${cacheKey}`
+        : `/api/w/${owner.sId}/files/${fileId}/metadata`
+      : null;
 
   const { data, error, mutateRegardlessOfQueryParams } = useSWRWithDefaults(
     swrKey,
-    fileMetadataFetcher
+    fileMetadataFetcher,
+    { disabled: swrKey === null }
   );
 
   return {
     fileMetadata: data,
-    isFileMetadataLoading: !error && !data,
+    isFileMetadataLoading: swrKey !== null && !error && !data,
     isFileMetadataError: error,
     mutateFileMetadata: mutateRegardlessOfQueryParams,
   };


### PR DESCRIPTION
## Description

Load Pod Frame sheet metadata only while the sheet is open, fail closed when the resource is unavailable, and pass the stable identity only for Frames v2.

This optional renderer tip replaces the remaining Pod sheet portion of #31401. No visual or Sparkle property changes.

## Tests

- Front Vitest: 1 file, 1 test passed
- `git diff --check`

## Risk

Low and feature-gated. Closed sheets stop an unnecessary metadata request. Rollback is reverting this PR.

## Deploy Plan

Merge after the Frame function reference base. It can deploy independently of the other renderer children.
