### PR TITLE
Add Frame move path and storage foundation

### DIFF
--- a/front/lib/api/frames/move_source.test_utils.ts
+++ b/front/lib/api/frames/move_source.test_utils.ts
@@ -1,0 +1,75 @@
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+
+export const frameManifest = JSON.stringify({ version: 1, name: "Status" });
+
+export async function setupMoveFrameV2SourceTest() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const sourceMountDirectory = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const sourceObjects = [
+    `${sourceMountDirectory}/${FRAME_MANIFEST_FILE}`,
+    `${sourceMountDirectory}/index.tsx`,
+  ];
+  const objectSizes = new Map<string, string>();
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(frameManifest),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: {
+      activePublicationId: "publication-1",
+      conversationId: conversation.sId,
+    },
+    mountFilePath: sourceObjects[0],
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+  fileStorageMock.setObject(sourceObjects[0], frameManifest);
+  fileStorageMock.setObject(sourceObjects[1], "ui source");
+  fileStorageMock.setFileExists(
+    (filePath) => fileStorageMock.getObject(filePath) !== undefined
+  );
+  const listedObjects = [...sourceObjects];
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    listedObjects
+      .filter(
+        (name) =>
+          name.startsWith(prefix) &&
+          fileStorageMock.getObject(name) !== undefined
+      )
+      .map((name) => ({
+        name,
+        metadata: {
+          contentType: "text/plain",
+          size: objectSizes.get(name) ?? "10",
+        },
+      }))
+  );
+
+  return {
+    auth,
+    conversation,
+    frame,
+    listedObjects,
+    objectSizes,
+    sourceDirectoryPath,
+    sourceMountDirectory,
+    sourceObjects,
+    workspace,
+  };
+}

--- a/front/lib/api/frames/move_source_errors.ts
+++ b/front/lib/api/frames/move_source_errors.ts
@@ -1,0 +1,28 @@
+import { Err } from "@app/types/shared/result";
+
+export class FrameSourceMoveError extends Error {
+  constructor(
+    readonly code:
+      | "commit_failed"
+      | "conflict"
+      | "copy_failed"
+      | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceMoveError";
+  }
+}
+
+export function isFrameSourceMoveError(
+  error: unknown
+): error is FrameSourceMoveError {
+  return error instanceof FrameSourceMoveError;
+}
+
+export function frameSourceMoveError(
+  code: FrameSourceMoveError["code"],
+  message: string
+) {
+  return new Err(new FrameSourceMoveError(code, message));
+}

--- a/front/lib/api/frames/move_source_paths.test.ts
+++ b/front/lib/api/frames/move_source_paths.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+
+import { resolveFrameSourceMovePaths } from "@app/lib/api/frames/move_source_paths";
+import { describe, expect, it } from "vitest";
+
+describe("resolveFrameSourceMovePaths", () => {
+  it("resolves normalized paths and audit metadata in one conversation", () => {
+    const result = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      destinationDirectoryPath: "conversation-conv_123/Archive/Renamed",
+    });
+
+    expect(result.isOk() && result.value).toMatchObject({
+      auditEvent: {
+        parentRelativePath: "Archive",
+        relativeFilePath: "Status",
+      },
+      destinationDirectoryPath: "conversation-conv_123/Archive/Renamed",
+      destinationManifestPath:
+        "conversation-conv_123/Archive/Renamed/manifest.json",
+      destinationScope: {
+        useCase: "conversation",
+        conversationId: "conv_123",
+      },
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      sourceManifestPath: "conversation-conv_123/Status/manifest.json",
+    });
+  });
+
+  it("resolves a move in one Pod", () => {
+    const result = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "pod-pod_123/Status",
+      destinationDirectoryPath: "pod-pod_123/Renamed",
+    });
+
+    expect(result.isOk() && result.value.destinationScope).toEqual({
+      useCase: "pod",
+      podId: "pod_123",
+    });
+  });
+
+  it("rejects nested and cross-mount destinations", () => {
+    const nested = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      destinationDirectoryPath: "conversation-conv_123/Status/Nested",
+    });
+    const crossMount = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      destinationDirectoryPath: "pod-pod_123/Status",
+    });
+
+    expect(nested.isErr() && nested.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(crossMount.isErr() && crossMount.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+});

