### PR TITLE
[front] enh: show the model name in the input bar model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -2,11 +2,13 @@ import { InputBarContext } from "@app/components/assistant/conversation/input_ba
 import { ModelPickerHighlight } from "@app/components/assistant/conversation/input_bar/ModelPickerHighlight";
 import type { ModelPickerProps } from "@app/components/model_picker/ModelPicker";
 import { ModelPicker } from "@app/components/model_picker/ModelPicker";
+import { useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
 import { useContext } from "react";
 
 type InputBarModelPickerProps = Omit<
   ModelPickerProps,
   | "buttonVariant"
+  | "showDropdownArrow"
   | "showLabel"
   | "setStickyModelOverride"
   | "stickyModelOverride"
@@ -28,6 +30,10 @@ export function InputBarModelPicker({
   const { stickyModelOverride, setStickyModelOverride, openModelPickerRef } =
     useContext(InputBarContext);
 
+  // On mobile (and in the narrow extension) the input bar has no room for the
+  // model name, so the trigger stays icon-only with its tooltip.
+  const isWidthConstrained = useIsWidthConstrained();
+
   return (
     <ModelPickerHighlight>
       <ModelPicker
@@ -37,7 +43,8 @@ export function InputBarModelPicker({
         owner={owner}
         buttonVariant="ghost-secondary"
         buttonSize={buttonSize}
-        showLabel={false}
+        showLabel={!isWidthConstrained}
+        showDropdownArrow
         side={side}
         disabled={disabled}
         selectionRef={selectionRef}

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -19,6 +19,7 @@ import {
   getInitialEffort,
   getModelTier,
   getModelWithReasoningEffortLabel,
+  getReasoningEffortLabel,
   getTierLockReason,
   isPremiumModel,
   isSameSelection,
@@ -38,7 +39,12 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
+import {
+  Button,
+  Chip,
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
 import type { MutableRefObject } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -264,10 +270,20 @@ export function ModelPicker({
       ? MODEL_TIER_ICON[shown.display.tierId]
       : getModelMakerLogo(getModelMaker(shown.display.model), isDark);
 
-  const label =
+  // Model name and reasoning effort read as one string for the tooltip and the
+  // accessible name, but the visible trigger splits the effort into its own
+  // chip so it reads as a modifier rather than part of the model's name.
+  const label = getModelWithReasoningEffortLabel(shown.display);
+
+  const triggerLabel =
     shown.display.kind === "tier"
       ? getModelTier(shown.display.tierId).name
-      : getModelWithReasoningEffortLabel(shown.display);
+      : shown.display.model.displayName;
+
+  const effortLabel =
+    shown.display.kind === "model"
+      ? getReasoningEffortLabel(shown.display.effort)
+      : null;
 
   return (
     <DropdownMenu
@@ -286,9 +302,15 @@ export function ModelPicker({
           variant={buttonVariant}
           size={buttonSize}
           icon={buttonIcon}
-          label={showLabel ? label : undefined}
+          label={showLabel ? triggerLabel : undefined}
+          iconRight={
+            showLabel && effortLabel ? (
+              <Chip size="mini" label={effortLabel} />
+            ) : undefined
+          }
           isSelect={showLabel && showDropdownArrow}
           tooltip={showLabel ? undefined : `Model picker: ${label}`}
+          aria-label={`Model picker: ${label}`}
           disabled={disabled}
         />
       </DropdownMenuTrigger>

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -305,10 +305,6 @@ export function ModelPicker({
           label={showLabel ? triggerLabel : undefined}
           iconRight={
             showLabel && effortLabel ? (
-              // The chip's default `primary` background is stone-50, the same
-              // token as the input bar surface (`bg-muted-background`), so it
-              // reads as invisible there in light mode. One step up on the ramp
-              // separates it from the surface in both themes.
               <Chip
                 size="mini"
                 label={effortLabel}

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -305,7 +305,15 @@ export function ModelPicker({
           label={showLabel ? triggerLabel : undefined}
           iconRight={
             showLabel && effortLabel ? (
-              <Chip size="mini" label={effortLabel} />
+              // The chip's default `primary` background is stone-50, the same
+              // token as the input bar surface (`bg-muted-background`), so it
+              // reads as invisible there in light mode. One step up on the ramp
+              // separates it from the surface in both themes.
+              <Chip
+                size="mini"
+                label={effortLabel}
+                className="bg-primary-150"
+              />
             ) : undefined
           }
           isSelect={showLabel && showDropdownArrow}

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -50,6 +50,9 @@ export interface ModelPickerProps {
   buttonVariant: "outline" | "ghost-secondary";
   buttonSize: "xs" | "sm";
   showLabel: boolean;
+  // Appends the dropdown chevron to the trigger. Only meaningful alongside
+  // `showLabel`: icon-only triggers stay a single glyph.
+  showDropdownArrow?: boolean;
   // Which side the dropdown opens toward. Mirrors the agent picker: "top" in an
   // active conversation (input bar pinned to the bottom), "bottom" on the new
   // conversation screen where there is room below.
@@ -82,6 +85,7 @@ export function ModelPicker({
   buttonVariant,
   buttonSize,
   showLabel,
+  showDropdownArrow = false,
   side = "top",
   disabled,
   selectionRef,
@@ -283,6 +287,7 @@ export function ModelPicker({
           size={buttonSize}
           icon={buttonIcon}
           label={showLabel ? label : undefined}
+          isSelect={showLabel && showDropdownArrow}
           tooltip={showLabel ? undefined : `Model picker: ${label}`}
           disabled={disabled}
         />

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -137,13 +137,21 @@ export function getDefaultTierId(
   return standard && !standard.isSelectable ? "fast" : "standard";
 }
 
+// The reasoning effort on its own, for surfaces that show it apart from the
+// model name (e.g. the picker trigger's chip). `none` has no effort to show.
+export function getReasoningEffortLabel(
+  effort: ReasoningEffort
+): string | null {
+  return effort === "none" ? null : capitalize(effort);
+}
+
 export function formatModelEffortLabel(
   displayName: string,
   effort: ReasoningEffort
 ): string {
-  return effort === "none"
-    ? displayName
-    : `${displayName} ${capitalize(effort)}`;
+  const effortLabel = getReasoningEffortLabel(effort);
+
+  return effortLabel ? `${displayName} ${effortLabel}` : displayName;
 }
 
 export function getTierResolvedModelLabel(

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -137,8 +137,6 @@ export function getDefaultTierId(
   return standard && !standard.isSelectable ? "fast" : "standard";
 }
 
-// The reasoning effort on its own, for surfaces that show it apart from the
-// model name (e.g. the picker trigger's chip). `none` has no effort to show.
 export function getReasoningEffortLabel(
   effort: ReasoningEffort
 ): string | null {


### PR DESCRIPTION
## Description

<img width="857" height="251" alt="Screenshot 2026-09-01 at 10 14 25" src="https://github.com/user-attachments/assets/781cf2fa-264b-404b-8253-6f22884ba92d" />
<img width="896" height="259" alt="Screenshot 2026-09-01 at 10 15 08" src="https://github.com/user-attachments/assets/c26240b8-05f9-4eb0-b72a-6bf1f91b4d41" />



The input bar's model picker trigger was icon-only, with the model name hidden behind a tooltip. It now shows the label next to the maker logo, followed by a dropdown chevron, so the active model is readable at a glance

## Tests

Local tests

## Risk

Low

## Deploy Plan

Standard deploy, no ordering constraints — front-end only, no schema or API changes.