### PR TITLE
Use Project database replica lifecycle names

### DIFF
--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -3,7 +3,7 @@ import { getFileContent } from "@app/lib/api/files/utils";
 import { deleteProjectFile } from "@app/lib/api/projects/context";
 import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import {
-  deletePodDatabaseReplica,
+  deleteProjectDatabaseReplica,
   restartLitestreamDaemon,
 } from "@app/lib/api/sandbox/db";
 import {
@@ -540,7 +540,7 @@ export async function deletePodApp(
 
   // 4. Replicas: the durable copy, and so the step that makes a database deletion stick.
   for (const database of app.databases) {
-    const deleteReplicaResult = await deletePodDatabaseReplica(auth, pod, {
+    const deleteReplicaResult = await deleteProjectDatabaseReplica(auth, pod, {
       database: database.onDiskName,
     });
     if (deleteReplicaResult.isErr()) {

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -1,5 +1,7 @@
 import {
   checkReplicaMountLiveness,
+  deletePodDatabaseReplica,
+  deleteProjectDatabaseReplica,
   isFuseStatfsMagic,
   isValidPodDatabaseName,
   isValidSandboxDatabaseName,
@@ -31,6 +33,10 @@ describe("sandbox state helpers", () => {
 
   test("keeps the Pod database validator as a compatibility alias", () => {
     expect(isValidPodDatabaseName).toBe(isValidSandboxDatabaseName);
+  });
+
+  test("keeps the Pod replica deletion helper as a compatibility alias", () => {
+    expect(deletePodDatabaseReplica).toBe(deleteProjectDatabaseReplica);
   });
 
   test("parses replica enumeration output (watcher {db}.db layout), dropping non-conforming entries", () => {

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -813,26 +813,27 @@ export async function deletePodStatePrefix(
 }
 
 /**
- * Delete ONE database's litestream replica: the GCS prefix the directory watcher keys on that
- * database's filename.
+ * Delete one Project database's Litestream replica: the GCS prefix the directory watcher keys on
+ * that database's filename.
  *
- * The replica is the durable copy of a pod database, and `setupSandboxStateOnColdStart` restores every
- * replica it finds. So a replica that survives resurrects a database whose live files were deleted —
- * which makes this the step that actually makes a database deletion stick.
+ * The replica is the durable copy of a Project database, and `setupSandboxStateOnColdStart`
+ * restores every replica it finds. So a replica that survives resurrects a database whose live
+ * files were deleted, which makes this the step that actually makes a database deletion stick.
  *
  * Call it AFTER the live files are gone AND the daemon has been restarted (`restartLitestreamDaemon`):
  * a running litestream keeps replicating a database it can still see, and removing the files does not
  * make it let go — the directory watcher only enumerates at start, so until the restart the daemon
  * still holds the database and recreates the prefix this wipes. The delete is verified by re-listing,
- * because a silently-surviving replica is indistinguishable from success until the pod next boots.
+ * because a silently-surviving replica is indistinguishable from success until the Project's
+ * sandbox next boots.
  */
-export async function deletePodDatabaseReplica(
+export async function deleteProjectDatabaseReplica(
   auth: Authenticator,
   space: SpaceResource,
   { database }: { database: string }
 ): Promise<Result<void, Error>> {
-  if (!isValidPodDatabaseName(database)) {
-    return new Err(new Error(`Invalid pod database name: '${database}'.`));
+  if (!isValidSandboxDatabaseName(database)) {
+    return new Err(new Error(`Invalid Project database name: '${database}'.`));
   }
 
   const statePrefix = getPodStateBasePath({
@@ -851,8 +852,8 @@ export async function deletePodDatabaseReplica(
     if (remaining.includes(replicaDirName)) {
       return new Err(
         new Error(
-          `Replica of pod database '${database}' still present after deletion; ` +
-            "the database would be restored on the pod's next cold start."
+          `Replica of Project database '${database}' still present after deletion; ` +
+            "the database would be restored on the Project sandbox's next cold start."
         )
       );
     }
@@ -862,3 +863,6 @@ export async function deletePodDatabaseReplica(
     return new Err(normalizeError(err));
   }
 }
+
+/** @deprecated Use `deleteProjectDatabaseReplica`. */
+export const deletePodDatabaseReplica = deleteProjectDatabaseReplica;

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -401,8 +401,9 @@ const deleteEnvelopeSchema = z.union([
  *
  * Only the LIVE files go. The litestream replica is the durable copy, so a caller deleting a database
  * for good must also restart the daemon (`restartLitestreamDaemon`, which is what makes it let go of
- * the removed files) and wipe the replica prefix (`deletePodDatabaseReplica`), or the next cold-start
- * restore brings the database back. Returns the sandbox so that restart needs no second lookup.
+ * the removed files) and wipe the replica prefix (`deleteProjectDatabaseReplica`), or the next
+ * cold-start restore brings the database back. Returns the sandbox so that restart needs no second
+ * lookup.
  */
 export async function deleteDatabaseOnSandbox(
   auth: Authenticator,


### PR DESCRIPTION
## Description

Name Project-owned replica deletion after its actual lifecycle owner. Active app deletion now calls `deleteProjectDatabaseReplica`; `deletePodDatabaseReplica` remains an exact compatibility alias. Physical Pod state keys and deletion behavior do not change.

Stacked on #31577.

## Tests

Added alias identity coverage and ran the focused sandbox DB helper tests.

## Risk

Low. This is a naming-only migration with the legacy export preserved.

## Deploy Plan

Merge after #31577, then standard deploy.