### PR TITLE
Define canonical Frames v2 invocation contract

### DIFF
--- a/front-api/lib/api/frame_function_invocation_schemas.test.ts
+++ b/front-api/lib/api/frame_function_invocation_schemas.test.ts
@@ -1,0 +1,34 @@
+import {
+  FrameFunctionInvocationParamsSchema,
+  PostFrameFunctionInvocationBodySchema,
+} from "@front-api/lib/api/frame_function_invocation_schemas";
+import { describe, expect, it } from "vitest";
+
+describe("canonical Frame invocation schemas", () => {
+  it("accepts a Frame id, bare function name, and invocation body", () => {
+    expect(
+      FrameFunctionInvocationParamsSchema.safeParse({
+        frameId: "fil_frame",
+        name: "run-function",
+      }).success
+    ).toBe(true);
+    expect(
+      PostFrameFunctionInvocationBodySchema.safeParse({
+        input: { message: "hello" },
+        context: { timezone: "Europe/Paris" },
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects qualified names and unknown body fields", () => {
+    expect(
+      FrameFunctionInvocationParamsSchema.safeParse({
+        frameId: "fil_frame",
+        name: "fil_other/run-function",
+      }).success
+    ).toBe(false);
+    expect(
+      PostFrameFunctionInvocationBodySchema.safeParse({ extra: true }).success
+    ).toBe(false);
+  });
+});

--- a/front-api/lib/api/frame_function_invocation_schemas.ts
+++ b/front-api/lib/api/frame_function_invocation_schemas.ts
@@ -1,0 +1,18 @@
+import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
+import { z } from "zod";
+
+export const FrameFunctionInvocationParamsSchema = z.object({
+  frameId: z.string().min(1),
+  name: z.string().refine(isValidSandboxFunctionSlug),
+});
+
+export const PostFrameFunctionInvocationBodySchema = z
+  .object({
+    input: z.unknown().optional(),
+    context: z
+      .object({
+        timezone: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strict();

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9335,6 +9335,78 @@
         }
       }
     },
+    "/api/w/{wId}/frames/{frameId}/functions/{name}/invocations": {
+      "post": {
+        "summary": "Invoke an active Frames v2 function",
+        "description": "Resolves a bare function name from the Frame's active immutable publication, checks Frame use rights, and starts an invocation pinned to that publication.",
+        "tags": [
+          "Private Frames"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "frameId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "description": "Bare function name declared by the active Frame publication.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateFrameFunctionInvocationRequest"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Invocation created. Fast invocations may also include their terminal outcome.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateFrameFunctionInvocationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The function requires a workspace member or a stricter caller identity."
+          },
+          "404": {
+            "description": "Frame, active publication, function, or Frame use right not found."
+          },
+          "500": {
+            "description": "Invocation failed before it could be created."
+          }
+        }
+      }
+    },
     "/api/w/{wId}/sandbox-functions/{functionId}/invocations/{invocationId}/events": {
       "get": {
         "summary": "Stream sandbox function invocation events",
@@ -13236,6 +13308,123 @@
           "userId": {
             "type": "string",
             "description": "sId of the user who owns the wake-up."
+          }
+        }
+      },
+      "PrivateSandboxFunctionInvocation": {
+        "type": "object",
+        "required": [
+          "sId",
+          "functionId",
+          "status",
+          "createdAt"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "functionId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "errored",
+              "succeeded"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PrivateSandboxFunctionCallError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Classification forwarded from the runner, API, or invocation layer."
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateFrameFunctionInvocationRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "input": {
+            "description": "Input validated against the published function contract."
+          },
+          "context": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "timezone": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "PrivateFrameFunctionInvocationResponse": {
+        "type": "object",
+        "required": [
+          "invocation"
+        ],
+        "properties": {
+          "invocation": {
+            "$ref": "#/components/schemas/PrivateSandboxFunctionInvocation"
+          },
+          "outcome": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "status",
+                  "result"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "succeeded"
+                    ]
+                  },
+                  "result": {
+                    "description": "Parsed result validated against the function output schema."
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "status",
+                  "error"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "errored"
+                    ]
+                  },
+                  "error": {
+                    "$ref": "#/components/schemas/PrivateSandboxFunctionCallError"
+                  }
+                }
+              }
+            ]
           }
         }
       },

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1654,6 +1654,67 @@
  *         userId:
  *           type: string
  *           description: sId of the user who owns the wake-up.
