### PR TITLE
[front] feat: add other usage to the programmatic/other card

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -30,6 +30,7 @@ const EMPTY_POOL_SUMMARY = {
   currentCycleEndMs: null,
   currentCycleConsumedCredits: null,
   programmaticConsumedCredits: null,
+  otherConsumedCredits: null,
 };
 
 beforeEach(() => {

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -81,6 +81,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     currentCycleStartMs,
     currentCycleEndMs,
     programmaticConsumedCredits,
+    otherConsumedCredits,
   } = awuPoolCurrentCycle ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
@@ -88,6 +89,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     currentCycleStartMs: null,
     currentCycleEndMs: null,
     programmaticConsumedCredits: null,
+    otherConsumedCredits: null,
   };
 
   const hasPool = totalActiveCredits > 0;
@@ -105,6 +107,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
       currentCycleStartMs={currentCycleStartMs}
       currentCycleEndMs={currentCycleEndMs}
       programmaticConsumedCredits={programmaticConsumedCredits}
+      otherConsumedCredits={otherConsumedCredits}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -49,6 +49,7 @@ interface WorkspaceCreditUsageValueCardsProps {
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
   isLoading: boolean;
 }
 
@@ -59,6 +60,7 @@ export function WorkspaceCreditUsageValueCards({
   currentCycleStartMs,
   currentCycleEndMs,
   programmaticConsumedCredits,
+  otherConsumedCredits,
   isLoading,
 }: WorkspaceCreditUsageValueCardsProps) {
   const cycleDayLabel = formatCycleDayLabel(
@@ -86,13 +88,17 @@ export function WorkspaceCreditUsageValueCards({
         hint={cycleDayLabel}
       />
       <SummaryCard
-        label="Programmatic usage this cycle"
+        label="Programmatic / Other usage this cycle"
         value={
           typeof programmaticConsumedCredits === "number"
             ? formatCredits(programmaticConsumedCredits)
             : "—"
         }
-        hint={null}
+        hint={`Other: ${
+          typeof otherConsumedCredits === "number"
+            ? formatCredits(otherConsumedCredits)
+            : "—"
+        }`}
       />
     </div>
   );
@@ -107,6 +113,7 @@ interface WorkspaceCreditPoolSectionProps {
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -118,6 +125,7 @@ export function WorkspaceCreditPoolSection({
   currentCycleStartMs,
   currentCycleEndMs,
   programmaticConsumedCredits,
+  otherConsumedCredits,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -147,6 +155,7 @@ export function WorkspaceCreditPoolSection({
           currentCycleStartMs={currentCycleStartMs}
           currentCycleEndMs={currentCycleEndMs}
           programmaticConsumedCredits={programmaticConsumedCredits}
+          otherConsumedCredits={otherConsumedCredits}
           isLoading={false}
         />
       )}

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,3 +1,4 @@
+import { sumActiveMembersPoolConsumedCredits } from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
@@ -276,12 +277,21 @@ async function getAwuPoolCurrentCycleUncached(
     contextResult.value;
   const awuCreditTypeId = getCreditTypeAwuId();
 
-  const [balancesResult, invoicesResult, poolLedgerDataResult] =
-    await Promise.all([
-      listMetronomeBalances(metronomeCustomerId),
-      listMetronomeDraftInvoices(metronomeCustomerId),
-      getPoolLedgerData({ metronomeCustomerId }),
-    ]);
+  const [
+    balancesResult,
+    invoicesResult,
+    poolLedgerDataResult,
+    membersPoolConsumedCredits,
+  ] = await Promise.all([
+    listMetronomeBalances(metronomeCustomerId),
+    listMetronomeDraftInvoices(metronomeCustomerId),
+    getPoolLedgerData({ metronomeCustomerId }),
+    sumActiveMembersPoolConsumedCredits({
+      workspace,
+      metronomeCustomerId,
+      metronomeContractId,
+    }),
+  ]);
 
   if (balancesResult.isErr()) {
     return new Err(
@@ -347,6 +357,7 @@ async function getAwuPoolCurrentCycleUncached(
       currentCycleEndMs: null,
       currentCycleConsumedCredits,
       programmaticConsumedCredits,
+      otherConsumedCredits: null,
     });
   }
 
@@ -405,6 +416,18 @@ async function getAwuPoolCurrentCycleUncached(
         awuCreditTypeId,
       });
 
+  const otherConsumedCredits =
+    currentCycleConsumedCredits !== null &&
+    programmaticConsumedCredits !== null &&
+    membersPoolConsumedCredits !== null
+      ? Math.max(
+          0,
+          currentCycleConsumedCredits -
+            programmaticConsumedCredits -
+            membersPoolConsumedCredits
+        )
+      : null;
+
   return new Ok({
     totalRemainingCredits,
     totalActiveCredits,
@@ -415,5 +438,6 @@ async function getAwuPoolCurrentCycleUncached(
     currentCycleEndMs,
     currentCycleConsumedCredits,
     programmaticConsumedCredits,
+    otherConsumedCredits,
   });
 }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -748,6 +748,77 @@ async function fetchFreeSeatCreditsForMembersTable({
   return { freeBalanceByUserId, freeStartingByUserId };
 }
 
+export async function sumActiveMembersPoolConsumedCredits({
+  workspace,
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<number | null> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return null;
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  if (memberships.length === 0) {
+    return 0;
+  }
+  const users = await UserResource.fetchByModelIds(
+    memberships.map((m) => m.userId)
+  );
+  const userByModelId = new Map(users.map((u) => [u.id, u]));
+  const members = memberships.flatMap((m) => {
+    const user = userByModelId.get(m.userId);
+    return user ? [{ sId: user.sId, seatType: m.seatType ?? null }] : [];
+  });
+
+  const [usageByMetronomeUserId, { freeStartingByUserId }, seatDataByUserId] =
+    await Promise.all([
+      fetchPerUserUsageCreditsForMembersTable({
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        metronomeContractId,
+        userIds: members.map((m) =>
+          m.seatType === "free" ? toFreeMetronomeUserId(m.sId) : m.sId
+        ),
+      }),
+      fetchFreeSeatCreditsForMembersTable({ metronomeCustomerId }),
+      fetchSeatDataForMembersTable({
+        metronomeCustomerId,
+        metronomeContractId,
+      }),
+    ]);
+
+  let sumConsumedFromPoolAwuCredits = 0;
+  for (const member of members) {
+    const metronomeUserId =
+      member.seatType === "free"
+        ? toFreeMetronomeUserId(member.sId)
+        : member.sId;
+    const totalConsumedCredits =
+      usageByMetronomeUserId.get(metronomeUserId) ?? 0;
+    const freeStartingBalanceAwu =
+      member.seatType === "free"
+        ? (freeStartingByUserId.get(member.sId) ?? null)
+        : null;
+    const effectiveAllocationAwu =
+      freeStartingBalanceAwu ??
+      seatDataByUserId.get(member.sId)?.awuAllocation ??
+      0;
+    const consumedFromAllowanceAwuCredits = Math.min(
+      totalConsumedCredits,
+      effectiveAllocationAwu
+    );
+    sumConsumedFromPoolAwuCredits +=
+      totalConsumedCredits - consumedFromAllowanceAwuCredits;
+  }
+  return sumConsumedFromPoolAwuCredits;
+}
+
 /**
  * Resolve the inputs needed to compute the effective per-user spend limit for
  * the members table:

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -19,6 +19,7 @@ export type AwuPoolCurrentCycleResponseBody = {
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   programmaticConsumedCredits: number | null;
+  otherConsumedCredits: number | null;
 };
 
 export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody;


### PR DESCRIPTION
## Description

Adds the "Other" figure to the programmatic/other card: current-cycle pool consumption not already attributed to a member's seat allowance or to programmatic usage.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. **#31592 (this PR)** — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Low. Additive field/card only.

## Deploy Plan

Deploy front.
