### PR TITLE
[front] feat: add previous-cycle consumption table to Poke pool usage

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,18 +1,18 @@
 import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import {
   AwuPoolSummaryQuerySchema,
-  getAwuPoolSummary,
+  getAwuPoolCycleHistory,
 } from "@app/lib/api/credits/awu_pool_summary";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 
-function summaryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+export type { AwuPoolCycleHistoryResponseBody };
+
+function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
   switch (err.type) {
     case "not_configured":
       return apiError(ctx, {
@@ -43,24 +43,20 @@ function summaryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
   }
 }
 
-// Mounted at /api/w/:wId/credits/awu-pool-summary.
-const app = workspaceApp();
+// Mounted at /api/poke/workspaces/:wId/credits/awu-pool-cycle-history.
+const app = pokeApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsManager(),
-  validate("query", AwuPoolSummaryQuerySchema),
-  async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
-    const auth = ctx.get("auth");
-    const { cycleHistoryLimit } = ctx.req.valid("query");
+app.get("/", validate("query", AwuPoolSummaryQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { cycleHistoryLimit } = ctx.req.valid("query");
 
-    const result = await getAwuPoolSummary(auth, { cycleHistoryLimit });
-    if (result.isErr()) {
-      return summaryErrorToApi(ctx, result.error);
-    }
-    return ctx.json(result.value);
+  const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
+  if (result.isErr()) {
+    return cycleHistoryErrorToApi(ctx, result.error);
   }
-);
+
+  return ctx.json(result.value);
+});
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-summary.ts
@@ -1,8 +1,12 @@
-import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import {
+  AwuPoolSummaryQuerySchema,
+  getAwuPoolSummary,
+} from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 
 export type { AwuPoolSummaryResponseBody };
 
