### PR TITLE
Audit legacy Frame conversions

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -19,6 +19,16 @@ import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
   return {
@@ -233,6 +243,7 @@ async function setupLegacyFrameConversion({
 
 beforeEach(() => {
   fileStorageMock.reset();
+  mockEmitAuditLogEvent.mockClear();
 });
 
 describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
@@ -261,6 +272,16 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
       converted.publicationId
     );
     expect(await frame?.getShareInfo()).toEqual(shareInfo);
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.converted",
+        metadata: {
+          manifest_path: context.manifestPath,
+          publication_id: converted.publicationId,
+          source_path: context.sourcePath,
+        },
+      })
+    );
   });
 
   it("publishes the same source snapshot that conversion validates", async () => {

--- a/front/admin/audit_log_schemas/frame.converted.json
+++ b/front/admin/audit_log_schemas/frame.converted.json
@@ -1,0 +1,12 @@
+{
+  "action": "frame.converted",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "manifest_path": "string",
+    "publication_id": "string",
+    "source_path": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.converted": 1,
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -176,6 +176,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.converted",
   "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",

--- a/front/lib/api/frames/convert_from_source.ts
+++ b/front/lib/api/frames/convert_from_source.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
 
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import {
   getConvertedFrameMetadata,
@@ -62,6 +67,34 @@ function conversionError(
   message: string
 ) {
   return new Err(new FrameV2ConversionError(code, message));
+}
+
+function emitFrameConvertedAuditEvent(
+  auth: Authenticator,
+  {
+    frameId,
+    manifestPath,
+    publicationId,
+    sourcePath,
+  }: ConvertLegacyFrameToV2Result & { sourcePath: string }
+) {
+  void emitAuditLogEvent({
+    auth,
+    action: "frame.converted",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("frame", {
+        sId: frameId,
+        name: path.posix.basename(path.posix.dirname(manifestPath)),
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      manifest_path: manifestPath,
+      publication_id: publicationId,
+      source_path: sourcePath,
+    },
+  });
 }
 
 /** Convert a legacy Frame in place, preserving its stable identity and use-rights rows. */
@@ -271,6 +304,7 @@ export async function convertLegacyFrameToV2(
         manifestPath: manifest,
         publicationId: publication.value.publicationId,
       };
+      emitFrameConvertedAuditEvent(auth, { ...result, sourcePath: source });
       return new Ok(result);
     } catch (error) {
       const restored = await restore();


### PR DESCRIPTION
## Description

Emit the `frame.converted` WorkOS audit event only after conversion succeeds. Add the schema, registry entries, targets, metadata, and direct endpoint coverage.

Stack: #31542 -> this PR -> #31547.

## Tests

- endpoint coverage asserts one post-success conversion audit event
- audit schema suite and lint pass
- schema registration dry-run includes only `frame.converted`
- Biome and diff checks pass

## Deploy Plan

Merge after #31542. Before enabling or using conversion, register the WorkOS schema with `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`, land the full chain through #31544, and keep the conversion workflow flag disabled until both are complete.