### PR TITLE
Fence legacy Frame mutations during conversion

### DIFF
--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -7,6 +7,7 @@ import {
   getFileContent,
   getUpdatedContentAndOccurrences,
 } from "@app/lib/api/files/utils";
+import { withLegacyFrameMutationLock } from "@app/lib/api/frames/operation_lock";
 import {
   diffAuthorizedFileRefs,
   fetchShareableFileAllowlistState,
@@ -14,7 +15,6 @@ import {
 } from "@app/lib/api/viz/authorized_file_access";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
-import { executeWithLock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -190,7 +190,7 @@ export async function editClientExecutableFile(
   // Acquire edit lock to prevent concurrent modifications.
   // TODO(YJS): Replace with YJS-based concurrent editing for proper multi-agent support.
   try {
-    return await executeWithLock(`file:edit:${fileId}`, async () => {
+    return await withLegacyFrameMutationLock(fileId, async () => {
       // Fetch the existing file.
       const fileContentResult = await getClientExecutableFileContent(
         auth,

--- a/front/lib/api/frames/convert_from_source.ts
+++ b/front/lib/api/frames/convert_from_source.ts
@@ -5,7 +5,10 @@ import {
   getConvertedFrameMetadata,
   getFrameSourceOwner,
 } from "@app/lib/api/frames/conversion_primitives";
-import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
+import {
+  withFrameSourceLock,
+  withLegacyFrameMutationLock,
+} from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import {
   captureFrameV2SourceSnapshot,
@@ -13,6 +16,7 @@ import {
 } from "@app/lib/api/frames/publish_from_source";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
+import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
 import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
@@ -147,10 +151,7 @@ export async function convertLegacyFrameToV2(
     );
   }
 
-  const conversion = await withFrameSourceLock<
-    ConvertLegacyFrameToV2Result,
-    ConvertLegacyFrameToV2Error
-  >(legacyFrame.sId, async () => {
+  const convertWithSourceLock = async () => {
     const frame = await FileResource.fetchById(auth, legacyFrame.sId);
     if (!frame || frame.mountFilePath !== sourceMountPath) {
       return conversionError(
@@ -280,7 +281,30 @@ export async function convertLegacyFrameToV2(
           : "Frame conversion failed and its legacy source binding could not be restored."
       );
     }
-  });
+  };
+  let conversion: Result<
+    ConvertLegacyFrameToV2Result,
+    ConvertLegacyFrameToV2Error | LockAcquisitionTimeoutError
+  >;
+  try {
+    conversion = await withLegacyFrameMutationLock(legacyFrame.sId, () =>
+      withFrameSourceLock<
+        ConvertLegacyFrameToV2Result,
+        ConvertLegacyFrameToV2Error
+      >(legacyFrame.sId, convertWithSourceLock)
+    );
+  } catch (error) {
+    if (isLockAcquisitionTimeoutError(error)) {
+      return conversionError(
+        "conflict",
+        "Another source operation is in progress for this Frame; retry shortly."
+      );
+    }
+    return conversionError(
+      "internal",
+      `Frame conversion failed: ${normalizeError(error).message}`
+    );
+  }
   if (conversion.isErr()) {
     if (isLockAcquisitionTimeoutError(conversion.error)) {
       return conversionError(

--- a/front/lib/api/frames/operation_lock.test.ts
+++ b/front/lib/api/frames/operation_lock.test.ts
@@ -1,7 +1,9 @@
 import {
   getFramePublishLockName,
   getFrameSourceLockName,
+  getLegacyFrameMutationLockName,
   withFrameSourceLock,
+  withLegacyFrameMutationLock,
 } from "@app/lib/api/frames/operation_lock";
 import type { RedisClientType } from "@app/lib/api/redis";
 import { Ok } from "@app/types/shared/result";
@@ -53,5 +55,58 @@ describe("Frame operation locks", () => {
       expect.any(String),
       expect.objectContaining({ PX: 10 * 60_000 })
     );
+  });
+
+  it("keeps every legacy Frame mutation serialized beyond five seconds", async () => {
+    let lock: { expiresAt: number; value: string } | null = null;
+    const redis = {
+      eval: vi.fn(
+        async (
+          _script: string,
+          { arguments: [value] }: { arguments: string[] }
+        ) => {
+          if (lock?.value === value) {
+            lock = null;
+          }
+          return 1;
+        }
+      ),
+      set: vi.fn(
+        async (_key: string, value: string, { PX: ttlMs }: { PX: number }) => {
+          if (lock && lock.expiresAt > Date.now()) {
+            return null;
+          }
+          lock = { expiresAt: Date.now() + ttlMs, value };
+          return "OK";
+        }
+      ),
+    } as unknown as LockRedisClient;
+    getRedisStreamClientMock.mockResolvedValue(redis);
+
+    let releaseFirst!: () => void;
+    const first = withLegacyFrameMutationLock(
+      "frame-123",
+      () =>
+        new Promise<string>((resolve) => {
+          releaseFirst = () => resolve("first");
+        })
+    );
+    await vi.advanceTimersByTimeAsync(5_500);
+
+    let secondEntered = false;
+    const second = withLegacyFrameMutationLock("frame-123", async () => {
+      secondEntered = true;
+      return "second";
+    });
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(secondEntered).toBe(false);
+    expect(getLegacyFrameMutationLockName("frame-123")).toBe(
+      "file:edit:frame-123"
+    );
+    releaseFirst();
+    await expect(first).resolves.toBe("first");
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(second).resolves.toBe("second");
   });
 });

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,5 +1,5 @@
 import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
-import { executeWithLockResult } from "@app/lib/lock";
+import { executeWithLock, executeWithLockResult } from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
@@ -11,6 +11,10 @@ export function getFramePublishLockName(frameId: string): string {
 
 export function getFrameSourceLockName(frameId: string): string {
   return `frame:source:${frameId}`;
+}
+
+export function getLegacyFrameMutationLockName(frameId: string): string {
+  return `file:edit:${frameId}`;
 }
 
 export function withFramePublishLock<T, E>(
@@ -31,6 +35,19 @@ export function withFrameSourceLock<T, E>(
 ): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
   return executeWithLockResult(
     getFrameSourceLockName(frameId),
+    callback,
+    FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS,
+    { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
+  );
+}
+
+/** Serialize conversion with every mutation of the same legacy Frame. */
+export function withLegacyFrameMutationLock<T>(
+  frameId: string,
+  callback: () => Promise<T>
+): Promise<T> {
+  return executeWithLock(
+    getLegacyFrameMutationLockName(frameId),
     callback,
     FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS,
     { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -15,7 +15,11 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import {
+  frameContentType,
+  frameV2ContentType,
+  sandboxFunctionContentType,
+} from "@app/types/files";
 import { splitFrameEntryScopedPath } from "@app/types/mount_path";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
@@ -204,9 +208,11 @@ describe("publishFrame", () => {
     }
 
     // The frame now renders the bundle, and the build root and entry are recorded for republish.
-    expect(file.getRenderableVersion()).toBe("processed");
-    expect(file.useCaseMetadata?.frameBundleRootPath).toBe(ROOT);
-    expect(file.useCaseMetadata?.frameEntryRelPath).toBe("Dashboard.tsx");
+    const published = await FileResource.fetchById(auth, file.sId);
+    assert(published);
+    expect(published.getRenderableVersion()).toBe("processed");
+    expect(published.useCaseMetadata?.frameBundleRootPath).toBe(ROOT);
+    expect(published.useCaseMetadata?.frameEntryRelPath).toBe("Dashboard.tsx");
 
     expect(uploadBundleSpy).toHaveBeenCalledTimes(1);
     const bundle = uploadBundleSpy.mock.calls[0][1];
@@ -423,7 +429,8 @@ export default function Dashboard() {
     if (result.isOk()) {
       expect(result.value.warnings).toEqual([]);
     }
-    expect(file.getRenderableVersion()).toBe("processed");
+    const published = await FileResource.fetchById(auth, file.sId);
+    expect(published?.getRenderableVersion()).toBe("processed");
     expect(uploadBundleSpy).toHaveBeenCalledTimes(1);
 
     // Only the entry was read (graph-driven), so the broken sibling could not contribute a
@@ -450,25 +457,24 @@ export default function Dashboard() {
     expect(file.getRenderableVersion()).toBe("original");
   });
 
-  it("refuses to publish a non-interactive-content file", async () => {
+  it("refuses a queued publish after the Frame stops being legacy", async () => {
     const { authenticator: auth } = await createResourceTest({});
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-      messagesCreatedAt: [new Date()],
-    });
-    const file = await FileFactory.create(auth, null, {
-      contentType: "text/plain",
-      fileName: "notes.txt",
-      fileSize: 10,
-      status: "ready",
-      useCase: "conversation",
-      useCaseMetadata: { conversationId: conversation.sId },
+    const file = await createFrameFile(auth);
+    const staleLegacyFile = await FileResource.fetchById(auth, file.sId);
+    assert(staleLegacyFile);
+    await file.updateFrameSourceBinding({
+      contentType: frameV2ContentType,
+      fileName: "frame.json",
+      fileSize: file.fileSize,
+      mountFilePath: `${ROOT}/frame.json`,
+      useCase: file.useCase,
+      useCaseMetadata: file.useCaseMetadata ?? {},
     });
 
     const result = await publishFrame(auth, {
-      file,
-      reader: inMemoryReader({ "notes.txt": "hello" }),
-      entryRelPath: "notes.txt",
+      file: staleLegacyFile,
+      reader: inMemoryReader(VALID_SOURCES),
+      entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
     });
 
@@ -545,12 +551,15 @@ export default function Dashboard() {
 
     expect(firstResult.isOk()).toBe(true);
     expect(secondResult.isOk()).toBe(true);
-    expect(first.getRenderableVersion()).toBe("processed");
-    expect(second.getRenderableVersion()).toBe("processed");
-    expect(first.useCaseMetadata?.frameEntryRelPath).toBe(
+    const publishedFirst = await FileResource.fetchById(auth, first.sId);
+    const publishedSecond = await FileResource.fetchById(auth, second.sId);
+    assert(publishedFirst && publishedSecond);
+    expect(publishedFirst.getRenderableVersion()).toBe("processed");
+    expect(publishedSecond.getRenderableVersion()).toBe("processed");
+    expect(publishedFirst.useCaseMetadata?.frameEntryRelPath).toBe(
       firstSplit.value.entryRelPath
     );
-    expect(second.useCaseMetadata?.frameEntryRelPath).toBe(
+    expect(publishedSecond.useCaseMetadata?.frameEntryRelPath).toBe(
       secondSplit.value.entryRelPath
     );
   });

--- a/front/lib/api/viz/publish_frame.ts
+++ b/front/lib/api/viz/publish_frame.ts
@@ -3,13 +3,13 @@ import {
   validateTailwindCode,
   validateTypeScriptSyntax,
 } from "@app/lib/api/files/content_validation";
+import { withLegacyFrameMutationLock } from "@app/lib/api/frames/operation_lock";
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { FrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import { buildFrameBundle } from "@app/lib/api/viz/build_frame_bundle";
 import { validateFramePodFunctionReferences } from "@app/lib/api/viz/validate_frame_pod_functions";
 import type { Authenticator } from "@app/lib/auth";
-import { executeWithLock } from "@app/lib/lock";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -96,7 +96,17 @@ export async function publishFrame(
   }
 
   try {
-    return await executeWithLock(`file:edit:${file.sId}`, async () => {
+    return await withLegacyFrameMutationLock(file.sId, async () => {
+      const currentFile = await FileResource.fetchById(auth, file.sId);
+      if (!currentFile?.isInteractiveContent) {
+        return new Err(
+          new PublishFrameError(
+            "not_interactive_content",
+            `File '${file.sId}' is not interactive content.`
+          )
+        );
+      }
+
       // 1. Bundle from the entry. The bundler walks the import graph and reads each module
       //    lazily. This wrapper validates and caches every file as it is pulled, so only the
       //    frame's actual sources are read and checked, never unrelated files in the mount.
@@ -170,7 +180,7 @@ export async function publishFrame(
       const podFunctionValidation = await validateFramePodFunctionReferences(
         auth,
         {
-          file,
+          file: currentFile,
           sources: cache,
         }
       );
@@ -187,15 +197,15 @@ export async function publishFrame(
       //    stay in sync with what was published (the entry is always read during the build).
       const entrySource = cache.get(entryRelPath);
       if (entrySource !== undefined) {
-        await file.uploadContent(auth, entrySource);
+        await currentFile.uploadContent(auth, entrySource);
       }
 
       // 4. Store the bundle as the rendered version and mark the frame published.
-      await file.uploadProcessed(auth, buildResult.value.code);
+      await currentFile.uploadProcessed(auth, buildResult.value.code);
       // frameBundleRootPath and frameEntryRelPath flip rendering to the bundle and let live
       // edits rebuild later without a model in the loop.
-      await file.setUseCaseMetadata(auth, {
-        ...(file.useCaseMetadata ?? {}),
+      await currentFile.setUseCaseMetadata(auth, {
+        ...(currentFile.useCaseMetadata ?? {}),
         frameBundleRootPath: rootScopedPath,
         frameEntryRelPath: entryRelPath,
         ...(publishedByAgentConfigurationId
@@ -206,7 +216,10 @@ export async function publishFrame(
       });
 
       // 5. Recompute the allowlist against the rendered bundle.
-      const allowlist = await ensureAuthorizedFileAccessForShare(auth, file);
+      const allowlist = await ensureAuthorizedFileAccessForShare(
+        auth,
+        currentFile
+      );
       if (allowlist.isErr()) {
         return new Err(
           new PublishFrameError("allowlist_failed", allowlist.error.message)


### PR DESCRIPTION
## Description

Serialize conversion with legacy Frame mutations through one shared `file:edit` helper. Conversion, legacy publish, and legacy edit holders all use the same fixed 10-minute lease for the complete operation, with no refresh loop. Conversion also retains the existing Frame source lock; legacy publication takes the narrower publish lock after `file:edit`.

This closes the source-binding review comment and prevents a shorter legacy holder lease from invalidating the conversion guarantee. Broader move/delete/rename hardening remains in the mandatory tips #31690, #31691, and #31694.

Stack: #31541 -> this PR -> #31542.

## Tests

- operation-lock coverage proves serialization beyond the former five-second lease
- legacy publication/edit and conversion suites pass
- included in the final 134-test changed-front suite
- Biome and diff checks pass

## Deploy Plan

Merge after #31541 and before #31542. Do not use conversion in production; keep the conversion workflow flag-disabled until the full chain through #31544 has landed and the WorkOS `frame.converted` schema is registered.