### PR TITLE
[front] feat: add consumed-this-cycle card to Poke pool usage

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,0 +1,57 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+export type { AwuPoolCurrentCycleResponseBody };
+
+function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/poke/workspaces/:wId/credits/awu-pool-current-cycle.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+
+  const result = await getAwuPoolCurrentCycle(auth);
+  if (result.isErr()) {
+    return currentCycleErrorToApi(ctx, result.error);
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -4,6 +4,7 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import apiKeysUsage from "./api-keys-usage";
+import awuPoolCurrentCycle from "./awu-pool-current-cycle";
 import awuPoolSummary from "./awu-pool-summary";
 import consumptionExport from "./consumption-export";
 import membersUsage from "./members-usage";
@@ -38,6 +39,7 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
 
 app.route("/api-keys-usage", apiKeysUsage);
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
 app.route("/consumption-export", consumptionExport);
 app.route("/members-usage", membersUsage);
 app.route("/top-ups", topUps);

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -26,6 +26,9 @@ const EMPTY_POOL_SUMMARY = {
   overageCredits: null,
   overageAmountCents: null,
   overageCurrency: null,
+  currentCycleStartMs: null,
+  currentCycleEndMs: null,
+  currentCycleConsumedCredits: null,
 };
 
 beforeEach(() => {

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -14,7 +14,7 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { expandMaxTierName } from "@app/lib/client/model_tiers";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
-  usePokeAwuPoolSummary,
+  usePokeAwuPoolCurrentCycle,
   usePokeMembersUsage,
 } from "@app/poke/swr/credits";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
@@ -68,22 +68,40 @@ interface PoolCreditCardProps {
 }
 
 function PoolCreditCard({ owner }: PoolCreditCardProps) {
-  const { awuPoolSummary, isAwuPoolSummaryLoading, isAwuPoolSummaryError } =
-    usePokeAwuPoolSummary({ owner });
+  const {
+    awuPoolCurrentCycle,
+    isAwuPoolCurrentCycleLoading,
+    isAwuPoolCurrentCycleError,
+  } = usePokeAwuPoolCurrentCycle({ owner });
 
-  const totalRemainingCredits = awuPoolSummary?.totalRemainingCredits ?? 0;
-  const totalActiveCredits = awuPoolSummary?.totalActiveCredits ?? 0;
+  const {
+    totalRemainingCredits,
+    totalActiveCredits,
+    currentCycleConsumedCredits,
+    currentCycleStartMs,
+    currentCycleEndMs,
+  } = awuPoolCurrentCycle ?? {
+    totalRemainingCredits: 0,
+    totalActiveCredits: 0,
+    currentCycleConsumedCredits: null,
+    currentCycleStartMs: null,
+    currentCycleEndMs: null,
+  };
+
   const hasPool = totalActiveCredits > 0;
 
   return (
     <WorkspaceCreditPoolSection
       cardsStatus={toCreditPoolFetchStatus(
-        isAwuPoolSummaryLoading,
-        !!isAwuPoolSummaryError
+        isAwuPoolCurrentCycleLoading,
+        !!isAwuPoolCurrentCycleError
       )}
       showPoolCard={hasPool}
       isVisible={hasPool}
       totalRemainingCredits={totalRemainingCredits}
+      consumedCredits={currentCycleConsumedCredits}
+      currentCycleStartMs={currentCycleStartMs}
+      currentCycleEndMs={currentCycleEndMs}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,4 +1,5 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
+import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
 import { formatCredits } from "@app/lib/client/credits";
 import { AlertCircle, ContentMessage, Page, Spinner } from "@dust-tt/sparkle";
 
@@ -14,11 +15,78 @@ export function toCreditPoolFetchStatus(
   return isLoading ? "loading" : "ready";
 }
 
+function formatCycleDayLabel(
+  currentCycleStartMs: number | null,
+  currentCycleEndMs: number | null
+): string | null {
+  if (
+    currentCycleStartMs === null ||
+    currentCycleEndMs === null ||
+    currentCycleEndMs <= currentCycleStartMs
+  ) {
+    return null;
+  }
+  const totalDays = Math.round(
+    (currentCycleEndMs - currentCycleStartMs) / ONE_DAY_MS
+  );
+  const elapsedDays = Math.min(
+    totalDays,
+    Math.max(0, Math.ceil((Date.now() - currentCycleStartMs) / ONE_DAY_MS))
+  );
+  return `Day ${elapsedDays}/${totalDays}`;
+}
+
+interface WorkspaceCreditUsageValueCardsProps {
+  showPoolCard: boolean;
+  totalRemainingCredits: number;
+  consumedCredits: number | null;
+  currentCycleStartMs: number | null;
+  currentCycleEndMs: number | null;
+  isLoading: boolean;
+}
+
+export function WorkspaceCreditUsageValueCards({
+  showPoolCard,
+  totalRemainingCredits,
+  consumedCredits,
+  currentCycleStartMs,
+  currentCycleEndMs,
+  isLoading,
+}: WorkspaceCreditUsageValueCardsProps) {
+  const cycleDayLabel = formatCycleDayLabel(
+    currentCycleStartMs,
+    currentCycleEndMs
+  );
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {showPoolCard && (
+        <SummaryCard
+          label="Remaining credits pool"
+          value={formatCredits(totalRemainingCredits)}
+          hint={null}
+        />
+      )}
+      <SummaryCard
+        label="Used this cycle"
+        value={
+          typeof consumedCredits === "number"
+            ? formatCredits(consumedCredits)
+            : "—"
+        }
+        hint={cycleDayLabel}
+      />
+    </div>
+  );
+}
+
 interface WorkspaceCreditPoolSectionProps {
   cardsStatus: CreditPoolFetchStatus;
   showPoolCard: boolean;
   isVisible: boolean;
   totalRemainingCredits: number;
+  consumedCredits: number | null;
+  currentCycleStartMs: number | null;
+  currentCycleEndMs: number | null;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -26,6 +94,9 @@ export function WorkspaceCreditPoolSection({
   showPoolCard,
   isVisible,
   totalRemainingCredits,
+  consumedCredits,
+  currentCycleStartMs,
+  currentCycleEndMs,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -48,13 +119,14 @@ export function WorkspaceCreditPoolSection({
           <Spinner />
         </div>
       ) : (
-        showPoolCard && (
-          <SummaryCard
-            label="Remaining credits pool"
-            value={formatCredits(totalRemainingCredits)}
-            hint={null}
-          />
-        )
+        <WorkspaceCreditUsageValueCards
+          showPoolCard={showPoolCard}
+          totalRemainingCredits={totalRemainingCredits}
+          consumedCredits={consumedCredits}
+          currentCycleStartMs={currentCycleStartMs}
+          currentCycleEndMs={currentCycleEndMs}
+          isLoading={false}
+        />
       )}
     </Page.Vertical>
   );

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -15,11 +15,103 @@ import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { cacheWithRedis } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
+import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isNumber } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Invoice } from "@metronome/sdk/resources/v1/customers";
+
+const AUTOMATED_INVOICE_DEDUCTION_LEDGER_TYPES = new Set([
+  "PREPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION",
+  "POSTPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION",
+  "CREDIT_AUTOMATED_INVOICE_DEDUCTION",
+]);
+
+type PoolLedgerEntry = {
+  sourceId: string;
+  invoiceId: string;
+  amountCredits: number;
+  timestampMs: number;
+};
+
+type PoolLedgerData = {
+  poolCommitIds: Set<string>;
+  ledgerEntries: PoolLedgerEntry[];
+};
+
+// Balance listing bounded to a single cycle — the header cards only need the
+// current cycle's ledger, not the full history.
+async function getPoolLedgerData({
+  metronomeCustomerId,
+}: {
+  metronomeCustomerId: string;
+}): Promise<Result<PoolLedgerData, Error>> {
+  const balancesResult = await listMetronomeBalances(metronomeCustomerId, {
+    coveringDate: null,
+    onlyPoolCredits: true,
+    includeArchived: true,
+    includeLedgers: true,
+  });
+  if (balancesResult.isErr()) {
+    return new Err(balancesResult.error);
+  }
+
+  const poolCommitIds = new Set<string>();
+  const ledgerEntries: PoolLedgerEntry[] = [];
+  for (const source of balancesResult.value) {
+    poolCommitIds.add(source.id);
+    for (const item of source.ledger ?? []) {
+      if (
+        !AUTOMATED_INVOICE_DEDUCTION_LEDGER_TYPES.has(item.type) ||
+        !("invoice_id" in item)
+      ) {
+        continue;
+      }
+      ledgerEntries.push({
+        sourceId: source.id,
+        invoiceId: item.invoice_id,
+        amountCredits: item.amount,
+        timestampMs: new Date(item.timestamp).getTime(),
+      });
+    }
+  }
+  return new Ok({ poolCommitIds, ledgerEntries });
+}
+
+function sumPoolLedgerEntriesForInvoice(
+  ledgerEntries: PoolLedgerEntry[],
+  invoiceId: string
+): number {
+  return ledgerEntries
+    .filter((entry) => entry.invoiceId === invoiceId)
+    .reduce((sum, entry) => sum + Math.abs(entry.amountCredits), 0);
+}
+
+type MetronomeContext = {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+};
+
+function resolveMetronomeContext(
+  auth: Authenticator
+): Result<MetronomeContext, AwuPoolSummaryError> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
+    return new Err(new AwuPoolSummaryError("not_configured"));
+  }
+  return new Ok({
+    workspace,
+    metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  });
+}
 
 function creditTypeIdToCurrency(
   creditTypeId: string
@@ -36,6 +128,39 @@ function creditTypeIdToCurrency(
   return null;
 }
 
+// PAYG overage on credit-priced contracts shows up as a `cpu_conversion`
+function extractOverageFromInvoice(invoice: Invoice): {
+  overageCredits: number | null;
+  overageAmountCents: number | null;
+  overageCurrency: SupportedCurrency | null;
+} {
+  const overageCurrency = creditTypeIdToCurrency(invoice.credit_type.id);
+  if (!overageCurrency) {
+    return {
+      overageCredits: null,
+      overageAmountCents: null,
+      overageCurrency: null,
+    };
+  }
+  let overageCredits: number | null = null;
+  let overageAmountCents: number | null = null;
+  for (const item of invoice.line_items) {
+    if (item.type !== "cpu_conversion") {
+      continue;
+    }
+    if (isNumber(item.quantity)) {
+      overageCredits = (overageCredits ?? 0) + item.quantity;
+    }
+    overageAmountCents =
+      (overageAmountCents ?? 0) + amountCents(item.total, overageCurrency);
+  }
+  return {
+    overageCredits,
+    overageAmountCents,
+    overageCurrency: overageCredits !== null ? overageCurrency : null,
+  };
+}
+
 export class AwuPoolSummaryError extends Error {
   constructor(
     readonly type:
@@ -48,21 +173,69 @@ export class AwuPoolSummaryError extends Error {
   }
 }
 
+type AwuPoolSummaryErrorType = AwuPoolSummaryError["type"];
+
+type SerializableAwuPoolCurrentCycleOutcome =
+  | { status: "ok"; body: AwuPoolCurrentCycleResponseBody }
+  | { status: "error"; errorType: AwuPoolSummaryErrorType };
+
+async function computeAwuPoolCurrentCycleOutcome(
+  auth: Authenticator
+): Promise<SerializableAwuPoolCurrentCycleOutcome> {
+  const result = await getAwuPoolCurrentCycleUncached(auth);
+  if (result.isErr()) {
+    return { status: "error", errorType: result.error.type };
+  }
+  return { status: "ok", body: result.value };
+}
+
+const AWU_POOL_CURRENT_CYCLE_CACHE_ID = "awuPoolCurrentCycle";
+const AWU_POOL_CURRENT_CYCLE_CACHE_TTL_MS = 60 * 1000;
+
+const getCachedAwuPoolCurrentCycleOutcome = cacheWithRedis(
+  computeAwuPoolCurrentCycleOutcome,
+  (auth) => auth.getNonNullableWorkspace().sId,
+  {
+    cacheId: AWU_POOL_CURRENT_CYCLE_CACHE_ID,
+    ttlMs: AWU_POOL_CURRENT_CYCLE_CACHE_TTL_MS,
+  }
+);
+
+// Header-card data only — cheap, bounded to a single cycle's ledger.
+export async function getAwuPoolCurrentCycle(
+  auth: Authenticator
+): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
+  const outcome = await getCachedAwuPoolCurrentCycleOutcome(auth);
+  if (outcome.status === "error") {
+    return new Err(new AwuPoolSummaryError(outcome.errorType));
+  }
+  return new Ok(outcome.body);
+}
+
+// The legacy combined endpoint currently returns exactly the current-cycle
+// figures — it grows a cycle-history component alongside the history table.
 export async function getAwuPoolSummary(
   auth: Authenticator
-): Promise<Result<AwuPoolSummaryResponseBody, AwuPoolSummaryError>> {
-  const workspace = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-  const { metronomeCustomerId } = workspace;
-  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
-    return new Err(new AwuPoolSummaryError("not_configured"));
-  }
-  const { metronomeContractId } = subscription;
+): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
+  return getAwuPoolCurrentCycle(auth);
+}
 
