### PR TITLE
Use sandbox-neutral database quota env in runner

### DIFF
--- a/cli/dust-sandbox/functions-runner/db/common.ts
+++ b/cli/dust-sandbox/functions-runner/db/common.ts
@@ -1,7 +1,7 @@
 // Shared helpers for the `dsbx db` runner subcommands (reconcile/schema/query).
 //
-// The Rust layer resolves database names to file paths (name validation + DUST_POD_DATABASES_DIR
-// resolution) and passes absolute paths here, so these helpers only deal with files.
+// The Rust layer resolves database names under the configured databases directory and passes
+// absolute paths here, so these helpers only deal with files.
 
 import { Database } from "bun:sqlite";
 import { Err, Ok, type Result } from "#result.ts";
@@ -34,7 +34,7 @@ export function errorEnvelope(error: DbCommandError): {
   return { ok: false, error: { kind: error.kind, message: error.message } };
 }
 
-// Tables that live in a pod database but are not part of the data model: the same reserved
+// Tables that live in a sandbox database but are not part of the data model: the same reserved
 // prefixes build rejects for declared tables (SQLite internals, drizzle bookkeeping,
 // litestream sequencing, plus prefixes drizzle-kit's introspection ignores).
 export function isInternalTable(name: string): boolean {
@@ -76,19 +76,27 @@ export function applyWritePragmas(db: Database): void {
   db.exec("PRAGMA synchronous = NORMAL;");
 }
 
-export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
+export const SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV =
+  "DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES";
+export const LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV =
   "DUST_POD_DATABASE_MAX_SIZE_BYTES";
 
-// The per-database size quota, the same env var @dust/pod reads for workload writes.
-export function podDatabaseMaxSizeBytes(): Result<number, DbCommandError> {
-  const raw = process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+// The per-database size quota shared with the workload runtime.
+export function sandboxDatabaseMaxSizeBytes(): Result<number, DbCommandError> {
+  const canonicalValue = process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV];
+  const legacyValue = process.env[LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  const [envName, raw] = canonicalValue
+    ? [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV, canonicalValue]
+    : legacyValue
+      ? [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV, legacyValue]
+      : [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV, canonicalValue];
   const parsed =
     raw !== undefined && /^[0-9]+$/.test(raw) ? Number(raw) : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     return new Err(
       new DbCommandError(
         "internal",
-        `${POD_DATABASE_MAX_SIZE_BYTES_ENV} must be a positive integer byte count; got ${JSON.stringify(raw)}`
+        `${envName} must be a positive integer byte count; got ${JSON.stringify(raw)}`
       )
     );
   }

--- a/cli/dust-sandbox/functions-runner/db/common.ts
+++ b/cli/dust-sandbox/functions-runner/db/common.ts
@@ -85,11 +85,12 @@ export const LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV =
 export function sandboxDatabaseMaxSizeBytes(): Result<number, DbCommandError> {
   const canonicalValue = process.env[SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV];
   const legacyValue = process.env[LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV];
-  const [envName, raw] = canonicalValue
-    ? [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV, canonicalValue]
-    : legacyValue
-      ? [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV, legacyValue]
-      : [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV, canonicalValue];
+  const [envName, raw] =
+    canonicalValue !== undefined
+      ? [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV, canonicalValue]
+      : legacyValue !== undefined
+        ? [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV, legacyValue]
+        : [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV, canonicalValue];
   const parsed =
     raw !== undefined && /^[0-9]+$/.test(raw) ? Number(raw) : Number.NaN;
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {

--- a/cli/dust-sandbox/functions-runner/db/query.test.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.test.ts
@@ -392,18 +392,25 @@ describe("runner db-query envelope", () => {
   async function run(
     args: string[],
     stdin?: string,
-    env?: Record<string, string>
+    env?: Record<string, string | undefined>
   ) {
+    const childEnv = {
+      ...process.env,
+      [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
+    };
+    for (const [key, value] of Object.entries(env ?? {})) {
+      if (value === undefined) {
+        delete childEnv[key];
+      } else {
+        childEnv[key] = value;
+      }
+    }
     const proc = Bun.spawn(["bun", runner, ...args], {
       stdin: stdin === undefined ? "ignore" : new Blob([stdin]),
       stdout: "pipe",
       stderr: "pipe",
       // Bun.spawn replaces the environment; carry the parent env and default the quota.
-      env: {
-        ...process.env,
-        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
-        ...env,
-      },
+      env: childEnv,
     });
     const [stdout, code] = await Promise.all([
       new Response(proc.stdout).text(),
@@ -438,8 +445,8 @@ describe("runner db-query envelope", () => {
       const dbPath = join(dir, "chat.db");
       await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
       const { stdout, code } = await run(["db-query", dbPath], "SELECT 1", {
-        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "",
-        [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: "",
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: undefined,
+        [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: undefined,
       });
       expect(code).toBe(1);
       const envelope = JSON.parse(stdout.trim());
@@ -453,7 +460,7 @@ describe("runner db-query envelope", () => {
       const dbPath = join(dir, "chat.db");
       await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
       const { stdout, code } = await run(["db-query", dbPath], "SELECT 1", {
-        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "",
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: undefined,
         [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
       });
       expect(code).toBe(0);
@@ -461,12 +468,12 @@ describe("runner db-query envelope", () => {
     });
   });
 
-  test("db-query prefers the canonical size quota env", async () => {
+  test("db-query treats an empty canonical quota as invalid", async () => {
     await withDir(async (dir) => {
       const dbPath = join(dir, "chat.db");
       await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
       const { stdout, code } = await run(["db-query", dbPath], "SELECT 1", {
-        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "invalid",
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "",
         [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
       });
       expect(code).toBe(1);

--- a/cli/dust-sandbox/functions-runner/db/query.test.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Result } from "#result.ts";
 import type { DbErrorKind } from "#types/db.ts";
-import { DbCommandError, POD_DATABASE_MAX_SIZE_BYTES_ENV } from "./common.ts";
+import {
+  DbCommandError,
+  LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV,
+  SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV,
+} from "./common.ts";
 import {
   QUERY_INLINE_PAYLOAD_CAP_BYTES,
   QUERY_INLINE_ROW_CAP,
@@ -397,7 +401,7 @@ describe("runner db-query envelope", () => {
       // Bun.spawn replaces the environment; carry the parent env and default the quota.
       env: {
         ...process.env,
-        [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
         ...env,
       },
     });
@@ -434,12 +438,42 @@ describe("runner db-query envelope", () => {
       const dbPath = join(dir, "chat.db");
       await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
       const { stdout, code } = await run(["db-query", dbPath], "SELECT 1", {
-        [POD_DATABASE_MAX_SIZE_BYTES_ENV]: "",
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "",
+        [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: "",
       });
       expect(code).toBe(1);
       const envelope = JSON.parse(stdout.trim());
       expect(envelope.error.kind).toBe("internal");
       expect(envelope.error.message).toMatch(/positive integer byte count/);
+    });
+  });
+
+  test("db-query falls back to the legacy size quota env", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
+      const { stdout, code } = await run(["db-query", dbPath], "SELECT 1", {
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "",
+        [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
+      });
+      expect(code).toBe(0);
+      expect(JSON.parse(stdout.trim()).ok).toBe(true);
+    });
+  });
+
+  test("db-query prefers the canonical size quota env", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "chat.db");
+      await run(["db-reconcile", dbPath, fx("chat.db.ts")]);
+      const { stdout, code } = await run(["db-query", dbPath], "SELECT 1", {
+        [SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV]: "invalid",
+        [LEGACY_POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(1024 * 1024 * 1024),
+      });
+      expect(code).toBe(1);
+      const envelope = JSON.parse(stdout.trim());
+      expect(envelope.error.message).toContain(
+        SANDBOX_DATABASE_MAX_SIZE_BYTES_ENV
+      );
     });
   });
 });

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -12,7 +12,7 @@
 //                                                under spillDir that the envelope names)
 
 import { build } from "./build.ts";
-import { errorEnvelope, podDatabaseMaxSizeBytes } from "./db/common.ts";
+import { errorEnvelope, sandboxDatabaseMaxSizeBytes } from "./db/common.ts";
 import { runQuery } from "./db/query.ts";
 import { reconcile } from "./db/reconcile.ts";
 import { generateSchemaFileText } from "./db/schema.ts";
@@ -130,7 +130,7 @@ async function dbQueryHandler(args: string[]): Promise<number> {
       "usage: runner db-query <dbPath> [spillDir] (SQL on stdin)"
     );
   }
-  const maxSizeBytes = podDatabaseMaxSizeBytes();
+  const maxSizeBytes = sandboxDatabaseMaxSizeBytes();
   if (maxSizeBytes.isErr()) {
     emitEnvelopeLine(errorEnvelope(maxSizeBytes.error));
     return 1;


### PR DESCRIPTION
## Description

- Make the embedded database runner read `DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES`.
- Preserve `DUST_POD_DATABASE_MAX_SIZE_BYTES` as a fallback for older Front deployments.
- Prefer the canonical key when both are present and rename the internal helper to match its owner-neutral scope.

This is independent of the env producer and runtime package changes.

## Tests

- `bun test` (127 tests)
- `bun run build`
- Biome on the 3 changed files

## Risk

Low. The legacy key remains supported and the quota behavior is unchanged.

## Deploy Plan

Deploy normally. Front can begin emitting the canonical key before or after this change.