### PR TITLE
Retry transient lock refresh failures

### DIFF
--- a/front/lib/lock.test.ts
+++ b/front/lib/lock.test.ts
@@ -152,7 +152,7 @@ describe("renewing locks", () => {
     expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
   });
 
-  it("fails the lease when refresh errors", async () => {
+  it("fails the lease after transient refresh errors exhaust its safe lifetime", async () => {
     const redisClient = makeRedisClient();
     vi.mocked(redisClient.eval).mockRejectedValue(
       new Error("redis unavailable")
@@ -161,9 +161,10 @@ describe("renewing locks", () => {
 
     const resultPromise = executeWithRenewingLockResult(
       "frame:source:123",
-      async () => {
-        await vi.advanceTimersByTimeAsync(30);
-        return new Ok("callback-completed");
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(90);
+        const leaseResult = lease.check();
+        return leaseResult.isErr() ? leaseResult : new Ok("unexpectedly-held");
       },
       1_000,
       { lockTtlMs: 90 }
@@ -171,6 +172,32 @@ describe("renewing locks", () => {
     const result = await resultPromise;
 
     expect(result.isErr() && isLockLeaseLostError(result.error)).toBe(true);
+  });
+
+  it("keeps the lease after a transient refresh error recovers", async () => {
+    const redisClient = makeRedisClient();
+    vi.mocked(redisClient.eval)
+      .mockRejectedValueOnce(new Error("redis unavailable"))
+      .mockResolvedValue(1);
+    getRedisStreamClientMock.mockResolvedValue(redisClient);
+
+    const result = await executeWithRenewingLockResult(
+      "frame:source:123",
+      async (lease) => {
+        await vi.advanceTimersByTimeAsync(60);
+        const held = lease.check();
+        return held.isErr() ? held : new Ok("held");
+      },
+      1_000,
+      { lockTtlMs: 90 }
+    );
+
+    expect(result.isOk() && result.value).toBe("held");
+    expect(
+      vi
+        .mocked(redisClient.eval)
+        .mock.calls.filter(([script]) => String(script).includes("pexpire"))
+    ).toHaveLength(2);
   });
 
   it("fails the lease immediately when Redis reports a different owner", async () => {

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -78,6 +78,8 @@ export async function distributedRefresh(
 }
 
 const DEFAULT_RETRY_INTERVAL_MS = 100;
+const RENEWAL_RETRY_INITIAL_DELAY_MS = 250;
+const RENEWAL_RETRY_MAX_DELAY_MS = 30_000;
 
 export class LockAcquisitionTimeoutError extends Error {
   constructor(readonly lockName: string) {
@@ -137,7 +139,6 @@ async function acquireLock(
   lockValue: string | undefined;
 }> {
   const client = await getRedisStreamClient({ origin: "lock" });
-  let lockAttemptStartedAtMs: number | undefined;
 
   const acquire = async (): Promise<string | undefined> => {
     const startMs = Date.now();
@@ -157,6 +158,8 @@ async function acquireLock(
     }
     return acquired;
   };
+
+  let lockAttemptStartedAtMs: number | undefined;
 
   const lockValue = traceAcquireResource
     ? await tracer.trace(
@@ -215,6 +218,7 @@ function createLockLeaseGuard(
   guard: LockLeaseGuard;
   markLost: () => void;
   markRenewed: (renewedAtMs: number) => void;
+  remainingSafeLifetimeMs: () => number;
 } {
   const safetyMarginMs = Math.max(1, Math.floor(lockTtlMs / 10));
   let confirmedUntilMs = lockAttemptStartedAtMs + lockTtlMs - safetyMarginMs;
@@ -237,6 +241,7 @@ function createLockLeaseGuard(
     markRenewed: (renewedAtMs) => {
       confirmedUntilMs = renewedAtMs + lockTtlMs - safetyMarginMs;
     },
+    remainingSafeLifetimeMs: () => confirmedUntilMs - performance.now(),
   };
 }
 
@@ -251,6 +256,10 @@ async function runWithRenewingLockResult<T, E>(
   lockAttemptStartedAtMs: number
 ): Promise<Result<T, E | LockLeaseLostError>> {
   const renewalIntervalMs = Math.max(1, Math.floor(lockTtlMs / 3));
+  const renewalRetryInitialDelayMs = Math.min(
+    RENEWAL_RETRY_INITIAL_DELAY_MS,
+    renewalIntervalMs
+  );
   const lease = createLockLeaseGuard(
     lockName,
     lockTtlMs,
@@ -261,8 +270,16 @@ async function runWithRenewingLockResult<T, E>(
     const nextRenewalDelayMs = () =>
       renewalIntervalMs * (0.8 + Math.random() * 0.2);
     let waitMs = nextRenewalDelayMs();
+    let retryDelayMs = renewalRetryInitialDelayMs;
+    let lastRefreshError: Error | undefined;
     while (await waitForRenewal(waitMs, stopController.signal)) {
       if (lease.guard.check().isErr()) {
+        if (lastRefreshError) {
+          logger.error(
+            { error: lastRefreshError, lockName },
+            "Lost a distributed lock lease after refresh errors"
+          );
+        }
         return;
       }
       try {
@@ -282,14 +299,32 @@ async function runWithRenewingLockResult<T, E>(
           return;
         }
         lease.markRenewed(refreshStartedAtMs);
+        if (lastRefreshError) {
+          logger.info({ lockName }, "Recovered distributed lock lease renewal");
+        }
+        lastRefreshError = undefined;
+        retryDelayMs = renewalRetryInitialDelayMs;
         waitMs = nextRenewalDelayMs();
       } catch (error) {
-        lease.markLost();
-        logger.warn(
-          { error: normalizeError(error), lockName },
-          "Lost a distributed lock lease after a refresh error"
-        );
-        return;
+        const refreshError = normalizeError(error);
+        if (!lastRefreshError) {
+          logger.warn(
+            { error: refreshError, lockName },
+            "Failed to refresh a distributed lock lease; retrying"
+          );
+        }
+        lastRefreshError = refreshError;
+        const remainingSafeLifetimeMs = lease.remainingSafeLifetimeMs();
+        if (remainingSafeLifetimeMs <= 0) {
+          lease.markLost();
+          logger.error(
+            { error: refreshError, lockName },
+            "Lost a distributed lock lease after refresh errors"
+          );
+          return;
+        }
+        waitMs = Math.min(retryDelayMs, remainingSafeLifetimeMs);
+        retryDelayMs = Math.min(retryDelayMs * 2, RENEWAL_RETRY_MAX_DELAY_MS);
       }
     }
   };


### PR DESCRIPTION
## Description\n\nRetry transient Redis refresh failures while the last confirmed lease lifetime is still provably safe. Retries use bounded exponential backoff, fail closed at the safety boundary, and log first failure, recovery, or final loss.\n\nThis is a late hardening tip on #31514. Functional Frame lock adoption does not depend on it.\n\n## Tests\n\n- Renewable lock suite: 9 tests passed, including transient recovery and exhausted safe lifetime\n- Biome and diff checks\n\n## Risk\n\nLow to moderate. Definitive owner changes still fail immediately; only transient Redis errors are retried.\n\n## Deploy Plan\n\nMerge after #31514 when convenient. No functional stack depends on this tip.