@@ -10,10 +14,11 @@ export type { AwuPoolSummaryResponseBody };
 const app = pokeApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx) => {
+app.get("/", validate("query", AwuPoolSummaryQuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
+  const { cycleHistoryLimit } = ctx.req.valid("query");
 
-  const result = await getAwuPoolSummary(auth);
+  const result = await getAwuPoolSummary(auth, { cycleHistoryLimit });
   if (result.isErr()) {
     const err = result.error;
     switch (err.type) {

--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -5,6 +5,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import apiKeysUsage from "./api-keys-usage";
 import awuPoolCurrentCycle from "./awu-pool-current-cycle";
+import awuPoolCycleHistory from "./awu-pool-cycle-history";
 import awuPoolSummary from "./awu-pool-summary";
 import consumptionExport from "./consumption-export";
 import membersUsage from "./members-usage";
@@ -40,6 +41,7 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
 app.route("/api-keys-usage", apiKeysUsage);
 app.route("/awu-pool-summary", awuPoolSummary);
 app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
+app.route("/awu-pool-cycle-history", awuPoolCycleHistory);
 app.route("/consumption-export", consumptionExport);
 app.route("/members-usage", membersUsage);
 app.route("/top-ups", topUps);

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -15,6 +15,7 @@ import { expandMaxTierName } from "@app/lib/client/model_tiers";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   usePokeAwuPoolCurrentCycle,
+  usePokeAwuPoolCycleHistory,
   usePokeMembersUsage,
 } from "@app/poke/swr/credits";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
@@ -73,6 +74,12 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     isAwuPoolCurrentCycleLoading,
     isAwuPoolCurrentCycleError,
   } = usePokeAwuPoolCurrentCycle({ owner });
+  const {
+    cycleBreakdown: poolCycleBreakdown,
+    excessCycleBreakdown,
+    isAwuPoolCycleHistoryLoading,
+    isAwuPoolCycleHistoryError,
+  } = usePokeAwuPoolCycleHistory({ owner });
 
   const {
     totalRemainingCredits,
@@ -80,28 +87,33 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     currentCycleConsumedCredits,
     currentCycleStartMs,
     currentCycleEndMs,
+    excessConsumedCredits,
     programmaticConsumedCredits,
     otherConsumedCredits,
-    excessConsumedCredits,
   } = awuPoolCurrentCycle ?? {
     totalRemainingCredits: 0,
     totalActiveCredits: 0,
     currentCycleConsumedCredits: null,
     currentCycleStartMs: null,
     currentCycleEndMs: null,
+    excessConsumedCredits: null,
     programmaticConsumedCredits: null,
     otherConsumedCredits: null,
-    excessConsumedCredits: null,
   };
 
   const hasPool = totalActiveCredits > 0;
-  const hasExcessData = excessConsumedCredits !== null;
+  const hasExcessData =
+    excessConsumedCredits !== null || excessCycleBreakdown.length > 0;
 
   return (
     <WorkspaceCreditPoolSection
       cardsStatus={toCreditPoolFetchStatus(
         isAwuPoolCurrentCycleLoading,
         !!isAwuPoolCurrentCycleError
+      )}
+      tableStatus={toCreditPoolFetchStatus(
+        isAwuPoolCycleHistoryLoading,
+        !!isAwuPoolCycleHistoryError
       )}
       showPoolCard={hasPool}
       isVisible={hasPool || hasExcessData}
@@ -111,6 +123,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
       }
       currentCycleStartMs={currentCycleStartMs}
       currentCycleEndMs={currentCycleEndMs}
+      cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
       otherConsumedCredits={otherConsumedCredits}
     />

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,13 +1,18 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
+import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
 import { formatCredits } from "@app/lib/client/credits";
+import type { AwuPoolCycleBreakdown } from "@app/types/api/credits/awu_pool_summary";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   AlertCircle,
   ContentMessage,
   cn,
+  DataTable,
   Page,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -104,26 +109,116 @@ export function WorkspaceCreditUsageValueCards({
   );
 }
 
+interface WorkspaceCreditPoolCycleHistoryTableProps {
+  cycleBreakdown: AwuPoolCycleBreakdown[];
+}
+
+type CycleHistoryRowData = {
+  cycle: string;
+  consumedCredits: string;
+  onClick?: () => void;
+};
+
+const CYCLE_HISTORY_COLUMNS: ColumnDef<CycleHistoryRowData, string>[] = [
+  {
+    accessorKey: "cycle",
+    header: "Cycle",
+    enableSorting: false,
+    cell: ({ row }) => (
+      <DataTable.CellContent>{row.original.cycle}</DataTable.CellContent>
+    ),
+  },
+  {
+    accessorKey: "consumedCredits",
+    header: "Used credits",
+    enableSorting: false,
+    meta: { headerAlign: "right" },
+    cell: ({ row }) => (
+      <span className="block text-right text-sm">
+        {row.original.consumedCredits}
+      </span>
+    ),
+  },
+];
+
+export function WorkspaceCreditPoolCycleHistoryTable({
+  cycleBreakdown,
+}: WorkspaceCreditPoolCycleHistoryTableProps) {
+  if (cycleBreakdown.length === 0) {
+    return null;
+  }
+  const rows: CycleHistoryRowData[] = cycleBreakdown.map((cycle) => ({
+    cycle:
+      cycle.cycleStartMs && cycle.cycleEndMs
+        ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
+        : "Unknown cycle",
+    consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
+  }));
+  return <DataTable data={rows} columns={CYCLE_HISTORY_COLUMNS} />;
+}
+
+interface WorkspaceCreditPoolHistoryProps {
+  tableStatus: CreditPoolFetchStatus;
+  cycleBreakdown: AwuPoolCycleBreakdown[];
+}
+
+// Table area rendered under the value cards. Kept separate so a slow cycle
+// history fetch never blocks the (fast) cards above it from showing.
+function WorkspaceCreditPoolHistory({
+  tableStatus,
+  cycleBreakdown,
+}: WorkspaceCreditPoolHistoryProps) {
+  switch (tableStatus) {
+    case "error":
+      return (
+        <ContentMessage
+          title="Failed to load cycle history"
+          icon={AlertCircle}
+          variant="warning"
+        >
+          An error occurred while loading past-cycle consumption.
+        </ContentMessage>
+      );
+    case "loading":
+      return (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      );
+    case "ready":
+      return (
+        <WorkspaceCreditPoolCycleHistoryTable cycleBreakdown={cycleBreakdown} />
+      );
+    default:
+      assertNeverAndIgnore(tableStatus);
+      return null;
+  }
+}
+
 interface WorkspaceCreditPoolSectionProps {
   cardsStatus: CreditPoolFetchStatus;
+  tableStatus: CreditPoolFetchStatus;
   showPoolCard: boolean;
   isVisible: boolean;
   totalRemainingCredits: number;
   consumedCredits: number | null;
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
+  cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
   otherConsumedCredits: number | null;
 }
 
 export function WorkspaceCreditPoolSection({
   cardsStatus,
+  tableStatus,
   showPoolCard,
   isVisible,
   totalRemainingCredits,
   consumedCredits,
   currentCycleStartMs,
   currentCycleEndMs,
+  cycleBreakdown,
   programmaticConsumedCredits,
   otherConsumedCredits,
 }: WorkspaceCreditPoolSectionProps) {
@@ -148,16 +243,22 @@ export function WorkspaceCreditPoolSection({
           <Spinner />
         </div>
       ) : (
-        <WorkspaceCreditUsageValueCards
-          showPoolCard={showPoolCard}
-          totalRemainingCredits={totalRemainingCredits}
-          consumedCredits={consumedCredits}
-          currentCycleStartMs={currentCycleStartMs}
-          currentCycleEndMs={currentCycleEndMs}
-          programmaticConsumedCredits={programmaticConsumedCredits}
-          otherConsumedCredits={otherConsumedCredits}
-          isLoading={false}
-        />
+        <>
+          <WorkspaceCreditUsageValueCards
+            showPoolCard={showPoolCard}
+            totalRemainingCredits={totalRemainingCredits}
+            consumedCredits={consumedCredits}
+            currentCycleStartMs={currentCycleStartMs}
+            currentCycleEndMs={currentCycleEndMs}
+            programmaticConsumedCredits={programmaticConsumedCredits}
+            otherConsumedCredits={otherConsumedCredits}
+            isLoading={false}
+          />
+          <WorkspaceCreditPoolHistory
+            tableStatus={tableStatus}
+            cycleBreakdown={cycleBreakdown}
+          />
+        </>
       )}
     </Page.Vertical>
   );

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -12,6 +12,7 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type {
   AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
@@ -191,6 +192,30 @@ export function usePokeAwuPoolCurrentCycle({
     isAwuPoolCurrentCycleError: error,
     isAwuPoolCurrentCycleValidating: isValidating,
     mutateAwuPoolCurrentCycle: mutate,
+  };
+}
+
+export function usePokeAwuPoolCycleHistory({
+  owner,
+  disabled,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-cycle-history`,
+    fetcherFn
+  );
+
+  return {
+    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
+    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
+    isAwuPoolCycleHistoryError: error,
+    isAwuPoolCycleHistoryValidating: isValidating,
+    mutateAwuPoolCycleHistory: mutate,
   };
 }
 


### PR DESCRIPTION
## Description

New getAwuPoolCycleHistory endpoint scans the full cycleHistoryLimit ledger window to build the previous-cycles table, cached and fetched separately from the current-cycle endpoint so header cards render first.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. **#31595 (this PR)** — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked (front, front-api). awu-pool-summary.test.ts passes with the extended fixture (adds a listMetronomeFinalizedInvoices mock).

## Risk

Low-medium. Adds AwuPoolSummaryQuerySchema validation to the existing /w/ and /poke/ awu-pool-summary routes (cycleHistoryLimit, defaulted and bounded); no change to their existing response shape for current callers.

## Deploy Plan

Deploy front and front-api.
