### PR TITLE
Pin canonical database env inheritance in dsbx

### DIFF
--- a/cli/dust-sandbox/src/commands/db/list.rs
+++ b/cli/dust-sandbox/src/commands/db/list.rs
@@ -11,7 +11,7 @@ struct DatabaseEntry {
     size_bytes: u64,
 }
 
-/// List the live pod databases (`*.db` files in the databases directory) with
+/// List the live sandbox databases (`*.db` files in the databases directory) with
 /// their sizes as a one-line JSON envelope. A missing directory is an empty
 /// list: it is created by the first reconcile that claims a database.
 pub fn cmd_db_list() -> Result<()> {
@@ -48,8 +48,8 @@ fn enumerate_databases(dir: &Path) -> std::io::Result<Vec<DatabaseEntry>> {
         let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
             continue;
         };
-        // Hostile-name allowlist: only names satisfying the frozen contract are pod databases
-        // (consistent with db_file_path and Track 1's replica-name filtering).
+        // Hostile-name allowlist: only names satisfying the frozen contract are databases
+        // (consistent with db_file_path and replica-name filtering).
         if !super::is_valid_db_name(name) {
             continue;
         }
@@ -86,7 +86,7 @@ mod tests {
         std::fs::write(dir.path().join("chat.db-shm"), b"s")?;
         std::fs::write(dir.path().join("readme.txt"), b"t")?;
         std::fs::create_dir(dir.path().join("subdir.db"))?;
-        // Names outside the frozen ^[a-z][a-z0-9_]{0,63}$ contract are not pod databases.
+        // Names outside the frozen ^[a-z][a-z0-9_]{0,63}$ contract are not databases.
         std::fs::write(dir.path().join("Weird Name.db"), b"n")?;
         std::fs::write(dir.path().join("UPPER.db"), b"n")?;
 

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -1,8 +1,8 @@
-//! `dsbx db` — pod database subcommands (reconcile/schema/list/query).
+//! `dsbx db` database subcommands (reconcile/schema/list/query).
 //!
-//! Databases are per-pod SQLite files `{name}.db` under `$DUST_POD_DATABASES_DIR`
-//! (falling back to the image's `/pod-state/databases`). This Rust layer owns name
-//! validation and path resolution; the DDL/SQL
+//! Databases are SQLite files `{name}.db` under `$DUST_SANDBOX_DATABASES_DIR`.
+//! The legacy `$DUST_POD_DATABASES_DIR` key and image path remain fallbacks during
+//! migration. This Rust layer owns name validation and path resolution; the DDL/SQL
 //! work runs in the embedded Bun runner (same privilege-drop machinery as
 //! `dsbx function`: dropped to `agent-proxied` via `runuser` whenever dsbx runs as
 //! root, NODE_PATH pointed at the image's global npm modules so `drizzle-kit`
@@ -27,45 +27,44 @@ pub use schema::cmd_db_schema;
 
 pub(crate) use super::function::emit_error;
 
-/// Directory holding the live pod databases. Set by front on `function run` /
-/// `db *` execs; the constant fallback matches the image layout.
-/// TODO(pod-state): function/mod.rs (Track 3, merged) carries identically-named consts plus
-/// an Option-typed `pod_databases_dir()` for `function run` — dedup onto a single shared
-/// definition (these here are the superset: PathBuf-typed helper + empty-value fallback).
-pub(crate) const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
-pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/pod-state/databases";
+/// Directory holding the live sandbox databases. Front sets it on `function run`
+/// and `db *` execs. The default remains the current image path during migration.
+pub(crate) const SANDBOX_DATABASES_DIR_ENV: &str = "DUST_SANDBOX_DATABASES_DIR";
+const LEGACY_POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
+pub(crate) const DEFAULT_SANDBOX_DATABASES_DIR: &str = "/pod-state/databases";
 
 #[derive(Subcommand)]
 pub enum DbCommand {
-    /// Reconcile a pod database with a drizzle schema file (additive DDL only)
+    /// Reconcile a sandbox database with a drizzle schema file (additive DDL only)
     Reconcile {
-        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        /// Database name (resolved under the configured sandbox databases directory)
         name: String,
         /// Path to the drizzle schema file (databases/{db}.db.ts)
         schema_file: String,
     },
-    /// Regenerate a drizzle schema file from a live pod database
+    /// Regenerate a drizzle schema file from a live sandbox database
     Schema {
-        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        /// Database name (resolved under the configured sandbox databases directory)
         name: String,
         /// Output path for the regenerated schema file
         out_schema: String,
     },
-    /// List pod databases with sizes
+    /// List sandbox databases with sizes
     List,
-    /// Execute one SQL statement (from stdin) against a pod database (SELECT/DML; DDL is refused)
+    /// Execute one SQL statement against a sandbox database (SELECT/DML; DDL is refused)
     Query {
-        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        /// Database name (resolved under the configured sandbox databases directory)
         name: String,
     },
 }
 
-/// The configured pod databases directory, falling back to the image constant.
+/// The configured sandbox databases directory, falling back to the legacy key and image path.
 pub(crate) fn databases_dir() -> PathBuf {
-    std::env::var_os(POD_DATABASES_DIR_ENV)
+    std::env::var_os(SANDBOX_DATABASES_DIR_ENV)
         .filter(|dir| !dir.is_empty())
+        .or_else(|| std::env::var_os(LEGACY_POD_DATABASES_DIR_ENV).filter(|dir| !dir.is_empty()))
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_POD_DATABASES_DIR))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SANDBOX_DATABASES_DIR))
 }
 
 /// Valid database names: `^[a-z][a-z0-9_]{0,63}$`. Also blocks
