### PR TITLE
Keep legacy Frames renderable during conversion

### DIFF
--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -194,6 +194,46 @@ describe("FileResource", () => {
       expect(result?.content).toBe(expectedContent);
     });
 
+    it("serves the legacy artifact during a pending v2 conversion", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const frame = await FileFactory.create(auth, null, {
+        contentType: frameV2ContentType,
+        fileName: "manifest.json",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: {
+          conversationId: "conv-conversion",
+          pendingFrameV2Conversion: {
+            legacyContentType: frameContentType,
+            legacyFileName: "Legacy.tsx",
+            legacyFileSize: 1000,
+            legacyMountFilePath: "legacy/Legacy.tsx",
+            legacyRenderableVersion: "processed",
+            legacyUseCase: "conversation",
+            legacyUseCaseMetadata: { conversationId: "conv-conversion" },
+            manifestMountFilePath: "converted/manifest.json",
+            manifestPath:
+              "conversation-conv-conversion/Converted/manifest.json",
+            sourcePath: "conversation-conv-conversion/Legacy.tsx",
+          },
+        },
+      });
+      const read = vi
+        .spyOn(frame, "getSharedReadStream")
+        .mockReturnValue(Readable.from([Buffer.from(expectedContent)]));
+
+      await expect(
+        frame.getRenderableContent(auth.getNonNullableWorkspace())
+      ).resolves.toBe(expectedContent);
+      expect(read).toHaveBeenCalledWith(
+        auth.getNonNullableWorkspace(),
+        "processed"
+      );
+    });
+
     it("should return null for soft-deleted conversation", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1138,8 +1138,14 @@ export class FileResource extends BaseResource<FileModel> {
     }
 
     const publicationId = this.useCaseMetadata?.activePublicationId;
-    if (!publicationId || owner.id !== this.workspaceId) {
+    if (owner.id !== this.workspaceId) {
       return null;
+    }
+    if (!publicationId) {
+      const pending = this.useCaseMetadata?.pendingFrameV2Conversion;
+      return pending
+        ? this.getFileContent(owner, pending.legacyRenderableVersion)
+        : null;
     }
 
     try {
@@ -1968,6 +1974,13 @@ export class FileResource extends BaseResource<FileModel> {
       useCase,
       useCaseMetadata,
     });
+  }
+
+  finishFrameV2Conversion() {
+    assert(this.isFrameV2, "Only Frames v2 can finish a conversion");
+    const { pendingFrameV2Conversion: _pending, ...useCaseMetadata } =
+      this.useCaseMetadata ?? {};
+    return this.update({ useCaseMetadata });
   }
 
   // Sharing logic.

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -37,7 +37,7 @@ export type FileUseCase =
   // Workspace branding: logo/favicon uploaded by workspace admins.
   | "workspace_branding";
 
-export type FileUseCaseMetadata = {
+type StableFileUseCaseMetadata = {
   conversationId?: string;
   skillId?: string;
   spaceId?: string;
@@ -68,6 +68,23 @@ export type FileUseCaseMetadata = {
   // activation, so they describe what is served, not what the source folder currently says.
   frameName?: string;
   frameDescription?: string;
+};
+
+export type FileUseCaseMetadata = StableFileUseCaseMetadata & {
+  // Durable v1-to-v2 transition state. Until activation, rendering keeps serving the legacy
+  // artifact. A retry can either finish the conversion or restore the original source binding.
+  pendingFrameV2Conversion?: {
+    legacyContentType: InteractiveContentFileContentType;
+    legacyFileName: string;
+    legacyFileSize: number;
+    legacyMountFilePath: string;
+    legacyRenderableVersion: "original" | "processed";
+    legacyUseCase: FileUseCase;
+    legacyUseCaseMetadata: StableFileUseCaseMetadata;
+    manifestMountFilePath: string;
+    manifestPath: string;
+    sourcePath: string;
+  };
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

Persist the pending-conversion marker and legacy render metadata required to keep an interrupted conversion renderable. This supplies the durable state used by #31548 recovery.

Stack: #31543 -> this PR -> #31548.

## Tests

- FileResource coverage proves pending legacy render metadata is retained and cleared correctly
- included in the final 134-test changed-front suite
- Biome and diff checks pass

## Deploy Plan

Merge after #31543. Do not use conversion in production; keep the conversion workflow flag-disabled until #31548, #31690, #31691, #31694, and #31544 have landed and the WorkOS `frame.converted` schema is registered.