### PR TITLE
Expose legacy Frame conversion endpoint

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/convert.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/convert.ts
@@ -1,0 +1,102 @@
+import {
+  type ConvertLegacyFrameToV2Error,
+  type ConvertLegacyFrameToV2Result,
+  convertLegacyFrameToV2,
+  isFrameV2ConversionError,
+} from "@app/lib/api/frames/convert_from_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+import { frameSourceErrorStatus } from "./errors";
+
+const FrameConvertRequestSchema = z.object({
+  manifestPath: z.string().min(1),
+  sourcePath: z.string().min(1),
+});
+
+function frameConvertErrorStatus(
+  error: ConvertLegacyFrameToV2Error
+): 400 | 403 | 500 {
+  if (isFrameV2ConversionError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+  return frameSourceErrorStatus(error);
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameConvertRequestSchema),
+  async (ctx): HandlerResult<ConvertLegacyFrameToV2Result> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot convert Frames.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const { manifestPath, sourcePath } = ctx.req.valid("json");
+    const conversion = await convertLegacyFrameToV2(auth, {
+      conversation: conversation.toJSON(),
+      manifestPath,
+      sourcePath,
+    });
+    if (conversion.isErr()) {
+      const status = frameConvertErrorStatus(conversion.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: conversion.error.message,
+          },
+        },
+        conversion.error
+      );
+    }
+
+    return ctx.json(conversion.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -96,6 +96,22 @@ function requestFrameShare(
   );
 }
 
+function requestFrameConvert(
+  workspaceId: string,
+  token: string,
+  sourcePath: string,
+  manifestPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/convert`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourcePath, manifestPath }),
+  });
+}
+
 async function setup({ registered = true }: { registered?: boolean } = {}) {
   const context = await createSandboxTokenTestContext();
   await FeatureFlagFactory.basic(context.auth, "frames_v2");
@@ -176,11 +192,132 @@ async function setupLegacyFrame() {
   return { ...context, frame, sourcePath };
 }
 
+async function setupLegacyFrameConversion({
+  includeUi = true,
+}: {
+  includeUi?: boolean;
+} = {}) {
+  const context = await setupLegacyFrame();
+  await context.frame.ensureShareableFrame(context.auth);
+  const sourceDirectoryPath = `conversation-${context.conversation.sId}/Converted`;
+  const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+  const mountDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: context.workspace.sId,
+    conversationId: context.conversation.sId,
+  })}Converted`;
+  const sourceByPath = new Map([
+    [`${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifest],
+    ...(includeUi
+      ? ([[`${mountDirectoryPath}/index.tsx`, uiSource]] as const)
+      : []),
+  ]);
+  fileStorageMock.setFileContent(
+    (filePath) => sourceByPath.get(filePath) ?? null
+  );
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    prefix === `${mountDirectoryPath}/`
+      ? [...sourceByPath.entries()].map(([name, content]) => ({
+          name,
+          metadata: {
+            contentType: name.endsWith(".tsx")
+              ? "text/typescript"
+              : "application/json",
+            size: String(Buffer.byteLength(content)),
+          },
+        }))
+      : null
+  );
+
+  return { ...context, manifestPath };
+}
+
 beforeEach(() => {
   fileStorageMock.reset();
 });
 
 describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
+  it("converts a legacy Frame while preserving identity and use rights", async () => {
+    const context = await setupLegacyFrameConversion();
+    const shareInfo = await context.frame.getShareInfo();
+
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    const converted = await response.json();
+    expect(response.status, JSON.stringify(converted)).toBe(200);
+    expect(converted).toMatchObject({
+      frameId: context.frame.sId,
+      manifestPath: context.manifestPath,
+      publicationId: expect.any(String),
+    });
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.isFrameV2).toBe(true);
+    expect(frame?.toScopedPath(context.auth)).toBe(context.manifestPath);
+    expect(frame?.useCaseMetadata?.activePublicationId).toBe(
+      converted.publicationId
+    );
+    expect(await frame?.getShareInfo()).toEqual(shareInfo);
+  });
+
+  it("publishes the same source snapshot that conversion validates", async () => {
+    const context = await setupLegacyFrameConversion();
+    const mountManifestPath = `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Converted/${FRAME_MANIFEST_FILE}`;
+    const mountUiPath = mountManifestPath.replace(
+      FRAME_MANIFEST_FILE,
+      "index.tsx"
+    );
+    const manifestWithDatabase = JSON.stringify({
+      version: 1,
+      name: "Status",
+      description: "Show the current status.",
+      databases: [{ name: "tasks", schema: "databases/tasks.db.ts" }],
+    });
+    let manifestReadCount = 0;
+    fileStorageMock.setFileContent((filePath) => {
+      if (filePath === mountManifestPath) {
+        manifestReadCount += 1;
+        return manifestReadCount === 1 ? manifest : manifestWithDatabase;
+      }
+      return filePath === mountUiPath ? uiSource : null;
+    });
+
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    expect(response.status, await response.text()).toBe(200);
+    expect(manifestReadCount).toBe(1);
+  });
+
+  it("restores the legacy Frame when its first v2 publication fails", async () => {
+    const context = await setupLegacyFrameConversion({ includeUi: false });
+    const shareInfo = await context.frame.getShareInfo();
+
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    expect(response.status).toBe(400);
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.isInteractiveContent).toBe(true);
+    expect(frame?.isFrameV2).toBe(false);
+    expect(frame?.toScopedPath(context.auth)).toBe(context.sourcePath);
+    expect(await frame?.getShareInfo()).toEqual(shareInfo);
+  });
+
   it("registers one stable Frame identity", async () => {
     const context = await setup({ registered: false });
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 
 import call from "./call";
 import callById from "./call_by_id";
+import convert from "./convert";
 import { frameSourceErrorStatus } from "./errors";
 import register from "./register";
 import share from "./share";
@@ -34,6 +35,7 @@ const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
 app.route("/call", call);
+app.route("/convert", convert);
 app.route("/:frameId/call", callById);
 app.route("/register", register);
 app.route("/share", share);

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -20,6 +20,12 @@ export class SandboxFunctionError extends Error {
   }
 }
 
+export function isSandboxFunctionError(
+  error: unknown
+): error is SandboxFunctionError {
+  return error instanceof SandboxFunctionError;
+}
+
 export type SandboxFunctionInvocationErrorCode =
   | "user_authentication_required"
   | "frame_runtime_unavailable";


### PR DESCRIPTION
## Description

Expose the in-place conversion service through the feature-gated Frames v2 sandbox endpoint. The route validates source and manifest paths, reuses the shared exhaustive source-error mapper, mounts the endpoint, and returns the preserved Frame identity with its first Frames v2 publication.

Stack: #31546 -> this PR -> #31543.

## Tests

- sandbox endpoint success and typed failure coverage passes
- included in the final 86-test changed-front-api suite
- Biome, Swagger annotation, and diff checks pass

## Deploy Plan

Merge after #31546. The endpoint must remain unused and the conversion workflow flag-disabled until #31543, #31547, #31548, #31690, #31691, #31694, and #31544 have landed and the WorkOS `frame.converted` schema is registered.