-  const [balancesResult, invoicesResult] = await Promise.all([
-    listMetronomeBalances(metronomeCustomerId),
-    listMetronomeDraftInvoices(metronomeCustomerId),
-  ]);
+async function getAwuPoolCurrentCycleUncached(
+  auth: Authenticator
+): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
+  const contextResult = resolveMetronomeContext(auth);
+  if (contextResult.isErr()) {
+    return contextResult;
+  }
+  const { metronomeCustomerId, metronomeContractId } = contextResult.value;
+  const awuCreditTypeId = getCreditTypeAwuId();
+
+  const [balancesResult, invoicesResult, poolLedgerDataResult] =
+    await Promise.all([
+      listMetronomeBalances(metronomeCustomerId),
+      listMetronomeDraftInvoices(metronomeCustomerId),
+      getPoolLedgerData({ metronomeCustomerId }),
+    ]);
 
   if (balancesResult.isErr()) {
     return new Err(
@@ -73,6 +246,21 @@ export async function getAwuPoolSummary(
     return new Err(
       new AwuPoolSummaryError("invoices_fetch_failed", invoicesResult.error)
     );
+  }
+
+  // `null` means the ledger couldn't be read (fetch failure)
+  let ledgerEntries: PoolLedgerEntry[] | null = null;
+  if (poolLedgerDataResult.isErr()) {
+    logger.error(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        error: poolLedgerDataResult.error,
+      },
+      "[AwuPoolSummary] Failed to read pool ledger for the current cycle"
+    );
+  } else {
+    ledgerEntries = poolLedgerDataResult.value.ledgerEntries;
   }
 
   const now = Date.now();
@@ -90,6 +278,11 @@ export async function getAwuPoolSummary(
     return startMs <= now && now < endMs;
   });
 
