### PR TITLE
Hide private Frames endpoints from Swagger

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9047,7 +9047,7 @@
     "/api/w/{wId}/files/{fileId}": {
       "get": {
         "summary": "Get or download a file",
-        "description": "View or download a file. Skill attachments require read access to their associated skill. Feature-flagged Frames v2 return the active published UI bundle when viewed. Use query parameters `version` (original, processed, public) and `action` (view, download).",
+        "description": "View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).",
         "tags": [
           "Private Files"
         ],
@@ -9335,137 +9335,10 @@
         }
       }
     },
-    "/api/w/{wId}/frames/{frameId}/functions/{name}/invocations": {
-      "post": {
-        "summary": "Invoke an active Frames v2 function",
-        "description": "Resolves a bare function name from the Frame's active immutable publication, checks Frame use rights, and starts an invocation pinned to that publication.",
-        "tags": [
-          "Private Frames"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "wId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "frameId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "description": "Bare function name declared by the active Frame publication.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PrivateFrameFunctionInvocationRequest"
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Invocation created. Fast invocations may also include their terminal outcome.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PrivateFrameFunctionInvocationResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "The function requires a workspace member or a stricter caller identity."
-          },
-          "404": {
-            "description": "Frame, active publication, function, or Frame use right not found."
-          },
-          "500": {
-            "description": "Invocation failed before it could be created."
-          }
-        }
-      }
-    },
-    "/api/w/{wId}/frames/{frameId}/invocations/{invocationId}/events": {
-      "get": {
-        "summary": "Stream Frames v2 function invocation events",
-        "description": "Authorizes through the stable Frame identity and redirects to the SSE service. The invocation's own publication is used, so a republish cannot break an existing stream.",
-        "tags": [
-          "Private Frames"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "wId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "frameId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "invocationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Server-Sent Event stream.",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "$ref": "#/components/schemas/PrivateSandboxFunctionInvocationEvent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Frame use right or Frame-owned invocation not found."
-          }
-        }
-      }
-    },
     "/api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events": {
       "get": {
         "summary": "Stream sandbox function invocation events",
-        "description": "Stream real-time events for a Pod or Frame function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.",
+        "description": "Stream real-time events for a Pod function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.",
         "tags": [
           "Private Events"
         ],
@@ -9483,7 +9356,7 @@
             "in": "path",
             "name": "functionId",
             "required": true,
-            "description": "ID of the Pod or Frame function",
+            "description": "ID of the Pod function",
             "schema": {
               "type": "string"
             }
@@ -13363,123 +13236,6 @@
           "userId": {
             "type": "string",
             "description": "sId of the user who owns the wake-up."
-          }
-        }
-      },
-      "PrivateSandboxFunctionInvocation": {
-        "type": "object",
-        "required": [
-          "sId",
-          "functionId",
-          "status",
-          "createdAt"
-        ],
-        "properties": {
-          "sId": {
-            "type": "string"
-          },
-          "functionId": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "created",
-              "errored",
-              "succeeded"
-            ]
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "PrivateSandboxFunctionCallError": {
-        "type": "object",
-        "required": [
-          "code",
-          "message"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "Classification forwarded from the runner, API, or invocation layer."
-          },
-          "message": {
-            "type": "string"
-          },
-          "status": {
-            "type": "integer"
-          }
-        }
-      },
-      "PrivateFrameFunctionInvocationRequest": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "input": {
-            "description": "Input validated against the published function contract."
-          },
-          "context": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "timezone": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "PrivateFrameFunctionInvocationResponse": {
-        "type": "object",
-        "required": [
-          "invocation"
-        ],
-        "properties": {
-          "invocation": {
-            "$ref": "#/components/schemas/PrivateSandboxFunctionInvocation"
-          },
-          "outcome": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "status",
-                  "result"
-                ],
-                "properties": {
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "succeeded"
-                    ]
-                  },
-                  "result": {
-                    "description": "Parsed result validated against the function output schema."
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "required": [
-                  "status",
-                  "error"
-                ],
-                "properties": {
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "errored"
-                    ]
-                  },
-                  "error": {
-                    "$ref": "#/components/schemas/PrivateSandboxFunctionCallError"
-                  }
-                }
-              }
-            ]
           }
         }
       },

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1654,67 +1654,6 @@
  *         userId:
  *           type: string
  *           description: sId of the user who owns the wake-up.
