### PR TITLE
Resolve invocations through Frame ownership

### DIFF
--- a/front/lib/resources/sandbox_function_frame_invocation.test.ts
+++ b/front/lib/resources/sandbox_function_frame_invocation.test.ts
@@ -1,0 +1,42 @@
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { makeTestFrameInvocation } from "@app/tests/utils/FrameFunctionFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+describe("SandboxFunctionResource.fetchInvocationByFrameAndId", () => {
+  it("resolves the invocation after the Frame republishes", async () => {
+    const { auth, frame, invocation } = await makeTestFrameInvocation();
+    await frame.setActiveFramePublication("publication-2");
+
+    await expect(
+      SandboxFunctionResource.fetchInvocationByFrameAndId(auth, {
+        frame,
+        invocationId: invocation.sId,
+      })
+    ).resolves.toMatchObject({ sId: invocation.sId });
+  });
+
+  it("rejects an invocation owned by another Frame", async () => {
+    const { adminAuth, auth, invocation, space } =
+      await makeTestFrameInvocation();
+    const otherFrame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: "other-manifest.json",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: {
+        spaceId: space.sId,
+        activePublicationId: "publication-1",
+      },
+    });
+
+    await expect(
+      SandboxFunctionResource.fetchInvocationByFrameAndId(auth, {
+        frame: otherFrame,
+        invocationId: invocation.sId,
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -590,6 +590,60 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     });
   }
 
+  /**
+   * Fetch an invocation through its stable Frame identity. The function row is resolved from the
+   * invocation itself rather than from the active publication, so an in-flight stream survives a
+   * republish or removal of the function from a later publication.
+   */
+  static async fetchInvocationByFrameAndId(
+    auth: Authenticator,
+    {
+      frame,
+      invocationId,
+    }: {
+      frame: FileResource;
+      invocationId: string;
+    }
+  ): Promise<SandboxFunctionInvocationResource | null> {
+    if (
+      !frame.isFrameV2 ||
+      !isResourceSId("sandbox_function_invocation", invocationId)
+    ) {
+      return null;
+    }
+    const invocationModelId = getResourceIdFromSId(invocationId);
+    if (invocationModelId === null) {
+      return null;
+    }
+
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      attributes: ["sandboxFunctionId"],
+      where: {
+        id: invocationModelId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: {
+        id: invocation.sandboxFunctionId,
+        fileId: frame.id,
+      },
+      includeFrameFunctions: true,
+    });
+    if (!sandboxFunction) {
+      return null;
+    }
+
+    return SandboxFunctionInvocationResource.fetchById(auth, {
+      sandboxFunction,
+      invocationId,
+    });
+  }
+
   static async listBySpace(
     auth: Authenticator,
     space: SpaceResource


### PR DESCRIPTION
## Description

Resolve a sandbox function invocation through its owning Frame and function row. The lookup is independent of the active publication, so an in-flight stream survives a Frame republish while cross-Frame access fails closed.

This is the SSE resolver foundation replacing part of #31491.

## Tests

- Front Vitest: 1 file, 2 tests passed
- `git diff --check`

## Risk

Low. The helper is additive and scopes every lookup to the current workspace and owning Frame. Rollback is reverting this PR.

## Deploy Plan

Merge after #31523 and #31545, then retarget from the temporary integration base to main. Merge before the SSE endpoint.