### PR TITLE
Add generation preconditions to FileStorage operations

### DIFF
--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -1,6 +1,9 @@
 import config from "@app/lib/file_storage/config";
 import type { GCSAPIError } from "@app/lib/file_storage/types";
-import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import {
+  isGCSNotFoundError,
+  isGCSPreconditionFailedError,
+} from "@app/lib/file_storage/types";
 import { setTimeoutAsync, withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AllSupportedFileContentType } from "@app/types/files";
@@ -52,6 +55,27 @@ type RawContentSaveOptions = Pick<
   SaveOptions,
   "preconditionOpts" | "resumable"
 >;
+
+export type FileCopyResult = {
+  destinationGeneration: string;
+};
+
+function getCopyResponseGeneration(response: unknown): string | null {
+  if (
+    typeof response !== "object" ||
+    response === null ||
+    !("resource" in response) ||
+    typeof response.resource !== "object" ||
+    response.resource === null ||
+    !("generation" in response.resource)
+  ) {
+    return null;
+  }
+  const { generation } = response.resource;
+  return isString(generation) || isNumber(generation)
+    ? String(generation)
+    : null;
+}
 
 function isRetryableGCSError(err: unknown): boolean {
   // ApiError only adds optional fields on top of Error, so a normalized Error
@@ -481,10 +505,13 @@ export class FileStorage {
 
   async delete(
     filePath: string,
-    { ignoreNotFound }: { ignoreNotFound?: boolean } = {}
+    {
+      ignoreNotFound,
+      ifGenerationMatch,
+    }: { ignoreNotFound?: boolean; ifGenerationMatch?: string } = {}
   ) {
     try {
-      return await this.file(filePath).delete();
+      return await this.file(filePath).delete({ ifGenerationMatch });
     } catch (err) {
       if (ignoreNotFound && isGCSNotFoundError(err)) {
         return;
@@ -505,8 +532,14 @@ export class FileStorage {
     srcPath: string,
     destPath: string,
     destinationStorage: FileStorage = this,
-    { sourceGeneration }: { sourceGeneration?: string } = {}
-  ): Promise<void> {
+    {
+      destinationGenerationMatch,
+      sourceGeneration,
+    }: {
+      destinationGenerationMatch?: number | string;
+      sourceGeneration?: string;
+    } = {}
+  ): Promise<FileCopyResult> {
     const destinationFile = destinationStorage.file(destPath);
     const sourceFile = sourceGeneration
       ? this.bucket.file(srcPath, { generation: sourceGeneration })
@@ -517,10 +550,18 @@ export class FileStorage {
       attempt <= GCS_TRANSIENT_RETRY_MAX_ATTEMPTS;
       attempt++
     ) {
+      let response: unknown;
       try {
-        await sourceFile.copy(destinationFile);
-        return;
+        [, response] = await sourceFile.copy(destinationFile, {
+          preconditionOpts:
+            destinationGenerationMatch !== undefined
+              ? { ifGenerationMatch: destinationGenerationMatch }
+              : undefined,
+        });
       } catch (err) {
+        if (isGCSPreconditionFailedError(err)) {
+          throw err;
+        }
         if (attempt === GCS_TRANSIENT_RETRY_MAX_ATTEMPTS) {
           throw err;
         }
@@ -542,8 +583,17 @@ export class FileStorage {
         );
 
         await setTimeoutAsync(delayMs);
+        continue;
       }
+
+      const destinationGeneration = getCopyResponseGeneration(response);
+      if (!destinationGeneration) {
+        throw new Error("GCS copy response is missing its generation.");
+      }
+      return { destinationGeneration };
     }
+
+    throw new Error("GCS copy retry loop exhausted unexpectedly.");
   }
 
   async deleteByPrefix(prefix: string): Promise<void> {

--- a/front/tests/utils/mocks/file_storage.test.ts
+++ b/front/tests/utils/mocks/file_storage.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("fileStorageMock", () => {
+  beforeEach(() => {
+    fileStorageMock.reset();
+  });
+
+  it("preserves the legacy no-op for an unpinned missing copy source", async () => {
+    const bucket = getPrivateUploadBucket();
+
+    await expect(
+      bucket.copyFile("missing-source", "missing-destination")
+    ).resolves.toBeUndefined();
+    expect(fileStorageMock.getObject("missing-destination")).toBeUndefined();
+    await expect(
+      bucket.copyFile("missing-source", "missing-destination", undefined, {
+        sourceGeneration: "1",
+      })
+    ).rejects.toMatchObject({ code: 404 });
+  });
+
+  it("distinguishes missing objects from generation mismatches on delete", async () => {
+    const bucket = getPrivateUploadBucket();
+
+    await expect(
+      bucket.delete("missing", {
+        ignoreNotFound: true,
+        ifGenerationMatch: "1",
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      bucket.delete("missing", { ifGenerationMatch: "1" })
+    ).rejects.toMatchObject({ code: 404 });
+    await expect(bucket.delete("missing")).resolves.toBeUndefined();
+
+    fileStorageMock.setObject("source", "old");
+    const oldGeneration = fileStorageMock.getObjectGeneration("source");
+    assert(oldGeneration);
+    fileStorageMock.setObject("source", "new");
+
+    await expect(
+      bucket.delete("source", {
+        ignoreNotFound: true,
+        ifGenerationMatch: oldGeneration,
+      })
+    ).rejects.toMatchObject({ code: 412 });
+    expect(fileStorageMock.getObject("source")).toBe("new");
+
+    const currentGeneration = fileStorageMock.getObjectGeneration("source");
+    assert(currentGeneration);
+    await expect(
+      bucket.delete("source", { ifGenerationMatch: currentGeneration })
+    ).resolves.toBeUndefined();
+    expect(fileStorageMock.getObject("source")).toBeUndefined();
+  });
+});

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -60,6 +60,9 @@ class FileStorageMock {
   private _signedUploadUrlCalls: SignedUrlCall[] = [];
   private _metadataCalls: string[] = [];
   private _objectStore = new Map<string, string>();
+  private _objectGenerations = new Map<string, string>();
+  private _objectVersions = new Map<string, Map<string, string>>();
+  private _nextGeneration = 1;
   private _fetchNotFoundPredicate: (filePath: string) => boolean = () => false;
   private _existsPredicate: (filePath: string) => boolean = () => true;
   private _saveShouldFail: (filePath: string) => boolean = () => false;
@@ -70,6 +73,7 @@ class FileStorageMock {
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
+  private _afterCopyFile: (src: string, dest: string) => void = () => {};
   private _filesByPrefix: (
     prefix: string
   ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
@@ -156,6 +160,10 @@ class FileStorageMock {
     this._copyFileShouldFail = predicate;
   }
 
+  setAfterCopyFile(callback: (src: string, dest: string) => void): void {
+    this._afterCopyFile = callback;
+  }
+
   /**
    * Controls what `bucket.getAllFilesByPrefix({ prefix })` resolves to, keyed by the prefix. Return
    * null (the default) to resolve an empty list. Reset between tests via `reset()`.
@@ -213,9 +221,18 @@ class FileStorageMock {
     return this._objectStore.get(filePath);
   }
 
+  getObjectGeneration(filePath: string): string | undefined {
+    return this._objectGenerations.get(filePath);
+  }
+
   // Seed the in-memory object store directly (no write path).
   setObject(filePath: string, content: string): void {
+    const generation = String(this._nextGeneration++);
     this._objectStore.set(filePath, content);
+    this._objectGenerations.set(filePath, generation);
+    const versions = this._objectVersions.get(filePath) ?? new Map();
+    versions.set(generation, content);
+    this._objectVersions.set(filePath, versions);
   }
 
   reset(): void {
@@ -226,6 +243,9 @@ class FileStorageMock {
     this._signedUploadUrlCalls.length = 0;
     this._metadataCalls.length = 0;
     this._objectStore.clear();
+    this._objectGenerations.clear();
+    this._objectVersions.clear();
+    this._nextGeneration = 1;
     this._fetchNotFoundPredicate = () => false;
     this._existsPredicate = () => true;
     this._saveShouldFail = () => false;
@@ -233,6 +253,7 @@ class FileStorageMock {
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
+    this._afterCopyFile = () => {};
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
     this._deletedPrefixes.length = 0;
@@ -293,10 +314,22 @@ class FileStorageMock {
           }
           return stream;
         }),
-      delete: vi.fn().mockImplementation(() => {
-        this._objectStore.delete(filePath ?? "unknown");
-        return Promise.resolve(undefined);
-      }),
+      delete: vi
+        .fn()
+        .mockImplementation((options?: { ifGenerationMatch?: string }) => {
+          const path = filePath ?? "unknown";
+          if (
+            options?.ifGenerationMatch !== undefined &&
+            this._objectGenerations.get(path) !== options.ifGenerationMatch
+          ) {
+            return Promise.reject(
+              new MockGcsError(412, `Object generation changed: ${path}`)
+            );
+          }
+          this._objectStore.delete(path);
+          this._objectGenerations.delete(path);
+          return Promise.resolve(undefined);
+        }),
       download: vi.fn().mockImplementation(() => {
         const content = this._objectStore.get(filePath ?? "unknown") ?? "";
         return Promise.resolve([Buffer.from(content, "utf-8")]);
@@ -435,18 +468,47 @@ class FileStorageMock {
         }
         return Promise.resolve(new Uint8Array());
       }),
-      copyFile: vi.fn((src: string, dest: string) => {
-        if (this._copyFileShouldFail(src, dest)) {
-          return Promise.reject(
-            new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
-          );
+      copyFile: vi.fn(
+        (
+          src: string,
+          dest: string,
+          _destinationStorage?: unknown,
+          options?: {
+            destinationGenerationMatch?: number | string;
+            sourceGeneration?: string;
+          }
+        ) => {
+          if (
+            options?.destinationGenerationMatch === 0 &&
+            this._objectStore.has(dest)
+          ) {
+            return Promise.reject(
+              new MockGcsError(412, `Object already exists: ${dest}`)
+            );
+          }
+          if (this._copyFileShouldFail(src, dest)) {
+            return Promise.reject(
+              new Error(`Simulated GCS copy failure: ${src} -> ${dest}`)
+            );
+          }
+          const content = options?.sourceGeneration
+            ? this._objectVersions.get(src)?.get(options.sourceGeneration)
+            : (this._objectStore.get(src) ?? this._contentForPath(src));
+          if (content === null || content === undefined) {
+            if (options?.sourceGeneration === undefined) {
+              // Preserve the legacy no-op for tests that do not seed GCS objects.
+              return Promise.resolve(undefined);
+            }
+            return Promise.reject(
+              new MockGcsError(404, `Source generation not found: ${src}`)
+            );
+          }
+          this.setObject(dest, content);
+          const destinationGeneration = this._objectGenerations.get(dest);
+          this._afterCopyFile(src, dest);
+          return Promise.resolve({ destinationGeneration });
         }
-        const content = this._objectStore.get(src) ?? this._contentForPath(src);
-        if (content !== null && content !== undefined) {
-          this._objectStore.set(dest, content);
-        }
-        return Promise.resolve(undefined);
-      }),
+      ),
       // Mirrors real GCS compose: concatenates each source's stored content, in order,
       // into the destination object.
       composeFiles: vi.fn((sourcePaths: string[], destinationPath: string) => {
@@ -463,10 +525,36 @@ class FileStorageMock {
         });
         return Promise.resolve(undefined);
       }),
-      delete: vi.fn((filePath: string) => {
-        this._objectStore.delete(filePath);
-        return Promise.resolve(undefined);
-      }),
+      delete: vi.fn(
+        (
+          filePath: string,
+          options?: { ignoreNotFound?: boolean; ifGenerationMatch?: string }
+        ) => {
+          if (!this._objectStore.has(filePath)) {
+            if (
+              options?.ignoreNotFound ||
+              options?.ifGenerationMatch === undefined
+            ) {
+              // Preserve the legacy no-op for unconditioned mock deletes.
+              return Promise.resolve(undefined);
+            }
+            return Promise.reject(
+              new MockGcsError(404, `No such object: ${filePath}`)
+            );
+          }
+          if (
+            options?.ifGenerationMatch !== undefined &&
+            this._objectGenerations.get(filePath) !== options.ifGenerationMatch
+          ) {
+            return Promise.reject(
+              new MockGcsError(412, `Object generation changed: ${filePath}`)
+            );
+          }
+          this._objectStore.delete(filePath);
+          this._objectGenerations.delete(filePath);
+          return Promise.resolve(undefined);
+        }
+      ),
       deleteByPrefix: vi.fn(async (prefix: string) => {
         this._deletedPrefixes.push(prefix);
         this._onDeleteByPrefix(prefix);


### PR DESCRIPTION
## Description

Add optional generation preconditions to generic FileStorage copy and delete operations. Copy can require an empty destination, pin a source generation, and return the destination generation. Delete can pin the generation it removes. The shared FileStorage mock matches GCS 404 and 412 behavior.

This optional foundation is rebased directly on current main, which already contains #31537. Its one-commit diff contains only the FileStorage precondition slice.

## Tests

- This PR head passes front tsgo independently.
- Six focused Frame and FileStorage suites: 18 tests passed on the fully stacked head.
- npm run format:changed.

## Risk

Low. Existing callers may ignore the new copy result and omit all new options. Precondition failures are surfaced without transient retries, matching GCS semantics.

## Deploy Plan

Merge normally. #31549 is the next optional child.