### PR TITLE
Move Frames within one mount

### DIFF
--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -422,7 +422,7 @@ async function moveGCSMountFile({
   return new Ok(undefined);
 }
 
-async function emitGCSMountFileMovedAuditLog(
+export async function emitGCSMountFileMovedAuditLog(
   auth: Authenticator,
   scope: GCSMountPoint,
   {

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const emitMovedAuditLog = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@app/lib/api/files/gcs_mount/files")
+  >()),
+  emitGCSMountFileMovedAuditLog: emitMovedAuditLog,
+}));
+
+vi.mock("@app/lib/lock", async (importActual) => ({
+  ...(await importActual<typeof import("@app/lib/lock")>()),
+  executeWithLockResult: async <T>(_name: string, cb: () => Promise<T>) => cb(),
+}));
+
+import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import {
+  frameManifest,
+  setupFrameSourceStorageTest,
+} from "@app/lib/api/frames/source_storage.test_utils";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import assert from "assert";
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  emitMovedAuditLog.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("moveFrameV2Source", () => {
+  it("moves the folder while preserving the Frame identity and publication", async () => {
+    const c = await setupFrameSourceStorageTest();
+    const storage = getPrivateUploadBucket();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(storage);
+    vi.spyOn(storage, "copyFile").mockImplementation(async (source, target) => {
+      const content = fileStorageMock.getObject(source);
+      if (content !== undefined) {
+        fileStorageMock.setObject(target, content);
+      }
+      return { destinationGeneration: "mock" } as never;
+    });
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Archive/Renamed`;
+    const destinationMountDirectory = c.sourceMountDirectory.replace(
+      "/Status",
+      "/Archive/Renamed"
+    );
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    expect(moved.value).toEqual({
+      destinationDirectoryPath,
+      frameId: c.frame.sId,
+      sourceDeletionFailed: false,
+    });
+    const reloaded = await FileResource.fetchById(c.auth, c.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${destinationMountDirectory}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.useCaseMetadata).toEqual({
+      activePublicationId: "publication-1",
+      conversationId: c.conversation.sId,
+    });
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBeUndefined();
+    expect(
+      fileStorageMock.getObject(
+        `${destinationMountDirectory}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBe(frameManifest);
+    expect(emitMovedAuditLog).toHaveBeenCalledOnce();
+  });
+});

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -1,0 +1,207 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { emitGCSMountFileMovedAuditLog } from "@app/lib/api/files/gcs_mount/files";
+import {
+  FrameSourceMoveError,
+  resolveFrameSourceMovePaths,
+} from "@app/lib/api/frames/move_source_paths";
+import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import {
+  copyFrameSourceStorage,
+  deleteFrameSourceStorage,
+  inspectFrameSourceStorage,
+} from "@app/lib/api/frames/source_storage";
+import type { Authenticator } from "@app/lib/auth";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
+import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { UniqueConstraintError } from "sequelize";
+
+const moveError = (code: FrameSourceMoveError["code"], message: string) =>
+  new Err(new FrameSourceMoveError(code, message));
+
+export type MoveFrameV2SourceError = DustFileSystemError | FrameSourceMoveError;
+
+type FrameSourceMove = {
+  destinationDirectoryPath: string;
+  frameId: string;
+  sourceDeletionFailed: boolean;
+};
+
+/**
+ * Move a registered Frames v2 source folder within one GCS mount.
+ *
+ * This intentionally uses a non-transactional copy, DB update, then source delete sequence.
+ * Until the DB update succeeds, the source FileResource path remains authoritative.
+ */
+export async function moveFrameV2Source(
+  auth: Authenticator,
+  {
+    conversation,
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    destinationDirectoryPath: string;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<FrameSourceMove, MoveFrameV2SourceError>> {
+  const pathsResult = resolveFrameSourceMovePaths({
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  });
+  if (pathsResult.isErr()) {
+    return pathsResult;
+  }
+  const paths = pathsResult.value;
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [paths.sourceDirectoryPath, paths.destinationDirectoryPath],
+  });
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return moveError(
+      "invalid_source",
+      "Frames v2 source moves do not support database-backed mounts."
+    );
+  }
+  for (const scopedPath of [
+    paths.sourceDirectoryPath,
+    paths.destinationDirectoryPath,
+  ]) {
+    const access = dustFs.checkWriteAccess(scopedPath);
+    if (access.isErr()) {
+      return access;
+    }
+  }
+
+  const sourceMountPath = dustFs.toMountFilePath(paths.sourceManifestPath);
+  const destinationMountPath = dustFs.toMountFilePath(
+    paths.destinationManifestPath
+  );
+  if (!sourceMountPath || !destinationMountPath) {
+    return moveError("invalid_source", "Invalid Frame source or destination.");
+  }
+
+  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+    sourceMountPath,
+  ]);
+  if (!frame?.isFrameV2) {
+    return moveError(
+      "invalid_source",
+      `No registered Frame found at ${paths.sourceManifestPath}.`
+    );
+  }
+
+  const locked = await withFramePublishLock<
+    FrameSourceMove,
+    MoveFrameV2SourceError
+  >(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (
+      !freshFrame ||
+      freshFrame.toScopedPath(auth) !== paths.sourceManifestPath
+    ) {
+      return moveError(
+        "conflict",
+        "The Frame source changed while it was being moved; retry from its current path."
+      );
+    }
+
+    const [registeredDestination] = await FileResource.fetchByMountFilePaths(
+      auth,
+      [destinationMountPath]
+    );
+    if (registeredDestination) {
+      return moveError(
+        "conflict",
+        "A registered file already uses the destination path."
+      );
+    }
+
+    const snapshot = await inspectFrameSourceStorage({
+      destinationMountPath,
+      sourceMountPath,
+    });
+    if (snapshot.isErr()) {
+      return moveError(snapshot.error.code, snapshot.error.message);
+    }
+    const registeredSourceFiles = await FileResource.fetchByMountFilePaths(
+      auth,
+      snapshot.value.sourceObjectNames
+    );
+    if (registeredSourceFiles.some((file) => file.id !== freshFrame.id)) {
+      return moveError(
+        "conflict",
+        "Move nested registered files separately before moving this Frame."
+      );
+    }
+
+    const copied = await copyFrameSourceStorage(snapshot.value);
+    if (copied.isErr()) {
+      return moveError(copied.error.code, copied.error.message);
+    }
+
+    try {
+      await freshFrame.updateMount({
+        destFileName: FRAME_MANIFEST_FILE,
+        destMountFilePath: destinationMountPath,
+        destUseCase: freshFrame.useCase,
+        destUseCaseMetadata: freshFrame.useCaseMetadata ?? undefined,
+      });
+    } catch (error) {
+      const normalized = normalizeError(error);
+      return moveError(
+        error instanceof UniqueConstraintError ? "conflict" : "commit_failed",
+        error instanceof UniqueConstraintError
+          ? "A registered file already uses the destination path."
+          : `Failed to commit the Frame source move; the source remains authoritative and destination objects may remain: ${normalized.message}`
+      );
+    }
+
+    const deleted = await deleteFrameSourceStorage(
+      snapshot.value.sourceMountPrefix
+    );
+    if (deleted.isErr()) {
+      logger.warn(
+        {
+          destinationDirectoryPath: paths.destinationDirectoryPath,
+          error: deleted.error,
+          frameId: frame.sId,
+          sourceDirectoryPath: paths.sourceDirectoryPath,
+        },
+        "Frame source moved but the old folder could not be removed"
+      );
+    }
+
+    void emitGCSMountFileMovedAuditLog(auth, paths.destinationScope, {
+      relativeFilePath: paths.auditEvent.relativeFilePath,
+      parentRelativePath: paths.auditEvent.parentRelativePath,
+    });
+
+    return new Ok({
+      destinationDirectoryPath: paths.destinationDirectoryPath,
+      frameId: frame.sId,
+      sourceDeletionFailed: deleted.isErr(),
+    });
+  });
+
+  if (locked.isErr()) {
+    return isLockAcquisitionTimeoutError(locked.error)
+      ? moveError(
+          "conflict",
+          "Another Frame operation is in progress; retry the move."
+        )
+      : new Err(locked.error);
+  }
+  return locked;
+}


### PR DESCRIPTION
## Description

- compose the merged path and storage foundations from #31536 and #31537 into the bounded Frames v2 move operation
- preserve the stable FileResource identity, publication metadata, sharing state, and source ownership metadata
- reject nested registered files before copying
- commit the FileResource path, best-effort delete the source, and emit the existing file.moved audit event

This branch is now directly based on current main and contains one move-operation commit. It uses the final FrameSourceMoveError class exported by the merged path foundation. The operation is deliberately non-crash-safe and has no production caller until its HTTP child merges. Reservations, recovery, generation fencing, rollback, and renewable locks remain out of scope.

## Tests

- 10 focused path, storage, and move tests pass.
- Biome passes on all path, storage, move, and mount files.
- Front tsgo passes.

## Risk

Once called, a crash or typed failure can leave partial destination objects. The FileResource path remains authoritative. Generation-safe copy and cleanup stay isolated in #31495.

## Deploy Plan

Standard deploy from main. #31536 and #31537 are already merged. No migration or backfill.