### PR TITLE
[front] Fix workspace deletion after agent identity migration

### DIFF
--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -1,10 +1,14 @@
 import { Authenticator } from "@app/lib/auth";
+import { AgentModel } from "@app/lib/models/agent/agent";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { deleteSpacesActivity } from "@app/poke/temporal/activities";
+import {
+  deleteAgentsActivity,
+  deleteSpacesActivity,
+} from "@app/poke/temporal/activities";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -26,6 +30,22 @@ vi.mock("@app/lib/api/data_sources", async (importOriginal) => {
       }
     ),
   };
+});
+
+describe("deleteAgentsActivity", () => {
+  it("deletes stable agent identities left by a partial previous run", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    await AgentModel.create({
+      sId: "agent-test",
+      workspaceId: workspace.id,
+    });
+
+    await deleteAgentsActivity({ workspaceId: workspace.sId });
+
+    await expect(
+      AgentModel.count({ where: { workspaceId: workspace.id } })
+    ).resolves.toBe(0);
+  });
 });
 
 describe("deleteSpacesActivity", () => {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -18,6 +18,7 @@ import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfigurationModel,
+  AgentModel,
   AgentUserRelationModel,
   GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
@@ -457,6 +458,10 @@ export async function deleteAgentsActivity({
     hardDeleteLogger.info({ agentId: agent.sId }, "Deleting agent");
     await agent.destroy();
   }
+
+  await AgentModel.destroy({
+    where: { workspaceId: workspace.id },
+  });
 }
 
 export async function deleteAppsActivity({


### PR DESCRIPTION
## Description

Delete stable `AgentModel` rows at the end of `deleteAgentsActivity`, after all agent configurations are removed. This unblocks workspace hard deletion when `agents_workspaceId_fkey` still references the workspace and makes retries converge after a partial previous run.

## Tests

- `npm run test -- poke/temporal/activities.test.ts`
- `npx tsgo --noEmit`
- `npx biome check front/poke/temporal/activities.ts front/poke/temporal/activities.test.ts`

## Risk

Low. The change affects only the Poke workspace hard-deletion activity. It deletes identity rows only after their configuration rows have been deleted. Re-running the activity is safe when no identity rows remain.

## Deploy Plan

Deploy Front workers normally. Monitor or retry the affected workspace deletion workflow after the new activity code is live.