### PR TITLE
feat: return spaces of api keys instead of groups

### DIFF
--- a/front-api/routes/w/[wId]/keys/[id]/disable.ts
+++ b/front-api/routes/w/[wId]/keys/[id]/disable.ts
@@ -61,10 +61,7 @@ app.post(
     });
 
     return ctx.json({
-      key: {
-        ...key.toJSON(user.id),
-        status: "disabled",
-      },
+      key: await key.toJSONWithSpaces(auth, user.id),
     });
   }
 );

--- a/front-api/routes/w/[wId]/keys/[id]/index.ts
+++ b/front-api/routes/w/[wId]/keys/[id]/index.ts
@@ -163,7 +163,9 @@ app.patch(
         workspace: owner,
         id,
       });
-      return ctx.json({ key: (updated ?? key).toJSON(user.id) });
+      return ctx.json({
+        key: await (updated ?? key).toJSONWithSpaces(auth, user.id),
+      });
     }
 
     // Legacy USD monthly cap.
@@ -216,7 +218,7 @@ app.patch(
     });
 
     return ctx.json({
-      key: key.toJSON(user.id),
+      key: await key.toJSONWithSpaces(auth, user.id),
     });
   }
 );

--- a/front-api/routes/w/[wId]/keys/index.test.ts
+++ b/front-api/routes/w/[wId]/keys/index.test.ts
@@ -3,7 +3,9 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { KeyType } from "@app/types/key";
 import { redactString } from "@app/types/shared/utils/string_utils";
+import type { SpaceType } from "@app/types/space";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -198,6 +200,45 @@ describe("POST /api/w/:wId/keys — space scoping", () => {
     expect(key.groupIds.toSorted()).toEqual(
       [globalGroup.id, ...podGroups.map((group) => group.id)].toSorted()
     );
+  });
+
+  it("returns the scoped space when the key is created and when it is listed", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    const res = await createKey(workspace, {
+      name: "space-echo-key",
+      space_ids: [space.sId],
+    });
+    expect(res.status).toBe(201);
+
+    const { key } = await res.json();
+    expect(key.spaces.map((s: SpaceType) => s.sId)).toEqual([space.sId]);
+
+    const listRes = await honoApp.request(`/api/w/${workspace.sId}/keys`);
+    expect(listRes.status).toBe(200);
+
+    const { keys } = await listRes.json();
+    const listed = keys.find((k: KeyType) => k.name === "space-echo-key");
+    expect(listed.spaces.map((s: SpaceType) => s.sId)).toEqual([space.sId]);
+  });
+
+  it("returns a scoped pod once even though the key holds both of its groups", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const pod = await SpaceFactory.project(workspace);
+
+    // An admin key carries the pod's member *and* editor group, each with its own grant on the pod.
+    const res = await createKey(workspace, {
+      name: "pod-echo-key",
+      space_ids: [pod.sId],
+      role: "admin",
+    });
+    expect(res.status).toBe(201);
+
+    const { key } = await res.json();
+    expect(key.spaces.map((s: SpaceType) => s.sId)).toEqual([pod.sId]);
   });
 
   it("rejects scoping to an open space", async () => {

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -40,7 +40,7 @@ app.get(
     const keys = await KeyResource.listNonSystemKeysByWorkspace(owner);
 
     return ctx.json({
-      keys: keys.map((k) => k.toJSON(user.id)),
+      keys: await KeyResource.toJSONWithSpaces(auth, keys, user.id),
     });
   }
 );
@@ -105,7 +105,7 @@ app.post(
 
     return ctx.json(
       {
-        key: keyRes.value.toJSON(user.id),
+        key: await keyRes.value.toJSONWithSpaces(auth, user.id),
       },
       201
     );

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -15,13 +15,10 @@ import { formatCredits } from "@app/lib/client/credits";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { useKeys } from "@app/lib/swr/apps";
-import { useKeyScopableGroups } from "@app/lib/swr/groups";
 import { useKeyScopableSpaces } from "@app/lib/swr/spaces";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
-import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 import { isCreditPricedPlan } from "@app/types/plan";
-import type { ModelId } from "@app/types/shared/model_id";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { BookOpen01, Button, LoadingBlock, Page } from "@dust-tt/sparkle";
@@ -125,21 +122,9 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
   const [editCapKey, setEditCapKey] = useState<KeyType | null>(null);
 
   const { isKeysError, isKeysLoading, keys } = useKeys(owner);
-  const { groups, isGroupsError, isGroupsLoading } = useKeyScopableGroups({
-    owner,
-  });
   const { spaces, isSpacesError, isSpacesLoading } = useKeyScopableSpaces({
     owner,
   });
-  const isDataLoading = isKeysLoading || isGroupsLoading;
-  const isDataError = !!isKeysError || isGroupsError;
-
-  const groupsById = useMemo(() => {
-    return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
-      acc[group.id] = group;
-      return acc;
-    }, {});
-  }, [groups]);
 
   const sendNotification = useSendNotification();
 
