### PR TITLE
Add bounded Frame source storage copies

### DIFF
--- a/front/lib/api/frames/source_storage.test.ts
+++ b/front/lib/api/frames/source_storage.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+
+import path from "node:path";
+import {
+  copyFrameSourceStorage,
+  inspectFrameSourceStorage,
+} from "@app/lib/api/frames/source_storage";
+import { setupFrameSourceStorageTest } from "@app/lib/api/frames/source_storage.test_utils";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+describe("Frame source storage copies", () => {
+  it("copies the complete raw source tree into an empty destination", async () => {
+    const c = await setupFrameSourceStorageTest();
+    const storage = getPrivateUploadBucket();
+    vi.mocked(getPrivateUploadBucket)
+      .mockReturnValueOnce(storage)
+      .mockReturnValueOnce(storage);
+    const destinationMountPath = c.sourceObjects[0].replace(
+      "/Status/",
+      "/Archive/"
+    );
+    const hiddenObject = `${c.sourceMountDirectory}/.cache/state.json`;
+    const placeholderObject = `${c.sourceMountDirectory}/empty/`;
+    for (const objectPath of [hiddenObject, placeholderObject]) {
+      c.listedObjects.push(objectPath);
+      fileStorageMock.setObject(objectPath, objectPath);
+    }
+
+    const snapshot = await inspectFrameSourceStorage({
+      destinationMountPath,
+      sourceMountPath: c.sourceObjects[0],
+    });
+    assert(snapshot.isOk(), snapshot.isErr() ? snapshot.error.message : "");
+    const copied = await copyFrameSourceStorage(snapshot.value);
+
+    assert(copied.isOk(), copied.isErr() ? copied.error.message : "");
+    for (const source of c.listedObjects) {
+      const destination = source.replace("/Status/", "/Archive/");
+      const file = storage.file(destination);
+      const chunks = await file.createReadStream().toArray();
+      const expected = fileStorageMock.getObject(source);
+      expect(Buffer.concat(chunks).toString("utf8")).toBe(expected);
+    }
+  });
+
+  it("rejects an occupied destination", async () => {
+    const c = await setupFrameSourceStorageTest();
+    const destinationMountPath = c.sourceObjects[0].replace(
+      "/Status/",
+      "/Archive/"
+    );
+    fileStorageMock.setObject(
+      path.posix.dirname(destinationMountPath),
+      "occupied"
+    );
+
+    const snapshot = await inspectFrameSourceStorage({
+      destinationMountPath,
+      sourceMountPath: c.sourceObjects[0],
+    });
+
+    expect(snapshot.isErr() && snapshot.error).toMatchObject({
+      code: "conflict",
+    });
+  });
+
+  it("counts hidden objects toward the source size limit", async () => {
+    const c = await setupFrameSourceStorageTest();
+    const hiddenObject = `${c.sourceMountDirectory}/.cache/large.bin`;
+    c.listedObjects.push(hiddenObject);
+    c.objectSizes.set(hiddenObject, String(101 * 1024 * 1024));
+    fileStorageMock.setObject(hiddenObject, "");
+
+    const snapshot = await inspectFrameSourceStorage({
+      destinationMountPath: c.sourceObjects[0].replace("/Status/", "/Archive/"),
+      sourceMountPath: c.sourceObjects[0],
+    });
+
+    expect(snapshot.isErr() && snapshot.error).toMatchObject({
+      code: "invalid_source",
+    });
+  });
+
+  it("returns a typed copy failure", async () => {
+    const c = await setupFrameSourceStorageTest();
+    fileStorageMock.setCopyFileFails((source) => source === c.sourceObjects[0]);
+    const snapshot = await inspectFrameSourceStorage({
+      destinationMountPath: c.sourceObjects[0].replace("/Status/", "/Archive/"),
+      sourceMountPath: c.sourceObjects[0],
+    });
+    assert(snapshot.isOk(), snapshot.isErr() ? snapshot.error.message : "");
+
+    const copied = await copyFrameSourceStorage(snapshot.value);
+
+    expect(copied.isErr() && copied.error).toMatchObject({
+      code: "copy_failed",
+    });
+  });
+});