@@ -94,8 +93,7 @@ pub(crate) fn db_file_path(name: &str) -> Result<PathBuf> {
 mod tests {
     use super::*;
 
-    // The crate-shared env lock (commands/mod.rs): DUST_POD_DATABASES_DIR is process-global
-    // and other modules' tests (Track 3's function::tests post-merge) mutate it too.
+    // Both database directory keys are process-global, so tests share the crate-level lock.
     use crate::commands::ENV_LOCK;
 
     #[test]
@@ -124,35 +122,62 @@ mod tests {
     #[test]
     fn databases_dir_defaults_to_the_image_constant() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
-        assert_eq!(databases_dir(), PathBuf::from(DEFAULT_POD_DATABASES_DIR));
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
+        assert_eq!(
+            databases_dir(),
+            PathBuf::from(DEFAULT_SANDBOX_DATABASES_DIR)
+        );
     }
 
     #[test]
     fn databases_dir_honors_the_env_override() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var(POD_DATABASES_DIR_ENV, "/tmp/pod-dbs");
-        assert_eq!(databases_dir(), PathBuf::from("/tmp/pod-dbs"));
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
     }
 
     #[test]
     fn empty_env_override_falls_back_to_the_constant() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var(POD_DATABASES_DIR_ENV, "");
-        assert_eq!(databases_dir(), PathBuf::from(DEFAULT_POD_DATABASES_DIR));
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "");
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
+        assert_eq!(
+            databases_dir(),
+            PathBuf::from(DEFAULT_SANDBOX_DATABASES_DIR)
+        );
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
     }
 
     #[test]
     fn db_file_path_joins_name_and_dir() {
         let _guard = ENV_LOCK.lock().unwrap();
-        std::env::set_var(POD_DATABASES_DIR_ENV, "/tmp/pod-dbs");
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         assert_eq!(
             db_file_path("chat").unwrap(),
-            PathBuf::from("/tmp/pod-dbs/chat.db")
+            PathBuf::from("/tmp/sandbox-dbs/chat.db")
         );
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn databases_dir_falls_back_to_the_legacy_env_key() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+        std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/legacy-dbs"));
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
+    }
+
+    #[test]
+    fn canonical_database_dir_wins_over_the_legacy_key() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
+        std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
+        assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
+        std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn databases_dir_defaults_to_the_image_constant() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
         std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
         assert_eq!(
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn databases_dir_honors_the_env_override() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));
         std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn empty_env_override_falls_back_to_the_constant() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "");
         std::env::remove_var(LEGACY_POD_DATABASES_DIR_ENV);
         assert_eq!(
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn db_file_path_joins_name_and_dir() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         assert_eq!(
             db_file_path("chat").unwrap(),
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn databases_dir_falls_back_to_the_legacy_env_key() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
         std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
         assert_eq!(databases_dir(), PathBuf::from("/tmp/legacy-dbs"));
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn canonical_database_dir_wins_over_the_legacy_key() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/tmp/sandbox-dbs");
         std::env::set_var(LEGACY_POD_DATABASES_DIR_ENV, "/tmp/legacy-dbs");
         assert_eq!(databases_dir(), PathBuf::from("/tmp/sandbox-dbs"));

--- a/cli/dust-sandbox/src/commands/db/query.rs
+++ b/cli/dust-sandbox/src/commands/db/query.rs
@@ -9,7 +9,7 @@ use super::{db_file_path, spawn_runner};
 /// must match the env var set in front/lib/api/sandbox_functions/dsbx_db.ts.
 const POD_QUERY_SPILL_DIR_ENV: &str = "DUST_POD_QUERY_SPILL_DIR";
 
-/// Execute one SQL statement (from stdin) against the pod database `name`.
+/// Execute one SQL statement (from stdin) against the sandbox database `name`.
 /// The runner allows SELECT and DML and refuses DDL (a statement that changes
 /// the schema is rolled back), so the schema only evolves through reconcile.
 /// Rows come back in the stdout JSON envelope; a result crossing the inline

--- a/cli/dust-sandbox/src/commands/db/reconcile.rs
+++ b/cli/dust-sandbox/src/commands/db/reconcile.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 
 use super::{db_file_path, emit_error, spawn_runner};
 
-/// Reconcile the pod database `name` with the drizzle schema file at
+/// Reconcile the sandbox database `name` with the drizzle schema file at
 /// `schema_file`: the runner plans via drizzle-kit, applies ADDITIVE statements
 /// only (CREATE TABLE / ADD COLUMN / CREATE [UNIQUE] INDEX / DROP INDEX) in one
 /// transaction, and rejects anything destructive with a typed error. The

--- a/cli/dust-sandbox/src/commands/db/schema.rs
+++ b/cli/dust-sandbox/src/commands/db/schema.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use super::{db_file_path, spawn_runner};
 
-/// Regenerate a drizzle `{db}.db.ts` schema file from the live pod database
+/// Regenerate a drizzle `{db}.db.ts` schema file from the live sandbox database
 /// `name`, writing it to `out_schema` (file-output pattern: the file is the
 /// payload, stdout only carries the `{ok}` envelope). Column modes are not
 /// recoverable from SQLite — the regenerated file carries storage types only.

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -392,12 +392,8 @@ pub(crate) fn is_valid_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
-// The environment is process-global and `cargo test` runs tests on parallel
-// threads within one process: any test (in this module or `warm`) that reads
-// or mutates env vars must hold this lock for the whole window where it
-// relies on them.
 #[cfg(test)]
-pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) use crate::commands::ENV_LOCK;
 
 #[cfg(test)]
 mod tests {

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -152,9 +152,7 @@ pub(crate) async fn spawn_function_at(
         c.arg(&*runner).arg(subcommand).arg(handler);
         c
     };
-    // No env_clear: the child inherits dsbx's env verbatim, so per-exec vars
-    // front sets (e.g. DUST_POD_DATABASES_DIR, read by `@dust/pod`) flow
-    // through without dsbx naming each one — pinned by the inheritance tests.
+    // No env_clear: Bun inherits every per-exec Front variable, as pinned by the tests below.
     cmd.env("NODE_PATH", harness_node_path())
         .stdin(if input.is_some() {
             Stdio::piped()
@@ -471,10 +469,8 @@ mod tests {
         assert!(resolve_existing("../escape").is_err());
     }
 
-    /// The pod-databases env contract: front sets it per exec, `@dust/pod`
-    /// reads it in the bun child, and dsbx passes it along by plain env
-    /// inheritance — the tests below pin that inheritance.
-    const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
+    // Front sets this per exec; the database runtime reads it in the Bun child.
+    const SANDBOX_DATABASES_DIR_ENV: &str = "DUST_SANDBOX_DATABASES_DIR";
 
     /// Restore an env var to its captured original value.
     fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
@@ -493,17 +489,11 @@ mod tests {
             .is_ok()
     }
 
-    /// Function fixture that turns the bun child's environment into an
-    /// observable output: its schema `description` is a template literal, so
-    /// it is evaluated *inside whichever bun process imports the module*, and
-    /// the schema text that comes back records what DUST_POD_DATABASES_DIR
-    /// looked like in that child — `unset` when absent. Asserting on the
-    /// schema output is therefore asserting on the child's env, from outside.
-    /// `zod` resolves via NODE_PATH (set by the tests to the functions-runner
-    /// package's node_modules).
+    // The fixture records the child process's database-dir env in its schema description.
+    // Zod resolves through the NODE_PATH configured by these tests.
     const ENV_PROBE_FIXTURE: &str = r#"import { z } from "zod";
 export const schema = {
-  description: `pod-databases-dir=${process.env.DUST_POD_DATABASES_DIR ?? "unset"}`,
+  description: `sandbox-databases-dir=${process.env.DUST_SANDBOX_DATABASES_DIR ?? "unset"}`,
   input: z.object({}),
   output: z.object({}),
 };
@@ -517,19 +507,13 @@ export default {
     const RUNNER_NODE_MODULES: &str =
         concat!(env!("CARGO_MANIFEST_DIR"), "/functions-runner/node_modules");
 
-    /// End-to-end pin of the env contract's dsbx hop, through the production
-    /// `dsbx function get` path: a var present in dsbx's process env (front
-    /// sets it per exec) must reach the untrusted bun child, where
-    /// `@dust/pod`'s `db()` reads it. spawn_function has no forwarding code —
-    /// the var travels by plain inheritance — so this test is what fails if
-    /// anyone scrubs the child env later (env_clear, a runuser flag): cargo
-    /// runs bun nowhere else.
+    // Pin plain env inheritance through the production `dsbx function get` path.
     #[tokio::test]
     // The spawned bun child inherits process-global env, so the env lock must
     // span the spawn awaits; contending tests just block on the mutex (each
     // #[tokio::test] runs its own runtime, so no deadlock is possible).
     #[allow(clippy::await_holding_lock)]
-    async fn function_get_bun_child_inherits_pod_databases_dir() {
+    async fn function_get_bun_child_inherits_sandbox_databases_dir() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         if !bun_available() {
             eprintln!("skipping: bun not on PATH");
@@ -538,7 +522,7 @@ export default {
         let original_functions_dir = std::env::var_os(FUNCTIONS_DIR_ENV);
         let original_working_dir = std::env::var_os(FUNCTION_WORKING_DIR_ENV);
         let original_node_path = std::env::var_os("NODE_PATH");
-        let original_pod_dir = std::env::var_os(POD_DATABASES_DIR_ENV);
+        let original_database_dir = std::env::var_os(SANDBOX_DATABASES_DIR_ENV);
 
         // Stage the probe where resolve_existing() will find it, so
         // `spawn_function("get", "envprobe", ...)` runs the real runner
@@ -552,53 +536,49 @@ export default {
         std::env::set_var("NODE_PATH", RUNNER_NODE_MODULES);
 
         // A var set on dsbx's own process reaches the child by inheritance.
-        std::env::set_var(POD_DATABASES_DIR_ENV, "/custom/pod-databases");
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/custom/sandbox-databases");
         let (code, stdout) = spawn_function("get", "envprobe", None, true)
             .await
             .expect("spawn get");
         let stdout = stdout.unwrap_or_default();
         assert_eq!(code, 0, "runner failed: {stdout}");
         assert!(
-            stdout.contains("pod-databases-dir=/custom/pod-databases"),
+            stdout.contains("sandbox-databases-dir=/custom/sandbox-databases"),
             "unexpected stdout: {stdout}"
         );
 
         // Absent env var: no dsbx-side default, the child sees it unset.
-        // (Empty-string normalization is `@dust/pod`'s job, tested there.)
-        std::env::remove_var(POD_DATABASES_DIR_ENV);
+        // Empty-string normalization belongs to the runtime consumer.
+        std::env::remove_var(SANDBOX_DATABASES_DIR_ENV);
         let (code, stdout) = spawn_function("get", "envprobe", None, true)
             .await
             .expect("spawn get");
         let stdout = stdout.unwrap_or_default();
         assert_eq!(code, 0, "runner failed: {stdout}");
         assert!(
-            stdout.contains("pod-databases-dir=unset"),
+            stdout.contains("sandbox-databases-dir=unset"),
             "unexpected stdout: {stdout}"
         );
 
         restore_env(FUNCTIONS_DIR_ENV, original_functions_dir);
         restore_env(FUNCTION_WORKING_DIR_ENV, original_working_dir);
         restore_env("NODE_PATH", original_node_path);
-        restore_env(POD_DATABASES_DIR_ENV, original_pod_dir);
+        restore_env(SANDBOX_DATABASES_DIR_ENV, original_database_dir);
     }
 
-    /// Same pin for the `dsbx function build` path: schema extraction imports
-    /// the just-built bundle in a bun child (running its top-level code), so
-    /// a function calling `db()` at top level must see the same env at build
-    /// time as at run time. Here the probe's env recording comes back through
-    /// the extracted schema file rather than stdout.
+    // Pin the same env inheritance during build-time schema extraction.
     #[tokio::test]
-    // See function_get_bun_child_inherits_pod_databases_dir: the env lock
+    // See function_get_bun_child_inherits_sandbox_databases_dir: the env lock
     // intentionally spans the spawn await.
     #[allow(clippy::await_holding_lock)]
-    async fn build_bun_child_inherits_pod_databases_dir() {
+    async fn build_bun_child_inherits_sandbox_databases_dir() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         if !bun_available() {
             eprintln!("skipping: bun not on PATH");
             return;
         }
         let original_node_path = std::env::var_os("NODE_PATH");
-        let original_pod_dir = std::env::var_os(POD_DATABASES_DIR_ENV);
+        let original_database_dir = std::env::var_os(SANDBOX_DATABASES_DIR_ENV);
 
         let src_dir = tempfile::tempdir().expect("src tempdir");
         let src = src_dir.path().join("envprobe.ts");
@@ -611,7 +591,7 @@ export default {
         let out_bundle = out_dir.path().join("out.bundle.js");
         let out_schema = out_dir.path().join("out.schema.json");
         std::env::set_var("NODE_PATH", RUNNER_NODE_MODULES);
-        std::env::set_var(POD_DATABASES_DIR_ENV, "/custom/pod-databases");
+        std::env::set_var(SANDBOX_DATABASES_DIR_ENV, "/custom/sandbox-databases");
 
         // Build's schema extraction imports the built bundle, so the fixture's
         // description records the env var the build-time bun child saw.
@@ -621,12 +601,12 @@ export default {
         assert_eq!(code, 0);
         let schema = std::fs::read_to_string(&out_schema).expect("schema file");
         assert!(
-            schema.contains("pod-databases-dir=/custom/pod-databases"),
+            schema.contains("sandbox-databases-dir=/custom/sandbox-databases"),
             "unexpected schema: {schema}"
         );
 
         restore_env("NODE_PATH", original_node_path);
-        restore_env(POD_DATABASES_DIR_ENV, original_pod_dir);
+        restore_env(SANDBOX_DATABASES_DIR_ENV, original_database_dir);
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -397,6 +397,8 @@ pub(crate) use crate::commands::ENV_LOCK;
 mod tests {
     use super::*;
 
+    use crate::commands::db::SANDBOX_DATABASES_DIR_ENV;
+
     use super::ENV_LOCK;
 
     #[test]
@@ -468,9 +470,6 @@ mod tests {
         std::env::remove_var(FUNCTIONS_DIR_ENV);
         assert!(resolve_existing("../escape").is_err());
     }
-
-    // Front sets this per exec; the database runtime reads it in the Bun child.
-    const SANDBOX_DATABASES_DIR_ENV: &str = "DUST_SANDBOX_DATABASES_DIR";
 
     /// Restore an env var to its captured original value.
     fn restore_env(key: &str, original: Option<std::ffi::OsString>) {

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -406,7 +406,7 @@ fn lost_outcome_after_ack() -> serde_json::Value {
 
 async fn roundtrip(mut stream: UnixStream, name: &str, input: &str) -> Result<WarmRun> {
     // The request carries the client's full environment: per-invocation
-    // values (sandbox token, user identity, pod databases dir) travel in env
+    // values (sandbox token, user identity, sandbox databases dir) travel in env
     // vars, and the resident worker's own env is stale by definition. This
     // mirrors the env inheritance of the cold path's bun child.
     // vars_os + lossy filtering: std::env::vars() panics on non-unicode

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -20,11 +20,7 @@ pub use resolve::cmd_resolve;
 pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools, OffloadResolutionError};
 pub use version::cmd_version;
 
-/// Serializes tests that mutate process-global environment variables (e.g.
-/// DUST_POD_DATABASES_DIR). Env vars are shared across the whole test binary, so every module
-/// whose tests touch them must take this ONE lock — two module-local mutexes guarding the same
-/// variable would not exclude each other under parallel test threads.
-/// TODO(pod-state): function::tests currently keeps its own ENV_LOCK (and, post Track 3 merge,
-/// also mutates DUST_POD_DATABASES_DIR) — migrate it to this shared lock after the stacks merge.
+/// Serializes tests that mutate process-global environment variables. Every module whose tests
+/// touch them must take this one lock so parallel test threads cannot race.
 #[cfg(test)]
 pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -29,7 +29,7 @@ enum Commands {
         #[command(subcommand)]
         command: commands::function::FunctionCommand,
     },
-    /// Manage pod databases
+    /// Manage sandbox databases
     Db {
         #[command(subcommand)]
         command: commands::db::DbCommand,


### PR DESCRIPTION
## Description

- Exercise `DUST_SANDBOX_DATABASES_DIR` through the real cold `function get` and build-time Bun child paths.
- Remove the remaining Pod database wording from the generic function process layer.
- Keep production behavior unchanged: dsbx forwards all per-exec env through normal process inheritance.

This is stacked on #31579 only because both PRs touch the shared env-test lock.

## Tests

- `cargo test --manifest-path cli/dust-sandbox/Cargo.toml` (403 unit tests and 1 local e2e test)
- `cargo clippy --manifest-path cli/dust-sandbox/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path cli/dust-sandbox/Cargo.toml -- --check`

## Risk

Very low. Production code is unchanged apart from comments; the two e2e tests now pin the canonical env key.

## Deploy Plan

Merge after #31579 and deploy normally.