### PR TITLE
[front] poke: add reset fair-use button to members usage table

### DIFF
--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -3,6 +3,7 @@ import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLog
 import { GrantFreeCreditsButton } from "@app/components/poke/credits/GrantFreeCreditsButton";
 import { MemberConsumptionExportButton } from "@app/components/poke/credits/MemberConsumptionExportButton";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
+import { ResetFairUseButton } from "@app/components/poke/credits/ResetFairUseButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits, formatCreditsPrecise } from "@app/lib/client/credits";
@@ -401,6 +402,13 @@ function makeColumns({
       enableSorting: false,
       cell: ({ row }) => (
         <div className="flex items-center justify-end gap-2">
+          {row.original.fairUse && row.original.email && (
+            <ResetFairUseButton
+              owner={owner}
+              userEmail={row.original.email}
+              onReset={onReconciled}
+            />
+          )}
           {row.original.seatType === "free" && (
             <GrantFreeCreditsButton
               owner={owner}

--- a/front/components/poke/credits/ResetFairUseButton.tsx
+++ b/front/components/poke/credits/ResetFairUseButton.tsx
@@ -1,0 +1,73 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useRunPokePlugin } from "@app/poke/swr/plugins";
+import type { WorkspaceType } from "@app/types/user";
+import { Button } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const RESET_MESSAGE_RATE_LIMIT_PLUGIN_ID = "reset-message-rate-limit";
+
+interface ResetFairUseButtonProps {
+  owner: WorkspaceType;
+  // Email of the member whose fair-use AWU counter should be reset.
+  userEmail: string;
+  label?: string;
+  // Called after a successful reset so callers can refresh their data.
+  onReset?: () => void;
+}
+
+export function ResetFairUseButton({
+  owner,
+  userEmail,
+  label = "Reset",
+  onReset,
+}: ResetFairUseButtonProps) {
+  const sendNotification = useSendNotification();
+  const [isRunning, setIsRunning] = useState(false);
+
+  const { doRunPlugin } = useRunPokePlugin({
+    pluginId: RESET_MESSAGE_RATE_LIMIT_PLUGIN_ID,
+    pluginResourceTarget: {
+      resourceType: "workspaces",
+      resourceId: owner.sId,
+      workspace: owner,
+    },
+  });
+
+  const handleClick = async () => {
+    setIsRunning(true);
+    const result = await doRunPlugin({
+      resetTarget: ["user_awu_fair_use"],
+      userEmail,
+    });
+    setIsRunning(false);
+
+    if (result.isErr()) {
+      sendNotification({
+        type: "error",
+        title: "Failed to reset fair-use",
+        description: result.error,
+      });
+      return;
+    }
+
+    sendNotification({
+      type: "success",
+      title: "Fair-use reset",
+      description:
+        result.value.display === "text"
+          ? result.value.value
+          : `Fair-use limit reset for ${userEmail}.`,
+    });
+    onReset?.();
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="xs"
+      label={label}
+      isLoading={isRunning}
+      onClick={handleClick}
+    />
+  );
+}


### PR DESCRIPTION
## Description

Adds a "Reset" button shortcut to the poke Usage tab members table (`PokeMembersUsageTable`) so support can reset a member's current AWU fair-use consumption directly from the row, next to the existing Grant / Reconcile actions.

<img width="464" height="141" alt="Screenshot 2026-09-01 at 11 51 45" src="https://github.com/user-attachments/assets/469c8fc6-e8e6-4316-932d-a4bed8fab723" />

The button reuses the existing `reset-message-rate-limit` poke plugin with its `user_awu_fair_use` target (which expires the per-user fair-use Redis counter via `resetFairUseAwuCreditsRateLimitForUser`) — no new plugin was needed. It only renders for rows that carry a fair-use limit and a known email, and refreshes the table on success.

## Tests

Manually verified type-checking (`npx tsgo --noEmit`) and formatting. The underlying plugin path is unchanged; this is a UI shortcut into an existing, already-registered plugin (gated on the `support` poke role).

## Risk

Low. UI-only change in poke (internal admin). No API/schema changes; the reset action goes through the existing plugin with its existing role gating. Safe to roll back by reverting.

## Deploy Plan

Standard front deploy. No migrations or coordination required.
