### PR TITLE
Expose canonical Frames v2 invocation event stream

### DIFF
--- a/front-api/lib/api/sse/frame_function_invocation_events.ts
+++ b/front-api/lib/api/sse/frame_function_invocation_events.ts
@@ -1,0 +1,50 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { streamEvents } from "@front-api/lib/api/sse/stream_events";
+import type { Context } from "hono";
+import { z } from "zod";
+
+export const FrameFunctionInvocationEventParamSchema = z.object({
+  frameId: z.string().min(1),
+  invocationId: z.string().min(1),
+});
+
+export async function streamFrameFunctionInvocationEventsForRoute(
+  ctx: Context,
+  auth: Authenticator,
+  {
+    frameId,
+    invocationId,
+    lastEventId,
+  }: {
+    frameId: string;
+    invocationId: string;
+    lastEventId: string | null;
+  }
+) {
+  const frame = await FileResource.fetchById(auth, frameId);
+  if (!frame?.isFrameV2 || !(await frame.canCurrentUserUseFrame(auth))) {
+    return ctx.notFound();
+  }
+
+  const invocation = await SandboxFunctionResource.fetchInvocationByFrameAndId(
+    auth,
+    { frame, invocationId }
+  );
+  if (!invocation) {
+    return ctx.notFound();
+  }
+
+  return streamEvents({
+    ctx,
+    iterator: (signal) =>
+      getSandboxFunctionInvocationEvents({
+        invocationId: invocation.sId,
+        lastEventId,
+        signal,
+      }),
+    writeDoneSentinel: true,
+  });
+}

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9407,6 +9407,61 @@
         }
       }
     },