- *     PrivateSandboxFunctionInvocation:
- *       type: object
- *       required: [sId, functionId, status, createdAt]
- *       properties:
- *         sId:
- *           type: string
- *         functionId:
- *           type: string
- *         status:
- *           type: string
- *           enum: [created, errored, succeeded]
- *         createdAt:
- *           type: string
- *           format: date-time
- *     PrivateSandboxFunctionCallError:
- *       type: object
- *       required: [code, message]
- *       properties:
- *         code:
- *           type: string
- *           description: Classification forwarded from the runner, API, or invocation layer.
- *         message:
- *           type: string
- *         status:
- *           type: integer
- *     PrivateFrameFunctionInvocationRequest:
- *       type: object
- *       additionalProperties: false
- *       properties:
- *         input:
- *           description: Input validated against the published function contract.
- *         context:
- *           type: object
- *           additionalProperties: false
- *           properties:
- *             timezone:
- *               type: string
- *     PrivateFrameFunctionInvocationResponse:
- *       type: object
- *       required: [invocation]
- *       properties:
- *         invocation:
- *           $ref: '#/components/schemas/PrivateSandboxFunctionInvocation'
- *         outcome:
- *           oneOf:
- *             - type: object
- *               required: [status, result]
- *               properties:
- *                 status:
- *                   type: string
- *                   enum: [succeeded]
- *                 result:
- *                   description: Parsed result validated against the function output schema.
- *             - type: object
- *               required: [status, error]
- *               properties:
- *                 status:
- *                   type: string
- *                   enum: [errored]
- *                 error:
- *                   $ref: '#/components/schemas/PrivateSandboxFunctionCallError'
  *     PrivateSandboxFunctionInvocationEvent:
  *       type: object
  *       description: Server-Sent Event for sandbox function invocation streaming. Discriminated on the `type` field.

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -72,7 +72,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  * /api/w/{wId}/files/{fileId}:
  *   get:
  *     summary: Get or download a file
- *     description: View or download a file. Skill attachments require read access to their associated skill. Feature-flagged Frames v2 return the active published UI bundle when viewed. Use query parameters `version` (original, processed, public) and `action` (view, download).
+ *     description: View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).
  *     tags:
  *       - Private Files
  *     parameters:

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
@@ -4,54 +4,6 @@ import invocations from "./invocations";
 
 const app = workspaceApp();
 
-/**
- * @swagger
- * /api/w/{wId}/frames/{frameId}/functions/{name}/invocations:
- *   post:
- *     summary: Invoke an active Frames v2 function
- *     description: Resolves a bare function name from the Frame's active immutable publication, checks Frame use rights, and starts an invocation pinned to that publication.
- *     tags:
- *       - Private Frames
- *     parameters:
- *       - in: path
- *         name: wId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: frameId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: name
- *         required: true
- *         description: Bare function name declared by the active Frame publication.
- *         schema:
- *           type: string
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/PrivateFrameFunctionInvocationRequest'
- *     security:
- *       - BearerAuth: []
- *     responses:
- *       201:
- *         description: Invocation created. Fast invocations may also include their terminal outcome.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/PrivateFrameFunctionInvocationResponse'
- *       401:
- *         description: The function requires a workspace member or a stricter caller identity.
- *       404:
- *         description: Frame, active publication, function, or Frame use right not found.
- *       500:
- *         description: Invocation failed before it could be created.
- */
-
 app.route("/invocations", invocations);
 
 export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.ts
