### PR TITLE
Add a Frame sandbox cleanup hook

### DIFF
--- a/front/lib/resources/frame_sandbox_adapter.test.ts
+++ b/front/lib/resources/frame_sandbox_adapter.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockExecuteWithLock,
+  mockExecuteWithRenewingLockResult,
   mockGetSandboxImage,
   mockGetSandboxProvider,
   mockProviderCreate,
@@ -9,6 +10,7 @@ const {
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockExecuteWithLock: vi.fn(),
+  mockExecuteWithRenewingLockResult: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
   mockProviderCreate: vi.fn(),
@@ -31,6 +33,7 @@ vi.mock("@app/lib/api/sandbox/image", () => ({
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
   executeWithLockResult: mockExecuteWithLock,
+  executeWithRenewingLockResult: mockExecuteWithRenewingLockResult,
 }));
 
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -89,6 +92,10 @@ describe("FrameSandboxAdapter", () => {
           }
         }
       }
+    );
+    mockExecuteWithRenewingLockResult.mockImplementation(
+      async (key: string, fn: (lease: unknown) => Promise<unknown>) =>
+        mockExecuteWithLock(key, () => fn({ check: () => new Ok(undefined) }))
     );
     mockGetSandboxImage.mockReturnValue(
       new Ok({

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -261,14 +261,16 @@ export class FrameSandboxAdapter {
     frame: FrameSandboxOwner,
     {
       afterSandboxCleanup,
+      beforeSandboxCleanup,
     }: {
       afterSandboxCleanup?: () => Promise<Result<undefined, Error>>;
+      beforeSandboxCleanup?: () => Result<void, Error>;
     } = {}
   ): Promise<Result<undefined, Error>> {
     return SandboxResource.deleteByOwner(
       auth,
       this.toSandboxDeleteOwner(auth, frame),
-      { afterSandboxCleanup }
+      { afterSandboxCleanup, beforeSandboxCleanup }
     );
   }
 


### PR DESCRIPTION
## Description

Allow Frame deletion to run a guarded callback immediately before sandbox cleanup. This small contract is shared by the otherwise independent publication/resource and sandbox lock-adoption lanes.

Stack: #31489 -> this PR.

## Tests

- All 4 focused Frame sandbox adapter tests pass.
- Biome and diff checks pass.

## Risk

Existing callers are unchanged because the hook is optional. Callback failure stops cleanup.

## Deploy Plan

Merge after #31489. No migration is required.