### PR TITLE
[front] perf: dedupe and widen per-user AWU usage windowing

### DIFF
--- a/front/lib/metronome/per_user_usage.test.ts
+++ b/front/lib/metronome/per_user_usage.test.ts
@@ -5,7 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("buildUsageQuerySegments", () => {
-  it("returns a single DAY segment when both boundaries are UTC midnight", () => {
+  it("returns a single NONE segment when both boundaries are UTC midnight", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-01T00:00:00.000Z"),
       requestEnd: new Date("2026-07-01T00:00:00.000Z"),
@@ -14,12 +14,12 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-01T00:00:00.000Z",
         endingBefore: "2026-07-01T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
     ]);
   });
 
-  it("adds an HOUR segment for a non-midnight start, DAY for the interior", () => {
+  it("adds an HOUR segment for a non-midnight start, NONE for the interior", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-15T15:00:00.000Z"),
       requestEnd: new Date("2026-07-01T00:00:00.000Z"),
@@ -33,12 +33,12 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-16T00:00:00.000Z",
         endingBefore: "2026-07-01T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
     ]);
   });
 
-  it("adds an HOUR segment for a non-midnight end, DAY for the interior", () => {
+  it("adds an HOUR segment for a non-midnight end, NONE for the interior", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-01T00:00:00.000Z"),
       requestEnd: new Date("2026-06-20T09:30:00.000Z"),
@@ -47,7 +47,7 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-01T00:00:00.000Z",
         endingBefore: "2026-06-20T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
       {
         startingOn: "2026-06-20T00:00:00.000Z",
@@ -57,7 +57,7 @@ describe("buildUsageQuerySegments", () => {
     ]);
   });
 
-  it("produces HOUR + DAY + HOUR for non-midnight start and end, multi-day", () => {
+  it("produces HOUR + NONE + HOUR for non-midnight start and end, multi-day", () => {
     const segments = buildUsageQuerySegments({
       cycleStart: new Date("2026-06-15T15:00:00.000Z"),
       requestEnd: new Date("2026-06-20T09:30:00.000Z"),
@@ -71,7 +71,7 @@ describe("buildUsageQuerySegments", () => {
       {
         startingOn: "2026-06-16T00:00:00.000Z",
         endingBefore: "2026-06-20T00:00:00.000Z",
-        windowSize: "DAY",
+        windowSize: "NONE",
       },
       {
         startingOn: "2026-06-20T00:00:00.000Z",

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -33,10 +33,7 @@ interface UsageQuerySegment {
  * segments the usage endpoint can query directly: a single segment covering
  * the interior days (the bulk of a typical month-long billing period),
  * queried with `windowSize: "NONE"` so it comes back as one aggregate bucket
- * per group instead of one per day — callers here only ever sum rows into a
- * per-group total, so the daily breakdown would just multiply page count for
- * no benefit — plus HOUR-granularity segments only for the partial
- * first/last day when a boundary isn't already UTC midnight.
+ * per group instead of one per day.
  *
  * Segments are contiguous and non-overlapping by construction, so summing
  * their results is safe.
@@ -383,15 +380,8 @@ function perUserAwuUsageCacheKey(
   return `per-user-awu-usage:${metronomeCustomerId}:${metronomeContractId}:${userId}`;
 }
 
-// In-process single-flight registry, keyed by the same string as the Redis
-// cache key. Closes the gap between "checked Redis" and "wrote Redis": two
-// concurrent callers requesting overlapping users (e.g. the pool summary card
-// and the members table both fetching "all active members" at page load)
-// would otherwise both see a cache miss and both fire their own Metronome
-// batch. A caller that finds an in-flight entry here awaits it instead of
-// starting a second fetch. Only dedupes within this process — a second
-// request landing on a different replica still fetches independently, same
-// as before this registry existed.
+// In-process single-flight registry, keyed by the same string as the Redis cache key.
+// Concurrent overlapping callers await one fetch instead of each firing their own Metronome batch.
 const inFlightPerUserAwuUsage = new Map<string, Promise<number>>();
 
 /**

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -20,7 +20,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-type UsageWindowSize = "HOUR" | "DAY";
+type UsageWindowSize = "HOUR" | "DAY" | "NONE";
 
 interface UsageQuerySegment {
   startingOn: string;
@@ -30,10 +30,13 @@ interface UsageQuerySegment {
 
 /**
  * Partition `[cycleStart, requestEnd)` into the fewest midnight-aligned
- * segments the usage endpoint can query directly: a single DAY-granularity
- * segment for the interior days (the bulk of a typical month-long billing
- * period), plus HOUR-granularity segments only for the partial first/last day
- * when a boundary isn't already UTC midnight.
+ * segments the usage endpoint can query directly: a single segment covering
+ * the interior days (the bulk of a typical month-long billing period),
+ * queried with `windowSize: "NONE"` so it comes back as one aggregate bucket
+ * per group instead of one per day — callers here only ever sum rows into a
+ * per-group total, so the daily breakdown would just multiply page count for
+ * no benefit — plus HOUR-granularity segments only for the partial
+ * first/last day when a boundary isn't already UTC midnight.
  *
  * Segments are contiguous and non-overlapping by construction, so summing
  * their results is safe.
@@ -75,7 +78,7 @@ export function buildUsageQuerySegments({
   segments.push({
     startingOn: dayStart.toISOString(),
     endingBefore: dayEnd.toISOString(),
-    windowSize: "DAY",
+    windowSize: "NONE",
   });
   if (requestEnd.getTime() > dayEnd.getTime()) {
     segments.push({
@@ -370,7 +373,7 @@ export async function fetchPerUserAwuUsageRows({
   return new Ok(rows);
 }
 
-const PER_USER_AWU_USAGE_CACHE_TTL_MS = 60 * 1000;
+const PER_USER_AWU_USAGE_CACHE_TTL_MS = 10 * 60 * 1000;
 
 function perUserAwuUsageCacheKey(
   metronomeCustomerId: string,
@@ -380,9 +383,20 @@ function perUserAwuUsageCacheKey(
   return `per-user-awu-usage:${metronomeCustomerId}:${metronomeContractId}:${userId}`;
 }
 
+// In-process single-flight registry, keyed by the same string as the Redis
+// cache key. Closes the gap between "checked Redis" and "wrote Redis": two
+// concurrent callers requesting overlapping users (e.g. the pool summary card
+// and the members table both fetching "all active members" at page load)
+// would otherwise both see a cache miss and both fire their own Metronome
+// batch. A caller that finds an in-flight entry here awaits it instead of
+// starting a second fetch. Only dedupes within this process — a second
+// request landing on a different replica still fetches independently, same
+// as before this registry existed.
+const inFlightPerUserAwuUsage = new Map<string, Promise<number>>();
+
 /**
  * Per-user-cached AWU consumption for the current billing period. Each user is
- * cached under its own key (60s TTL); the users not in cache are fetched in ONE
+ * cached under its own key (10min TTL); the users not in cache are fetched in ONE
  * batched Metronome query and written back — including 0 for users with no
  * usage, so they don't perpetually miss. Caching per user (rather than per
  * requested set) lets the members table, single-user cap checks and reconcile
@@ -425,35 +439,89 @@ export async function getPerUserAwuUsage({
         }
       });
 
-      if (misses.length > 0) {
-        const fetched = await fetchPerUserAwuUsage({
+      if (misses.length === 0) {
+        return result;
+      }
+
+      // Split misses into users someone else in this process is already
+      // fetching (await their promise) vs. users nobody is fetching yet
+      // (this call owns them and starts the batch).
+      const waiters: Array<{ userId: string; promise: Promise<number> }> = [];
+      const newMisses: string[] = [];
+      for (const userId of misses) {
+        const key = perUserAwuUsageCacheKey(
+          metronomeCustomerId,
+          metronomeContractId,
+          userId
+        );
+        const existing = inFlightPerUserAwuUsage.get(key);
+        if (existing) {
+          waiters.push({ userId, promise: existing });
+        } else {
+          newMisses.push(userId);
+        }
+      }
+
+      if (newMisses.length > 0) {
+        const batchPromise = fetchPerUserAwuUsage({
           workspaceId,
           metronomeCustomerId,
-          userIds: misses,
+          userIds: newMisses,
+        }).then((fetched) => {
+          if (fetched.isErr()) {
+            throw fetched.error;
+          }
+          return fetched.value;
         });
-        if (fetched.isErr()) {
-          throw fetched.error;
+
+        // Register a per-user promise for each newly-owned miss before
+        // awaiting anything, so a caller arriving during the fetch finds it.
+        for (const userId of newMisses) {
+          const key = perUserAwuUsageCacheKey(
+            metronomeCustomerId,
+            metronomeContractId,
+            userId
+          );
+          const userPromise = batchPromise.then(
+            (usageByUserId) => usageByUserId.get(userId) ?? 0
+          );
+          inFlightPerUserAwuUsage.set(key, userPromise);
+          // Stop advertising this fetch as in-flight once it settles, so a
+          // later miss (after the Redis TTL expires) starts a fresh one
+          // instead of reusing a stale reference.
+          void userPromise
+            .catch(() => {
+              // Swallow here — the rejection still propagates to every
+              // waiter through their own awaited `promise` below.
+            })
+            .finally(() => {
+              if (inFlightPerUserAwuUsage.get(key) === userPromise) {
+                inFlightPerUserAwuUsage.delete(key);
+              }
+            });
+          waiters.push({ userId, promise: userPromise });
         }
-        await concurrentExecutor(
-          misses,
-          async (userId) => {
-            // Cache 0 too: a user with no usage this period would otherwise
-            // miss on every request.
-            const value = fetched.value.get(userId) ?? 0;
-            result.set(userId, value);
-            await redis.set(
-              perUserAwuUsageCacheKey(
-                metronomeCustomerId,
-                metronomeContractId,
-                userId
-              ),
-              JSON.stringify(value),
-              { PX: PER_USER_AWU_USAGE_CACHE_TTL_MS }
-            );
-          },
-          { concurrency: 16 }
-        );
       }
+
+      await concurrentExecutor(
+        waiters,
+        async ({ userId, promise }) => {
+          // Cache 0 too: a user with no usage this period would otherwise
+          // miss on every request.
+          const value = await promise;
+          result.set(userId, value);
+          await redis.set(
+            perUserAwuUsageCacheKey(
+              metronomeCustomerId,
+              metronomeContractId,
+              userId
+            ),
+            JSON.stringify(value),
+            { PX: PER_USER_AWU_USAGE_CACHE_TTL_MS }
+          );
+        },
+        { concurrency: 16 }
+      );
 
       return result;
     }


### PR DESCRIPTION
## Description

Widens the per-user AWU usage query to windowSize NONE (one bucket per group instead of one per day) and adds an in-process single-flight registry so concurrent callers don't each fire their own Metronome batch. Prerequisite perf work for the extra load the new Poke page introduces.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. **#31587 (this PR)** — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Existing per_user_usage.test.ts updated and passing.

## Risk

Low-medium. Touches a shared, heavily-used usage-fetching path; behavior (returned totals) is unchanged, only fetch granularity and caching.

## Deploy Plan

Deploy front.
