### PR TITLE
Make dsbx database commands sandbox-neutral

### DIFF
--- a/cli/dust-sandbox/src/commands/db/list.rs
+++ b/cli/dust-sandbox/src/commands/db/list.rs
@@ -11,7 +11,7 @@ struct DatabaseEntry {
     size_bytes: u64,
 }
 
-/// List the live pod databases (`*.db` files in the databases directory) with
+/// List the live sandbox databases (`*.db` files in the databases directory) with
 /// their sizes as a one-line JSON envelope. A missing directory is an empty
 /// list: it is created by the first reconcile that claims a database.
 pub fn cmd_db_list() -> Result<()> {
@@ -48,8 +48,8 @@ fn enumerate_databases(dir: &Path) -> std::io::Result<Vec<DatabaseEntry>> {
         let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
             continue;
         };
-        // Hostile-name allowlist: only names satisfying the frozen contract are pod databases
-        // (consistent with db_file_path and Track 1's replica-name filtering).
+        // Hostile-name allowlist: only names satisfying the frozen contract are databases
+        // (consistent with db_file_path and replica-name filtering).
         if !super::is_valid_db_name(name) {
             continue;
         }
@@ -86,7 +86,7 @@ mod tests {
         std::fs::write(dir.path().join("chat.db-shm"), b"s")?;
         std::fs::write(dir.path().join("readme.txt"), b"t")?;
         std::fs::create_dir(dir.path().join("subdir.db"))?;
-        // Names outside the frozen ^[a-z][a-z0-9_]{0,63}$ contract are not pod databases.
+        // Names outside the frozen ^[a-z][a-z0-9_]{0,63}$ contract are not databases.
         std::fs::write(dir.path().join("Weird Name.db"), b"n")?;
         std::fs::write(dir.path().join("UPPER.db"), b"n")?;
 

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -1,8 +1,8 @@
-//! `dsbx db` — pod database subcommands (reconcile/schema/list/query).
+//! `dsbx db` database subcommands (reconcile/schema/list/query).
 //!
-//! Databases are per-pod SQLite files `{name}.db` under `$DUST_POD_DATABASES_DIR`
-//! (falling back to the image's `/pod-state/databases`). This Rust layer owns name
-//! validation and path resolution; the DDL/SQL
+//! Databases are SQLite files `{name}.db` under `$DUST_SANDBOX_DATABASES_DIR`.
+//! The legacy `$DUST_POD_DATABASES_DIR` key and image path remain fallbacks during
+//! migration. This Rust layer owns name validation and path resolution; the DDL/SQL
 //! work runs in the embedded Bun runner (same privilege-drop machinery as
 //! `dsbx function`: dropped to `agent-proxied` via `runuser` whenever dsbx runs as
 //! root, NODE_PATH pointed at the image's global npm modules so `drizzle-kit`
@@ -27,45 +27,44 @@ pub use schema::cmd_db_schema;
 
 pub(crate) use super::function::emit_error;
 
-/// Directory holding the live pod databases. Set by front on `function run` /
-/// `db *` execs; the constant fallback matches the image layout.
-/// TODO(pod-state): function/mod.rs (Track 3, merged) carries identically-named consts plus
-/// an Option-typed `pod_databases_dir()` for `function run` — dedup onto a single shared
-/// definition (these here are the superset: PathBuf-typed helper + empty-value fallback).
-pub(crate) const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
-pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/pod-state/databases";
+/// Directory holding the live sandbox databases. Front sets it on `function run`
+/// and `db *` execs. The default remains the current image path during migration.
+pub(crate) const SANDBOX_DATABASES_DIR_ENV: &str = "DUST_SANDBOX_DATABASES_DIR";
+const LEGACY_POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
+pub(crate) const DEFAULT_SANDBOX_DATABASES_DIR: &str = "/pod-state/databases";
 
 #[derive(Subcommand)]
 pub enum DbCommand {
-    /// Reconcile a pod database with a drizzle schema file (additive DDL only)
+    /// Reconcile a sandbox database with a drizzle schema file (additive DDL only)
     Reconcile {
-        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        /// Database name (resolved under the configured sandbox databases directory)
         name: String,
         /// Path to the drizzle schema file (databases/{db}.db.ts)
         schema_file: String,
     },
-    /// Regenerate a drizzle schema file from a live pod database
+    /// Regenerate a drizzle schema file from a live sandbox database
     Schema {
-        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        /// Database name (resolved under the configured sandbox databases directory)
         name: String,
         /// Output path for the regenerated schema file
         out_schema: String,
     },
-    /// List pod databases with sizes
+    /// List sandbox databases with sizes
     List,
-    /// Execute one SQL statement (from stdin) against a pod database (SELECT/DML; DDL is refused)
+    /// Execute one SQL statement against a sandbox database (SELECT/DML; DDL is refused)
     Query {
-        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        /// Database name (resolved under the configured sandbox databases directory)
         name: String,
     },
 }
 
-/// The configured pod databases directory, falling back to the image constant.
+/// The configured sandbox databases directory, falling back to the legacy key and image path.
 pub(crate) fn databases_dir() -> PathBuf {
-    std::env::var_os(POD_DATABASES_DIR_ENV)
+    std::env::var_os(SANDBOX_DATABASES_DIR_ENV)
         .filter(|dir| !dir.is_empty())
+        .or_else(|| std::env::var_os(LEGACY_POD_DATABASES_DIR_ENV).filter(|dir| !dir.is_empty()))
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_POD_DATABASES_DIR))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SANDBOX_DATABASES_DIR))
 }
 
 /// Valid database names: `^[a-z][a-z0-9_]{0,63}$`. Also blocks
