### PR TITLE
Use owner-neutral sandbox database runtime names

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -19,7 +19,7 @@ import { podEnv } from "./context.ts";
  * nothing.
  *
  * `name` is the app-relative name the function's source writes, and the app
- * prefix comes from the environment ({@link POD_DATABASE_PREFIX_ENV}) rather
+ * prefix comes from the environment ({@link SANDBOX_DATABASE_PREFIX_ENV}) rather
  * than the source. That is what lets a whole app folder be copied within a pod
  * without editing any source: the copy publishes under its own prefix and
  * therefore resolves `db("chat")` to its own database. See
@@ -33,8 +33,8 @@ import { podEnv } from "./context.ts";
  *   bounding the count is the reconcile path's job.
  * - Each database is capped via `PRAGMA max_page_count` at the byte quota
  *   front chooses and passes per exec (1 GiB in production — see
- *   {@link POD_DATABASE_MAX_SIZE_BYTES_ENV}). Writes past the cap fail with
- *   {@link PodDatabaseFullError}; the database stays readable and rows can
+ *   {@link SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV}). Writes past the cap fail with
+ *   {@link SandboxDatabaseFullError}; the database stays readable and rows can
  *   still be deleted, so the agent recovers in place by reclaiming space.
  * - The WAL is not counted by `max_page_count`: Litestream owns checkpointing
  *   and truncates the WAL as frames are replicated (see `applyPragmas`).
@@ -52,7 +52,10 @@ import { podEnv } from "./context.ts";
  * `dsbx function run`, which forwards it here — no layer below front carries
  * its own copy of the path.
  */
-export const POD_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
+export const SANDBOX_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
+
+/** Compatibility alias for existing `@dust/pod` consumers. */
+export const POD_DATABASES_DIR_ENV = SANDBOX_DATABASES_DIR_ENV;
 
 /**
  * Sandbox-global env var carrying the Pod sId for Pod-owned sandboxes.
@@ -74,14 +77,18 @@ export const FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV =
  * rewrite it — acceptable because the cap is not a security boundary (see
  * the module doc).
  */
-export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
+export const SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV =
   "DUST_POD_DATABASE_MAX_SIZE_BYTES";
 
+/** Compatibility alias for existing `@dust/pod` consumers. */
+export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
+  SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV;
+
 /**
- * Env var carrying the app prefix (separator included, e.g. `"myapp__"`) that
- * namespaces this function's databases inside the pod's flat databases
- * directory. Optional: empty or absent means unprefixed names, which is what
- * functions published outside an app folder get.
+ * Env var carrying the per-invocation database namespace prefix (separator
+ * included, e.g. `"myapp__"`). Optional: empty or absent means unprefixed
+ * names, including Frame functions and Pod functions published outside an app
+ * folder.
  *
  * Front owns the value and derives it from the invoked function's slug, so no
  * layer below front knows how a prefix is built. Read through `podEnv`, so a
@@ -92,62 +99,70 @@ export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
  * can read and write directly, so app prefixing prevents accidental collisions
  * between apps, it does not isolate them.
  */
+export const SANDBOX_DATABASE_PREFIX_ENV = "DUST_SANDBOX_DATABASE_PREFIX";
+
+/** Legacy env key read for sandboxes launched before the owner-neutral ABI. */
 export const POD_DATABASE_PREFIX_ENV = "DUST_POD_DATABASE_PREFIX";
 
 /** How long a connection waits on a locked database before failing. */
-export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
+export const SANDBOX_DATABASE_BUSY_TIMEOUT_MS = 5000;
+
+/** Compatibility alias for existing `@dust/pod` consumers. */
+export const POD_DATABASE_BUSY_TIMEOUT_MS = SANDBOX_DATABASE_BUSY_TIMEOUT_MS;
 
 /** Valid database names (also the manifest/publish contract). */
-export const POD_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+export const SANDBOX_DATABASE_NAME_REGEX = /^[a-z][a-z0-9_]{0,63}$/;
+
+/** Compatibility alias for existing `@dust/pod` consumers. */
+export const POD_DATABASE_NAME_REGEX = SANDBOX_DATABASE_NAME_REGEX;
 export const SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION = 1;
 
 const framePublicationDatabaseContractSchema = z.object({
   schemaVersion: z.literal(SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION),
   manifest: z.object({
     databases: z.array(
-      z.object({ name: z.string().regex(POD_DATABASE_NAME_REGEX) })
+      z.object({ name: z.string().regex(SANDBOX_DATABASE_NAME_REGEX) })
     ),
   }),
 });
 
-export class PodDatabaseError extends Error {
+export class SandboxDatabaseError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "PodDatabaseError";
+    this.name = "SandboxDatabaseError";
   }
 }
 
