### PR TITLE
[front] fix: exclude sub-conversations (depth > 0) from conversation search

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/search.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/search.test.ts
@@ -169,6 +169,41 @@ describe("GET /api/w/:wId/assistant/conversations/search", () => {
       expect(sIds).toContain(conv3.sId);
     });
 
+    it("excludes sub-conversations (depth > 0), even with a participation row", async () => {
+      const { workspace, auth, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      const rootConv = await createConversationWithTitle(
+        auth,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "Deep dive on testing",
+        user.id
+      );
+
+      await createConversationWithTitle(
+        auth,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+          depth: 1,
+        },
+        "run_agent deep-dive > dust_task testing",
+        user.id
+      );
+
+      const response = await search(workspace, { query: "testing" });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].sId).toBe(rootConv.sId);
+    });
+
     it("performs case-insensitive search", async () => {
       const { workspace, auth, user } = await createPrivateApiMockRequest({
         method: "GET",

--- a/front-api/routes/w/[wId]/assistant/conversations/semantic_search.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/semantic_search.test.ts
@@ -325,6 +325,59 @@ describe("GET /api/w/:wId/assistant/conversations/semantic_search", () => {
       expect(data.conversations[2].sId).toBe(conv2.sId);
     });
 
+    it("excludes sub-conversations (depth > 0)", async () => {
+      const { workspace, user, auth, globalGroup } =
+        await createPrivateApiMockRequest({ method: "GET", role: "admin" });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space");
+      }
+
+      await auth.refresh();
+
+      const { mockDataSourceId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(auth, projectSpace);
+
+      const rootConv = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+      const subConv = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+        depth: 1,
+      });
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: [
+            createMockDocument(mockDataSourceId, subConv.sId, 0.9),
+            createMockDocument(mockDataSourceId, rootConv.sId, 0.7),
+          ],
+        })
+      );
+
+      const response = await get(workspace, { query: "test query" });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].sId).toBe(rootConv.sId);
+    });
+
     it("handles documents with multiple chunks and uses max score", async () => {
       const { workspace, user, auth, globalGroup } =
         await createPrivateApiMockRequest({ method: "GET", role: "admin" });

--- a/front-api/routes/w/[wId]/assistant/conversations/semantic_search.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/semantic_search.ts
@@ -63,7 +63,9 @@ app.get(
     const results = filteredResults
       .map((r) => {
         const conv = conversationMap.get(r.conversationId);
-        if (!conv) {
+        // Sub-conversations (depth > 0) are indexed for agent search but must
+        // not surface in user-facing search.
+        if (!conv || conv.depth > 0) {
           return null;
         }
         return {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/search_conversations.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/search_conversations.test.ts
@@ -287,6 +287,77 @@ describe("GET /api/w/:wId/spaces/:spaceId/search_conversations", () => {
     expect(data.conversations[2].sId).toBe(conv2.sId);
   });
 
+  it("excludes sub-conversations (depth > 0)", async () => {
+    const { workspace, auth, globalGroup, projectSpace } =
+      await setupProjectSpaceWithMember();
+
+    const { mockDataSourceId } = await setupDataSourceMocks(
+      workspace,
+      globalGroup
+    );
+    await createDataSourceAndConnectorForProject(auth, projectSpace);
+
+    const rootConv = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+      spaceId: projectSpace.id,
+    });
+    const subConv = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+      spaceId: projectSpace.id,
+      depth: 1,
+    });
+
+    const mockDocuments: CoreAPIDocument[] = [
+      {
+        data_source_id: mockDataSourceId,
+        created: Date.now(),
+        document_id: "doc-sub",
+        parents: [],
+        parent_id: null,
+        timestamp: Date.now(),
+        tags: [`conversation:${subConv.sId}`],
+        hash: "hash-sub",
+        text_size: 100,
+        chunk_count: 1,
+        chunks: [{ text: "test", hash: "chunk-hash", offset: 0, score: 0.9 }],
+        title: "Doc sub",
+        mime_type: null,
+      },
+      {
+        data_source_id: mockDataSourceId,
+        created: Date.now(),
+        document_id: "doc-root",
+        parents: [],
+        parent_id: null,
+        timestamp: Date.now(),
+        tags: [`conversation:${rootConv.sId}`],
+        hash: "hash-root",
+        text_size: 100,
+        chunk_count: 1,
+        chunks: [{ text: "test", hash: "chunk-hash", offset: 0, score: 0.7 }],
+        title: "Doc root",
+        mime_type: null,
+      },
+    ];
+
+    vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+      new Ok({
+        documents: mockDocuments,
+      })
+    );
+
+    const response = await search(workspace, projectSpace.sId, {
+      query: "test query",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.conversations).toHaveLength(1);
+    expect(data.conversations[0].sId).toBe(rootConv.sId);
+  });
+
   it("returns empty array when no conversations found", async () => {
     const { workspace, auth, globalGroup, projectSpace } =
       await setupProjectSpaceWithMember();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -2,7 +2,6 @@ import { searchProjectConversations } from "@app/lib/api/projects/search";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { SearchConversationsResponseBody } from "@app/types/api/projects/search";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -72,10 +71,16 @@ app.get(
     const conversationMap = new Map(conversations.map((ctx) => [ctx.sId, ctx]));
 
     const results = filteredResults
-      .map((r) => conversationMap.get(r.conversationId)?.toJSON())
-      .filter(
-        (ctx): ctx is ConversationWithoutContentType => ctx !== undefined
-      );
+      .map((r) => {
+        const conv = conversationMap.get(r.conversationId);
+        // Sub-conversations (depth > 0) are indexed for agent search but must
+        // not surface in user-facing search.
+        if (!conv || conv.depth > 0) {
+          return null;
+        }
+        return conv.toJSON();
+      })
+      .filter((conv) => conv !== null);
 
     return ctx.json({ conversations: results });
   }

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -26,6 +26,9 @@ interface ConversationSearchResult {
   spaceId: string;
 }
 
+// TODO(2026-09-01 SEARCH): sub-conversations (depth > 0) are indexed and consume
+// the topK budget; callers filter them out post-fetch. Exclude them at sync time
+// instead (listSpaceConversationsForSync) and clean up already-indexed documents.
 export async function searchProjectConversations(
   auth: Authenticator,
   options: SearchProjectConversationsOptions

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2739,6 +2739,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       pagination,
       extraWhereClause: {
         title: { [Op.iLike]: `%${query}%` },
+        depth: { [Op.eq]: 0 }, // Only fetch root conversations
       },
     });
   }


### PR DESCRIPTION
## Fix

Sub-conversations created by `run_agent` (e.g. deep-dive calling dust_task agents) show up in the sidebar conversation search.

<kbd>
<img width="323" height="673" alt="Screenshot 2026-09-01 at 11 50 05" src="https://github.com/user-attachments/assets/6aaff238-b404-4521-9279-e87ec9633a20" />
</kbd>

## Description

Since #28348 child conversations are created in the same pod as their parent, so they get indexed into the pod's `dust_project` data source and surface in semantic search. #28679 hid depth > 0 conversations from the pod lists but missed the search paths.

- `semantic_search` (sidebar search): drop depth > 0 results after fetch.
- `spaces/[spaceId]/search_conversations` (pod page search): same filter, consistent with the pod conversation list which already hides them.
- `searchByTitlePaginated` (sidebar title search): add `depth = 0` to the where clause. Current sub-conversations have no participation row so they don't surface here, but sub-conversations created before the participation skip (#13361) can.

Sub-conversations stay indexed in the pod data source (agent search may rely on them); only the user-facing endpoints filter them out.

Follow up of #28679.

## Tests

One regression test per endpoint: a depth 1 conversation matching the query is not returned.

## Risk

Worst case, a legitimate root conversation is hidden from search results. Safe to rollback.
