### PR TITLE
Move live databases to sandbox state

### DIFF
--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -1,5 +1,6 @@
 import {
   checkReplicaMountLiveness,
+  ensurePodStateHealthOnSleep,
   isFuseStatfsMagic,
   isValidPodDatabaseName,
   parseLiveDatabaseNames,
@@ -142,5 +143,45 @@ describe("pod state helpers", () => {
 
     expect(result.isErr()).toBe(true);
     expect(execRoot).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    ["legacy image", "/pod-state/databases"],
+    ["canonical image", "/sandbox-state/databases"],
+  ])("syncs using the database path registered by the %s", async (_, dir) => {
+    const execRoot = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 0, stdout: "65735546\n", stderr: "" })
+      )
+      .mockResolvedValueOnce(
+        new Ok({
+          exitCode: 0,
+          stdout: "/pod-state/databases/chat.db\n",
+          stderr: "",
+        })
+      )
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 0, stdout: "SQLite format 3", stderr: "" })
+      )
+      .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 0, stdout: `${dir}\n`, stderr: "" })
+      )
+      .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+
+    const result = await ensurePodStateHealthOnSleep(
+      { getNonNullableWorkspace: () => ({ sId: "w" }) } as never,
+      { sId: "sandbox", execRoot } as never
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      renderRootCommand(execRoot.mock.calls[4][1] as RootCommand)
+    ).toContain("/usr/bin/realpath -- /pod-state/databases");
+    expect(
+      renderRootCommand(execRoot.mock.calls[5][1] as RootCommand)
+    ).toContain(`${dir}/chat.db`);
+    expect(execRoot).toHaveBeenCalledTimes(6);
   });
 });

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -63,6 +63,7 @@ const RUNUSER_BIN = "/usr/sbin/runuser";
 const SYSTEMCTL_BIN = "/usr/bin/systemctl";
 const SQLITE3_BIN = "/usr/bin/sqlite3";
 const FIND_BIN = "/usr/bin/find";
+const REALPATH_BIN = "/usr/bin/realpath";
 const STAT_BIN = "/usr/bin/stat";
 const MV_BIN = "/usr/bin/mv";
 const RM_BIN = "/usr/bin/rm";
