### PR TITLE
[front] feat: split AWU pool summary into fast current-cycle and slow cycle-history fetchesy

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,0 +1,57 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+export type { AwuPoolCurrentCycleResponseBody };
+
+function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/poke/workspaces/:wId/credits/awu-pool-current-cycle.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+
+  const result = await getAwuPoolCurrentCycle(auth);
+  if (result.isErr()) {
+    return currentCycleErrorToApi(ctx, result.error);
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,0 +1,62 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import {
+  AwuPoolSummaryQuerySchema,
+  getAwuPoolCycleHistory,
+} from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { Context } from "hono";
+
+export type { AwuPoolCycleHistoryResponseBody };
+
+function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/poke/workspaces/:wId/credits/awu-pool-cycle-history.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", validate("query", AwuPoolSummaryQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { cycleHistoryLimit } = ctx.req.valid("query");
+
+  const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
+  if (result.isErr()) {
+    return cycleHistoryErrorToApi(ctx, result.error);
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -4,6 +4,8 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import apiKeysUsage from "./api-keys-usage";
+import awuPoolCurrentCycle from "./awu-pool-current-cycle";
+import awuPoolCycleHistory from "./awu-pool-cycle-history";
 import awuPoolSummary from "./awu-pool-summary";
 import consumptionExport from "./consumption-export";
 import membersUsage from "./members-usage";
@@ -38,6 +40,8 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
 
 app.route("/api-keys-usage", apiKeysUsage);
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
+app.route("/awu-pool-cycle-history", awuPoolCycleHistory);
 app.route("/consumption-export", consumptionExport);
 app.route("/members-usage", membersUsage);
 app.route("/top-ups", topUps);

--- a/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,0 +1,60 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/awu-pool-current-cycle.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  async (ctx): HandlerResult<AwuPoolCurrentCycleResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await getAwuPoolCurrentCycle(auth);
+    if (result.isErr()) {
+      return currentCycleErrorToApi(ctx, result.error);
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,0 +1,66 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import {
+  AwuPoolSummaryQuerySchema,
+  getAwuPoolCycleHistory,
+} from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { Context } from "hono";
+
+function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/awu-pool-cycle-history.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  validate("query", AwuPoolSummaryQuerySchema),
+  async (ctx): HandlerResult<AwuPoolCycleHistoryResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cycleHistoryLimit } = ctx.req.valid("query");
+
+    const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
+    if (result.isErr()) {
+      return cycleHistoryErrorToApi(ctx, result.error);
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -10,6 +10,8 @@ import type {
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 
+import awuPoolCurrentCycle from "./awu-pool-current-cycle";
+import awuPoolCycleHistory from "./awu-pool-cycle-history";
 import awuPoolSummary from "./awu-pool-summary";
 import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
@@ -25,6 +27,8 @@ import usageConfiguration from "./usage-configuration";
 const app = workspaceApp();
 
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
+app.route("/awu-pool-cycle-history", awuPoolCycleHistory);
 app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/my-top-conversations", myTopConversations);

--- a/front/components/pages/workspace/UsagePageRedesign.tsx
+++ b/front/components/pages/workspace/UsagePageRedesign.tsx
@@ -53,7 +53,8 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import {
-  useAwuPoolSummary,
+  useAwuPoolCurrentCycle,
+  useAwuPoolCycleHistory,
   useAwuPurchaseInfo,
   useCreditPurchaseInfo,
   useMyUsage,
@@ -470,15 +471,23 @@ export function UsagePageRedesign() {
     currentCycleConsumedCredits,
     currentCycleStartMs,
     currentCycleEndMs,
-    cycleBreakdown,
     excessConsumedCredits,
-    excessCycleBreakdown,
     programmaticConsumedCredits,
     otherConsumedCredits,
-    isAwuPoolSummaryLoading,
-    isAwuPoolSummaryError,
-    mutateAwuPoolSummary,
-  } = useAwuPoolSummary({
+    isAwuPoolCurrentCycleLoading,
+    isAwuPoolCurrentCycleError,
+    mutateAwuPoolCurrentCycle,
+  } = useAwuPoolCurrentCycle({
+    workspaceId: owner.sId,
+  });
+
+  const {
+    cycleBreakdown,
+    excessCycleBreakdown,
+    isAwuPoolCycleHistoryLoading,
+    isAwuPoolCycleHistoryError,
+    mutateAwuPoolCycleHistory,
+  } = useAwuPoolCycleHistory({
     workspaceId: owner.sId,
   });
 
@@ -1103,7 +1112,8 @@ export function UsagePageRedesign() {
         isOpen={showBuyCreditDialog}
         onClose={() => setShowBuyCreditDialog(false)}
         onPurchaseSuccess={() => {
-          void mutateAwuPoolSummary();
+          void mutateAwuPoolCurrentCycle();
+          void mutateAwuPoolCycleHistory();
         }}
         workspaceId={owner.sId}
         awuPurchaseInfo={awuPurchaseInfo}
@@ -1276,8 +1286,10 @@ export function UsagePageRedesign() {
 
         {!showConsumptionAnalytics && (
           <WorkspaceCreditPoolSection
-            isLoading={isAwuPoolSummaryLoading}
-            isError={!!isAwuPoolSummaryError}
+            isCardsLoading={isAwuPoolCurrentCycleLoading}
+            isCardsError={!!isAwuPoolCurrentCycleError}
+            isTableLoading={isAwuPoolCycleHistoryLoading}
+            isTableError={!!isAwuPoolCycleHistoryError}
             showPoolBranch={hasPool || isReadOnly}
             isVisible={hasPool || isReadOnly || hasExcessData}
             totalRemainingCredits={totalRemainingCredits}
@@ -1427,7 +1439,7 @@ export function UsagePageRedesign() {
                   <ModelTiersSettingsCard owner={owner} readOnly={isReadOnly} />
                 )}
                 <LockedSection
-                  locked={!isAwuPoolSummaryLoading && !hasPool}
+                  locked={!isAwuPoolCurrentCycleLoading && !hasPool}
                   className="flex flex-col gap-10"
                 >
                   <UsageProgrammaticLimitCard

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -13,7 +13,8 @@ import { expandMaxTierName } from "@app/lib/client/model_tiers";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
-  usePokeAwuPoolSummary,
+  usePokeAwuPoolCurrentCycle,
+  usePokeAwuPoolCycleHistory,
   usePokeMembersUsage,
 } from "@app/poke/swr/credits";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
@@ -24,7 +25,6 @@ import {
   usePokeWorkspaceAllowedModelTiers,
 } from "@app/poke/swr/model_tiers";
 import { usePokeWorkspaceInfo } from "@app/poke/swr/workspace_info";
-import type { AwuPoolCycleBreakdown } from "@app/types/api/credits/awu_pool_summary";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { isCapEligibleGroupKind } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -72,30 +72,35 @@ interface PoolCreditCardProps {
 }
 
 function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
-  const { awuPoolSummary, isAwuPoolSummaryLoading, isAwuPoolSummaryError } =
-    usePokeAwuPoolSummary({ owner });
+  const {
+    awuPoolCurrentCycle,
+    isAwuPoolCurrentCycleLoading,
+    isAwuPoolCurrentCycleError,
+  } = usePokeAwuPoolCurrentCycle({ owner });
+  const {
+    cycleBreakdown,
+    excessCycleBreakdown,
+    isAwuPoolCycleHistoryLoading,
+    isAwuPoolCycleHistoryError,
+  } = usePokeAwuPoolCycleHistory({ owner });
   const {
     totalRemainingCredits,
     totalActiveCredits,
     overageCredits,
-    cycleBreakdown,
     currentCycleConsumedCredits,
     currentCycleStartMs,
     currentCycleEndMs,
     excessConsumedCredits,
-    excessCycleBreakdown,
     programmaticConsumedCredits,
     otherConsumedCredits,
-  } = awuPoolSummary ?? {
+  } = awuPoolCurrentCycle ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
     overageCredits: null,
-    cycleBreakdown: [] as AwuPoolCycleBreakdown[],
     currentCycleConsumedCredits: null,
     currentCycleStartMs: null,
     currentCycleEndMs: null,
     excessConsumedCredits: null,
-    excessCycleBreakdown: [] as AwuPoolCycleBreakdown[],
     programmaticConsumedCredits: null,
     otherConsumedCredits: null,
   };
@@ -106,8 +111,10 @@ function PoolCreditCard({ owner, isEnterprise }: PoolCreditCardProps) {
 
   return (
     <WorkspaceCreditPoolSection
-      isLoading={isAwuPoolSummaryLoading}
-      isError={!!isAwuPoolSummaryError}
+      isCardsLoading={isAwuPoolCurrentCycleLoading}
+      isCardsError={!!isAwuPoolCurrentCycleError}
+      isTableLoading={isAwuPoolCycleHistoryLoading}
+      isTableError={!!isAwuPoolCycleHistoryError}
       showPoolBranch={hasPool}
       isVisible={hasPool || hasExcessData}
       totalRemainingCredits={totalRemainingCredits}

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -221,9 +221,47 @@ export function WorkspaceCreditPoolCycleHistoryTable({
   return <DataTable data={rows} columns={CYCLE_HISTORY_COLUMNS} />;
 }
 
+interface WorkspaceCreditPoolHistoryProps {
+  isTableLoading: boolean;
+  isTableError: boolean;
+  cycleBreakdown: AwuPoolCycleBreakdown[];
+}
+
+// Table area rendered under the value cards. Kept separate so a slow cycle
+// history fetch never blocks the (fast) cards above it from showing.
+function WorkspaceCreditPoolHistory({
+  isTableLoading,
+  isTableError,
+  cycleBreakdown,
+}: WorkspaceCreditPoolHistoryProps) {
+  if (isTableError) {
+    return (
+      <ContentMessage
+        title="Failed to load cycle history"
+        icon={AlertCircle}
+        variant="warning"
+      >
+        An error occurred while loading past-cycle consumption.
+      </ContentMessage>
+    );
+  }
+  if (isTableLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner />
+      </div>
+    );
+  }
+  return (
+    <WorkspaceCreditPoolCycleHistoryTable cycleBreakdown={cycleBreakdown} />
+  );
+}
+
 interface WorkspaceCreditPoolSectionProps {
-  isLoading: boolean;
-  isError: boolean;
+  isCardsLoading: boolean;
+  isCardsError: boolean;
+  isTableLoading: boolean;
+  isTableError: boolean;
   showPoolBranch: boolean;
   isVisible: boolean;
   totalRemainingCredits: number;
@@ -243,8 +281,10 @@ interface WorkspaceCreditPoolSectionProps {
 // consumption" block so the customer-facing usage page and its Poke mirror
 // can't drift from each other on this section's structure
 export function WorkspaceCreditPoolSection({
-  isLoading,
-  isError,
+  isCardsLoading,
+  isCardsError,
+  isTableLoading,
+  isTableError,
   showPoolBranch,
   isVisible,
   totalRemainingCredits,
@@ -259,7 +299,7 @@ export function WorkspaceCreditPoolSection({
   poolSecondaryContent,
   footer,
 }: WorkspaceCreditPoolSectionProps) {
-  if (!isLoading && !isError && !isVisible) {
+  if (!isCardsLoading && !isCardsError && !isVisible) {
     return null;
   }
 
@@ -269,7 +309,7 @@ export function WorkspaceCreditPoolSection({
         {showPoolBranch ? "Workspace credit pool" : "Excess credit consumption"}
       </Page.H>
 
-      {isError ? (
+      {isCardsError ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"
           icon={AlertCircle}
@@ -277,7 +317,7 @@ export function WorkspaceCreditPoolSection({
         >
           An error occurred while loading the workspace&apos;s credit pool data.
         </ContentMessage>
-      ) : isLoading ? (
+      ) : isCardsLoading ? (
         <div className="flex justify-center py-8">
           <Spinner />
         </div>
@@ -293,7 +333,9 @@ export function WorkspaceCreditPoolSection({
             isLoading={false}
           />
           {poolSecondaryContent}
-          <WorkspaceCreditPoolCycleHistoryTable
+          <WorkspaceCreditPoolHistory
+            isTableLoading={isTableLoading}
+            isTableError={isTableError}
             cycleBreakdown={cycleBreakdown}
           />
           {footer}
@@ -308,7 +350,9 @@ export function WorkspaceCreditPoolSection({
             otherConsumedCredits={otherConsumedCredits}
             isLoading={false}
           />
-          <WorkspaceCreditPoolCycleHistoryTable
+          <WorkspaceCreditPoolHistory
+            isTableLoading={isTableLoading}
+            isTableError={isTableError}
             cycleBreakdown={excessCycleBreakdown}
           />
           {footer}

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -13,7 +13,7 @@ import {
   CONSUMPTION_DIMENSION_FIELDS,
   CREDIT_MICRO_FIELD,
 } from "@app/lib/api/analytics/consumption/scope";
-import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -86,7 +86,7 @@ async function fetchPoolCapCredits(
     return null;
   }
 
-  const poolResult = await getAwuPoolSummary(auth);
+  const poolResult = await getAwuPoolCurrentCycle(auth);
   if (poolResult.isErr()) {
     return null;
   }

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -26,7 +26,9 @@ import {
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type {
+  AwuPoolCurrentCycleResponseBody,
   AwuPoolCycleBreakdown,
+  AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -147,6 +149,28 @@ function computeCycleBreakdown({
     }))
     .filter((cycle) => cycle.consumedCredits > 0)
     .slice(0, cycleHistoryLimit);
+}
+
+type MetronomeContext = {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+};
+
+function resolveMetronomeContext(
+  auth: Authenticator
+): Result<MetronomeContext, AwuPoolSummaryError> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
+    return new Err(new AwuPoolSummaryError("not_configured"));
+  }
+  return new Ok({
+    workspace,
+    metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  });
 }
 
 function creditTypeIdToCurrency(
@@ -296,7 +320,7 @@ async function computeAwuPoolSummaryOutcome(
 const AWU_POOL_SUMMARY_CACHE_ID = "awuPoolSummary";
 const AWU_POOL_SUMMARY_CACHE_TTL_MS = 60 * 1000;
 
-function awuPoolSummaryCacheResolverKey(
+function cacheResolverKeyWithHistoryLimit(
   workspaceId: string,
   cycleHistoryLimit: number
 ): string {
@@ -306,7 +330,7 @@ function awuPoolSummaryCacheResolverKey(
 const getCachedAwuPoolSummaryOutcome = cacheWithRedis(
   computeAwuPoolSummaryOutcome,
   (auth, cycleHistoryLimit) =>
-    awuPoolSummaryCacheResolverKey(
+    cacheResolverKeyWithHistoryLimit(
       auth.getNonNullableWorkspace().sId,
       cycleHistoryLimit
     ),
@@ -331,36 +355,120 @@ export async function getAwuPoolSummary(
   return new Ok(outcome.body);
 }
 
-async function getAwuPoolSummaryUncached(
+type SerializableAwuPoolCurrentCycleOutcome =
+  | { status: "ok"; body: AwuPoolCurrentCycleResponseBody }
+  | { status: "error"; errorType: AwuPoolSummaryErrorType };
+
+async function computeAwuPoolCurrentCycleOutcome(
+  auth: Authenticator
+): Promise<SerializableAwuPoolCurrentCycleOutcome> {
+  const result = await getAwuPoolCurrentCycleUncached(auth);
+  if (result.isErr()) {
+    return { status: "error", errorType: result.error.type };
+  }
+  return { status: "ok", body: result.value };
+}
+
+const AWU_POOL_CURRENT_CYCLE_CACHE_ID = "awuPoolCurrentCycle";
+const AWU_POOL_CURRENT_CYCLE_CACHE_TTL_MS = 60 * 1000;
+
+const getCachedAwuPoolCurrentCycleOutcome = cacheWithRedis(
+  computeAwuPoolCurrentCycleOutcome,
+  (auth) => auth.getNonNullableWorkspace().sId,
+  {
+    cacheId: AWU_POOL_CURRENT_CYCLE_CACHE_ID,
+    ttlMs: AWU_POOL_CURRENT_CYCLE_CACHE_TTL_MS,
+  }
+);
+
+// Header-card data only — cheap, meant to render before cycle history is
+// available. See `getAwuPoolCycleHistory` for the history table.
+export async function getAwuPoolCurrentCycle(
+  auth: Authenticator
+): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
+  const outcome = await getCachedAwuPoolCurrentCycleOutcome(auth);
+  if (outcome.status === "error") {
+    return new Err(new AwuPoolSummaryError(outcome.errorType));
+  }
+  return new Ok(outcome.body);
+}
+
+type SerializableAwuPoolCycleHistoryOutcome =
+  | { status: "ok"; body: AwuPoolCycleHistoryResponseBody }
+  | { status: "error"; errorType: AwuPoolSummaryErrorType };
+
+async function computeAwuPoolCycleHistoryOutcome(
+  auth: Authenticator,
+  cycleHistoryLimit: number
+): Promise<SerializableAwuPoolCycleHistoryOutcome> {
+  const result = await getAwuPoolCycleHistoryUncached(auth, {
+    cycleHistoryLimit,
+  });
+  if (result.isErr()) {
+    return { status: "error", errorType: result.error.type };
+  }
+  return { status: "ok", body: result.value };
+}
+
+const AWU_POOL_CYCLE_HISTORY_CACHE_ID = "awuPoolCycleHistory";
+const AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS = 60 * 1000;
+
+const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
+  computeAwuPoolCycleHistoryOutcome,
+  (auth, cycleHistoryLimit) =>
+    cacheResolverKeyWithHistoryLimit(
+      auth.getNonNullableWorkspace().sId,
+      cycleHistoryLimit
+    ),
+  {
+    cacheId: AWU_POOL_CYCLE_HISTORY_CACHE_ID,
+    ttlMs: AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS,
+  }
+);
+
+// History-table data only — slower (scans the full ledger window). See
+// `getAwuPoolCurrentCycle` for the header-card figures.
+export async function getAwuPoolCycleHistory(
   auth: Authenticator,
   {
     cycleHistoryLimit = DEFAULT_CYCLE_HISTORY_LIMIT,
   }: {
     cycleHistoryLimit?: number;
   } = {}
-): Promise<Result<AwuPoolSummaryResponseBody, AwuPoolSummaryError>> {
-  const workspace = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-  const { metronomeCustomerId } = workspace;
-  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
-    return new Err(new AwuPoolSummaryError("not_configured"));
+): Promise<Result<AwuPoolCycleHistoryResponseBody, AwuPoolSummaryError>> {
+  const outcome = await getCachedAwuPoolCycleHistoryOutcome(
+    auth,
+    cycleHistoryLimit
+  );
+  if (outcome.status === "error") {
+    return new Err(new AwuPoolSummaryError(outcome.errorType));
   }
-  const { metronomeContractId } = subscription;
+  return new Ok(outcome.body);
+}
+
+// Everything the header cards need: current balances, current cycle
+// consumption, overage. Bounds its ledger lookup to a single cycle (see
+// `getPoolLedgerData`), so it stays cheap regardless of `cycleHistoryLimit`.
+async function getAwuPoolCurrentCycleUncached(
+  auth: Authenticator
+): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
+  const contextResult = resolveMetronomeContext(auth);
+  if (contextResult.isErr()) {
+    return contextResult;
+  }
+  const { workspace, metronomeCustomerId, metronomeContractId } =
+    contextResult.value;
   const awuCreditTypeId = getCreditTypeAwuId();
 
   const [
     balancesResult,
     invoicesResult,
     poolLedgerDataResult,
-    finalizedInvoicesResult,
     membersPoolConsumedCredits,
   ] = await Promise.all([
     listMetronomeBalances(metronomeCustomerId),
     listMetronomeDraftInvoices(metronomeCustomerId),
-    getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit }),
-    listMetronomeFinalizedInvoices(metronomeCustomerId, {
-      limit: cycleHistoryLimit,
-    }),
+    getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit: 1 }),
     sumActiveMembersPoolConsumedCredits({
       workspace,
       metronomeCustomerId,
@@ -382,37 +490,19 @@ async function getAwuPoolSummaryUncached(
   let poolCommitIds = new Set<string>();
   // `null` means the ledger couldn't be read (fetch failure)
   let ledgerEntries: PoolLedgerEntry[] | null = null;
-  let cycleBreakdown: AwuPoolCycleBreakdown[] = [];
-  if (poolLedgerDataResult.isErr() || finalizedInvoicesResult.isErr()) {
+  if (poolLedgerDataResult.isErr()) {
     logger.error(
       {
         metronomeCustomerId,
         metronomeContractId,
-        poolLedgerDataError: poolLedgerDataResult.isErr()
-          ? poolLedgerDataResult.error
-          : null,
-        invoicesError: finalizedInvoicesResult.isErr()
-          ? finalizedInvoicesResult.error
-          : null,
+        error: poolLedgerDataResult.error,
       },
-      "[AwuPoolSummary] Failed to compute cycle breakdown"
+      "[AwuPoolSummary] Failed to read pool ledger for the current cycle"
     );
   } else {
     poolCommitIds = poolLedgerDataResult.value.poolCommitIds;
     ledgerEntries = poolLedgerDataResult.value.ledgerEntries;
-    cycleBreakdown = computeCycleBreakdown({
-      finalizedInvoices: finalizedInvoicesResult.value,
-      ledgerEntries,
-      cycleHistoryLimit,
-    });
   }
-
-  const excessCycleBreakdown = finalizedInvoicesResult.isErr()
-    ? []
-    : computeExcessCycleBreakdown(
-        finalizedInvoicesResult.value,
-        cycleHistoryLimit
-      );
 
   const now = Date.now();
 
@@ -451,9 +541,7 @@ async function getAwuPoolSummaryUncached(
       currentCycleStartMs: null,
       currentCycleEndMs: null,
       currentCycleConsumedCredits,
-      cycleBreakdown,
       excessConsumedCredits,
-      excessCycleBreakdown,
       programmaticConsumedCredits,
       otherConsumedCredits: null,
     });
@@ -545,10 +633,84 @@ async function getAwuPoolSummaryUncached(
     currentCycleStartMs,
     currentCycleEndMs,
     currentCycleConsumedCredits,
-    cycleBreakdown,
     excessConsumedCredits,
-    excessCycleBreakdown,
     programmaticConsumedCredits,
     otherConsumedCredits,
+  });
+}
+
+// Past-cycle breakdown for the history table. Scans the full
+// `cycleHistoryLimit` ledger window, so it's slower than the current-cycle
+// figures above — kept separate so the header cards don't wait on it.
+async function getAwuPoolCycleHistoryUncached(
+  auth: Authenticator,
+  { cycleHistoryLimit }: { cycleHistoryLimit: number }
+): Promise<Result<AwuPoolCycleHistoryResponseBody, AwuPoolSummaryError>> {
+  const contextResult = resolveMetronomeContext(auth);
+  if (contextResult.isErr()) {
+    return contextResult;
+  }
+  const { metronomeCustomerId, metronomeContractId } = contextResult.value;
+
+  const [poolLedgerDataResult, finalizedInvoicesResult] = await Promise.all([
+    getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit }),
+    listMetronomeFinalizedInvoices(metronomeCustomerId, {
+      limit: cycleHistoryLimit,
+    }),
+  ]);
+
+  if (poolLedgerDataResult.isErr() || finalizedInvoicesResult.isErr()) {
+    logger.error(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        poolLedgerDataError: poolLedgerDataResult.isErr()
+          ? poolLedgerDataResult.error
+          : null,
+        invoicesError: finalizedInvoicesResult.isErr()
+          ? finalizedInvoicesResult.error
+          : null,
+      },
+      "[AwuPoolSummary] Failed to compute cycle breakdown"
+    );
+    return new Ok({ cycleBreakdown: [], excessCycleBreakdown: [] });
+  }
+
+  const cycleBreakdown = computeCycleBreakdown({
+    finalizedInvoices: finalizedInvoicesResult.value,
+    ledgerEntries: poolLedgerDataResult.value.ledgerEntries,
+    cycleHistoryLimit,
+  });
+  const excessCycleBreakdown = computeExcessCycleBreakdown(
+    finalizedInvoicesResult.value,
+    cycleHistoryLimit
+  );
+
+  return new Ok({ cycleBreakdown, excessCycleBreakdown });
+}
+
+// Full body — current cycle plus history, composed for callers that want
+// everything in one shot (Poke, the legacy combined endpoint).
+async function getAwuPoolSummaryUncached(
+  auth: Authenticator,
+  {
+    cycleHistoryLimit = DEFAULT_CYCLE_HISTORY_LIMIT,
+  }: {
+    cycleHistoryLimit?: number;
+  } = {}
+): Promise<Result<AwuPoolSummaryResponseBody, AwuPoolSummaryError>> {
+  const [currentCycleResult, cycleHistoryResult] = await Promise.all([
+    getAwuPoolCurrentCycleUncached(auth),
+    getAwuPoolCycleHistoryUncached(auth, { cycleHistoryLimit }),
+  ]);
+  if (currentCycleResult.isErr()) {
+    return currentCycleResult;
+  }
+  if (cycleHistoryResult.isErr()) {
+    return cycleHistoryResult;
+  }
+  return new Ok({
+    ...currentCycleResult.value,
+    ...cycleHistoryResult.value,
   });
 }

--- a/front/lib/metronome/per_user_usage.test.ts
+++ b/front/lib/metronome/per_user_usage.test.ts
@@ -5,7 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("buildUsageQuerySegments", () => {
-  it("returns a single DAY segment when both boundaries are UTC midnight", () => {
+  it("returns a single NONE segment when both boundaries are UTC midnight", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-01T00:00:00.000Z"),
       requestEnd: new Date("2026-07-01T00:00:00.000Z"),
@@ -14,12 +14,12 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-01T00:00:00.000Z",
         endingBefore: "2026-07-01T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
     ]);
   });
 
-  it("adds an HOUR segment for a non-midnight start, DAY for the interior", () => {
+  it("adds an HOUR segment for a non-midnight start, NONE for the interior", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-15T15:00:00.000Z"),
       requestEnd: new Date("2026-07-01T00:00:00.000Z"),
@@ -33,12 +33,12 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-16T00:00:00.000Z",
         endingBefore: "2026-07-01T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
     ]);
   });
 
-  it("adds an HOUR segment for a non-midnight end, DAY for the interior", () => {
+  it("adds an HOUR segment for a non-midnight end, NONE for the interior", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-01T00:00:00.000Z"),
       requestEnd: new Date("2026-06-20T09:30:00.000Z"),
@@ -47,7 +47,7 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-01T00:00:00.000Z",
         endingBefore: "2026-06-20T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
       {
         startingOn: "2026-06-20T00:00:00.000Z",
@@ -57,7 +57,7 @@ describe("buildUsageQuerySegments", () => {
     ]);
   });
 
-  it("produces HOUR + DAY + HOUR for non-midnight start and end, multi-day", () => {
+  it("produces HOUR + NONE + HOUR for non-midnight start and end, multi-day", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-15T15:00:00.000Z"),
       requestEnd: new Date("2026-06-20T09:30:00.000Z"),
@@ -71,7 +71,7 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-16T00:00:00.000Z",
         endingBefore: "2026-06-20T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
       {
         startingOn: "2026-06-20T00:00:00.000Z",

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -380,6 +380,17 @@ function perUserAwuUsageCacheKey(
   return `per-user-awu-usage:${metronomeCustomerId}:${metronomeContractId}:${userId}`;
 }
 
+// In-process single-flight registry, keyed by the same string as the Redis
+// cache key. Closes the gap between "checked Redis" and "wrote Redis": two
+// concurrent callers requesting overlapping users (e.g. the pool summary card
+// and the members table both fetching "all active members" at page load)
+// would otherwise both see a cache miss and both fire their own Metronome
+// batch. A caller that finds an in-flight entry here awaits it instead of
+// starting a second fetch. Only dedupes within this process — a second
+// request landing on a different replica still fetches independently, same
+// as before this registry existed.
+const inFlightPerUserAwuUsage = new Map<string, Promise<number>>();
+
 /**
  * Per-user-cached AWU consumption for the current billing period. Each user is
  * cached under its own key (10min TTL); the users not in cache are fetched in ONE
@@ -425,35 +436,89 @@ export async function getPerUserAwuUsage({
         }
       });
 
-      if (misses.length > 0) {
-        const fetched = await fetchPerUserAwuUsage({
+      if (misses.length === 0) {
+        return result;
+      }
+
+      // Split misses into users someone else in this process is already
+      // fetching (await their promise) vs. users nobody is fetching yet
+      // (this call owns them and starts the batch).
+      const waiters: Array<{ userId: string; promise: Promise<number> }> = [];
+      const newMisses: string[] = [];
+      for (const userId of misses) {
+        const key = perUserAwuUsageCacheKey(
+          metronomeCustomerId,
+          metronomeContractId,
+          userId
+        );
+        const existing = inFlightPerUserAwuUsage.get(key);
+        if (existing) {
+          waiters.push({ userId, promise: existing });
+        } else {
+          newMisses.push(userId);
+        }
+      }
+
+      if (newMisses.length > 0) {
+        const batchPromise = fetchPerUserAwuUsage({
           workspaceId,
           metronomeCustomerId,
-          userIds: misses,
+          userIds: newMisses,
+        }).then((fetched) => {
+          if (fetched.isErr()) {
+            throw fetched.error;
+          }
+          return fetched.value;
         });
-        if (fetched.isErr()) {
-          throw fetched.error;
+
+        // Register a per-user promise for each newly-owned miss before
+        // awaiting anything, so a caller arriving during the fetch finds it.
+        for (const userId of newMisses) {
+          const key = perUserAwuUsageCacheKey(
+            metronomeCustomerId,
+            metronomeContractId,
+            userId
+          );
+          const userPromise = batchPromise.then(
+            (usageByUserId) => usageByUserId.get(userId) ?? 0
+          );
+          inFlightPerUserAwuUsage.set(key, userPromise);
+          // Stop advertising this fetch as in-flight once it settles, so a
+          // later miss (after the Redis TTL expires) starts a fresh one
+          // instead of reusing a stale reference.
+          void userPromise
+            .catch(() => {
+              // Swallow here — the rejection still propagates to every
+              // waiter through their own awaited `promise` below.
+            })
+            .finally(() => {
+              if (inFlightPerUserAwuUsage.get(key) === userPromise) {
+                inFlightPerUserAwuUsage.delete(key);
+              }
+            });
+          waiters.push({ userId, promise: userPromise });
         }
-        await concurrentExecutor(
-          misses,
-          async (userId) => {
-            // Cache 0 too: a user with no usage this period would otherwise
-            // miss on every request.
-            const value = fetched.value.get(userId) ?? 0;
-            result.set(userId, value);
-            await redis.set(
-              perUserAwuUsageCacheKey(
-                metronomeCustomerId,
-                metronomeContractId,
-                userId
-              ),
-              JSON.stringify(value),
-              { PX: PER_USER_AWU_USAGE_CACHE_TTL_MS }
-            );
-          },
-          { concurrency: 16 }
-        );
       }
+
+      await concurrentExecutor(
+        waiters,
+        async ({ userId, promise }) => {
+          // Cache 0 too: a user with no usage this period would otherwise
+          // miss on every request.
+          const value = await promise;
+          result.set(userId, value);
+          await redis.set(
+            perUserAwuUsageCacheKey(
+              metronomeCustomerId,
+              metronomeContractId,
+              userId
+            ),
+            JSON.stringify(value),
+            { PX: PER_USER_AWU_USAGE_CACHE_TTL_MS }
+          );
+        },
+        { concurrency: 16 }
+      );
 
       return result;
     }

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -20,7 +20,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-type UsageWindowSize = "HOUR" | "DAY";
+type UsageWindowSize = "HOUR" | "DAY" | "NONE";
 
 interface UsageQuerySegment {
   startingOn: string;
@@ -30,10 +30,13 @@ interface UsageQuerySegment {
 
 /**
  * Partition `[cycleStart, requestEnd)` into the fewest midnight-aligned
- * segments the usage endpoint can query directly: a single DAY-granularity
- * segment for the interior days (the bulk of a typical month-long billing
- * period), plus HOUR-granularity segments only for the partial first/last day
- * when a boundary isn't already UTC midnight.
+ * segments the usage endpoint can query directly: a single segment covering
+ * the interior days (the bulk of a typical month-long billing period),
+ * queried with `windowSize: "NONE"` so it comes back as one aggregate bucket
+ * per group instead of one per day — callers here only ever sum rows into a
+ * per-group total, so the daily breakdown would just multiply page count for
+ * no benefit — plus HOUR-granularity segments only for the partial
+ * first/last day when a boundary isn't already UTC midnight.
  *
  * Segments are contiguous and non-overlapping by construction, so summing
  * their results is safe.
@@ -75,7 +78,7 @@ export function buildUsageQuerySegments({
   segments.push({
     startingOn: dayStart.toISOString(),
     endingBefore: dayEnd.toISOString(),
-    windowSize: "DAY",
+    windowSize: "NONE",
   });
   if (requestEnd.getTime() > dayEnd.getTime()) {
     segments.push({

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -952,7 +952,7 @@ describe("GroupResource", () => {
         },
         { memberIds: [user.id] }
       );
-      await capped500.updatePoolCap(authenticator, 500);
+      await capped500.updatePoolCap(500);
 
       const capped800 = await GroupResource.makeNew(
         {
@@ -963,7 +963,7 @@ describe("GroupResource", () => {
         },
         { memberIds: [user.id] }
       );
-      await capped800.updatePoolCap(authenticator, 800);
+      await capped800.updatePoolCap(800);
 
       const result =
         await GroupResource.listMaxPoolCapGroupByUserModelIdInWorkspace({

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -5,7 +5,11 @@ import type { GetAwuPurchaseInfoResponseBody } from "@app/lib/credits/awu_purcha
 import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type {
+  AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleHistoryResponseBody,
+  AwuPoolSummaryResponseBody,
+} from "@app/types/api/credits/awu_pool_summary";
 import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import type { GetMyTopConversationsResponseBody } from "@app/types/api/credits/my_top_conversations";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
@@ -266,6 +270,77 @@ export function useAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function useAwuPoolCurrentCycle({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuFetcher: Fetcher<AwuPoolCurrentCycleResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/awu-pool-current-cycle`,
+    awuFetcher,
+    {
+      disabled,
+      refreshInterval: () => {
+        const count = getAwuPostPurchaseRefreshCount(workspaceId);
+        if (count < 5) {
+          incrementAwuPostPurchaseRefreshCount(workspaceId);
+          return 5000;
+        }
+        return 0;
+      },
+    }
+  );
+
+  return {
+    totalRemainingCredits: data?.totalRemainingCredits ?? 0,
+    totalActiveCredits: data?.totalActiveCredits ?? 0,
+    overageCredits: data?.overageCredits ?? null,
+    overageAmountCents: data?.overageAmountCents ?? null,
+    overageCurrency: data?.overageCurrency ?? null,
+    currentCycleConsumedCredits: data?.currentCycleConsumedCredits ?? null,
+    currentCycleStartMs: data?.currentCycleStartMs ?? null,
+    currentCycleEndMs: data?.currentCycleEndMs ?? null,
+    excessConsumedCredits: data?.excessConsumedCredits ?? null,
+    programmaticConsumedCredits: data?.programmaticConsumedCredits ?? null,
+    otherConsumedCredits: data?.otherConsumedCredits ?? null,
+    isAwuPoolCurrentCycleLoading: !error && !data && !disabled,
+    isAwuPoolCurrentCycleError: error,
+    isAwuPoolCurrentCycleValidating: isValidating,
+    mutateAwuPoolCurrentCycle: mutate,
+  };
+}
+
+export function useAwuPoolCycleHistory({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuFetcher: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/awu-pool-cycle-history`,
+    awuFetcher,
+    { disabled }
+  );
+
+  return {
+    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
+    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
+    isAwuPoolCycleHistoryError: error,
+    isAwuPoolCycleHistoryValidating: isValidating,
+    mutateAwuPoolCycleHistory: mutate,
   };
 }
 

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -10,7 +10,11 @@ import type { GetApiKeysUsageResponseBody } from "@app/lib/api/credits/api_keys_
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type {
+  AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleHistoryResponseBody,
+  AwuPoolSummaryResponseBody,
+} from "@app/types/api/credits/awu_pool_summary";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
 import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
 import type {
@@ -186,6 +190,72 @@ export function usePokeAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function usePokeAwuPoolCurrentCycle({
+  owner,
+  disabled,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<AwuPoolCurrentCycleResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-current-cycle`,
+    fetcherFn
+  );
+
+  // Defaulted field-by-field (mirroring `useAwuPoolCurrentCycle`), not just
+  // whole-object, so a cached response predating a newer field can't leave
+  // that field `undefined` downstream.
+  const awuPoolCurrentCycle: AwuPoolCurrentCycleResponseBody | null = data
+    ? {
+        totalRemainingCredits: data.totalRemainingCredits ?? 0,
+        totalActiveCredits: data.totalActiveCredits ?? 0,
+        overageCredits: data.overageCredits ?? null,
+        overageAmountCents: data.overageAmountCents ?? null,
+        overageCurrency: data.overageCurrency ?? null,
+        currentCycleConsumedCredits: data.currentCycleConsumedCredits ?? null,
+        currentCycleStartMs: data.currentCycleStartMs ?? null,
+        currentCycleEndMs: data.currentCycleEndMs ?? null,
+        excessConsumedCredits: data.excessConsumedCredits ?? null,
+        programmaticConsumedCredits: data.programmaticConsumedCredits ?? null,
+        otherConsumedCredits: data.otherConsumedCredits ?? null,
+      }
+    : null;
+
+  return {
+    awuPoolCurrentCycle,
+    isAwuPoolCurrentCycleLoading: !error && !data && !disabled,
+    isAwuPoolCurrentCycleError: error,
+    isAwuPoolCurrentCycleValidating: isValidating,
+    mutateAwuPoolCurrentCycle: mutate,
+  };
+}
+
+export function usePokeAwuPoolCycleHistory({
+  owner,
+  disabled,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-cycle-history`,
+    fetcherFn
+  );
+
+  return {
+    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
+    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
+    isAwuPoolCycleHistoryError: error,
+    isAwuPoolCycleHistoryValidating: isValidating,
+    mutateAwuPoolCycleHistory: mutate,
   };
 }
 

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -6,7 +6,9 @@ export type AwuPoolCycleBreakdown = {
   consumedCredits: number;
 };
 
-export type AwuPoolSummaryResponseBody = {
+// Current-cycle figures only — cheap to compute (bounded ledger lookup),
+// meant to render before cycle history is available.
+export type AwuPoolCurrentCycleResponseBody = {
   totalRemainingCredits: number;
   totalActiveCredits: number;
   /**
@@ -19,14 +21,22 @@ export type AwuPoolSummaryResponseBody = {
   overageAmountCents: number | null;
   /** Invoice currency — needed to format `overageAmountCents`. */
   overageCurrency: SupportedCurrency | null;
-  // Per-cycle pool consumption, most recent first
-  cycleBreakdown: AwuPoolCycleBreakdown[];
   currentCycleConsumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   // PAYG credits
   excessConsumedCredits: number | null;
-  excessCycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
   otherConsumedCredits: number | null;
 };
+
+// Past-cycle history — requires scanning the full ledger window, slower than
+// `AwuPoolCurrentCycleResponseBody`.
+export type AwuPoolCycleHistoryResponseBody = {
+  // Per-cycle pool consumption, most recent first
+  cycleBreakdown: AwuPoolCycleBreakdown[];
+  excessCycleBreakdown: AwuPoolCycleBreakdown[];
+};
+
+export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody &
+  AwuPoolCycleHistoryResponseBody;


### PR DESCRIPTION
Lets the customer-facing usage page and Poke's mirror render the header
cards as soon as current-cycle data is ready instead of waiting on the
full ledger-history scan that only the cycle history table needs.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
