### PR TITLE
[front] feat: add seat usage loading circle column to Poke pool usage

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -33,6 +33,7 @@ const MEMBER_USAGE = {
   scheduledSeatChangeAt: null,
   scheduledSeatType: null,
   seatType: "max" as const,
+  seatUsageTarget: null,
   seatBalanceAwu: 100,
   spendLimitAlertId: null,
   spendLimitAwuCredits: null,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -160,6 +160,7 @@ function memberFromUpgradeRequest(
     freeCreditEmptyAlert: null,
     creditState: "capped",
     nearLimit: false,
+    seatUsageTarget: null,
   };
 }
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -38,6 +38,7 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Clock,
+  cn,
   createSelectionColumn,
   DataTable,
   Icon,
@@ -533,6 +534,147 @@ const seatsIconColumn: ColumnDef<RowData, string> = {
   },
 };
 
+function computeSeatUsage({
+  seatType,
+  memberUsageLimit,
+  seatBalanceAwu,
+  consumedFromAllowanceAwuCredits,
+}: {
+  seatType: MembershipSeatType | null;
+  memberUsageLimit: number | null;
+  seatBalanceAwu: number | null;
+  consumedFromAllowanceAwuCredits: number;
+}): {
+  percent: number;
+  isOverAllowance: boolean;
+  consumed: number;
+  allowance: number;
+} {
+  const allowance = memberUsageLimit ?? 0;
+  const isFreeWithBalance =
+    seatType === "free" &&
+    typeof seatBalanceAwu === "number" &&
+    typeof memberUsageLimit === "number";
+  const consumed = isFreeWithBalance
+    ? Math.max(0, memberUsageLimit - seatBalanceAwu)
+    : consumedFromAllowanceAwuCredits;
+  if (allowance <= 0) {
+    return {
+      percent: consumed > 0 ? 100 : 0,
+      isOverAllowance: consumed > 0,
+      consumed,
+      allowance,
+    };
+  }
+  return {
+    percent: Math.min(100, (consumed / allowance) * 100),
+    isOverAllowance: consumed > allowance,
+    consumed,
+    allowance,
+  };
+}
+
+interface SeatUsageRingProps {
+  percent: number;
+  colorClassName: string;
+}
+
+function SeatUsageRing({ percent, colorClassName }: SeatUsageRingProps) {
+  const radius = 6;
+  const circumference = 2 * Math.PI * radius;
+  const clamped = Math.min(100, Math.max(0, percent));
+  const dashOffset = circumference * (1 - clamped / 100);
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" className="-rotate-90">
+      <circle
+        cx="8"
+        cy="8"
+        r={radius}
+        strokeWidth="2"
+        fill="none"
+        stroke="currentColor"
+        className="text-muted-background"
+      />
+      {clamped > 0 && (
+        <circle
+          cx="8"
+          cy="8"
+          r={radius}
+          strokeWidth="2"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          className={colorClassName}
+        />
+      )}
+    </svg>
+  );
+}
+
+const seatUsageColumn: ColumnDef<RowData, string> = {
+  id: "seatUsage" as const,
+  header: "Seat usage",
+  enableSorting: false,
+  accessorFn: (row) =>
+    computeSeatUsage({
+      seatType: row.seatType,
+      memberUsageLimit: row.memberUsageLimit,
+      seatBalanceAwu: row.seatBalanceAwu,
+      consumedFromAllowanceAwuCredits: row.consumedFromAllowanceAwuCredits,
+    }).percent.toString(),
+  cell: (info: Info) => {
+    const { seatType, memberUsageLimit, seatBalanceAwu, isSeatChangePending } =
+      info.row.original;
+    if (
+      isSeatChangePending ||
+      !seatType ||
+      memberUsageLimit === null ||
+      memberUsageLimit <= 0
+    ) {
+      return (
+        <DataTable.CellContent className="justify-center">
+          <span className="text-sm text-muted-foreground">--</span>
+        </DataTable.CellContent>
+      );
+    }
+    const { percent, isOverAllowance, consumed, allowance } = computeSeatUsage({
+      seatType,
+      memberUsageLimit,
+      seatBalanceAwu,
+      consumedFromAllowanceAwuCredits:
+        info.row.original.consumedFromAllowanceAwuCredits,
+    });
+    const colorClassName = isOverAllowance
+      ? "text-warning-700"
+      : getSeatIconColorClass(seatType);
+    return (
+      <DataTable.CellContent className="justify-center">
+        <Tooltip
+          tooltipTriggerAsChild
+          label={`${formatCredits(consumed)} / ${formatCredits(allowance)} credits used`}
+          trigger={
+            <div className="flex items-center gap-2">
+              <span className={cn("text-xs font-medium", colorClassName)}>
+                {Math.round(percent)}%
+              </span>
+              <SeatUsageRing
+                percent={percent}
+                colorClassName={colorClassName}
+              />
+            </div>
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-24",
+    headerAlign: "center",
+  },
+};
+
 function buildConsumedAwuCreditsColumn(
   creditsResetAt: string | null
 ): ColumnDef<RowData, string> {
@@ -660,7 +802,7 @@ function buildColumns({
     ...(() => {
       switch (variant) {
         case "compact":
-          return [seatsIconColumn];
+          return [seatsIconColumn, seatUsageColumn];
         case "legacy":
           return [seatTypeColumn];
         default:

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -26,6 +26,7 @@ import {
 import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
+import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -85,6 +86,7 @@ type RowData = {
   consumedAwuCredits: number;
   consumedFromAllowanceAwuCredits: number;
   consumedFromPoolAwuCredits: number;
+  seatUsageTarget: CreditUsageTarget | null;
   spendLimitAwuCredits: number | null;
   spendLimitSource: EffectiveSpendLimitSource;
   scheduledSeatType: MembershipSeatType | null;
@@ -625,8 +627,13 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
       consumedFromAllowanceAwuCredits: row.consumedFromAllowanceAwuCredits,
     }).percent.toString(),
   cell: (info: Info) => {
-    const { seatType, memberUsageLimit, seatBalanceAwu, isSeatChangePending } =
-      info.row.original;
+    const {
+      seatType,
+      memberUsageLimit,
+      seatBalanceAwu,
+      seatUsageTarget,
+      isSeatChangePending,
+    } = info.row.original;
     if (
       isSeatChangePending ||
       !seatType ||
@@ -639,16 +646,21 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
         </DataTable.CellContent>
       );
     }
-    const { percent, isOverAllowance, consumed, allowance } = computeSeatUsage({
+    const { percent, consumed, allowance } = computeSeatUsage({
       seatType,
       memberUsageLimit,
       seatBalanceAwu,
       consumedFromAllowanceAwuCredits:
         info.row.original.consumedFromAllowanceAwuCredits,
     });
-    const colorClassName = isOverAllowance
-      ? "text-warning-700"
-      : getSeatIconColorClass(seatType);
+    const isOffPace =
+      seatUsageTarget === "elevated" || seatUsageTarget === "critical";
+    const colorClassName =
+      percent >= 100
+        ? "text-red-500"
+        : isOffPace
+          ? "text-warning-500"
+          : "text-muted-foreground";
     return (
       <DataTable.CellContent className="justify-center">
         <Tooltip
@@ -923,6 +935,7 @@ export function MembersUsageTable({
           consumedAwuCredits: m.consumedAwuCredits,
           consumedFromAllowanceAwuCredits: m.consumedFromAllowanceAwuCredits,
           consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
+          seatUsageTarget: m.seatUsageTarget,
           spendLimitAwuCredits: m.spendLimitAwuCredits,
           spendLimitSource: m.spendLimitSource,
           scheduledSeatType: m.scheduledSeatType,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -45,6 +45,7 @@ import {
   Icon,
   LoadingBlock,
   ProgressBar,
+  ProgressRing,
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -576,45 +577,6 @@ function computeSeatUsage({
   };
 }
 
-interface SeatUsageRingProps {
-  percent: number;
-  colorClassName: string;
-}
-
-function SeatUsageRing({ percent, colorClassName }: SeatUsageRingProps) {
-  const radius = 6;
-  const circumference = 2 * Math.PI * radius;
-  const clamped = Math.min(100, Math.max(0, percent));
-  const dashOffset = circumference * (1 - clamped / 100);
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" className="-rotate-90">
-      <circle
-        cx="8"
-        cy="8"
-        r={radius}
-        strokeWidth="2"
-        fill="none"
-        stroke="currentColor"
-        className="text-muted-background"
-      />
-      {clamped > 0 && (
-        <circle
-          cx="8"
-          cy="8"
-          r={radius}
-          strokeWidth="2"
-          fill="none"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={dashOffset}
-          className={colorClassName}
-        />
-      )}
-    </svg>
-  );
-}
-
 const seatUsageColumn: ColumnDef<RowData, string> = {
   id: "seatUsage" as const,
   header: "Seat usage",
@@ -671,9 +633,10 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
               <span className={cn("text-xs font-medium", colorClassName)}>
                 {Math.round(percent)}%
               </span>
-              <SeatUsageRing
-                percent={percent}
-                colorClassName={colorClassName}
+              <ProgressRing
+                percentage={percent}
+                label="Seat usage"
+                className={colorClassName}
               />
             </div>
           }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -66,7 +66,10 @@ import {
   setFixedWindowCount,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
-import type { CreditUsageStatus } from "@app/types/api/credits/usage_status";
+import type {
+  CreditUsageStatus,
+  CreditUsageTarget,
+} from "@app/types/api/credits/usage_status";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,
@@ -162,6 +165,11 @@ export type MemberUsageType = {
   // Whether the user has consumed ≥ 80% of their effective limit. Driven by
   // the nearLimit Redis flag (see user_block.ts). Poke-only.
   nearLimit: boolean;
+  // Classifies seat-allowance consumption against how far the billing cycle
+  // has elapsed: "elevated"/"critical" mean the member is burning through
+  // their seat allowance faster than a linear pace would predict. Poke-only
+  // (null otherwise, or when the billing cycle can't be resolved).
+  seatUsageTarget: CreditUsageTarget | null;
   // Per-user fair-use AWU credit usage (credits, with decimals) backed by the
   // microCredit rate-limit counter. Applies to non-credit-based plans
   // (free/trial) where a fair-use limit is set. Null when the plan carries no
@@ -1569,6 +1577,7 @@ export async function getMemberUsage({
     freeCreditEmptyAlert: null,
     creditState: membership.creditState,
     nearLimit: false,
+    seatUsageTarget: null,
   };
 
   return {
@@ -2023,13 +2032,15 @@ export async function getMembersUsage({
   // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
   // display beside the Elasticsearch-derived usage. The counter is bucketed on
   // the current contract billing cycle — resolve the window once, then read each
-  // user's key.
+  // user's key. The same cycle also backs the per-member seat-usage pace below.
   const rateLimiterSpendByUserId = new Map<string, number>();
+  let billingCycle: BillingCycle | null = null;
   if (includeAlertLinks) {
     const periodResult = await getCachedMetronomeCurrentBillingPeriod(
       workspace.sId
     );
     if (periodResult.isOk() && periodResult.value) {
+      billingCycle = periodResult.value;
       const bounds = makeSpendLimitCycleWindowBounds(
         periodResult.value.cycleStart,
         periodResult.value.cycleEnd
@@ -2214,6 +2225,25 @@ export async function getMembersUsage({
         ? (freeCreditAlertIds?.get(metronomeUserId) ?? null)
         : null;
 
+    // Seat-allowance consumption used for pace classification below: free
+    // seats track their live Metronome balance instead of the period spend
+    // (same distinction the seat-usage ring draws client-side).
+    const seatAllowanceAwu =
+      effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null;
+    const seatConsumedAwu =
+      membership.seatType === "free" && seatAllowanceAwu !== null
+        ? Math.max(0, seatAllowanceAwu - (freeBalanceByUserId.get(userId) ?? 0))
+        : consumedFromAllowanceAwuCredits;
+    const seatUsageTarget =
+      billingCycle && seatAllowanceAwu !== null
+        ? (computeCreditUsageStatus({
+            consumedAwuCredits: seatConsumedAwu,
+            limitAwuCredits: seatAllowanceAwu,
+            billingCycle,
+            nowMs: Date.now(),
+          })?.target ?? null)
+        : null;
+
     return [
       {
         sId: userId,
@@ -2260,6 +2290,7 @@ export async function getMembersUsage({
         creditState: membership.creditState,
         nearLimit: nearLimitByUserId.get(userId) ?? false,
         fairUse: fairUseByUserId.get(userId) ?? null,
+        seatUsageTarget,
       },
     ];
   });

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2227,15 +2227,27 @@ export async function getMembersUsage({
 
     // Seat-allowance consumption used for pace classification below: free
     // seats track their live Metronome balance instead of the period spend
-    // (same distinction the seat-usage ring draws client-side).
+    // (same distinction the seat-usage ring draws client-side). A missing
+    // entry means the balance read failed (the fetcher degrades to an empty
+    // map on Metronome failure), not that the balance is zero, so it must
+    // stay unknown rather than be treated as fully consumed.
+    const freeBalanceAwu = freeBalanceByUserId.get(userId) ?? null;
     const seatAllowanceAwu =
       effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null;
     const seatConsumedAwu =
-      membership.seatType === "free" && seatAllowanceAwu !== null
-        ? Math.max(0, seatAllowanceAwu - (freeBalanceByUserId.get(userId) ?? 0))
+      membership.seatType === "free"
+        ? seatAllowanceAwu !== null && freeBalanceAwu !== null
+          ? Math.max(0, seatAllowanceAwu - freeBalanceAwu)
+          : null
         : consumedFromAllowanceAwuCredits;
+    // Free seats have a lifetime, non-renewing grant, not a recurring
+    // billing-cycle allowance, so the billing-cycle pace classification
+    // (on-track/orange/critical) doesn't apply to them.
     const seatUsageTarget =
-      billingCycle && seatAllowanceAwu !== null
+      billingCycle &&
+      membership.seatType !== "free" &&
+      seatAllowanceAwu !== null &&
+      seatConsumedAwu !== null
         ? (computeCreditUsageStatus({
             consumedAwuCredits: seatConsumedAwu,
             limitAwuCredits: seatAllowanceAwu,
@@ -2258,7 +2270,7 @@ export async function getMembersUsage({
           effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
         seatBalanceAwu:
           membership.seatType === "free"
-            ? (freeBalanceByUserId.get(userId) ?? 0)
+            ? freeBalanceAwu
             : effectiveAllocationAwu > 0
               ? (seatBalanceByUserId.get(userId) ?? null)
               : null,

--- a/sparkle/src/components/ProgressRing.tsx
+++ b/sparkle/src/components/ProgressRing.tsx
@@ -1,0 +1,98 @@
+import { cn } from "@sparkle/lib/utils";
+import * as React from "react";
+
+export type ProgressRingProps = Omit<
+  React.SVGAttributes<SVGSVGElement>,
+  "children"
+> & {
+  /**
+   * Completion percentage (0-100). Out-of-range values are clamped.
+   */
+  percentage: number;
+  /**
+   * Diameter of the ring in pixels.
+   */
+  size?: number;
+  /**
+   * Stroke width of the ring, in the same unit as the viewBox.
+   */
+  strokeWidth?: number;
+  /**
+   * Accessible name announced by screen readers for the progressbar role.
+   * Name what is progressing (e.g. "Seat usage").
+   */
+  label?: string;
+};
+
+/**
+ * A small circular determinate progress indicator for a known completion
+ * percentage. Exposes the `progressbar` role with value semantics; pass
+ * `label` to name what is progressing for screen readers.
+ *
+ * The fill color follows `currentColor`, so pass a text color utility via
+ * `className` (e.g. `text-warning-500`) to color it.
+ *
+ * For a linear indicator, use ProgressBar instead.
+ *
+ * @summary Determinate circular progress indicator (0-100%).
+ */
+export const ProgressRing = React.forwardRef<SVGSVGElement, ProgressRingProps>(
+  (
+    {
+      percentage,
+      size = 16,
+      strokeWidth = 2,
+      label = "Progress",
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const clamped = Math.min(100, Math.max(0, percentage));
+    const dashOffset = circumference * (1 - clamped / 100);
+    const center = size / 2;
+    return (
+      <svg
+        ref={ref}
+        role="progressbar"
+        aria-label={label}
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="-rotate-90"
+        {...props}
+      >
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          strokeWidth={strokeWidth}
+          fill="none"
+          stroke="currentColor"
+          className="text-muted-background"
+        />
+        {clamped > 0 && (
+          <circle
+            cx={center}
+            cy={center}
+            r={radius}
+            strokeWidth={strokeWidth}
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            className={cn(className)}
+          />
+        )}
+      </svg>
+    );
+  }
+);
+
+ProgressRing.displayName = "ProgressRing";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -244,6 +244,7 @@ export {
 } from "./Popover";
 export { PriceTable } from "./PriceTable";
 export { ProgressBar } from "./ProgressBar";
+export { ProgressRing } from "./ProgressRing";
 export { PuzzleSpinner } from "./PuzzleSpinner";
 export { RadioGroup, RadioGroupCustomItem, RadioGroupItem } from "./RadioGroup";
 export { RainbowEffect } from "./RainbowEffect";

--- a/sparkle/src/stories/ProgressRing.stories.tsx
+++ b/sparkle/src/stories/ProgressRing.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { ProgressRing } from "../components/ProgressRing";
+
+const meta = {
+  title: "Data Display/ProgressRing",
+  component: ProgressRing,
+  parameters: {
+    docs: {
+      description: {
+        component: `A small circular determinate progress indicator — e.g. a per-seat or per-item usage ring shown inline in a table cell.
+
+**When to use**
+- To show a proportion or completion percentage in a compact, inline form where a full-width bar would not fit.
+
+**Guidelines**
+- Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
+- The fill follows \`currentColor\`, so color it with a text color utility via \`className\` (e.g. \`text-warning-500\`).
+- Use \`size\` and \`strokeWidth\` to adjust the ring's dimensions.`,
+      },
+    },
+  },
+  args: {
+    percentage: 40,
+    label: "Seat usage",
+  },
+  argTypes: {
+    percentage: {
+      control: { type: "number", min: 0, max: 100 },
+    },
+  },
+} satisfies Meta<typeof ProgressRing>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A ring at 40% — adjust `percentage` from the Controls panel to see any
+ * fill level.
+ * @summary Ring at an adjustable percentage.
+ */
+export const Default: Story = {
+  render: (args) => <ProgressRing {...args} />,
+};
+
+/**
+ * Visual gallery: the same ring at 10 / 40 / 75 / 100% to compare fill
+ * levels side by side.
+ * @summary Visual gallery of fill levels.
+ */
+export const Percentages: Story = {
+  tags: ["!manifest"],
+  render: () => (
+    <div className="flex items-center gap-3">
+      {[10, 40, 75, 100].map((percentage) => (
+        <ProgressRing key={percentage} percentage={percentage} />
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * Color follows `currentColor`, so it can be set per-instance via
+ * `className` to reflect state (e.g. normal, off-pace, over limit).
+ * @summary Colored via `className`.
+ */
+export const Colors: Story = {
+  tags: ["!manifest"],
+  render: () => (
+    <div className="flex items-center gap-3">
+      <ProgressRing percentage={40} className="text-muted-foreground" />
+      <ProgressRing percentage={75} className="text-warning-500" />
+      <ProgressRing percentage={100} className="text-red-500" />
+    </div>
+  ),
+};


### PR DESCRIPTION
## Description

Adds a seatUsageColumn showing seat-allowance consumption as a percentage ring, compact-variant only. Not yet sortable (see a later PR in the stack).

Also adds `seatUsageTarget` (elevated/critical), classifying seat-allowance consumption pace against elapsed billing-cycle time the same way the existing credit-usage-status helper does elsewhere, and wires it into the ring's color (red at/over 100%, orange when off-pace, muted otherwise).

The ring itself is now a new `ProgressRing` Sparkle component (mirroring `ProgressBar`) instead of a bespoke inline SVG, so it can be reused elsewhere.

<img width="1130" height="823" alt="Capture d’écran 2026-09-01 à 17 56 01" src="https://github.com/user-attachments/assets/b91f4e34-919e-444e-a5de-da4dc8711897" />

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. **#31601 (this PR)** — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Low. New column and new unused-so-far field, compact-variant only.

## Deploy Plan

Deploy front.
