### PR TITLE
Fence Frame clone source copies

### DIFF
--- a/front/lib/api/frames/clone_source.test.ts
+++ b/front/lib/api/frames/clone_source.test.ts
@@ -2,12 +2,15 @@
 // @vitest-environment node
 
 import { cloneFrameV2Source } from "@app/lib/api/frames/clone_source";
+import * as frameOperationLock from "@app/lib/api/frames/operation_lock";
 import { setupFrameSourceStorageTest } from "@app/lib/api/frames/source_storage.test_utils";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { LockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { Err } from "@app/types/shared/result";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,6 +20,11 @@ beforeEach(() => {
 
 describe("cloneFrameV2Source", () => {
   it("copies into a fresh identity and activates its first publication", async () => {
+    const sourceLock = vi.spyOn(frameOperationLock, "withFrameSourceLock");
+    const workspaceLock = vi.spyOn(
+      frameOperationLock,
+      "withFrameWorkspaceSourceLock"
+    );
     const c = await setupFrameSourceStorageTest();
     fileStorageMock.setObject(
       c.sourceObjects[0],
@@ -53,6 +61,11 @@ describe("cloneFrameV2Source", () => {
       result.value.publicationId
     );
     expect(await FileResource.fetchById(c.auth, c.frame.sId)).toBeTruthy();
+    expect(sourceLock).toHaveBeenCalledWith(c.frame.sId, expect.any(Function));
+    expect(workspaceLock).toHaveBeenCalledWith(
+      c.workspace.sId,
+      expect.any(Function)
+    );
   });
 
   it("rejects a destination inside the source folder", async () => {
@@ -71,5 +84,26 @@ describe("cloneFrameV2Source", () => {
     expect(result.isErr() && result.error).toMatchObject({
       code: "invalid_source",
     });
+  });
+
+  it("does not copy when the source operation lock is busy", async () => {
+    const c = await setupFrameSourceStorageTest();
+    vi.spyOn(frameOperationLock, "withFrameSourceLock").mockResolvedValueOnce(
+      new Err(
+        new LockAcquisitionTimeoutError(
+          frameOperationLock.getFrameSourceLockName(c.frame.sId)
+        )
+      )
+    );
+    const copyFile = vi.spyOn(getPrivateUploadBucket(), "copyFile");
+
+    const result = await cloneFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+      destinationDirectoryPath: `conversation-${c.conversation.sId}/Copy`,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({ code: "conflict" });
+    expect(copyFile).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/frames/clone_source.ts
+++ b/front/lib/api/frames/clone_source.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 
 import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
+import {
+  withFrameSourceLock,
+  withFrameWorkspaceSourceLock,
+} from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
 import { registerFrameV2FromSourceUsingFileSystem } from "@app/lib/api/frames/register_from_source";
@@ -11,6 +15,8 @@ import {
 } from "@app/lib/api/frames/source_storage";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
+import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
@@ -100,6 +106,7 @@ export async function cloneFrameV2Source(
       "Frame source and destination must be folders in a conversation or Pod mount."
     );
   }
+  const owner = auth.getNonNullableWorkspace();
   if (source === destination || destination.startsWith(`${source}/`)) {
     return cloneError(
       "invalid_source",
@@ -162,28 +169,56 @@ export async function cloneFrameV2Source(
     );
   }
 
-  const snapshot = await inspectFrameSourceStorage({
-    destinationMountPath,
-    sourceMountPath,
-  });
-  if (snapshot.isErr()) {
-    return cloneStorageError(snapshot.error);
-  }
+  const copied = await withFrameSourceLock<
+    void,
+    CloneFrameV2SourceError | LockAcquisitionTimeoutError
+  >(sourceFrame.sId, () =>
+    withFrameWorkspaceSourceLock<void, CloneFrameV2SourceError>(
+      owner.sId,
+      async () => {
+        const freshSourceFrame = await sourceFrame.fetchFreshFrameV2(auth);
+        if (
+          !freshSourceFrame ||
+          freshSourceFrame.mountFilePath !== sourceMountPath
+        ) {
+          return cloneError(
+            "invalid_source",
+            "The source Frame moved or was deleted before cloning started."
+          );
+        }
 
-  const registeredSourceFiles = await FileResource.fetchByMountFilePaths(
-    auth,
-    snapshot.value.sourceObjectNames
+        const snapshot = await inspectFrameSourceStorage({
+          destinationMountPath,
+          sourceMountPath,
+        });
+        if (snapshot.isErr()) {
+          return cloneStorageError(snapshot.error);
+        }
+
+        const registeredSourceFiles = await FileResource.fetchByMountFilePaths(
+          auth,
+          snapshot.value.sourceObjectNames
+        );
+        if (registeredSourceFiles.some((file) => file.id !== sourceFrame.id)) {
+          return cloneError(
+            "conflict",
+            "Clone nested registered files separately before cloning this Frame."
+          );
+        }
+
+        const copy = await copyFrameSourceStorage(snapshot.value);
+        return copy.isErr() ? cloneStorageError(copy.error) : copy;
+      }
+    )
   );
-  if (registeredSourceFiles.some((file) => file.id !== sourceFrame.id)) {
-    return cloneError(
-      "conflict",
-      "Clone nested registered files separately before cloning this Frame."
-    );
-  }
-
-  const copied = await copyFrameSourceStorage(snapshot.value);
   if (copied.isErr()) {
-    return cloneStorageError(copied.error);
+    if (isLockAcquisitionTimeoutError(copied.error)) {
+      return cloneError(
+        "conflict",
+        "Another Frame source operation is in progress; retry shortly."
+      );
+    }
+    return new Err(copied.error);
   }
 
   const registration = await registerFrameV2FromSourceUsingFileSystem(auth, {


### PR DESCRIPTION
## Description

Fence the clone copy with two existing locks:

- the source Frame lock prevents cloning through a stale path while that Frame is moved or deleted;
- the workspace source-mutation lock prevents concurrent move or clone operations from claiming the same destination.

The service refreshes the source Frame under the locks, validates and copies the source, then releases them before registration and publication to preserve lock ordering.

This PR is stacked on #31515. The endpoint follows in #31496.

## Tests

- Clone service tests cover both locks and prove that a busy source lock prevents copying.
- Front typecheck.
- Biome on changed files.

## Risk

Low. Concurrent source mutations now return the existing typed clone conflict and can be retried.

## Deploy Plan

Merge after #31515. No migration is required.