### PR TITLE
Build Frame packages in the file explorer

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
@@ -1,7 +1,10 @@
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,9 +13,9 @@ vi.mock("@app/lib/lock", () => ({
 }));
 
 async function setupProject() {
-  const { workspace, user } = await createPrivateApiMockRequest();
+  const { auth, workspace, user } = await createPrivateApiMockRequest();
   const project = await SpaceFactory.project(workspace, user.id);
-  return { workspace, user, project };
+  return { auth, workspace, user, project };
 }
 
 function makeGCSFile(
@@ -122,6 +125,40 @@ describe("GET /api/w/:wId/spaces/:spaceId/files", () => {
     expect(dir).toBeDefined();
     expect(dir.path).toBe(`pod-${project.sId}/reports`);
     expect(dir.fileName).toBe("reports");
+  });
+
+  it("uses a linked Frame resource's identity and content type", async () => {
+    const { auth, workspace, project } = await setupProject();
+    const manifestMountPath = `w/${workspace.sId}/pods/${project.sId}/files/status/${FRAME_MANIFEST_FILE}`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 100,
+      mountFilePath: manifestMountPath,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: project.sId },
+    });
+
+    fileStorageMock.setFilesByPrefix(() => [
+      makeGCSFile(workspace.sId, project.sId, `status/${FRAME_MANIFEST_FILE}`, {
+        contentType: "application/json",
+      }),
+    ]);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/spaces/${project.sId}/files`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.files).toMatchObject([
+      {
+        contentType: "application/json",
+        fileId: frame.sId,
+        fileResourceContentType: frameV2ContentType,
+      },
+    ]);
   });
 });
 

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -110,6 +110,7 @@ export function FileExplorerContent({
         );
 
       case "folder":
+      case "frame_package":
         return null;
 
       default:

--- a/front/components/file_explorer/fileExplorerPipeline.test.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.test.ts
@@ -1,23 +1,182 @@
 import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
 import { describe, expect, it } from "vitest";
 
 function mountFile(
   scopedPath: string,
-  fileName = scopedPath.split("/").pop() ?? scopedPath
+  fileName = scopedPath.split("/").pop() ?? scopedPath,
+  {
+    contentType = "text/plain",
+    fileId = "file-1",
+    fileResourceContentType,
+  }: {
+    contentType?: string;
+    fileId?: string | null;
+    fileResourceContentType?: string;
+  } = {}
 ): FileSystemEntry {
   return {
     isDirectory: false,
     fileName,
     path: scopedPath,
-    contentType: "text/plain",
-    fileId: "file-1",
+    contentType,
+    fileId,
+    fileResourceContentType,
     sizeBytes: 100,
     lastModifiedMs: 0,
     thumbnailUrl: null,
   };
 }
+
+function frameManifest(scopedPath: string): FileSystemEntry {
+  return mountFile(scopedPath, FRAME_MANIFEST_FILE, {
+    contentType: "application/json",
+    fileId: "frame-1",
+    fileResourceContentType: frameV2ContentType,
+  });
+}
+
+describe("getFileExplorerPipeline Frame packages", () => {
+  it("collapses a registered source folder into one Frame package", () => {
+    const files = [
+      frameManifest("conversation-c1/apps/status/manifest.json"),
+      mountFile("conversation-c1/apps/status/index.tsx"),
+    ];
+
+    const pipeline = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "apps",
+      displayFramePackages: true,
+      files,
+      searchQuery: "",
+      sortMode: "last-modified",
+    });
+
+    expect(pipeline.sortedNodes).toMatchObject([
+      {
+        contentType: frameV2ContentType,
+        isDirectory: false,
+        name: "status",
+        path: "apps/status",
+      },
+    ]);
+    expect(pipeline.entryByRelativePath.get("apps/status")).toMatchObject({
+      kind: "frame_package",
+      fileId: "frame-1",
+      sourceFolderPath: "apps/status",
+    });
+    expect(pipeline.filterCounts.frames).toBe(1);
+  });
+
+  it("shows raw source after opening the package folder", () => {
+    const files = [
+      frameManifest("conversation-c1/apps/status/manifest.json"),
+      mountFile("conversation-c1/apps/status/index.tsx"),
+    ];
+
+    const pipeline = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "apps/status",
+      displayFramePackages: true,
+      files,
+      searchQuery: "",
+      sortMode: "name-asc",
+    });
+
+    expect(pipeline.sortedNodes.map((node) => node.name)).toEqual([
+      "index.tsx",
+      "manifest.json",
+    ]);
+    expect(
+      pipeline.entryByRelativePath.get("apps/status/manifest.json")?.kind
+    ).toBe("file");
+  });
+
+  it("keeps an unregistered manifest as ordinary source", () => {
+    const files = [
+      mountFile(
+        "conversation-c1/apps/status/manifest.json",
+        FRAME_MANIFEST_FILE,
+        {
+          contentType: "application/json",
+          fileId: null,
+        }
+      ),
+      mountFile("conversation-c1/apps/status/index.tsx"),
+    ];
+
+    const pipeline = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "apps",
+      displayFramePackages: true,
+      files,
+      searchQuery: "",
+      sortMode: "name-asc",
+    });
+
+    expect(pipeline.sortedNodes).toMatchObject([
+      { isDirectory: true, name: "status", path: "apps/status" },
+    ]);
+  });
+
+  it("keeps registered source as a folder when package display is disabled", () => {
+    const files = [
+      frameManifest("conversation-c1/apps/status/manifest.json"),
+      mountFile("conversation-c1/apps/status/index.tsx"),
+    ];
+
+    const pipeline = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "apps",
+      files,
+      searchQuery: "",
+      sortMode: "name-asc",
+    });
+
+    expect(pipeline.sortedNodes).toMatchObject([
+      { isDirectory: true, name: "status", path: "apps/status" },
+    ]);
+  });
+
+  it("collapses packages under virtual scope roots", () => {
+    const files = [
+      withVirtualExplorerPath(
+        frameManifest("conversation-c1/status/manifest.json"),
+        "conversation"
+      ),
+      withVirtualExplorerPath(
+        mountFile("conversation-c1/status/index.tsx"),
+        "conversation"
+      ),
+    ];
+
+    const pipeline = getFileExplorerPipeline({
+      activeFilter: "all",
+      contentNodes: [],
+      currentFolderPath: "conversation",
+      displayFramePackages: true,
+      files,
+      searchQuery: "",
+      sortMode: "last-modified",
+      virtualScopeRoots: ["conversation", "pod"],
+    });
+
+    expect(pipeline.sortedNodes).toMatchObject([
+      {
+        isDirectory: false,
+        name: "status",
+        path: "conversation/status",
+      },
+    ]);
+  });
+});
 
 describe("getFileExplorerPipeline virtualScopeRoots", () => {
   it("shows scope folders at the virtual root", () => {

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -5,6 +5,7 @@ import type {
   FileExplorerPathEntry,
   FileExplorerSortMode,
   FileSystemTreeNode,
+  FramePackageEntry,
 } from "@app/components/file_explorer/types";
 import {
   buildFileSystemTree,
@@ -14,9 +15,12 @@ import {
   getChildrenAtFolderPath,
   getExplorerRelativePath,
   getFileExplorerBucket,
+  getParentFolderRelativePath,
   getVirtualScopeRootNodes,
   isFileExplorerNodeHidden,
 } from "@app/components/file_explorer/utils";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
 
 interface FileExplorerPipeline {
   /** Tree nodes at the current folder level, filtered + sorted. */
@@ -38,8 +42,118 @@ interface GetFileExplorerPipelineParams {
   files: FileExplorerPathEntry[];
   searchQuery: string;
   sortMode: FileExplorerSortMode;
+  /** Collapse registered Frames v2 source folders into package entries. */
+  displayFramePackages?: boolean;
   /** Top-level scope folders at the virtual root (e.g. `conversation`, `pod`). */
   virtualScopeRoots?: readonly string[];
+}
+
+function isPathAtOrBelow(path: string, parentPath: string): boolean {
+  return path === parentPath || path.startsWith(`${parentPath}/`);
+}
+
+function getCollapsedFramePackages({
+  currentFolderPath,
+  files,
+}: {
+  currentFolderPath: string;
+  files: FileExplorerPathEntry[];
+}): FramePackageEntry[] {
+  const candidates = new Map<string, FramePackageEntry>();
+
+  for (const file of files) {
+    if (
+      file.isDirectory ||
+      file.fileResourceContentType !== frameV2ContentType ||
+      file.fileName !== FRAME_MANIFEST_FILE ||
+      !file.fileId
+    ) {
+      continue;
+    }
+
+    const manifestExplorerPath = getExplorerRelativePath(file);
+    const sourceFolderPath = getParentFolderRelativePath(manifestExplorerPath);
+    if (
+      !sourceFolderPath ||
+      isPathAtOrBelow(currentFolderPath, sourceFolderPath)
+    ) {
+      continue;
+    }
+
+    candidates.set(sourceFolderPath, {
+      ...file,
+      kind: "frame_package",
+      contentType: frameV2ContentType,
+      fileId: file.fileId,
+      fileName: sourceFolderPath.slice(sourceFolderPath.lastIndexOf("/") + 1),
+      sourceFolderPath,
+      virtualPath: sourceFolderPath,
+    });
+  }
+
+  // If packages are nested, only the outer package is visible until its source is opened.
+  const packages: FramePackageEntry[] = [];
+  const packagePaths = new Set(candidates.keys());
+  for (const [sourceFolderPath, framePackage] of candidates) {
+    let ancestorPath = getParentFolderRelativePath(sourceFolderPath);
+    let hasPackageAncestor = false;
+    while (ancestorPath) {
+      if (packagePaths.has(ancestorPath)) {
+        hasPackageAncestor = true;
+        break;
+      }
+      ancestorPath = getParentFolderRelativePath(ancestorPath);
+    }
+    if (!hasPackageAncestor) {
+      packages.push(framePackage);
+    }
+  }
+
+  return packages;
+}
+
+function collapseFramePackages({
+  currentFolderPath,
+  displayFramePackages,
+  files,
+}: {
+  currentFolderPath: string;
+  displayFramePackages: boolean;
+  files: FileExplorerPathEntry[];
+}): {
+  files: FileExplorerPathEntry[];
+  packagesByPath: Map<string, FramePackageEntry>;
+} {
+  if (!displayFramePackages) {
+    return { files, packagesByPath: new Map() };
+  }
+
+  const packages = getCollapsedFramePackages({ currentFolderPath, files });
+  if (packages.length === 0) {
+    return { files, packagesByPath: new Map() };
+  }
+
+  const packagesByPath = new Map(
+    packages.map((framePackage) => [
+      framePackage.sourceFolderPath,
+      framePackage,
+    ])
+  );
+  const visibleFiles = files.filter((file) => {
+    let candidatePath = getExplorerRelativePath(file);
+    while (candidatePath) {
+      if (packagesByPath.has(candidatePath)) {
+        return false;
+      }
+      candidatePath = getParentFolderRelativePath(candidatePath);
+    }
+    return true;
+  });
+
+  return {
+    files: [...visibleFiles, ...packages],
+    packagesByPath,
+  };
 }
 
 function filterVisibleNodes(
@@ -67,19 +181,29 @@ export function getFileExplorerPipeline({
   activeFilter,
   contentNodes,
   currentFolderPath,
+  displayFramePackages = false,
   files,
   searchQuery,
   sortMode,
   virtualScopeRoots,
 }: GetFileExplorerPipelineParams): FileExplorerPipeline {
+  const collapsed = collapseFramePackages({
+    currentFolderPath,
+    displayFramePackages,
+    files,
+  });
   const entryByRelativePath = new Map<string, FileExplorerEntry>();
-  for (const f of files) {
+  for (const f of collapsed.files) {
     if (f.isDirectory) {
       continue;
     }
 
     const relativePath = getExplorerRelativePath(f);
-    entryByRelativePath.set(relativePath, { ...f, kind: "file" });
+    const framePackage = collapsed.packagesByPath.get(relativePath);
+    entryByRelativePath.set(
+      relativePath,
+      framePackage ?? { ...f, kind: "file" }
+    );
   }
 
   // Content nodes are always flat (no folder structure). They appear only at
@@ -88,7 +212,7 @@ export function getFileExplorerPipeline({
     entryByRelativePath.set(node.path, node);
   }
 
-  const tree = buildFileSystemTree(files);
+  const tree = buildFileSystemTree(collapsed.files);
 
   // Synthetic tree nodes for content-node entries — always flat, at root level.
   const contentNodeTreeNodes: FileSystemTreeNode[] = contentNodes.map((cn) => ({

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -3,6 +3,7 @@ import type {
   FileSystemFileEntry,
 } from "@app/types/api/file_system/types";
 import type { ConnectorProvider } from "@app/types/data_source";
+import type { frameV2ContentType } from "@app/types/files";
 import type React from "react";
 
 /** Explorer input: canonical `path` plus an optional UI-only navigation path. */
@@ -16,6 +17,18 @@ export type FileEntry = FileSystemFileEntry & {
   virtualPath?: string;
 };
 export type FileEntryWithId = FileEntry & { fileId: string };
+
+export type FramePackageEntry = Omit<
+  FileEntryWithId,
+  "contentType" | "fileName" | "kind"
+> & {
+  kind: "frame_package";
+  contentType: typeof frameV2ContentType;
+  /** Display name of the source folder represented by this package. */
+  fileName: string;
+  /** Explorer navigation path of the package's source folder. */
+  sourceFolderPath: string;
+};
 
 export type ContentNodeEntry = {
   kind: "node";
@@ -34,7 +47,11 @@ export type FolderEntry = {
   name: string;
 };
 
-export type FileExplorerEntry = FileEntry | ContentNodeEntry | FolderEntry;
+export type FileExplorerEntry =
+  | FileEntry
+  | FramePackageEntry
+  | ContentNodeEntry
+  | FolderEntry;
 
 export type FileExplorerMenuAction = {
   label: string;

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -2,6 +2,7 @@ import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import {
   frameSlideshowContentType,
   getFileFormatCategory,
+  isFrameV2ContentType,
   isInteractiveContentType,
   isMarkdownContentType,
   isPdfContentType,
@@ -217,7 +218,10 @@ export function getFileExplorerBucket(
     return null;
   }
 
-  if (isInteractiveContentType(contentType)) {
+  if (
+    isInteractiveContentType(contentType) ||
+    isFrameV2ContentType(contentType)
+  ) {
     return "frames";
   }
 

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -138,7 +138,7 @@ export async function streamThumbnail(
 // ---------------------------------------------------------------------------
 
 /**
- * Enrich a list of file entries with their linked FileResource sId (fileId).
+ * Enrich file entries with their linked FileResource identity and semantic content type.
  * A single batch DB query covers all entries; pod files probe the legacy projects/ path too.
  *
  * Intended for endpoints that expose file listings to the client (conversation files,
@@ -176,11 +176,18 @@ export async function enrichListWithFileResourceIds(
     mountPaths
   );
 
-  // Map every known mountFilePath to its FileResource sId.
-  const byMountPath = new Map<string, string>();
+  // Keep raw GCS contentType for source previews. The linked resource can represent a higher-level
+  // object such as a registered Frame package, so expose its semantic type separately.
+  const byMountPath = new Map<
+    string,
+    { contentType: string; fileId: string }
+  >();
   for (const fr of fileResources) {
     if (fr.mountFilePath) {
-      byMountPath.set(fr.mountFilePath, fr.sId);
+      byMountPath.set(fr.mountFilePath, {
+        contentType: fr.contentType,
+        fileId: fr.sId,
+      });
     }
   }
 
@@ -193,9 +200,15 @@ export async function enrichListWithFileResourceIds(
       return entry;
     }
     const legacyPath = gcsPath.replace(/\/pods\//, "/projects/");
-    const fileId =
+    const linkedFile =
       byMountPath.get(gcsPath) ?? byMountPath.get(legacyPath) ?? null;
-    return { ...entry, fileId };
+    return linkedFile
+      ? {
+          ...entry,
+          fileId: linkedFile.fileId,
+          fileResourceContentType: linkedFile.contentType,
+        }
+      : entry;
   });
 }
 

--- a/front/lib/file_icon_utils.ts
+++ b/front/lib/file_icon_utils.ts
@@ -1,4 +1,8 @@
-import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import {
+  frameContentType,
+  frameSlideshowContentType,
+  frameV2ContentType,
+} from "@app/types/files";
 import {
   ActionFrame,
   BigQueryLogo,
@@ -110,7 +114,11 @@ const FILE_TYPE_MAPPINGS: FileTypeMapping[] = [
   },
   {
     icon: ActionFrame,
-    mimeTypes: [frameContentType, frameSlideshowContentType],
+    mimeTypes: [
+      frameContentType,
+      frameSlideshowContentType,
+      frameV2ContentType,
+    ],
     extensions: [".js", ".jsx", ".ts", ".tsx"],
   },
 ];

--- a/front/types/api/file_system/types.ts
+++ b/front/types/api/file_system/types.ts
@@ -22,6 +22,8 @@ export type FileSystemFileEntry = FileSystemEntryBase & {
   contentType: string;
   /** sId of the corresponding FileResource record, or null when none exists. */
   fileId: string | null;
+  /** Semantic type of the linked FileResource, when it differs from the source bytes. */
+  fileResourceContentType?: string;
   thumbnailUrl: string | null;
   /** Present when the caller requested signed URLs. */
   signedDownloadUrl?: string | null;


### PR DESCRIPTION
## Description

Aggregate a registered Frames v2 manifest and its source descendants into one package node while preserving previewable source entries. This is the pure explorer-pipeline slice extracted from #31413; component rendering remains separate.

Stack: #31533 -> this PR.

## Tests

- All 10 focused pipeline tests pass.
- Biome and diff checks pass.

## Risk

Only entries carrying the optional Frame metadata from #31533 are grouped. Ordinary files and folders retain the existing pipeline.

## Deploy Plan

Merge after #31533. No migration is required.