@@ -94,8 +93,7 @@ pub(crate) fn db_file_path(name: &str) -> Result<PathBuf> {
 mod tests {
     use super::*;
 
-    // The crate-shared env lock (commands/mod.rs): DUST_POD_DATABASES_DIR is process-global
-    // and other modules' tests (Track 3's function::tests post-merge) mutate it too.
+    // Both database directory keys are process-global, so tests share the crate-level lock.
     use crate::commands::ENV_LOCK;
 
     #[test]
@@ -124,35 +122,62 @@ mod tests {
     #[test]
     fn databases_dir_defaults_to_the_image_constant() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
-        assert_eq!(databases_dir(), PathBuf::from(DEFAULT_POD_DATABASES_DIR));
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
+        assert_eq!(
+            databases_dir(),
+            PathBuf::from(DEFAULT_SANDBOX_DATABASES_DIR)
+        );
     }
 
     #[test]
     fn databases_dir_honors_the_env_override() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var(POD_DATABASES_DIR_ENV, "/tmp/pod-dbs");
-        assert_eq!(databases_dir(), PathBuf::from("/tmp/pod-dbs"));
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
     }
 
     #[test]
     fn empty_env_override_falls_back_to_the_constant() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var(POD_DATABASES_DIR_ENV, "");
-        assert_eq!(databases_dir(), PathBuf::from(DEFAULT_POD_DATABASES_DIR));
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "");
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
+        assert_eq!(
+            databases_dir(),
+            PathBuf::from(DEFAULT_SANDBOX_DATABASES_DIR)
+        );
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
     }
 
     #[test]
     fn db_file_path_joins_name_and_dir() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var(POD_DATABASES_DIR_ENV, "/tmp/pod-dbs");
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         assert_eq!(
             db_file_path("chat").unwrap(),
-            PathBuf::from("/tmp/pod-dbs/chat.db")
+            PathBuf::from("/tmp/sandbox-dbs/chat.db")
         );
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn databases_dir_falls_back_to_the_legacy_env_key() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+        std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/legacy-dbs"));
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn canonical_database_dir_wins_over_the_legacy_key() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
+        std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn databases_dir_defaults_to_the_image_constant() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
         std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
         assert_eq!(
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn databases_dir_honors_the_env_override() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));
         std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn empty_env_override_falls_back_to_the_constant() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "");
         std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
         assert_eq!(
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn db_file_path_joins_name_and_dir() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         assert_eq!(
             db_file_path("chat").unwrap(),
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn databases_dir_falls_back_to_the_legacy_env_key() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
         std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
         assert_eq!(databases_dir(), PathBuf::from("/tmp/legacy-dbs"));
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn canonical_database_dir_wins_over_the_legacy_key() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
         assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));

