### PR TITLE
[front] feat: add excess credit consumption to consumed-this-cycle

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -31,6 +31,7 @@ const EMPTY_POOL_SUMMARY = {
   currentCycleConsumedCredits: null,
   programmaticConsumedCredits: null,
   otherConsumedCredits: null,
+  excessConsumedCredits: null,
 };
 
 beforeEach(() => {

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -82,6 +82,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     currentCycleEndMs,
     programmaticConsumedCredits,
     otherConsumedCredits,
+    excessConsumedCredits,
   } = awuPoolCurrentCycle ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
@@ -90,9 +91,11 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     currentCycleEndMs: null,
     programmaticConsumedCredits: null,
     otherConsumedCredits: null,
+    excessConsumedCredits: null,
   };
 
   const hasPool = totalActiveCredits > 0;
+  const hasExcessData = excessConsumedCredits !== null;
 
   return (
     <WorkspaceCreditPoolSection
@@ -101,9 +104,11 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         !!isAwuPoolCurrentCycleError
       )}
       showPoolCard={hasPool}
-      isVisible={hasPool}
+      isVisible={hasPool || hasExcessData}
       totalRemainingCredits={totalRemainingCredits}
-      consumedCredits={currentCycleConsumedCredits}
+      consumedCredits={
+        hasPool ? currentCycleConsumedCredits : excessConsumedCredits
+      }
       currentCycleStartMs={currentCycleStartMs}
       currentCycleEndMs={currentCycleEndMs}
       programmaticConsumedCredits={programmaticConsumedCredits}

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,4 +1,7 @@
-import { sumActiveMembersPoolConsumedCredits } from "@app/lib/api/credits/members_usage";
+import {
+  getEsConsumedAwuCreditsForWorkspace,
+  sumActiveMembersPoolConsumedCredits,
+} from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
@@ -342,6 +345,8 @@ async function getAwuPoolCurrentCycleUncached(
       : null;
 
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    const excessConsumedCredits =
+      await getEsConsumedAwuCreditsForWorkspace(workspace);
     const programmaticConsumedCredits =
       await fetchProgrammaticConsumedCreditsOrNull({
         workspace,
@@ -356,6 +361,7 @@ async function getAwuPoolCurrentCycleUncached(
       currentCycleStartMs: null,
       currentCycleEndMs: null,
       currentCycleConsumedCredits,
+      excessConsumedCredits,
       programmaticConsumedCredits,
       otherConsumedCredits: null,
     });
@@ -408,6 +414,16 @@ async function getAwuPoolCurrentCycleUncached(
     }
   }
 
+  const excessConsumedCredits =
+    totalActiveCredits <= 0
+      ? await getEsConsumedAwuCreditsForWorkspace(workspace, {
+          cycle: {
+            cycleStart: new Date(currentCycleStartMs),
+            cycleEnd: new Date(currentCycleEndMs),
+          },
+        })
+      : null;
+
   const programmaticConsumedCredits = poolLedgerDataResult.isErr()
     ? null
     : sumProgrammaticPoolConsumedFromInvoice({
@@ -437,6 +453,7 @@ async function getAwuPoolCurrentCycleUncached(
     currentCycleStartMs,
     currentCycleEndMs,
     currentCycleConsumedCredits,
+    excessConsumedCredits,
     programmaticConsumedCredits,
     otherConsumedCredits,
   });

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,5 +1,6 @@
 import {
   getEsConsumedAwuCreditsForWorkspace,
+  resolveMetronomeCycle,
   sumActiveMembersPoolConsumedCredits,
 } from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
@@ -345,8 +346,12 @@ async function getAwuPoolCurrentCycleUncached(
       : null;
 
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
-    const excessConsumedCredits =
-      await getEsConsumedAwuCreditsForWorkspace(workspace);
+    const fallbackCycle = await resolveMetronomeCycle(workspace);
+    const excessConsumedCredits = fallbackCycle
+      ? await getEsConsumedAwuCreditsForWorkspace(workspace, {
+          cycle: fallbackCycle,
+        })
+      : null;
     const programmaticConsumedCredits =
       await fetchProgrammaticConsumedCreditsOrNull({
         workspace,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -601,6 +601,58 @@ export async function getEsConsumedProgrammaticAwuCredits(
   );
 }
 
+/**
+ * The workspace's total Elasticsearch-derived AWU consumption for the
+ * current billing cycle.
+ */
+export async function getEsConsumedAwuCreditsForWorkspace(
+  workspace: LightWorkspaceType,
+  { cycle }: { cycle?: BillingCycle } = {}
+): Promise<number | null> {
+  const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
+  if (!resolvedCycle) {
+    return null;
+  }
+  const { cycleStart, cycleEnd } = resolvedCycle;
+
+  const result = await searchAnalytics<
+    never,
+    { credits?: estypes.AggregationsSumAggregate }
+  >(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              timestamp: {
+                gte: cycleStart.toISOString(),
+                lte: cycleEnd.toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    },
+    {
+      aggregations: { credits: { sum: { field: "cost.billable_awu" } } },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to read total consumed credits from analytics index"
+    );
+    return null;
+  }
+
+  return Math.max(
+    0,
+    Math.round(result.value.aggregations?.credits?.value ?? 0)
+  );
+}
+
 async function fetchPerUserUsageCreditsForMembersTable({
   workspaceId,
   metronomeCustomerId,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -270,7 +270,7 @@ async function fetchCreditsResetAt(
 
 // The workspace's current Metronome contract billing period, or null when it
 // cannot be resolved (no contract, or a Metronome failure).
-async function resolveMetronomeCycle(
+export async function resolveMetronomeCycle(
   workspace: LightWorkspaceType
 ): Promise<BillingCycle | null> {
   const periodResult = await getCachedMetronomeCurrentBillingPeriod(
@@ -607,15 +607,11 @@ export async function getEsConsumedProgrammaticAwuCredits(
  */
 export async function getEsConsumedAwuCreditsForWorkspace(
   workspace: LightWorkspaceType,
-  { cycle }: { cycle?: BillingCycle } = {}
+  { cycle }: { cycle: BillingCycle }
 ): Promise<number | null> {
-  const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
-  if (!resolvedCycle) {
-    return null;
-  }
-  const { cycleStart, cycleEnd } = resolvedCycle;
+  const { cycleStart, cycleEnd } = cycle;
 
-  const result = await searchAnalytics<
+  const result = await searchConsumptionAnalytics<
     never,
     { credits?: estypes.AggregationsSumAggregate }
   >(
@@ -625,7 +621,7 @@ export async function getEsConsumedAwuCreditsForWorkspace(
           { term: { workspace_id: workspace.sId } },
           {
             range: {
-              timestamp: {
+              completed_at: {
                 gte: cycleStart.toISOString(),
                 lte: cycleEnd.toISOString(),
               },
@@ -635,7 +631,7 @@ export async function getEsConsumedAwuCreditsForWorkspace(
       },
     },
     {
-      aggregations: { credits: { sum: { field: "cost.billable_awu" } } },
+      aggregations: { credits: { sum: { field: "credit_micro" } } },
       size: 0,
     }
   );
@@ -649,7 +645,9 @@ export async function getEsConsumedAwuCreditsForWorkspace(
 
   return Math.max(
     0,
-    Math.round(result.value.aggregations?.credits?.value ?? 0)
+    Math.round(
+      microCreditsToCredits(result.value.aggregations?.credits?.value ?? 0)
+    )
   );
 }
 

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -18,6 +18,8 @@ export type AwuPoolCurrentCycleResponseBody = {
   currentCycleConsumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  // PAYG credits
+  excessConsumedCredits: number | null;
   programmaticConsumedCredits: number | null;
   otherConsumedCredits: number | null;
 };


### PR DESCRIPTION
## Description

Falls back to Elasticsearch-derived total consumption (billed as PAYG excess) for workspaces with no active credit pool, so the card shows something instead of a pool-only "—".

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. **#31593 (this PR)** — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Low. Only affects the (currently Poke-only) pool-less-workspace fallback path.

## Deploy Plan

Deploy front.