@@ -176,6 +177,35 @@ function execFailure(
   return new Error(
     `${label} failed (exit ${result.exitCode}): ${result.stderr || result.stdout || "no output"}`
   );
+}
+
+async function resolveLiveDatabasesDir(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<string, Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(REALPATH_BIN, ["--", SANDBOX_STATE_DATABASES_DIR]),
+    { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(
+      execFailure("live database directory resolution", result.value)
+    );
+  }
+
+  const databasesDir = result.value.stdout.trim();
+  if (!databasesDir.startsWith("/")) {
+    return new Err(
+      new Error(
+        `live database directory resolved to ${databasesDir || "empty"}`
+      )
+    );
+  }
+  return new Ok(databasesDir);
 }
 
 /**
@@ -559,9 +589,26 @@ export async function ensurePodStateHealthOnSleep(
     return daemonResult;
   }
 
-  // 4. Sync each database through the daemon control socket.
+  // 4. Litestream keys its control API by exact path and does not resolve
+  // symlinks. Resolve the image's live directory once: old images return the
+  // legacy path, while the compatibility symlink in new images returns the
+  // canonical path registered by their watcher.
+  const databasesDirResult = await resolveLiveDatabasesDir(auth, sandbox);
+  if (databasesDirResult.isErr()) {
+    if (databasesDirResult.error instanceof SandboxNotFoundError) {
+      return new Ok(undefined);
+    }
+    recordPodStateHealth("failure");
+    childLogger.error(
+      { err: databasesDirResult.error },
+      "Sandbox state pre-sleep: database path resolution failed, not pausing"
+    );
+    return databasesDirResult;
+  }
+
+  // 5. Sync each database through the daemon control socket.
   for (const name of names) {
-    const dbPath = `${SANDBOX_STATE_DATABASES_DIR}/${name}.db`;
+    const dbPath = `${databasesDirResult.value}/${name}.db`;
     const syncResult = await sandbox.execRoot(
       auth,
       rootCommand.exec(LITESTREAM_BIN, [

--- a/front/lib/api/sandbox/image/litestream/litestream.service
+++ b/front/lib/api/sandbox/image/litestream/litestream.service
@@ -21,12 +21,11 @@ RuntimeDirectoryMode=0755
 
 # Defense in depth, modeled on dust-egress-resolver.service. The daemon only
 # needs rw under /sandbox-state (live databases and replica gcsfuse mount).
-# /pod-state remains writable only for the legacy database-path symlink. The
-# control socket is AF_UNIX and the file replica needs no network.
+# The control socket is AF_UNIX and the file replica needs no network.
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
-ReadWritePaths=/sandbox-state /pod-state
+ReadWritePaths=/sandbox-state
 ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes

--- a/front/lib/api/sandbox/image/litestream/litestream.service
+++ b/front/lib/api/sandbox/image/litestream/litestream.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Dust Litestream replication daemon for pod state
+Description=Dust Litestream replication daemon for sandbox state
 After=network.target
 
 [Service]
@@ -15,18 +15,18 @@ SyslogIdentifier=litestream
 # Control socket directory (/run/litestream), created by systemd as
 # dust-state. The pre-sleep `litestream sync -wait` runs against the socket
 # in there; the socket is enabled by the static /etc/litestream.yml baked at
-# image build (directory-watcher config over /pod-state/databases).
+# image build (directory-watcher config over /sandbox-state/databases).
 RuntimeDirectory=litestream
 RuntimeDirectoryMode=0755
 
 # Defense in depth, modeled on dust-egress-resolver.service. The daemon only
-# needs rw under /pod-state (live databases) and /sandbox-state (replica
-# gcsfuse mount); the
+# needs rw under /sandbox-state (live databases and replica gcsfuse mount).
+# /pod-state remains writable only for the legacy database-path symlink. The
 # control socket is AF_UNIX and the file replica needs no network.
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
-ReadWritePaths=/pod-state /sandbox-state
+ReadWritePaths=/sandbox-state /pod-state
 ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes

--- a/front/lib/api/sandbox/image/litestream/litestream.yml
+++ b/front/lib/api/sandbox/image/litestream/litestream.yml
@@ -1,8 +1,8 @@
 # Managed by Dust. Static config: every path is a fixed constant of the
-# pod-state layout, so it is baked at image build. The litestream.service unit
-# stays disabled at build and is started by front at runtime AFTER the replica
-# gcsfuse mount and the cold-start restore — starting at boot would let the
-# daemon write to the unmounted local directory and manage files mid-restore.
+# sandbox-state layout, so it is baked at image build. The litestream.service
+# unit stays disabled at build and is started by front at runtime AFTER the
+# replica gcsfuse mount and the cold-start restore — starting at boot would let
+# the daemon write to the unmounted local directory and manage files mid-restore.
 
 # JSON logs (slog): fluent-bit parses the journal MESSAGE with its json
 # parser, so level/msg land as structured fields in Datadog.
@@ -21,7 +21,7 @@ socket:
 # ignored by the watcher (header validation). Replica subdirectories are
 # named by database FILENAME: /sandbox-state/replica/{db}.db/ltx/...
 dbs:
-  - dir: /pod-state/databases
+  - dir: /sandbox-state/databases
     pattern: "*.db"
     watch: true
     replica:

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -625,9 +625,8 @@ describe("sandbox image registry", () => {
     expect(litestreamUnit).toContain("RuntimeDirectory=litestream");
     expect(litestreamUnit).toContain("NoNewPrivileges=yes");
     expect(litestreamUnit).toContain("ProtectSystem=strict");
-    expect(litestreamUnit).toContain(
-      "ReadWritePaths=/sandbox-state /pod-state"
-    );
+    expect(litestreamUnit).toContain("ReadWritePaths=/sandbox-state");
+    expect(litestreamUnit).not.toContain("ReadWritePaths=/pod-state");
     expect(litestreamUnit).toContain("RestrictAddressFamilies=AF_UNIX");
     expect(litestreamUnit).toContain("MemoryDenyWriteExecute=yes");
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.106",
+      tag: "0.8.107",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -555,7 +555,7 @@ describe("sandbox image registry", () => {
     );
   });
 
-  test("creates the dust-state user and the pod-state directory layout", () => {
+  test("creates one sandbox database directory with a legacy path alias", () => {
     const runCommands = getRunCommands(getDustBaseImageOperations());
 
     expect(runCommands).toEqual(
@@ -563,19 +563,42 @@ describe("sandbox image registry", () => {
         expect.stringContaining(
           "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state"
         ),
-        expect.stringContaining("install -d -o root -g root -m 755 /pod-state"),
-        expect.stringContaining(
-          "install -d -o dust-state -g agent -m 2770 /pod-state/databases"
-        ),
-        expect.stringContaining("setfacl -R -d -m g::rwx /pod-state/databases"),
-        expect.stringContaining("setfacl -R -m g::rwx /pod-state/databases"),
         expect.stringContaining(
           "install -d -o root -g root -m 755 /sandbox-state"
         ),
         expect.stringContaining(
+          "install -d -o dust-state -g agent -m 2770 /sandbox-state/databases"
+        ),
+        expect.stringContaining(
+          "setfacl -R -d -m g::rwx /sandbox-state/databases"
+        ),
+        expect.stringContaining(
+          "setfacl -R -m g::rwx /sandbox-state/databases"
+        ),
+        expect.stringContaining(
           "install -d -o dust-state -g dust-state -m 700 /sandbox-state/replica"
         ),
+        expect.stringContaining("install -d -o root -g root -m 755 /pod-state"),
+        expect.stringContaining(
+          "ln -s /sandbox-state/databases /pod-state/databases"
+        ),
       ])
+    );
+    expect(
+      runCommands.some((command) =>
+        command.includes(
+          "install -d -o dust-state -g agent -m 2770 /pod-state/databases"
+        )
+      )
+    ).toBe(false);
+    const stateSetupCommand =
+      runCommands.find((command) =>
+        command.includes("ln -s /sandbox-state/databases /pod-state/databases")
+      ) ?? "";
+    expectContentInOrder(
+      stateSetupCommand,
+      "install -d -o dust-state -g agent -m 2770 /sandbox-state/databases",
+      "ln -s /sandbox-state/databases /pod-state/databases"
     );
   });
 
@@ -589,7 +612,7 @@ describe("sandbox image registry", () => {
     );
 
     expect(litestreamUnit).toContain(
-      "Description=Dust Litestream replication daemon for pod state"
+      "Description=Dust Litestream replication daemon for sandbox state"
     );
     expect(litestreamUnit).toContain("User=dust-state");
     expect(litestreamUnit).toContain("Group=dust-state");
@@ -603,7 +626,7 @@ describe("sandbox image registry", () => {
     expect(litestreamUnit).toContain("NoNewPrivileges=yes");
     expect(litestreamUnit).toContain("ProtectSystem=strict");
     expect(litestreamUnit).toContain(
-      "ReadWritePaths=/pod-state /sandbox-state"
+      "ReadWritePaths=/sandbox-state /pod-state"
     );
     expect(litestreamUnit).toContain("RestrictAddressFamilies=AF_UNIX");
     expect(litestreamUnit).toContain("MemoryDenyWriteExecute=yes");
@@ -639,7 +662,8 @@ describe("sandbox image registry", () => {
 
     // Directory watcher: post-cold-start databases are discovered
     // automatically; the replica subdir is named by db FILENAME ({db}.db).
-    expect(litestreamConfig).toContain("dir: /pod-state/databases");
+    expect(litestreamConfig).toContain("dir: /sandbox-state/databases");
+    expect(litestreamConfig).not.toContain("dir: /pod-state/databases");
     expect(litestreamConfig).toContain('pattern: "*.db"');
     expect(litestreamConfig).toContain("watch: true");
     expect(litestreamConfig).toContain("type: file");
@@ -690,7 +714,7 @@ describe("sandbox image registry", () => {
     );
   });
 
-  test("runs pod-state install ops before the final hardening re-run", () => {
+  test("runs sandbox-state install ops before the final hardening re-run", () => {
     const runCommands = getRunCommands(getDustBaseImageOperations());
     const lastHardeningIndex = runCommands.reduce(
       (last, command, index) =>
@@ -702,7 +726,7 @@ describe("sandbox image registry", () => {
     const litestreamIndex = runCommands.findIndex((command) =>
       command.includes("benbjohnson/litestream/releases/download")
     );
-    const podStateIndex = runCommands.findIndex((command) =>
+    const sandboxStateIndex = runCommands.findIndex((command) =>
       command.includes("install -d -o dust-state -g agent -m 2770")
     );
     const drizzleIndex = runCommands.findIndex((command) =>
@@ -715,7 +739,7 @@ describe("sandbox image registry", () => {
     expect(lastHardeningIndex).toBeGreaterThanOrEqual(0);
     for (const index of [
       litestreamIndex,
-      podStateIndex,
+      sandboxStateIndex,
       drizzleIndex,
       sandboxPackageMkdirIndex,
     ]) {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -28,7 +28,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.106";
+const DUST_BASE_IMAGE_VERSION = "0.8.107";
 const DSBX_CLI_VERSION = "0.1.56";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
@@ -205,7 +205,7 @@ function getLocalDirContent(
 
 function getAgentProxiedSetupCommand(): string {
   // agent-proxied has its own primary group. Supplementary membership in
-  // agent is limited to explicit shared state such as /files and pod DBs.
+  // agent is limited to explicit shared state such as /files and sandbox DBs.
   return [
     `groupadd --gid ${AGENT_PROXIED_UID} agent-proxied`,
     `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent-proxied --groups agent --shell /bin/bash agent-proxied`,
@@ -224,7 +224,7 @@ function getEgressResolverUserSetupCommand(): string {
 }
 
 function getDustStateUserSetupCommand(): string {
-  // dust-state runs the litestream replication daemon (pod state). Primary
+  // dust-state runs the Litestream replication daemon (sandbox state). Primary
   // group dust-state owns the replica mount point; supplementary membership
   // in `agent` grants rw on the live databases dir shared with agent-proxied
   // function code. Deliberately not egress-controlled: it never executes
@@ -235,21 +235,24 @@ function getDustStateUserSetupCommand(): string {
   ].join(" && ");
 }
 
-function getPodStateSetupCommand(): string {
-  // /pod-state/databases holds the live SQLite files: both agent-proxied
+function getSandboxStateSetupCommand(): string {
+  // /sandbox-state/databases holds the live SQLite files: both agent-proxied
   // function code (group agent) and the litestream daemon (user dust-state)
   // need rw, so it gets the same setgid + default-ACL treatment as /files.
   // /sandbox-state/replica is the gcsfuse mount point for the litestream replica
-  // — the durable copy of pod state. Untrusted workload code must never read
+  // — the durable copy of sandbox state. Untrusted workload code must never read
   // or tamper with it, so the directory is dust-state-only: 0700 here, no
   // allow_other on the runtime mount.
+  // /pod-state/databases remains an absolute symlink for callers that still
+  // emit the legacy path. There is only one physical live database directory.
   return [
-    "install -d -o root -g root -m 755 /pod-state",
-    "install -d -o dust-state -g agent -m 2770 /pod-state/databases",
-    "setfacl -R -d -m g::rwx /pod-state/databases",
-    "setfacl -R -m g::rwx /pod-state/databases",
     "install -d -o root -g root -m 755 /sandbox-state",
+    "install -d -o dust-state -g agent -m 2770 /sandbox-state/databases",
+    "setfacl -R -d -m g::rwx /sandbox-state/databases",
+    "setfacl -R -m g::rwx /sandbox-state/databases",
     "install -d -o dust-state -g dust-state -m 700 /sandbox-state/replica",
+    "install -d -o root -g root -m 755 /pod-state",
+    "ln -s /sandbox-state/databases /pod-state/databases",
   ].join(" && ");
 }
 
@@ -346,7 +349,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   )
   .runCmd(getEgressResolverUserSetupCommand(), { user: "root" })
   .runCmd(getDustStateUserSetupCommand(), { user: "root" })
-  .runCmd(getPodStateSetupCommand(), { user: "root" })
+  .runCmd(getSandboxStateSetupCommand(), { user: "root" })
   // Hidden tools: installed but not in manifest (back profile functions)
   .runCmd(
     "apt-get update && apt-get install -y ripgrep fd-find sd systemd-resolved",

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -7,9 +7,9 @@ import {
   assertNoEmptyPasswordAccounts,
   assertNoPasswordlessSudoers,
   assertNoPrivilegedGroupMembers,
-  assertPodStateDirsSafe,
   assertRootInvokedHelpersSafe,
   assertRootPathSafe,
+  assertSandboxStatePathsSafe,
   assertSshAndDnsHardening,
   assertStaticRootConsumedDirsSafe,
   assertSudoAbsent,
@@ -204,36 +204,42 @@ describe("sandbox security check assertions", () => {
     ).toThrow("missing root-invoked helper audit for /opt/bin/litestream");
   });
 
-  test("detects unsafe pod-state directory ownership or modes", () => {
+  test("detects unsafe sandbox-state paths", () => {
     const safeOutput = [
-      "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x",
-      "POD_STATE_DIR=/pod-state/databases dust-state:agent 2770 drwxrws---",
-      "POD_STATE_DIR=/sandbox-state root:root 755 drwxr-xr-x",
-      "POD_STATE_DIR=/sandbox-state/replica dust-state:dust-state 700 drwx------",
+      "SANDBOX_STATE_DIR=/sandbox-state root:root 755 drwxr-xr-x",
+      "SANDBOX_STATE_DIR=/sandbox-state/databases dust-state:agent 2770 drwxrws---",
+      "SANDBOX_STATE_DIR=/sandbox-state/replica dust-state:dust-state 700 drwx------",
+      "SANDBOX_STATE_DIR=/pod-state root:root 755 drwxr-xr-x",
+      "SANDBOX_STATE_LEGACY_DATABASE_LINK=/pod-state/databases /sandbox-state/databases",
     ].join("\n");
 
-    expect(() => assertPodStateDirsSafe(safeOutput)).not.toThrow();
+    expect(() => assertSandboxStatePathsSafe(safeOutput)).not.toThrow();
     expect(() =>
-      assertPodStateDirsSafe(
+      assertSandboxStatePathsSafe(
         safeOutput.replace(
           "/sandbox-state/replica dust-state:dust-state 700",
           "/sandbox-state/replica dust-state:dust-state 755"
         )
       )
-    ).toThrow("pod-state directory /sandbox-state/replica");
+    ).toThrow("sandbox-state directory /sandbox-state/replica");
     expect(() =>
-      assertPodStateDirsSafe(
+      assertSandboxStatePathsSafe(
         safeOutput.replace(
-          "/pod-state/databases dust-state:agent 2770",
-          "/pod-state/databases agent:agent 2770"
+          "/sandbox-state/databases dust-state:agent 2770",
+          "/sandbox-state/databases agent:agent 2770"
         )
       )
-    ).toThrow("pod-state directory /pod-state/databases");
+    ).toThrow("sandbox-state directory /sandbox-state/databases");
     expect(() =>
-      assertPodStateDirsSafe(
-        "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x"
+      assertSandboxStatePathsSafe(
+        safeOutput.replace(
+          "/pod-state/databases /sandbox-state/databases",
+          "/pod-state/databases /pod-state/other"
+        )
       )
-    ).toThrow("missing pod-state directory audit for /pod-state/databases");
+    ).toThrow(
+      "legacy database state path must be a symlink to /sandbox-state/databases"
+    );
   });
 
   test("detects root PATH entries that can resolve agent-writable binaries", () => {

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -823,47 +823,65 @@ export function assertRootInvokedHelpersSafe(output: string): void {
   }
 }
 
-const POD_STATE_DIR_EXPECTATIONS = [
-  { path: "/pod-state", owner: "root:root", mode: "755" },
-  { path: "/pod-state/databases", owner: "dust-state:agent", mode: "2770" },
+const SANDBOX_STATE_DIR_EXPECTATIONS = [
   { path: "/sandbox-state", owner: "root:root", mode: "755" },
+  {
+    path: "/sandbox-state/databases",
+    owner: "dust-state:agent",
+    mode: "2770",
+  },
   {
     path: "/sandbox-state/replica",
     owner: "dust-state:dust-state",
     mode: "700",
   },
+  { path: "/pod-state", owner: "root:root", mode: "755" },
 ] as const;
 
-export function assertPodStateDirsSafe(output: string): void {
+const LEGACY_DATABASE_STATE_LINK = {
+  path: "/pod-state/databases",
+  target: "/sandbox-state/databases",
+} as const;
+
+export function assertSandboxStatePathsSafe(output: string): void {
   const lineByPath = new Map<string, string>();
   for (const line of output.split("\n")) {
-    if (!line.startsWith("POD_STATE_DIR=")) {
+    if (!line.startsWith("SANDBOX_STATE_DIR=")) {
       continue;
     }
-    const [path] = line.replace("POD_STATE_DIR=", "").split(/\s+/, 1);
+    const [path] = line.replace("SANDBOX_STATE_DIR=", "").split(/\s+/, 1);
     if (path) {
       lineByPath.set(path, line);
     }
   }
 
-  for (const expectation of POD_STATE_DIR_EXPECTATIONS) {
+  for (const expectation of SANDBOX_STATE_DIR_EXPECTATIONS) {
     const line = lineByPath.get(expectation.path);
     if (!line) {
       throw new Error(
-        `missing pod-state directory audit for ${expectation.path}:\n${output}`
+        `missing sandbox-state directory audit for ${expectation.path}:\n${output}`
       );
     }
 
-    const fields = line.replace("POD_STATE_DIR=", "").split(/\s+/);
+    const fields = line.replace("SANDBOX_STATE_DIR=", "").split(/\s+/);
     const owner = fields[1];
     const mode = fields[2];
 
     if (owner !== expectation.owner || mode !== expectation.mode) {
       throw new Error(
-        `pod-state directory ${expectation.path} must be ${expectation.owner} ` +
+        `sandbox-state directory ${expectation.path} must be ${expectation.owner} ` +
           `mode ${expectation.mode}:\n${line}`
       );
     }
+  }
+
+  const expectedLegacyLink =
+    `SANDBOX_STATE_LEGACY_DATABASE_LINK=${LEGACY_DATABASE_STATE_LINK.path} ` +
+    LEGACY_DATABASE_STATE_LINK.target;
+  if (!output.split("\n").includes(expectedLegacyLink)) {
+    throw new Error(
+      `legacy database state path must be a symlink to ${LEGACY_DATABASE_STATE_LINK.target}:\n${output}`
+    );
   }
 }
 
@@ -954,12 +972,20 @@ for path in ${SANDBOX_ROOT_INVOKED_HELPERS.map((path) => shellQuote(path)).join(
     stat -c '%n %U:%G %a %A' "$path"
   fi
 done
-echo "--- pod-state-dirs ---"
-for dir in ${POD_STATE_DIR_EXPECTATIONS.map((expectation) =>
+echo "--- sandbox-state-paths ---"
+for dir in ${SANDBOX_STATE_DIR_EXPECTATIONS.map((expectation) =>
       shellQuote(expectation.path)
     ).join(" ")}; do
-  stat -c 'POD_STATE_DIR=%n %U:%G %a %A' "$dir"
+  /usr/bin/stat -c 'SANDBOX_STATE_DIR=%n %U:%G %a %A' "$dir"
 done
+if [ -L ${shellQuote(LEGACY_DATABASE_STATE_LINK.path)} ]; then
+  printf 'SANDBOX_STATE_LEGACY_DATABASE_LINK=%s %s\n' \
+    ${shellQuote(LEGACY_DATABASE_STATE_LINK.path)} \
+    "$(/usr/bin/readlink ${shellQuote(LEGACY_DATABASE_STATE_LINK.path)})"
+else
+  printf 'SANDBOX_STATE_LEGACY_DATABASE_LINK=%s %s\n' \
+    ${shellQuote(LEGACY_DATABASE_STATE_LINK.path)} '<not-a-symlink>'
+fi
 echo "--- root-path ---"
 printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
 /bin/bash --noprofile --norc -c 'source /etc/profile; printf "ROOT_LOGIN_PATH=%s\n" "$PATH"'
@@ -975,7 +1001,7 @@ printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
   assertStaticRootConsumedDirsSafe(output);
   assertSystemdUnitPathsSafe(output);
   assertRootInvokedHelpersSafe(output);
-  assertPodStateDirsSafe(output);
+  assertSandboxStatePathsSafe(output);
   assertRootPathSafe(output);
 }
 
@@ -1154,7 +1180,7 @@ fi
   }
 }
 
-async function checkPodStateWorkloadAccess(
+async function checkSandboxDatabaseStateAccess(
   provider: E2BSandboxProvider,
   providerId: string
 ): Promise<void> {
@@ -1166,16 +1192,20 @@ async function checkPodStateWorkloadAccess(
     providerId,
     `
 set -euo pipefail
-test -d /pod-state/databases
-proof=$(mktemp /pod-state/databases/dust-security-smoke-XXXXXX)
+test -d /sandbox-state/databases
+test -L /pod-state/databases
+test "$(readlink /pod-state/databases)" = "/sandbox-state/databases"
+proof=$(mktemp /sandbox-state/databases/dust-security-smoke-XXXXXX)
 printf 'db-ok' > "$proof"
-test "$(cat "$proof")" = "db-ok"
-rm -f "$proof"
+legacy_proof="/pod-state/databases/$(basename "$proof")"
+test "$(cat "$legacy_proof")" = "db-ok"
+rm -f "$legacy_proof"
+test ! -e "$proof"
 `,
     { user: AGENT_PROXIED_USER }
   );
   assertCommandSucceeded(
-    "pod-state databases workload access",
+    "sandbox database state workload access",
     databasesAccess
   );
 
@@ -1208,7 +1238,7 @@ fi
 `,
     { user: AGENT_PROXIED_USER }
   );
-  assertCommandSucceeded("pod-state workload denial probes", denials);
+  assertCommandSucceeded("sandbox-state workload denial probes", denials);
 }
 
 export function assertSshAndDnsHardening(output: string): void {
@@ -1369,7 +1399,7 @@ async function checkImage(image: SandboxImage): Promise<void> {
     await checkControlledUidEgress(provider, providerId);
     await checkRootExecPathHijack(provider, providerId);
     await checkSystemdUnitSearchPathShadow(provider, providerId);
-    await checkPodStateWorkloadAccess(provider, providerId);
+    await checkSandboxDatabaseStateAccess(provider, providerId);
 
     logger.info(
       { imageId, providerId },


### PR DESCRIPTION
## Description

- store live SQLite files in `/sandbox-state/databases`
- keep `/pod-state/databases` as a symlink to the same physical directory
- point Litestream and security checks at the canonical layout
- resolve pre-sleep sync paths against each image's real directory

Stacked on #31585. Front keeps emitting the legacy path in this PR, so the image bridge must roll out first.

## Tests

Added image, control-path, and security assertions for both image generations. Ran the 44 focused tests and Front `tsgo` locally.

## Risk

Moderate. This changes the base-image filesystem contract, but existing callers keep working through the compatibility symlink. Pre-sleep sync resolves to the path registered by each image. Rollback uses `dust-base:0.8.106`.

## Deploy Plan

1. Merge and release #31585.
2. Merge this PR and roll out `dust-base:0.8.107`.
3. Cycle older sandboxes before switching Front to the canonical path.