### PR TITLE
Fence Frame source storage copies by generation

### DIFF
--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -171,9 +171,7 @@ export async function moveFrameV2Source(
       );
     }
 
-    const deleted = await deleteFrameSourceStorage(
-      snapshot.value.sourceMountPrefix
-    );
+    const deleted = await deleteFrameSourceStorage(snapshot.value);
     if (deleted.isErr()) {
       logger.warn(
         {

--- a/front/lib/api/frames/source_storage.test.ts
+++ b/front/lib/api/frames/source_storage.test.ts
@@ -22,6 +22,7 @@ describe("Frame source storage copies", () => {
     vi.mocked(getPrivateUploadBucket)
       .mockReturnValueOnce(storage)
       .mockReturnValueOnce(storage);
+    const copyFile = vi.mocked(storage.copyFile);
     const destinationMountPath = c.sourceObjects[0].replace(
       "/Status/",
       "/Archive/"
@@ -47,6 +48,10 @@ describe("Frame source storage copies", () => {
       const chunks = await file.createReadStream().toArray();
       const expected = fileStorageMock.getObject(source);
       expect(Buffer.concat(chunks).toString("utf8")).toBe(expected);
+      expect(copyFile).toHaveBeenCalledWith(source, destination, undefined, {
+        destinationGenerationMatch: 0,
+        sourceGeneration: expect.any(String),
+      });
     }
   });
 

--- a/front/lib/api/frames/source_storage.test_utils.ts
+++ b/front/lib/api/frames/source_storage.test_utils.ts
@@ -56,6 +56,7 @@ export async function setupFrameSourceStorageTest() {
         name,
         metadata: {
           contentType: "text/plain",
+          generation: fileStorageMock.getObjectGeneration(name),
           size: objectSizes.get(name) ?? "10",
         },
       }))

--- a/front/lib/api/frames/source_storage.ts
+++ b/front/lib/api/frames/source_storage.ts
@@ -1,9 +1,14 @@
 import path from "node:path";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
+import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 
 const FRAME_SOURCE_COPY_CONCURRENCY = 4;
 const MAX_FRAME_SOURCE_FILE_COUNT = 1024;
@@ -27,6 +32,7 @@ export type FrameSourceStorageSnapshot = {
   destinationMountPrefix: string;
   sourceMountPrefix: string;
   sourceObjectNames: string[];
+  sourceObjects: Array<{ generation: string; name: string }>;
 };
 
 export async function inspectFrameSourceStorage({
@@ -79,6 +85,7 @@ export async function inspectFrameSourceStorage({
   }
 
   let sourceSizeBytes = 0;
+  const sourceSnapshot: Array<{ generation: string; name: string }> = [];
   for (const sourceObject of sourceObjects) {
     const sizeBytes = Number(sourceObject.metadata.size);
     if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
@@ -88,6 +95,14 @@ export async function inspectFrameSourceStorage({
       );
     }
     sourceSizeBytes += sizeBytes;
+    const generation = sourceObject.metadata.generation;
+    if (!isString(generation) || generation.length === 0) {
+      return storageError(
+        "invalid_source",
+        `Frame source object has invalid generation metadata: ${sourceObject.name}`
+      );
+    }
+    sourceSnapshot.push({ generation, name: sourceObject.name });
   }
   if (sourceSizeBytes > MAX_FRAME_SOURCE_BYTES) {
     return storageError(
@@ -105,7 +120,8 @@ export async function inspectFrameSourceStorage({
   return new Ok({
     destinationMountPrefix,
     sourceMountPrefix,
-    sourceObjectNames: sourceObjects.map((entry) => entry.name),
+    sourceObjectNames: sourceSnapshot.map((entry) => entry.name),
+    sourceObjects: sourceSnapshot,
   });
 }
 
@@ -114,20 +130,26 @@ export async function copyFrameSourceStorage(
 ): Promise<Result<void, FrameSourceStorageError>> {
   const bucket = getPrivateUploadBucket();
   const copyResults = await concurrentExecutor(
-    snapshot.sourceObjectNames,
-    async (sourceObjectName) => {
-      if (!sourceObjectName.startsWith(snapshot.sourceMountPrefix)) {
+    snapshot.sourceObjects,
+    async (sourceObject) => {
+      if (!sourceObject.name.startsWith(snapshot.sourceMountPrefix)) {
         return new Err(
-          new Error(`Invalid Frame source object path: ${sourceObjectName}`)
+          new Error(`Invalid Frame source object path: ${sourceObject.name}`)
         );
       }
-      const relativePath = sourceObjectName.slice(
+      const relativePath = sourceObject.name.slice(
         snapshot.sourceMountPrefix.length
       );
       try {
         await bucket.copyFile(
-          sourceObjectName,
-          `${snapshot.destinationMountPrefix}${relativePath}`
+          sourceObject.name,
+          `${snapshot.destinationMountPrefix}${relativePath}`,
+          undefined,
+          {
+            destinationGenerationMatch:
+              GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+            sourceGeneration: sourceObject.generation,
+          }
         );
         return new Ok(undefined);
       } catch (error) {
@@ -137,20 +159,52 @@ export async function copyFrameSourceStorage(
     { concurrency: FRAME_SOURCE_COPY_CONCURRENCY }
   );
   const copyFailure = copyResults.find((result) => result.isErr());
-  return copyFailure?.isErr()
-    ? storageError(
-        "copy_failed",
-        `Failed to copy the Frame source; the source remains authoritative and partial destination objects may remain: ${copyFailure.error.message}`
-      )
-    : new Ok(undefined);
+  if (copyFailure?.isErr()) {
+    return isGCSPreconditionFailedError(copyFailure.error)
+      ? storageError(
+          "conflict",
+          "A file or folder was created at the destination while the Frame source was being copied."
+        )
+      : storageError(
+          "copy_failed",
+          `Failed to copy the Frame source; the source remains authoritative and partial destination objects may remain: ${copyFailure.error.message}`
+        );
+  }
+  return new Ok(undefined);
 }
 
 export async function deleteFrameSourceStorage(
-  sourceMountPrefix: string
+  snapshot: FrameSourceStorageSnapshot
 ): Promise<Result<void, Error>> {
+  const bucket = getPrivateUploadBucket();
+  const deletionResults = await concurrentExecutor(
+    snapshot.sourceObjects,
+    async ({ generation, name }) => {
+      try {
+        await bucket.delete(name, {
+          ignoreNotFound: true,
+          ifGenerationMatch: generation,
+        });
+        return new Ok(undefined);
+      } catch (error) {
+        return new Err(normalizeError(error));
+      }
+    },
+    { concurrency: FRAME_SOURCE_COPY_CONCURRENCY }
+  );
+  const deletionFailure = deletionResults.find((result) => result.isErr());
+
   try {
-    await getPrivateUploadBucket().deleteByPrefix(sourceMountPrefix);
-    return new Ok(undefined);
+    const remainingSourceObjects = await bucket.getFiles({
+      prefix: snapshot.sourceMountPrefix,
+      maxResults: 1,
+    });
+    if (deletionFailure?.isErr()) {
+      return deletionFailure;
+    }
+    return remainingSourceObjects.length > 0
+      ? new Err(new Error("Concurrent source writes survived cleanup."))
+      : new Ok(undefined);
   } catch (error) {
     return new Err(normalizeError(error));
   }


### PR DESCRIPTION
## Description

Make the operation-neutral Frame source-storage helper generation-safe. Inspection snapshots each source object generation, copy pins those generations and requires absent destinations, 412 responses become typed conflicts, and deletion removes only the observed source generations.

This optional hardening is a one-commit direct child of #31540. It owns the required adaptation of the existing move consumer to the new snapshot-based deletion contract, so this intermediate PR is independently type-correct. It does not duplicate its FileStorage foundation.

## Tests

- This PR head passes front tsgo independently.
- Six focused Frame and FileStorage suites: 18 tests passed on the fully stacked head.
- npm run format:changed.

## Risk

Low and optional. Concurrent source or destination changes fail safely rather than overwriting newer content.

## Deploy Plan

Merge after #31540. #31495 is the focused regression-proof child.