@@ -313,9 +298,8 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
           keys={keys}
           workspaceId={owner.sId}
           period={period}
-          groupsById={groupsById}
-          isLoading={isDataLoading}
-          isError={isDataError}
+          isLoading={isKeysLoading}
+          isError={!!isKeysError}
           showAnalyticsConsumption
           isRevoking={isRevoking}
           isGenerating={isGenerating}

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -4,9 +4,7 @@ import { formatCredits } from "@app/lib/client/credits";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
-import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
-import type { ModelId } from "@app/types/shared/model_id";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { RoleType, WorkspaceType } from "@app/types/user";
@@ -43,7 +41,6 @@ import type {
 import capitalize from "lodash/capitalize";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
-import { prettifyGroupName } from "./utils";
 
 const API_KEYS_PAGE_SIZE = 10;
 const MAX_API_KEY_CONSUMPTION_ROWS = 100;
@@ -54,7 +51,6 @@ interface APIKeysTableProps {
   keys: KeyType[];
   workspaceId: WorkspaceType["sId"];
   period: ConsumptionPeriodSelection;
-  groupsById: Record<ModelId, GroupType>;
   isLoading: boolean;
   isError: boolean;
   showAnalyticsConsumption: boolean;
@@ -80,15 +76,6 @@ interface APIKeyRowData {
   lastUsedAt: number | null;
   menuItems: MenuItem[];
 }
-
-const getKeyGroups = (
-  key: KeyType,
-  groupsById: Record<ModelId, GroupType>
-): GroupType[] => {
-  return key.groupIds
-    .map((groupId) => groupsById[groupId])
-    .filter((group): group is GroupType => group !== undefined);
-};
 
 const formatKeyScope = (role: RoleType): string => {
   switch (role) {
@@ -453,7 +440,6 @@ export function APIKeysTable({
   keys,
   workspaceId,
   period,
-  groupsById,
   isLoading,
   isError,
   showAnalyticsConsumption,
@@ -480,12 +466,12 @@ export function APIKeysTable({
   const { spaces: workspaceSpaces, isSpacesLoading } = useSpacesAsAdmin({
     workspaceId,
   });
-  const privateSpaceGroupIds = useMemo(
+  const restrictedSpaceIds = useMemo(
     () =>
       new Set(
         workspaceSpaces
           .filter((space) => space.isRestricted)
-          .flatMap((space) => space.groupIds)
+          .map((space) => space.sId)
       ),
     [workspaceSpaces]
   );
@@ -521,8 +507,7 @@ export function APIKeysTable({
   const rows = useMemo<APIKeyRowData[]>(
     () =>
       keys.map((key) => {
-        const keyGroups = getKeyGroups(key, groupsById);
-        const spaces = keyGroups.map((group) => prettifyGroupName(group));
+        const spaces = key.spaces.map((space) => space.name);
         const scope = formatKeyScope(key.role);
         const status = getKeyStatus(key);
         const creator = key.creator ?? "Unknown creator";
@@ -549,8 +534,8 @@ export function APIKeysTable({
           name: key.name || "Unnamed",
           creator,
           spaces,
-          hasPrivateSpace: keyGroups.some((group) =>
-            privateSpaceGroupIds.has(group.sId)
+          hasPrivateSpace: key.spaces.some((space) =>
+            restrictedSpaceIds.has(space.sId)
           ),
           scope,
           secret: key.secret,
@@ -568,11 +553,10 @@ export function APIKeysTable({
     [
       consumptionByName,
       consumptionError,
-      groupsById,
       hasMoreConsumptionRows,
       keys,
       onEditCap,
-      privateSpaceGroupIds,
+      restrictedSpaceIds,
       showAnalyticsConsumption,
       showCreditMonthlyCap,
       showLegacyUsdMonthlyCap,

--- a/front/components/workspace/api-keys/utils.ts
+++ b/front/components/workspace/api-keys/utils.ts
@@ -1,9 +1,3 @@
-import type { GroupType } from "@app/types/groups";
-import {
-  AGENT_GROUP_PREFIX,
-  GLOBAL_SPACE_NAME,
-  SPACE_GROUP_PREFIX,
-} from "@app/types/groups";
 import { z } from "zod";
 
 export const KEY_ROLES = ["user", "admin"] as const;
@@ -73,15 +67,3 @@ export function creditsToString(credits: number | null): string {
 export function parseCreditsString(value: string): number | null {
   return value === "" ? null : parseInt(value, 10);
 }
-
-export const prettifyGroupName = (group: GroupType) => {
-  if (group.kind === "global") {
-    return GLOBAL_SPACE_NAME;
-  }
-
-  if (group.kind === "agent_editors") {
-    return group.name.replace(AGENT_GROUP_PREFIX, "");
-  }
-
-  return group.name.replace(SPACE_GROUP_PREFIX, "");
-};

--- a/front/lib/resources/key_resource.test.ts
+++ b/front/lib/resources/key_resource.test.ts
@@ -83,9 +83,11 @@ import {
   KeyResource,
   MARK_AS_USED_MIN_INTERVAL_MS,
 } from "@app/lib/resources/key_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { LightWorkspaceType } from "@app/types/user";
 
 function toCacheKey(secret: string): string {
@@ -230,6 +232,65 @@ describe("KeyResource", () => {
       const fetched = await KeyResource.fetchBySecret(key.secret);
       expect(fetched).not.toBeNull();
       expect(fetched!.monthlyCapMicroUsd).toBe(500_000);
+    });
+  });
+
+  describe("toJSONWithSpaces", () => {
+    it("returns the spaces the key's groups grant access to", async () => {
+      const space = await SpaceFactory.regular(
+        authenticator.getNonNullableWorkspace()
+      );
+      const spaceGroups = await SpaceResource.listRegularAutoGroupsForSpaces(
+        authenticator,
+        [space]
+      );
+      const key = await KeyFactory.regular([globalGroup, ...spaceGroups]);
+
+      const [json] = await KeyResource.toJSONWithSpaces(
+        authenticator,
+        [key],
+        authenticator.getNonNullableUser().id
+      );
+
+      expect(json.spaces.map((s) => s.sId)).toEqual([space.sId]);
+    });
+
+    it("lists a space once when several of the key's groups grant on it", async () => {
+      // A pod has both a member and an editor group, each with its own grant on the space, so an
+      // admin key scoped to it carries two groups pointing at the same space.
+      const pod = await SpaceFactory.project(
+        authenticator.getNonNullableWorkspace()
+      );
+      const podGroups = await SpaceResource.listRegularAutoGroupsForSpaces(
+        authenticator,
+        [pod]
+      );
+      expect(podGroups).toHaveLength(2);
+
+      const key = await KeyFactory.regular([globalGroup, ...podGroups]);
+
+      const [json] = await KeyResource.toJSONWithSpaces(
+        authenticator,
+        [key],
+        authenticator.getNonNullableUser().id
+      );
+
+      expect(json.spaces.map((s) => s.sId)).toEqual([pod.sId]);
+    });
+
+    it("ignores the workspace global group", async () => {
+      // Every key carries the global group, which reads every open space: mapping it would list
+      // most of the workspace on every key.
+      await SpaceFactory.regular(authenticator.getNonNullableWorkspace());
+      const key = await KeyFactory.regular(globalGroup);
+
+      const [json] = await KeyResource.toJSONWithSpaces(
+        authenticator,
+        [key],
+        authenticator.getNonNullableUser().id
+      );
+
+      expect(json.spaces).toEqual([]);
     });
   });
 

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -3,7 +3,9 @@
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -20,6 +22,7 @@ import type { ApiKeyCreditState, KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { redactString } from "@app/types/shared/utils/string_utils";
+import type { SpaceType } from "@app/types/space";
 import type {
   AssignableRoleType,
   LightWorkspaceType,
@@ -351,7 +354,7 @@ export class KeyResource extends BaseResource<KeyModel> {
     );
   }
 
-  toJSON(requestingUserModelId: ModelId): KeyType {
+  private toJSON(requestingUserModelId: ModelId, spaces: SpaceType[]): KeyType {
     // We only display the full secret key to the admin who created it, and only
     // for the first 10 minutes after creation. Every other admin (or the
     // creator past the window) sees a redacted value.
@@ -376,11 +379,111 @@ export class KeyResource extends BaseResource<KeyModel> {
       secret,
       status: this.status,
       groupIds: this.groupIds,
+      spaces,
       role: this.role,
       monthlyCapMicroUsd: this.monthlyCapMicroUsd,
       monthlyCapAwuCredits: this.monthlyCapAwuCredits,
       creditState: this.creditState,
     };
+  }
+
+  /**
+   * The spaces each of `keys` can reach, keyed by key model id.
+   *
+   * A key stores the groups it was scoped to, never spaces, so the spaces are reverse-mapped from
+   * those groups through their `space` grants in `group_permissions`. The workspace global group is
+   * ignored: every key carries it and it holds `reader` on every open space, so mapping it would
+   * list most of the workspace on every row.
+   *
+   * Display-only: it never feeds back into authorization.
+   */
+  private static async listSpacesByKeyModelId(
+    auth: Authenticator,
+    keys: KeyResource[]
+  ): Promise<Map<ModelId, SpaceType[]>> {
+    if (keys.length === 0) {
+      return new Map();
+    }
+
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    const globalGroupModelId = globalGroupRes.isOk()
+      ? globalGroupRes.value.id
+      : null;
+
+    const groupModelIds = [
+      ...new Set(keys.flatMap((key) => key.groupIds)),
+    ].filter((groupModelId) => groupModelId !== globalGroupModelId);
+    if (groupModelIds.length === 0) {
+      return new Map();
+    }
+
+    const grants = await GroupPermissionResource.listForGroups(
+      auth.getNonNullableWorkspace(),
+      { groupModelIds, resourceType: "space" }
+    );
+
+    const spaces = await SpaceResource.fetchByModelIds(auth, [
+      ...new Set(grants.map((grant) => grant.resourceId)),
+    ]);
+    const spaceByModelId = new Map(
+      spaces.map((space) => [space.id, space.toJSON()])
+    );
+
+    const spacesByGroupModelId = new Map<ModelId, SpaceType[]>();
+    for (const grant of grants) {
+      // A grant on a space we could not resolve (deleted, say) has nothing to display.
+      const space = spaceByModelId.get(grant.resourceId);
+      if (!space) {
+        continue;
+      }
+
+      const existing = spacesByGroupModelId.get(grant.groupId);
+      if (existing) {
+        existing.push(space);
+      } else {
+        spacesByGroupModelId.set(grant.groupId, [space]);
+      }
+    }
+
+    return new Map(
+      keys.map((key) => {
+        const spaces = new Set(
+          key.groupIds.flatMap(
+            (groupModelId) => spacesByGroupModelId.get(groupModelId) ?? []
+          )
+        );
+
+        return [
+          key.id,
+          [...spaces].sort((a, b) => a.name.localeCompare(b.name)),
+        ];
+      })
+    );
+  }
+
+  static async toJSONWithSpaces(
+    auth: Authenticator,
+    keys: KeyResource[],
+    requestingUserModelId: ModelId
+  ): Promise<KeyType[]> {
+    const spacesByKeyModelId = await this.listSpacesByKeyModelId(auth, keys);
+
+    return keys.map((key) =>
+      key.toJSON(requestingUserModelId, spacesByKeyModelId.get(key.id) ?? [])
+    );
+  }
+
+  async toJSONWithSpaces(
+    auth: Authenticator,
+    requestingUserModelId: ModelId
+  ): Promise<KeyType> {
+    const [json] = await KeyResource.toJSONWithSpaces(
+      auth,
+      [this],
+      requestingUserModelId
+    );
+
+    return json;
   }
 
   // Use to serialize a KeyResource in the Authenticator.

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -447,15 +447,17 @@ export class KeyResource extends BaseResource<KeyModel> {
 
     return new Map(
       keys.map((key) => {
-        const spaces = new Set(
-          key.groupIds.flatMap(
-            (groupModelId) => spacesByGroupModelId.get(groupModelId) ?? []
-          )
+        const spaces = new Map(
+          key.groupIds
+            .flatMap(
+              (groupModelId) => spacesByGroupModelId.get(groupModelId) ?? []
+            )
+            .map((space) => [space.sId, space])
         );
 
         return [
           key.id,
-          [...spaces].sort((a, b) => a.name.localeCompare(b.name)),
+          [...spaces.values()].sort((a, b) => a.name.localeCompare(b.name)),
         ];
       })
     );

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -11,7 +11,6 @@ import type {
   PostMemberGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
-import type { GetKeyScopableGroupsResponseBody } from "@app/types/api/keys";
 import type { GroupKind } from "@app/types/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -64,35 +63,6 @@ export function useGroups({
     isGroupsLoading: !error && !data && !disabled,
     isGroupsError: !!error,
     mutateGroups: mutate,
-  };
-}
-
-// The groups the caller may scope a new API key to (the groups they are a
-// member of). Distinct from `useGroups`, which lists workspace groups by kind:
-// key scoping is gated on membership, not visibility.
-export function useKeyScopableGroups({
-  owner,
-  disabled,
-}: {
-  owner: LightWorkspaceType;
-  disabled?: boolean;
-}) {
-  const { fetcher } = useFetcher();
-  const groupsFetcher: Fetcher<GetKeyScopableGroupsResponseBody> = fetcher;
-
-  const {
-    data,
-    error,
-    mutate: mutateGroups,
-  } = useSWRWithDefaults(`/api/w/${owner.sId}/keys/groups`, groupsFetcher, {
-    disabled,
-  });
-
-  return {
-    groups: data?.groups ?? emptyArray(),
-    isGroupsLoading: !error && !data && !disabled,
-    isGroupsError: !!error,
-    mutateGroups,
   };
 }
 

--- a/front/types/key.ts
+++ b/front/types/key.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@app/types/shared/model_id";
+import type { SpaceType } from "@app/types/space";
 import type { RoleType } from "@app/types/user";
 
 // Per-API-key credit state, mirroring the per-user `memberships.creditState`
@@ -28,6 +29,7 @@ export type KeyType = {
   status: string;
   name: string;
   groupIds: ModelId[];
+  spaces: SpaceType[];
   role: RoleType;
   monthlyCapMicroUsd: number | null;
   monthlyCapAwuCredits: number | null;


### PR DESCRIPTION
## Description

This PR returns the spaces accessible to each API key instead of requiring the frontend to resolve and display its underlying groups.

## Tests

Manually.

## Risks

The new response serialization performs additional group-permission and space lookups when API keys are returned. Incorrect permission mapping could result in incomplete or inaccurate space labels in the UI, but authorization behavior remains unchanged because the derived spaces are display-only.

## Deploy Plan

Standard deployment.