+  const currentCycleConsumedCredits =
+    currentInvoice && ledgerEntries
+      ? sumPoolLedgerEntriesForInvoice(ledgerEntries, currentInvoice.id)
+      : null;
+
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
     return new Ok({
       totalRemainingCredits: 0,
@@ -97,39 +290,29 @@ export async function getAwuPoolSummary(
       overageCredits: null,
       overageAmountCents: null,
       overageCurrency: null,
+      currentCycleStartMs: null,
+      currentCycleEndMs: null,
+      currentCycleConsumedCredits,
     });
   }
 
-  // PAYG overage on credit-priced contracts shows up as a `cpu_conversion`
-  // line item (Metronome converts AWU spend that exceeds the prepaid AWU
-  // pool into fiat using the rate-card's `fiat_per_custom_credit`). There is
-  // no dedicated overage product — the line's `type` is the signal.
-  //   - `quantity` is the number of overage AWU credits consumed
-  //   - `total` is the fiat amount in the invoice's native unit (USD in
-  //     cents, other currencies in whole units — normalized via amountCents)
-  const overageCurrency = creditTypeIdToCurrency(currentInvoice.credit_type.id);
-  let overageCredits: number | null = null;
-  let overageAmountCents: number | null = null;
-  if (overageCurrency) {
-    for (const item of currentInvoice.line_items) {
-      if (item.type !== "cpu_conversion") {
-        continue;
-      }
-      if (isNumber(item.quantity)) {
-        overageCredits = (overageCredits ?? 0) + item.quantity;
-      }
-      overageAmountCents =
-        (overageAmountCents ?? 0) + amountCents(item.total, overageCurrency);
-    }
-  }
+  const currentCycleStartMs = new Date(
+    currentInvoice.start_timestamp
+  ).getTime();
+  const currentCycleEndMs = new Date(currentInvoice.end_timestamp).getTime();
+
+  const { overageCredits, overageAmountCents, overageCurrency } =
+    extractOverageFromInvoice(currentInvoice);
 
   // Filter to active, non-seat AWU pool credits and commits. The set of
   // seat product IDs is derived from the contract's tagged subscriptions
   // (via the `DUST_SEAT_TYPE` custom field) rather than a hardcoded list.
