### PR TITLE
[front] feat: replace Poke pool usage header with a remaining-pool card

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -5,7 +5,10 @@ import {
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
-import { WorkspaceCreditPoolSection } from "@app/components/workspace/WorkspaceCreditPoolCards";
+import {
+  toCreditPoolFetchStatus,
+  WorkspaceCreditPoolSection,
+} from "@app/components/workspace/WorkspaceCreditPoolCards";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
@@ -74,8 +77,10 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
 
   return (
     <WorkspaceCreditPoolSection
-      isCardsLoading={isAwuPoolSummaryLoading}
-      isCardsError={!!isAwuPoolSummaryError}
+      cardsStatus={toCreditPoolFetchStatus(
+        isAwuPoolSummaryLoading,
+        !!isAwuPoolSummaryError
+      )}
       showPoolCard={hasPool}
       isVisible={hasPool}
       totalRemainingCredits={totalRemainingCredits}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -5,6 +5,7 @@ import {
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
+import { WorkspaceCreditPoolSection } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
@@ -26,9 +27,7 @@ import {
   toBaseSeatType,
 } from "@app/types/memberships";
 import {
-  AlertCircle,
   Button,
-  ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -38,7 +37,6 @@ import {
   LinkWrapper,
   Page,
   SearchInput,
-  Spinner,
   Tabs,
   TabsContent,
   TabsList,
@@ -65,8 +63,6 @@ interface PoolCreditCardProps {
   owner: ReturnType<typeof useWorkspace>;
 }
 
-// Mirrors the "Workspace credit pool" widget on the customer-facing usage
-// page, so Poke shows the same numbers an admin would see.
 function PoolCreditCard({ owner }: PoolCreditCardProps) {
   const { awuPoolSummary, isAwuPoolSummaryLoading, isAwuPoolSummaryError } =
     usePokeAwuPoolSummary({ owner });
@@ -75,57 +71,23 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
   const totalActiveCredits = awuPoolSummary?.totalActiveCredits ?? 0;
   const overageCredits = awuPoolSummary?.overageCredits ?? null;
   const hasPool = totalActiveCredits > 0;
-  const totalConsumedCredits = Math.max(
-    0,
-    totalActiveCredits - totalRemainingCredits
-  );
-
-  if (!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && !hasPool) {
-    return null;
-  }
 
   return (
-    <Page.Vertical gap="xs" align="stretch">
-      <Page.H variant="h4">Workspace credit pool</Page.H>
-
-      {isAwuPoolSummaryError ? (
-        <ContentMessage
-          title="Failed to load Workspace Credits Pool"
-          icon={AlertCircle}
-          variant="warning"
-        >
-          An error occurred while loading the workspace&apos;s credit pool data.
-        </ContentMessage>
-      ) : isAwuPoolSummaryLoading ? (
-        <div className="flex justify-center py-8">
-          <Spinner />
-        </div>
-      ) : (
-        <>
-          <div className="flex items-baseline gap-1">
-            <span className="heading-mono-4xl text-foreground">
-              {formatCredits(totalConsumedCredits)}
-            </span>
-            <span className="copy-sm text-muted-foreground">
-              /{formatCredits(totalActiveCredits)}
-            </span>
-          </div>
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/20">
-            <div
-              className="h-full rounded-full bg-foreground/80 transition-all"
-              style={{
-                width: `${Math.min(100, totalActiveCredits > 0 ? (totalConsumedCredits / totalActiveCredits) * 100 : 0)}%`,
-              }}
-            />
-          </div>
-          {overageCredits !== null && overageCredits > 0 && (
-            <span className="copy-sm text-muted-foreground">
-              {formatCredits(overageCredits)} overage credits
-            </span>
-          )}
-        </>
-      )}
-    </Page.Vertical>
+    <WorkspaceCreditPoolSection
+      isCardsLoading={isAwuPoolSummaryLoading}
+      isCardsError={!!isAwuPoolSummaryError}
+      showPoolCard={hasPool}
+      isVisible={hasPool}
+      totalRemainingCredits={totalRemainingCredits}
+      poolSecondaryContent={
+        overageCredits !== null &&
+        overageCredits > 0 && (
+          <span className="copy-sm text-muted-foreground">
+            {formatCredits(overageCredits)} overage credits
+          </span>
+        )
+      }
+    />
   );
 }
 

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -30,7 +30,9 @@ import {
   toBaseSeatType,
 } from "@app/types/memberships";
 import {
+  AlertCircle,
   Button,
+  ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -11,7 +11,6 @@ import {
 } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import { formatCredits } from "@app/lib/client/credits";
 import { expandMaxTierName } from "@app/lib/client/model_tiers";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
@@ -74,7 +73,6 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
 
   const totalRemainingCredits = awuPoolSummary?.totalRemainingCredits ?? 0;
   const totalActiveCredits = awuPoolSummary?.totalActiveCredits ?? 0;
-  const overageCredits = awuPoolSummary?.overageCredits ?? null;
   const hasPool = totalActiveCredits > 0;
 
   return (
@@ -86,14 +84,6 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
       showPoolCard={hasPool}
       isVisible={hasPool}
       totalRemainingCredits={totalRemainingCredits}
-      poolSecondaryContent={
-        overageCredits !== null &&
-        overageCredits > 0 && (
-          <span className="copy-sm text-muted-foreground">
-            {formatCredits(overageCredits)} overage credits
-          </span>
-        )
-      }
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,0 +1,70 @@
+import { formatCredits } from "@app/lib/client/credits";
+import {
+  AlertCircle,
+  ContentMessage,
+  Page,
+  Spinner,
+  ValueCard,
+} from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+interface WorkspaceCreditPoolSectionProps {
+  isCardsLoading: boolean;
+  isCardsError: boolean;
+  showPoolCard: boolean;
+  isVisible: boolean;
+  totalRemainingCredits: number;
+  poolSecondaryContent?: ReactNode;
+}
+
+// Single source of truth for the "Credit usage" block so the customer-facing
+// usage page and its Poke mirror can't drift from each other on this
+// section's structure. Accounts with and without a credit pool render the
+// same cards; the pool remaining-balance card is the only thing that differs.
+export function WorkspaceCreditPoolSection({
+  isCardsLoading,
+  isCardsError,
+  showPoolCard,
+  isVisible,
+  totalRemainingCredits,
+  poolSecondaryContent,
+}: WorkspaceCreditPoolSectionProps) {
+  if (!isCardsLoading && !isCardsError && !isVisible) {
+    return null;
+  }
+
+  return (
+    <Page.Vertical gap="xs" align="stretch">
+      <Page.H variant="h4">Credit usage</Page.H>
+
+      {isCardsError ? (
+        <ContentMessage
+          title="Failed to load Workspace Credits Pool"
+          icon={AlertCircle}
+          variant="warning"
+        >
+          An error occurred while loading the workspace&apos;s credit pool data.
+        </ContentMessage>
+      ) : isCardsLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          {showPoolCard && (
+            <ValueCard
+              title="Remaining credits pool"
+              isLoading={false}
+              content={
+                <div className="truncate text-2xl text-foreground">
+                  {formatCredits(totalRemainingCredits)}
+                </div>
+              }
+            />
+          )}
+          {poolSecondaryContent}
+        </>
+      )}
+    </Page.Vertical>
+  );
+}

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -8,9 +8,20 @@ import {
 } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
+export type CreditPoolFetchStatus = "loading" | "error" | "ready";
+
+export function toCreditPoolFetchStatus(
+  isLoading: boolean,
+  isError: boolean
+): CreditPoolFetchStatus {
+  if (isError) {
+    return "error";
+  }
+  return isLoading ? "loading" : "ready";
+}
+
 interface WorkspaceCreditPoolSectionProps {
-  isCardsLoading: boolean;
-  isCardsError: boolean;
+  cardsStatus: CreditPoolFetchStatus;
   showPoolCard: boolean;
   isVisible: boolean;
   totalRemainingCredits: number;
@@ -22,14 +33,13 @@ interface WorkspaceCreditPoolSectionProps {
 // section's structure. Accounts with and without a credit pool render the
 // same cards; the pool remaining-balance card is the only thing that differs.
 export function WorkspaceCreditPoolSection({
-  isCardsLoading,
-  isCardsError,
+  cardsStatus,
   showPoolCard,
   isVisible,
   totalRemainingCredits,
   poolSecondaryContent,
 }: WorkspaceCreditPoolSectionProps) {
-  if (!isCardsLoading && !isCardsError && !isVisible) {
+  if (cardsStatus === "ready" && !isVisible) {
     return null;
   }
 
@@ -37,7 +47,7 @@ export function WorkspaceCreditPoolSection({
     <Page.Vertical gap="xs" align="stretch">
       <Page.H variant="h4">Credit usage</Page.H>
 
-      {isCardsError ? (
+      {cardsStatus === "error" ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"
           icon={AlertCircle}
@@ -45,7 +55,7 @@ export function WorkspaceCreditPoolSection({
         >
           An error occurred while loading the workspace&apos;s credit pool data.
         </ContentMessage>
-      ) : isCardsLoading ? (
+      ) : cardsStatus === "loading" ? (
         <div className="flex justify-center py-8">
           <Spinner />
         </div>

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -28,10 +28,6 @@ interface WorkspaceCreditPoolSectionProps {
   poolSecondaryContent?: ReactNode;
 }
 
-// Single source of truth for the "Credit usage" block so the customer-facing
-// usage page and its Poke mirror can't drift from each other on this
-// section's structure. Accounts with and without a credit pool render the
-// same cards; the pool remaining-balance card is the only thing that differs.
 export function WorkspaceCreditPoolSection({
   cardsStatus,
   showPoolCard,

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,7 +1,6 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { formatCredits } from "@app/lib/client/credits";
 import { AlertCircle, ContentMessage, Page, Spinner } from "@dust-tt/sparkle";
-import type { ReactNode } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -20,7 +19,6 @@ interface WorkspaceCreditPoolSectionProps {
   showPoolCard: boolean;
   isVisible: boolean;
   totalRemainingCredits: number;
-  poolSecondaryContent?: ReactNode;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -28,7 +26,6 @@ export function WorkspaceCreditPoolSection({
   showPoolCard,
   isVisible,
   totalRemainingCredits,
-  poolSecondaryContent,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -51,16 +48,13 @@ export function WorkspaceCreditPoolSection({
           <Spinner />
         </div>
       ) : (
-        <>
-          {showPoolCard && (
-            <SummaryCard
-              label="Remaining credits pool"
-              value={formatCredits(totalRemainingCredits)}
-              hint={null}
-            />
-          )}
-          {poolSecondaryContent}
-        </>
+        showPoolCard && (
+          <SummaryCard
+            label="Remaining credits pool"
+            value={formatCredits(totalRemainingCredits)}
+            hint={null}
+          />
+        )
       )}
     </Page.Vertical>
   );

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,11 +1,6 @@
+import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { formatCredits } from "@app/lib/client/credits";
-import {
-  AlertCircle,
-  ContentMessage,
-  Page,
-  Spinner,
-  ValueCard,
-} from "@dust-tt/sparkle";
+import { AlertCircle, ContentMessage, Page, Spinner } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
@@ -58,14 +53,10 @@ export function WorkspaceCreditPoolSection({
       ) : (
         <>
           {showPoolCard && (
-            <ValueCard
-              title="Remaining credits pool"
-              isLoading={false}
-              content={
-                <div className="truncate text-2xl text-foreground">
-                  {formatCredits(totalRemainingCredits)}
-                </div>
-              }
+            <SummaryCard
+              label="Remaining credits pool"
+              value={formatCredits(totalRemainingCredits)}
+              hint={null}
             />
           )}
           {poolSecondaryContent}


### PR DESCRIPTION
## Description

Extracts a shared WorkspaceCreditPoolSection card (single remaining-pool value card) and swaps it in for the ad-hoc header on the new Poke page. Card is hidden when the workspace has no pool.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. **#31589 (this PR)** — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Low. New component, only consumed by the new Poke page so far.

## Deploy Plan

Deploy front.
