### PR TITLE
Expose Frame conversion in dsbx

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -10,9 +10,9 @@ use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, FrameCallByIdRequest, FrameCallFromSourceRequest,
-    FrameCallResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
-    FrameRegisterResponse, FrameShareLinkResponse, FrameValidateRequest, FrameValidateResponse,
-    MCPServerView, SandboxServerViewsResponse,
+    FrameCallResponse, FrameConvertRequest, FrameConvertResponse, FramePublishRequest,
+    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, FrameShareLinkResponse,
+    FrameValidateRequest, FrameValidateResponse, MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -211,6 +211,22 @@ impl DustApiClient {
         self.get(
             "sandbox/frames/share",
             &[("sourceDirectoryPath", source_directory_path)],
+        )
+        .await
+    }
+
+    pub async fn convert_frame(
+        &self,
+        source_path: &str,
+        manifest_path: &str,
+    ) -> anyhow::Result<FrameConvertResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/convert",
+            &FrameConvertRequest {
+                source_path,
+                manifest_path,
+            },
+            POLL_MAX_DURATION,
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -46,6 +46,13 @@ pub struct FrameValidateRequest<'a> {
     pub manifest_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameConvertRequest<'a> {
+    pub source_path: &'a str,
+    pub manifest_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -81,6 +88,14 @@ pub struct FrameShareLinkResponse {
     pub share_scope: String,
     pub share_url: String,
     pub source_directory_path: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameConvertResponse {
+    pub frame_id: String,
+    pub manifest_path: String,
+    pub publication_id: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/cli/dust-sandbox/src/commands/frame/convert.rs
+++ b/cli/dust-sandbox/src/commands/frame/convert.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_manifest_path, scoped_path};
+
+pub async fn run(source: &Path, manifest: &Path) -> anyhow::Result<()> {
+    let source_path = scoped_path(source)?;
+    let manifest_path = scoped_manifest_path(manifest)?;
+    let client = DustApiClient::from_env()?;
+    let response = client.convert_frame(&source_path, &manifest_path).await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,4 +1,5 @@
 mod call;
+mod convert;
 mod create;
 mod publish;
 mod register;
@@ -11,6 +12,7 @@ use anyhow::{bail, Context};
 use clap::Subcommand;
 
 pub use call::run as cmd_frame_call;
+pub use convert::run as cmd_frame_convert;
 pub use create::run as cmd_frame_create;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
@@ -31,6 +33,13 @@ pub enum FrameCommand {
         /// JSON input passed to the function
         #[arg(long, value_name = "JSON")]
         input: Option<String>,
+    },
+    /// Convert a legacy Frame to Frames v2 while preserving identity and use rights
+    Convert {
+        /// Existing legacy Frame entry file under /files
+        source: PathBuf,
+        /// New v2 manifest path under the same mounted scope
+        manifest: PathBuf,
     },
     /// Create and register a new Frame folder
     Create {

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -14,8 +14,8 @@ pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
 pub use frame::{
-    cmd_frame_call, cmd_frame_create, cmd_frame_publish, cmd_frame_register, cmd_frame_share_link,
-    cmd_frame_validate,
+    cmd_frame_call, cmd_frame_convert, cmd_frame_create, cmd_frame_publish, cmd_frame_register,
+    cmd_frame_share_link, cmd_frame_validate,
 };
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -136,6 +136,9 @@ async fn run() -> anyhow::Result<()> {
                 function_name,
                 input,
             } => commands::cmd_frame_call(&target, &function_name, input.as_deref()).await?,
+            commands::frame::FrameCommand::Convert { source, manifest } => {
+                commands::cmd_frame_convert(&source, &manifest).await?
+            }
             commands::frame::FrameCommand::Create {
                 directory,
                 name,
@@ -610,5 +613,33 @@ mod tests {
             "/files/conversation-conv_123/Status",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn frame_convert_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "convert",
+            "/files/conversation-conv_123/Legacy.tsx",
+            "/files/conversation-conv_123/Status/manifest.json",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command: commands::frame::FrameCommand::Convert { source, manifest },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Legacy.tsx")
+                );
+                assert_eq!(
+                    manifest,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status/manifest.json")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected convert"),
+            _ => panic!("expected frame"),
+        }
     }
 }

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -65,6 +65,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("dsbx frame share-link");
     expect(instructions).toContain("dsbx frame call");
+    expect(instructions).toContain("dsbx frame convert");
     expect(instructions).toContain("stable Frame ID");
     expect(instructions).toContain("additionally requires read access");
     expect(instructions).toContain("does not test the Frame");

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -53,6 +53,18 @@ dsbx frame register /files/<scope>/<frame-folder>/manifest.json
 Registration validates the manifest and assigns its stable Frame identity. Repeating the command
 for the same manifest path returns the same Frame. Registration does not publish the source.
 
+## Convert a legacy Frame
+
+To migrate an existing legacy Frame without changing its identity or use rights, prepare a Frames
+v2 folder in the same conversation or Pod mount, then run:
+
+\`\`\`bash
+dsbx frame convert /files/<scope>/<legacy-entry>.tsx /files/<scope>/<frame-folder>/manifest.json
+\`\`\`
+
+The command validates and publishes one snapshot before switching the existing Frame to the new
+manifest. The first v2 manifest cannot declare databases. Add them and publish again afterward.
+
 ## Retrieve a registered Frame's share link
 
 Frame sharing and use rights are configured by the user in the Dust UI. Agents must not change


### PR DESCRIPTION
## Description

Expose the fully hardened conversion endpoint through `dsbx frame convert` and document the workflow in the Frames skill. This PR contains only CLI wiring, its parser/path tests, and agent instructions. It is physically based on the final lifecycle-hardening tip so agents cannot access conversion before recovery, deletion, move, rename, and revert behavior is safe.

Stack: #31694 -> this PR. This is the final code PR in the conversion chain.

## Tests

- `cargo fmt --check`
- `cargo test frame_convert_parses`
- `cargo test commands::frame::tests`
- Frames skill tests are included in the 134-test changed-front suite
- Biome and diff checks pass

## Deploy Plan

Merge last, after #31694. Even after merge, keep conversion unused and the workflow flag disabled until the full stack is deployed and the WorkOS `frame.converted` schema is registered. The separate dust-base release must then include this `dsbx` version before agents can invoke the command.