--- a/front/lib/api/frames/move_source_paths.ts
+++ b/front/lib/api/frames/move_source_paths.ts
@@ -1,0 +1,123 @@
+import path from "node:path";
+
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
+import type { FrameSourceMoveError } from "@app/lib/api/frames/move_source_errors";
+import { frameSourceMoveError } from "@app/lib/api/frames/move_source_errors";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+type FrameSourceOwner = {
+  useCase: FileUseCase;
+  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
+};
+
+export type FrameSourceMovePaths = {
+  auditEvent: {
+    parentRelativePath: string;
+    relativeFilePath: string;
+  };
+  destinationDirectoryPath: string;
+  destinationManifestPath: string;
+  destinationScope: GCSMountPoint;
+  sourceDirectoryPath: string;
+  sourceManifestPath: string;
+};
+
+function sourceOwnerFromPath(scopedPath: string): FrameSourceOwner | null {
+  const parsed = parseScopedPrefix(scopedPath);
+  const slash = scopedPath.indexOf("/");
+  if (!parsed || slash < 0 || slash === scopedPath.length - 1) {
+    return null;
+  }
+
+  switch (parsed.kind) {
+    case "conversation":
+      return {
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parsed.id },
+      };
+    case "pod":
+      return {
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: parsed.id },
+      };
+    case "user":
+      return null;
+  }
+}
+
+function isSameOwner(a: FrameSourceOwner, b: FrameSourceOwner): boolean {
+  return (
+    a.useCase === b.useCase &&
+    a.useCaseMetadata.conversationId === b.useCaseMetadata.conversationId &&
+    a.useCaseMetadata.spaceId === b.useCaseMetadata.spaceId
+  );
+}
+
+export function resolveFrameSourceMovePaths({
+  destinationDirectoryPath,
+  sourceDirectoryPath,
+}: {
+  destinationDirectoryPath: string;
+  sourceDirectoryPath: string;
+}): Result<FrameSourceMovePaths, FrameSourceMoveError> {
+  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  const destination = DustFileSystem.normalizeScopedPath(
+    destinationDirectoryPath
+  );
+  if (!source || !destination) {
+    return frameSourceMoveError(
+      "invalid_source",
+      "Frame source and destination must be scoped paths."
+    );
+  }
+  if (source === destination || destination.startsWith(`${source}/`)) {
+    return frameSourceMoveError(
+      "invalid_source",
+      "Frame source and destination must be different, non-nested folders."
+    );
+  }
+
+  const sourceOwner = sourceOwnerFromPath(source);
+  const destinationOwner = sourceOwnerFromPath(destination);
+  if (
+    !sourceOwner ||
+    !destinationOwner ||
+    !isSameOwner(sourceOwner, destinationOwner)
+  ) {
+    return frameSourceMoveError(
+      "invalid_source",
+      "Frame source and destination must use the same conversation or Pod mount."
+    );
+  }
+
+  const destinationScope: GCSMountPoint =
+    destinationOwner.useCase === "conversation"
+      ? {
+          useCase: "conversation",
+          conversationId: destinationOwner.useCaseMetadata.conversationId ?? "",
+        }
+      : {
+          useCase: "pod",
+          podId: destinationOwner.useCaseMetadata.spaceId ?? "",
+        };
+  const scopedPrefix = source.split("/", 1)[0];
+  const parentRelativePath = path.posix.dirname(
+    path.posix.relative(scopedPrefix, destination)
+  );
+
+  return new Ok({
+    auditEvent: {
+      parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
+      relativeFilePath: path.posix.relative(scopedPrefix, source),
+    },
+    destinationDirectoryPath: destination,
+    destinationManifestPath: path.posix.join(destination, FRAME_MANIFEST_FILE),
+    destinationScope,
+    sourceDirectoryPath: source,
+    sourceManifestPath: path.posix.join(source, FRAME_MANIFEST_FILE),
+  });
+}

