### PR TITLE
[front] feat: add programmatic usage card to Poke pool usage

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -29,6 +29,7 @@ const EMPTY_POOL_SUMMARY = {
   currentCycleStartMs: null,
   currentCycleEndMs: null,
   currentCycleConsumedCredits: null,
+  programmaticConsumedCredits: null,
 };
 
 beforeEach(() => {

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -80,12 +80,14 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     currentCycleConsumedCredits,
     currentCycleStartMs,
     currentCycleEndMs,
+    programmaticConsumedCredits,
   } = awuPoolCurrentCycle ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
     currentCycleConsumedCredits: null,
     currentCycleStartMs: null,
     currentCycleEndMs: null,
+    programmaticConsumedCredits: null,
   };
 
   const hasPool = totalActiveCredits > 0;
@@ -102,6 +104,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
       consumedCredits={currentCycleConsumedCredits}
       currentCycleStartMs={currentCycleStartMs}
       currentCycleEndMs={currentCycleEndMs}
+      programmaticConsumedCredits={programmaticConsumedCredits}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -87,16 +87,14 @@ export function WorkspaceCreditUsageValueCards({
         }
         hint={cycleDayLabel}
       />
-      <ValueCard
-        title="Programmatic usage this cycle"
-        isLoading={isLoading}
-        content={
-          <div className="truncate text-2xl text-foreground">
-            {typeof programmaticConsumedCredits === "number"
-              ? formatCredits(programmaticConsumedCredits)
-              : "—"}
-          </div>
+      <SummaryCard
+        label="Programmatic usage this cycle"
+        value={
+          typeof programmaticConsumedCredits === "number"
+            ? formatCredits(programmaticConsumedCredits)
+            : "—"
         }
+        hint={null}
       />
     </div>
   );

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,7 +1,13 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
 import { formatCredits } from "@app/lib/client/credits";
-import { AlertCircle, ContentMessage, Page, Spinner } from "@dust-tt/sparkle";
+import {
+  AlertCircle,
+  ContentMessage,
+  Page,
+  Spinner,
+  ValueCard,
+} from "@dust-tt/sparkle";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -42,6 +48,7 @@ interface WorkspaceCreditUsageValueCardsProps {
   consumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
   isLoading: boolean;
 }
 
@@ -51,6 +58,7 @@ export function WorkspaceCreditUsageValueCards({
   consumedCredits,
   currentCycleStartMs,
   currentCycleEndMs,
+  programmaticConsumedCredits,
   isLoading,
 }: WorkspaceCreditUsageValueCardsProps) {
   const cycleDayLabel = formatCycleDayLabel(
@@ -58,7 +66,11 @@ export function WorkspaceCreditUsageValueCards({
     currentCycleEndMs
   );
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div
+      className={
+        showPoolCard ? "grid grid-cols-3 gap-4" : "grid grid-cols-2 gap-4"
+      }
+    >
       {showPoolCard && (
         <SummaryCard
           label="Remaining credits pool"
@@ -75,6 +87,17 @@ export function WorkspaceCreditUsageValueCards({
         }
         hint={cycleDayLabel}
       />
+      <ValueCard
+        title="Programmatic usage this cycle"
+        isLoading={isLoading}
+        content={
+          <div className="truncate text-2xl text-foreground">
+            {typeof programmaticConsumedCredits === "number"
+              ? formatCredits(programmaticConsumedCredits)
+              : "—"}
+          </div>
+        }
+      />
     </div>
   );
 }
@@ -87,6 +110,7 @@ interface WorkspaceCreditPoolSectionProps {
   consumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -97,6 +121,7 @@ export function WorkspaceCreditPoolSection({
   consumedCredits,
   currentCycleStartMs,
   currentCycleEndMs,
+  programmaticConsumedCredits,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -125,6 +150,7 @@ export function WorkspaceCreditPoolSection({
           consumedCredits={consumedCredits}
           currentCycleStartMs={currentCycleStartMs}
           currentCycleEndMs={currentCycleEndMs}
+          programmaticConsumedCredits={programmaticConsumedCredits}
           isLoading={false}
         />
       )}

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -4,9 +4,9 @@ import { formatCredits } from "@app/lib/client/credits";
 import {
   AlertCircle,
   ContentMessage,
+  cn,
   Page,
   Spinner,
-  ValueCard,
 } from "@dust-tt/sparkle";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
@@ -67,9 +67,7 @@ export function WorkspaceCreditUsageValueCards({
   );
   return (
     <div
-      className={
-        showPoolCard ? "grid grid-cols-3 gap-4" : "grid grid-cols-2 gap-4"
-      }
+      className={cn("grid gap-4", showPoolCard ? "grid-cols-3" : "grid-cols-2")}
     >
       {showPoolCard && (
         <SummaryCard

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -186,7 +186,7 @@ function sumProgrammaticPoolConsumedFromInvoice({
     .reduce((sum, item) => sum + item.total, 0);
 }
 
-// Read live from Metronome rather than ES
+// Read live from Metronome
 async function fetchProgrammaticConsumedCreditsOrNull({
   workspace,
   metronomeCustomerId,

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -9,8 +9,11 @@ import {
   CREDIT_TYPE_GBP_ID,
   CREDIT_TYPE_USD_ID,
   getCreditTypeAwuId,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
@@ -159,6 +162,52 @@ function extractOverageFromInvoice(invoice: Invoice): {
   };
 }
 
+// Programmatic AWU spend against the pool, read straight from the current
+// draft invoice's own usage line items
+function sumProgrammaticPoolConsumedFromInvoice({
+  invoice,
+  poolCommitIds,
+  awuCreditTypeId,
+}: {
+  invoice: Invoice;
+  poolCommitIds: Set<string>;
+  awuCreditTypeId: string;
+}): number {
+  return invoice.line_items
+    .filter(
+      (item) =>
+        item.type === "usage" &&
+        item.commit_id != null &&
+        poolCommitIds.has(item.commit_id) &&
+        item.credit_type.id === awuCreditTypeId &&
+        item.pricing_group_values?.[USAGE_TYPE_GROUP_KEY] ===
+          USAGE_TYPE_PROGRAMMATIC
+    )
+    .reduce((sum, item) => sum + item.total, 0);
+}
+
+// Read live from Metronome rather than ES
+async function fetchProgrammaticConsumedCreditsOrNull({
+  workspace,
+  metronomeCustomerId,
+}: {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string;
+}): Promise<number | null> {
+  const result = await fetchProgrammaticAwuSpend({
+    workspaceId: workspace.sId,
+    metronomeCustomerId,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, error: result.error },
+      "[AwuPoolSummary] Failed to fetch programmatic AWU spend from Metronome"
+    );
+    return null;
+  }
+  return result.value;
+}
+
 export class AwuPoolSummaryError extends Error {
   constructor(
     readonly type:
@@ -223,7 +272,8 @@ async function getAwuPoolCurrentCycleUncached(
   if (contextResult.isErr()) {
     return contextResult;
   }
-  const { metronomeCustomerId, metronomeContractId } = contextResult.value;
+  const { workspace, metronomeCustomerId, metronomeContractId } =
+    contextResult.value;
   const awuCreditTypeId = getCreditTypeAwuId();
 
   const [balancesResult, invoicesResult, poolLedgerDataResult] =
@@ -244,6 +294,7 @@ async function getAwuPoolCurrentCycleUncached(
     );
   }
 
+  let poolCommitIds = new Set<string>();
   // `null` means the ledger couldn't be read (fetch failure)
   let ledgerEntries: PoolLedgerEntry[] | null = null;
   if (poolLedgerDataResult.isErr()) {
@@ -256,6 +307,7 @@ async function getAwuPoolCurrentCycleUncached(
       "[AwuPoolSummary] Failed to read pool ledger for the current cycle"
     );
   } else {
+    poolCommitIds = poolLedgerDataResult.value.poolCommitIds;
     ledgerEntries = poolLedgerDataResult.value.ledgerEntries;
   }
 
@@ -280,6 +332,11 @@ async function getAwuPoolCurrentCycleUncached(
       : null;
 
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    const programmaticConsumedCredits =
+      await fetchProgrammaticConsumedCreditsOrNull({
+        workspace,
+        metronomeCustomerId,
+      });
     return new Ok({
       totalRemainingCredits: 0,
       totalActiveCredits: 0,
@@ -289,6 +346,7 @@ async function getAwuPoolCurrentCycleUncached(
       currentCycleStartMs: null,
       currentCycleEndMs: null,
       currentCycleConsumedCredits,
+      programmaticConsumedCredits,
     });
   }
 
@@ -306,9 +364,7 @@ async function getAwuPoolCurrentCycleUncached(
   //
   // A pool grant under a superseded contract can still cover `now`,
   // so it must not be excluded.
-  const activeContract = await getActiveContract(
-    auth.getNonNullableWorkspace().sId
-  );
+  const activeContract = await getActiveContract(workspace.sId);
   const productSeatTypes = await getProductSeatTypes();
   const seatProductIds = activeContract
     ? new Set(
@@ -341,6 +397,14 @@ async function getAwuPoolCurrentCycleUncached(
     }
   }
 
+  const programmaticConsumedCredits = poolLedgerDataResult.isErr()
+    ? null
+    : sumProgrammaticPoolConsumedFromInvoice({
+        invoice: currentInvoice,
+        poolCommitIds,
+        awuCreditTypeId,
+      });
+
   return new Ok({
     totalRemainingCredits,
     totalActiveCredits,
@@ -350,5 +414,6 @@ async function getAwuPoolCurrentCycleUncached(
     currentCycleStartMs,
     currentCycleEndMs,
     currentCycleConsumedCredits,
+    programmaticConsumedCredits,
   });
 }

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -18,6 +18,7 @@ export type AwuPoolCurrentCycleResponseBody = {
   currentCycleConsumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  programmaticConsumedCredits: number | null;
 };
 
 export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody;


### PR DESCRIPTION
## Description

Adds a programmatic-usage value card, reading programmatic AWU spend against the pool from the current draft invoice's own usage line items.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. **#31591 (this PR)** — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Low. Additive field/card only.

## Deploy Plan

Deploy front.