-export class PodDatabaseInvalidNameError extends PodDatabaseError {
+export class SandboxDatabaseInvalidNameError extends SandboxDatabaseError {
   constructor(name: string) {
     super(
-      `Invalid pod database name ${JSON.stringify(name)}: names must match ` +
-        `${POD_DATABASE_NAME_REGEX.source} (lowercase letter first, then lowercase ` +
+      `Invalid sandbox database name ${JSON.stringify(name)}: names must match ` +
+        `${SANDBOX_DATABASE_NAME_REGEX.source} (lowercase letter first, then lowercase ` +
         `letters, digits or underscores, 64 characters max).`
     );
-    this.name = "PodDatabaseInvalidNameError";
+    this.name = "SandboxDatabaseInvalidNameError";
   }
 }
 
-export class PodDatabasesUnavailableError extends PodDatabaseError {
+export class SandboxDatabasesUnavailableError extends SandboxDatabaseError {
   constructor() {
     super(
       `Databases are not available in this sandbox: neither ${POD_SPACE_ID_ENV} ` +
-        `nor ${FRAME_ID_ENV} is set, which means this sandbox does not belong ` +
-        `to a Pod or Frame. db() only works in functions running in a Pod or ` +
-        `Frame sandbox.`
+        `nor ${FRAME_ID_ENV} is set, so the sandbox has no database owner. ` +
+        `db() only works in an owner-bound function sandbox.`
     );
-    this.name = "PodDatabasesUnavailableError";
+    this.name = "SandboxDatabasesUnavailableError";
   }
 }
 
-export class FramePublicationDescriptorError extends PodDatabaseError {
+export class FramePublicationDescriptorError extends SandboxDatabaseError {
   constructor(message: string) {
     super(message);
     this.name = "FramePublicationDescriptorError";
   }
 }
 
-export class FrameDatabaseNotDeclaredError extends PodDatabaseError {
+export class FrameDatabaseNotDeclaredError extends SandboxDatabaseError {
   constructor(dbName: string) {
     super(
       `Frame database "${dbName}" is not declared in this publication. ` +
@@ -157,7 +172,7 @@ export class FrameDatabaseNotDeclaredError extends PodDatabaseError {
   }
 }
 
-export class FrameDatabaseUnavailableError extends PodDatabaseError {
+export class FrameDatabaseUnavailableError extends SandboxDatabaseError {
   constructor(dbName: string, path: string) {
     super(
       `Frame database "${dbName}" is declared but unavailable (no database ` +
@@ -167,7 +182,7 @@ export class FrameDatabaseUnavailableError extends PodDatabaseError {
   }
 }
 
-export class PodDatabaseNotDeclaredError extends PodDatabaseError {
+export class PodDatabaseNotDeclaredError extends SandboxDatabaseError {
   constructor(dbName: string, path: string) {
     super(
       `Pod database "${dbName}" does not exist (no database file at ${path}). ` +
@@ -179,21 +194,30 @@ export class PodDatabaseNotDeclaredError extends PodDatabaseError {
   }
 }
 
-export class PodDatabaseFullError extends PodDatabaseError {
+export class SandboxDatabaseFullError extends SandboxDatabaseError {
   constructor(dbName: string, maxSizeBytes: number) {
     super(
-      `Pod database "${dbName}" is full: it reached its size quota of ` +
+      `Sandbox database "${dbName}" is full: it reached its size quota of ` +
         `${maxSizeBytes} bytes. Delete unneeded rows to reclaim space before ` +
         `writing more data.`
     );
-    this.name = "PodDatabaseFullError";
+    this.name = "SandboxDatabaseFullError";
   }
 }
 
 /** The Drizzle handle returned by {@link db}. */
-export type PodDatabase = BunSQLiteDatabase<Record<string, never>> & {
+export type SandboxDatabase = BunSQLiteDatabase<Record<string, never>> & {
   $client: Database;
 };
+
+// Keep the original public API working while new callers use owner-neutral names.
+export {
+  SandboxDatabaseError as PodDatabaseError,
+  SandboxDatabaseFullError as PodDatabaseFullError,
+  SandboxDatabaseInvalidNameError as PodDatabaseInvalidNameError,
+  SandboxDatabasesUnavailableError as PodDatabasesUnavailableError,
+};
+export type PodDatabase = SandboxDatabase;
 
 function isSqliteErrorWithCode(err: unknown, code: string): boolean {
   return err instanceof Error && "code" in err && err.code === code;
@@ -218,7 +242,7 @@ function translateSqliteError(
   maxSizeBytes: number
 ): unknown {
   if (isSqliteErrorWithCode(err, "SQLITE_FULL")) {
-    return new PodDatabaseFullError(dbName, maxSizeBytes);
+    return new SandboxDatabaseFullError(dbName, maxSizeBytes);
   }
   return err;
 }
@@ -251,11 +275,11 @@ function wrapStatement<T extends object>(
 
 /**
  * A bun:sqlite Database that translates `SQLITE_FULL` (the quota surface of
- * `PRAGMA max_page_count`) into {@link PodDatabaseFullError} on every
+ * `PRAGMA max_page_count`) into {@link SandboxDatabaseFullError} on every
  * execution path Drizzle uses: `exec`/`run` directly, and statements obtained
  * through `prepare` (which `query()` and `transaction()` also go through).
  */
-class PodSqliteDatabase extends Database {
+class SandboxSqliteDatabase extends Database {
   private readonly dbName: string;
   private readonly maxSizeBytes: number;
 
@@ -305,11 +329,11 @@ class PodSqliteDatabase extends Database {
   }
 }
 
-function podDatabasesDir(): string {
-  const dir = podEnv(POD_DATABASES_DIR_ENV);
+function sandboxDatabasesDir(): string {
+  const dir = podEnv(SANDBOX_DATABASES_DIR_ENV);
   if (dir === undefined || dir.length === 0) {
-    throw new PodDatabaseError(
-      `${POD_DATABASES_DIR_ENV} is not set: the databases directory is ` +
+    throw new SandboxDatabaseError(
+      `${SANDBOX_DATABASES_DIR_ENV} is not set: the databases directory is ` +
         `chosen by front and passed through dsbx function run, so db() only ` +
         `works in functions launched that way.`
     );
@@ -337,7 +361,10 @@ function resolveDatabasePath(dir: string, name: string): string {
   // concurrent invocations from different apps, and their prefixes differ. Read
   // straight from process.env and every warm invocation would resolve against
   // whichever prefix the cold run happened to leave there.
-  const prefix = podEnv(POD_DATABASE_PREFIX_ENV) ?? "";
+  const prefix =
+    podEnv(SANDBOX_DATABASE_PREFIX_ENV) ??
+    podEnv(POD_DATABASE_PREFIX_ENV) ??
+    "";
   if (prefix.length > 0) {
     // No need to re-check the name contract here: a prefix long enough to push
     // the qualified name past it is one reconcile refuses to create a file for,
@@ -350,11 +377,11 @@ function resolveDatabasePath(dir: string, name: string): string {
   return `${dir}/${name}.db`;
 }
 
-function podDatabaseMaxSizeBytes(): number {
-  const raw = podEnv(POD_DATABASE_MAX_SIZE_BYTES_ENV);
+function sandboxDatabaseMaxSizeBytes(): number {
+  const raw = podEnv(SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV);
   if (raw === undefined || raw.length === 0) {
-    throw new PodDatabaseError(
-      `${POD_DATABASE_MAX_SIZE_BYTES_ENV} is not set: the per-database size ` +
+    throw new SandboxDatabaseError(
+      `${SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV} is not set: the per-database size ` +
         `quota is chosen by front and passed through dsbx function run, so ` +
         `db() only works in functions launched that way.`
     );
@@ -363,8 +390,8 @@ function podDatabaseMaxSizeBytes(): number {
   const parsed = /^[0-9]+$/.test(raw) ? Number(raw) : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     // No default to fall back to; failing loudly beats masking a broken quota.
-    throw new PodDatabaseError(
-      `${POD_DATABASE_MAX_SIZE_BYTES_ENV} is not a positive integer byte ` +
+    throw new SandboxDatabaseError(
+      `${SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV} is not a positive integer byte ` +
         `count: ${JSON.stringify(raw)}.`
     );
   }
@@ -376,13 +403,16 @@ function podDatabaseMaxSizeBytes(): number {
  * not set here: it is a persistent per-database setting, applied once when
  * reconcile creates the file.
  */
-function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
+function applyPragmas(
+  sqlite: SandboxSqliteDatabase,
+  maxSizeBytes: number
+): void {
   // WAL allows a single writer at a time: concurrent function invocations —
   // and Litestream, which briefly takes the write lock to checkpoint — must
   // wait for it instead of failing instantly with SQLITE_BUSY. 5s is the
   // value the Litestream docs recommend and comfortably covers the short
   // transactions functions are expected to run.
-  sqlite.exec(`PRAGMA busy_timeout = ${POD_DATABASE_BUSY_TIMEOUT_MS}`);
+  sqlite.exec(`PRAGMA busy_timeout = ${SANDBOX_DATABASE_BUSY_TIMEOUT_MS}`);
   // Under WAL, NORMAL fsyncs at checkpoint time instead of on every commit:
   // a host crash can lose the most recent commits but cannot corrupt the
   // database. Commits happen inside function calls, so FULL's per-commit
@@ -399,7 +429,7 @@ function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
   sqlite.exec("PRAGMA wal_autocheckpoint = 0");
   const row = sqlite.query<{ page_size: number }, []>("PRAGMA page_size").get();
   if (row === null) {
-    throw new PodDatabaseError("PRAGMA page_size returned no row");
+    throw new SandboxDatabaseError("PRAGMA page_size returned no row");
   }
   // The per-database size cap (see the module doc). max_page_count counts
   // pages, so the byte quota is converted using this database's actual page
@@ -411,7 +441,7 @@ function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
 }
 
 // One instance per resolved database file path, opened lazily on first db().
-const instances = new Map<string, PodDatabase>();
+const instances = new Map<string, SandboxDatabase>();
 
 // Publication descriptors are immutable, so declarations can be cached by
 // their exact mounted path without mixing warm invocations across publications.
@@ -469,7 +499,7 @@ function assertDatabaseOwnerCanUse(name: string): boolean {
 
   const spaceId = podEnv(POD_SPACE_ID_ENV);
   if (!spaceId) {
-    throw new PodDatabasesUnavailableError();
+    throw new SandboxDatabasesUnavailableError();
   }
   return false;
 }
@@ -479,38 +509,38 @@ function assertDatabaseOwnerCanUse(name: string): boolean {
  * resolve app-relative names through {@link resolveDatabasePath}; Frame
  * functions use unprefixed names declared by the selected publication.
  *
- * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
- * @throws PodDatabasesUnavailableError when both SPACE_ID and FRAME_ID are
- *   absent — this sandbox is owned by neither a Pod nor a Frame.
+ * @throws SandboxDatabaseInvalidNameError when `name` does not match the contract.
+ * @throws SandboxDatabasesUnavailableError when both SPACE_ID and FRAME_ID are
+ *   absent, so this sandbox has no database owner.
  * @throws FramePublicationDescriptorError when a Frame invocation has no valid
  *   selected publication descriptor.
  * @throws FrameDatabaseNotDeclaredError when the selected Frame publication
  *   does not declare `name`.
  * @throws FrameDatabaseUnavailableError when declared state was not reconciled.
- * @throws PodDatabaseError when DUST_POD_DATABASES_DIR or
+ * @throws SandboxDatabaseError when DUST_POD_DATABASES_DIR or
  *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
  *   in functions launched by `dsbx function run`.
- * @throws PodDatabaseNotDeclaredError when no database file exists — databases
+ * @throws PodDatabaseNotDeclaredError for a Pod function when no database file exists. Databases
  *   are created by their first reconcile.
- * @throws PodDatabaseFullError (from queries) when the database hits its quota.
+ * @throws SandboxDatabaseFullError (from queries) when the database hits its quota.
  */
-export function db(name: string): PodDatabase {
-  if (!POD_DATABASE_NAME_REGEX.test(name)) {
-    throw new PodDatabaseInvalidNameError(name);
+export function db(name: string): SandboxDatabase {
+  if (!SANDBOX_DATABASE_NAME_REGEX.test(name)) {
+    throw new SandboxDatabaseInvalidNameError(name);
   }
   // Recheck before the instance cache: a warm worker may have opened this
   // database for an older publication that declared it.
   const isFrame = assertDatabaseOwnerCanUse(name);
-  const path = resolveDatabasePath(podDatabasesDir(), name);
+  const path = resolveDatabasePath(sandboxDatabasesDir(), name);
   const cached = instances.get(path);
   if (cached !== undefined) {
     return cached;
   }
 
-  const maxSizeBytes = podDatabaseMaxSizeBytes();
-  let sqlite: PodSqliteDatabase;
+  const maxSizeBytes = sandboxDatabaseMaxSizeBytes();
+  let sqlite: SandboxSqliteDatabase;
   try {
-    sqlite = new PodSqliteDatabase(path, name, maxSizeBytes);
+    sqlite = new SandboxSqliteDatabase(path, name, maxSizeBytes);
   } catch (err) {
     if (isSqliteErrorWithCode(err, "SQLITE_CANTOPEN")) {
       if (isFrame) {

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -11,7 +11,7 @@ import { podEnv } from "./context.ts";
  * Frame and Pod state databases.
  *
  * `db(name)` returns a cached Drizzle instance over the sandbox owner's live
- * SQLite database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. Pod names
+ * SQLite database at `${DUST_SANDBOX_DATABASES_DIR}/{prefix}{name}.db`. Pod names
  * may be prefixed; Frame names are unprefixed and must be declared by the
  * selected immutable publication. Databases are created by reconciliation,
  * never here: the file is opened must-exist so a typo'd name errors clearly
@@ -52,10 +52,10 @@ import { podEnv } from "./context.ts";
  * `dsbx function run`, which forwards it here — no layer below front carries
  * its own copy of the path.
  */
-export const SANDBOX_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
+export const SANDBOX_DATABASES_DIR_ENV = "DUST_SANDBOX_DATABASES_DIR";
 
-/** Compatibility alias for existing `@dust/pod` consumers. */
-export const POD_DATABASES_DIR_ENV = SANDBOX_DATABASES_DIR_ENV;
+/** Legacy env key read for sandboxes launched before the owner-neutral ABI. */
+export const POD_DATABASES_DIR_ENV = "DUST_POD_DATABASES_DIR";
 
 /**
  * Sandbox-global env var carrying the Pod sId for Pod-owned sandboxes.
@@ -78,11 +78,11 @@ export const FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV =
  * the module doc).
  */
 export const SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV =
-  "DUST_POD_DATABASE_MAX_SIZE_BYTES";
+  "DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES";
 
-/** Compatibility alias for existing `@dust/pod` consumers. */
+/** Legacy env key read for sandboxes launched before the owner-neutral ABI. */
 export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
-  SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV;
+  "DUST_POD_DATABASE_MAX_SIZE_BYTES";
 
 /**
  * Env var carrying the per-invocation database namespace prefix (separator
@@ -126,10 +126,14 @@ const framePublicationDatabaseContractSchema = z.object({
   }),
 });
 
+/**
+ * Compatibility ABI: shared errors keep their legacy `Pod*` `Error.name`
+ * values while the legacy class aliases below remain public.
+ */
 export class SandboxDatabaseError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "SandboxDatabaseError";
+    this.name = "PodDatabaseError";
   }
 }
 
@@ -140,7 +144,7 @@ export class SandboxDatabaseInvalidNameError extends SandboxDatabaseError {
         `${SANDBOX_DATABASE_NAME_REGEX.source} (lowercase letter first, then lowercase ` +
         `letters, digits or underscores, 64 characters max).`
     );
-    this.name = "SandboxDatabaseInvalidNameError";
+    this.name = "PodDatabaseInvalidNameError";
   }
 }
 
@@ -151,7 +155,7 @@ export class SandboxDatabasesUnavailableError extends SandboxDatabaseError {
         `nor ${FRAME_ID_ENV} is set, so the sandbox has no database owner. ` +
         `db() only works in an owner-bound function sandbox.`
     );
-    this.name = "SandboxDatabasesUnavailableError";
+    this.name = "PodDatabasesUnavailableError";
   }
 }
 
@@ -201,7 +205,7 @@ export class SandboxDatabaseFullError extends SandboxDatabaseError {
         `${maxSizeBytes} bytes. Delete unneeded rows to reclaim space before ` +
         `writing more data.`
     );
-    this.name = "SandboxDatabaseFullError";
+    this.name = "PodDatabaseFullError";
   }
 }
 
@@ -330,7 +334,8 @@ class SandboxSqliteDatabase extends Database {
 }
 
 function sandboxDatabasesDir(): string {
-  const dir = podEnv(SANDBOX_DATABASES_DIR_ENV);
+  const dir =
+    podEnv(SANDBOX_DATABASES_DIR_ENV) ?? podEnv(POD_DATABASES_DIR_ENV);
   if (dir === undefined || dir.length === 0) {
     throw new SandboxDatabaseError(
       `${SANDBOX_DATABASES_DIR_ENV} is not set: the databases directory is ` +
@@ -378,7 +383,9 @@ function resolveDatabasePath(dir: string, name: string): string {
 }
 
 function sandboxDatabaseMaxSizeBytes(): number {
-  const raw = podEnv(SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV);
+  const raw =
+    podEnv(SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV) ??
+    podEnv(POD_DATABASE_MAX_SIZE_BYTES_ENV);
   if (raw === undefined || raw.length === 0) {
     throw new SandboxDatabaseError(
       `${SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV} is not set: the per-database size ` +
@@ -517,8 +524,8 @@ function assertDatabaseOwnerCanUse(name: string): boolean {
  * @throws FrameDatabaseNotDeclaredError when the selected Frame publication
  *   does not declare `name`.
  * @throws FrameDatabaseUnavailableError when declared state was not reconciled.
- * @throws SandboxDatabaseError when DUST_POD_DATABASES_DIR or
- *   DUST_POD_DATABASE_MAX_SIZE_BYTES is absent or invalid — db() only works
+ * @throws SandboxDatabaseError when DUST_SANDBOX_DATABASES_DIR or
+ *   DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES is absent or invalid. db() only works
  *   in functions launched by `dsbx function run`.
  * @throws PodDatabaseNotDeclaredError for a Pod function when no database file exists. Databases
  *   are created by their first reconcile.

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -98,9 +98,9 @@ let originalFramePublicationDescriptorPath: string | undefined;
 
 beforeEach(() => {
   databasesDir = mkdtempSync(join(tmpdir(), "dust-pod-test-"));
-  process.env[POD_DATABASES_DIR_ENV] = databasesDir;
+  process.env[SANDBOX_DATABASES_DIR_ENV] = databasesDir;
   // Both env vars are required and normally set by front through dsbx.
-  process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(ONE_GIB_BYTES);
+  process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV] = String(ONE_GIB_BYTES);
   // Pod sandboxes carry SPACE_ID as a sandbox-global env var.
   originalSpaceId = process.env[POD_SPACE_ID_ENV];
   process.env[POD_SPACE_ID_ENV] = "spc_test_pod";
@@ -112,6 +112,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete process.env[SANDBOX_DATABASES_DIR_ENV];
+  delete process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV];
   delete process.env[POD_DATABASES_DIR_ENV];
   delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
   delete process.env[SANDBOX_DATABASE_PREFIX_ENV];
@@ -136,10 +138,14 @@ afterEach(() => {
 });
 
 describe("legacy database compatibility aliases", () => {
-  test("constants reference their owner-neutral counterparts", () => {
-    expect(POD_DATABASES_DIR_ENV).toBe(SANDBOX_DATABASES_DIR_ENV);
+  test("legacy environment keys remain exported", () => {
+    expect(SANDBOX_DATABASES_DIR_ENV).toBe("DUST_SANDBOX_DATABASES_DIR");
+    expect(POD_DATABASES_DIR_ENV).toBe("DUST_POD_DATABASES_DIR");
+    expect(SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV).toBe(
+      "DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES"
+    );
     expect(POD_DATABASE_MAX_SIZE_BYTES_ENV).toBe(
-      SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV
+      "DUST_POD_DATABASE_MAX_SIZE_BYTES"
     );
     expect(POD_DATABASE_BUSY_TIMEOUT_MS).toBe(SANDBOX_DATABASE_BUSY_TIMEOUT_MS);
     expect(POD_DATABASE_NAME_REGEX).toBe(SANDBOX_DATABASE_NAME_REGEX);
@@ -162,6 +168,19 @@ describe("legacy database compatibility aliases", () => {
     );
     expect(new SandboxDatabaseFullError("test", 1)).toBeInstanceOf(
       PodDatabaseFullError
+    );
+
+    // Error.name is part of the legacy compatibility ABI, including when the
+    // same constructor is reached through its canonical export.
+    expect(new SandboxDatabaseError("test").name).toBe("PodDatabaseError");
+    expect(new SandboxDatabaseInvalidNameError("invalid").name).toBe(
+      "PodDatabaseInvalidNameError"
+    );
+    expect(new SandboxDatabasesUnavailableError().name).toBe(
+      "PodDatabasesUnavailableError"
+    );
+    expect(new SandboxDatabaseFullError("test", 1).name).toBe(
+      "PodDatabaseFullError"
     );
   });
 
@@ -213,8 +232,8 @@ describe("sandbox database owner guard", () => {
 describe("Frame publication database contract", () => {
   function frameInvocationEnv(descriptorPath?: string) {
     return {
-      [POD_DATABASES_DIR_ENV]: databasesDir,
-      [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+      [SANDBOX_DATABASES_DIR_ENV]: databasesDir,
+      [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
       [FRAME_ID_ENV]: "fil_test_frame",
       ...(descriptorPath
         ? { [FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV]: descriptorPath }
@@ -311,7 +330,7 @@ describe("name validation", () => {
   });
 
   test("validates the name before touching the filesystem", () => {
-    delete process.env[POD_DATABASES_DIR_ENV];
+    delete process.env[SANDBOX_DATABASES_DIR_ENV];
     expect(() => db("NOT_VALID")).toThrow(PodDatabaseInvalidNameError);
   });
 });
@@ -337,19 +356,20 @@ describe("must-exist open", () => {
   test("throws when the databases dir env var is absent", () => {
     // No fallback path lives here: front owns the location and passes it
     // through dsbx. Unset means a broken launch context, not an empty pod.
-    delete process.env[POD_DATABASES_DIR_ENV];
+    delete process.env[SANDBOX_DATABASES_DIR_ENV];
     const name = uniqueName("nodir");
     expect(() => db(name)).toThrow(PodDatabaseError);
-    expect(() => db(name)).toThrow(/DUST_POD_DATABASES_DIR is not set/);
+    expect(() => db(name)).toThrow(/DUST_SANDBOX_DATABASES_DIR is not set/);
   });
 
   test("an empty databases dir env var is treated as absent", () => {
     // dsbx passes env through verbatim; empty means the same broken launch
     // context as unset, and this is the one layer that normalizes it.
-    process.env[POD_DATABASES_DIR_ENV] = "";
+    process.env[SANDBOX_DATABASES_DIR_ENV] = "";
+    process.env[POD_DATABASES_DIR_ENV] = databasesDir;
     const name = uniqueName("nodir");
     expect(() => db(name)).toThrow(PodDatabaseError);
-    expect(() => db(name)).toThrow(/DUST_POD_DATABASES_DIR is not set/);
+    expect(() => db(name)).toThrow(/DUST_SANDBOX_DATABASES_DIR is not set/);
   });
 });
 
@@ -474,8 +494,8 @@ describe("app prefix resolution", () => {
   // touching process.env, so the prefix has to come from the invocation context.
   describe("inside an invocation context", () => {
     const contextEnv = (prefix: string) => ({
-      [POD_DATABASES_DIR_ENV]: databasesDir,
-      [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+      [SANDBOX_DATABASES_DIR_ENV]: databasesDir,
+      [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
       [POD_SPACE_ID_ENV]: "spc_test_pod",
       [SANDBOX_DATABASE_PREFIX_ENV]: prefix,
     });
@@ -497,8 +517,8 @@ describe("app prefix resolution", () => {
       expect(
         runWithInvocationEnv(
           {
-            [POD_DATABASES_DIR_ENV]: databasesDir,
-            [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+            [SANDBOX_DATABASES_DIR_ENV]: databasesDir,
+            [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
             [FRAME_ID_ENV]: "fil_test_frame",
             [FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV]: descriptorPath,
             [SANDBOX_DATABASE_PREFIX_ENV]: "",
@@ -620,7 +640,7 @@ describe("pragmas", () => {
   test("the quota env var drives max_page_count", () => {
     const name = uniqueName("quota");
     createDatabaseFile(name);
-    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
+    process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
 
     const client = db(name).$client;
     expect(
@@ -633,7 +653,9 @@ describe("pragmas", () => {
   test("quotas above 1 GiB are honored, not clamped", () => {
     const name = uniqueName("quota");
     createDatabaseFile(name);
-    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(2 * ONE_GIB_BYTES);
+    process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV] = String(
+      2 * ONE_GIB_BYTES
+    );
 
     const client = db(name).$client;
     const pageSize = client
@@ -651,10 +673,10 @@ describe("pragmas", () => {
     // No default lives here: front owns the quota and passes it through dsbx.
     const name = uniqueName("quota");
     createDatabaseFile(name);
-    delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+    delete process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV];
     expect(() => db(name)).toThrow(PodDatabaseError);
     expect(() => db(name)).toThrow(
-      /DUST_POD_DATABASE_MAX_SIZE_BYTES is not set/
+      /DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES is not set/
     );
   });
 
@@ -663,9 +685,10 @@ describe("pragmas", () => {
     createDatabaseFile(name);
     // Canonical decimal digits only: Number() alone would accept "1e3",
     // "0x10" or " 42 ".
+    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = String(ONE_GIB_BYTES);
     const invalid = ["0", "-1", "1.5", "abc", "1e100", "1e3", "0x10", " 42 "];
     for (const raw of invalid) {
-      process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = raw;
+      process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV] = raw;
       expect(() => db(name)).toThrow(/not a positive integer byte count/);
     }
   });
@@ -694,7 +717,7 @@ describe("size quota enforcement", () => {
       name,
       "CREATE TABLE blobs (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB)"
     );
-    process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
+    process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV] = "20480"; // 5 pages of 4096.
 
     const handle = db(name);
     let thrown: unknown;

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { PodDatabase, SandboxDatabase } from "@dust/pod";
 import {
   db,
   FRAME_ID_ENV,
@@ -12,6 +13,7 @@ import {
   FramePublicationDescriptorError,
   POD_DATABASE_BUSY_TIMEOUT_MS,
   POD_DATABASE_MAX_SIZE_BYTES_ENV,
+  POD_DATABASE_NAME_REGEX,
   POD_DATABASE_PREFIX_ENV,
   POD_DATABASES_DIR_ENV,
   POD_SPACE_ID_ENV,
@@ -21,6 +23,15 @@ import {
   PodDatabaseNotDeclaredError,
   PodDatabasesUnavailableError,
   runWithInvocationEnv,
+  SANDBOX_DATABASE_BUSY_TIMEOUT_MS,
+  SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV,
+  SANDBOX_DATABASE_NAME_REGEX,
+  SANDBOX_DATABASE_PREFIX_ENV,
+  SANDBOX_DATABASES_DIR_ENV,
+  SandboxDatabaseError,
+  SandboxDatabaseFullError,
+  SandboxDatabaseInvalidNameError,
+  SandboxDatabasesUnavailableError,
   SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION,
 } from "@dust/pod";
 import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
@@ -103,6 +114,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env[POD_DATABASES_DIR_ENV];
   delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  delete process.env[SANDBOX_DATABASE_PREFIX_ENV];
   delete process.env[POD_DATABASE_PREFIX_ENV];
   if (originalSpaceId === undefined) {
     delete process.env[POD_SPACE_ID_ENV];
@@ -123,13 +135,53 @@ afterEach(() => {
   rmSync(databasesDir, { recursive: true, force: true });
 });
 
+describe("legacy database compatibility aliases", () => {
+  test("constants reference their owner-neutral counterparts", () => {
+    expect(POD_DATABASES_DIR_ENV).toBe(SANDBOX_DATABASES_DIR_ENV);
+    expect(POD_DATABASE_MAX_SIZE_BYTES_ENV).toBe(
+      SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV
+    );
+    expect(POD_DATABASE_BUSY_TIMEOUT_MS).toBe(SANDBOX_DATABASE_BUSY_TIMEOUT_MS);
+    expect(POD_DATABASE_NAME_REGEX).toBe(SANDBOX_DATABASE_NAME_REGEX);
+    expect(POD_DATABASE_PREFIX_ENV).toBe("DUST_POD_DATABASE_PREFIX");
+    expect(SANDBOX_DATABASE_PREFIX_ENV).toBe("DUST_SANDBOX_DATABASE_PREFIX");
+  });
+
+  test("error aliases preserve constructor and instanceof behavior", () => {
+    expect(PodDatabaseError).toBe(SandboxDatabaseError);
+    expect(PodDatabaseInvalidNameError).toBe(SandboxDatabaseInvalidNameError);
+    expect(PodDatabasesUnavailableError).toBe(SandboxDatabasesUnavailableError);
+    expect(PodDatabaseFullError).toBe(SandboxDatabaseFullError);
+
+    expect(new PodDatabaseError("test")).toBeInstanceOf(SandboxDatabaseError);
+    expect(new SandboxDatabaseInvalidNameError("invalid")).toBeInstanceOf(
+      PodDatabaseInvalidNameError
+    );
+    expect(new SandboxDatabasesUnavailableError()).toBeInstanceOf(
+      PodDatabasesUnavailableError
+    );
+    expect(new SandboxDatabaseFullError("test", 1)).toBeInstanceOf(
+      PodDatabaseFullError
+    );
+  });
+
+  test("the database handle type remains compatible", () => {
+    const name = uniqueName("compatibility");
+    createDatabaseFile(name);
+
+    const legacyHandle: PodDatabase = db(name);
+    const sandboxHandle: SandboxDatabase = legacyHandle;
+    expect(sandboxHandle).toBe(legacyHandle);
+  });
+});
+
 describe("sandbox database owner guard", () => {
   test("both owner ids absent throws even when the file exists", () => {
     const name = uniqueName("guard");
     createDatabaseFile(name);
     delete process.env[POD_SPACE_ID_ENV];
     expect(() => db(name)).toThrow(PodDatabasesUnavailableError);
-    expect(() => db(name)).toThrow(/does not belong to a Pod or Frame/);
+    expect(() => db(name)).toThrow(/has no database owner/);
   });
 
   test("empty owner ids are treated as absent", () => {
@@ -322,15 +374,42 @@ describe("app prefix resolution", () => {
 
   test("opens the app-prefixed database when it exists", () => {
     const name = uniqueName("chat");
-    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
     createDatabaseOwnedBy(`myapp__${name}`, "myapp");
 
     expect(ownerOf(name)).toBe("myapp");
   });
 
+  test("reads the legacy Pod prefix from an invocation context", () => {
+    const name = uniqueName("chat");
+    createDatabaseOwnedBy(`legacyapp__${name}`, "legacyapp");
+
+    expect(
+      runWithInvocationEnv(
+        {
+          [POD_DATABASES_DIR_ENV]: databasesDir,
+          [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+          [POD_SPACE_ID_ENV]: "spc_test_pod",
+          [POD_DATABASE_PREFIX_ENV]: "legacyapp__",
+        },
+        () => ownerOf(name)
+      )
+    ).toBe("legacyapp");
+  });
+
+  test("prefers the canonical prefix over the legacy key", () => {
+    const name = uniqueName("chat");
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "canonical__";
+    process.env[POD_DATABASE_PREFIX_ENV] = "legacy__";
+    createDatabaseOwnedBy(`canonical__${name}`, "canonical");
+    createDatabaseOwnedBy(`legacy__${name}`, "legacy");
+
+    expect(ownerOf(name)).toBe("canonical");
+  });
+
   test("prefers the app-prefixed database over a same-named legacy one", () => {
     const name = uniqueName("chat");
-    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
     createDatabaseOwnedBy(name, "legacy");
     createDatabaseOwnedBy(`myapp__${name}`, "myapp");
 
@@ -341,7 +420,7 @@ describe("app prefix resolution", () => {
     // Transitional: databases created before app namespacing keep their bare filenames, and
     // litestream replicates them under a prefix keyed on that filename.
     const name = uniqueName("chat");
-    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
     createDatabaseOwnedBy(name, "legacy");
 
     expect(ownerOf(name)).toBe("legacy");
@@ -352,9 +431,9 @@ describe("app prefix resolution", () => {
     createDatabaseOwnedBy(`myapp__${name}`, "myapp");
     createDatabaseOwnedBy(`otherapp__${name}`, "otherapp");
 
-    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
     expect(ownerOf(name)).toBe("myapp");
-    process.env[POD_DATABASE_PREFIX_ENV] = "otherapp__";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "otherapp__";
     expect(ownerOf(name)).toBe("otherapp");
   });
 
@@ -368,7 +447,7 @@ describe("app prefix resolution", () => {
   test("an empty prefix means unprefixed", () => {
     // front passes "" for functions published outside an app folder.
     const name = uniqueName("chat");
-    process.env[POD_DATABASE_PREFIX_ENV] = "";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "";
     createDatabaseOwnedBy(name, "bare");
 
     expect(ownerOf(name)).toBe("bare");
@@ -378,7 +457,7 @@ describe("app prefix resolution", () => {
     // A prefix this long cannot produce a valid qualified name, so reconcile could never have
     // created one; looking for it would only mask the database that does exist.
     const name = uniqueName("chat");
-    process.env[POD_DATABASE_PREFIX_ENV] = `${"a".repeat(60)}__`;
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = `${"a".repeat(60)}__`;
     createDatabaseOwnedBy(name, "bare");
 
     expect(ownerOf(name)).toBe("bare");
@@ -386,7 +465,7 @@ describe("app prefix resolution", () => {
 
   test("still throws when neither the prefixed nor the bare database exists", () => {
     const name = uniqueName("missing");
-    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
 
     expect(() => db(name)).toThrow(PodDatabaseNotDeclaredError);
   });
@@ -398,7 +477,7 @@ describe("app prefix resolution", () => {
       [POD_DATABASES_DIR_ENV]: databasesDir,
       [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
       [POD_SPACE_ID_ENV]: "spc_test_pod",
-      [POD_DATABASE_PREFIX_ENV]: prefix,
+      [SANDBOX_DATABASE_PREFIX_ENV]: prefix,
     });
 
     test("reads the prefix from the context env", () => {
@@ -422,7 +501,7 @@ describe("app prefix resolution", () => {
             [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
             [FRAME_ID_ENV]: "fil_test_frame",
             [FRAME_PUBLICATION_DESCRIPTOR_PATH_ENV]: descriptorPath,
-            [POD_DATABASE_PREFIX_ENV]: "",
+            [SANDBOX_DATABASE_PREFIX_ENV]: "",
           },
           () => ownerOf(name)
         )
@@ -433,7 +512,7 @@ describe("app prefix resolution", () => {
       const name = uniqueName("chat");
       createDatabaseOwnedBy(`myapp__${name}`, "myapp");
       createDatabaseOwnedBy(`otherapp__${name}`, "otherapp");
-      process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+      process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
 
       expect(
         runWithInvocationEnv(contextEnv("otherapp__"), () => ownerOf(name))
@@ -444,7 +523,7 @@ describe("app prefix resolution", () => {
       const name = uniqueName("chat");
       createDatabaseOwnedBy(name, "bare");
       createDatabaseOwnedBy(`myapp__${name}`, "myapp");
-      process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+      process.env[SANDBOX_DATABASE_PREFIX_ENV] = "myapp__";
 
       expect(runWithInvocationEnv(contextEnv(""), () => ownerOf(name))).toBe(
         "bare"


### PR DESCRIPTION
## Description

- make `SandboxDatabase*` and `SANDBOX_DATABASE_*` the canonical shared runtime API
- retain every existing `PodDatabase*` and `POD_DATABASE_*` export as a compatibility alias
- prefer the three `DUST_SANDBOX_DATABASE_*` keys while accepting legacy Pod keys

Pod-only missing-database errors and app namespace behavior stay Pod-specific.

## Tests

Added alias identity, cross-`instanceof`, legacy `Error.name`, type compatibility, and canonical/legacy env precedence coverage. Exercised all 92 runtime package tests and the bundled package locally.

## Risk

Low. Existing imports, constructors, `instanceof` checks, and `Error.name` values keep working. Shared error messages become owner-neutral.

## Deploy Plan

Source-only and dormant until #31585 is merged and deployed. That PR bumps the runtime package and base-image versions, then older sandboxes can be recycled.