--- a/front/lib/api/frames/move_source_storage.test.ts
+++ b/front/lib/api/frames/move_source_storage.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+
+import path from "node:path";
+import { setupMoveFrameV2SourceTest } from "@app/lib/api/frames/move_source.test_utils";
+import {
+  copyFrameSourceMoveStorage,
+  inspectFrameSourceMoveStorage,
+} from "@app/lib/api/frames/move_source_storage";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+describe("Frame source move storage", () => {
+  it("copies the complete raw source tree into an empty destination", async () => {
+    const c = await setupMoveFrameV2SourceTest();
+    const destinationMountPath = c.sourceObjects[0].replace(
+      "/Status/",
+      "/Archive/"
+    );
+    const hiddenObject = `${c.sourceMountDirectory}/.cache/state.json`;
+    const placeholderObject = `${c.sourceMountDirectory}/empty/`;
+    for (const objectPath of [hiddenObject, placeholderObject]) {
+      c.listedObjects.push(objectPath);
+      fileStorageMock.setObject(objectPath, objectPath);
+    }
+
+    const snapshot = await inspectFrameSourceMoveStorage({
+      destinationMountPath,
+      sourceMountPath: c.sourceObjects[0],
+    });
+    assert(snapshot.isOk(), snapshot.isErr() ? snapshot.error.message : "");
+    const copied = await copyFrameSourceMoveStorage(snapshot.value);
+
+    assert(copied.isOk(), copied.isErr() ? copied.error.message : "");
+    for (const objectPath of c.listedObjects) {
+      expect(
+        fileStorageMock.getObject(objectPath.replace("/Status/", "/Archive/"))
+      ).toBe(fileStorageMock.getObject(objectPath));
+    }
+  });
+
+  it("rejects an occupied destination", async () => {
+    const c = await setupMoveFrameV2SourceTest();
+    const destinationMountPath = c.sourceObjects[0].replace(
+      "/Status/",
+      "/Archive/"
+    );
+    fileStorageMock.setObject(
+      path.posix.dirname(destinationMountPath),
+      "occupied"
+    );
+
+    const snapshot = await inspectFrameSourceMoveStorage({
+      destinationMountPath,
+      sourceMountPath: c.sourceObjects[0],
+    });
+
+    expect(snapshot.isErr() && snapshot.error).toMatchObject({
+      code: "conflict",
+    });
+  });
+
+  it("counts hidden objects toward the source size limit", async () => {
+    const c = await setupMoveFrameV2SourceTest();
+    const hiddenObject = `${c.sourceMountDirectory}/.cache/large.bin`;
+    c.listedObjects.push(hiddenObject);
+    c.objectSizes.set(hiddenObject, String(101 * 1024 * 1024));
+    fileStorageMock.setObject(hiddenObject, "");
+
+    const snapshot = await inspectFrameSourceMoveStorage({
+      destinationMountPath: c.sourceObjects[0].replace("/Status/", "/Archive/"),
+      sourceMountPath: c.sourceObjects[0],
+    });
+
+    expect(snapshot.isErr() && snapshot.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+
+  it("returns a typed copy failure", async () => {
+    const c = await setupMoveFrameV2SourceTest();
+    fileStorageMock.setCopyFileFails((source) => source === c.sourceObjects[0]);
+    const snapshot = await inspectFrameSourceMoveStorage({
+      destinationMountPath: c.sourceObjects[0].replace("/Status/", "/Archive/"),
+      sourceMountPath: c.sourceObjects[0],
+    });
+    assert(snapshot.isOk(), snapshot.isErr() ? snapshot.error.message : "");
+
+    const copied = await copyFrameSourceMoveStorage(snapshot.value);
+
+    expect(copied.isErr() && copied.error).toMatchObject({
+      code: "copy_failed",
+    });
+  });
+});

--- a/front/lib/api/frames/move_source_storage.ts
+++ b/front/lib/api/frames/move_source_storage.ts
@@ -1,0 +1,145 @@
+import path from "node:path";
+import type { FrameSourceMoveError } from "@app/lib/api/frames/move_source_errors";
+import { frameSourceMoveError } from "@app/lib/api/frames/move_source_errors";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const FRAME_SOURCE_MOVE_COPY_CONCURRENCY = 4;
+const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
+const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
+
+export type FrameSourceMoveStorageSnapshot = {
+  destinationMountPrefix: string;
+  sourceMountPrefix: string;
+  sourceObjectNames: string[];
+};
+
+export async function inspectFrameSourceMoveStorage({
+  destinationMountPath,
+  sourceMountPath,
+}: {
+  destinationMountPath: string;
+  sourceMountPath: string;
+}): Promise<Result<FrameSourceMoveStorageSnapshot, FrameSourceMoveError>> {
+  const bucket = getPrivateUploadBucket();
+  const sourceMountPrefix = `${path.posix.dirname(sourceMountPath)}/`;
+  const destinationMountDirectory = path.posix.dirname(destinationMountPath);
+  const destinationMountPrefix = `${destinationMountDirectory}/`;
+
+  try {
+    const [[destinationFileExists], destinationObjects] = await Promise.all([
+      bucket.file(destinationMountDirectory).exists(),
+      bucket.getFiles({ prefix: destinationMountPrefix, maxResults: 1 }),
+    ]);
+    if (destinationFileExists || destinationObjects.length > 0) {
+      return frameSourceMoveError(
+        "conflict",
+        "A file or folder already exists at the destination."
+      );
+    }
+  } catch (error) {
+    return frameSourceMoveError(
+      "copy_failed",
+      `Failed to inspect the Frame destination; the source remains authoritative: ${normalizeError(error).message}`
+    );
+  }
+
+  let sourceObjects;
+  try {
+    sourceObjects = await bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    });
+  } catch (error) {
+    return frameSourceMoveError(
+      "copy_failed",
+      `Failed to inspect the Frame source; the source remains authoritative: ${normalizeError(error).message}`
+    );
+  }
+  if (sourceObjects.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+    return frameSourceMoveError(
+      "invalid_source",
+      "Frame source exceeds the move size or file count limit."
+    );
+  }
+
+  let sourceSizeBytes = 0;
+  for (const sourceObject of sourceObjects) {
+    const sizeBytes = Number(sourceObject.metadata.size);
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+      return frameSourceMoveError(
+        "invalid_source",
+        `Frame source object has invalid size metadata: ${sourceObject.name}`
+      );
+    }
+    sourceSizeBytes += sizeBytes;
+  }
+  if (sourceSizeBytes > MAX_FRAME_SOURCE_BYTES) {
+    return frameSourceMoveError(
+      "invalid_source",
+      "Frame source exceeds the move size or file count limit."
+    );
+  }
+  if (!sourceObjects.some((entry) => entry.name === sourceMountPath)) {
+    return frameSourceMoveError(
+      "invalid_source",
+      "Frame manifest not found in source folder."
+    );
+  }
+
+  return new Ok({
+    destinationMountPrefix,
+    sourceMountPrefix,
+    sourceObjectNames: sourceObjects.map((entry) => entry.name),
+  });
+}
+
+export async function copyFrameSourceMoveStorage(
+  snapshot: FrameSourceMoveStorageSnapshot
+): Promise<Result<void, FrameSourceMoveError>> {
+  const bucket = getPrivateUploadBucket();
+  const copyResults = await concurrentExecutor(
+    snapshot.sourceObjectNames,
+    async (sourceObjectName) => {
+      if (!sourceObjectName.startsWith(snapshot.sourceMountPrefix)) {
+        return new Err(
+          new Error(`Invalid Frame source object path: ${sourceObjectName}`)
+        );
+      }
+      const relativePath = sourceObjectName.slice(
+        snapshot.sourceMountPrefix.length
+      );
+      try {
+        await bucket.copyFile(
+          sourceObjectName,
+          `${snapshot.destinationMountPrefix}${relativePath}`
+        );
+        return new Ok(undefined);
+      } catch (error) {
+        return new Err(normalizeError(error));
+      }
+    },
+    { concurrency: FRAME_SOURCE_MOVE_COPY_CONCURRENCY }
+  );
+  const copyFailure = copyResults.find((result) => result.isErr());
+  return copyFailure?.isErr()
+    ? frameSourceMoveError(
+        "copy_failed",
+        `Failed to copy the Frame source; the source remains authoritative and partial destination objects may remain: ${copyFailure.error.message}`
+      )
+    : new Ok(undefined);
+}
+
+export async function deleteFrameSourceMoveStorage(
+  sourceMountPrefix: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPrivateUploadBucket().deleteByPrefix(sourceMountPrefix);
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -439,6 +439,10 @@ class FileStorageMock {
             new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
           );
         }
+        const content = this._objectStore.get(src) ?? this._contentForPath(src);
+        if (content !== null && content !== undefined) {
+          this._objectStore.set(dest, content);
+        }
         return Promise.resolve(undefined);
       }),
       // Mirrors real GCS compose: concatenates each source's stored content, in order,


### PR DESCRIPTION
## Description

- resolve and validate normalized same-mount Frame source and destination paths
- derive the destination mount scope and audit paths in one place
- inspect bounded raw GCS source trees, including hidden objects and placeholders
- reject occupied destinations and invalid or oversized source snapshots
- copy snapshotted object names and expose best-effort source cleanup

These helpers have no production caller until the move operation child merges.

## Tests

Added 7 focused tests covering conversation and Pod path resolution, nested and cross-mount rejection, raw hidden and placeholder copies, occupied destinations, source size bounds, and typed copy failures. Biome and the front typecheck pass.

## Risk

Low. This adds backend helpers and test support without wiring a production caller. The initial copy helper is deliberately not generation-safe; generation fencing remains isolated in #31495.

## Deploy Plan

Standard deploy. No migration or backfill.