### PR TITLE
Fence Frame moves with source locks

### DIFF
--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const emitMovedAuditLog = vi.hoisted(() => vi.fn());
+const lockEvents = vi.hoisted(() => [] as string[]);
 
 vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => ({
   ...(await importActual<
@@ -13,10 +14,19 @@ vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => ({
 
 vi.mock("@app/lib/lock", async (importActual) => ({
   ...(await importActual<typeof import("@app/lib/lock")>()),
-  executeWithLockResult: async <T>(_name: string, cb: () => Promise<T>) => cb(),
+  executeWithLockResult: async <T>(name: string, cb: () => Promise<T>) => {
+    lockEvents.push(`acquire:${name}`);
+    const result = await cb();
+    lockEvents.push(`release:${name}`);
+    return result;
+  },
 }));
 
 import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import {
+  getFramePublishLockName,
+  getFrameSourceLockName,
+} from "@app/lib/api/frames/operation_lock";
 import {
   frameManifest,
   setupFrameSourceStorageTest,
@@ -30,6 +40,7 @@ import assert from "assert";
 beforeEach(() => {
   fileStorageMock.reset();
   emitMovedAuditLog.mockReset();
+  lockEvents.length = 0;
   vi.restoreAllMocks();
 });
 
@@ -78,5 +89,11 @@ describe("moveFrameV2Source", () => {
       )
     ).toBe(frameManifest);
     expect(emitMovedAuditLog).toHaveBeenCalledOnce();
+    expect(lockEvents).toEqual([
+      `acquire:${getFrameSourceLockName(c.frame.sId)}`,
+      `acquire:${getFramePublishLockName(c.frame.sId)}`,
+      `release:${getFramePublishLockName(c.frame.sId)}`,
+      `release:${getFrameSourceLockName(c.frame.sId)}`,
+    ]);
   });
 });

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -4,7 +4,10 @@ import {
   FrameSourceMoveError,
   resolveFrameSourceMovePaths,
 } from "@app/lib/api/frames/move_source_paths";
-import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import {
+  withFramePublishLock,
+  withFrameSourceLock,
+} from "@app/lib/api/frames/operation_lock";
 import {
   copyFrameSourceStorage,
   deleteFrameSourceStorage,
@@ -102,10 +105,10 @@ export async function moveFrameV2Source(
     );
   }
 
-  const locked = await withFramePublishLock<
-    FrameSourceMove,
-    MoveFrameV2SourceError
-  >(frame.sId, async () => {
+  async function moveWithLocksHeld(
+    lockedSourceMountPath: string,
+    lockedDestinationMountPath: string
+  ) {
     const freshFrame = await frame.fetchFreshFrameV2(auth);
     if (
       !freshFrame ||
@@ -119,7 +122,7 @@ export async function moveFrameV2Source(
 
     const [registeredDestination] = await FileResource.fetchByMountFilePaths(
       auth,
-      [destinationMountPath]
+      [lockedDestinationMountPath]
     );
     if (registeredDestination) {
       return moveError(
@@ -129,8 +132,8 @@ export async function moveFrameV2Source(
     }
 
     const snapshot = await inspectFrameSourceStorage({
-      destinationMountPath,
-      sourceMountPath,
+      destinationMountPath: lockedDestinationMountPath,
+      sourceMountPath: lockedSourceMountPath,
     });
     if (snapshot.isErr()) {
       return moveError(snapshot.error.code, snapshot.error.message);
@@ -154,7 +157,7 @@ export async function moveFrameV2Source(
     try {
       await freshFrame.updateMount({
         destFileName: FRAME_MANIFEST_FILE,
-        destMountFilePath: destinationMountPath,
+        destMountFilePath: lockedDestinationMountPath,
         destUseCase: freshFrame.useCase,
         destUseCaseMetadata: freshFrame.useCaseMetadata ?? undefined,
       });
@@ -193,7 +196,13 @@ export async function moveFrameV2Source(
       frameId: frame.sId,
       sourceDeletionFailed: deleted.isErr(),
     });
-  });
+  }
+
+  const locked = await withFrameSourceLock(frame.sId, () =>
+    withFramePublishLock(frame.sId, () =>
+      moveWithLocksHeld(sourceMountPath, destinationMountPath)
+    )
+  );
 
   if (locked.isErr()) {
     return isLockAcquisitionTimeoutError(locked.error)


### PR DESCRIPTION
## Description

Acquire the fixed Frame source lock outside the existing publish lock for Frames v2 moves. Re-fetch and revalidate the Frame after both locks are held, then perform the storage copy, identity update, and source cleanup inside the shared critical section.

The lock order is source then publish, matching publication and preventing deadlocks. Lock acquisition timeouts return the existing typed move conflict.

## Tests

Added focused coverage for source then publish acquisition and reverse-order release around a successful move.

## Risk

Moves can wait up to 30 seconds for an active source or publication operation, then return a retryable conflict. The move sequence itself is unchanged.

## Deploy Plan

Standard deploy.