-  // The contract filter prevents sandbox prepaid commits on other contracts
-  // from inflating the balance.
-  const awuCreditTypeId = getCreditTypeAwuId();
-  const activeContract = await getActiveContract(workspace.sId);
+  //
+  // A pool grant under a superseded contract can still cover `now`,
+  // so it must not be excluded.
+  const activeContract = await getActiveContract(
+    auth.getNonNullableWorkspace().sId
+  );
   const productSeatTypes = await getProductSeatTypes();
   const seatProductIds = activeContract
     ? new Set(
@@ -142,20 +325,19 @@ export async function getAwuPoolSummary(
   const awuBalances = balancesResult.value.filter(
     (entry) =>
       entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
-      !seatProductIds.has(entry.product.id) &&
-      (entry.contract?.id === metronomeContractId || !entry.contract)
+      !seatProductIds.has(entry.product.id)
   );
 
   let totalRemainingCredits = 0;
   let totalActiveCredits = 0;
   for (const entry of awuBalances) {
     const scheduleItems = entry.access_schedule?.schedule_items ?? [];
-    const isActive = scheduleItems.some((item) => {
+    const activeItems = scheduleItems.filter((item) => {
       const itemStartMs = new Date(item.starting_at).getTime();
       const itemEndMs = new Date(item.ending_before).getTime();
       return itemStartMs <= now && now < itemEndMs;
     });
-    if (isActive) {
+    if (activeItems.length > 0) {
       totalRemainingCredits += entry.balance ?? 0;
       for (const item of scheduleItems) {
         totalActiveCredits += item.amount;
@@ -169,5 +351,8 @@ export async function getAwuPoolSummary(
     overageCredits,
     overageAmountCents,
     overageCurrency: overageCredits !== null ? overageCurrency : null,
+    currentCycleStartMs,
+    currentCycleEndMs,
+    currentCycleConsumedCredits,
   });
 }

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -43,8 +43,6 @@ type PoolLedgerData = {
   ledgerEntries: PoolLedgerEntry[];
 };
 
-// Balance listing bounded to a single cycle — the header cards only need the
-// current cycle's ledger, not the full history.
 async function getPoolLedgerData({
   metronomeCustomerId,
 }: {
@@ -212,8 +210,6 @@ export async function getAwuPoolCurrentCycle(
   return new Ok(outcome.body);
 }
 
-// The legacy combined endpoint currently returns exactly the current-cycle
-// figures — it grows a cycle-history component alongside the history table.
 export async function getAwuPoolSummary(
   auth: Authenticator
 ): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2314,7 +2314,9 @@ export async function listMetronomeBalances(
     includeArchived = false,
     coveringDate = new Date(),
     effectiveBefore,
+    startingAt,
     onlyPoolCredits = true,
+    includeLedgers = false,
   }: {
     // Pass `null` to drop the `covering_date` filter and return balances of any
     // date (including expired and, depending on `effectiveBefore`, future ones).
@@ -2322,9 +2324,12 @@ export async function listMetronomeBalances(
     // Restrict to balances with any access before this date — used to hide
     // future-dated balances while still returning expired ones.
     effectiveBefore?: Date;
+    startingAt?: Date;
     includeArchived?: boolean;
     // Restrict to balances related to pool credits
     onlyPoolCredits?: boolean;
+    // Include each entry's full transaction ledger.
+    includeLedgers?: boolean;
   } = {}
 ): Promise<Result<MetronomeBalance[], Error>> {
   if (!config.getMetronomeApiKey()) {
@@ -2345,7 +2350,11 @@ export async function listMetronomeBalances(
       ...(effectiveBefore !== undefined
         ? { effective_before: effectiveBefore.toISOString() }
         : {}),
+      ...(startingAt !== undefined
+        ? { starting_at: startingAt.toISOString() }
+        : {}),
       ...(includeArchived ? { include_archived: true } : {}),
+      ...(includeLedgers ? { include_ledgers: true } : {}),
     })) {
       // Mirror the pool balance alert filter for credits: include only
       // credits explicitly tagged DUST_CONTRACT_CREDIT_TYPE=pool. Excess

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -10,7 +10,10 @@ import type { GetApiKeysUsageResponseBody } from "@app/lib/api/credits/api_keys_
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type {
+  AwuPoolCurrentCycleResponseBody,
+  AwuPoolSummaryResponseBody,
+} from "@app/types/api/credits/awu_pool_summary";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
 import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
 import type {
@@ -165,6 +168,29 @@ export function usePokeAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function usePokeAwuPoolCurrentCycle({
+  owner,
+  disabled,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<AwuPoolCurrentCycleResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-current-cycle`,
+    fetcherFn
+  );
+
+  return {
+    awuPoolCurrentCycle: data ?? null,
+    isAwuPoolCurrentCycleLoading: !error && !data && !disabled,
+    isAwuPoolCurrentCycleError: error,
+    isAwuPoolCurrentCycleValidating: isValidating,
+    mutateAwuPoolCurrentCycle: mutate,
   };
 }
 

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -1,6 +1,8 @@
 import type { SupportedCurrency } from "@app/types/currency";
 
-export type AwuPoolSummaryResponseBody = {
+// Current-cycle figures only — cheap to compute (bounded ledger lookup),
+// meant to render before cycle history is available.
+export type AwuPoolCurrentCycleResponseBody = {
   totalRemainingCredits: number;
   totalActiveCredits: number;
   /**
@@ -13,4 +15,9 @@ export type AwuPoolSummaryResponseBody = {
   overageAmountCents: number | null;
   /** Invoice currency — needed to format `overageAmountCents`. */
   overageCurrency: SupportedCurrency | null;
+  currentCycleConsumedCredits: number | null;
+  currentCycleStartMs: number | null;
+  currentCycleEndMs: number | null;
 };
+
+export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody;


### PR DESCRIPTION
## Description

New getAwuPoolCurrentCycle endpoint computes header-card figures (remaining/active pool, overage, current-cycle consumption) from a single most-recent invoice, cached separately from the slower cycle-history scan.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. **#31590 (this PR)** — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked (front, front-api). awu-pool-summary.test.ts passes with the extended fixture.

## Risk

Low. New endpoint and card; legacy /w/ and /poke/ awu-pool-summary endpoints keep working via the same underlying function.

## Deploy Plan

Deploy front and front-api.
