### PR TITLE
Audit successful Frame clones

### DIFF
--- a/front/admin/audit_log_schemas/frame.cloned.json
+++ b/front/admin/audit_log_schemas/frame.cloned.json
@@ -1,0 +1,13 @@
+{
+  "action": "frame.cloned",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "destination_path": "string",
+    "publication_id": "string",
+    "source_frame_id": "string",
+    "source_path": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.cloned": 1,
   "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -176,6 +176,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.cloned",
   "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",

--- a/front/lib/api/frames/clone_source.test.ts
+++ b/front/lib/api/frames/clone_source.test.ts
@@ -14,8 +14,19 @@ import { Err } from "@app/types/shared/result";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
 beforeEach(() => {
   fileStorageMock.reset();
+  mockEmitAuditLogEvent.mockClear();
 });
 
 describe("cloneFrameV2Source", () => {
@@ -65,6 +76,12 @@ describe("cloneFrameV2Source", () => {
     expect(workspaceLock).toHaveBeenCalledWith(
       c.workspace.sId,
       expect.any(Function)
+    );
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.cloned",
+        metadata: expect.objectContaining({ source_frame_id: c.frame.sId }),
+      })
     );
   });
 

--- a/front/lib/api/frames/clone_source.ts
+++ b/front/lib/api/frames/clone_source.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
 
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import {
   withFrameSourceLock,
@@ -257,6 +262,25 @@ export async function cloneFrameV2Source(
     },
     "Cloned Frame v2"
   );
+
+  void emitAuditLogEvent({
+    auth,
+    action: "frame.cloned",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("frame", {
+        sId: clonedFrame.sId,
+        name: path.posix.basename(destination),
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      destination_path: destination,
+      publication_id: publication.value.publicationId,
+      source_frame_id: sourceFrame.sId,
+      source_path: source,
+    },
+  });
 
   return new Ok({
     destinationDirectoryPath: destination,


### PR DESCRIPTION
## Description

Emit the `frame.cloned` WorkOS audit event after source copy, registration, and initial publication succeed.

The event records the source Frame and path, destination path, new Frame target, and publication ID. Failed clones do not emit it.

This is an observability child of #31553 and independent from the endpoint and CLI children.

## Tests

- Clone service test asserts the emitted event.
- Audit schema tests.
- Front typecheck and Biome checks.

## Risk

Low. Audit emission happens after the clone has succeeded and does not change the clone result.

## Deploy Plan

Merge after #31553. No migration is required.