@@ -3,42 +3,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 
 const app = workspaceApp();
 
-/**
- * @swagger
- * /api/w/{wId}/frames/{frameId}/invocations/{invocationId}/events:
- *   get:
- *     summary: Stream Frames v2 function invocation events
- *     description: Authorizes through the stable Frame identity and redirects to the SSE service. The invocation's own publication is used, so a republish cannot break an existing stream.
- *     tags:
- *       - Private Frames
- *     parameters:
- *       - in: path
- *         name: wId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: frameId
- *         required: true
- *         schema:
- *           type: string
- *       - in: path
- *         name: invocationId
- *         required: true
- *         schema:
- *           type: string
- *     security:
- *       - BearerAuth: []
- *     responses:
- *       200:
- *         description: Server-Sent Event stream.
- *         content:
- *           text/event-stream:
- *             schema:
- *               $ref: '#/components/schemas/PrivateSandboxFunctionInvocationEvent'
- *       404:
- *         description: Frame use right or Frame-owned invocation not found.
- */
+/** @ignoreswagger */
 app.get("/", redirectToSse);
 
 export default app;

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -58,7 +58,7 @@ const app = workspaceApp();
  * /api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events:
  *   get:
  *     summary: Stream sandbox function invocation events
- *     description: Stream real-time events for a Pod or Frame function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.
+ *     description: Stream real-time events for a Pod function invocation using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.
  *     tags:
  *       - Private Events
  *     parameters:
@@ -71,7 +71,7 @@ const app = workspaceApp();
  *       - in: path
  *         name: functionId
  *         required: true
- *         description: ID of the Pod or Frame function
+ *         description: ID of the Pod function
  *         schema:
  *           type: string
  *       - in: path

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -135,9 +135,6 @@ export function isValidSandboxFunctionSlug(value: unknown): value is string {
   return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);
 }
 
-/**
- * @swaggerschema PrivateSandboxFunctionInvocation (swagger_private_schemas.ts)
- */
 export type SandboxFunctionInvocationType = {
   sId: string;
   functionId: string;
@@ -181,9 +178,6 @@ export type SandboxFunctionCallErrorCode =
   | SandboxFunctionFrontErrorCode
   | APIErrorType;
 
-/**
- * @swaggerschema PrivateSandboxFunctionCallError (swagger_private_schemas.ts)
- */
 export type SandboxFunctionCallError = {
   code: SandboxFunctionCallErrorCode;
   message: string;
@@ -247,9 +241,6 @@ export type SandboxFunctionInvocationContext = {
   timezone?: string;
 };
 
-/**
- * @swaggerschema PrivateFrameFunctionInvocationRequest (swagger_private_schemas.ts)
- */
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;
   context?: SandboxFunctionInvocationContext;
@@ -261,9 +252,6 @@ export type SandboxFunctionInvocationOutcome =
   | { status: "succeeded"; result: unknown }
   | { status: "errored"; error: SandboxFunctionCallError };
 
-/**
- * @swaggerschema PrivateFrameFunctionInvocationResponse (swagger_private_schemas.ts)
- */
 export type PostSandboxFunctionInvocationResponseBody = {
   invocation: SandboxFunctionInvocationType;
   // Set when the invocation settled before the response was sent. Callers that get an outcome are


### PR DESCRIPTION
## Description

- Mark the authenticated Frames v2 invocation stream as Swagger-ignored.
- Remove the private Frame invocation paths, schemas, and stale schema links from generated Swagger.
- Remove Frames v2 claims from generic private compatibility endpoint docs.

Sandbox Frame routes were already ignored. Public shared-Frame routes are unchanged.

## Tests

Regenerated and validated `front-api/public/swagger.json`.

## Risk

Low. Runtime routing and request handling are unchanged.

## Deploy Plan

Standard deploy.
