### PR TITLE
Add shareable user menu modal links

### DIFF
--- a/front-spa/src/app/pages/IndexPage.tsx
+++ b/front-spa/src/app/pages/IndexPage.tsx
@@ -1,5 +1,10 @@
 import config from "@dust-tt/front/lib/api/config";
 import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
+import {
+  getUserMenuModalRoute,
+  isUserMenuModal,
+  USER_MENU_GOTO_QUERY_PARAM,
+} from "@dust-tt/front/lib/user_menu";
 import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -8,7 +13,11 @@ function getWorkspaceRedirectPath(
   workspaceId: string,
   searchParams: URLSearchParams
 ): string {
-  const goto = searchParams.get("goto");
+  const goto = searchParams.get(USER_MENU_GOTO_QUERY_PARAM);
+
+  if (isUserMenuModal(goto)) {
+    return getUserMenuModalRoute(workspaceId, goto);
+  }
 
   if (goto === "subscription") {
     return `/w/${workspaceId}/subscription/manage`;

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -120,6 +120,7 @@ export function UserMenu({
   const [automationsOpen, setAutomationsOpen] = useState(false);
   const [analyticsOpen, setAnalyticsOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const userMenuModal = router.query[USER_MENU_MODAL_QUERY_PARAM];
 
   const isFirefox =
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
@@ -139,12 +140,11 @@ export function UserMenu({
   }, []);
 
   useEffect(() => {
-    const modal = router.query[USER_MENU_MODAL_QUERY_PARAM];
-    if (!router.isReady || !isUserMenuModal(modal)) {
+    if (!router.isReady || !isUserMenuModal(userMenuModal)) {
       return;
     }
 
-    switch (modal) {
+    switch (userMenuModal) {
       case "personal-usage":
         setAnalyticsOpen(true);
         break;
@@ -152,11 +152,11 @@ export function UserMenu({
         setAutomationsOpen(true);
         break;
       default:
-        assertNeverAndIgnore(modal);
+        assertNeverAndIgnore(userMenuModal);
     }
 
     void removeParamFromRouter(router, USER_MENU_MODAL_QUERY_PARAM);
-  }, [router, router.isReady, router.query[USER_MENU_MODAL_QUERY_PARAM]]);
+  }, [router, userMenuModal]);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -30,7 +30,12 @@ import {
   TRACKING_AREAS,
   trackEvent,
 } from "@app/lib/tracking";
+import {
+  isUserMenuModal,
+  USER_MENU_MODAL_QUERY_PARAM,
+} from "@app/lib/user_menu";
 import { getConversationRoute } from "@app/lib/utils/router";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
@@ -40,6 +45,7 @@ import {
 } from "@app/types/extension";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isOnlyAdmin, isOnlyManager, isOnlyUser } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
@@ -131,6 +137,26 @@ export function UserMenu({
     return () =>
       window.removeEventListener(OPEN_USER_ANALYTICS_EVENT, openAnalytics);
   }, []);
+
+  useEffect(() => {
+    const modal = router.query[USER_MENU_MODAL_QUERY_PARAM];
+    if (!router.isReady || !isUserMenuModal(modal)) {
+      return;
+    }
+
+    switch (modal) {
+      case "personal-usage":
+        setAnalyticsOpen(true);
+        break;
+      case "personal-automations":
+        setAutomationsOpen(true);
+        break;
+      default:
+        assertNeverAndIgnore(modal);
+    }
+
+    void removeParamFromRouter(router, USER_MENU_MODAL_QUERY_PARAM);
+  }, [router, router.isReady, router.query[USER_MENU_MODAL_QUERY_PARAM]]);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();

--- a/front/lib/user_menu.test.ts
+++ b/front/lib/user_menu.test.ts
@@ -1,0 +1,32 @@
+import {
+  getUserMenuModalRoute,
+  getUserMenuModalShareRoute,
+  isUserMenuModal,
+} from "@app/lib/user_menu";
+import { describe, expect, it } from "vitest";
+
+describe("user menu links", () => {
+  it.each([
+    ["personal-usage", "/w/workspace-id/conversation/new?modal=personal-usage"],
+    [
+      "personal-automations",
+      "/w/workspace-id/conversation/new?modal=personal-automations",
+    ],
+  ] as const)("builds the %s modal route", (modal, expectedRoute) => {
+    expect(getUserMenuModalRoute("workspace-id", modal)).toBe(expectedRoute);
+  });
+
+  it("only accepts supported modal values", () => {
+    expect(isUserMenuModal("personal-usage")).toBe(true);
+    expect(isUserMenuModal("personal-automations")).toBe(true);
+    expect(isUserMenuModal("apps")).toBe(false);
+    expect(isUserMenuModal(["personal-usage"])).toBe(false);
+  });
+
+  it.each([
+    ["personal-usage", "/?goto=personal-usage"],
+    ["personal-automations", "/?goto=personal-automations"],
+  ] as const)("builds the shareable %s route", (modal, expectedRoute) => {
+    expect(getUserMenuModalShareRoute(modal)).toBe(expectedRoute);
+  });
+});

--- a/front/lib/user_menu.ts
+++ b/front/lib/user_menu.ts
@@ -1,0 +1,29 @@
+import { getConversationRoute } from "@app/lib/utils/router";
+import { isString } from "@app/types/shared/utils/general";
+
+export const USER_MENU_MODAL_QUERY_PARAM = "modal";
+export const USER_MENU_GOTO_QUERY_PARAM = "goto";
+
+export type UserMenuModal = "personal-usage" | "personal-automations";
+
+export function isUserMenuModal(value: unknown): value is UserMenuModal {
+  return (
+    isString(value) &&
+    (value === "personal-usage" || value === "personal-automations")
+  );
+}
+
+export function getUserMenuModalRoute(
+  workspaceId: string,
+  modal: UserMenuModal
+): string {
+  return getConversationRoute(
+    workspaceId,
+    "new",
+    `${USER_MENU_MODAL_QUERY_PARAM}=${modal}`
+  );
+}
+
+export function getUserMenuModalShareRoute(modal: UserMenuModal): string {
+  return `/?${USER_MENU_GOTO_QUERY_PARAM}=${modal}`;
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds go to links so we can provide direct links to users to open their analytics or automations modal. A bit sad about this implementation as this whole modal used to be driven by router, but this is gone somehow.

The two new links are: `/?goto=personal-usage` and `/?goto=personal-automations`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