--- a/front/lib/api/frames/source_storage.test_utils.ts
+++ b/front/lib/api/frames/source_storage.test_utils.ts
@@ -1,0 +1,75 @@
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+
+export const frameManifest = JSON.stringify({ version: 1, name: "Status" });
+
+export async function setupFrameSourceStorageTest() {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const sourceMountDirectory = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const sourceObjects = [
+    `${sourceMountDirectory}/${FRAME_MANIFEST_FILE}`,
+    `${sourceMountDirectory}/index.tsx`,
+  ];
+  const objectSizes = new Map<string, string>();
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(frameManifest),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: {
+      activePublicationId: "publication-1",
+      conversationId: conversation.sId,
+    },
+    mountFilePath: sourceObjects[0],
+  });
+  await frame.markFrameV2AsReadyFromMount(auth);
+  fileStorageMock.setObject(sourceObjects[0], frameManifest);
+  fileStorageMock.setObject(sourceObjects[1], "ui source");
+  fileStorageMock.setFileExists(
+    (filePath) => fileStorageMock.getObject(filePath) !== undefined
+  );
+  const listedObjects = [...sourceObjects];
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    listedObjects
+      .filter(
+        (name) =>
+          name.startsWith(prefix) &&
+          fileStorageMock.getObject(name) !== undefined
+      )
+      .map((name) => ({
+        name,
+        metadata: {
+          contentType: "text/plain",
+          size: objectSizes.get(name) ?? "10",
+        },
+      }))
+  );
+
+  return {
+    auth,
+    conversation,
+    frame,
+    listedObjects,
+    objectSizes,
+    sourceDirectoryPath,
+    sourceMountDirectory,
+    sourceObjects,
+    workspace,
+  };
+}

