### PR TITLE
Reserve canonical Frames v2 routes

### DIFF
--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
@@ -1,0 +1,5 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+const app = workspaceApp();
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import functionName from "./[name]";
+
+const app = workspaceApp();
+
+app.route("/:name", functionName);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/index.ts
@@ -1,0 +1,11 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import functions from "./functions";
+import invocations from "./invocations";
+
+const app = workspaceApp();
+
+app.route("/functions", functions);
+app.route("/invocations", invocations);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/index.ts
@@ -1,0 +1,5 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+const app = workspaceApp();
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/index.ts
@@ -1,0 +1,9 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import invocationId from "./[invocationId]";
+
+const app = workspaceApp();
+
+app.route("/:invocationId", invocationId);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/index.test.ts
+++ b/front-api/routes/w/[wId]/frames/index.test.ts
@@ -1,0 +1,31 @@
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("canonical Frames v2 route namespace", () => {
+  it("is feature-gated", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/fil_frame/functions/run/invocations`,
+      { method: "POST" }
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("falls through unmatched canonical routes when enabled", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "frames_v2");
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/fil_frame/functions/run/invocations`,
+      { method: "POST" }
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/w/[wId]/frames/index.ts
+++ b/front-api/routes/w/[wId]/frames/index.ts
@@ -1,0 +1,17 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+
+import frameId from "./[frameId]";
+
+const app = workspaceApp();
+
+app.use(
+  "*",
+  withFeatureFlag("frames_v2", {
+    message: "Frames v2 are not enabled for this workspace.",
+  })
+);
+
+app.route("/:frameId", frameId);
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -54,6 +54,7 @@ import extension from "./extension";
 import fairUseCredits from "./fair-use-credits";
 import featureFlags from "./feature-flags";
 import files from "./files";
+import frames from "./frames";
 import googleDrivePickerToken from "./google_drive/picker_token";
 import googleDriveSearchForAuthorization from "./google_drive/search_for_authorization";
 import governancePermissions from "./governance-permissions";
@@ -1053,6 +1054,7 @@ app.route("/dust_app_secrets", dustAppSecrets);
 app.route("/extension", extension);
 app.route("/fair-use-credits", fairUseCredits);
 app.route("/files", files);
+app.route("/frames", frames);
 app.route("/google_drive/picker_token", googleDrivePickerToken);
 app.route(
   "/google_drive/search_for_authorization",


### PR DESCRIPTION
## Description

Reserve the feature-gated private route namespace for canonical Frames v2 function and invocation endpoints. The leaf routers intentionally return 404 until their focused POST or SSE child lands.

This is the shared base replacing route ancestry duplicated across #31412 and #31491.

## Tests

- Front API Vitest: 1 file, 2 tests passed
- `npm run lint:swagger-annotations` in `front-api`
- `git diff --check`

## Risk

Low and feature-gated. The new namespace has no active endpoint in this PR. Rollback is reverting this PR.

## Deploy Plan

Merge first. The POST and SSE resolver lanes can then proceed in parallel.
