### PR TITLE
[front] feat: add Pool Usage page to Poke

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -27,6 +27,7 @@ import { PlansPage } from "@dust-tt/front/components/poke/pages/PlansPage";
 import { PluginsPage } from "@dust-tt/front/components/poke/pages/PluginsPage";
 import { PodFunctionPage } from "@dust-tt/front/components/poke/pages/PodFunctionPage";
 import { PokefyPage } from "@dust-tt/front/components/poke/pages/PokefyPage";
+import { PoolUsagePage } from "@dust-tt/front/components/poke/pages/PoolUsagePage";
 import { ProductionChecksPage } from "@dust-tt/front/components/poke/pages/ProductionChecksPage";
 import { SkillDetailsPage } from "@dust-tt/front/components/poke/pages/SkillDetailsPage";
 import { SkillSuggestionDetailsPage } from "@dust-tt/front/components/poke/pages/SkillSuggestionDetailsPage";
@@ -106,6 +107,7 @@ export const routes: RouteObject[] = [
         children: [
           { index: true, element: <WorkspacePage /> },
           { path: "analytics", element: <AnalyticsPage /> },
+          { path: "pool-usage", element: <PoolUsagePage /> },
           { path: "memberships", element: <MembershipsPage /> },
           { path: "llm-traces/:runId", element: <LLMTracePage /> },
           {

--- a/front/components/poke/analytics/PokeConsumptionPreview.tsx
+++ b/front/components/poke/analytics/PokeConsumptionPreview.tsx
@@ -47,7 +47,7 @@ export function PokeConsumptionPreview({ owner }: PokeConsumptionPreviewProps) {
       showMemberGroupFilter={false}
       showOverviewError
       state={state}
-      usageHref={`/poke/${owner.sId}?tab=usage`}
+      usageHref={`/poke/${owner.sId}/pool-usage`}
       usageLinkLabel="View Usage"
     />
   );

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -1,0 +1,397 @@
+import { PokeTopUpsHistoryTable } from "@app/components/poke/credits/PokeTopUpsHistoryTable";
+import {
+  SEAT_TYPE_ICONS,
+  seatTypeDisplayName,
+} from "@app/components/workspace/billing/seatTypeUtils";
+import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
+import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { formatCredits } from "@app/lib/client/credits";
+import { expandMaxTierName } from "@app/lib/client/model_tiers";
+import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
+import {
+  usePokeAwuPoolSummary,
+  usePokeMembersUsage,
+} from "@app/poke/swr/credits";
+import { usePokePageMetadata } from "@app/poke/swr/currentPage";
+import { usePokeGroups } from "@app/poke/swr/groups";
+import {
+  usePokeGroupAllowedModelTiers,
+  usePokeUserAllowedModelTiers,
+  usePokeWorkspaceAllowedModelTiers,
+} from "@app/poke/swr/model_tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { isCapEligibleGroupKind } from "@app/types/groups";
+import type { MembershipSeatType } from "@app/types/memberships";
+import {
+  BILLABLE_SEAT_TYPES,
+  SEAT_TYPE_ORDER,
+  toBaseSeatType,
+} from "@app/types/memberships";
+import {
+  AlertCircle,
+  Button,
+  ContentMessage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Icon,
+  LinkExternal01,
+  LinkWrapper,
+  Page,
+  SearchInput,
+  Spinner,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@dust-tt/sparkle";
+import type { PaginationState, SortingState } from "@tanstack/react-table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+const EMPTY_PENDING_MEMBER_IDS: ReadonlySet<string> = new Set();
+
+function noopOnMember(_member: MemberUsageType) {}
+
+// Base seat types a workspace can offer (yearly variants collapse into their
+// base tier), ordered lowest to highest. Poke has no per-workspace seat-plan
+// lookup, so — unlike the customer-facing filter — this always offers the
+// full catalog rather than only the plans this workspace actually sells.
+const SEAT_FILTER_OPTIONS: MembershipSeatType[] = Array.from(
+  new Set(BILLABLE_SEAT_TYPES.map(toBaseSeatType))
+).sort((a, b) => SEAT_TYPE_ORDER[a] - SEAT_TYPE_ORDER[b]);
+
+interface PoolCreditCardProps {
+  owner: ReturnType<typeof useWorkspace>;
+}
+
+// Mirrors the "Workspace credit pool" widget on the customer-facing usage
+// page, so Poke shows the same numbers an admin would see.
+function PoolCreditCard({ owner }: PoolCreditCardProps) {
+  const { awuPoolSummary, isAwuPoolSummaryLoading, isAwuPoolSummaryError } =
+    usePokeAwuPoolSummary({ owner });
+
+  const totalRemainingCredits = awuPoolSummary?.totalRemainingCredits ?? 0;
+  const totalActiveCredits = awuPoolSummary?.totalActiveCredits ?? 0;
+  const overageCredits = awuPoolSummary?.overageCredits ?? null;
+  const hasPool = totalActiveCredits > 0;
+  const totalConsumedCredits = Math.max(
+    0,
+    totalActiveCredits - totalRemainingCredits
+  );
+
+  if (!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && !hasPool) {
+    return null;
+  }
+
+  return (
+    <Page.Vertical gap="xs" align="stretch">
+      <Page.H variant="h4">Workspace credit pool</Page.H>
+
+      {isAwuPoolSummaryError ? (
+        <ContentMessage
+          title="Failed to load Workspace Credits Pool"
+          icon={AlertCircle}
+          variant="warning"
+        >
+          An error occurred while loading the workspace&apos;s credit pool data.
+        </ContentMessage>
+      ) : isAwuPoolSummaryLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <div className="flex items-baseline gap-1">
+            <span className="heading-mono-4xl text-foreground">
+              {formatCredits(totalConsumedCredits)}
+            </span>
+            <span className="copy-sm text-muted-foreground">
+              /{formatCredits(totalActiveCredits)}
+            </span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/20">
+            <div
+              className="h-full rounded-full bg-foreground/80 transition-all"
+              style={{
+                width: `${Math.min(100, totalActiveCredits > 0 ? (totalConsumedCredits / totalActiveCredits) * 100 : 0)}%`,
+              }}
+            />
+          </div>
+          {overageCredits !== null && overageCredits > 0 && (
+            <span className="copy-sm text-muted-foreground">
+              {formatCredits(overageCredits)} overage credits
+            </span>
+          )}
+        </>
+      )}
+    </Page.Vertical>
+  );
+}
+
+export function PoolUsagePage() {
+  const owner = useWorkspace();
+  usePokePageMetadata({ name: owner.name, subtitle: "Pool Usage" });
+
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [seatTypeFilter, setSeatTypeFilter] =
+    useState<MembershipSeatType | null>(null);
+  const [groupFilter, setGroupFilter] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "name", desc: false },
+  ]);
+
+  // Debounce the search input, and reset to the first page on a new query.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSearch(searchInput);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    }, 300);
+    return () => clearTimeout(id);
+  }, [searchInput]);
+
+  const handleSetSorting = useCallback((next: SortingState) => {
+    setSorting(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  const handleSetSeatTypeFilter = useCallback(
+    (next: MembershipSeatType | null) => {
+      setSeatTypeFilter(next);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
+
+  const handleSetGroupFilter = useCallback((next: string | null) => {
+    setGroupFilter(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  const sort = sorting[0];
+  const orderColumn =
+    sort?.id === "email" || sort?.id === "consumedAwuCredits"
+      ? sort.id
+      : "name";
+  const orderDirection = sort?.desc ? "desc" : "asc";
+
+  const {
+    members,
+    totalMembers,
+    creditsResetAt,
+    isMembersUsageLoading,
+    isMembersUsageValidating,
+  } = usePokeMembersUsage({
+    owner,
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+    search,
+    orderColumn,
+    orderDirection,
+    seatType: seatTypeFilter ?? undefined,
+    groupId: groupFilter ?? undefined,
+  });
+
+  const { data: allGroups } = usePokeGroups({ owner });
+  const groups = useMemo(
+    () => allGroups.filter((group) => isCapEligibleGroupKind(group.kind)),
+    [allGroups]
+  );
+  const selectedGroupName = groups.find(
+    (group) => group.sId === groupFilter
+  )?.name;
+
+  const { users: userAllowedModelTiers } = usePokeUserAllowedModelTiers({
+    owner,
+  });
+  const { groups: groupAllowedModelTiers } = usePokeGroupAllowedModelTiers({
+    owner,
+  });
+  const { maxTierName: workspaceMaxTierName } =
+    usePokeWorkspaceAllowedModelTiers({ owner });
+  const workspaceAllowedModelTiers = useMemo(
+    () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
+    [workspaceMaxTierName]
+  );
+  const userAllowedModelTiersByUserId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [userAllowedModelTiers]);
+  const groupModelTiersByGroupId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of groupAllowedModelTiers) {
+      map[entry.groupId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [groupAllowedModelTiers]);
+  const groupNameToId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const group of allGroups) {
+      map.set(group.name, group.sId);
+    }
+    return map;
+  }, [allGroups]);
+
+  const seatFilterDropdown = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={
+            seatTypeFilter ? seatTypeDisplayName(seatTypeFilter) : "All seats"
+          }
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          label="All seats"
+          onClick={() => handleSetSeatTypeFilter(null)}
+        />
+        {SEAT_FILTER_OPTIONS.map((seatType) => (
+          <DropdownMenuItem
+            key={seatType}
+            label={seatTypeDisplayName(seatType)}
+            icon={
+              <Icon
+                visual={SEAT_TYPE_ICONS[seatType]}
+                size="sm"
+                className={getSeatIconColorClass(seatType)}
+              />
+            }
+            onClick={() => handleSetSeatTypeFilter(seatType)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const groupsFilterDropdown = groups.length > 0 && (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={selectedGroupName ?? "All groups"}
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          label="All groups"
+          onClick={() => handleSetGroupFilter(null)}
+        />
+        {groups.map((group) => (
+          <DropdownMenuItem
+            key={group.sId}
+            label={group.name}
+            onClick={() => handleSetGroupFilter(group.sId)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  return (
+    <main className="mx-auto w-full max-w-7xl">
+      <Page.Header
+        title={
+          <div className="flex w-full items-center justify-between gap-4">
+            <Page.H variant="h3">Pool usage</Page.H>
+            <Button
+              label="Breakdown in analytics"
+              iconRight={LinkExternal01}
+              size="xs"
+              variant="highlight-ghost"
+              href={`/poke/${owner.sId}/analytics`}
+            />
+          </div>
+        }
+        description={
+          <>
+            For workspace{" "}
+            <LinkWrapper
+              href={`/poke/${owner.sId}`}
+              className="text-highlight-500"
+            >
+              {owner.name}
+            </LinkWrapper>
+            . Poke uses workspace-admin visibility, so resolved labels may
+            differ from a customer manager&apos;s view. This is a read-only view
+            — seat and spend-limit changes are disabled.
+          </>
+        }
+      />
+
+      <div className="flex flex-col items-stretch gap-10 py-6 pb-20">
+        <PoolCreditCard owner={owner} />
+
+        <Tabs defaultValue="members">
+          <TabsList className="mb-4">
+            <TabsTrigger value="members" label="Members" />
+            <TabsTrigger value="top-ups" label="Top-ups history" />
+          </TabsList>
+
+          <TabsContent value="members">
+            <Page.Vertical gap="sm" align="stretch">
+              <SearchInput
+                placeholder="Search members"
+                value={searchInput}
+                name="search"
+                onChange={setSearchInput}
+              />
+              <div className="flex flex-row items-center justify-end gap-2">
+                {groupsFilterDropdown}
+                {seatFilterDropdown}
+              </div>
+              <MembersUsageTable
+                members={members}
+                creditsResetAt={creditsResetAt}
+                isLoading={isMembersUsageLoading}
+                isRefreshing={
+                  isMembersUsageValidating && !isMembersUsageLoading
+                }
+                totalAllowedUsagePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
+                seatChangePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
+                isSeatBased
+                showSpendLimit
+                readOnly
+                onChangeSeat={noopOnMember}
+                onRemoveSeat={noopOnMember}
+                onEditSpendLimit={noopOnMember}
+                pagination={pagination}
+                setPagination={setPagination}
+                totalRowCount={totalMembers}
+                sorting={sorting}
+                setSorting={handleSetSorting}
+                showGroupsColumn={groups.length > 0}
+                showModelTiersColumn
+                userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
+                groupModelTiersByGroupId={groupModelTiersByGroupId}
+                workspaceAllowedModelTiers={workspaceAllowedModelTiers}
+                groupNameToId={groupNameToId}
+              />
+            </Page.Vertical>
+          </TabsContent>
+
+          <TabsContent value="top-ups">
+            <PokeTopUpsHistoryTable owner={owner} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </main>
+  );
+}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -186,6 +186,7 @@ export function PoolUsagePage() {
     creditsResetAt,
     isMembersUsageLoading,
     isMembersUsageValidating,
+    isMembersUsageError,
   } = usePokeMembersUsage({
     owner,
     pageIndex: pagination.pageIndex,
@@ -211,10 +212,12 @@ export function PoolUsagePage() {
     groups: groupAllowedModelTiers,
     maxTierName: workspaceMaxTierName,
   } = usePokeAllowedModelTiers({ owner });
+
   const workspaceAllowedModelTiers = useMemo(
     () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
     [workspaceMaxTierName]
   );
+
   const userAllowedModelTiersByUserId = useMemo(() => {
     const map: Record<string, ModelsTierName[]> = {};
     for (const entry of userAllowedModelTiers) {
@@ -222,6 +225,7 @@ export function PoolUsagePage() {
     }
     return map;
   }, [userAllowedModelTiers]);
+
   const groupModelTiersByGroupId = useMemo(() => {
     const map: Record<string, ModelsTierName[]> = {};
     for (const entry of groupAllowedModelTiers) {
@@ -229,6 +233,7 @@ export function PoolUsagePage() {
     }
     return map;
   }, [groupAllowedModelTiers]);
+
   const groupNameToId = useMemo(() => {
     const map = new Map<string, string>();
     for (const group of allGroups) {
@@ -350,33 +355,44 @@ export function PoolUsagePage() {
                 {groupsFilterDropdown}
                 {seatFilterDropdown}
               </div>
-              <MembersUsageTable
-                members={members}
-                creditsResetAt={creditsResetAt}
-                isLoading={isMembersUsageLoading}
-                isRefreshing={
-                  isMembersUsageValidating && !isMembersUsageLoading
-                }
-                totalAllowedUsagePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
-                seatChangePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
-                isSeatBased
-                showSpendLimit
-                readOnly
-                onChangeSeat={noopOnMember}
-                onRemoveSeat={noopOnMember}
-                onEditSpendLimit={noopOnMember}
-                pagination={pagination}
-                setPagination={setPagination}
-                totalRowCount={totalMembers}
-                sorting={sorting}
-                setSorting={handleSetSorting}
-                showGroupsColumn={groups.length > 0}
-                showModelTiersColumn
-                userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
-                groupModelTiersByGroupId={groupModelTiersByGroupId}
-                workspaceAllowedModelTiers={workspaceAllowedModelTiers}
-                groupNameToId={groupNameToId}
-              />
+              {isMembersUsageError ? (
+                <ContentMessage
+                  title="Failed to load members usage"
+                  icon={AlertCircle}
+                  variant="warning"
+                >
+                  Could not load per-member seat and credit pool consumption
+                  data for this workspace.
+                </ContentMessage>
+              ) : (
+                <MembersUsageTable
+                  members={members}
+                  creditsResetAt={creditsResetAt}
+                  isLoading={isMembersUsageLoading}
+                  isRefreshing={
+                    isMembersUsageValidating && !isMembersUsageLoading
+                  }
+                  totalAllowedUsagePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
+                  seatChangePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
+                  isSeatBased
+                  showSpendLimit
+                  readOnly
+                  onChangeSeat={noopOnMember}
+                  onRemoveSeat={noopOnMember}
+                  onEditSpendLimit={noopOnMember}
+                  pagination={pagination}
+                  setPagination={setPagination}
+                  totalRowCount={totalMembers}
+                  sorting={sorting}
+                  setSorting={handleSetSorting}
+                  showGroupsColumn={groups.length > 0}
+                  showModelTiersColumn
+                  userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
+                  groupModelTiersByGroupId={groupModelTiersByGroupId}
+                  workspaceAllowedModelTiers={workspaceAllowedModelTiers}
+                  groupNameToId={groupNameToId}
+                />
+              )}
             </Page.Vertical>
           </TabsContent>
 

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -16,11 +16,7 @@ import {
 } from "@app/poke/swr/credits";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeGroups } from "@app/poke/swr/groups";
-import {
-  usePokeGroupAllowedModelTiers,
-  usePokeUserAllowedModelTiers,
-  usePokeWorkspaceAllowedModelTiers,
-} from "@app/poke/swr/model_tiers";
+import { usePokeAllowedModelTiers } from "@app/poke/swr/model_tiers";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { isCapEligibleGroupKind } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -210,14 +206,11 @@ export function PoolUsagePage() {
     (group) => group.sId === groupFilter
   )?.name;
 
-  const { users: userAllowedModelTiers } = usePokeUserAllowedModelTiers({
-    owner,
-  });
-  const { groups: groupAllowedModelTiers } = usePokeGroupAllowedModelTiers({
-    owner,
-  });
-  const { maxTierName: workspaceMaxTierName } =
-    usePokeWorkspaceAllowedModelTiers({ owner });
+  const {
+    users: userAllowedModelTiers,
+    groups: groupAllowedModelTiers,
+    maxTierName: workspaceMaxTierName,
+  } = usePokeAllowedModelTiers({ owner });
   const workspaceAllowedModelTiers = useMemo(
     () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
     [workspaceMaxTierName]

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -25,6 +25,7 @@ import { WebhookSourceDataTable } from "@app/components/poke/webhook_sources/tab
 import { WorkspaceMetadataTab } from "@app/components/poke/workspace/MetadataTab";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
 import { WorkspaceAnalyticsButton } from "@app/components/poke/workspace/WorkspaceAnalyticsButton";
+import { WorkspacePoolUsageButton } from "@app/components/poke/workspace/WorkspacePoolUsageButton";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -249,6 +250,7 @@ export function WorkspacePage() {
                     temporalFrontNamespace={temporalFrontNamespace}
                   />
                   <WorkspaceAnalyticsButton workspaceId={owner.sId} />
+                  <WorkspacePoolUsageButton workspaceId={owner.sId} />
                 </div>
               </TabsContent>
               <TabsContent value="subscriptions">

--- a/front/components/poke/workspace/WorkspacePoolUsageButton.tsx
+++ b/front/components/poke/workspace/WorkspacePoolUsageButton.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@app/components/poke/shadcn/lib/utils";
+import {
+  ArrowRight,
+  CoinsStacked01,
+  Icon,
+  LinkWrapper,
+} from "@dust-tt/sparkle";
+
+interface WorkspacePoolUsageButtonProps {
+  workspaceId: string;
+}
+
+export function WorkspacePoolUsageButton({
+  workspaceId,
+}: WorkspacePoolUsageButtonProps) {
+  return (
+    <LinkWrapper
+      href={`/poke/${workspaceId}/pool-usage`}
+      className={cn(
+        "group relative isolate flex min-h-20 w-full items-center gap-3 overflow-hidden",
+        "rounded-lg border border-highlight-200 bg-linear-to-r from-background via-background to-highlight-50/50",
+        "p-4 text-left shadow-sm outline-hidden",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted-background"
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "flex h-11 w-11 shrink-0 items-center justify-center",
+          "rounded-lg border border-highlight-200 bg-background text-highlight-500 shadow-sm"
+        )}
+      >
+        <Icon visual={CoinsStacked01} size="md" />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-semibold text-foreground">
+          Pool Usage
+        </span>
+        <span className="text-xs text-muted-foreground">
+          Review member seats and credit pool consumption.
+        </span>
+      </div>
+      <Icon visual={ArrowRight} size="sm" className="text-highlight-500" />
+    </LinkWrapper>
+  );
+}

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -199,6 +199,7 @@ export function usePokeMembersUsage({
   orderDirection,
   seatType,
   creditState,
+  groupId,
 }: PokeConditionalFetchProps & {
   pageIndex: number;
   pageSize: number;
@@ -212,6 +213,7 @@ export function usePokeMembersUsage({
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType;
   creditState?: UserCreditState;
+  groupId?: string;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetMembersUsageResponseBody> = fetcher;
@@ -232,6 +234,9 @@ export function usePokeMembersUsage({
   if (creditState) {
     params.set("creditState", creditState);
   }
+  if (groupId) {
+    params.set("groupId", groupId);
+  }
   if (orderDirection) {
     params.set("orderDirection", orderDirection);
   }
@@ -247,6 +252,7 @@ export function usePokeMembersUsage({
   return {
     members: data?.members ?? emptyArray(),
     totalMembers: data?.total ?? 0,
+    creditsResetAt: data?.creditsResetAt ?? null,
     isMembersUsageLoading: !error && !data && !disabled,
     isMembersUsageError: error,
     isMembersUsageValidating: isValidating,


### PR DESCRIPTION
## Description

Duplicates the customer-facing usage page's members table and workspace credit pool widget into a new read-only Poke page, using existing hooks.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. **#31588 (this PR)** — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked (front, front-api). No automated tests for this UI-only addition; not manually verified in a running browser.

## Risk

Low. New Poke-only page and route; no changes to existing surfaces.

## Deploy Plan

Deploy front, front-api and front-spa.