--- a/cli/dust-sandbox/src/commands/db/query.rs
+++ b/cli/dust-sandbox/src/commands/db/query.rs
@@ -9,7 +9,7 @@ use super::{db_file_path, spawn_runner};
 /// must match the env var set in front/lib/api/sandbox_functions/dsbx_db.ts.
 const POD_QUERY_SPILL_DIR_ENV: &str = "DUST_POD_QUERY_SPILL_DIR";
 
-/// Execute one SQL statement (from stdin) against the pod database `name`.
+/// Execute one SQL statement (from stdin) against the sandbox database `name`.
 /// The runner allows SELECT and DML and refuses DDL (a statement that changes
 /// the schema is rolled back), so the schema only evolves through reconcile.
 /// Rows come back in the stdout JSON envelope; a result crossing the inline

--- a/cli/dust-sandbox/src/commands/db/reconcile.rs
+++ b/cli/dust-sandbox/src/commands/db/reconcile.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 
 use super::{db_file_path, emit_error, spawn_runner};
 
-/// Reconcile the pod database `name` with the drizzle schema file at
+/// Reconcile the sandbox database `name` with the drizzle schema file at
 /// `schema_file`: the runner plans via drizzle-kit, applies ADDITIVE statements
 /// only (CREATE TABLE / ADD COLUMN / CREATE [UNIQUE] INDEX / DROP INDEX) in one
 /// transaction, and rejects anything destructive with a typed error. The

--- a/cli/dust-sandbox/src/commands/db/schema.rs
+++ b/cli/dust-sandbox/src/commands/db/schema.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use super::{db_file_path, spawn_runner};
 
-/// Regenerate a drizzle `{db}.db.ts` schema file from the live pod database
+/// Regenerate a drizzle `{db}.db.ts` schema file from the live sandbox database
 /// `name`, writing it to `out_schema` (file-output pattern: the file is the
 /// payload, stdout only carries the `{ok}` envelope). Column modes are not
 /// recoverable from SQLite — the regenerated file carries storage types only.

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -392,12 +392,8 @@ pub(crate) fn is_valid_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
-// The environment is process-global and `cargo test` runs tests on parallel
-// threads within one process: any test (in this module or `warm`) that reads
-// or mutates env vars must hold this lock for the whole window where it
-// relies on them.
 #[cfg(test)]
-pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) use crate::commands::ENV_LOCK;
 
 #[cfg(test)]
 mod tests {

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -22,11 +22,7 @@ pub use resolve::cmd_resolve;
 pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools, OffloadResolutionError};
 pub use version::cmd_version;
 
-/// Serializes tests that mutate process-global environment variables (e.g.
-/// DUST_POD_DATABASES_DIR). Env vars are shared across the whole test binary, so every module
-/// whose tests touch them must take this ONE lock — two module-local mutexes guarding the same
-/// variable would not exclude each other under parallel test threads.
-/// TODO(pod-state): function::tests currently keeps its own ENV_LOCK (and, post Track 3 merge,
-/// also mutates DUST_POD_DATABASES_DIR) — migrate it to this shared lock after the stacks merge.
+/// Serializes tests that mutate process-global environment variables. Every module whose tests
+/// touch them must take this one lock so parallel test threads cannot race.
 #[cfg(test)]
 pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -29,7 +29,7 @@ enum Commands {
         #[command(subcommand)]
         command: commands::function::FunctionCommand,
     },
-    /// Manage pod databases
+    /// Manage sandbox databases
     Db {
         #[command(subcommand)]
         command: commands::db::DbCommand,


### PR DESCRIPTION
## Description

- Read `DUST_SANDBOX_DATABASES_DIR` first for every `dsbx db` command.
- Fall back to `DUST_POD_DATABASES_DIR`, then the current image path, so existing sandboxes remain compatible.
- Rename the CLI help and internal documentation to sandbox databases.
- Reuse the crate-wide env-test mutex so legacy and canonical key tests cannot race function tests.

This is independent of the Front env producer and can merge in either order.

## Tests

- `cargo test --manifest-path cli/dust-sandbox/Cargo.toml` (403 unit tests and 1 local e2e test)
- `cargo clippy --manifest-path cli/dust-sandbox/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path cli/dust-sandbox/Cargo.toml -- --check`

## Risk

Low. The canonical key is additive, the legacy key remains supported, and the physical default stays `/pod-state/databases`.

## Deploy Plan

Deploy normally. Front can start emitting the canonical key before or after this change.