### PR TITLE
Serve canonical Frames v2 invocations

### DIFF
--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
@@ -1,5 +1,7 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import invocations from "./invocations";
+
 const app = workspaceApp();
 
 /**
@@ -49,5 +51,7 @@ const app = workspaceApp();
  *       500:
  *         description: Invocation failed before it could be created.
  */
+
+app.route("/invocations", invocations);
 
 export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.test.ts
@@ -1,0 +1,67 @@
+import { makeTestFrameFunction } from "@app/tests/utils/FrameFunctionFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...mod,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+    getSandboxFunctionInvocationEvents: vi.fn(async function* () {}),
+  };
+});
+
+vi.mock("@app/temporal/sandbox_functions/client", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/temporal/sandbox_functions/client")
+    >();
+  return {
+    ...mod,
+    launchSandboxFunctionInvocationWorkflow: vi.fn(
+      async () => new Ok(undefined)
+    ),
+  };
+});
+
+import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/w/:wId/frames/:frameId/functions/:name/invocations", () => {
+  it("invokes the named function from the active publication", async () => {
+    const { workspace, frame, sandboxFunction } = await makeTestFrameFunction();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/${frame.sId}/functions/run-function/invocations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ input: { message: "hello" } }),
+      }
+    );
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      invocation: {
+        functionId: sandboxFunction.sId,
+        status: "created",
+      },
+    });
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sandboxFunction: expect.objectContaining({
+          sId: sandboxFunction.sId,
+          publicationId: "publication-1",
+        }),
+      })
+    );
+  });
+});

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -1,14 +1,14 @@
 import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
-import {
-  FrameFunctionInvocationParamsSchema,
-  PostFrameFunctionInvocationBodySchema,
-} from "@front-api/lib/api/frame_function_invocation_schemas";
 import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { resolveActiveFrameFunctionForUse } from "@app/lib/api/sandbox_functions/frame_share_capability";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
 } from "@app/types/api/sandbox_functions";
+import {
+  FrameFunctionInvocationParamsSchema,
+  PostFrameFunctionInvocationBodySchema,
+} from "@front-api/lib/api/frame_function_invocation_schemas";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -1,0 +1,87 @@
+import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
+import {
+  FrameFunctionInvocationParamsSchema,
+  PostFrameFunctionInvocationBodySchema,
+} from "@front-api/lib/api/frame_function_invocation_schemas";
+import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
+import { resolveActiveFrameFunctionForUse } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  PostSandboxFunctionInvocationResponseBody,
+} from "@app/types/api/sandbox_functions";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("param", FrameFunctionInvocationParamsSchema),
+  validate("json", PostFrameFunctionInvocationBodySchema),
+  async (ctx): HandlerResult<PostSandboxFunctionInvocationResponseBody> => {
+    const auth = ctx.get("auth");
+    const { frameId, name } = ctx.req.valid("param");
+    const body: PostSandboxFunctionInvocationRequestBody =
+      ctx.req.valid("json");
+
+    const sandboxFunction = await resolveActiveFrameFunctionForUse(auth, {
+      frameId,
+      functionName: name,
+    });
+    if (!sandboxFunction) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_not_found",
+          message: "Frame function not found.",
+        },
+      });
+    }
+
+    const invocationResult = await sandboxFunction.invoke(auth, body, {
+      origin:
+        auth.authMethod() === "session" ? "interactive_session" : "delegated",
+    });
+    if (invocationResult.isErr()) {
+      if (isSandboxFunctionInvocationError(invocationResult.error)) {
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: invocationResult.error.code,
+            message: invocationResult.error.message,
+          },
+        });
+      }
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Frame function invocation failed.",
+          },
+        },
+        invocationResult.error
+      );
+    }
+
+    const invocation = invocationResult.value;
+    const outcome =
+      invocation.settledOutcome() ??
+      (await awaitSandboxFunctionInvocationOutcome({
+        invocationId: invocation.sId,
+      }));
+
+    return ctx.json(
+      {
+        invocation: invocation.toJSON(),
+        ...(outcome ? { outcome } : {}),
+      },
+      201
+    );
+  }
+);
+
+export default app;

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -135,6 +135,9 @@ export function isValidSandboxFunctionSlug(value: unknown): value is string {
   return typeof value === "string" && SANDBOX_FUNCTION_SLUG_REGEX.test(value);
 }
 
+/**
+ * @swaggerschema PrivateSandboxFunctionInvocation (swagger_private_schemas.ts)
+ */
 export type SandboxFunctionInvocationType = {
   sId: string;
   functionId: string;
@@ -178,6 +181,9 @@ export type SandboxFunctionCallErrorCode =
   | SandboxFunctionFrontErrorCode
   | APIErrorType;
 
+/**
+ * @swaggerschema PrivateSandboxFunctionCallError (swagger_private_schemas.ts)
+ */
 export type SandboxFunctionCallError = {
   code: SandboxFunctionCallErrorCode;
   message: string;
@@ -241,6 +247,9 @@ export type SandboxFunctionInvocationContext = {
   timezone?: string;
 };
 
+/**
+ * @swaggerschema PrivateFrameFunctionInvocationRequest (swagger_private_schemas.ts)
+ */
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;
   context?: SandboxFunctionInvocationContext;
@@ -252,6 +261,9 @@ export type SandboxFunctionInvocationOutcome =
   | { status: "succeeded"; result: unknown }
   | { status: "errored"; error: SandboxFunctionCallError };
 
+/**
+ * @swaggerschema PrivateFrameFunctionInvocationResponse (swagger_private_schemas.ts)
+ */
 export type PostSandboxFunctionInvocationResponseBody = {
   invocation: SandboxFunctionInvocationType;
   // Set when the invocation settled before the response was sent. Callers that get an outcome are


### PR DESCRIPTION
## Description

Serve the canonical POST endpoint for invoking a Frames v2 function by stable Frame id and bare function name. The transport uses the shared strict parsers and active-publication resolver, preserves caller identity policy and response shape, and keeps the contract generated by its parent.

This focused behavior child replaces the transport portion of #31412. The private API change is additive and backward compatible.

## Tests

- Front API Vitest: 1 file, 1 test passed
- `npm run docs` in `front-api`
- `npm run lint:swagger-annotations` in `front-api`
- `git diff --check`

## Risk

Low and feature-gated. Missing Frames, functions, publications, or use rights fail closed. Rollback is reverting this PR.

## Deploy Plan

Merge after the active Frame function resolver. Deploy normally.