+    "/api/w/{wId}/frames/{frameId}/invocations/{invocationId}/events": {
+      "get": {
+        "summary": "Stream Frames v2 function invocation events",
+        "description": "Authorizes through the stable Frame identity and redirects to the SSE service. The invocation's own publication is used, so a republish cannot break an existing stream.",
+        "tags": [
+          "Private Frames"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "frameId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "invocationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server-Sent Event stream.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateSandboxFunctionInvocationEvent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Frame use right or Frame-owned invocation not found."
+          }
+        }
+      }
+    },
     "/api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events": {
       "get": {
         "summary": "Stream sandbox function invocation events",

--- a/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.test.ts
@@ -1,0 +1,102 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import { makeTestFrameInvocation } from "@app/tests/utils/FrameFunctionFactory";
+import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_functions";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...mod,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+    getSandboxFunctionInvocationEvents: vi.fn(async function* () {}),
+  };
+});
+
+function getEvents({
+  workspaceId,
+  frameId,
+  invocationId,
+}: {
+  workspaceId: string;
+  frameId: string;
+  invocationId: string;
+}) {
+  return honoApp.request(
+    `/api/sse/w/${workspaceId}/frames/${frameId}/invocations/${invocationId}/events`
+  );
+}
+
+function mockEventStream(event: SandboxFunctionInvocationEvent) {
+  vi.mocked(getSandboxFunctionInvocationEvents).mockImplementation(
+    async function* () {
+      yield { eventId: "event-1", data: event };
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/sse/w/:wId/frames/:frameId/invocations/:invocationId/events", () => {
+  it("keeps an invocation streamable after the Frame republishes", async () => {
+    const { frame, invocation, sandboxFunction, workspace } =
+      await makeTestFrameInvocation();
+    await frame.setActiveFramePublication("publication-2");
+    mockEventStream({
+      type: "sandbox_function_invocation_result",
+      created: Date.now(),
+      invocationId: invocation.sId,
+      functionId: sandboxFunction.sId,
+      result: { ok: true },
+    });
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"result":{"ok":true}');
+    expect(getSandboxFunctionInvocationEvents).toHaveBeenCalledWith({
+      invocationId: invocation.sId,
+      lastEventId: null,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("rechecks Frame use rights", async () => {
+    const { adminAuth, frame, invocation, workspace } =
+      await makeTestFrameInvocation();
+    await frame.setShareScope(adminAuth, "emails_only");
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("is available only behind frames_v2", async () => {
+    const { frame, invocation, workspace } = await makeTestFrameInvocation({
+      enableFramesV2: false,
+    });
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      frameId: frame.sId,
+      invocationId: invocation.sId,
+    });
+
+    expect(response.status).toBe(403);
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
@@ -1,0 +1,38 @@
+import {
+  FrameFunctionInvocationEventParamSchema,
+  streamFrameFunctionInvocationEventsForRoute,
+} from "@front-api/lib/api/sse/frame_function_invocation_events";
+import { SseQuerySchema } from "@front-api/lib/api/sse/stream_events";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { streamingTag } from "@front-api/middlewares/streaming";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+
+const app = workspaceApp();
+
+app.use("*", streamingTag);
+app.use(
+  "*",
+  withFeatureFlag("frames_v2", {
+    message: "Frames v2 are not enabled for this workspace.",
+  })
+);
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("param", FrameFunctionInvocationEventParamSchema),
+  validate("query", SseQuerySchema),
+  async (ctx) => {
+    const { frameId, invocationId } = ctx.req.valid("param");
+    const { lastEventId } = ctx.req.valid("query");
+
+    return streamFrameFunctionInvocationEventsForRoute(ctx, ctx.var.auth, {
+      frameId,
+      invocationId,
+      lastEventId,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/sse/w/[wId]/index.ts
+++ b/front-api/routes/sse/w/[wId]/index.ts
@@ -3,6 +3,7 @@ import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 
 import conversationEvents from "./assistant/conversations/[cId]/events";
 import messageEvents from "./assistant/conversations/[cId]/messages/[mId]/events";
+import frameFunctionInvocationEvents from "./frames/[frameId]/invocations/[invocationId]/events";
 import mcpRequests from "./mcp/requests";
 import sandboxFunctionInvocationEvents from "./sandbox-functions/[functionId]/invocations/[invocationId]/events";
 
@@ -16,6 +17,10 @@ app.use("*", workspaceAuth());
 
 app.route("/assistant/conversations/:cId/events", conversationEvents);
 app.route("/assistant/conversations/:cId/messages/:mId/events", messageEvents);
+app.route(
+  "/frames/:frameId/invocations/:invocationId/events",
+  frameFunctionInvocationEvents
+);
 app.route("/mcp/requests", mcpRequests);
 app.route(
   "/sandbox-functions/:functionId/invocations/:invocationId/events",

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
@@ -1,0 +1,44 @@
+import { redirectToSse } from "@front-api/lib/api/sse/redirect";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+const app = workspaceApp();
+
+/**
+ * @swagger
+ * /api/w/{wId}/frames/{frameId}/invocations/{invocationId}/events:
+ *   get:
+ *     summary: Stream Frames v2 function invocation events
+ *     description: Authorizes through the stable Frame identity and redirects to the SSE service. The invocation's own publication is used, so a republish cannot break an existing stream.
+ *     tags:
+ *       - Private Frames
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: frameId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: invocationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Server-Sent Event stream.
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateSandboxFunctionInvocationEvent'
+ *       404:
+ *         description: Frame use right or Frame-owned invocation not found.
+ */
+app.get("/", redirectToSse);
+
+export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/index.ts
@@ -1,5 +1,9 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import events from "./events";
+
 const app = workspaceApp();
+
+app.route("/events", events);
 
 export default app;


### PR DESCRIPTION
## Description

Add the canonical Frames v2 invocation event stream keyed by stable Frame identity and invocation id. The private route redirects to the SSE service, which repeats the feature gate and authorization checks and preserves Last-Event-ID replay.

This replaces the endpoint portion of #31491 and includes synchronized private Swagger documentation.

## Tests

- Front API Vitest: 1 file, 3 tests passed
- `npm run docs` in `front-api`
- `npm run lint:swagger-annotations` in `front-api`
- `git diff --check`

## Risk

Low and feature-gated. Missing use rights or Frame-owned invocations fail closed. Rollback is reverting this PR.

## Deploy Plan

Merge after the Frame invocation resolver. It can deploy independently of the canonical POST lane.
