### PR TITLE
[front] Rename space/app enrichment to enrich<X>With<Aspect>

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -77,7 +77,7 @@ app.get(
       agentConfigurations,
       authors,
       lastVersionEditors,
-      spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
+      spaces: await SpaceResource.enrichSpacesWithAccess(auth, spaces),
       skillsByVersion,
     });
   }

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -48,7 +48,7 @@ app.get(
     return ctx.json({
       skill: serializedSkill,
       editedByUser: editedByUser ? editedByUser.toJSON() : null,
-      spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
+      spaces: await SpaceResource.enrichSpacesWithAccess(auth, spaces),
       agentsUsage,
       usedBySkills,
     });

--- a/front-api/routes/poke/workspaces/[wId]/spaces/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/index.ts
@@ -15,7 +15,7 @@ app.get("/", async (ctx): HandlerResult<PokeListSpaces> => {
   const spaces = await SpaceResource.listWorkspaceSpaces(auth);
 
   return ctx.json({
-    spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
+    spaces: await SpaceResource.enrichSpacesWithAccess(auth, spaces),
   });
 });
 

--- a/front-api/routes/v1/w/[wId]/apps/index.ts
+++ b/front-api/routes/v1/w/[wId]/apps/index.ts
@@ -30,14 +30,14 @@ app.get(
 
     // All apps belong to `space`; load its group sIds once so the public app response keeps the
     // space's `groupIds` without relying on the eagerly-loaded grants.
-    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+    const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(auth, [
       space,
     ]);
 
     return ctx.json({
       apps: apps
         .filter((a) => a.canRead(auth))
-        .map((a) => a.toJSONEnriched(enrichedSpace)),
+        .map((a) => a.enrichWithSpaceAccess(enrichedSpace)),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -93,14 +93,14 @@ app.get(
 
     // All apps belong to `space`; load its group sIds once so the public app response keeps the
     // space's `groupIds` without relying on the eagerly-loaded grants.
-    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+    const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(auth, [
       space,
     ]);
 
     return ctx.json({
       apps: apps
         .filter((a) => a.canRead(auth))
-        .map((a) => a.toJSONEnriched(enrichedSpace)),
+        .map((a) => a.enrichWithSpaceAccess(enrichedSpace)),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -205,7 +205,7 @@ app.post(
       });
     }
 
-    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+    const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(auth, [
       space,
     ]);
 

--- a/front-api/routes/v1/w/[wId]/spaces/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/index.ts
@@ -91,7 +91,7 @@ app.get(
     });
 
     return ctx.json({
-      spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
+      spaces: await SpaceResource.enrichSpacesWithAccess(auth, spaces),
     });
   }
 );

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
@@ -103,7 +103,10 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
     conversationsBySpace,
     lastUserActivityBySpace
   );
-  const enriched = await SpaceResource.batchToJSONEnriched(auth, sortedSpaces);
+  const enriched = await SpaceResource.enrichSpacesWithAccess(
+    auth,
+    sortedSpaces
+  );
   return ctx.json({
     summary: sortedSpaces.map((space, i) => ({
       space: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -314,7 +314,7 @@ app.get(
       ? await ProjectMetadataResource.fetchBySpace(auth, space)
       : undefined;
 
-    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+    const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(auth, [
       space,
     ]);
 

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -186,7 +186,7 @@ app.get(
     const projectSpaces = spaces.filter((s) => s.kind === "project");
 
     const nonProjectsJson: EnrichedSpaceType[] =
-      await SpaceResource.batchToJSONEnriched(auth, nonProjectSpaces);
+      await SpaceResource.enrichSpacesWithAccess(auth, nonProjectSpaces);
     const projectsJson: PodType[] =
       projectSpaces.length > 0
         ? await enrichProjectsWithMetadata(auth, projectSpaces)

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -81,7 +81,7 @@ export async function listSelectableSpaces(
     .filter((space) => space.isRegular())
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  const enriched = await SpaceResource.batchToJSONEnriched(
+  const enriched = await SpaceResource.enrichSpacesWithAccess(
     auth,
     selectableSpaceResources
   );
@@ -206,7 +206,7 @@ export async function addSelectedConversationSpaces(
         }
       );
 
-    const enriched = await SpaceResource.batchToJSONEnriched(
+    const enriched = await SpaceResource.enrichSpacesWithAccess(
       auth,
       selectedSpaces
     );
@@ -317,7 +317,7 @@ export async function addSelectedConversationSpaces(
         }
       );
 
-    const enriched = await SpaceResource.batchToJSONEnriched(
+    const enriched = await SpaceResource.enrichSpacesWithAccess(
       auth,
       allSelectedSpaces
     );

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -215,7 +215,10 @@ export async function enrichProjectsWithMetadata(
     metadatas.map((m) => [m.spaceId, m])
   );
 
-  const enrichedSpaces = await SpaceResource.batchToJSONEnriched(auth, spaces);
+  const enrichedSpaces = await SpaceResource.enrichSpacesWithAccess(
+    auth,
+    spaces
+  );
 
   return spaces.map((space, i) => ({
     ...enrichedSpaces[i],
@@ -275,7 +278,7 @@ export async function listAllProjectsWithAdminMetadata(
   );
   const metadataMap = new Map(metadatas.map((m) => [m.spaceId, m]));
 
-  const enrichedSpaces = await SpaceResource.batchToJSONEnriched(
+  const enrichedSpaces = await SpaceResource.enrichSpacesWithAccess(
     auth,
     projectSpaces
   );

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -20,7 +20,7 @@ export async function spaceToPokeJSON(
   space: SpaceResource
 ): Promise<PokeSpaceType> {
   const groups = await space.fetchGroupResources(auth);
-  const [enriched] = await SpaceResource.batchToJSONEnriched(auth, [space]);
+  const [enriched] = await SpaceResource.enrichSpacesWithAccess(auth, [space]);
   return {
     id: space.id,
     ...space.toJSON(),

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -320,9 +320,9 @@ export class AppResource extends ResourceWithSpace<AppModel> {
 
   // The app serialized with its space in enriched form (`groupIds`, `isRestricted` — part of the
   // public app contract). The caller obtains the `EnrichedSpaceType` on demand via
-  // `SpaceResource.batchToJSONEnriched`, so app serialization does not depend on the space's
+  // `SpaceResource.enrichSpacesWithAccess`, so app serialization does not depend on the space's
   // eagerly-loaded grants.
-  toJSONEnriched(space: EnrichedSpaceType): EnrichedAppType {
+  enrichWithSpaceAccess(space: EnrichedSpaceType): EnrichedAppType {
     return {
       ...this.toJSON(),
       space,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1740,8 +1740,8 @@ describe("SpaceResource", () => {
           workspaceId: workspace.id,
         }),
       ]);
-      // groupIds/isRestricted are likewise loaded on demand (via `batchToJSONEnriched`).
-      const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(
+      // groupIds/isRestricted are likewise loaded on demand (via `enrichSpacesWithAccess`).
+      const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(
         adminAuth,
         [regularSpace]
       );

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -128,14 +128,14 @@ const POD_MEMBERSHIP_GRANT_TYPES: ReadonlySet<GrantType> = new Set(
 const EMPTY_GROUP_MODEL_IDS: ReadonlySet<ModelId> = new Set();
 
 // A space's grant-derived serialization fields, loaded on demand from `group_permissions` (see
-// `listSpaceEnrichmentBySpaceModelId`) and passed to `toJSONEnriched`.
-type SpaceGrantEnrichment = {
+// `listSpaceAccessBySpaceModelId`) and folded into `EnrichedSpaceType` by `enrichSpacesWithAccess`.
+type SpaceAccess = {
   groupIds: string[];
   isRestricted: boolean;
 };
 
-// The enrichment for a space with no grants loaded (used as the fallback when serializing).
-const EMPTY_SPACE_GRANT_ENRICHMENT: SpaceGrantEnrichment = {
+// The access for a space with no grants loaded (used as the fallback when serializing).
+const EMPTY_SPACE_ACCESS: SpaceAccess = {
   groupIds: [],
   isRestricted: false,
 };
@@ -2332,8 +2332,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // holds no `reader` grant on it (an open space grants that group a `reader` grant, which is what
   // makes it visible to every workspace member). Global, conversations and system spaces are never
   // restricted. This is the resource-level equivalent of the serialized `EnrichedSpaceType.isRestricted`.
-  // Resolved from `group_permissions`; serialize a batch of spaces via `batchToJSONEnriched` to avoid
-  // one query per space.
+  // Resolved from `group_permissions`; serialize a batch of spaces via `enrichSpacesWithAccess` to
+  // avoid one query per space.
   async isRestricted(auth: Authenticator): Promise<boolean> {
     if (!this.isRegular() && !this.isProject()) {
       return false;
@@ -2596,50 +2596,42 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     };
   }
 
-  // Serialize with the space's grant-derived fields (`groupIds` and `isRestricted`). Private: these
+  // Enrich each of `spaces` to `EnrichedSpaceType` (base `toJSON` fields + grant-derived `groupIds`
+  // and `isRestricted`), loading the grants in a single `group_permissions` query. The grant fields
   // are not carried on `toJSON` (that would force the eager `group_permissions` include on every
-  // space load), so callers go through the batched `batchToJSONEnriched` rather than pairing this
-  // with the loader themselves.
-  private toJSONEnriched({
-    groupIds,
-    isRestricted,
-  }: SpaceGrantEnrichment): EnrichedSpaceType {
-    return {
-      ...this.toJSON(),
-      groupIds,
-      isRestricted,
-    };
-  }
-
-  // Serialize each of `spaces` to `EnrichedSpaceType` (base fields + grant-derived `groupIds` and
-  // `isRestricted`), loading the grants in a single `group_permissions` query. This keeps the whole
-  // enrichment flow inside the resource: the public API, the space-management UI and poke go through
-  // here instead of wiring the loader + per-space fallback at each call site. The result preserves
-  // the order of `spaces`.
-  static async batchToJSONEnriched(
+  // space load), so this batched method is the sole way to produce the enriched shape — the public
+  // API, the space-management UI and poke go through it instead of wiring the loader + per-space
+  // fallback at each call site. The result preserves the order of `spaces`.
+  static async enrichSpacesWithAccess(
     auth: Authenticator,
     spaces: SpaceResource[]
   ): Promise<EnrichedSpaceType[]> {
-    const enrichmentBySpaceModelId =
-      await this.listSpaceEnrichmentBySpaceModelId(auth, spaces);
-    return spaces.map((space) =>
-      space.toJSONEnriched(
-        enrichmentBySpaceModelId.get(space.id) ?? EMPTY_SPACE_GRANT_ENRICHMENT
-      )
+    const accessBySpaceModelId = await this.listSpaceAccessBySpaceModelId(
+      auth,
+      spaces
     );
+    return spaces.map((space) => {
+      const { groupIds, isRestricted } =
+        accessBySpaceModelId.get(space.id) ?? EMPTY_SPACE_ACCESS;
+      return {
+        ...space.toJSON(),
+        groupIds,
+        isRestricted,
+      };
+    });
   }
 
-  // The grant-derived enrichment (`groupIds` + `isRestricted`) for each of `spaces`, keyed by space
-  // model id. One query against `group_permissions` (the source of truth) so `batchToJSONEnriched`
+  // The grant-derived access (`groupIds` + `isRestricted`) for each of `spaces`, keyed by space
+  // model id. One query against `group_permissions` (the source of truth) so `enrichSpacesWithAccess`
   // can serialize each space. `groupIds` is every grant group (members, editors, provisioned, and
   // the open-space global reader); `isRestricted` mirrors `isRestricted()`.
-  private static async listSpaceEnrichmentBySpaceModelId(
+  private static async listSpaceAccessBySpaceModelId(
     auth: Authenticator,
     spaces: SpaceResource[]
-  ): Promise<Map<ModelId, SpaceGrantEnrichment>> {
-    const enrichmentBySpaceModelId = new Map<ModelId, SpaceGrantEnrichment>();
+  ): Promise<Map<ModelId, SpaceAccess>> {
+    const accessBySpaceModelId = new Map<ModelId, SpaceAccess>();
     if (spaces.length === 0) {
-      return enrichmentBySpaceModelId;
+      return accessBySpaceModelId;
     }
 
     const grants = await GroupPermissionModel.findAll({
@@ -2674,12 +2666,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       // Only regular and project spaces can be restricted (the unique kinds never are), matching
       // `isRestricted()`.
       const isOpen = hasReaderGrantBySpaceModelId.get(space.id) ?? false;
-      enrichmentBySpaceModelId.set(space.id, {
+      accessBySpaceModelId.set(space.id, {
         groupIds: groupIdsBySpaceModelId.get(space.id) ?? [],
         isRestricted: (space.isRegular() || space.isProject()) && !isOpen,
       });
     }
 
-    return enrichmentBySpaceModelId;
+    return accessBySpaceModelId;
   }
 }

--- a/front/lib/utils/apps.ts
+++ b/front/lib/utils/apps.ts
@@ -399,7 +399,7 @@ export async function exportApps(
   // All apps belong to `space`; load its grant-derived enrichment once so the exported app keeps the
   // space's `groupIds`/`isRestricted` (part of the public app contract) without relying on the
   // eagerly-loaded grants.
-  const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+  const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(auth, [
     space,
   ]);
 
@@ -448,7 +448,7 @@ export async function exportApps(
       }
 
       return {
-        ...app.toJSONEnriched(enrichedSpace),
+        ...app.enrichWithSpaceAccess(enrichedSpace),
         datasets,
         coreSpecifications,
       };

--- a/front/types/app.ts
+++ b/front/types/app.ts
@@ -25,7 +25,7 @@ export type AppType = {
 };
 
 // An app serialized with its space's `groupIds` (part of the public app contract). Produced by
-// `AppResource.toJSONEnriched` for the public API; the internal `AppType` omits them so app
+// `AppResource.enrichWithSpaceAccess` for the public API; the internal `AppType` omits them so app
 // serialization does not depend on the space's eagerly-loaded grants.
 export type EnrichedAppType = Omit<AppType, "space"> & {
   space: EnrichedSpaceType;


### PR DESCRIPTION
## Description

Follow-up to #31324. Adopts the `enrich<X>With<Aspect>` naming (as in `enrichConversationWithFeedback`) for the grant-derived space/app serialization, keeping the distinct `EnrichedSpaceType` / `EnrichedAppType` return types.

- `SpaceResource.batchToJSONEnriched` → `enrichSpacesWithAccess`
- `SpaceResource.toJSONEnriched` (private) inlined into `enrichSpacesWithAccess` and removed
- `SpaceResource.listSpaceEnrichmentBySpaceModelId` → `listSpaceAccessBySpaceModelId`
- `SpaceGrantEnrichment` → `SpaceAccess`; `EMPTY_SPACE_GRANT_ENRICHMENT` → `EMPTY_SPACE_ACCESS`
- `AppResource.toJSONEnriched` → `enrichWithSpaceAccess`

Pure rename + inline of a private helper; no behavior change.

## Tests

- `tsgo` clean in `front` and `front-api`.
- `space_resource` suite (77) passing; all call sites updated across both workspaces.

## Risk

None — mechanical rename, no runtime change. Safe to rollback.

## Deploy Plan

Standard.