### PR TITLE
[front] Don't SDK-retry the seat contracts.edit (deltas stack on 504)

### DIFF
--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -301,16 +301,21 @@ describe("adjustSeatCreditBalances", () => {
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockAddManualBalanceEntry).toHaveBeenCalledWith({
-      id: "credit-1",
-      customer_id: "cust-1",
-      contract_id: "contract-1",
-      segment_id: "segment-1",
-      amount: -1500,
-      per_group_amounts: { seatA: -1000, seatB: -500 },
-      reason: "test adjustment",
-      timestamp: "2026-06-11T15:00:00.000Z",
-    });
+    expect(mockAddManualBalanceEntry).toHaveBeenCalledWith(
+      {
+        id: "credit-1",
+        customer_id: "cust-1",
+        contract_id: "contract-1",
+        segment_id: "segment-1",
+        amount: -1500,
+        per_group_amounts: { seatA: -1000, seatB: -500 },
+        reason: "test adjustment",
+        timestamp: "2026-06-11T15:00:00.000Z",
+      },
+      // Manual ledger entries can't be deduped (no uniqueness_key), so we
+      // disable the SDK retry to avoid stacking the delta on a 504.
+      { maxRetries: 0 }
+    );
   });
 
   it("is a no-op when no per-seat amounts are provided", async () => {
@@ -502,6 +507,22 @@ describe("updateSubscriptionSeats", () => {
     expect(
       call.update_subscriptions[0].seat_updates.add_seat_ids[0].seat_ids
     ).toHaveLength(1000);
+    // Each edit carries a uniqueness_key so an SDK retry can't stack the delta.
+    expect(typeof call.uniqueness_key).toBe("string");
+  });
+
+  it("treats a duplicate-key 409 as success (edit already applied on a 504 retry)", async () => {
+    mockContractsEdit.mockRejectedValueOnce(new MockConflictError("duplicate"));
+
+    const result = await updateSubscriptionSeats({
+      metronomeCustomerId: "cust-1",
+      contractId: "contract-1",
+      fromSubscriptionId: "sub-1",
+      addUnassignedSeats: 137,
+      startingAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    unwrapOk(result);
   });
 
   it("chunks adds and removes into separate edits above the cap", async () => {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import config from "@app/lib/api/config";
 import type { ContractCreditType } from "@app/lib/metronome/constants";
 import {
@@ -1650,13 +1652,38 @@ export async function updateSubscriptionSeats({
       continue;
     }
 
+    // Seat updates are cumulative DELTAS (`add/remove_seat_ids`,
+    // `add/remove_unassigned_seats`), and the edit endpoint returns 504s that
+    // still apply server-side — so the SDK's retry-on-5xx (client maxRetries: 5)
+    // would blindly re-send the delta and stack it (an add of 137 unassigned
+    // landing 4× → 548). A fresh per-edit `uniqueness_key` makes the retry safe:
+    // Metronome rejects a duplicate key with a 409, so a retry of an
+    // already-applied edit is a no-op we treat as success — the edit becomes
+    // idempotent against retries instead of stacking.
+    const uniquenessKey = randomUUID();
     try {
       await getMetronomeClient().v2.contracts.edit({
         customer_id: metronomeCustomerId,
         contract_id: contractId,
         update_subscriptions: updateSubscriptions,
+        uniqueness_key: uniquenessKey,
       });
     } catch (err) {
+      if (err instanceof ConflictError) {
+        // Duplicate uniqueness_key → this exact edit already landed (a retry
+        // after a 504 that applied server-side). Idempotent success.
+        logger.info(
+          {
+            metronomeCustomerId,
+            contractId,
+            fromSubscriptionId,
+            toSubscriptionId,
+            uniquenessKey,
+          },
+          "[Metronome] Subscription seat edit already applied (duplicate uniqueness_key) — treating as success"
+        );
+        continue;
+      }
       const error = normalizeError(err);
       logger.error(
         {
@@ -3769,18 +3796,27 @@ export async function adjustSeatCreditBalances({
   );
 
   try {
-    await getMetronomeClient().v1.contracts.addManualBalanceEntry({
-      id: creditId,
-      customer_id: metronomeCustomerId,
-      contract_id: metronomeContractId,
-      segment_id: segmentId,
-      amount: totalAmount,
-      per_group_amounts: perSeatAmounts,
-      reason,
-      timestamp: alignToHour
-        ? floorToHourISO(timestamp)
-        : timestamp.toISOString(),
-    });
+    // A manual ledger entry is a cumulative DELTA and the endpoint 504s while
+    // still applying server-side — so an SDK retry would post the entry twice and
+    // over-adjust the balance. Unlike `contracts.edit`, `addManualBalanceEntry`
+    // has no `uniqueness_key`, so we can't dedup a retry; `maxRetries: 0` is the
+    // mitigation. On failure callers get `Err` and retry at their own (bounded,
+    // spaced) level instead.
+    await getMetronomeClient().v1.contracts.addManualBalanceEntry(
+      {
+        id: creditId,
+        customer_id: metronomeCustomerId,
+        contract_id: metronomeContractId,
+        segment_id: segmentId,
+        amount: totalAmount,
+        per_group_amounts: perSeatAmounts,
+        reason,
+        timestamp: alignToHour
+          ? floorToHourISO(timestamp)
+          : timestamp.toISOString(),
+      },
+      { maxRetries: 0 }
+    );
     logger.info(
       {
         metronomeCustomerId,


### PR DESCRIPTION
## Description

The Metronome SDK client uses `maxRetries: 5`, so any 5xx is retried up to 5 times. **Two** of our contract edits are cumulative **deltas**, and the edit endpoint returns **504 gateway timeouts that still apply server-side** — so an SDK retry re-applies the delta and **stacks** it. (Vanta cleanup: a single "add 137 unassigned" that 504'd landed **4× → 548**.)

Fix, per what each endpoint supports:

- **`updateSubscriptionSeats` (`contracts.edit`)** — attach a fresh per-edit **`uniqueness_key`**. Metronome rejects a duplicate key with a **409**, so an SDK retry of an already-applied edit is a no-op we catch (`ConflictError`) and treat as success. This keeps the SDK's transient-5xx recovery *and* makes the edit idempotent against retries — strictly better than disabling retries. (Thanks @tdraier for the pointer to `uniqueness_key`.)
- **`addManualBalanceEntry`** (per-seat ledger deltas, the pro↔max credit carry) — the v1 endpoint has **no** `uniqueness_key`, so a retry can't be deduped. There we set **`maxRetries: 0`** and let the caller retry at its own bounded/spaced level (the seat-sync Temporal activity, #31422, which re-reads first).

**Not** applied to the other `contracts.edit` callers, on purpose — those are idempotent and *should* keep retrying:
- `add_credits` / `add_commits` already carry a `uniqueness_key`.
- `updateSubscriptionQuantity`, `editCredit`, billing-provider config, contract-name — absolute *sets*.

## Tests

- `tsgo --noEmit` clean. Adds a `uniqueness_key` body field + a `ConflictError` branch on one call, and a per-request `maxRetries: 0` on another; no change to the edit payloads' semantics. Existing seat-sync suites unaffected.

## Risk

- Low. `contracts.edit` gains a fresh uniqueness_key per edit (each edit is still a distinct key, so nothing is wrongly deduped across separate reconciles); a 409 on our own key means the edit already applied → success. `addManualBalanceEntry` now surfaces a transient 5xx as `Err` instead of silently retrying — the activity retries it (bounded + spaced). Net: no more silent double-applies on either delta. Safe to roll back by reverting.

## Deploy Plan

- Standard deploy; no migration. Independent of the other seat-sync PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)