### PR TITLE
Prepare Frame source conversion primitives

### DIFF
--- a/front/lib/api/frames/conversion_primitives.test.ts
+++ b/front/lib/api/frames/conversion_primitives.test.ts
@@ -1,0 +1,42 @@
+import {
+  getConvertedFrameMetadata,
+  getFrameSourceOwner,
+} from "@app/lib/api/frames/conversion_primitives";
+import { describe, expect, it } from "vitest";
+
+describe("Frame conversion primitives", () => {
+  it("maps supported source scopes to FileResource ownership", () => {
+    expect(getFrameSourceOwner("conversation-conv/Status")).toMatchObject({
+      key: "conversation:conv",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conv" },
+    });
+    expect(getFrameSourceOwner("pod-space/Status")).toMatchObject({
+      key: "pod:space",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: "space" },
+    });
+    expect(getFrameSourceOwner("user-user/Status")).toBeNull();
+  });
+
+  it("keeps stable metadata while replacing source and runtime ownership", () => {
+    const owner = getFrameSourceOwner("conversation-next/Status");
+    expect(owner).not.toBeNull();
+    if (!owner) {
+      return;
+    }
+
+    expect(
+      getConvertedFrameMetadata(
+        {
+          activePublicationId: "publication",
+          conversationId: "previous",
+          frameBundleRootPath: "previous/root",
+          frameEntryRelPath: "index.tsx",
+          skillId: "skill",
+        },
+        owner
+      )
+    ).toEqual({ conversationId: "next", skillId: "skill" });
+  });
+});

--- a/front/lib/api/frames/conversion_primitives.ts
+++ b/front/lib/api/frames/conversion_primitives.ts
@@ -1,0 +1,50 @@
+import { parseScopedPrefix } from "@app/lib/api/file_system";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+
+export type FrameSourceOwner = {
+  key: string;
+  useCase: FileUseCase;
+  useCaseMetadata: Pick<FileUseCaseMetadata, "conversationId" | "spaceId">;
+};
+
+export function getFrameSourceOwner(
+  scopedPath: string
+): FrameSourceOwner | null {
+  const parsed = parseScopedPrefix(scopedPath);
+  if (!parsed) {
+    return null;
+  }
+
+  switch (parsed.kind) {
+    case "conversation":
+      return {
+        key: `${parsed.kind}:${parsed.id}`,
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parsed.id },
+      };
+    case "pod":
+      return {
+        key: `${parsed.kind}:${parsed.id}`,
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: parsed.id },
+      };
+    case "user":
+      return null;
+  }
+}
+
+export function getConvertedFrameMetadata(
+  metadata: FileUseCaseMetadata | undefined,
+  owner: FrameSourceOwner
+): FileUseCaseMetadata {
+  const {
+    activePublicationId: _activePublicationId,
+    conversationId: _conversationId,
+    frameBundleRootPath: _frameBundleRootPath,
+    frameEntryRelPath: _frameEntryRelPath,
+    spaceId: _spaceId,
+    ...stableMetadata
+  } = metadata ?? {};
+
+  return { ...stableMetadata, ...owner.useCaseMetadata };
+}

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment node
 
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { getFrameSourceLockName } from "@app/lib/api/frames/operation_lock";
 import {
+  captureFrameV2SourceSnapshot,
   publishFrameFromSource,
   publishFrameV2FromSource,
 } from "@app/lib/api/frames/publish_from_source";
