### PR TITLE
[front] enh: surface webhook source id and GCS bucket link in poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,7 +1,9 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { PokeGetTriggerDetails } from "@app/lib/api/poke/triggers";
+import { makeWebhookRequestsGcsUrl } from "@app/lib/api/webhook_source";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -52,10 +54,32 @@ app.get(
       : [];
     const editorUser = editorUsers.length > 0 ? editorUsers[0].toJSON() : null;
 
+    const triggerJSON = trigger.toJSON();
+
+    const webhookSourceView =
+      triggerJSON.kind === "webhook" && triggerJSON.webhookSourceViewId
+        ? await WebhookSourcesViewResource.fetchById(
+            auth,
+            triggerJSON.webhookSourceViewId
+          )
+        : null;
+    const webhookSource = webhookSourceView?.webhookSource ?? null;
+
     return ctx.json({
-      trigger: trigger.toJSON(),
+      trigger: triggerJSON,
       agent: agentConfiguration,
       editorUser,
+      webhookSource: webhookSource
+        ? {
+            id: webhookSource.id,
+            sId: webhookSource.sId,
+            name: webhookSource.name,
+            payloadsGcsUrl: makeWebhookRequestsGcsUrl({
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              webhookSourceId: webhookSource.id,
+            }),
+          }
+        : null,
     });
   }
 );

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -74,7 +74,7 @@ app.get(
             ...webhookSource.toJSON(),
             payloadsGcsUrl: makeWebhookRequestsGcsUrl({
               workspaceId: auth.getNonNullableWorkspace().sId,
-              webhookSourceId: webhookSource.id,
+              webhookSourceModelId: webhookSource.id,
             }),
           }
         : null,

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -71,9 +71,7 @@ app.get(
       editorUser,
       webhookSource: webhookSource
         ? {
-            id: webhookSource.id,
-            sId: webhookSource.sId,
-            name: webhookSource.name,
+            ...webhookSource.toJSON(),
             payloadsGcsUrl: makeWebhookRequestsGcsUrl({
               workspaceId: auth.getNonNullableWorkspace().sId,
               webhookSourceId: webhookSource.id,

--- a/front/components/poke/pages/TriggerDetailsPage.tsx
+++ b/front/components/poke/pages/TriggerDetailsPage.tsx
@@ -45,7 +45,7 @@ export function TriggerDetailsPage() {
     );
   }
 
-  const { trigger, agent, editorUser } = triggerDetails;
+  const { trigger, agent, editorUser, webhookSource } = triggerDetails;
 
   return (
     <>
@@ -61,6 +61,7 @@ export function TriggerDetailsPage() {
           agent={agent}
           owner={owner}
           editorUser={editorUser}
+          webhookSource={webhookSource}
         />
         <div className="mt-4 flex grow flex-col gap-4">
           <PluginList

--- a/front/components/poke/pages/WebhookSourceDetailsPage.tsx
+++ b/front/components/poke/pages/WebhookSourceDetailsPage.tsx
@@ -49,7 +49,8 @@ export function WebhookSourceDetailsPage() {
     );
   }
 
-  const { webhookSource, views, triggers, requestStats } = details;
+  const { webhookSource, views, triggers, requestStats, payloadsGcsUrl } =
+    details;
 
   return (
     <>
@@ -70,6 +71,12 @@ export function WebhookSourceDetailsPage() {
                   <PokeTableRow>
                     <PokeTableHead>sId</PokeTableHead>
                     <PokeTableCellWithCopy label={webhookSource.sId} />
+                  </PokeTableRow>
+                  <PokeTableRow>
+                    <PokeTableHead>Id</PokeTableHead>
+                    <PokeTableCellWithCopy
+                      label={webhookSource.id.toString()}
+                    />
                   </PokeTableRow>
                   <PokeTableRow>
                     <PokeTableHead>Name</PokeTableHead>
@@ -121,6 +128,18 @@ export function WebhookSourceDetailsPage() {
                     <PokeTableHead>OAuth Connection</PokeTableHead>
                     <PokeTableCell>
                       {webhookSource.oauthConnectionId ?? "-"}
+                    </PokeTableCell>
+                  </PokeTableRow>
+                  <PokeTableRow>
+                    <PokeTableHead>Payloads (GCS)</PokeTableHead>
+                    <PokeTableCell>
+                      <LinkWrapper
+                        href={payloadsGcsUrl}
+                        target="_blank"
+                        className="text-xs text-highlight-400"
+                      >
+                        Open bucket
+                      </LinkWrapper>
                     </PokeTableCell>
                   </PokeTableRow>
                   <PokeTableRow>

--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -8,18 +8,20 @@ import {
   PokeTableHead,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
+import type { PokeGetTriggerDetails } from "@app/lib/api/poke/triggers";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import { DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { Chip } from "@dust-tt/sparkle";
+import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 
 interface ViewTriggerTableProps {
   trigger: TriggerType;
   agent: LightAgentConfigurationType;
   owner: LightWorkspaceType;
   editorUser?: UserType | null;
+  webhookSource: PokeGetTriggerDetails["webhookSource"];
 }
 
 export function ViewTriggerTable({
@@ -27,6 +29,7 @@ export function ViewTriggerTable({
   agent,
   owner,
   editorUser,
+  webhookSource,
 }: ViewTriggerTableProps) {
   return (
     <div className="flex flex-col space-y-8">
@@ -141,6 +144,29 @@ export function ViewTriggerTable({
                         label={trigger.webhookSourceViewId}
                       />
                     </PokeTableRow>
+                  )}
+                  {webhookSource && (
+                    <>
+                      <PokeTableRow>
+                        <PokeTableHead>Webhook Source</PokeTableHead>
+                        <PokeTableCellWithLink
+                          href={`/poke/${owner.sId}/webhook-sources/${webhookSource.sId}`}
+                          content={`${webhookSource.name} (${webhookSource.sId} / ${webhookSource.id})`}
+                        />
+                      </PokeTableRow>
+                      <PokeTableRow>
+                        <PokeTableHead>Payloads (GCS)</PokeTableHead>
+                        <PokeTableCell>
+                          <LinkWrapper
+                            href={webhookSource.payloadsGcsUrl}
+                            target="_blank"
+                            className="text-xs text-highlight-400"
+                          >
+                            Open bucket
+                          </LinkWrapper>
+                        </PokeTableCell>
+                      </PokeTableRow>
+                    </>
                   )}
                 </>
               )}

--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -151,7 +151,7 @@ export function ViewTriggerTable({
                         <PokeTableHead>Webhook Source</PokeTableHead>
                         <PokeTableCellWithLink
                           href={`/poke/${owner.sId}/webhook-sources/${webhookSource.sId}`}
-                          content={`${webhookSource.name} (${webhookSource.sId} / ${webhookSource.id})`}
+                          content={`${webhookSource.name} (${webhookSource.sId})`}
                         />
                       </PokeTableRow>
                       <PokeTableRow>

--- a/front/components/poke/webhook_sources/columns.tsx
+++ b/front/components/poke/webhook_sources/columns.tsx
@@ -29,6 +29,12 @@ export function makeColumnsForWebhookSources(
       ),
     },
     {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Id" />
+      ),
+    },
+    {
       accessorKey: "name",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Name" />

--- a/front/lib/api/poke/triggers.ts
+++ b/front/lib/api/poke/triggers.ts
@@ -22,6 +22,7 @@ import type { TriggerType } from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import type { WebhookSourceType } from "@app/types/triggers/webhooks";
 import type { UserType } from "@app/types/user";
 import { z } from "zod";
 
@@ -161,10 +162,5 @@ export type PokeGetTriggerDetails = {
   trigger: TriggerType;
   agent: LightAgentConfigurationType;
   editorUser: UserType | null;
-  webhookSource: {
-    id: ModelId;
-    sId: string;
-    name: string;
-    payloadsGcsUrl: string;
-  } | null;
+  webhookSource: (WebhookSourceType & { payloadsGcsUrl: string }) | null;
 };

--- a/front/lib/api/poke/triggers.ts
+++ b/front/lib/api/poke/triggers.ts
@@ -161,4 +161,10 @@ export type PokeGetTriggerDetails = {
   trigger: TriggerType;
   agent: LightAgentConfigurationType;
   editorUser: UserType | null;
+  webhookSource: {
+    id: ModelId;
+    sId: string;
+    name: string;
+    payloadsGcsUrl: string;
+  } | null;
 };

--- a/front/lib/api/poke/webhook_sources.ts
+++ b/front/lib/api/poke/webhook_sources.ts
@@ -17,4 +17,5 @@ export type PokeGetWebhookSourceDetails = {
   views: WebhookSourceViewForAdminType[];
   triggers: Array<TriggerType & { editorUser: UserType | null }>;
   requestStats: { last24h: number; last7d: number; last30d: number };
+  payloadsGcsUrl: string;
 };

--- a/front/lib/api/poke/webhook_sources.ts
+++ b/front/lib/api/poke/webhook_sources.ts
@@ -1,21 +1,10 @@
-import type { TriggerType } from "@app/types/assistant/triggers";
 import type {
-  WebhookSourceForAdminType,
-  WebhookSourceType,
-  WebhookSourceViewForAdminType,
-} from "@app/types/triggers/webhooks";
-import type { UserType } from "@app/types/user";
+  WebhookSourceAdminDetails,
+  WebhookSourceWithCounts,
+} from "@app/lib/api/webhook_source";
 
 export type PokeListWebhookSources = {
-  webhookSources: Array<
-    WebhookSourceType & { viewCount: number; triggerCount: number }
-  >;
+  webhookSources: WebhookSourceWithCounts[];
 };
 
-export type PokeGetWebhookSourceDetails = {
-  webhookSource: WebhookSourceForAdminType;
-  views: WebhookSourceViewForAdminType[];
-  triggers: Array<TriggerType & { editorUser: UserType | null }>;
-  requestStats: { last24h: number; last7d: number; last30d: number };
-  payloadsGcsUrl: string;
-};
+export type PokeGetWebhookSourceDetails = WebhookSourceAdminDetails;

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -99,7 +99,7 @@ export async function deleteWebhookSource(
   return new Ok(undefined);
 }
 
-type WebhookSourceWithCounts = WebhookSourceType & {
+export type WebhookSourceWithCounts = WebhookSourceType & {
   viewCount: number;
   triggerCount: number;
 };
@@ -142,7 +142,7 @@ export async function listWebhookSourcesWithCounts(
   return results;
 }
 
-type WebhookSourceAdminDetails = {
+export type WebhookSourceAdminDetails = {
   webhookSource: WebhookSourceForAdminType;
   views: WebhookSourceViewForAdminType[];
   triggers: Array<TriggerType & { editorUser: UserType | null }>;
@@ -152,14 +152,14 @@ type WebhookSourceAdminDetails = {
 
 export function makeWebhookRequestsGcsUrl({
   workspaceId,
-  webhookSourceId,
+  webhookSourceModelId,
 }: {
   workspaceId: string;
-  webhookSourceId: ModelId;
+  webhookSourceModelId: ModelId;
 }): string {
   const directory = WebhookRequestResource.getGcsDirectory({
     workspaceId,
-    webhookSourceId,
+    webhookSourceModelId,
   });
 
   return `https://console.cloud.google.com/storage/browser/${fileStorageConfig.getWebhookRequestsBucket()}/${directory}`;
@@ -214,7 +214,7 @@ export async function getWebhookSourceAdminDetails(
     requestStats,
     payloadsGcsUrl: makeWebhookRequestsGcsUrl({
       workspaceId: auth.getNonNullableWorkspace().sId,
-      webhookSourceId: source.id,
+      webhookSourceModelId: source.id,
     }),
   };
 }

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -5,6 +5,7 @@ import type {
 import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/services";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import fileStorageConfig from "@app/lib/file_storage/config";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -13,6 +14,7 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import logger from "@app/logger/logger";
 import type { TriggerType } from "@app/types/assistant/triggers";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -145,7 +147,23 @@ type WebhookSourceAdminDetails = {
   views: WebhookSourceViewForAdminType[];
   triggers: Array<TriggerType & { editorUser: UserType | null }>;
   requestStats: { last24h: number; last7d: number; last30d: number };
+  payloadsGcsUrl: string;
 };
+
+export function makeWebhookRequestsGcsUrl({
+  workspaceId,
+  webhookSourceId,
+}: {
+  workspaceId: string;
+  webhookSourceId: ModelId;
+}): string {
+  const directory = WebhookRequestResource.getGcsDirectory({
+    workspaceId,
+    webhookSourceId,
+  });
+
+  return `https://console.cloud.google.com/storage/browser/${fileStorageConfig.getWebhookRequestsBucket()}/${directory}`;
+}
 
 /**
  * For a given webhook source, return its admin-only JSON, all of its views,
@@ -194,6 +212,10 @@ export async function getWebhookSourceAdminDetails(
     views: views.map((v) => v.toJSONForAdmin()),
     triggers: triggersWithEditors,
     requestStats,
+    payloadsGcsUrl: makeWebhookRequestsGcsUrl({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      webhookSourceId: source.id,
+    }),
   };
 }
 

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -462,6 +462,16 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     };
   }
 
+  static getGcsDirectory({
+    workspaceId,
+    webhookSourceId,
+  }: {
+    workspaceId: string;
+    webhookSourceId: ModelId;
+  }): string {
+    return `${workspaceId}/webhook_source_${webhookSourceId}`;
+  }
+
   static getGcsPath({
     workspaceId,
     webhookSourceId,
@@ -471,7 +481,11 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     webhookSourceId: ModelId;
     webRequestId: ModelId;
   }): string {
-    return `${workspaceId}/webhook_source_${webhookSourceId}/webhook_request_${webRequestId}.json`;
+    const directory = WebhookRequestResource.getGcsDirectory({
+      workspaceId,
+      webhookSourceId,
+    });
+    return `${directory}/webhook_request_${webRequestId}.json`;
   }
 
   private static async deleteMany(

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -464,28 +464,28 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
 
   static getGcsDirectory({
     workspaceId,
-    webhookSourceId,
+    webhookSourceModelId,
   }: {
     workspaceId: string;
-    webhookSourceId: ModelId;
+    webhookSourceModelId: ModelId;
   }): string {
-    return `${workspaceId}/webhook_source_${webhookSourceId}`;
+    return `${workspaceId}/webhook_source_${webhookSourceModelId}`;
   }
 
   static getGcsPath({
     workspaceId,
-    webhookSourceId,
-    webRequestId,
+    webhookSourceModelId,
+    webhookRequestModelId,
   }: {
     workspaceId: string;
-    webhookSourceId: ModelId;
-    webRequestId: ModelId;
+    webhookSourceModelId: ModelId;
+    webhookRequestModelId: ModelId;
   }): string {
     const directory = WebhookRequestResource.getGcsDirectory({
       workspaceId,
-      webhookSourceId,
+      webhookSourceModelId,
     });
-    return `${directory}/webhook_request_${webRequestId}.json`;
+    return `${directory}/webhook_request_${webhookRequestModelId}.json`;
   }
 
   private static async deleteMany(

--- a/front/lib/triggers/trigger_usage_estimation.ts
+++ b/front/lib/triggers/trigger_usage_estimation.ts
@@ -81,8 +81,8 @@ export async function computeFilteredWebhookTriggerForecast(
     async (webhookRequest) => {
       const gcsPath = WebhookRequestResource.getGcsPath({
         workspaceId: owner.sId,
-        webhookSourceId: webhookSource.id,
-        webRequestId: webhookRequest.id,
+        webhookSourceModelId: webhookSource.id,
+        webhookRequestModelId: webhookRequest.id,
       });
 
       const file = bucket.file(gcsPath);

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -574,8 +574,8 @@ async function storePayloadInGCS(
 
   const gcsPath = WebhookRequestResource.getGcsPath({
     workspaceId: auth.getNonNullableWorkspace().sId,
-    webhookSourceId: webhookSource.id,
-    webRequestId: webhookRequest.id,
+    webhookSourceModelId: webhookSource.id,
+    webhookRequestModelId: webhookRequest.id,
   });
 
   try {
@@ -646,8 +646,8 @@ export async function getWebhookRequestPayloadFromGCS(
     const file = bucket.file(
       WebhookRequestResource.getGcsPath({
         workspaceId: auth.getNonNullableWorkspace().sId,
-        webhookSourceId: webhookRequest.webhookSourceId,
-        webRequestId: webhookRequest.id,
+        webhookSourceModelId: webhookRequest.webhookSourceId,
+        webhookRequestModelId: webhookRequest.id,
       })
     );
     const [content] = await file.download();
@@ -852,8 +852,8 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
       if (bucket && requestCanHavePayload) {
         const gcsPath = WebhookRequestResource.getGcsPath({
           workspaceId: workspace.sId,
-          webhookSourceId: wrt.webhookRequest.webhookSourceId,
-          webRequestId: wrt.webhookRequest.id,
+          webhookSourceModelId: wrt.webhookRequest.webhookSourceId,
+          webhookRequestModelId: wrt.webhookRequest.id,
         });
 
         try {


### PR DESCRIPTION
## Description

Poke only showed webhook source *views*, so getting to a source's stored payloads meant looking up its model id by hand. The trigger page now links to the webhook source (name, sId, id) and to its GCS folder, and the source page shows the id plus the same bucket link.

## Tests

Manual: opened a webhook trigger and its webhook source in poke, checked both links resolve.

## Risk

Low, poke-only reads.

## Deploy Plan

Deploy front and front-api.