### PR TITLE
[front] fix: drop the "Up to " prefix from Poke's Models column

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -386,6 +386,7 @@ export function PoolUsagePage() {
                   totalRowCount={totalMembers}
                   sorting={sorting}
                   setSorting={handleSetSorting}
+                  variant="compact"
                   showGroupsColumn={false}
                   showModelTiersColumn
                   userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -34,10 +34,7 @@ import {
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
-import {
-  assertNever,
-  assertNeverAndIgnore,
-} from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Clock,
@@ -545,7 +542,8 @@ function buildModelTiersColumn(
             case "legacy":
               return "Models tier";
             default:
-              return assertNever(variant);
+              assertNeverAndIgnore(variant);
+              return "Models tier";
           }
         })()}
         <ModelTiersInfoButton />
@@ -742,7 +740,8 @@ export function MembersUsageTable({
               case "legacy":
                 return formatModelTiersSummary(maxTierName);
               default:
-                return assertNever(variant);
+                assertNeverAndIgnore(variant);
+                return formatModelTiersSummary(maxTierName);
             }
           })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -27,13 +27,17 @@ import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
   isPaidSeatType,
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Clock,
@@ -527,35 +531,48 @@ function buildConsumedAwuCreditsColumn(
   };
 }
 
-const modelTiersColumn: ColumnDef<RowData, string> = {
-  id: "modelTiers" as const,
-  header: () => (
-    <span className="flex items-center gap-1">
-      Models tier
-      <ModelTiersInfoButton />
-    </span>
-  ),
-  enableSorting: false,
-  accessorFn: (row) => row.modelTiersSummary,
-  cell: (info: Info) => {
-    const summary = info.row.original.modelTiersSummary;
-    const customSuffix = info.row.original.hasUserLevelModelTiersOverride
-      ? " (custom)"
-      : "";
+function buildModelTiersColumn(
+  variant: MembersUsageTableVariant
+): ColumnDef<RowData, string> {
+  return {
+    id: "modelTiers" as const,
+    header: () => (
+      <span className="flex items-center gap-1">
+        {(() => {
+          switch (variant) {
+            case "compact":
+              return "Models";
+            case "legacy":
+              return "Models tier";
+            default:
+              return assertNever(variant);
+          }
+        })()}
+        <ModelTiersInfoButton />
+      </span>
+    ),
+    enableSorting: false,
+    accessorFn: (row) => row.modelTiersSummary,
+    cell: (info: Info) => {
+      const summary = info.row.original.modelTiersSummary;
+      const customSuffix = info.row.original.hasUserLevelModelTiersOverride
+        ? " (custom)"
+        : "";
 
-    return (
-      <DataTable.CellContent>
-        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {summary}
-          {customSuffix}
-        </span>
-      </DataTable.CellContent>
-    );
-  },
-  meta: {
-    className: "w-48",
-  },
-};
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {summary}
+            {customSuffix}
+          </span>
+        </DataTable.CellContent>
+      );
+    },
+    meta: {
+      className: "w-48",
+    },
+  };
+}
 
 const actionsColumn: ColumnDef<RowData, string> = {
   id: "actions" as const,
@@ -580,17 +597,19 @@ function buildColumns({
   showGroupsColumn,
   showModelTiersColumn,
   creditsResetAt,
+  variant,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
   showModelTiersColumn: boolean;
   creditsResetAt: string | null;
+  variant: MembersUsageTableVariant;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
     nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
-    ...(showModelTiersColumn ? [modelTiersColumn] : []),
+    ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
     seatTypeColumn,
     {
       ...buildConsumedAwuCreditsColumn(creditsResetAt),
@@ -599,6 +618,11 @@ function buildColumns({
     actionsColumn,
   ];
 }
+
+// "compact" is the Poke Pool Usage page layout: no "Up to " prefix on the
+// Models tier summary, a "Models" header instead of "Models tier". "legacy"
+// keeps the customer-facing usage page unchanged.
+export type MembersUsageTableVariant = "legacy" | "compact";
 
 interface MembersUsageTableProps {
   members: MemberUsageType[];
@@ -623,6 +647,7 @@ interface MembersUsageTableProps {
     selection: UserModelTierSelection
   ) => void;
   showModelTiersColumn?: boolean;
+  variant?: MembersUsageTableVariant;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
   userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
   groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
@@ -656,6 +681,7 @@ export function MembersUsageTable({
   onEditSpendLimit,
   onSetUserModelTier,
   showModelTiersColumn = false,
+  variant = "legacy",
   userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
   userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
   groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
@@ -706,9 +732,19 @@ export function MembersUsageTable({
             m.sId
           ),
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
-          modelTiersSummary: formatModelTiersSummary(
-            getMaxTierName(resolvedModelTiers?.tiers ?? [])
-          ),
+          modelTiersSummary: (() => {
+            const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
+            switch (variant) {
+              case "compact":
+                return maxTierName
+                  ? getModelsTierDisplayName(maxTierName)
+                  : "--";
+              case "legacy":
+                return formatModelTiersSummary(maxTierName);
+              default:
+                return assertNever(variant);
+            }
+          })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
             ...(!m.seatType || m.seatType === "none"
@@ -793,6 +829,7 @@ export function MembersUsageTable({
       isSeatBased,
       showSpendLimit,
       showModelTiersColumn,
+      variant,
       userModelTierSelectionByUserId,
       userAllowedModelTiersByUserId,
       groupModelTiersByGroupId,
@@ -814,8 +851,15 @@ export function MembersUsageTable({
         showGroupsColumn,
         showModelTiersColumn,
         creditsResetAt,
+        variant,
       }),
-    [enableSelection, showGroupsColumn, showModelTiersColumn, creditsResetAt]
+    [
+      enableSelection,
+      showGroupsColumn,
+      showModelTiersColumn,
+      creditsResetAt,
+      variant,
+    ]
   );
 
   if (isLoading) {


### PR DESCRIPTION
## Description

Introduces a MembersUsageTableVariant ("legacy" | "compact") so the Models column can drop the "Up to " prefix and use a "Models" header for the compact Poke layout, without touching the customer-facing legacy variant.

Note: the `compact` variant is temporary and will be dropped once the new table rolls in.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. **#31598 (this PR)** — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Low. New variant plumbing; legacy variant's rendered output is unchanged (verified by reading the branch — compact-only code paths).

## Deploy Plan

Deploy front.