@@ -188,6 +190,24 @@ describe("publishFrameFromSource", () => {
 });
 
 describe("publishFrameV2FromSource", () => {
+  it("captures a reusable snapshot of the validated source", async () => {
+    const { auth, conversation, manifestPath } = await setup();
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    assert(fsResult.isOk());
+
+    const snapshot = await captureFrameV2SourceSnapshot(
+      fsResult.value,
+      manifestPath
+    );
+
+    assert(snapshot.isOk());
+    expect(snapshot.value.manifestPath).toBe(manifestPath);
+    expect(snapshot.value.manifestSizeBytes).toBe(Buffer.byteLength(manifest));
+    expect(
+      snapshot.value.sourceFiles.map(({ relativePath }) => relativePath)
+    ).toEqual([FRAME_MANIFEST_FILE, "index.tsx"]);
+  });
+
   it("publishes artifacts without copying source and activates one publication", async () => {
     const {
       auth,

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -68,6 +68,13 @@ export type ValidateFrameFromSourceResult = {
   warnings: ValidationWarning[];
 };
 
+export type FrameV2SourceSnapshot = {
+  manifest: FrameManifest;
+  manifestPath: string;
+  manifestSizeBytes: number;
+  sourceFiles: FramePublicationSourceFile[];
+};
+
 async function resolveFrameFromSource(
   auth: Authenticator,
   {
@@ -234,16 +241,13 @@ async function readFrameV2SourceWithSourceLockHeld(
   {
     frame,
     manifestPath,
+    sourceSnapshot,
   }: {
     frame: FileResource;
     manifestPath: string;
+    sourceSnapshot?: FrameV2SourceSnapshot;
   }
-): Promise<
-  Result<
-    { manifest: FrameManifest; sourceFiles: FramePublicationSourceFile[] },
-    FramePublicationError
-  >
-> {
+): Promise<Result<FrameV2SourceSnapshot, FramePublicationError>> {
   const canonicalManifestPath = frame.toScopedPath(auth);
   if (
     !canonicalManifestPath ||
@@ -278,6 +282,23 @@ async function readFrameV2SourceWithSourceLockHeld(
     return frameError("unauthorized", writeAccess.error.message);
   }
 
+  if (sourceSnapshot) {
+    if (sourceSnapshot.manifestPath !== canonicalManifestPath) {
+      return frameError(
+        "invalid_source",
+        `Frame '${frame.sId}' must be published from '${canonicalManifestPath}'.`
+      );
+    }
+    return new Ok(sourceSnapshot);
+  }
+
+  return captureFrameV2SourceSnapshot(dustFs, canonicalManifestPath);
+}
+
+export async function captureFrameV2SourceSnapshot(
+  dustFs: DustFileSystem,
+  canonicalManifestPath: string
+): Promise<Result<FrameV2SourceSnapshot, FramePublicationError>> {
   const manifestBufferResult = await dustFs.readBuffer(canonicalManifestPath);
   if (manifestBufferResult.isErr()) {
     return frameError("invalid_source", manifestBufferResult.error.message);
@@ -393,19 +414,30 @@ async function readFrameV2SourceWithSourceLockHeld(
     sourceFiles.push({ content: content.value, contentType, relativePath });
   }
 
-  return new Ok({ manifest: manifestResult.value, sourceFiles });
+  return new Ok({
+    manifest: manifestResult.value,
+    manifestPath: canonicalManifestPath,
+    manifestSizeBytes: manifestBuffer.length,
+    sourceFiles,
+  });
 }
 
-async function publishFrameV2FromSourceWithSourceLockHeld(
+/**
+ * Publish a Frames v2 FileResource from its current source folder. The FileResource path is the
+ * authority: callers cannot point a Frame identity at a different manifest or source tree.
+ */
+export async function publishFrameV2FromSourceWithLockHeld(
   auth: Authenticator,
   {
     conversation,
     frame,
     manifestPath,
+    sourceSnapshot,
   }: {
     conversation: ConversationWithoutContentType;
     frame: FileResource;
     manifestPath: string;
+    sourceSnapshot?: FrameV2SourceSnapshot;
   }
 ): Promise<
   Result<
@@ -413,9 +445,17 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
     FramePublicationError | SandboxFunctionError
   >
 > {
+  if (!frame.isFrameV2) {
+    return frameError(
+      "invalid_frame",
+      `File '${frame.sId}' is not a Frames v2 manifest.`
+    );
+  }
+
   const source = await readFrameV2SourceWithSourceLockHeld(auth, {
     frame,
     manifestPath,
+    sourceSnapshot,
   });
   if (source.isErr()) {
     return source;
@@ -424,7 +464,8 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
   return buildAndPublishFramePublication(auth, {
     conversation,
     frame,
-    ...source.value,
+    manifest: source.value.manifest,
+    sourceFiles: source.value.sourceFiles,
   });
 }
 
@@ -461,7 +502,7 @@ export async function publishFrameV2FromSource(
       );
     }
 
-    return publishFrameV2FromSourceWithSourceLockHeld(auth, {
+    return publishFrameV2FromSourceWithLockHeld(auth, {
       conversation,
       frame: freshFrame,
       manifestPath,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -80,6 +80,7 @@ import type {
   FileTypeWithUploadUrl,
   FileUseCase,
   FileUseCaseMetadata,
+  FrameFileContentType,
   SharingGrantType,
 } from "@app/types/files";
 import {
@@ -1938,6 +1939,34 @@ export class FileResource extends BaseResource<FileModel> {
       mountFilePath: destMountFilePath,
       useCase: destUseCase,
       useCaseMetadata: destUseCaseMetadata ?? null,
+    });
+  }
+
+  /** Rebind a stable Frame identity to another source entry without changing its sharing rows. */
+  updateFrameSourceBinding({
+    contentType,
+    fileName,
+    fileSize,
+    mountFilePath,
+    useCase,
+    useCaseMetadata,
+  }: {
+    contentType: FrameFileContentType;
+    fileName: string;
+    fileSize: number;
+    mountFilePath: string;
+    useCase: FileUseCase;
+    useCaseMetadata: FileUseCaseMetadata;
+  }) {
+    assert(this.isShareableFrame, "Only a Frame source binding can be updated");
+
+    return this.update({
+      contentType,
+      fileName: sanitizeFileSystemName(fileName),
+      fileSize,
+      mountFilePath,
+      useCase,
+      useCaseMetadata,
     });
   }
 

--- a/front/lib/resources/frame_file_resource.test.ts
+++ b/front/lib/resources/frame_file_resource.test.ts
@@ -1,6 +1,6 @@
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { frameV2ContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { describe, expect, it } from "vitest";
 
 describe("Frames v2 FileResource", () => {
@@ -17,5 +17,34 @@ describe("Frames v2 FileResource", () => {
     expect(frame.isFrameV2).toBe(true);
     expect(frame.isInteractiveContent).toBe(false);
     expect(frame.isShareableFrame).toBe(true);
+  });
+
+  it("rebinds a stable shared Frame identity to a v2 manifest", async () => {
+    const { authenticator } = await createResourceTest({});
+    const frame = await FileFactory.create(authenticator, null, {
+      contentType: frameContentType,
+      fileName: "legacy.tsx",
+      fileSize: 50,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conversation-id" },
+      mountFilePath: "/files/legacy.tsx",
+    });
+    await frame.ensureShareableFrame(authenticator);
+    const shareInfo = await frame.getShareInfo();
+
+    await frame.updateFrameSourceBinding({
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      mountFilePath: "/files/status/manifest.json",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conversation-id" },
+    });
+
+    expect(frame.isFrameV2).toBe(true);
+    expect(frame.fileName).toBe("manifest.json");
+    expect(frame.mountFilePath).toBe("/files/status/manifest.json");
+    expect(await frame.getShareInfo()).toEqual(shareInfo);
   });
 });


### PR DESCRIPTION
## Description

Add the conversion primitives: reusable Frames v2 source snapshots, publication from an already-held source lock, converted ownership metadata, and stable `FileResource` rebinding that preserves identity and sharing rows. No endpoint is exposed here.

Stack: current `main` -> this PR -> #31541.

## Tests

- conversion primitive tests pass
- included in the final 134-test changed-front suite
- Biome and diff checks pass

## Deploy Plan

Merge first. Do not use conversion in production; keep the conversion workflow flag-disabled until #31539, #31541, #31546, #31542, #31543, #31547, #31548, #31690, #31691, #31694, and #31544 have landed and the WorkOS `frame.converted` schema is registered.