### PR TITLE
[front] Emit only the aggregated Metronome usage event; drop legacy path

### DIFF
--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -1,11 +1,5 @@
 import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
-import {
-  billedCostAwuFromEvents,
-  buildLlmUsageEvents,
-  buildToolUseEvents,
-  buildUsageEvents,
-} from "@app/lib/metronome/events";
-import type { MetronomeEvent } from "@app/lib/metronome/types";
+import { buildUsageEvents } from "@app/lib/metronome/events";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { describe, expect, it } from "vitest";
 
@@ -26,6 +20,7 @@ function usage(overrides: Partial<RunUsageType>): RunUsageType {
 
 const commonEventInput = {
   workspaceId: "workspace",
+  isByok: false,
   conversationId: "conversation",
   userId: "user",
   isFreeSeatedUser: false,
@@ -34,6 +29,8 @@ const commonEventInput = {
   subAgentId: null,
   parentAgentMessageId: null,
   runKey: "execution",
+  runUsages: [],
+  actions: [],
   origin: "web" as const,
   usageType: "user" as const,
   authMethod: "session",
@@ -43,11 +40,10 @@ const commonEventInput = {
   timestamp: "2026-08-05T12:00:00.000Z",
 };
 
-describe("Metronome billing event adapters", () => {
-  it("emits the canonical LLM billing groups and credit amounts", () => {
-    const events = buildLlmUsageEvents({
+describe("Metronome aggregated usage event", () => {
+  it("emits a single event summing LLM and tool cost", () => {
+    const events = buildUsageEvents({
       ...commonEventInput,
-      isByok: false,
       runUsages: [
         usage({ costMicroUsd: 1, promptTokens: 2 }),
         usage({ costMicroUsd: 2, promptTokens: 3 }),
@@ -57,147 +53,12 @@ describe("Metronome billing event adapters", () => {
           providerId: "anthropic",
         }),
       ],
-    });
-
-    expect(events).toHaveLength(2);
-    expect(events.map(({ properties }) => properties)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          provider_id: "openai",
-          model_id: "gpt-4o",
-          prompt_tokens: 5,
-          cost_micro_usd: 3,
-          cost_awu: 1,
-        }),
-        expect.objectContaining({
-          provider_id: "anthropic",
-          model_id: "claude-opus-4-8",
-          cost_awu: 1,
-        }),
-      ])
-    );
-  });
-
-  it("emits canonical tool categories and free-usage overrides", () => {
-    const events = buildToolUseEvents({
-      ...commonEventInput,
       actions: [
         {
           toolName: "websearch",
           mcpServerId: null,
           internalMCPServerName: "web_search_&_browse",
           status: "succeeded",
-          executionDurationMs: 10,
-          shouldEmit: true,
-        },
-        {
-          toolName: "websearch",
-          mcpServerId: null,
-          internalMCPServerName: "web_search_&_browse",
-          status: "succeeded",
-          executionDurationMs: 20,
-          shouldEmit: true,
-        },
-      ],
-    });
-
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties).toMatchObject({
-      tool_category: "basic",
-      count: 2,
-      total_execution_duration_ms: 30,
-      usage_type: "user",
-    });
-  });
-
-  it("does not emit events for unbillable tool statuses", () => {
-    const events = buildToolUseEvents({
-      ...commonEventInput,
-      actions: [
-        {
-          toolName: "custom_tool",
-          mcpServerId: null,
-          internalMCPServerName: null,
-          status: "denied",
-          executionDurationMs: null,
-          shouldEmit: true,
-        },
-      ],
-    });
-
-    expect(events).toEqual([]);
-  });
-
-  it("splits paid and post-cap calls to the same tool", () => {
-    const events = buildToolUseEvents({
-      ...commonEventInput,
-      actions: Array.from({ length: 8 }, () => ({
-        toolName: "custom_tool",
-        mcpServerId: "mcp_server",
-        internalMCPServerName: null,
-        status: "succeeded" as const,
-        executionDurationMs: 10,
-        shouldEmit: true,
-      })),
-    });
-
-    expect(events).toHaveLength(2);
-    expect(events.map(({ properties }) => properties)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ count: 7, usage_type: "user" }),
-        expect.objectContaining({ count: 1, usage_type: "free" }),
-      ])
-    );
-    expect(
-      new Set(events.map(({ transaction_id }) => transaction_id)).size
-    ).toBe(2);
-  });
-
-  it("applies prior execution spend without re-emitting prior actions", () => {
-    const events = buildToolUseEvents({
-      ...commonEventInput,
-      actions: [
-        ...Array.from({ length: 7 }, () => ({
-          toolName: "custom_tool",
-          mcpServerId: "mcp_server",
-          internalMCPServerName: null,
-          status: "succeeded" as const,
-          executionDurationMs: 10,
-          shouldEmit: false,
-        })),
-        {
-          toolName: "custom_tool",
-          mcpServerId: "mcp_server",
-          internalMCPServerName: null,
-          status: "succeeded",
-          executionDurationMs: 10,
-          shouldEmit: true,
-        },
-      ],
-    });
-
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties).toMatchObject({
-      count: 1,
-      usage_type: "free",
-    });
-  });
-});
-
-describe("Aggregated usage event (shadow) and legacy cost parity", () => {
-  const aggregatedInput = { ...commonEventInput, isByok: false };
-
-  it("aggregates LLM and tool cost into a single llm_usage_v3 event", () => {
-    const events = buildUsageEvents({
-      ...aggregatedInput,
-      runUsages: [usage({ costMicroUsd: 1 })],
-      actions: [
-        {
-          toolName: "websearch",
-          mcpServerId: null,
-          internalMCPServerName: "web_search_&_browse",
-          status: "succeeded",
-          executionDurationMs: 10,
           shouldEmit: true,
         },
       ],
@@ -205,153 +66,222 @@ describe("Aggregated usage event (shadow) and legacy cost parity", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]?.event_type).toBe("llm_usage_v3");
+    expect(events[0]?.transaction_id).toBe(
+      "usage3-workspace-conversation-message-execution"
+    );
     expect(events[0]?.properties).toMatchObject({
+      provider_id: "aggregate",
       model_id: "aggregate",
-      // LLM ceil(1/µ) = 1 + one "basic" (1 AWU) tool = 2.
-      cost_awu: 2,
+      // LLM: ceil(3/µ)=1 + ceil(1/µ)=1 = 2. Tool: one "basic" (1 AWU) call = 1.
+      cost_awu: 3,
+      prompt_tokens: 5,
       usage_type: "user",
     });
   });
 
-  it("matches the legacy events' billed cost on a mixed message", () => {
+  it("always emits the required billable shape with valid values", () => {
+    // Even with no user / api key / agent, the required properties fall back to
+    // valid, non-empty values so the billable metric's `exists` filters match.
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      userId: null,
+      apiKeyName: null,
+      agentId: null,
+      runUsages: [usage({ costMicroUsd: 1 })],
+    });
+
+    expect(events).toHaveLength(1);
+    const props = events[0]?.properties ?? {};
+    for (const key of [
+      "agent_id",
+      "api_key_name",
+      "cost_awu",
+      "model_id",
+      "origin",
+      "usage_type",
+      "user_id",
+    ]) {
+      expect(props[key]).toBeDefined();
+    }
+    expect(props["user_id"]).toBe("unknown");
+    expect(props["api_key_name"]).toBe("unknown");
+    expect(props["agent_id"]).toBe("unknown");
+    expect(props["usage_type"]).toBe("user");
+  });
+
+  it("rounds LLM per model then adds tool weights flat, excluding free/capped", () => {
     const perAwu = MODEL_COST_MICRO_USD_PER_AWU_CREDIT;
 
-    const runUsages = [
-      // openai group: two usages summed (1 + 1 µUSD) THEN rounded → 1 credit.
-      usage({ costMicroUsd: 1 }),
-      usage({ costMicroUsd: 1 }),
-      // anthropic group: rounded on its own → 2 credits.
-      usage({
-        costMicroUsd: perAwu + 1,
-        modelId: "claude-opus-4-8",
-        providerId: "anthropic",
-      }),
-    ];
-    const actions = [
-      // 8 external "advanced" (3 AWU) calls: 7 billed (21) + 1 capped (free).
-      ...Array.from({ length: 8 }, () => ({
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      runUsages: [
+        // openai/gpt-4o group: two usages summed (1 + 1 µUSD) THEN rounded.
+        usage({ costMicroUsd: 1 }),
+        usage({ costMicroUsd: 1 }),
+        // anthropic group: a separate model, rounded on its own.
+        usage({
+          costMicroUsd: perAwu + 1,
+          modelId: "claude-opus-4-8",
+          providerId: "anthropic",
+        }),
+      ],
+      actions: [
+        // 8 external "advanced" (3 AWU) calls on one server: the 20-credit
+        // per-server cap is reached after 7 (21 credits), so the 8th is waived.
+        ...Array.from({ length: 8 }, () => ({
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded" as const,
+          shouldEmit: true,
+        })),
+        // A denied call is unbillable and must not contribute either.
+        {
+          toolName: "custom_tool",
+          mcpServerId: null,
+          internalMCPServerName: null,
+          status: "denied" as const,
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    // LLM = ceil(2/µ) + ceil((µ+1)/µ) = 1 + 2 = 3 (never a single ceiling over
+    // the combined micro-USD). Tools = 7 × 3 = 21 (capped 8th + denied add 0).
+    expect(events[0]?.properties["cost_awu"]).toBe(24);
+
+    // Guard against regressing to "round once at the end": ceil((2+µ+1)/µ) = 2.
+    expect(Math.ceil((2 + perAwu + 1) / perAwu)).not.toBe(3);
+  });
+
+  it("emits an LLM-only event when there are no tool actions", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      runUsages: [usage({ costMicroUsd: 1 })],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({
+      cost_awu: 1,
+      usage_type: "user",
+    });
+  });
+
+  it("emits no event when there is nothing to attribute", () => {
+    const events = buildUsageEvents({ ...commonEventInput });
+
+    expect(events).toEqual([]);
+  });
+
+  it("does not bill unbillable tool statuses", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      actions: [
+        {
+          toolName: "custom_tool",
+          mcpServerId: null,
+          internalMCPServerName: null,
+          status: "denied",
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    // The action is emitted for observability but denied statuses are never
+    // billed, so cost is 0.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 0 });
+  });
+
+  it("waives per-server-capped tool calls in the net cost", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      actions: Array.from({ length: 8 }, () => ({
         toolName: "custom_tool",
         mcpServerId: "mcp_server",
         internalMCPServerName: null,
         status: "succeeded" as const,
-        executionDurationMs: 10,
         shouldEmit: true,
       })),
-      // One internal "basic" (1 AWU) billed call.
-      {
-        toolName: "websearch",
-        mcpServerId: null,
-        internalMCPServerName: "web_search_&_browse" as const,
-        status: "succeeded" as const,
-        executionDurationMs: 5,
-        shouldEmit: true,
-      },
-      // A denied call: unbillable, must not contribute on either side.
-      {
-        toolName: "custom_tool",
-        mcpServerId: null,
-        internalMCPServerName: null,
-        status: "denied" as const,
-        executionDurationMs: null,
-        shouldEmit: true,
-      },
-    ];
-
-    const legacyEvents = [
-      ...buildLlmUsageEvents({ ...aggregatedInput, runUsages }),
-      ...buildToolUseEvents({ ...commonEventInput, actions }),
-    ];
-    const aggregatedEvents = buildUsageEvents({
-      ...aggregatedInput,
-      runUsages,
-      actions,
     });
 
-    // LLM 3 (1 + 2, per-model rounding) + tools 22 (7×3 capped + 1 basic) = 25.
-    const newCostAwu = Number(aggregatedEvents[0]?.properties["cost_awu"]);
-    expect(newCostAwu).toBe(25);
-    expect(billedCostAwuFromEvents(legacyEvents)).toBe(newCostAwu);
+    // External tools are "advanced" (3 AWU). The 20-credit per-server cap is
+    // reached after 7 calls (21 credits); the 8th is waived. Net billed = 21.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 21 });
   });
 
-  it("matches (both zero) for free-origin messages", () => {
-    const runUsages = [usage({ costMicroUsd: 1_000_000 })];
-    const actions = [
-      {
+  it("applies the free_mcp_server_cap per server, not globally", () => {
+    const serverActions = (mcpServerId: string) =>
+      Array.from({ length: 8 }, () => ({
         toolName: "custom_tool",
-        mcpServerId: "mcp_server",
+        mcpServerId,
         internalMCPServerName: null,
         status: "succeeded" as const,
-        executionDurationMs: 10,
         shouldEmit: true,
-      },
-    ];
-    const freeInput = {
-      ...aggregatedInput,
-      usageType: "free" as const,
-      origin: "agent_sidekick" as const,
-    };
+      }));
 
-    const legacyEvents = [
-      ...buildLlmUsageEvents({ ...freeInput, runUsages }),
-      ...buildToolUseEvents({
-        ...commonEventInput,
-        usageType: "free" as const,
-        origin: "agent_sidekick" as const,
-        actions,
-      }),
-    ];
-    const aggregatedEvents = buildUsageEvents({
-      ...freeInput,
-      runUsages,
-      actions,
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      actions: [
+        ...serverActions("mcp_server_a"),
+        ...serverActions("mcp_server_b"),
+      ],
     });
 
-    const newCostAwu = aggregatedEvents.reduce(
-      (total, event) => total + Number(event.properties["cost_awu"] ?? 0),
-      0
-    );
-    expect(newCostAwu).toBe(0);
-    expect(billedCostAwuFromEvents(legacyEvents)).toBe(0);
+    // 21 (server A) + 21 (server B) = 42; each server waives its own 8th call.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 42 });
   });
 
-  it("counts only user/programmatic usage types, skipping any other value", () => {
-    const events: MetronomeEvent[] = [
-      {
-        transaction_id: "a",
-        customer_id: "c",
-        event_type: "llm_usage_v3",
-        timestamp: "2026-08-05T12:00:00.000Z",
-        properties: { cost_awu: 5, usage_type: "user" },
-      },
-      {
-        transaction_id: "b",
-        customer_id: "c",
-        event_type: "llm_usage_v3",
-        timestamp: "2026-08-05T12:00:00.000Z",
-        properties: { cost_awu: 7, usage_type: "programmatic" },
-      },
-      {
-        transaction_id: "c",
-        customer_id: "c",
-        event_type: "llm_usage_v3",
-        timestamp: "2026-08-05T12:00:00.000Z",
-        properties: { cost_awu: 11, usage_type: "free" },
-      },
-      // An unknown usage_type is entitled at 0 in the rate card — skip it.
-      {
-        transaction_id: "d",
-        customer_id: "c",
-        event_type: "tool_use_v3",
-        timestamp: "2026-08-05T12:00:00.000Z",
-        properties: {
-          count: 4,
-          tool_category: "advanced",
-          usage_type: "other",
+  it("does not re-bill prior-execution actions", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      actions: [
+        ...Array.from({ length: 7 }, () => ({
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded" as const,
+          shouldEmit: false,
+        })),
+        {
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded",
+          shouldEmit: true,
         },
-      },
-    ];
+      ],
+    });
 
-    // Only the "user" (5) and "programmatic" (7) events count.
-    expect(billedCostAwuFromEvents(events)).toBe(12);
+    // Prior actions already reached the cap, so this execution's only action is
+    // waived: it is emitted but bills 0.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 0 });
+  });
+
+  it("bills nothing for free origins", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      usageType: "free",
+      origin: "agent_sidekick",
+      runUsages: [usage({ costMicroUsd: 1_000_000 })],
+      actions: [
+        {
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded",
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({
+      cost_awu: 0,
+      usage_type: "free",
+    });
   });
 });

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -3,8 +3,6 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   buildAgentMessageBillingPlan,
   isFreeOrigin,
-  isToolCostCategory,
-  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/credits/agent_message_billing";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -32,7 +30,6 @@ export {
 } from "@app/lib/credits/agent_message_billing";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
-const MAX_PROPERTY_VALUE_BYTES = 128;
 
 /**
  * If a transaction_id exceeds Metronome's 128-char limit, keep the first
@@ -45,21 +42,6 @@ function truncateTransactionId(id: string): string {
   }
   const hash = createHash("sha256").update(id).digest("hex").slice(0, 12);
   return `${id.slice(0, MAX_TRANSACTION_ID_LENGTH - 13)}-${hash}`;
-}
-
-/**
- * Truncate a string property value to fit Metronome's 256-byte limit.
- */
-function truncatePropertyValue(value: string): string {
-  if (Buffer.byteLength(value, "utf8") <= MAX_PROPERTY_VALUE_BYTES) {
-    return value;
-  }
-  // Truncate conservatively — slice characters until within byte limit.
-  let truncated = value;
-  while (Buffer.byteLength(truncated, "utf8") > MAX_PROPERTY_VALUE_BYTES - 3) {
-    truncated = truncated.slice(0, truncated.length - 1);
-  }
-  return truncated + "...";
 }
 
 // ---------------------------------------------------------------------------
@@ -76,19 +58,9 @@ export function getUsageType(
   return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
 }
 
-function getToolUsageType({
-  baseUsageType,
-  isFreeUsage,
-}: {
-  baseUsageType: UsageType;
-  isFreeUsage: boolean;
-}): UsageType {
-  return isFreeUsage ? USAGE_TYPE_FREE : baseUsageType;
-}
-
 // Intelligence (AI compute) credits for a *single execution's* run usages.
 // Usages are grouped by (providerId, modelId) and converted per group before
-// summing — this mirrors the per-execution `buildLlmUsageEvents` event so the
+// summing — this mirrors the per-execution `buildUsageEvents` event so the
 // total equals the billed amount for that execution. To get the message-level
 // total across interrupt/resume executions, use
 // `intelligenceAwuFromRunUsagesGroupedByRunKey` (which ceils per execution),
@@ -155,105 +127,7 @@ export function toolAwuFromAction(
 }
 
 // ---------------------------------------------------------------------------
-// LLM usage events
-// ---------------------------------------------------------------------------
-
-/**
- * Build aggregated Metronome llm_usage events for an agent message.
- * Usages are grouped by (providerId, modelId) — one event per model used
- * with aggregated token counts and cost.
- *
- * transaction_id pattern: llm-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{providerId}-{modelId}
- */
-export function buildLlmUsageEvents({
-  workspaceId,
-  isByok,
-  conversationId,
-  userId,
-  isFreeSeatedUser,
-  agentMessageId,
-  agentId,
-  subAgentId,
-  parentAgentMessageId,
-  runKey,
-  runUsages,
-  origin,
-  usageType,
-  authMethod,
-  apiKeyName,
-  messageStatus,
-  isSubAgentMessage,
-  timestamp,
-}: {
-  workspaceId: string;
-  isByok: boolean;
-  conversationId: string;
-  userId: string | null;
-  isFreeSeatedUser: boolean;
-  agentMessageId: string;
-  agentId: string | null;
-  subAgentId: string | null;
-  parentAgentMessageId: string | null;
-  runKey: string;
-  runUsages: RunUsageType[];
-  origin: UserMessageOrigin;
-  usageType: UsageType;
-  authMethod: string | null;
-  apiKeyName: string | null;
-  messageStatus: string;
-  isSubAgentMessage: boolean;
-  timestamp: string;
-}): MetronomeEvent[] {
-  const billingPlan = buildAgentMessageBillingPlan({
-    actions: [],
-    contextOrigin: origin,
-    runUsages: runUsages.map((usage) => ({ ...usage, runKey })),
-  });
-
-  return billingPlan.llm.map((group) => ({
-    transaction_id: `llm3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
-    customer_id: getMetronomeIngestAlias(workspaceId),
-    event_type: "llm_usage_v3",
-    timestamp,
-    properties: {
-      workspace_id: workspaceId,
-      user_id: userId
-        ? isFreeSeatedUser
-          ? toFreeMetronomeUserId(userId)
-          : userId
-        : "unknown",
-      is_byok: isByok ? "true" : "false",
-      agent_message_id: agentMessageId,
-      conversation_id: conversationId,
-      agent_id: agentId ?? "unknown",
-      sub_agent_id: subAgentId ?? "none",
-      parent_agent_message_id: parentAgentMessageId ?? "none",
-      provider_id: group.providerId,
-      model_id: group.modelId,
-      prompt_tokens: group.promptTokensCount,
-      completion_tokens: group.completionTokensCount,
-      cached_tokens: group.cachedTokensCount,
-      cache_creation_tokens: group.cacheCreationTokensCount,
-      // Provider cost without markup — markup is applied in Metronome rate card. Only used for legacy rates.
-      cost_micro_usd: group.providerCostMicroUsd,
-      // 1 AWU credit = $0.0085
-      cost_awu: group.ratedCredits,
-      // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
-      is_programmatic_usage:
-        usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
-      is_free_usage: usageType === USAGE_TYPE_FREE ? "true" : "false",
-      [USAGE_TYPE_GROUP_KEY]: usageType,
-      auth_method: authMethod ?? "unknown",
-      api_key_name: apiKeyName ?? "unknown",
-      message_status: messageStatus,
-      is_sub_agent_message: isSubAgentMessage ? "true" : "false",
-      origin,
-    },
-  }));
-}
-
-// ---------------------------------------------------------------------------
-// Tool use events
+// Usage events
 // ---------------------------------------------------------------------------
 
 interface ToolAction {
@@ -261,173 +135,23 @@ interface ToolAction {
   mcpServerId: string | null;
   internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
-  executionDurationMs: number | null;
   // The billing plan needs every chronological action in the message to apply
   // the per-server cap, while each execution emits only its own actions.
   shouldEmit: boolean;
 }
 
 /**
- * Build aggregated Metronome tool_use events for an agent message.
- * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status,
- * billingDisposition). Each group produces one event with `count` and
- * `total_execution_duration_ms`.
- *
- * transaction_id pattern: tool-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{toolHash}
- * toolHash is a 12-char SHA-256 of toolName|mcpServerId|status to keep under 128 chars.
- */
-export function buildToolUseEvents({
-  workspaceId,
-  conversationId,
-  userId,
-  isFreeSeatedUser,
-  agentMessageId,
-  agentId,
-  subAgentId,
-  parentAgentMessageId,
-  runKey,
-  actions,
-  origin,
-  usageType,
-  authMethod,
-  apiKeyName,
-  messageStatus,
-  isSubAgentMessage,
-  timestamp,
-}: {
-  workspaceId: string;
-  conversationId: string;
-  userId: string | null;
-  isFreeSeatedUser: boolean;
-  agentMessageId: string;
-  agentId: string | null;
-  subAgentId: string | null;
-  parentAgentMessageId: string | null;
-  runKey: string;
-  actions: ToolAction[];
-  origin: UserMessageOrigin;
-  usageType: UsageType;
-  authMethod: string | null;
-  apiKeyName: string | null;
-  messageStatus: string;
-  isSubAgentMessage: boolean;
-  timestamp: string;
-}): MetronomeEvent[] {
-  const billingPlan = buildAgentMessageBillingPlan({
-    actions,
-    contextOrigin: origin,
-    runUsages: [],
-  });
-
-  // Group actions by (toolName, internalMCPServerName, mcpServerId, status,
-  // billingDisposition). The disposition split is required when one execution
-  // contains both paid and post-cap calls to the same tool.
-  const groups = new Map<
-    string,
-    {
-      billingLine: (typeof billingPlan.tools)[number];
-      count: number;
-      totalDurationMs: number;
-    }
-  >();
-  for (const billingLine of billingPlan.tools) {
-    if (!billingLine.action.shouldEmit) {
-      continue;
-    }
-    // Metronome prices every emitted tool event. Actions that never reached the
-    // tool must therefore be omitted rather than represented as zero-cost.
-    if (billingLine.billingDisposition === "unbillable_status") {
-      continue;
-    }
-    const { action } = billingLine;
-    const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}|${billingLine.billingDisposition}`;
-    const existing = groups.get(key);
-    if (existing) {
-      existing.count++;
-      existing.totalDurationMs += action.executionDurationMs ?? 0;
-    } else {
-      groups.set(key, {
-        billingLine,
-        count: 1,
-        totalDurationMs: action.executionDurationMs ?? 0,
-      });
-    }
-  }
-
-  return [...groups.values()].map(({ billingLine, count, totalDurationMs }) => {
-    const { action, billingDisposition, toolCostCategory } = billingLine;
-    const effectiveUsageType = getToolUsageType({
-      baseUsageType: usageType,
-      isFreeUsage: billingDisposition !== "billed",
-    });
-    const transactionIdDispositionSuffix =
-      billingDisposition === "free_mcp_server_cap"
-        ? `-${billingDisposition}`
-        : "";
-    return {
-      transaction_id: truncateTransactionId(
-        `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}${transactionIdDispositionSuffix}`
-      ),
-      customer_id: getMetronomeIngestAlias(workspaceId),
-      event_type: "tool_use_v3",
-      timestamp,
-      properties: {
-        workspace_id: workspaceId,
-        user_id: userId
-          ? isFreeSeatedUser
-            ? toFreeMetronomeUserId(userId)
-            : userId
-          : "unknown",
-        agent_message_id: agentMessageId,
-        conversation_id: conversationId,
-        agent_id: agentId ?? "unknown",
-        sub_agent_id: subAgentId ?? "none",
-        parent_agent_message_id: parentAgentMessageId ?? "none",
-        auth_method: authMethod ?? "unknown",
-        api_key_name: apiKeyName ?? "unknown",
-        tool_name: truncatePropertyValue(action.toolName),
-        mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
-        internal_mcp_server_name: truncatePropertyValue(
-          action.internalMCPServerName ?? ""
-        ),
-        tool_category: toolCostCategory,
-        // Constant grouping key — used as presentation_group_key in Metronome to
-        // aggregate all tool categories into a single "Tool Usage" invoice line.
-        tool_group: "tools",
-        status: action.status,
-        count,
-        total_execution_duration_ms: totalDurationMs,
-        // TODO: Remove is_programmatic_usage, this is replaced by single property "usage type"
-        is_programmatic_usage:
-          effectiveUsageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
-        [USAGE_TYPE_GROUP_KEY]: effectiveUsageType,
-        message_status: messageStatus,
-        is_sub_agent_message: isSubAgentMessage ? "true" : "false",
-        origin,
-      },
-    };
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Aggregated usage event (shadow — not yet ingested)
-// ---------------------------------------------------------------------------
-
-/**
  * Build the single aggregated Metronome llm_usage_v3 event for one agent-message
  * execution: LLM (intelligence) and tool (platform action) costs are computed on
- * our side and summed into one `cost_awu`.
- *
- * This is the target shape that will eventually replace the per-model
- * `buildLlmUsageEvents` + per-tool `buildToolUseEvents` events. For now it is
- * only used to shadow-compute the aggregated amount for a parity log, so its
- * result is NOT ingested.
+ * our side and summed into one `cost_awu`. This is the only Metronome usage
+ * event we emit — `model_id`/`provider_id` are constant placeholders since the
+ * cost is no longer reported per model or per tool.
  *
  * `cost_awu` is the net billed credits: free origins, the per-server tool cap
- * and free tools are already waived in the number, so Metronome would price it
- * as a flat multiply on the shared AWU rate. Only actions belonging to this
- * execution (`shouldEmit`) contribute; prior-execution actions are still fed to
- * the billing plan so the per-server cap is applied across the whole message.
+ * and free tools are already waived in the number, so Metronome prices it as a
+ * flat multiply on the shared AWU rate. Only actions belonging to this execution
+ * (`shouldEmit`) contribute; prior-execution actions are still fed to the
+ * billing plan so the per-server cap is applied across the whole message.
  *
  * transaction_id pattern: usage3-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}
  */
@@ -564,41 +288,4 @@ export function buildUsageEvents({
       },
     },
   ];
-}
-
-/**
- * Sum the AWU that Metronome will bill from a set of legacy usage events:
- * `llm_usage_v3` → `cost_awu`; `tool_use_v3` → `count` × the tool category
- * weight. Events tagged `usage_type: free` are priced at 0 and contribute
- * nothing. Used to shadow-compare the legacy per-model/per-tool events against
- * the aggregated `buildUsageEvents` cost before switching over.
- */
-export function billedCostAwuFromEvents(events: MetronomeEvent[]): number {
-  return events.reduce((total, event) => {
-    // The rate card only prices the paid usage types; "free" and any other
-    // value are entitled at 0, so only count "user" and "programmatic".
-    const usageType = event.properties[USAGE_TYPE_GROUP_KEY];
-    if (
-      usageType !== USAGE_TYPE_USER &&
-      usageType !== USAGE_TYPE_PROGRAMMATIC
-    ) {
-      return total;
-    }
-    if (event.event_type === "tool_use_v3") {
-      const category = event.properties["tool_category"];
-      const count = event.properties["count"];
-      if (
-        typeof category === "string" &&
-        isToolCostCategory(category) &&
-        typeof count === "number"
-      ) {
-        return total + count * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-      }
-      return total;
-    } else if (event.event_type === "llm_usage_v3") {
-      const costAwu = event.properties["cost_awu"];
-      return total + (typeof costAwu === "number" ? costAwu : 0);
-    }
-    return total;
-  }, 0);
 }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -5,12 +5,9 @@ import {
   trackProgrammaticCost,
 } from "@app/lib/api/programmatic_usage/tracking";
 import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
-  billedCostAwuFromEvents,
-  buildLlmUsageEvents,
-  buildToolUseEvents,
   buildUsageEvents,
   computeRunKey,
   getUsageType,
@@ -204,9 +201,9 @@ export async function trackProgrammaticUsageActivity(
 }
 
 /**
- * Emit Metronome llm_usage and tool_use events for an agent message.
- * Called for ALL messages (not just programmatic) — always-on, fire-and-forget.
- * Metronome failures don't affect the agent loop.
+ * Emit the aggregated Metronome usage event (LLM + tool cost) for an agent
+ * message. Called for ALL messages (not just programmatic) — always-on,
+ * fire-and-forget. Metronome failures don't affect the agent loop.
  */
 export async function emitMetronomeUsageEventsActivity(
   authType: AuthenticatorType,
@@ -375,7 +372,6 @@ export async function emitMetronomeUsageEventsActivity(
       mcpServerId: json.mcpServerId,
       internalMCPServerName: json.internalMCPServerName,
       status: json.status,
-      executionDurationMs: json.executionDurationMs,
       shouldEmit:
         agentLoopArgs.startStep === undefined ||
         json.step >= agentLoopArgs.startStep,
@@ -389,51 +385,8 @@ export async function emitMetronomeUsageEventsActivity(
   // ceils per the exact same execution partition that is billed here.
   const runKey = computeRunKey(effectiveRunIds);
 
-  // Build the legacy (per-model llm_usage_v3 + per-tool tool_use_v3) events and
-  // the single aggregated event. Which set is ingested depends on the feature
-  // flag below; the cost parity of both is logged in all cases.
-  const llmEvents = buildLlmUsageEvents({
-    workspaceId: workspace.sId,
-    isByok,
-    conversationId,
-    userId,
-    isFreeSeatedUser,
-    agentMessageId,
-    agentId,
-    subAgentId,
-    parentAgentMessageId,
-    runKey,
-    runUsages,
-    origin: userMessageOrigin,
-    usageType,
-    authMethod,
-    apiKeyName,
-    messageStatus,
-    isSubAgentMessage,
-    timestamp,
-  });
-
-  const toolEvents = buildToolUseEvents({
-    workspaceId: workspace.sId,
-    conversationId,
-    userId,
-    isFreeSeatedUser,
-    agentMessageId,
-    agentId,
-    subAgentId,
-    parentAgentMessageId,
-    runKey,
-    actions: toolActions,
-    origin: userMessageOrigin,
-    usageType,
-    authMethod,
-    apiKeyName,
-    messageStatus,
-    isSubAgentMessage,
-    timestamp,
-  });
-
-  const aggregatedUsageEvents = buildUsageEvents({
+  // Build and ingest the single aggregated usage event (LLM + tool cost).
+  const usageEvents = buildUsageEvents({
     workspaceId: workspace.sId,
     isByok,
     conversationId,
@@ -455,35 +408,7 @@ export async function emitMetronomeUsageEventsActivity(
     timestamp,
   });
 
-  // When the flag is on, ingest the single aggregated event; otherwise keep
-  // ingesting the legacy events. Log the cost of both paths in all cases so we
-  // can confirm parity on real traffic.
-  const useAggregatedEvent = await hasFeatureFlag(
-    auth,
-    "metronome_aggregated_usage_event"
-  );
-  const newCostAwu = aggregatedUsageEvents.reduce((total, event) => {
-    const costAwu = event.properties["cost_awu"];
-    return total + (typeof costAwu === "number" ? costAwu : 0);
-  }, 0);
-  const oldCostAwu = billedCostAwuFromEvents([...llmEvents, ...toolEvents]);
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      conversationId,
-      agentMessageId,
-      runKey,
-      newCostAwu,
-      oldCostAwu,
-      costMatches: newCostAwu === oldCostAwu,
-      useAggregatedEvent,
-    },
-    "[UsageQueue] Metronome usage event cost parity check."
-  );
-
-  await ingestMetronomeEvents(
-    useAggregatedEvent ? aggregatedUsageEvents : [...llmEvents, ...toolEvents]
-  );
+  await ingestMetronomeEvents(usageEvents);
 
   // Per-key cap enforcement is pull-based: Metronome spend alerts can't
   // attribute spend by `api_key_name` (it's not the products' presentation

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -441,12 +441,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "achilleburah",
   },
-  metronome_aggregated_usage_event: {
-    description:
-      "Ingest a single aggregated Metronome usage event (LLM + tools) instead of the legacy per-model llm_usage_v3 and per-tool tool_use_v3 events.",
-    stage: "dust_only",
-    owner: "tdraier",
-  },
   legacy_trigger_limits: {
     description:
       "Keep the legacy trigger limits: automations may still be charged to personal credits on a non credit-priced plan.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -823,7 +823,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"
   | "disable_fair_use_awu_limit"
-  | "metronome_aggregated_usage_event"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Final step of the Metronome usage-event migration. The aggregated `llm_usage_v3` event has been ingested behind the `metronome_aggregated_usage_event` flag and its cost matched the legacy events on real traffic (no `costMatches: false` observed). This makes the aggregated event the **only** Metronome usage event and removes the flag-gated legacy path.

- **`activities.ts`**: always ingest `buildUsageEvents`. Removes the feature-flag branch, the legacy `buildLlmUsageEvents` + `buildToolUseEvents` ingestion, and the parity log.
- **`events.ts`**: removes `buildLlmUsageEvents`, `buildToolUseEvents`, `billedCostAwuFromEvents`, and their now-unused helpers (`getToolUsageType`, `truncatePropertyValue`). **No more `tool_use_v3` events are emitted.**
- **Feature flag removed**: `metronome_aggregated_usage_event` dropped from front's `WHITELISTABLE_FEATURES_CONFIG` and the SDK `WhitelistableFeaturesSchema` (kept in sync).

Net −465 lines.

## Tests

- `npm run test -- lib/metronome/events.test.ts` — 10 tests for `buildUsageEvents` (single event, required billable shape, per-model rounding + flat tool addition, per-server cap incl. per-server independence, resume no re-bill, free origins). The legacy-builder and parity tests were removed with the code they covered.
- `npx tsgo --noEmit` clean for the changed files; biome clean.

## Risk

Low–moderate. Billing amount is unchanged — the aggregated `cost_awu` equals the legacy events' billed total (validated in prod under the flag). The visible change is event shape: Metronome now receives one `llm_usage_v3` event per execution and no `tool_use_v3` events. Rollback = revert this commit (restores the flag-gated path). No schema/migration.

## Deploy Plan

1. Deploy. All workspaces immediately emit only the aggregated event.
2. Watch Metronome ingestion + invoices for the affected workspaces to confirm cost is unchanged.
3. Post-merge cleanup (separate, operational): delete stale `metronome_aggregated_usage_event` flag rows (`front/scripts/delete_legacy_feature_flag.ts`), and prune the now-dead Metronome `tool_use_v3` metric / `Tool Usage` product from `setup_new_pricing.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)