### PR TITLE
[front] Use project database terminology in v1 tools

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,6 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
-  POD_DATABASE_NAME_REGEX,
+  SANDBOX_DATABASE_NAME_REGEX,
   SANDBOX_FUNCTION_EXECUTION_MODES,
   SANDBOX_FUNCTION_SLUG_REGEX,
   SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
@@ -196,23 +196,24 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   },
   {
     name: "db_list",
-    description: "List the pod's SQLite databases and their sizes.",
+    description: "List the current project's SQLite databases and their sizes.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing pod databases...",
-      done: "Listed pod databases",
+      running: "Listing project databases...",
+      done: "Listed project databases",
     },
     toolCostCategory: "basic",
     freeUsage: true,
   },
   {
     name: "db_schema",
-    description: "Get a pod database's live schema as a drizzle schema file.",
+    description:
+      "Get a project database's live schema as a drizzle schema file.",
     schema: {
       database: z
         .string()
-        .regex(POD_DATABASE_NAME_REGEX)
+        .regex(SANDBOX_DATABASE_NAME_REGEX)
         .describe("The database name, as shown by the db_list tool."),
     },
     stake: "never_ask",
@@ -226,11 +227,11 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   {
     name: "db_query",
     description:
-      "Run a single SQL statement against a pod database: SELECT and DML.",
+      "Run a single SQL statement against a project database: SELECT and DML.",
     schema: {
       database: z
         .string()
-        .regex(POD_DATABASE_NAME_REGEX)
+        .regex(SANDBOX_DATABASE_NAME_REGEX)
         .describe("The database name, as shown by the db_list tool."),
       sql: z
         .string()
@@ -242,8 +243,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Querying pod database...",
-      done: "Queried pod database",
+      running: "Querying project database...",
+      done: "Queried project database",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -251,11 +252,11 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   {
     name: "db_reconcile",
     description:
-      "Apply a pod database's drizzle schema file to its live database (additive changes only).",
+      "Apply a project database's drizzle schema file to its live database (additive changes only).",
     schema: {
       database: z
         .string()
-        .regex(POD_DATABASE_NAME_REGEX)
+        .regex(SANDBOX_DATABASE_NAME_REGEX)
         .describe(
           "The database's short name as declared by the schema file (e.g. `chat`), without " +
             "the app prefix."
@@ -270,8 +271,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reconciling pod database...",
-      done: "Reconciled pod database",
+      running: "Reconciling project database...",
+      done: "Reconciled project database",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_list.test.ts
@@ -1,11 +1,11 @@
 import { formatDatabasesList } from "@app/lib/api/actions/servers/sandbox_functions/tools/db_list";
-import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
+import { SANDBOX_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
 import { describe, expect, it } from "vitest";
 import { DB_NAME_REGEX } from "../../../../../../../cli/dust-sandbox/functions-runner/types/db";
 
 describe("formatDatabasesList", () => {
   it("returns an explicit empty message when there are none", () => {
-    expect(formatDatabasesList([])).toContain("No live databases in this pod");
+    expect(formatDatabasesList([])).toBe("No project databases.");
   });
 
   it("renders each database with its size and points at db_schema/db_query", () => {
@@ -14,20 +14,24 @@ describe("formatDatabasesList", () => {
       { name: "notes", sizeBytes: 4096 },
     ]);
 
-    expect(out).toContain("Pod databases:");
-    expect(out).toContain("- chat (12648 bytes)");
-    expect(out).toContain("- notes (4096 bytes)");
-    expect(out).toContain("db_schema");
-    expect(out).toContain("db_query");
+    expect(out).toBe(
+      [
+        "Project databases:",
+        "- chat (12648 bytes)",
+        "- notes (4096 bytes)",
+        "",
+        "Use db_schema to inspect one or db_query to run SQL.",
+      ].join("\n")
+    );
   });
 });
 
 // The db tools pre-validate database names with front's mirrored regex; dsbx enforces the
 // same contract with DB_NAME_REGEX. Regex values cannot be type-checked and front cannot
 // runtime-import cli code, so their equality is asserted here.
-describe("POD_DATABASE_NAME_REGEX", () => {
+describe("SANDBOX_DATABASE_NAME_REGEX", () => {
   it("keeps the database name regex identical to the runner's", () => {
-    expect(POD_DATABASE_NAME_REGEX.source).toBe(DB_NAME_REGEX.source);
-    expect(POD_DATABASE_NAME_REGEX.flags).toBe(DB_NAME_REGEX.flags);
+    expect(SANDBOX_DATABASE_NAME_REGEX.source).toBe(DB_NAME_REGEX.source);
+    expect(SANDBOX_DATABASE_NAME_REGEX.flags).toBe(DB_NAME_REGEX.flags);
   });
 });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
@@ -10,15 +10,15 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export function formatDatabasesList(databases: LiveDatabaseEntry[]): string {
   if (databases.length === 0) {
-    return "No live databases in this pod";
+    return "No project databases.";
   }
 
   const lines = databases.map((db) => `- ${db.name} (${db.sizeBytes} bytes)`);
   return [
-    "Pod databases:",
+    "Project databases:",
     ...lines,
     "",
-    "Use db_schema to inspect a database and db_query to run SQL against it.",
+    "Use db_schema to inspect one or db_query to run SQL.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Description

- Present the v1 sandbox database tools as Project-owned, without implying Frame ownership.
- Validate names with `SANDBOX_DATABASE_NAME_REGEX`; the existing Pod-named compatibility alias remains unchanged.
- Keep the underlying Project/Pod resolution and Pod-scoped source paths unchanged.

## Tests

Updated and ran focused `db_list.test.ts` coverage for populated and empty rendering plus dsbx regex parity.

## Risk

Low. Tool names, payloads, handlers, and storage resolution are unchanged.

## Deploy Plan

Standard deploy.