### PR TITLE
Expose Frame package file metadata

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
@@ -1,7 +1,10 @@
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,9 +13,9 @@ vi.mock("@app/lib/lock", () => ({
 }));
 
 async function setupProject() {
-  const { workspace, user } = await createPrivateApiMockRequest();
+  const { auth, workspace, user } = await createPrivateApiMockRequest();
   const project = await SpaceFactory.project(workspace, user.id);
-  return { workspace, user, project };
+  return { auth, workspace, user, project };
 }
 
 function makeGCSFile(
@@ -122,6 +125,40 @@ describe("GET /api/w/:wId/spaces/:spaceId/files", () => {
     expect(dir).toBeDefined();
     expect(dir.path).toBe(`pod-${project.sId}/reports`);
     expect(dir.fileName).toBe("reports");
+  });
+
+  it("uses a linked Frame resource's identity and content type", async () => {
+    const { auth, workspace, project } = await setupProject();
+    const manifestMountPath = `w/${workspace.sId}/pods/${project.sId}/files/status/${FRAME_MANIFEST_FILE}`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 100,
+      mountFilePath: manifestMountPath,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: project.sId },
+    });
+
+    fileStorageMock.setFilesByPrefix(() => [
+      makeGCSFile(workspace.sId, project.sId, `status/${FRAME_MANIFEST_FILE}`, {
+        contentType: "application/json",
+      }),
+    ]);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/spaces/${project.sId}/files`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toMatchObject([
+      {
+        contentType: "application/json",
+        fileId: frame.sId,
+        fileResourceContentType: frameV2ContentType,
+      },
+    ]);
   });
 });
 

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -138,7 +138,7 @@ export async function streamThumbnail(
 // ---------------------------------------------------------------------------
 
 /**
- * Enrich a list of file entries with their linked FileResource sId (fileId).
+ * Enrich file entries with their linked FileResource identity and semantic content type.
  * A single batch DB query covers all entries; pod files probe the legacy projects/ path too.
  *
  * Intended for endpoints that expose file listings to the client (conversation files,
@@ -176,11 +176,18 @@ export async function enrichListWithFileResourceIds(
     mountPaths
   );
 
-  // Map every known mountFilePath to its FileResource sId.
-  const byMountPath = new Map<string, string>();
+  // Keep raw GCS contentType for source previews. The linked resource can represent a higher-level
+  // object such as a registered Frame package, so expose its semantic type separately.
+  const byMountPath = new Map<
+    string,
+    { contentType: string; fileId: string }
+  >();
   for (const fr of fileResources) {
     if (fr.mountFilePath) {
-      byMountPath.set(fr.mountFilePath, fr.sId);
+      byMountPath.set(fr.mountFilePath, {
+        contentType: fr.contentType,
+        fileId: fr.sId,
+      });
     }
   }
 
@@ -193,9 +200,15 @@ export async function enrichListWithFileResourceIds(
       return entry;
     }
     const legacyPath = gcsPath.replace(/\/pods\//, "/projects/");
-    const fileId =
+    const linkedFile =
       byMountPath.get(gcsPath) ?? byMountPath.get(legacyPath) ?? null;
-    return { ...entry, fileId };
+    return linkedFile
+      ? {
+          ...entry,
+          fileId: linkedFile.fileId,
+          fileResourceContentType: linkedFile.contentType,
+        }
+      : entry;
   });
 }
 

--- a/front/lib/file_icon_utils.ts
+++ b/front/lib/file_icon_utils.ts
@@ -1,4 +1,8 @@
-import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
 import {
   ActionFrame,
   BigQueryLogo,
@@ -110,7 +114,11 @@ const FILE_TYPE_MAPPINGS: FileTypeMapping[] = [
   },
   {
     icon: ActionFrame,
-    mimeTypes: [frameContentType, frameSlideshowContentType],
+    mimeTypes: [
+      frameContentType,
+      frameSlideshowContentType,
+      frameV2ContentType,
+    ],
     extensions: [".js", ".jsx", ".ts", ".tsx"],
   },
 ];

--- a/front/types/api/file_system/types.ts
+++ b/front/types/api/file_system/types.ts
@@ -22,6 +22,8 @@ export type FileSystemFileEntry = FileSystemEntryBase & {
   contentType: string;
   /** sId of the corresponding FileResource record, or null when none exists. */
   fileId: string | null;
+  /** Semantic type of the linked FileResource, when it differs from the source bytes. */
+  fileResourceContentType?: string;
   thumbnailUrl: string | null;
   /** Present when the caller requested signed URLs. */
   signedDownloadUrl?: string | null;


### PR DESCRIPTION
## Description

Annotate file-system entries that are registered Frames v2 with stable Frame identity and source-package path. This is the backend/type foundation extracted from #31413; explorer aggregation and rendering remain separate.

## Tests

- 26 focused space-file route tests pass.
- Biome and diff checks pass.

## Risk

The internal file-list response gains optional fields. Existing consumers remain compatible.

## Deploy Plan

Deploy normally. The route is internal and ignored by Swagger. No migration is required.