### PR TITLE
[core] Fix data source deletion with orphaned relational rows

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -2135,9 +2135,10 @@ impl DataSource {
         );
 
         // Delete tables (concurrently).
-        let (tables, total) = store
-            .list_data_source_tables(&self.project, &self.data_source_id, &None, &None, None)
+        let tables = store
+            .list_data_source_table_deletion_candidates(&self.project, &self.data_source_id)
             .await?;
+        let total = tables.len();
 
         info!(
             data_source_internal_id = self.internal_id(),
@@ -2146,12 +2147,10 @@ impl DataSource {
         );
 
         // Process tables deletion with bounded concurrency to avoid monopolizing the SQL pool.
-        stream::iter(tables.into_iter().map(|t| {
+        stream::iter(tables.into_iter().map(|table| {
             let store = store.clone();
             let databases_store = databases_store.clone();
-            // not deleting from search index here, as it's done more efficiently in the
-            // full-nodes deletion below
-            async move { t.delete(store, databases_store, None).await }
+            async move { table.delete(store, databases_store).await }
         }))
         .buffer_unordered(16)
         .try_collect::<Vec<_>>()
@@ -2164,15 +2163,16 @@ impl DataSource {
         );
 
         // Delete folders with bounded concurrency.
-        let (folders, total) = store
-            .list_data_source_folders(&self.project, &self.data_source_id, &None, &None, None)
+        let folder_ids = store
+            .list_data_source_folder_ids_for_deletion(&self.project, &self.data_source_id)
             .await?;
+        let total = folder_ids.len();
 
-        stream::iter(folders.into_iter().map(|f| {
+        stream::iter(folder_ids.into_iter().map(|folder_id| {
             let store = store.clone();
             async move {
                 store
-                    .delete_data_source_folder(&self.project, &self.data_source_id, &f.folder_id())
+                    .delete_data_source_folder(&self.project, &self.data_source_id, &folder_id)
                     .await
             }
         }))

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -56,6 +56,81 @@ pub fn get_table_unique_id(project: &Project, data_source_id: &str, table_id: &s
     format!("{}__{}__{}", project.project_id(), data_source_id, table_id)
 }
 
+#[derive(Clone)]
+pub struct TableDeletionCandidate {
+    project: Project,
+    data_source_id: String,
+    table_id: String,
+    remote_database_table_id: Option<String>,
+}
+
+impl TableDeletionCandidate {
+    pub fn new(
+        project: Project,
+        data_source_id: String,
+        table_id: String,
+        remote_database_table_id: Option<String>,
+    ) -> Self {
+        Self {
+            project,
+            data_source_id,
+            table_id,
+            remote_database_table_id,
+        }
+    }
+
+    pub fn table_id(&self) -> &str {
+        &self.table_id
+    }
+
+    pub async fn delete(
+        &self,
+        store: Box<dyn Store + Sync + Send>,
+        databases_store: Box<dyn DatabasesStore + Sync + Send>,
+    ) -> Result<()> {
+        if self.remote_database_table_id.is_none() {
+            try_join_all(
+                (store
+                    .find_databases_using_table(
+                        &self.project,
+                        &self.data_source_id,
+                        &self.table_id,
+                        HEARTBEAT_INTERVAL_MS,
+                    )
+                    .await?)
+                    .into_iter()
+                    .map(|db| {
+                        let store = store.clone();
+                        async move {
+                            db.invalidate(store).await?;
+                            Ok::<_, anyhow::Error>(())
+                        }
+                    }),
+            )
+            .await?;
+
+            databases_store
+                .delete_table_data(&self.project, &self.data_source_id, &self.table_id)
+                .await?;
+        }
+
+        store
+            .delete_data_source_table(&self.project, &self.data_source_id, &self.table_id)
+            .await
+    }
+}
+
+impl From<&Table> for TableDeletionCandidate {
+    fn from(table: &Table) -> Self {
+        Self::new(
+            table.project.clone(),
+            table.data_source_id.clone(),
+            table.table_id.clone(),
+            table.remote_database_table_id.clone(),
+        )
+    }
+}
+
 // Ensures tables are compatible with each other. Tables must be either:
 // - all local
 // - all remote for the same remote database (i.e, same secret_id)
@@ -266,34 +341,8 @@ impl Table {
             "DSSTRUCTSTAT [delete] Deleting table"
         );
         let now = utils::now();
-        if self.remote_database_table_id().is_none() {
-            // Invalidate the databases that use the table.
-            try_join_all(
-                (store
-                    .find_databases_using_table(
-                        &self.project,
-                        &self.data_source_id,
-                        &self.table_id,
-                        HEARTBEAT_INTERVAL_MS,
-                    )
-                    .await?)
-                    .into_iter()
-                    .map(|db| {
-                        let store = store.clone();
-                        async move {
-                            db.invalidate(store).await?;
-                            Ok::<_, anyhow::Error>(())
-                        }
-                    }),
-            )
-            .await?;
-
-            // Delete the table rows.
-            databases_store.delete_table_data(&self).await?;
-        }
-
-        store
-            .delete_data_source_table(&self.project, &self.data_source_id, &self.table_id)
+        TableDeletionCandidate::from(self)
+            .delete(store, databases_store)
             .await?;
 
         // Delete the table node from the search index.

--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -69,11 +69,23 @@ impl GoogleCloudStorageDatabasesStore {
     }
 
     pub fn get_csv_storage_file_path(table: &Table) -> String {
+        Self::get_csv_storage_file_path_from_ids(
+            table.project(),
+            table.data_source_id(),
+            table.table_id(),
+        )
+    }
+
+    fn get_csv_storage_file_path_from_ids(
+        project: &crate::project::Project,
+        data_source_id: &str,
+        table_id: &str,
+    ) -> String {
         format!(
             "project-{}/{}/{}.csv",
-            table.project().project_id(),
-            table.data_source_id(),
-            table.table_id()
+            project.project_id(),
+            data_source_id,
+            table_id
         )
     }
 
@@ -235,10 +247,15 @@ impl DatabasesStore for GoogleCloudStorageDatabasesStore {
         Ok(())
     }
 
-    async fn delete_table_data(&self, table: &Table) -> Result<()> {
+    async fn delete_table_data(
+        &self,
+        project: &crate::project::Project,
+        data_source_id: &str,
+        table_id: &str,
+    ) -> Result<()> {
         match Object::delete(
             &Self::get_bucket()?,
-            &Self::get_csv_storage_file_path(table),
+            &Self::get_csv_storage_file_path_from_ids(project, data_source_id, table_id),
         )
         .await
         {

--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::databases::table::{Row, Table};
 use crate::databases::table_schema::TableSchema;
+use crate::{
+    databases::table::{Row, Table},
+    project::Project,
+};
 
 #[async_trait]
 pub trait DatabasesStore {
@@ -19,7 +22,12 @@ pub trait DatabasesStore {
         rows: &Vec<Row>,
         truncate: bool,
     ) -> Result<()>;
-    async fn delete_table_data(&self, table: &Table) -> Result<()>;
+    async fn delete_table_data(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        table_id: &str,
+    ) -> Result<()>;
     async fn delete_table_row(&self, table: &Table, row_id: &str) -> Result<()>;
 
     fn clone_box(&self) -> Box<dyn DatabasesStore + Sync + Send>;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -23,7 +23,7 @@ use crate::{
     data_sources::data_source::{DataSource, DataSourceConfig, Document, DocumentVersion},
     data_sources::folder::Folder,
     databases::{
-        table::{get_table_unique_id, Table},
+        table::{get_table_unique_id, Table, TableDeletionCandidate},
         table_schema::TableSchema,
         transient_database::TransientDatabase,
     },
@@ -3172,6 +3172,38 @@ impl Store for PostgresStore {
         Ok((tables, total))
     }
 
+    async fn list_data_source_table_deletion_candidates(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+    ) -> Result<Vec<TableDeletionCandidate>> {
+        let project_id = project.project_id();
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        let rows = c
+            .query(
+                "SELECT t.table_id, t.remote_database_table_id \
+                   FROM tables t \
+                   INNER JOIN data_sources ds ON ds.id = t.data_source \
+                   WHERE ds.project = $1 AND ds.data_source_id = $2",
+                &[&project_id, &data_source_id],
+            )
+            .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                TableDeletionCandidate::new(
+                    project.clone(),
+                    data_source_id.to_string(),
+                    row.get(0),
+                    row.get(1),
+                )
+            })
+            .collect())
+    }
+
     async fn delete_data_source_table(
         &self,
         project: &Project,
@@ -3469,6 +3501,28 @@ impl Store for PostgresStore {
             })
             .collect::<Result<Vec<_>>>()?;
         Ok((folders, total))
+    }
+
+    async fn list_data_source_folder_ids_for_deletion(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+    ) -> Result<Vec<String>> {
+        let project_id = project.project_id();
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        let rows = c
+            .query(
+                "SELECT dsf.folder_id \
+                   FROM data_sources_folders dsf \
+                   INNER JOIN data_sources ds ON ds.id = dsf.data_source \
+                   WHERE ds.project = $1 AND ds.data_source_id = $2",
+                &[&project_id, &data_source_id],
+            )
+            .await?;
+
+        Ok(rows.into_iter().map(|row| row.get(0)).collect())
     }
 
     async fn delete_data_source_folder(
@@ -4135,5 +4189,205 @@ impl Store for PostgresStore {
 
     fn clone_box(&self) -> Box<dyn Store + Sync + Send> {
         Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+
+    use crate::{databases::table::Row, databases_store::store::DatabasesStore};
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct RecordingDatabasesStore {
+        deleted_tables: Arc<Mutex<Vec<(i64, String, String)>>>,
+    }
+
+    #[async_trait]
+    impl DatabasesStore for RecordingDatabasesStore {
+        async fn load_table_row(&self, _: &Table, _: &str) -> Result<Option<Row>> {
+            Err(anyhow!("Unexpected load_table_row call"))
+        }
+
+        async fn list_table_rows(
+            &self,
+            _: &Table,
+            _: Option<(usize, usize)>,
+        ) -> Result<(Vec<Row>, usize)> {
+            Err(anyhow!("Unexpected list_table_rows call"))
+        }
+
+        async fn batch_upsert_table_rows(
+            &self,
+            _: &Table,
+            _: &TableSchema,
+            _: &Vec<Row>,
+            _: bool,
+        ) -> Result<()> {
+            Err(anyhow!("Unexpected batch_upsert_table_rows call"))
+        }
+
+        async fn delete_table_data(
+            &self,
+            project: &Project,
+            data_source_id: &str,
+            table_id: &str,
+        ) -> Result<()> {
+            self.deleted_tables
+                .lock()
+                .map_err(|e| anyhow!(e.to_string()))?
+                .push((
+                    project.project_id(),
+                    data_source_id.to_string(),
+                    table_id.to_string(),
+                ));
+            Ok(())
+        }
+
+        async fn delete_table_row(&self, _: &Table, _: &str) -> Result<()> {
+            Err(anyhow!("Unexpected delete_table_row call"))
+        }
+
+        fn clone_box(&self) -> Box<dyn DatabasesStore + Sync + Send> {
+            Box::new(self.clone())
+        }
+    }
+
+    async fn data_source_deletion_test_store() -> Result<PostgresStore> {
+        let database_uri = std::env::var("OAUTH_DATABASE_URI")?;
+        let manager = PostgresConnectionManager::new_from_stringlike(database_uri, NoTls)?;
+        let pool = Pool::builder().max_size(1).build(manager).await?;
+        let store = PostgresStore { pool };
+
+        let connection = store.pool.get().await?;
+        connection
+            .batch_execute(
+                "CREATE TEMP TABLE data_sources (
+                    id BIGINT PRIMARY KEY,
+                    project BIGINT NOT NULL,
+                    data_source_id TEXT NOT NULL
+                );
+                CREATE TEMP TABLE databases (
+                    table_ids_hash TEXT NOT NULL
+                );
+                CREATE TEMP TABLE data_sources_documents (
+                    id BIGINT PRIMARY KEY,
+                    data_source BIGINT NOT NULL REFERENCES data_sources(id)
+                );
+                CREATE TEMP TABLE tables (
+                    id BIGINT PRIMARY KEY,
+                    data_source BIGINT NOT NULL REFERENCES data_sources(id),
+                    table_id TEXT NOT NULL,
+                    remote_database_table_id TEXT
+                );
+                CREATE TEMP TABLE data_sources_folders (
+                    id BIGINT PRIMARY KEY,
+                    data_source BIGINT NOT NULL REFERENCES data_sources(id),
+                    folder_id TEXT NOT NULL
+                );
+                CREATE TEMP TABLE data_sources_nodes (
+                    id BIGINT PRIMARY KEY,
+                    data_source BIGINT NOT NULL REFERENCES data_sources(id),
+                    node_id TEXT NOT NULL,
+                    document BIGINT REFERENCES data_sources_documents(id),
+                    \"table\" BIGINT REFERENCES tables(id),
+                    folder BIGINT REFERENCES data_sources_folders(id)
+                );
+                INSERT INTO data_sources (id, project, data_source_id)
+                VALUES (1, 42, 'data-source');",
+            )
+            .await?;
+        drop(connection);
+
+        Ok(store)
+    }
+
+    #[tokio::test]
+    async fn deletion_candidates_include_table_without_node() -> Result<()> {
+        let store = data_source_deletion_test_store().await?;
+        let databases_store = RecordingDatabasesStore::default();
+        let connection = store.pool.get().await?;
+        connection
+            .execute(
+                "INSERT INTO tables (id, data_source, table_id) VALUES (2, 1, 'orphaned-table')",
+                &[],
+            )
+            .await?;
+        drop(connection);
+
+        let candidates = store
+            .list_data_source_table_deletion_candidates(&Project::new_from_id(42), "data-source")
+            .await?;
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].table_id(), "orphaned-table");
+
+        candidates[0]
+            .delete(Box::new(store.clone()), Box::new(databases_store.clone()))
+            .await?;
+        store
+            .delete_data_source(&Project::new_from_id(42), "data-source")
+            .await?;
+
+        let connection = store.pool.get().await?;
+        let row = connection
+            .query_one(
+                "SELECT (SELECT COUNT(*) FROM data_sources), (SELECT COUNT(*) FROM tables)",
+                &[],
+            )
+            .await?;
+        assert_eq!(row.get::<usize, i64>(0), 0);
+        assert_eq!(row.get::<usize, i64>(1), 0);
+        assert_eq!(
+            *databases_store
+                .deleted_tables
+                .lock()
+                .map_err(|e| anyhow!(e.to_string()))?,
+            vec![(42, "data-source".to_string(), "orphaned-table".to_string())]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deletion_candidates_include_folder_without_node() -> Result<()> {
+        let store = data_source_deletion_test_store().await?;
+        let connection = store.pool.get().await?;
+        connection
+            .execute(
+                "INSERT INTO data_sources_folders (id, data_source, folder_id)
+                 VALUES (2, 1, 'orphaned-folder')",
+                &[],
+            )
+            .await?;
+        drop(connection);
+
+        let folder_ids = store
+            .list_data_source_folder_ids_for_deletion(&Project::new_from_id(42), "data-source")
+            .await?;
+        assert_eq!(folder_ids, vec!["orphaned-folder".to_string()]);
+
+        store
+            .delete_data_source_folder(&Project::new_from_id(42), "data-source", &folder_ids[0])
+            .await?;
+        store
+            .delete_data_source(&Project::new_from_id(42), "data-source")
+            .await?;
+
+        let connection = store.pool.get().await?;
+        let row = connection
+            .query_one(
+                "SELECT (SELECT COUNT(*) FROM data_sources),
+                        (SELECT COUNT(*) FROM data_sources_folders)",
+                &[],
+            )
+            .await?;
+        assert_eq!(row.get::<usize, i64>(0), 0);
+        assert_eq!(row.get::<usize, i64>(1), 0);
+
+        Ok(())
     }
 }

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -14,7 +14,11 @@ use crate::{
         folder::Folder,
         node::{Node, ProviderVisibility},
     },
-    databases::{table::Table, table_schema::TableSchema, transient_database::TransientDatabase},
+    databases::{
+        table::{Table, TableDeletionCandidate},
+        table_schema::TableSchema,
+        transient_database::TransientDatabase,
+    },
     dataset::Dataset,
     http::request::{HttpRequest, HttpResponse},
     project::Project,
@@ -310,6 +314,11 @@ pub trait Store {
         table_ids: &Option<Vec<String>>,
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<Table>, usize)>;
+    async fn list_data_source_table_deletion_candidates(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+    ) -> Result<Vec<TableDeletionCandidate>>;
     async fn delete_data_source_table(
         &self,
         project: &Project,
@@ -338,6 +347,11 @@ pub trait Store {
         folder_ids: &Option<Vec<String>>,
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<Folder>, usize)>;
+    async fn list_data_source_folder_ids_for_deletion(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+    ) -> Result<Vec<String>>;
     async fn delete_data_source_folder(
         &self,
         project: &Project,


### PR DESCRIPTION
## Description

`DataSource::delete` listed tables and folders through `data_sources_nodes`. A table or folder row without its node was skipped, so the final `data_sources` delete failed on `tables_data_source_fkey` or `data_sources_folders_data_source_fkey`.

Add deletion-specific relational candidate queries that read `tables` and `data_sources_folders` directly. Table candidates still use the existing table lifecycle, including transient database invalidation and GCS cleanup for local tables. Folder candidates use the existing transactional folder deletion. Normal table and folder listing behavior is unchanged.

Add PostgreSQL regression tests for both missing-node cases.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --all`

## Risk

Low. The new queries are used only during full data source deletion. Existing table and folder deletion paths still own cleanup, and retries remain idempotent after partial deletion.

## Deploy Plan

Deploy Core normally. After deployment, retry `poke-jaeLj27yy8-scrub-data-source-dts_NuzxXDRsVegj` and `poke-jaeLj27yy8-scrub-data-source-dts_j9wupsiOuhbpj`.