### PR TITLE
Expose sandbox runtime package in the base image

### DIFF
--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -96,15 +96,15 @@ jobs:
         working-directory: cli/dust-sandbox/functions-runner
         run: bun test
 
-      - name: Test pod package
-        # @dust/pod ships into the sandbox image as a bun bundle; its bun:test
+      - name: Test sandbox package
+        # @dust/sandbox ships into the sandbox image as a bun bundle; its bun:test
         # suite is the only coverage of db()'s open/pragma/quota/error logic.
         working-directory: cli/dust-sandbox/pod
         run: |
           bun install --frozen-lockfile
           bun test
 
-      - name: Build pod package bundle
+      - name: Build sandbox package bundle
         # Mirrors the sandbox-image vendor step (bun build index.ts --bundle
         # --target=bun --packages=external) so bundle regressions surface here
         # instead of at image build time.

--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -96,14 +96,15 @@ the release workflow, and `upsert_dsbx_to_sandbox.sh` build it on the host
 first. Rebuild it after changing any runner source (`protocol.ts`, `invoke.ts`,
 `schema.ts`, `runner.ts`).
 
-## The `@dust/pod` runtime package
+## The `@dust/sandbox` runtime package
 
 `pod/` is the runtime library sandbox function code imports (`db()`,
 `currentUser()`). It is not part of `dsbx`: the image vendors it into
-`/opt/npm-global/lib/node_modules/@dust/pod` at image build time (see
-`front/lib/api/sandbox/image/pod_package.ts`), and published bundles keep it as
-an external import. So neither rebuilding `dsbx` nor republishing a function
-picks up a change to it — only a new image does, gated by
+`/opt/npm-global/lib/node_modules/@dust/sandbox` at image build time and exposes
+`@dust/pod` as a compatibility symlink (see
+`front/lib/api/sandbox/image/sandbox_package.ts`). Published bundles keep the
+package as an external import. So neither rebuilding `dsbx` nor republishing a
+function picks up a change to it; only a new image does, gated by
 `DUST_BASE_IMAGE_VERSION`.
 
 For the dev loop, `upsert_pod_package_to_sandbox.sh` builds it and pushes it

--- a/cli/dust-sandbox/pod/bun.lock
+++ b/cli/dust-sandbox/pod/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@dust/pod",
+      "name": "@dust/sandbox",
       "dependencies": {
         "drizzle-orm": "0.45.2",
         "zod": "^4.4.3",

--- a/cli/dust-sandbox/pod/context.test.ts
+++ b/cli/dust-sandbox/pod/context.test.ts
@@ -5,7 +5,7 @@ import {
   INVOCATION_CONTEXT_KEY,
   podEnv,
   runWithInvocationEnv,
-} from "@dust/pod";
+} from "@dust/sandbox";
 
 const MARKER = "POD_CONTEXT_TEST_MARKER";
 