--- a/front/lib/api/frames/source_storage.ts
+++ b/front/lib/api/frames/source_storage.ts
@@ -1,0 +1,157 @@
+import path from "node:path";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const FRAME_SOURCE_COPY_CONCURRENCY = 4;
+const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
+const MAX_FRAME_SOURCE_BYTES = 100 * 1024 * 1024;
+
+export class FrameSourceStorageError extends Error {
+  constructor(
+    readonly code: "conflict" | "copy_failed" | "invalid_source",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameSourceStorageError";
+  }
+}
+
+function storageError(code: FrameSourceStorageError["code"], message: string) {
+  return new Err(new FrameSourceStorageError(code, message));
+}
+
+export type FrameSourceStorageSnapshot = {
+  destinationMountPrefix: string;
+  sourceMountPrefix: string;
+  sourceObjectNames: string[];
+};
+
+export async function inspectFrameSourceStorage({
+  destinationMountPath,
+  sourceMountPath,
+}: {
+  destinationMountPath: string;
+  sourceMountPath: string;
+}): Promise<Result<FrameSourceStorageSnapshot, FrameSourceStorageError>> {
+  const bucket = getPrivateUploadBucket();
+  const sourceMountPrefix = `${path.posix.dirname(sourceMountPath)}/`;
+  const destinationMountDirectory = path.posix.dirname(destinationMountPath);
+  const destinationMountPrefix = `${destinationMountDirectory}/`;
+
+  try {
+    const [[destinationFileExists], destinationObjects] = await Promise.all([
+      bucket.file(destinationMountDirectory).exists(),
+      bucket.getFiles({ prefix: destinationMountPrefix, maxResults: 1 }),
+    ]);
+    if (destinationFileExists || destinationObjects.length > 0) {
+      return storageError(
+        "conflict",
+        "A file or folder already exists at the destination."
+      );
+    }
+  } catch (error) {
+    return storageError(
+      "copy_failed",
+      `Failed to inspect the Frame destination; the source remains authoritative: ${normalizeError(error).message}`
+    );
+  }
+
+  let sourceObjects;
+  try {
+    sourceObjects = await bucket.getFiles({
+      prefix: sourceMountPrefix,
+      maxResults: MAX_FRAME_SOURCE_FILE_COUNT + 1,
+    });
+  } catch (error) {
+    return storageError(
+      "copy_failed",
+      `Failed to inspect the Frame source; the source remains authoritative: ${normalizeError(error).message}`
+    );
+  }
+  if (sourceObjects.length > MAX_FRAME_SOURCE_FILE_COUNT) {
+    return storageError(
+      "invalid_source",
+      "Frame source exceeds the copy size or file count limit."
+    );
+  }
+
+  let sourceSizeBytes = 0;
+  for (const sourceObject of sourceObjects) {
+    const sizeBytes = Number(sourceObject.metadata.size);
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+      return storageError(
+        "invalid_source",
+        `Frame source object has invalid size metadata: ${sourceObject.name}`
+      );
+    }
+    sourceSizeBytes += sizeBytes;
+  }
+  if (sourceSizeBytes > MAX_FRAME_SOURCE_BYTES) {
+    return storageError(
+      "invalid_source",
+      "Frame source exceeds the copy size or file count limit."
+    );
+  }
+  if (!sourceObjects.some((entry) => entry.name === sourceMountPath)) {
+    return storageError(
+      "invalid_source",
+      "Frame manifest not found in source folder."
+    );
+  }
+
+  return new Ok({
+    destinationMountPrefix,
+    sourceMountPrefix,
+    sourceObjectNames: sourceObjects.map((entry) => entry.name),
+  });
+}
+
+export async function copyFrameSourceStorage(
+  snapshot: FrameSourceStorageSnapshot
+): Promise<Result<void, FrameSourceStorageError>> {
+  const bucket = getPrivateUploadBucket();
+  const copyResults = await concurrentExecutor(
+    snapshot.sourceObjectNames,
+    async (sourceObjectName) => {
+      if (!sourceObjectName.startsWith(snapshot.sourceMountPrefix)) {
+        return new Err(
+          new Error(`Invalid Frame source object path: ${sourceObjectName}`)
+        );
+      }
+      const relativePath = sourceObjectName.slice(
+        snapshot.sourceMountPrefix.length
+      );
+      try {
+        await bucket.copyFile(
+          sourceObjectName,
+          `${snapshot.destinationMountPrefix}${relativePath}`
+        );
+        return new Ok(undefined);
+      } catch (error) {
+        return new Err(normalizeError(error));
+      }
+    },
+    { concurrency: FRAME_SOURCE_COPY_CONCURRENCY }
+  );
+  const copyFailure = copyResults.find((result) => result.isErr());
+  return copyFailure?.isErr()
+    ? storageError(
+        "copy_failed",
+        `Failed to copy the Frame source; the source remains authoritative and partial destination objects may remain: ${copyFailure.error.message}`
+      )
+    : new Ok(undefined);
+}
+
+export async function deleteFrameSourceStorage(
+  sourceMountPrefix: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPrivateUploadBucket().deleteByPrefix(sourceMountPrefix);
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -267,9 +267,11 @@ class FileStorageMock {
     return {
       copy: vi.fn().mockResolvedValue(undefined),
       createReadStream: vi.fn(() => {
-        this._readStreamCalls.push(filePath ?? "unknown");
-        const content = this._contentForPath(filePath ?? "");
-        if (content !== null) {
+        const path = filePath ?? "unknown";
+        this._readStreamCalls.push(path);
+        const content =
+          this._objectStore.get(path) ?? this._contentForPath(path);
+        if (content !== null && content !== undefined) {
           return Readable.from([Buffer.from(content, "utf8")]);
         }
         return new PassThrough();
@@ -438,6 +440,10 @@ class FileStorageMock {
           return Promise.reject(
             new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
           );
+        }
+        const content = this._objectStore.get(src) ?? this._contentForPath(src);
+        if (content !== null && content !== undefined) {
+          this._objectStore.set(dest, content);
         }
         return Promise.resolve(undefined);
       }),


### PR DESCRIPTION
## Description

Add an operation-neutral Frame source-storage foundation that inspects an empty destination, enumerates the complete raw source tree, enforces the 1,024-object and 100 MiB limits, validates the manifest, and copies with bounded concurrency.

The shared FileStorage mock now models baseline unconditional copy and reads copied object content. This fidelity belongs with the source-storage contract and is exercised directly by its copy test. Generation preconditions remain in child #31540 and generation-safe source copying remains in #31549.

## Tests

- Frame source-storage suite: 4 tests passed, including baseline copy and read fidelity.
- Biome on changed files.
- Front tsgo.

## Risk

Low. This direct-main foundation is not wired to a public endpoint. Typed failures preserve the source as authoritative.

## Deploy Plan

Deploy normally. Consumers may merge after this foundation.