### PR TITLE
Resume interrupted Frame conversions safely

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -238,7 +238,61 @@ async function setupLegacyFrameConversion({
       : null
   );
 
-  return { ...context, manifestPath };
+  return {
+    ...context,
+    manifestMountFilePath: `${mountDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    manifestPath,
+  };
+}
+
+async function markLegacyFrameConversionPending(
+  context: Awaited<ReturnType<typeof setupLegacyFrameConversion>>,
+  { publicationId }: { publicationId?: string } = {}
+) {
+  const legacyBinding = {
+    contentType: context.frame.contentType,
+    fileName: context.frame.fileName,
+    fileSize: context.frame.fileSize,
+    mountFilePath: context.frame.mountFilePath!,
+    useCase: context.frame.useCase,
+    useCaseMetadata: context.frame.useCaseMetadata ?? {},
+  };
+  await context.frame.updateFrameSourceBinding({
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(manifest),
+    mountFilePath: context.manifestMountFilePath,
+    useCase: "conversation",
+    useCaseMetadata: {
+      ...(publicationId ? { activePublicationId: publicationId } : {}),
+      conversationId: context.conversation.sId,
+      pendingFrameV2Conversion: {
+        legacyContentType: frameContentType,
+        legacyFileName: legacyBinding.fileName,
+        legacyFileSize: legacyBinding.fileSize,
+        legacyMountFilePath: legacyBinding.mountFilePath,
+        legacyRenderableVersion: "original",
+        legacyUseCase: legacyBinding.useCase,
+        legacyUseCaseMetadata: legacyBinding.useCaseMetadata,
+        manifestMountFilePath: context.manifestMountFilePath,
+        manifestPath: context.manifestPath,
+        sourcePath: context.sourcePath,
+      },
+    },
+  });
+}
+
+function seedLegacyCanonicalArtifacts(
+  context: Awaited<ReturnType<typeof setupLegacyFrameConversion>>
+) {
+  const canonicalPaths = (["original", "processed", "public"] as const).map(
+    (version) => context.frame.getCloudStoragePath(context.auth, version)
+  );
+  for (const canonicalPath of canonicalPaths) {
+    fileStorageMock.setObject(canonicalPath, "legacy artifact");
+  }
+  fileStorageMock.setObject(context.frame.mountFilePath!, uiSource);
+  return canonicalPaths;
 }
 
 beforeEach(() => {
@@ -250,6 +304,8 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
   it("converts a legacy Frame while preserving identity and use rights", async () => {
     const context = await setupLegacyFrameConversion();
     const shareInfo = await context.frame.getShareInfo();
+    const canonicalPaths = seedLegacyCanonicalArtifacts(context);
+    const legacyMountPath = context.frame.mountFilePath!;
 
     const response = await requestFrameConvert(
       context.workspace.sId,
@@ -271,7 +327,12 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.useCaseMetadata?.activePublicationId).toBe(
       converted.publicationId
     );
+    expect(frame?.useCaseMetadata?.pendingFrameV2Conversion).toBeUndefined();
     expect(await frame?.getShareInfo()).toEqual(shareInfo);
+    for (const canonicalPath of canonicalPaths) {
+      expect(fileStorageMock.getObject(canonicalPath)).toBeUndefined();
+    }
+    expect(fileStorageMock.getObject(legacyMountPath)).toBe(uiSource);
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "frame.converted",
@@ -337,6 +398,112 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.isFrameV2).toBe(false);
     expect(frame?.toScopedPath(context.auth)).toBe(context.sourcePath);
     expect(await frame?.getShareInfo()).toEqual(shareInfo);
+  });
+
+  it("finalizes an activated conversion left with its transition marker", async () => {
+    const context = await setupLegacyFrameConversion();
+    const canonicalPaths = seedLegacyCanonicalArtifacts(context);
+    const legacyMountPath = context.frame.mountFilePath!;
+    const publicationId = "already-active";
+    await markLegacyFrameConversionPending(context, { publicationId });
+
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ publicationId });
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.useCaseMetadata?.pendingFrameV2Conversion).toBeUndefined();
+    for (const canonicalPath of canonicalPaths) {
+      expect(fileStorageMock.getObject(canonicalPath)).toBeUndefined();
+    }
+    expect(fileStorageMock.getObject(legacyMountPath)).toBe(uiSource);
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.converted",
+        metadata: {
+          manifest_path: context.manifestPath,
+          publication_id: publicationId,
+          source_path: context.sourcePath,
+        },
+      })
+    );
+  });
+
+  it("retries legacy artifact cleanup before clearing the transition marker", async () => {
+    const context = await setupLegacyFrameConversion();
+    const canonicalPaths = seedLegacyCanonicalArtifacts(context);
+    const publicationId = "already-active";
+    await markLegacyFrameConversionPending(context, { publicationId });
+    fileStorageMock.setFileDeleteFails(
+      (path) =>
+        path === context.frame.getCloudStoragePath(context.auth, "processed")
+    );
+
+    const failedResponse = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    expect(failedResponse.status).toBe(500);
+    const pendingFrame = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(
+      pendingFrame?.useCaseMetadata?.pendingFrameV2Conversion
+    ).toBeDefined();
+
+    fileStorageMock.setFileDeleteFails(() => false);
+    const recoveredResponse = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    expect(recoveredResponse.status).toBe(200);
+    const recoveredFrame = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(
+      recoveredFrame?.useCaseMetadata?.pendingFrameV2Conversion
+    ).toBeUndefined();
+    for (const canonicalPath of canonicalPaths) {
+      expect(fileStorageMock.getObject(canonicalPath)).toBeUndefined();
+    }
+  });
+
+  it("restores a pending conversion when its manifest is no longer valid", async () => {
+    const context = await setupLegacyFrameConversion();
+    const shareInfo = await context.frame.getShareInfo();
+    await markLegacyFrameConversionPending(context);
+    fileStorageMock.setFileContent(() => "not-json");
+
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+
+    expect(response.status).not.toBe(200);
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.isInteractiveContent).toBe(true);
+    expect(frame?.isFrameV2).toBe(false);
+    expect(frame?.toScopedPath(context.auth)).toBe(context.sourcePath);
+    expect(frame?.useCaseMetadata?.pendingFrameV2Conversion).toBeUndefined();
+    expect(await frame?.getShareInfo()).toEqual(shareInfo);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "frame.converted" })
+    );
   });
 
   it("registers one stable Frame identity", async () => {

--- a/front/lib/api/frames/convert_from_source.ts
+++ b/front/lib/api/frames/convert_from_source.ts
@@ -28,6 +28,7 @@ import logger from "@app/logger/logger";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { DustFileSystemError } from "@app/types/file_system";
+import type { FileUseCaseMetadata } from "@app/types/files";
 import { frameV2ContentType, isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -97,6 +98,27 @@ function emitFrameConvertedAuditEvent(
   });
 }
 
+type PendingConversion = NonNullable<
+  FileUseCaseMetadata["pendingFrameV2Conversion"]
+>;
+
+function matchesPendingConversion(
+  pending: PendingConversion | undefined,
+  paths: {
+    manifest: string;
+    manifestMountPath: string;
+    source: string;
+    sourceMountPath: string;
+  }
+): pending is PendingConversion {
+  return (
+    pending?.manifestPath === paths.manifest &&
+    pending.manifestMountFilePath === paths.manifestMountPath &&
+    pending.sourcePath === paths.source &&
+    pending.legacyMountFilePath === paths.sourceMountPath
+  );
+}
+
 /** Convert a legacy Frame in place, preserving its stable identity and use-rights rows. */
 export async function convertLegacyFrameToV2(
   auth: Authenticator,
@@ -164,10 +186,23 @@ export async function convertLegacyFrameToV2(
     sourceMountPath,
     manifestMountPath,
   ]);
-  const legacyFrame = candidates.find(
-    (candidate) => candidate.mountFilePath === sourceMountPath
-  );
-  if (!legacyFrame?.isInteractiveContent || legacyFrame.isFrameV2) {
+  const frameCandidate =
+    candidates.find(
+      (file) =>
+        file.mountFilePath === sourceMountPath &&
+        file.isInteractiveContent &&
+        !file.isFrameV2
+    ) ??
+    candidates.find(
+      (file) =>
+        file.mountFilePath === manifestMountPath &&
+        file.isFrameV2 &&
+        matchesPendingConversion(
+          file.useCaseMetadata?.pendingFrameV2Conversion,
+          { manifest, manifestMountPath, source, sourceMountPath }
+        )
+    );
+  if (!frameCandidate) {
     return conversionError(
       "invalid_source",
       `No legacy Frame found at ${source}.`
@@ -175,7 +210,9 @@ export async function convertLegacyFrameToV2(
   }
   if (
     candidates.some(
-      (candidate) => candidate.mountFilePath === manifestMountPath
+      (file) =>
+        file.id !== frameCandidate.id &&
+        file.mountFilePath === manifestMountPath
     )
   ) {
     return conversionError(
@@ -185,15 +222,62 @@ export async function convertLegacyFrameToV2(
   }
 
   const convertWithSourceLock = async () => {
-    const frame = await FileResource.fetchById(auth, legacyFrame.sId);
-    if (!frame || frame.mountFilePath !== sourceMountPath) {
+    const frame = await FileResource.fetchById(auth, frameCandidate.sId);
+    if (!frame) {
       return conversionError(
         "conflict",
-        "The legacy Frame changed while it was being converted; retry from its current path."
+        "The legacy Frame was deleted while it was being converted."
       );
     }
+    let pending = frame.useCaseMetadata?.pendingFrameV2Conversion;
+    if (
+      pending &&
+      !matchesPendingConversion(pending, {
+        manifest,
+        manifestMountPath,
+        source,
+        sourceMountPath,
+      })
+    ) {
+      return conversionError(
+        "conflict",
+        "The legacy Frame is already being converted from another source path."
+      );
+    }
+    const activePublicationId = frame.useCaseMetadata?.activePublicationId;
+    if (frame.isFrameV2 && pending && activePublicationId) {
+      try {
+        await frame.finishFrameV2Conversion(auth);
+      } catch (error) {
+        logger.error(
+          {
+            error: normalizeError(error),
+            frameId: frame.sId,
+            manifestPath: manifest,
+            sourcePath: source,
+          },
+          "Failed to finish an activated Frame conversion"
+        );
+        return conversionError(
+          "internal",
+          "Frame conversion was activated but not finalized; retry the conversion command."
+        );
+      }
+      const result = {
+        frameId: frame.sId,
+        manifestPath: manifest,
+        publicationId: activePublicationId,
+      };
+      emitFrameConvertedAuditEvent(auth, { ...result, sourcePath: source });
+      return new Ok(result);
+    }
     const originalContentType = frame.contentType;
-    if (!isInteractiveContentType(originalContentType)) {
+    if (
+      !pending &&
+      (!isInteractiveContentType(originalContentType) ||
+        frame.isFrameV2 ||
+        frame.mountFilePath !== sourceMountPath)
+    ) {
       return conversionError(
         "conflict",
         "The legacy Frame changed while it was being converted; retry from its current path."
@@ -203,35 +287,23 @@ export async function convertLegacyFrameToV2(
       auth,
       [manifestMountPath]
     );
-    if (registeredManifest) {
+    if (registeredManifest && registeredManifest.id !== frame.id) {
       return conversionError(
         "conflict",
         "A registered file already uses the v2 manifest path."
       );
     }
 
-    const sourceSnapshot = await captureFrameV2SourceSnapshot(dustFs, manifest);
-    if (sourceSnapshot.isErr()) {
-      return sourceSnapshot;
-    }
-    if (sourceSnapshot.value.manifest.databases.length > 0) {
-      return conversionError(
-        "invalid_source",
-        "Convert the legacy Frame before adding Frame-owned databases, then publish again."
-      );
-    }
-
-    const original = {
-      contentType: originalContentType,
-      fileName: frame.fileName,
-      fileSize: frame.fileSize,
-      mountFilePath: sourceMountPath,
-      useCase: frame.useCase,
-      useCaseMetadata: frame.useCaseMetadata ?? {},
-    } satisfies Parameters<FileResource["updateFrameSourceBinding"]>[0];
-    const restore = async (): Promise<boolean> => {
+    const restore = async (transition: PendingConversion): Promise<boolean> => {
       try {
-        await frame.updateFrameSourceBinding(original);
+        await frame.updateFrameSourceBinding({
+          contentType: transition.legacyContentType,
+          fileName: transition.legacyFileName,
+          fileSize: transition.legacyFileSize,
+          mountFilePath: transition.legacyMountFilePath,
+          useCase: transition.legacyUseCase,
+          useCaseMetadata: transition.legacyUseCaseMetadata,
+        });
         return true;
       } catch (error) {
         logger.error(
@@ -247,29 +319,80 @@ export async function convertLegacyFrameToV2(
       }
     };
 
-    try {
-      await frame.updateFrameSourceBinding({
-        contentType: frameV2ContentType,
-        fileName: FRAME_MANIFEST_FILE,
-        fileSize: sourceSnapshot.value.manifestSizeBytes,
-        mountFilePath: manifestMountPath,
-        useCase: targetOwner.useCase,
-        useCaseMetadata: getConvertedFrameMetadata(
-          frame.useCaseMetadata ?? undefined,
-          targetOwner
-        ),
-      });
-    } catch (error) {
-      if (error instanceof UniqueConstraintError) {
+    const sourceSnapshot = await captureFrameV2SourceSnapshot(dustFs, manifest);
+    if (sourceSnapshot.isErr()) {
+      if (pending && !(await restore(pending))) {
         return conversionError(
-          "conflict",
-          "A registered file already uses the v2 manifest path."
+          "internal",
+          "Frame conversion recovery failed and its legacy source binding could not be restored."
         );
       }
-      return conversionError(
-        "internal",
-        `Frame conversion failed: ${normalizeError(error).message}`
+      return sourceSnapshot;
+    }
+    if (sourceSnapshot.value.manifest.databases.length > 0) {
+      const error = conversionError(
+        "invalid_source",
+        "Convert the legacy Frame before adding Frame-owned databases, then publish again."
       );
+      if (pending && !(await restore(pending))) {
+        return conversionError(
+          "internal",
+          "Frame conversion recovery failed and its legacy source binding could not be restored."
+        );
+      }
+      return error;
+    }
+
+    if (!pending) {
+      if (!isInteractiveContentType(originalContentType)) {
+        return conversionError("conflict", "The legacy Frame changed.");
+      }
+      pending = {
+        legacyContentType: originalContentType,
+        legacyFileName: frame.fileName,
+        legacyFileSize: frame.fileSize,
+        legacyMountFilePath: sourceMountPath,
+        legacyRenderableVersion: frame.useCaseMetadata?.frameBundleRootPath
+          ? "processed"
+          : "original",
+        legacyUseCase: frame.useCase,
+        legacyUseCaseMetadata: frame.useCaseMetadata ?? {},
+        manifestMountFilePath: manifestMountPath,
+        manifestPath: manifest,
+        sourcePath: source,
+      };
+      try {
+        await frame.updateFrameSourceBinding({
+          contentType: frameV2ContentType,
+          fileName: FRAME_MANIFEST_FILE,
+          fileSize: sourceSnapshot.value.manifestSizeBytes,
+          mountFilePath: manifestMountPath,
+          useCase: targetOwner.useCase,
+          useCaseMetadata: {
+            ...getConvertedFrameMetadata(
+              frame.useCaseMetadata ?? undefined,
+              targetOwner
+            ),
+            pendingFrameV2Conversion: pending,
+          },
+        });
+      } catch (error) {
+        if (error instanceof UniqueConstraintError) {
+          return conversionError(
+            "conflict",
+            "A registered file already uses the v2 manifest path."
+          );
+        }
+        return conversionError(
+          "internal",
+          `Frame conversion failed: ${normalizeError(error).message}`
+        );
+      }
+    }
+
+    const transition = pending;
+    if (!transition) {
+      return conversionError("internal", "Frame conversion marker is missing.");
     }
 
     try {
@@ -280,13 +403,15 @@ export async function convertLegacyFrameToV2(
         sourceSnapshot: sourceSnapshot.value,
       });
       if (publication.isErr()) {
-        return (await restore())
+        return (await restore(transition))
           ? new Err(publication.error)
           : conversionError(
               "internal",
               "Frame conversion failed and its legacy source binding could not be restored."
             );
       }
+
+      await frame.finishFrameV2Conversion(auth);
 
       logger.info(
         {
@@ -307,7 +432,14 @@ export async function convertLegacyFrameToV2(
       emitFrameConvertedAuditEvent(auth, { ...result, sourcePath: source });
       return new Ok(result);
     } catch (error) {
-      const restored = await restore();
+      const currentFrame = await FileResource.fetchById(auth, frame.sId);
+      if (currentFrame?.useCaseMetadata?.activePublicationId) {
+        return conversionError(
+          "internal",
+          "Frame conversion was activated but not finalized; retry the conversion command."
+        );
+      }
+      const restored = await restore(transition);
       return conversionError(
         "internal",
         restored
@@ -321,11 +453,11 @@ export async function convertLegacyFrameToV2(
     ConvertLegacyFrameToV2Error | LockAcquisitionTimeoutError
   >;
   try {
-    conversion = await withLegacyFrameMutationLock(legacyFrame.sId, () =>
+    conversion = await withLegacyFrameMutationLock(frameCandidate.sId, () =>
       withFrameSourceLock<
         ConvertLegacyFrameToV2Result,
         ConvertLegacyFrameToV2Error
-      >(legacyFrame.sId, convertWithSourceLock)
+      >(frameCandidate.sId, convertWithSourceLock)
     );
   } catch (error) {
     if (isLockAcquisitionTimeoutError(error)) {

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -393,6 +393,41 @@ describe("publishFrameV2FromSource", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
+  it("rejects normal publication while conversion recovery is pending", async () => {
+    const { auth, conversation, frame, gcsSourceDirectoryPath, manifestPath } =
+      await setup();
+    await frame.setUseCaseMetadata(auth, {
+      ...frame.useCaseMetadata,
+      pendingFrameV2Conversion: {
+        legacyContentType: frameContentType,
+        legacyFileName: "Legacy.tsx",
+        legacyFileSize: 1,
+        legacyMountFilePath: `${gcsSourceDirectoryPath}/Legacy.tsx`,
+        legacyRenderableVersion: "original",
+        legacyUseCase: "conversation",
+        legacyUseCaseMetadata: {
+          conversationId: conversation.sId,
+        },
+        manifestMountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+        manifestPath,
+        sourcePath: `conversation-${conversation.sId}/Legacy.tsx`,
+      },
+    });
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame,
+      manifestPath,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_frame",
+      message: expect.stringContaining("rerun the conversion command"),
+    });
+    expect(fileStorageMock.readStreamCalls).toHaveLength(0);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
   it("bounds source listing before reading the folder", async () => {
     const { auth, conversation, frame, gcsSourceDirectoryPath, manifestPath } =
       await setup();

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -501,6 +501,12 @@ export async function publishFrameV2FromSource(
         `Frame '${frame.sId}' no longer exists.`
       );
     }
+    if (freshFrame.useCaseMetadata?.pendingFrameV2Conversion) {
+      return frameError(
+        "invalid_frame",
+        `Frame '${frame.sId}' has an interrupted conversion; rerun the conversion command before publishing.`
+      );
+    }
 
     return publishFrameV2FromSourceWithLockHeld(auth, {
       conversation,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1976,8 +1976,25 @@ export class FileResource extends BaseResource<FileModel> {
     });
   }
 
-  finishFrameV2Conversion() {
+  async finishFrameV2Conversion(auth: Authenticator) {
     assert(this.isFrameV2, "Only Frames v2 can finish a conversion");
+    assert(
+      this.useCaseMetadata?.pendingFrameV2Conversion,
+      "Only a pending Frames v2 conversion can be finished"
+    );
+
+    // A converted Frame keeps its stable FileResource identity, so its legacy canonical
+    // objects still live under the same id. Remove only those front-owned artifacts here;
+    // the mount source remains user-owned. Cleanup precedes marker removal so recovery can
+    // retry it safely after a partial failure.
+    await Promise.all(
+      (["original", "processed", "public"] as const).map((version) =>
+        this.getBucketForVersion(version)
+          .file(this.getCloudStoragePath(auth, version))
+          .delete({ ignoreNotFound: true })
+      )
+    );
+
     const { pendingFrameV2Conversion: _pending, ...useCaseMetadata } =
       this.useCaseMetadata ?? {};
     return this.update({ useCaseMetadata });

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -63,6 +63,7 @@ class FileStorageMock {
   private _fetchNotFoundPredicate: (filePath: string) => boolean = () => false;
   private _existsPredicate: (filePath: string) => boolean = () => true;
   private _saveShouldFail: (filePath: string) => boolean = () => false;
+  private _deleteShouldFail: (filePath: string) => boolean = () => false;
   private _metadataForPath: (filePath: string) => MockFileMetadata | null =
     () => null;
   private _contentForPath: (filePath: string) => string | null = () => null;
@@ -118,6 +119,10 @@ class FileStorageMock {
    */
   setFileSaveFails(predicate: (filePath: string) => boolean): void {
     this._saveShouldFail = predicate;
+  }
+
+  setFileDeleteFails(predicate: (filePath: string) => boolean): void {
+    this._deleteShouldFail = predicate;
   }
 
   /**
@@ -229,6 +234,7 @@ class FileStorageMock {
     this._fetchNotFoundPredicate = () => false;
     this._existsPredicate = () => true;
     this._saveShouldFail = () => false;
+    this._deleteShouldFail = () => false;
     this._metadataForPath = () => null;
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
@@ -294,7 +300,13 @@ class FileStorageMock {
           return stream;
         }),
       delete: vi.fn().mockImplementation(() => {
-        this._objectStore.delete(filePath ?? "unknown");
+        const path = filePath ?? "unknown";
+        if (this._deleteShouldFail(path)) {
+          return Promise.reject(
+            new Error(`Simulated GCS delete failure: ${path}`)
+          );
+        }
+        this._objectStore.delete(path);
         return Promise.resolve(undefined);
       }),
       download: vi.fn().mockImplementation(() => {


### PR DESCRIPTION
## Description

Resume or safely restore interrupted legacy Frame conversions using the marker from #31547. Retry recognizes an already rebound identity, finalizes an active publication, restores the exact legacy binding when publication fails, and rejects ordinary Frames v2 publication while recovery is pending.

Finalization durably removes the legacy canonical original/processed/public objects before clearing the marker, while preserving the user-owned mount source. Partial cleanup remains retryable and idempotent.

Stack: #31547 -> this PR -> #31690.

## Tests

- conversion recovery covers activation retry, binding restore, pending-publish rejection, canonical cleanup, mount-source preservation, and partial-cleanup retry
- included in the final 134-test changed-front and 86-test changed-front-api suites
- Biome and diff checks pass

## Deploy Plan

Merge after #31547. Do not use conversion in production; keep the conversion workflow flag-disabled until #31690, #31691, #31694, and #31544 have landed and the WorkOS `frame.converted` schema is registered.