--- a/cli/dust-sandbox/pod/identity.test.ts
+++ b/cli/dust-sandbox/pod/identity.test.ts
@@ -5,7 +5,7 @@ import {
   POD_WORKSPACE_ID_ENV,
   PodUserIdentityError,
   runWithInvocationEnv,
-} from "@dust/pod";
+} from "@dust/sandbox";
 
 const identity = {
   workspaceId: "w_current",

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { PodDatabase, SandboxDatabase } from "@dust/pod";
+import type { PodDatabase, SandboxDatabase } from "@dust/sandbox";
 import {
   db,
   FRAME_ID_ENV,
@@ -33,7 +33,7 @@ import {
   SandboxDatabaseInvalidNameError,
   SandboxDatabasesUnavailableError,
   SUPPORTED_FRAME_PUBLICATION_SCHEMA_VERSION,
-} from "@dust/pod";
+} from "@dust/sandbox";
 import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // The production quota front passes per exec.

--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -1,8 +1,8 @@
 /**
- * `@dust/pod` — the runtime library for code running in a Dust pod sandbox.
+ * `@dust/sandbox` is the runtime library for code running in a Dust sandbox.
  *
  * Surfaces:
- * - `db(name)`: the pod's SQLite state databases, through Drizzle (./db.ts).
+ * - `db(name)`: the owner's SQLite state databases, through Drizzle (./db.ts).
  * - `currentUser()`: the workspace-scoped user attributed to this invocation.
  * - `podEnv(name)`: the invocation's environment (./context.ts).
  * - `resolveToolTextContent(block)`: full text of a tool output block,

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@dust/pod",
-  "version": "0.3.2",
+  "name": "@dust/sandbox",
+  "version": "0.3.3",
   "private": true,
-  "description": "Runtime library for code running in a Dust pod sandbox.",
+  "description": "Runtime library for code running in a Dust sandbox.",
   "type": "module",
   "main": "index.ts",
   "exports": { ".": "./index.ts" },

--- a/cli/dust-sandbox/pod/tool_output.test.ts
+++ b/cli/dust-sandbox/pod/tool_output.test.ts
@@ -6,7 +6,7 @@ import {
   resolveToolTextContent,
   TOOL_OUTPUT_OFFLOAD_META_KEY,
   ToolOutputResolutionError,
-} from "@dust/pod";
+} from "@dust/sandbox";
 
 let mountRootDir: string;
 

--- a/cli/dust-sandbox/pod/tools.test.ts
+++ b/cli/dust-sandbox/pod/tools.test.ts
@@ -11,7 +11,7 @@ import {
   ToolCallError,
   ToolCallResult,
   tools,
-} from "@dust/pod";
+} from "@dust/sandbox";
 
 const BASE_URL = "https://front.test/api/v1/w/w_test";
 const TOKEN = "sandbox-token";

--- a/cli/dust-sandbox/upsert_pod_package_to_sandbox.sh
+++ b/cli/dust-sandbox/upsert_pod_package_to_sandbox.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Build the @dust/pod runtime package and push it to an e2b sandbox.
+# Build the @dust/sandbox runtime package and push it to an e2b sandbox.
 #
-# @dust/pod is vendored into the sandbox image at build time (see
-# front/lib/api/sandbox/image/pod_package.ts), and published function bundles keep it as an
+# @dust/sandbox is vendored into the sandbox image at build time (see
+# front/lib/api/sandbox/image/sandbox_package.ts), and published function bundles keep it as an
 # external import, so neither republishing a function nor pushing a new dsbx picks up a change
 # to it. This script is the dev loop for iterating on it without rebuilding the image.
 #
@@ -16,8 +16,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUNDLE="$SCRIPT_DIR/pod/dist/index.js"
-# Mirrors POD_PACKAGE_IMAGE_DIR in front/lib/api/sandbox/image/pod_package.ts. Only index.js is
-# pushed: the package.json the image generates alongside it does not change.
+# Push through the legacy path so this works before and after dust-base 0.8.102;
+# new images symlink it to the canonical @dust/sandbox package.
 REMOTE_PATH="/opt/npm-global/lib/node_modules/@dust/pod/index.js"
 # $HOME of the agent-proxied user, where warm servers keep their sockets (warm_dir in
 # src/commands/function/warm.rs).
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       echo "Usage: $0 [--no-build] [sandbox-id]"
       echo ""
-      echo "Build the @dust/pod package and push it to a running e2b sandbox."
+      echo "Build the @dust/sandbox package and push it to a running e2b sandbox."
       echo ""
       echo "Options:"
       echo "  --no-build    Skip the build step (use existing bundle)"
@@ -54,13 +54,13 @@ done
 # --- Build ---
 if [[ "$NO_BUILD" == false ]]; then
   if ! command -v bun &>/dev/null; then
-    echo "Error: 'bun' is not installed (needed to build the @dust/pod bundle)."
+    echo "Error: 'bun' is not installed (needed to build the @dust/sandbox bundle)."
     echo "Install it from https://bun.com/ (or: curl -fsSL https://bun.sh/install | bash)"
     exit 1
   fi
-  # Same bun flags the image build uses (buildPodPackage), so what lands here is byte-identical
+  # Same bun flags the image build uses (buildSandboxPackage), so what lands here is byte-identical
   # to what a rebuilt image would ship.
-  echo "==> Building @dust/pod bundle..."
+  echo "==> Building @dust/sandbox bundle..."
   (cd "$SCRIPT_DIR/pod" && bun install --frozen-lockfile && bun run build)
   echo "==> Build complete: $BUNDLE"
 else
@@ -105,7 +105,7 @@ if [[ -z "${SANDBOX_ID:-}" ]]; then
   fi
 fi
 
-echo "==> Pushing @dust/pod to sandbox $SANDBOX_ID at $REMOTE_PATH..."
+echo "==> Pushing @dust/sandbox to sandbox $SANDBOX_ID at $REMOTE_PATH..."
 
 BUNDLE_SIZE=$(wc -c < "$BUNDLE" | tr -d ' ')
 echo "    Bundle size: $(( BUNDLE_SIZE / 1024 ))KB"
@@ -128,4 +128,4 @@ LOCAL_SHA=$(shasum -a 256 "$BUNDLE" | cut -d' ' -f1)
 e2b sandbox exec "$SANDBOX_ID" -u root \
   "echo '$LOCAL_SHA  $REMOTE_PATH' | sha256sum -c -" 2>&1 || true
 
-echo "==> Done! @dust/pod deployed to sandbox $SANDBOX_ID"
+echo "==> Done! @dust/sandbox deployed to sandbox $SANDBOX_ID"

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.105",
+      tag: "0.8.106",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -646,7 +646,7 @@ describe("sandbox image registry", () => {
     expect(litestreamConfig).toContain("path: /sandbox-state/replica");
   });
 
-  test("pins drizzle packages and vendors @dust/pod", () => {
+  test("pins drizzle packages and vendors @dust/sandbox", () => {
     const operations = getDustBaseImageOperations();
     const runCommands = getRunCommands(operations);
     const copyOperations = getCopyOperations(operations);
@@ -663,22 +663,29 @@ describe("sandbox image registry", () => {
       ])
     );
 
-    // Vendored copy of @dust/pod. Do NOT materialize the content here: the
-    // generator bun-builds cli/dust-sandbox/pod, which is written by a
-    // parallel track and may be absent in this checkout.
-    const podCopy = copyOperations.find(
+    // Do not materialize the content here: the generator bun-builds the whole
+    // runtime, while this test only needs to verify the image operation.
+    const runtimeCopies = copyOperations.filter(
       (operation) =>
+        operation.dest === "/opt/npm-global/lib/node_modules/@dust/sandbox" ||
         operation.dest === "/opt/npm-global/lib/node_modules/@dust/pod"
     );
-    expect(podCopy).toBeDefined();
-    expect(podCopy?.src.type).toBe("content");
+    expect(runtimeCopies).toHaveLength(1);
+    expect(runtimeCopies[0]?.dest).toBe(
+      "/opt/npm-global/lib/node_modules/@dust/sandbox"
+    );
+    expect(runtimeCopies[0]?.src.type).toBe("content");
+    expect(runCommands).toContain(
+      "ln -s /opt/npm-global/lib/node_modules/@dust/sandbox /opt/npm-global/lib/node_modules/@dust/pod"
+    );
 
     expect(image.tools).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.3.2" }),
+        expect.objectContaining({ name: "@dust/sandbox", version: "0.3.3" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.3.3" }),
       ])
     );
   });
@@ -701,7 +708,7 @@ describe("sandbox image registry", () => {
     const drizzleIndex = runCommands.findIndex((command) =>
       command.includes("drizzle-orm@0.45.2")
     );
-    const podPackageMkdirIndex = runCommands.findIndex((command) =>
+    const sandboxPackageMkdirIndex = runCommands.findIndex((command) =>
       command.includes("mkdir -p /opt/npm-global/lib/node_modules/@dust")
     );
 
@@ -710,7 +717,7 @@ describe("sandbox image registry", () => {
       litestreamIndex,
       podStateIndex,
       drizzleIndex,
-      podPackageMkdirIndex,
+      sandboxPackageMkdirIndex,
     ]) {
       expect(index).toBeGreaterThanOrEqual(0);
       expect(index).toBeLessThan(lastHardeningIndex);

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -593,7 +593,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
       name: SANDBOX_PACKAGE_NAME,
       version: SANDBOX_PACKAGE_VERSION,
       description:
-        "Frame and Pod database access: db(name) returns a Drizzle instance over the sandbox owner's SQLite database",
+        "Sandbox database access: db(name) returns a Drizzle instance over the owner's SQLite database",
       runtime: "node",
     },
     {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -449,7 +449,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
         name: "drizzle-orm",
         version: "0.45.2",
         description:
-          "SQLite ORM (pod database schema files and function queries)",
+          "SQLite ORM (sandbox database schema files and function queries)",
         runtime: "node",
       },
       {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -3,15 +3,17 @@ import {
   getRootConsumedPathHardeningCommand,
   getSandboxServicePathHardeningCommand,
 } from "@app/lib/api/sandbox/hardening";
-import {
-  buildPodPackage,
-  POD_PACKAGE_IMAGE_DIR,
-  POD_PACKAGE_NAME,
-  POD_PACKAGE_VERSION,
-} from "@app/lib/api/sandbox/image/pod_package";
 import { PROFILE_DIR } from "@app/lib/api/sandbox/image/profile";
 import { buildDustToolsBinary } from "@app/lib/api/sandbox/image/profile/build";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import {
+  buildSandboxPackage,
+  LEGACY_POD_PACKAGE_IMAGE_DIR,
+  LEGACY_POD_PACKAGE_NAME,
+  SANDBOX_PACKAGE_IMAGE_DIR,
+  SANDBOX_PACKAGE_NAME,
+  SANDBOX_PACKAGE_VERSION,
+} from "@app/lib/api/sandbox/image/sandbox_package";
 import type { ToolEntry } from "@app/lib/api/sandbox/image/types";
 import {
   DSBX_TOOL_NAME,
@@ -26,7 +28,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.105";
+const DUST_BASE_IMAGE_VERSION = "0.8.106";
 const DSBX_CLI_VERSION = "0.1.56";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
@@ -574,19 +576,33 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     "/etc/litestream.yml",
     { user: "root" }
   )
-  // Vendor @dust/pod into the global node_modules (see pod_package.ts for why
-  // this is a build-time copy rather than an npm install).
-  .runCmd(`mkdir -p ${path.posix.dirname(POD_PACKAGE_IMAGE_DIR)}`, {
+  // Vendor @dust/sandbox into the global node_modules (see sandbox_package.ts
+  // for why this is a build-time copy rather than an npm install).
+  .runCmd(`mkdir -p ${path.posix.dirname(SANDBOX_PACKAGE_IMAGE_DIR)}`, {
     user: "root",
   })
-  .copy(buildPodPackage, POD_PACKAGE_IMAGE_DIR, { user: "root" })
-  .registerTool({
-    name: POD_PACKAGE_NAME,
-    version: POD_PACKAGE_VERSION,
-    description:
-      "Frame and Pod database access: db(name) returns a Drizzle instance over the sandbox owner's SQLite database",
-    runtime: "node",
-  })
+  .copy(buildSandboxPackage, SANDBOX_PACKAGE_IMAGE_DIR, { user: "root" })
+  // Keep legacy function bundles on the same module instance, not a second
+  // copy of the runtime.
+  .runCmd(
+    `ln -s ${SANDBOX_PACKAGE_IMAGE_DIR} ${LEGACY_POD_PACKAGE_IMAGE_DIR}`,
+    { user: "root" }
+  )
+  .registerTool([
+    {
+      name: SANDBOX_PACKAGE_NAME,
+      version: SANDBOX_PACKAGE_VERSION,
+      description:
+        "Frame and Pod database access: db(name) returns a Drizzle instance over the sandbox owner's SQLite database",
+      runtime: "node",
+    },
+    {
+      name: LEGACY_POD_PACKAGE_NAME,
+      version: SANDBOX_PACKAGE_VERSION,
+      description: `Compatibility alias for ${SANDBOX_PACKAGE_NAME}`,
+      runtime: "node",
+    },
+  ])
   .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })
   // Core: compiled dust-tools binary + shared shell infra
   .copy(buildDustToolsBinary, `${PROFILE_DIR}/dust-tools`, { user: "root" })

--- a/front/lib/api/sandbox/image/sandbox_package.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_package.test.ts
@@ -12,7 +12,6 @@ describe("sandbox package build paths", () => {
     // Assert the walk through stable repo-root markers instead of its number
     // of parent directories.
     const srcDir = getSandboxPackageSrcDir();
-    // pod → dust-sandbox → cli → repo root.
     const repoRoot = path.dirname(path.dirname(path.dirname(srcDir)));
 
     expect(srcDir.endsWith("cli/dust-sandbox/pod")).toBe(true);

--- a/front/lib/api/sandbox/image/sandbox_package.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_package.test.ts
@@ -1,18 +1,17 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import {
-  getPodPackageSrcDir,
-  POD_PACKAGE_IMAGE_DIR,
-} from "@app/lib/api/sandbox/image/pod_package";
+  getSandboxPackageSrcDir,
+  LEGACY_POD_PACKAGE_IMAGE_DIR,
+  SANDBOX_PACKAGE_IMAGE_DIR,
+} from "@app/lib/api/sandbox/image/sandbox_package";
 import { describe, expect, test } from "vitest";
 
-describe("pod package build paths", () => {
-  test("resolves the @dust/pod source dir under the repo root", () => {
-    // cli/dust-sandbox/pod itself lands in a parallel stack, so assert the
-    // resolution through markers that exist in every checkout: the repo root
-    // must contain front/ (where this test runs from) and cli/dust-sandbox/
-    // (the parent of the pod package).
-    const srcDir = getPodPackageSrcDir();
+describe("sandbox package build paths", () => {
+  test("resolves the @dust/sandbox source dir under the repo root", () => {
+    // Assert the walk through stable repo-root markers instead of its number
+    // of parent directories.
+    const srcDir = getSandboxPackageSrcDir();
     // pod → dust-sandbox → cli → repo root.
     const repoRoot = path.dirname(path.dirname(path.dirname(srcDir)));
 
@@ -22,7 +21,10 @@ describe("pod package build paths", () => {
   });
 
   test("targets the @dust scope inside the global node_modules", () => {
-    expect(POD_PACKAGE_IMAGE_DIR).toBe(
+    expect(SANDBOX_PACKAGE_IMAGE_DIR).toBe(
+      "/opt/npm-global/lib/node_modules/@dust/sandbox"
+    );
+    expect(LEGACY_POD_PACKAGE_IMAGE_DIR).toBe(
       "/opt/npm-global/lib/node_modules/@dust/pod"
     );
   });

--- a/front/lib/api/sandbox/image/sandbox_package.ts
+++ b/front/lib/api/sandbox/image/sandbox_package.ts
@@ -2,27 +2,29 @@ import { runCachedBunBuild } from "@app/lib/api/sandbox/image/bun_build";
 import fs from "fs";
 import path from "path";
 
-// @dust/pod is the sandbox-state runtime package exposed to sandbox function
+// @dust/sandbox is the sandbox-state runtime package exposed to sandbox function
 // code: db(name) returns a handle on one of the owner's SQLite databases
 // (bun:sqlite). The @dust scope is never published to npm, so the package is
 // vendored at image build time: bun-bundle the entrypoint (dependencies stay
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
-export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.3.2";
-export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
+export const SANDBOX_PACKAGE_NAME = "@dust/sandbox";
+export const SANDBOX_PACKAGE_VERSION = "0.3.3";
+export const SANDBOX_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${SANDBOX_PACKAGE_NAME}`;
+export const LEGACY_POD_PACKAGE_NAME = "@dust/pod";
+export const LEGACY_POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${LEGACY_POD_PACKAGE_NAME}`;
 
-let podPackageSrcDir: string | undefined;
+let sandboxPackageSrcDir: string | undefined;
 
 /**
- * The @dust/pod source lives at cli/dust-sandbox/pod, resolved by walking up
+ * The @dust/sandbox source lives at cli/dust-sandbox/pod, resolved by walking up
  * from this file to the first ancestor containing cli/dust-sandbox instead of
  * counting `..` segments. Lazy on purpose: the repo layout exists where
  * images are built, not necessarily where front is deployed.
  */
-export function getPodPackageSrcDir(): string {
-  if (podPackageSrcDir) {
-    return podPackageSrcDir;
+export function getSandboxPackageSrcDir(): string {
+  if (sandboxPackageSrcDir) {
+    return sandboxPackageSrcDir;
   }
 
   let dir = __dirname;
@@ -36,15 +38,15 @@ export function getPodPackageSrcDir(): string {
     dir = parent;
   }
 
-  podPackageSrcDir = path.join(dir, "cli", "dust-sandbox", "pod");
-  return podPackageSrcDir;
+  sandboxPackageSrcDir = path.join(dir, "cli", "dust-sandbox", "pod");
+  return sandboxPackageSrcDir;
 }
 
 function buildPackageJson(): string {
   return `${JSON.stringify(
     {
-      name: POD_PACKAGE_NAME,
-      version: POD_PACKAGE_VERSION,
+      name: SANDBOX_PACKAGE_NAME,
+      version: SANDBOX_PACKAGE_VERSION,
       private: true,
       type: "module",
       main: "index.js",
@@ -54,15 +56,14 @@ function buildPackageJson(): string {
   )}\n`;
 }
 
-export function buildPodPackage(): Map<string, Buffer | string> {
-  const srcDir = getPodPackageSrcDir();
+export function buildSandboxPackage(): Map<string, Buffer | string> {
+  const srcDir = getSandboxPackageSrcDir();
   const entrypoint = path.join(srcDir, "index.ts");
 
-  // The source dir lands in a parallel PR. This generator only runs at image
-  // build time (content generators are lazy), so a missing dir must fail the
-  // build loudly rather than ship an image without the package.
+  // Content generators are lazy and run only at image build time, so a
+  // missing entrypoint must fail loudly rather than ship an incomplete image.
   if (!fs.existsSync(entrypoint)) {
-    throw new Error(`@dust/pod source not found at ${entrypoint}`);
+    throw new Error(`@dust/sandbox source not found at ${entrypoint}`);
   }
 
   return new Map<string, Buffer | string>([
@@ -70,7 +71,7 @@ export function buildPodPackage(): Map<string, Buffer | string> {
     [
       "index.js",
       runCachedBunBuild({
-        name: "the sandbox @dust/pod package",
+        name: "the @dust/sandbox package",
         entrypoint,
         srcDir,
         cwd: srcDir,


### PR DESCRIPTION
## Description

- vendor one canonical `@dust/sandbox` bundle and expose `@dust/pod` as a symlink to it
- make the source package and image builder sandbox-neutral
- bump the package to `0.3.3` and `dust-base` to `0.8.106`

#31571 and #31659 are merged; this PR is based on current `main`. `DSBX_CLI_VERSION` stays unchanged because this does not modify the CLI binary.

## Tests

Added image-operation coverage for the single-copy invariant and legacy alias. Ran the 92 runtime tests, 23 image tests, Front `tsgo`, and a manual dual-import identity check.

## Risk

Low. Existing `@dust/pod` imports resolve to the exact canonical module instance. Rollback selects the previous base image.

## Deploy Plan

1. Merge #31571.
2. Merge this PR.
3. Build and roll out `dust-base:0.8.106`; recycle older sandboxes.