### PR TITLE
[front] pod sync: exclude sub-conversations from the conversations data source

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.test.ts
@@ -108,6 +108,52 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversation_ids", () => {
     expect(data.conversationIds).toContain(convo2.sId);
   });
 
+  it("excludes sub-conversations (depth > 0)", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const addMembersRes = await space.addMembers(adminAuth, {
+      userIds: [user.sId],
+    });
+    if (!addMembersRes.isOk()) {
+      throw new Error("Failed to add user to space");
+    }
+
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Test Agent",
+    });
+
+    const rootConvo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+    });
+    const subConvo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+      depth: 1,
+    });
+
+    const response = await getConversationIds(workspace, key, space.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.conversationIds).toContain(rootConvo.sId);
+    expect(data.conversationIds).not.toContain(subConvo.sId);
+  });
+
   it("excludes deleted conversations", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
@@ -54,6 +54,9 @@ app.get(
           includeDeleted: false,
           // Don't include test conversations
           excludeTest: true,
+          // Exclude sub-conversations so the connector GC deletes their
+          // already-indexed documents from the pod's data source.
+          onlyRootConversations: true,
         },
       });
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversations/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversations/index.test.ts
@@ -148,6 +148,53 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
     expect(firstConvo.url).toContain(convo1.sId);
   });
 
+  it("should exclude sub-conversations (depth > 0)", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const addMembersRes = await space.addMembers(adminAuth, {
+      userIds: [user.sId],
+    });
+    if (!addMembersRes.isOk()) {
+      throw new Error("Failed to add user to space");
+    }
+
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Test Agent",
+    });
+
+    const rootConvo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+    });
+    const subConvo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+      depth: 1,
+    });
+
+    const response = await getConversations(workspace, space.sId, key);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const conversationIds = data.conversations.map((c: any) => c.sId);
+    expect(conversationIds).toContain(rootConvo.sId);
+    expect(conversationIds).not.toContain(subConvo.sId);
+  });
+
   it("should include deleted conversations", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -558,6 +558,10 @@ export async function listSpaceConversationsForSync(
       options: {
         dangerouslySkipPermissionFiltering: true, // System key has access
         includeDeleted: true,
+        // Sub-conversations (run_agent children) must not be indexed in the
+        // pod's data source: they would surface in search and leak in
+        // citations while being hidden from every conversation list.
+        onlyRootConversations: true,
         updatedSince: updatedSinceMs ?? undefined,
       },
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -79,6 +79,7 @@ import { col, fn, literal, Op, QueryTypes, Sequelize, where } from "sequelize";
 type FetchConversationOptions = {
   includeDeleted?: boolean;
   excludeTest?: boolean; // Explicitly exclude test conversations
+  onlyRootConversations?: boolean; // Exclude sub-conversations (depth > 0)
   dangerouslySkipPermissionFiltering?: boolean;
   includeForkingData?: boolean;
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
@@ -1036,6 +1037,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     if (options?.updatedSince !== undefined) {
       where.updatedAt = { [Op.gte]: new Date(options.updatedSince) };
+    }
+
+    if (options?.onlyRootConversations) {
+      where.depth = { [Op.eq]: 0 };
     }
 
     return {


### PR DESCRIPTION
## Fix

Sub-conversations (`run_agent` children, depth > 0) are indexed into the pod's `dust_project` data source: they show up in search and their citations link to conversations that are hidden from every list.

Stop indexing them, front only:

- `listSpaceConversationsForSync`: exclude depth > 0, the connector stops upserting them.
- `conversation_ids` (GC endpoint): exclude depth > 0, the connector GC deletes the already-indexed documents after each sync. No connector deploy, no manual cleanup.

Both use a new `onlyRootConversations` option on `FetchConversationOptions`.

Follow up of #31574 (whose read-time filters stay in place as guards).

## Tests

A depth 1 conversation is absent from the sync list and from the GC id list.

## Risk

Worst case, a root conversation's documents get GC'd from the pod index. Revert stops the exclusion; a removed document comes back on the conversation's next update or a manual full sync.
