### PR TITLE
Resolve active Frame functions for use

### DIFF
--- a/front/lib/api/sandbox_functions/frame_share_capability.test.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.test.ts
@@ -1,0 +1,52 @@
+import { resolveActiveFrameFunctionForUse } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { makeTestFrameFunction } from "@app/tests/utils/FrameFunctionFactory";
+import { describe, expect, it, vi } from "vitest";
+
+describe("resolveActiveFrameFunctionForUse", () => {
+  it("resolves a function from the active publication", async () => {
+    const { auth, frame, sandboxFunction } = await makeTestFrameFunction();
+
+    await expect(
+      resolveActiveFrameFunctionForUse(auth, {
+        frameId: frame.sId,
+        functionName: "run-function",
+      })
+    ).resolves.toMatchObject({ sId: sandboxFunction.sId });
+  });
+
+  it("fails closed when the publication changes during resolution", async () => {
+    const { auth, frame } = await makeTestFrameFunction();
+    const fetchFunction =
+      SandboxFunctionResource.fetchByFramePublicationAndSlug.bind(
+        SandboxFunctionResource
+      );
+    vi.spyOn(
+      SandboxFunctionResource,
+      "fetchByFramePublicationAndSlug"
+    ).mockImplementationOnce(async (...args) => {
+      await frame.setActiveFramePublication("publication-2");
+      return fetchFunction(...args);
+    });
+
+    await expect(
+      resolveActiveFrameFunctionForUse(auth, {
+        frameId: frame.sId,
+        functionName: "run-function",
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("enforces current Frame use rights", async () => {
+    const { auth, frame } = await makeTestFrameFunction({
+      shareScope: "emails_only",
+    });
+
+    await expect(
+      resolveActiveFrameFunctionForUse(auth, {
+        frameId: frame.sId,
+        functionName: "run-function",
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -68,8 +68,7 @@ export async function resolveSandboxFunctionWithCapability(
     if (isFramesV2Enabled) {
       const frameFunction = await resolveFrameV2FunctionReference(
         auth,
-        functionIdOrSlug,
-        { allowInactivePublication: allowInactiveFramePublication }
+        functionIdOrSlug
       );
       if (frameFunction) {
         return frameFunction;
@@ -95,8 +94,7 @@ export async function resolveSandboxFunctionWithCapability(
 
 async function resolveFrameV2FunctionReference(
   auth: Authenticator,
-  functionIdOrReference: string,
-  { allowInactivePublication }: { allowInactivePublication: boolean }
+  functionIdOrReference: string
 ): Promise<SandboxFunctionResource | null> {
   const [frameId, slug, ...rest] = functionIdOrReference.split("/");
   if (
@@ -108,20 +106,48 @@ async function resolveFrameV2FunctionReference(
   ) {
     return null;
   }
-  const frame = await FileResource.fetchById(auth, frameId);
-  const publicationId = frame?.useCaseMetadata?.activePublicationId;
-  if (!frame?.isFrameV2 || !publicationId) {
+  return resolveActiveFrameFunctionForUse(auth, {
+    frameId,
+    functionName: slug,
+  });
+}
+
+/** Resolve one function from the active publication of a Frame the caller may use. */
+export async function resolveActiveFrameFunctionForUse(
+  auth: Authenticator,
+  {
+    frameId,
+    functionName,
+  }: {
+    frameId: string;
+    functionName: string;
+  }
+): Promise<SandboxFunctionResource | null> {
+  if (
+    !isResourceSId("file", frameId) ||
+    !isValidSandboxFunctionSlug(functionName)
+  ) {
     return null;
   }
+
+  const frame = await FileResource.fetchById(auth, frameId);
+  const publicationId = frame?.useCaseMetadata?.activePublicationId;
+  if (
+    !frame?.isFrameV2 ||
+    !publicationId ||
+    !(await frame.canCurrentUserUseFrame(auth))
+  ) {
+    return null;
+  }
+
   const sandboxFunction =
     await SandboxFunctionResource.fetchByFramePublicationAndSlug(auth, {
       frame,
       publicationId,
-      slug,
+      slug: functionName,
     });
-
   return resolveFrameV2FunctionAccess(auth, sandboxFunction, {
-    allowInactivePublication,
+    allowInactivePublication: false,
   });
 }
 


### PR DESCRIPTION
## Description

Resolve one named function from a Frame's active immutable publication and recheck current Frame use rights. Resolution fails closed if the publication changes during lookup.

This is the POST resolver foundation replacing part of #31412.

## Tests

- Front Vitest: 1 file, 3 tests passed
- `git diff --check`

## Risk

Low and feature-gated at its callers. The helper is additive and the existing reference resolver keeps its public contract. Rollback is reverting this PR.

## Deploy Plan

Merge after #31538 and #31545, then retarget from the temporary integration base to main. Merge before the POST transport.