### PR TITLE
Use sandbox database wording in runner

### DIFF
--- a/cli/dust-sandbox/functions-runner/db/query.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.ts
@@ -22,8 +22,8 @@ export function runQuery(
   sql: string,
   // Omitted only by tests that don't exercise the quota; runner.ts always passes it.
   maxSizeBytes?: number,
-  // Directory the spill file is written to — a pod file, so the caller can read the full result
-  // set. runner.ts passes the pod-files dir from Rust; tests omit it and fall back to a temp dir.
+  // Directory where the spill file is written so the caller can read the full result set.
+  // runner.ts passes the sandbox files directory from Rust; tests fall back to a temp directory.
   spillDir?: string
 ): Result<QueryOutcome, DbCommandError> {
   const trimmed = sql.trim();
@@ -89,7 +89,7 @@ export function runQuery(
     // One statement, one transaction — the same path for reads and writes. The schema_version
     // re-check refuses DDL behaviorally: anything that moved the schema is turned into an Err and
     // never committed; a read leaves the version untouched. BEGIN IMMEDIATE means a read holds the
-    // write lock for its duration — fine for a single-writer per-pod database, and the price of not
+    // write lock for its duration — fine for a single-writer sandbox database, and the price of not
     // branching on a read/write guess that bun gives us no reliable way to make.
     db.exec("BEGIN IMMEDIATE;");
     const versionBefore = schemaVersion(db);
@@ -151,7 +151,7 @@ function openReadwrite(
   }
   applyWritePragmas(db);
   if (maxSizeBytes !== undefined) {
-    // The size cap @dust/pod enforces on workload writes; a write past it fails with SQLITE_FULL
+    // The size cap @dust/sandbox enforces on workload writes; a write past it fails with SQLITE_FULL
     // (-> database_full). page_size is a bigint here (safeIntegers) but small enough for Number().
     const row = db.query<{ page_size: bigint }, []>("PRAGMA page_size").get();
     if (row === null) {
@@ -246,7 +246,7 @@ function collectRows(
           continue;
         }
         const dir = spillDir ?? tmpdir();
-        // The pod-files spill dir (e.g. /files/pod-<id>/.tool_outputs/db) is not pre-created.
+        // The caller-provided spill directory is not pre-created.
         mkdirSync(dir, { recursive: true });
         spillPath = join(dir, `dsbx-query-${crypto.randomUUID()}.jsonl`);
         spillFd = openSync(spillPath, "w");

--- a/cli/dust-sandbox/functions-runner/db/reconcile.ts
+++ b/cli/dust-sandbox/functions-runner/db/reconcile.ts
@@ -1,4 +1,4 @@
-// `dsbx db reconcile` runner backend: bring a live pod database in line with its drizzle schema
+// `dsbx db reconcile` runner backend: bring a live sandbox database in line with its drizzle schema
 // file, applying ADDITIVE DDL only. Expected refusals come back as Err (ERR1), never thrown.
 //
 // `reconcile` orchestrates one numbered helper per step:

--- a/cli/dust-sandbox/functions-runner/db/validate.ts
+++ b/cli/dust-sandbox/functions-runner/db/validate.ts
@@ -1,8 +1,8 @@
-// Pod database schema validation for `dsbx db reconcile`.
+// Sandbox database schema validation for `dsbx db reconcile`.
 //
-// A pod database is defined by a drizzle schema file (`databases/{db}.db.ts`, next to the
+// A sandbox database is defined by a drizzle schema file (`databases/{db}.db.ts`, next to the
 // function sources). This module imports such a file, collects its exported tables via
-// drizzle's `getTableConfig`, and validates the pod database rules (one named check per
+// drizzle's `getTableConfig`, and validates the sandbox database rules (one named check per
 // rule); only table and column NAMES come out — reconcile's destructive pre-check reads
 // them, nothing stores shapes. Build and publish never validate databases — the rules are
 // enforced where the agent acts, by the reconcile tool. Failures come back as Err, never
@@ -111,7 +111,7 @@ export async function extractDatabaseSchema(
 
 type TableConfig = ReturnType<typeof getTableConfig>;
 
-// One named check per pod database rule. Each returns the violation or null.
+// One named check per sandbox database rule. Each returns the violation or null.
 type TableRule = (
   where: string,
   config: TableConfig
@@ -155,7 +155,7 @@ function checkNoReservedNames(
     RESERVED_TABLE_PREFIXES.some((prefix) => config.name.startsWith(prefix))
   ) {
     return invalid(
-      `${where}: table name uses a reserved prefix (${RESERVED_TABLE_PREFIXES.join(", ")}) and is not allowed in pod databases`
+      `${where}: table name uses a reserved prefix (${RESERVED_TABLE_PREFIXES.join(", ")}) and is not allowed in sandbox databases`
     );
   }
   const names = [
@@ -166,7 +166,7 @@ function checkNoReservedNames(
   for (const name of names) {
     if (RESERVED_OBJECT_KEYS.has(name)) {
       return invalid(
-        `${where}: name "${name}" is reserved and not allowed in pod databases`
+        `${where}: name "${name}" is reserved and not allowed in sandbox databases`
       );
     }
   }
@@ -179,7 +179,7 @@ function checkNoForeignKeys(
 ): DatabaseSchemaError | null {
   if (config.foreignKeys.length > 0) {
     return invalid(
-      `${where}: foreign keys (.references() / foreignKey()) are not allowed in pod databases — enforce relational integrity in function code instead`
+      `${where}: foreign keys (.references() / foreignKey()) are not allowed in sandbox databases — enforce relational integrity in function code instead`
     );
   }
   return null;
@@ -191,7 +191,7 @@ function checkNoCheckConstraints(
 ): DatabaseSchemaError | null {
   if (config.checks.length > 0) {
     return invalid(
-      `${where}: CHECK constraints are not allowed in pod databases — validate values in function code instead`
+      `${where}: CHECK constraints are not allowed in sandbox databases — validate values in function code instead`
     );
   }
   return null;
@@ -206,13 +206,13 @@ function checkNoUniqueConstraints(
 ): DatabaseSchemaError | null {
   if (config.uniqueConstraints.length > 0) {
     return invalid(
-      `${where}: UNIQUE constraints are not allowed in pod databases (they cannot be added or removed later without a table rebuild) — use uniqueIndex() instead`
+      `${where}: UNIQUE constraints are not allowed in sandbox databases (they cannot be added or removed later without a table rebuild) — use uniqueIndex() instead`
     );
   }
   for (const column of config.columns) {
     if (columnProps(column).isUnique === true) {
       return invalid(
-        `${where}: column "${column.name}" uses .unique() — UNIQUE constraints are not allowed in pod databases (they cannot be added or removed later without a table rebuild), use uniqueIndex() instead`
+        `${where}: column "${column.name}" uses .unique() — UNIQUE constraints are not allowed in sandbox databases (they cannot be added or removed later without a table rebuild), use uniqueIndex() instead`
       );
     }
   }

--- a/cli/dust-sandbox/functions-runner/fixtures/databases/chat.db.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/databases/chat.db.ts
@@ -1,4 +1,4 @@
-// Happy-path pod database schema fixture: covers modes, defaults, plain and unique indexes,
+// Happy-path sandbox database schema fixture: covers modes, defaults, plain and unique indexes,
 // and single-column table-level primaryKey().
 import {
   blob,

--- a/cli/dust-sandbox/functions-runner/runner.test.ts
+++ b/cli/dust-sandbox/functions-runner/runner.test.ts
@@ -30,7 +30,7 @@ describe("runner run", () => {
   });
 
   test("creates function-authored files group-writable (umask 007)", async () => {
-    // A pod database a function opens directly must stay writable by group
+    // A sandbox database a function opens directly must stay writable by group
     // `agent`, or litestream can never replicate it.
     const { stdout, code } = await run(
       ["run", fx("file-mode-probe.ts")],

--- a/cli/dust-sandbox/functions-runner/types/db.ts
+++ b/cli/dust-sandbox/functions-runner/types/db.ts
@@ -1,4 +1,4 @@
-// Pod database wire/type contract: the single authored definition.
+// Sandbox database wire/type contract: the single authored definition.
 //
 // This file must stay dependency-free (no imports): front type-imports the error kinds
 // (front/lib/api/sandbox_functions/build_on_sandbox.ts, dsbx_db.ts) and mirrors


### PR DESCRIPTION
## Description

Use owner-neutral sandbox database terminology in the db runner's schema errors, backend documentation, and test fixtures. Runtime behavior, wire error kinds, paths, and APIs are unchanged.

## Tests

- `bun test` in `cli/dust-sandbox/functions-runner` (125 tests)
- `bun run build` in `cli/dust-sandbox/functions-runner`
- Targeted runner and validation tests after the fixture cleanup (23 tests)
- Biome on the changed files

## Risk

Low. This changes human-readable validation messages and comments only. Roll back the PR if downstream tooling unexpectedly parses error text instead of the stable error kind.

## Deploy Plan

Deploy normally. No ordering dependency.
