### PR TITLE
Emit the canonical sandbox database path

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
@@ -157,12 +157,14 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix", () => {
       command.includes("/bin/rm -f --")
     );
     expect(removeCommand).toBeDefined();
-    expect(removeCommand).toContain("/pod-state/databases/tasklist__tasks.db");
     expect(removeCommand).toContain(
-      "/pod-state/databases/tasklist__tasks.db-wal"
+      "/sandbox-state/databases/tasklist__tasks.db"
     );
     expect(removeCommand).toContain(
-      "/pod-state/databases/tasklist__tasks.db-shm"
+      "/sandbox-state/databases/tasklist__tasks.db-wal"
+    );
+    expect(removeCommand).toContain(
+      "/sandbox-state/databases/tasklist__tasks.db-shm"
     );
   });
 

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -49,11 +49,11 @@ describe("pod state helpers", () => {
 
   test("parses live database enumeration output", () => {
     const findOutput = [
-      "/pod-state/databases/chat.db",
-      "/pod-state/databases/tasks.db",
-      "/pod-state/databases/.restore-chat.db",
-      "/pod-state/databases/UPPER.db",
-      "/pod-state/databases/not-a-db.txt",
+      "/sandbox-state/databases/chat.db",
+      "/sandbox-state/databases/tasks.db",
+      "/sandbox-state/databases/.restore-chat.db",
+      "/sandbox-state/databases/UPPER.db",
+      "/sandbox-state/databases/not-a-db.txt",
     ].join("\n");
 
     expect(parseLiveDatabaseNames(findOutput)).toEqual(["chat", "tasks"]);

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -887,10 +887,10 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     expect(opts?.envVars).toMatchObject({
       DUST_FUNCTIONS_DIR: `/sandbox-functions/pods/${space.sId}`,
-      DUST_SANDBOX_DATABASES_DIR: "/pod-state/databases",
+      DUST_SANDBOX_DATABASES_DIR: "/sandbox-state/databases",
       DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_SANDBOX_DATABASE_PREFIX: "",
-      DUST_POD_DATABASES_DIR: "/pod-state/databases",
+      DUST_POD_DATABASES_DIR: "/sandbox-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       // Published outside an app folder, so its databases are unprefixed.
       DUST_POD_DATABASE_PREFIX: "",
@@ -974,10 +974,10 @@ describe("SandboxFunctionInvocationResource", () => {
     const execOptions = execSpy.mock.calls[0]?.[2];
     expect(execOptions?.envVars).toMatchObject({
       DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH: `/frames/${frame.sId}/publications/${publicationId}/publication.json`,
-      DUST_SANDBOX_DATABASES_DIR: "/pod-state/databases",
+      DUST_SANDBOX_DATABASES_DIR: "/sandbox-state/databases",
       DUST_SANDBOX_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_SANDBOX_DATABASE_PREFIX: "",
-      DUST_POD_DATABASES_DIR: "/pod-state/databases",
+      DUST_POD_DATABASES_DIR: "/sandbox-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_POD_DATABASE_PREFIX: "",
       DUST_FUNCTIONS_DIR: `/frames/${frame.sId}/publications/${publicationId}/functions`,

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -142,7 +142,7 @@ export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/sandbox-state/replica";
  * it to GCS. Front is the only layer that hardcodes this location and passes it per exec through
  * both the canonical `DUST_SANDBOX_DATABASES_DIR` ABI and its legacy alias.
  */
-export const SANDBOX_STATE_DATABASES_DIR = "/pod-state/databases";
+export const SANDBOX_STATE_DATABASES_DIR = "/sandbox-state/databases";
 
 /**
  * Per-database size quota in bytes (1 GiB). The other half of the paths-env.v1 contract: like


### PR DESCRIPTION
## Description

Move Front's live SQLite path from `/pod-state/databases` to `/sandbox-state/databases`. Both canonical and legacy database environment keys carry the same canonical path.

Stacked on #31570 because that PR introduces the canonical environment keys. The image compatibility bridge is #31603.

## Tests

- Sandbox database and invocation tests (54 tests)
- Project app deletion test (7 tests)
- Front `tsgo`
- Biome on all changed files

## Risk

High if deployed before #31603's dust-base image. Safe afterward because the image owns the canonical directory and keeps the old path as a symlink.

## Deploy Plan

Merge after #31570. Deploy only after #31603 and its dust-base image have fully rolled out to sandboxes. Roll back this PR to resume emitting the legacy path.
