### PR TITLE
Resolve same-mount Frame move paths

### DIFF
--- a/front/lib/api/frames/move_source_paths.test.ts
+++ b/front/lib/api/frames/move_source_paths.test.ts
@@ -39,6 +39,19 @@ describe("resolveFrameSourceMovePaths", () => {
     });
   });
 
+  it("accepts nested folder paths with trailing slashes", () => {
+    const result = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status/",
+      destinationDirectoryPath: "conversation-conv_123/Archive/Renamed/",
+    });
+
+    expect(result.isOk() && result.value).toMatchObject({
+      destinationManifestPath:
+        "conversation-conv_123/Archive/Renamed/manifest.json",
+      sourceManifestPath: "conversation-conv_123/Status/manifest.json",
+    });
+  });
+
   it("rejects nested and cross-mount destinations", () => {
     const nested = resolveFrameSourceMovePaths({
       sourceDirectoryPath: "conversation-conv_123/Status",

--- a/front/lib/api/frames/move_source_paths.test.ts
+++ b/front/lib/api/frames/move_source_paths.test.ts
@@ -52,6 +52,24 @@ describe("resolveFrameSourceMovePaths", () => {
     });
   });
 
+  it("rejects identical and nested destinations after trimming trailing slashes", () => {
+    const identical = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status/",
+      destinationDirectoryPath: "conversation-conv_123/Status",
+    });
+    const nested = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status/",
+      destinationDirectoryPath: "conversation-conv_123/Status/Nested",
+    });
+
+    expect(identical.isErr() && identical.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(nested.isErr() && nested.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+
   it("rejects nested and cross-mount destinations", () => {
     const nested = resolveFrameSourceMovePaths({
       sourceDirectoryPath: "conversation-conv_123/Status",

--- a/front/lib/api/frames/move_source_paths.test.ts
+++ b/front/lib/api/frames/move_source_paths.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+
+import { resolveFrameSourceMovePaths } from "@app/lib/api/frames/move_source_paths";
+import { describe, expect, it } from "vitest";
+
+describe("resolveFrameSourceMovePaths", () => {
+  it("resolves normalized paths and audit metadata in one conversation", () => {
+    const result = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      destinationDirectoryPath: "conversation-conv_123/Archive/Renamed",
+    });
+
+    expect(result.isOk() && result.value).toMatchObject({
+      auditEvent: {
+        parentRelativePath: "Archive",
+        relativeFilePath: "Status",
+      },
+      destinationDirectoryPath: "conversation-conv_123/Archive/Renamed",
+      destinationManifestPath:
+        "conversation-conv_123/Archive/Renamed/manifest.json",
+      destinationScope: {
+        useCase: "conversation",
+        conversationId: "conv_123",
+      },
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      sourceManifestPath: "conversation-conv_123/Status/manifest.json",
+    });
+  });
+
+  it("resolves a move in one Pod", () => {
+    const result = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "pod-pod_123/Status",
+      destinationDirectoryPath: "pod-pod_123/Renamed",
+    });
+
+    expect(result.isOk() && result.value.destinationScope).toEqual({
+      useCase: "pod",
+      podId: "pod_123",
+    });
+  });
+
+  it("rejects nested and cross-mount destinations", () => {
+    const nested = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      destinationDirectoryPath: "conversation-conv_123/Status/Nested",
+    });
+    const crossMount = resolveFrameSourceMovePaths({
+      sourceDirectoryPath: "conversation-conv_123/Status",
+      destinationDirectoryPath: "pod-pod_123/Status",
+    });
+
+    expect(nested.isErr() && nested.error).toMatchObject({
+      code: "invalid_source",
+    });
+    expect(crossMount.isErr() && crossMount.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+});

--- a/front/lib/api/frames/move_source_paths.ts
+++ b/front/lib/api/frames/move_source_paths.ts
@@ -1,0 +1,147 @@
+import path from "node:path";
+
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export class FrameSourceMoveError extends Error {
+  constructor(
+    readonly code:
+      | "commit_failed"
+      | "conflict"
+      | "copy_failed"
+      | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceMoveError";
+  }
+}
+
+export function isFrameSourceMoveError(
+  error: unknown
+): error is FrameSourceMoveError {
+  return error instanceof FrameSourceMoveError;
+}
+
+export function frameSourceMoveError(
+  code: FrameSourceMoveError["code"],
+  message: string
+) {
+  return new Err(new FrameSourceMoveError(code, message));
+}
+
+function pathError(message: string) {
+  return frameSourceMoveError("invalid_source", message);
+}
+
+type FrameSourceOwner = {
+  useCase: FileUseCase;
+  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
+};
+
+export type FrameSourceMovePaths = {
+  auditEvent: {
+    parentRelativePath: string;
+    relativeFilePath: string;
+  };
+  destinationDirectoryPath: string;
+  destinationManifestPath: string;
+  destinationScope: GCSMountPoint;
+  sourceDirectoryPath: string;
+  sourceManifestPath: string;
+};
+
+function sourceOwnerFromPath(scopedPath: string): FrameSourceOwner | null {
+  const parsed = parseScopedPrefix(scopedPath);
+  const slash = scopedPath.indexOf("/");
+  if (!parsed || slash < 0 || slash === scopedPath.length - 1) {
+    return null;
+  }
+
+  switch (parsed.kind) {
+    case "conversation":
+      return {
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parsed.id },
+      };
+    case "pod":
+      return {
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: parsed.id },
+      };
+    case "user":
+      return null;
+  }
+}
+
+function isSameOwner(a: FrameSourceOwner, b: FrameSourceOwner): boolean {
+  return (
+    a.useCase === b.useCase &&
+    a.useCaseMetadata.conversationId === b.useCaseMetadata.conversationId &&
+    a.useCaseMetadata.spaceId === b.useCaseMetadata.spaceId
+  );
+}
+
+export function resolveFrameSourceMovePaths({
+  destinationDirectoryPath,
+  sourceDirectoryPath,
+}: {
+  destinationDirectoryPath: string;
+  sourceDirectoryPath: string;
+}): Result<FrameSourceMovePaths, FrameSourceMoveError> {
+  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
+  const destination = DustFileSystem.normalizeScopedPath(
+    destinationDirectoryPath
+  );
+  if (!source || !destination) {
+    return pathError("Frame source and destination must be scoped paths.");
+  }
+  if (source === destination || destination.startsWith(`${source}/`)) {
+    return pathError(
+      "Frame source and destination must be different, non-nested folders."
+    );
+  }
+
+  const sourceOwner = sourceOwnerFromPath(source);
+  const destinationOwner = sourceOwnerFromPath(destination);
+  if (
+    !sourceOwner ||
+    !destinationOwner ||
+    !isSameOwner(sourceOwner, destinationOwner)
+  ) {
+    return pathError(
+      "Frame source and destination must use the same conversation or Pod mount."
+    );
+  }
+
+  const destinationScope: GCSMountPoint =
+    destinationOwner.useCase === "conversation"
+      ? {
+          useCase: "conversation",
+          conversationId: destinationOwner.useCaseMetadata.conversationId ?? "",
+        }
+      : {
+          useCase: "pod",
+          podId: destinationOwner.useCaseMetadata.spaceId ?? "",
+        };
+  const scopedPrefix = source.split("/", 1)[0];
+  const parentRelativePath = path.posix.dirname(
+    path.posix.relative(scopedPrefix, destination)
+  );
+
+  return new Ok({
+    auditEvent: {
+      parentRelativePath: parentRelativePath === "." ? "" : parentRelativePath,
+      relativeFilePath: path.posix.relative(scopedPrefix, source),
+    },
+    destinationDirectoryPath: destination,
+    destinationManifestPath: path.posix.join(destination, FRAME_MANIFEST_FILE),
+    destinationScope,
+    sourceDirectoryPath: source,
+    sourceManifestPath: path.posix.join(source, FRAME_MANIFEST_FILE),
+  });
+}

--- a/front/lib/api/frames/move_source_paths.ts
+++ b/front/lib/api/frames/move_source_paths.ts
@@ -33,6 +33,15 @@ export type FrameSourceMovePaths = {
   sourceManifestPath: string;
 };
 
+function normalizeFrameDirectoryPath(scopedPath: string): string | null {
+  const normalized = DustFileSystem.normalizeScopedPath(scopedPath);
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+}
+
 export function resolveFrameSourceMovePaths({
   destinationDirectoryPath,
   sourceDirectoryPath,
@@ -40,10 +49,8 @@ export function resolveFrameSourceMovePaths({
   destinationDirectoryPath: string;
   sourceDirectoryPath: string;
 }): Result<FrameSourceMovePaths, FrameSourceMoveError> {
-  const source = DustFileSystem.normalizeScopedPath(sourceDirectoryPath);
-  const destination = DustFileSystem.normalizeScopedPath(
-    destinationDirectoryPath
-  );
+  const source = normalizeFrameDirectoryPath(sourceDirectoryPath);
+  const destination = normalizeFrameDirectoryPath(destinationDirectoryPath);
   if (!source || !destination) {
     return new Err(
       new FrameSourceMoveError(
@@ -66,8 +73,6 @@ export function resolveFrameSourceMovePaths({
   if (
     !source.includes("/") ||
     !destination.includes("/") ||
-    source.indexOf("/") === source.length - 1 ||
-    destination.indexOf("/") === destination.length - 1 ||
     !sourcePrefix ||
     !destinationPrefix ||
     sourcePrefix.kind === "user" ||

--- a/front/lib/api/frames/move_source_paths.ts
+++ b/front/lib/api/frames/move_source_paths.ts
@@ -5,6 +5,7 @@ import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export class FrameSourceMoveError extends Error {
   constructor(
@@ -65,8 +66,8 @@ export function resolveFrameSourceMovePaths({
   if (
     !source.includes("/") ||
     !destination.includes("/") ||
-    source.endsWith("/") ||
-    destination.endsWith("/") ||
+    source.indexOf("/") === source.length - 1 ||
+    destination.indexOf("/") === destination.length - 1 ||
     !sourcePrefix ||
     !destinationPrefix ||
     sourcePrefix.kind === "user" ||
@@ -82,16 +83,23 @@ export function resolveFrameSourceMovePaths({
     );
   }
 
-  const destinationScope: GCSMountPoint =
-    destinationPrefix.kind === "conversation"
-      ? {
-          useCase: "conversation",
-          conversationId: destinationPrefix.id,
-        }
-      : {
-          useCase: "pod",
-          podId: destinationPrefix.id,
-        };
+  let destinationScope: GCSMountPoint;
+  switch (destinationPrefix.kind) {
+    case "conversation":
+      destinationScope = {
+        useCase: "conversation",
+        conversationId: destinationPrefix.id,
+      };
+      break;
+    case "pod":
+      destinationScope = {
+        useCase: "pod",
+        podId: destinationPrefix.id,
+      };
+      break;
+    default:
+      assertNever(destinationPrefix);
+  }
   const scopedPrefix = source.split("/", 1)[0];
   const parentRelativePath = path.posix.dirname(
     path.posix.relative(scopedPrefix, destination)

--- a/front/lib/api/frames/move_source_paths.ts
+++ b/front/lib/api/frames/move_source_paths.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
-import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -21,28 +20,6 @@ export class FrameSourceMoveError extends Error {
   }
 }
 
-export function isFrameSourceMoveError(
-  error: unknown
-): error is FrameSourceMoveError {
-  return error instanceof FrameSourceMoveError;
-}
-
-export function frameSourceMoveError(
-  code: FrameSourceMoveError["code"],
-  message: string
-) {
-  return new Err(new FrameSourceMoveError(code, message));
-}
-
-function pathError(message: string) {
-  return frameSourceMoveError("invalid_source", message);
-}
-
-type FrameSourceOwner = {
-  useCase: FileUseCase;
-  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
-};
-
 export type FrameSourceMovePaths = {
   auditEvent: {
     parentRelativePath: string;
@@ -54,37 +31,6 @@ export type FrameSourceMovePaths = {
   sourceDirectoryPath: string;
   sourceManifestPath: string;
 };
-
-function sourceOwnerFromPath(scopedPath: string): FrameSourceOwner | null {
-  const parsed = parseScopedPrefix(scopedPath);
-  const slash = scopedPath.indexOf("/");
-  if (!parsed || slash < 0 || slash === scopedPath.length - 1) {
-    return null;
-  }
-
-  switch (parsed.kind) {
-    case "conversation":
-      return {
-        useCase: "conversation",
-        useCaseMetadata: { conversationId: parsed.id },
-      };
-    case "pod":
-      return {
-        useCase: "project_context",
-        useCaseMetadata: { spaceId: parsed.id },
-      };
-    case "user":
-      return null;
-  }
-}
-
-function isSameOwner(a: FrameSourceOwner, b: FrameSourceOwner): boolean {
-  return (
-    a.useCase === b.useCase &&
-    a.useCaseMetadata.conversationId === b.useCaseMetadata.conversationId &&
-    a.useCaseMetadata.spaceId === b.useCaseMetadata.spaceId
-  );
-}
 
 export function resolveFrameSourceMovePaths({
   destinationDirectoryPath,
@@ -98,35 +44,53 @@ export function resolveFrameSourceMovePaths({
     destinationDirectoryPath
   );
   if (!source || !destination) {
-    return pathError("Frame source and destination must be scoped paths.");
+    return new Err(
+      new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source and destination must be scoped paths."
+      )
+    );
   }
   if (source === destination || destination.startsWith(`${source}/`)) {
-    return pathError(
-      "Frame source and destination must be different, non-nested folders."
+    return new Err(
+      new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source and destination must be different, non-nested folders."
+      )
     );
   }
 
-  const sourceOwner = sourceOwnerFromPath(source);
-  const destinationOwner = sourceOwnerFromPath(destination);
+  const sourcePrefix = parseScopedPrefix(source);
+  const destinationPrefix = parseScopedPrefix(destination);
   if (
-    !sourceOwner ||
-    !destinationOwner ||
-    !isSameOwner(sourceOwner, destinationOwner)
+    !source.includes("/") ||
+    !destination.includes("/") ||
+    source.endsWith("/") ||
+    destination.endsWith("/") ||
+    !sourcePrefix ||
+    !destinationPrefix ||
+    sourcePrefix.kind === "user" ||
+    destinationPrefix.kind === "user" ||
+    sourcePrefix.kind !== destinationPrefix.kind ||
+    sourcePrefix.id !== destinationPrefix.id
   ) {
-    return pathError(
-      "Frame source and destination must use the same conversation or Pod mount."
+    return new Err(
+      new FrameSourceMoveError(
+        "invalid_source",
+        "Frame source and destination must use the same conversation or Pod mount."
+      )
     );
   }
 
   const destinationScope: GCSMountPoint =
-    destinationOwner.useCase === "conversation"
+    destinationPrefix.kind === "conversation"
       ? {
           useCase: "conversation",
-          conversationId: destinationOwner.useCaseMetadata.conversationId ?? "",
+          conversationId: destinationPrefix.id,
         }
       : {
           useCase: "pod",
-          podId: destinationOwner.useCaseMetadata.spaceId ?? "",
+          podId: destinationPrefix.id,
         };
   const scopedPrefix = source.split("/", 1)[0];
   const parentRelativePath = path.posix.dirname(


### PR DESCRIPTION
## Description

- normalize Frames v2 source and destination directories
- reject identical, nested, user, and cross-mount moves
- derive manifest paths, destination mount scope, and audit-relative paths
- expose the shared typed move error used by the orchestration layer

This pure path foundation has no production caller until the move operation merges.

## Tests

Added 5 focused tests covering conversation paths and audit metadata, Pod scope resolution, trailing-slash normalization, trailing-slash nesting regressions, and cross-mount rejection.

## Risk

Low. This adds a pure validation helper without a production caller.

## Deploy Plan

Standard deploy. No migration or backfill.