+ *     PrivateSandboxFunctionInvocation:
+ *       type: object
+ *       required: [sId, functionId, status, createdAt]
+ *       properties:
+ *         sId:
+ *           type: string
+ *         functionId:
+ *           type: string
+ *         status:
+ *           type: string
+ *           enum: [created, errored, succeeded]
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *     PrivateSandboxFunctionCallError:
+ *       type: object
+ *       required: [code, message]
+ *       properties:
+ *         code:
+ *           type: string
+ *           description: Classification forwarded from the runner, API, or invocation layer.
+ *         message:
+ *           type: string
+ *         status:
+ *           type: integer
+ *     PrivateFrameFunctionInvocationRequest:
+ *       type: object
+ *       additionalProperties: false
+ *       properties:
+ *         input:
+ *           description: Input validated against the published function contract.
+ *         context:
+ *           type: object
+ *           additionalProperties: false
+ *           properties:
+ *             timezone:
+ *               type: string
+ *     PrivateFrameFunctionInvocationResponse:
+ *       type: object
+ *       required: [invocation]
+ *       properties:
+ *         invocation:
+ *           $ref: '#/components/schemas/PrivateSandboxFunctionInvocation'
+ *         outcome:
+ *           oneOf:
+ *             - type: object
+ *               required: [status, result]
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   enum: [succeeded]
+ *                 result:
+ *                   description: Parsed result validated against the function output schema.
+ *             - type: object
+ *               required: [status, error]
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   enum: [errored]
+ *                 error:
+ *                   $ref: '#/components/schemas/PrivateSandboxFunctionCallError'
  *     PrivateSandboxFunctionInvocationEvent:
  *       type: object
  *       description: Server-Sent Event for sandbox function invocation streaming. Discriminated on the `type` field.

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/index.ts
@@ -2,4 +2,52 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 
 const app = workspaceApp();
 
+/**
+ * @swagger
+ * /api/w/{wId}/frames/{frameId}/functions/{name}/invocations:
+ *   post:
+ *     summary: Invoke an active Frames v2 function
+ *     description: Resolves a bare function name from the Frame's active immutable publication, checks Frame use rights, and starts an invocation pinned to that publication.
+ *     tags:
+ *       - Private Frames
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: frameId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         description: Bare function name declared by the active Frame publication.
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/PrivateFrameFunctionInvocationRequest'
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Invocation created. Fast invocations may also include their terminal outcome.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateFrameFunctionInvocationResponse'
+ *       401:
+ *         description: The function requires a workspace member or a stricter caller identity.
+ *       404:
+ *         description: Frame, active publication, function, or Frame use right not found.
+ *       500:
+ *         description: Invocation failed before it could be created.
+ */
+
 export default app;


### PR DESCRIPTION
## Description

Define the canonical Frames v2 invocation contract before transport wiring. This adds the strict parameter and request-body parsers, shared private Swagger schemas, generated endpoint documentation, and parser coverage.

This contract foundation replaces the documentation portion of #31412. It has no runtime handler.

## Tests

- Front API Vitest: 1 file, 2 parser tests passed
- `npm run docs` in `front-api`
- `npm run lint:swagger-annotations` in `front-api`
- `git diff --check`

## Risk

Very low. Runtime behavior is unchanged. Private Swagger can describe the additive route before the transport child merges.

## Deploy Plan

Merge after the canonical route foundation, then merge either resolver lane.
