### PR TITLE
[front] feat: pool credit usage column shows only extra seat usage

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -273,7 +273,7 @@ export function UsagePage() {
 
   const sort = sorting[0];
   const membersOrderColumn =
-    sort?.id === "email" || sort?.id === "consumedAwuCredits"
+    sort?.id === "email" || sort?.id === "consumedFromPoolAwuCredits"
       ? sort.id
       : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -272,10 +272,18 @@ export function UsagePage() {
   }, []);
 
   const sort = sorting[0];
+  // The legacy table's pool-usage cell displays total consumption
+  // (consumedAwuCredits), not the pool-only amount, so its "column" of the
+  // same id must sort by the total. Only the compact/Poke variant, which
+  // shows pool-only usage, sorts by consumedFromPoolAwuCredits.
+  // TODO(avervaet, 2026-09-02): remove once the app page and Poke page usage
+  // tables are uniformized.
   const membersOrderColumn =
-    sort?.id === "email" || sort?.id === "consumedFromPoolAwuCredits"
+    sort?.id === "email"
       ? sort.id
-      : "name";
+      : sort?.id === "consumedFromPoolAwuCredits"
+        ? "consumedAwuCredits"
+        : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 
   const { myUsage } = useMyUsage({ workspaceId: owner.sId });

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -176,7 +176,7 @@ export function PoolUsagePage() {
 
   const sort = sorting[0];
   const orderColumn =
-    sort?.id === "email" || sort?.id === "consumedAwuCredits"
+    sort?.id === "email" || sort?.id === "consumedFromPoolAwuCredits"
       ? sort.id
       : "name";
   const orderDirection = sort?.desc ? "desc" : "asc";

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -5,9 +5,11 @@ import {
 import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
 import {
+  AT_POOL_LIMIT_BAR_CLASSES,
   getSeatBarClasses,
   getSeatIconColorClass,
   MUTED_BAR_CLASSES,
+  OVER_POOL_LIMIT_BAR_CLASSES,
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
@@ -184,10 +186,10 @@ interface AwuUsageBarProps {
   spendLimitSource: EffectiveSpendLimitSource;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
-  // Shows only the workspace-pool portion of usage (pool consumed / pool
-  // remaining + overage), hiding the seat-allowance section entirely. The
-  // limit figure above the bar becomes the pool limit instead of the
-  // combined (seat + pool) effective limit. Used by the compact Poke
+  // Shows only the workspace-pool portion of usage as a single bar (muted,
+  // orange at the limit, red over it), hiding the seat-allowance section
+  // entirely. The limit figure above the bar becomes the pool limit instead
+  // of the combined (seat + pool) effective limit. Used by the compact Poke
   // layout, which surfaces seat allowance separately in its own column.
   poolOnly?: boolean;
 }
@@ -263,38 +265,40 @@ export function AwuUsageBar({
   const overage =
     poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
 
-  if (poolOnly && poolLimit !== null && poolLimit <= 0) {
-    // No pool access, but credits were still consumed from it (e.g. legacy
-    // overage predating the seat's current limit). Surface the actual
-    // amount instead of hiding it behind "--".
-    const hasUnexpectedPoolConsumption = consumedFromPool > 0;
+  if (poolOnly) {
+    // Single bar: muted while under the pool limit, orange exactly at it,
+    // red once consumption exceeds it. `poolLimit` of 0 (no pool access)
+    // falls out of the same rule — any consumption there is already over.
+    const isOverPoolLimit = poolLimit !== null && consumedFromPool > poolLimit;
+    const isAtPoolLimit =
+      poolLimit !== null && poolLimit > 0 && consumedFromPool === poolLimit;
+    const fillClassName = isOverPoolLimit
+      ? OVER_POOL_LIMIT_BAR_CLASSES.fill
+      : isAtPoolLimit
+        ? AT_POOL_LIMIT_BAR_CLASSES.fill
+        : MUTED_BAR_CLASSES.fill;
+    const percentage =
+      poolLimit !== null && poolLimit > 0
+        ? Math.min(100, (consumedFromPool / poolLimit) * 100)
+        : consumedFromPool > 0
+          ? 100
+          : 0;
+    const limitLabel = poolLimit === null ? "∞" : formatCredits(poolLimit);
     return (
       <div className="flex w-full flex-col gap-1">
-        <div className="flex justify-between text-xs tabular-nums text-muted-foreground">
-          <span>
-            {hasUnexpectedPoolConsumption
-              ? formatCredits(consumedFromPool)
-              : "--"}
-          </span>
-          {isPending ? <Spinner size="xs" /> : <span>--</span>}
+        <div className="flex justify-between text-xs tabular-nums text-foreground">
+          <span>{formatCredits(consumedFromPool)}</span>
+          {isPending ? <Spinner size="xs" /> : <span>{limitLabel}</span>}
         </div>
         <div className="flex h-3 w-full items-center">
           <ProgressBar
-            aria-label="Member credit usage"
-            aria-valuenow={hasUnexpectedPoolConsumption ? 100 : 0}
-            aria-valuetext={
-              hasUnexpectedPoolConsumption
-                ? `${formatCredits(consumedFromPool)} credits used from the workspace pool with no pool access`
-                : "No pool access"
-            }
+            aria-label="Member pool credit usage"
+            aria-valuenow={percentage}
+            aria-valuetext={`${formatCredits(consumedFromPool)} of ${limitLabel} pool credits used`}
             className="h-1 w-full gap-px bg-transparent"
             values={[
-              {
-                value: 1,
-                className: hasUnexpectedPoolConsumption
-                  ? OVERAGE_BAR_CLASSES.fill
-                  : MUTED_BAR_CLASSES.track,
-              },
+              { value: percentage, className: fillClassName },
+              { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
             ]}
           />
         </div>
@@ -308,14 +312,14 @@ export function AwuUsageBar({
     label: string;
   }> = [];
   const creditLabel = isFreeWithBalance ? "lifetime credits" : "seat allowance";
-  if (!poolOnly && seatConsumed > 0) {
+  if (seatConsumed > 0) {
     sections.push({
       value: seatConsumed,
       className: seatColors.fill,
       label: `${formatCredits(seatConsumed)} of ${formatCredits(allowance)} ${creditLabel} used`,
     });
   }
-  if (!poolOnly && seatRemaining > 0) {
+  if (seatRemaining > 0) {
     sections.push({
       value: seatRemaining,
       className: seatColors.track,
@@ -336,29 +340,17 @@ export function AwuUsageBar({
       label: `${formatCredits(poolRemaining)} credits remaining before spend limit`,
     });
   }
-  if (poolOnly && overage > 0) {
-    sections.push({
-      value: overage,
-      className: OVERAGE_BAR_CLASSES.fill,
-      label: `${formatCredits(overage)} credits over the pool limit`,
-    });
-  }
 
   const total = sections.reduce((sum, s) => sum + s.value, 0);
   const usedPercentage =
     total > 0
       ? Math.min(
           100,
-          Math.max(
-            0,
-            ((poolOnly ? poolConsumed + overage : seatConsumed + poolConsumed) /
-              total) *
-              100
-          )
+          Math.max(0, ((seatConsumed + poolConsumed) / total) * 100)
         )
       : 0;
 
-  const hasSeatSections = !poolOnly && (seatConsumed > 0 || seatRemaining > 0);
+  const hasSeatSections = seatConsumed > 0 || seatRemaining > 0;
   // Only surface the pool when there's actually a pool to spend from: a finite
   // positive limit, or uncapped (null). A zero pool limit (free) has no pool.
   const hasPoolSections =
@@ -442,19 +434,13 @@ export function AwuUsageBar({
     </div>
   );
 
-  const headlineConsumed = poolOnly
-    ? poolConsumed + overage
-    : isFreeWithBalance
-      ? Math.min(lifetimeConsumed! + overage, allowance)
-      : effectiveLimit !== null
-        ? Math.min(consumed, effectiveLimit)
-        : consumed;
+  const headlineConsumed = isFreeWithBalance
+    ? Math.min(lifetimeConsumed! + overage, allowance)
+    : effectiveLimit !== null
+      ? Math.min(consumed, effectiveLimit)
+      : consumed;
   // null means uncapped
-  const headlineLimit = poolOnly
-    ? poolLimit
-    : isFreeWithBalance
-      ? allowance
-      : effectiveLimit;
+  const headlineLimit = isFreeWithBalance ? allowance : effectiveLimit;
   const headlineLimitLabel =
     headlineLimit === null ? "Unlimited" : formatCredits(headlineLimit);
   return (

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -186,11 +186,7 @@ interface AwuUsageBarProps {
   spendLimitSource: EffectiveSpendLimitSource;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
-  // Shows only the workspace-pool portion of usage as a single bar (muted,
-  // orange at the limit, red over it), hiding the seat-allowance section
-  // entirely. The limit figure above the bar becomes the pool limit instead
-  // of the combined (seat + pool) effective limit. Used by the compact Poke
-  // layout, which surfaces seat allowance separately in its own column.
+  // TODO(avervaet, 2026-09-01): remove once the app page and Poke page usage tables are uniformized.
   poolOnly?: boolean;
 }
 
@@ -266,9 +262,6 @@ export function AwuUsageBar({
     poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
 
   if (poolOnly) {
-    // Single bar: muted while under the pool limit, orange exactly at it,
-    // red once consumption exceeds it. `poolLimit` of 0 (no pool access)
-    // falls out of the same rule — any consumption there is already over.
     const isOverPoolLimit = poolLimit !== null && consumedFromPool > poolLimit;
     const isAtPoolLimit =
       poolLimit !== null && poolLimit > 0 && consumedFromPool === poolLimit;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -177,14 +177,19 @@ interface AwuUsageBarProps {
   // instead of period spend.
   seatBalanceAwu?: number | null;
   // The fully-resolved spend cap from `spendLimitAwuCredits` (member override,
-  // group cap or workspace default, all including seat allowance). Always
-  // non-null for seated users — workspace default pool cap treats null as 0
-  // (seat-only). Pass `?? 0` as a TypeScript guard only.
-  effectiveLimit: number;
+  // group cap or workspace default, all including seat allowance). `null`
+  // means uncapped
+  effectiveLimit: number | null;
   // Where `effectiveLimit` comes from — shown as a tooltip on the limit figure.
   spendLimitSource: EffectiveSpendLimitSource;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
+  // Shows only the workspace-pool portion of usage (pool consumed / pool
+  // remaining + overage), hiding the seat-allowance section entirely. The
+  // limit figure above the bar becomes the pool limit instead of the
+  // combined (seat + pool) effective limit. Used by the compact Poke
+  // layout, which surfaces seat allowance separately in its own column.
+  poolOnly?: boolean;
 }
 
 // Human-readable origin of the effective spend limit, or null when there is
@@ -217,6 +222,7 @@ export function AwuUsageBar({
   spendLimitSource,
   seatType,
   isTotalAllowedUsagePending: isPending,
+  poolOnly = false,
 }: AwuUsageBarProps) {
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
@@ -257,20 +263,59 @@ export function AwuUsageBar({
   const overage =
     poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
 
+  if (poolOnly && poolLimit !== null && poolLimit <= 0) {
+    // No pool access, but credits were still consumed from it (e.g. legacy
+    // overage predating the seat's current limit). Surface the actual
+    // amount instead of hiding it behind "--".
+    const hasUnexpectedPoolConsumption = consumedFromPool > 0;
+    return (
+      <div className="flex w-full flex-col gap-1">
+        <div className="flex justify-between text-xs tabular-nums text-muted-foreground">
+          <span>
+            {hasUnexpectedPoolConsumption
+              ? formatCredits(consumedFromPool)
+              : "--"}
+          </span>
+          {isPending ? <Spinner size="xs" /> : <span>--</span>}
+        </div>
+        <div className="flex h-3 w-full items-center">
+          <ProgressBar
+            aria-label="Member credit usage"
+            aria-valuenow={hasUnexpectedPoolConsumption ? 100 : 0}
+            aria-valuetext={
+              hasUnexpectedPoolConsumption
+                ? `${formatCredits(consumedFromPool)} credits used from the workspace pool with no pool access`
+                : "No pool access"
+            }
+            className="h-1 w-full gap-px bg-transparent"
+            values={[
+              {
+                value: 1,
+                className: hasUnexpectedPoolConsumption
+                  ? OVERAGE_BAR_CLASSES.fill
+                  : MUTED_BAR_CLASSES.track,
+              },
+            ]}
+          />
+        </div>
+      </div>
+    );
+  }
+
   const sections: Array<{
     value: number;
     className: string;
     label: string;
   }> = [];
   const creditLabel = isFreeWithBalance ? "lifetime credits" : "seat allowance";
-  if (seatConsumed > 0) {
+  if (!poolOnly && seatConsumed > 0) {
     sections.push({
       value: seatConsumed,
       className: seatColors.fill,
       label: `${formatCredits(seatConsumed)} of ${formatCredits(allowance)} ${creditLabel} used`,
     });
   }
-  if (seatRemaining > 0) {
+  if (!poolOnly && seatRemaining > 0) {
     sections.push({
       value: seatRemaining,
       className: seatColors.track,
@@ -291,18 +336,29 @@ export function AwuUsageBar({
       label: `${formatCredits(poolRemaining)} credits remaining before spend limit`,
     });
   }
-  // Overage is surfaced in the tooltip only, not as a bar segment.
+  if (poolOnly && overage > 0) {
+    sections.push({
+      value: overage,
+      className: OVERAGE_BAR_CLASSES.fill,
+      label: `${formatCredits(overage)} credits over the pool limit`,
+    });
+  }
 
   const total = sections.reduce((sum, s) => sum + s.value, 0);
   const usedPercentage =
     total > 0
       ? Math.min(
           100,
-          Math.max(0, ((seatConsumed + poolConsumed) / total) * 100)
+          Math.max(
+            0,
+            ((poolOnly ? poolConsumed + overage : seatConsumed + poolConsumed) /
+              total) *
+              100
+          )
         )
       : 0;
 
-  const hasSeatSections = seatConsumed > 0 || seatRemaining > 0;
+  const hasSeatSections = !poolOnly && (seatConsumed > 0 || seatRemaining > 0);
   // Only surface the pool when there's actually a pool to spend from: a finite
   // positive limit, or uncapped (null). A zero pool limit (free) has no pool.
   const hasPoolSections =
@@ -386,30 +442,35 @@ export function AwuUsageBar({
     </div>
   );
 
+  const headlineConsumed = poolOnly
+    ? poolConsumed + overage
+    : isFreeWithBalance
+      ? Math.min(lifetimeConsumed! + overage, allowance)
+      : effectiveLimit !== null
+        ? Math.min(consumed, effectiveLimit)
+        : consumed;
+  // null means uncapped
+  const headlineLimit = poolOnly
+    ? poolLimit
+    : isFreeWithBalance
+      ? allowance
+      : effectiveLimit;
+  const headlineLimitLabel =
+    headlineLimit === null ? "Unlimited" : formatCredits(headlineLimit);
   return (
     <div className="flex w-full flex-col gap-1">
       <div className="flex justify-between text-xs tabular-nums text-foreground">
-        <span>
-          {isFreeWithBalance
-            ? formatCredits(Math.min(lifetimeConsumed! + overage, allowance))
-            : formatCredits(
-                effectiveLimit !== null
-                  ? Math.min(consumed, effectiveLimit)
-                  : consumed
-              )}
-        </span>
+        <span>{formatCredits(headlineConsumed)}</span>
         {isPending ? (
           <Spinner size="xs" />
-        ) : isFreeWithBalance ? (
-          <span>{formatCredits(allowance)}</span>
-        ) : sourceLabel !== null ? (
+        ) : !isFreeWithBalance && sourceLabel !== null ? (
           <Tooltip
             tooltipTriggerAsChild
             label={sourceLabel}
-            trigger={<span>{formatCredits(effectiveLimit)}</span>}
+            trigger={<span>{headlineLimitLabel}</span>}
           />
         ) : (
-          <span>{formatCredits(effectiveLimit)}</span>
+          <span>{headlineLimitLabel}</span>
         )}
       </div>
       {tooltipContent ? (
@@ -650,11 +711,12 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function buildConsumedAwuCreditsColumn(
-  creditsResetAt: string | null
+function buildPoolCreditUsageColumn(
+  creditsResetAt: string | null,
+  variant: MembersUsageTableVariant
 ): ColumnDef<RowData, string> {
   return {
-    id: "consumedAwuCredits" as const,
+    id: "consumedFromPoolAwuCredits" as const,
     header: () => (
       <div className="flex flex-col">
         <span>Credits usage this month</span>
@@ -670,7 +732,7 @@ function buildConsumedAwuCreditsColumn(
         )}
       </div>
     ),
-    accessorFn: (row) => row.consumedAwuCredits.toString(),
+    accessorFn: (row) => row.consumedFromPoolAwuCredits.toString(),
     cell: (info: Info) => (
       <div className="w-full pr-3">
         <AwuUsageBar
@@ -681,12 +743,13 @@ function buildConsumedAwuCreditsColumn(
           consumedFromPool={info.row.original.consumedFromPoolAwuCredits}
           memberUsageLimit={info.row.original.memberUsageLimit}
           seatBalanceAwu={info.row.original.seatBalanceAwu}
-          effectiveLimit={info.row.original.spendLimitAwuCredits ?? 0}
+          effectiveLimit={info.row.original.spendLimitAwuCredits}
           spendLimitSource={info.row.original.spendLimitSource}
           seatType={info.row.original.seatType}
           isTotalAllowedUsagePending={
             info.row.original.isTotalAllowedUsagePending
           }
+          poolOnly={variant === "compact"}
         />
       </div>
     ),
@@ -786,7 +849,7 @@ function buildColumns({
       }
     })(),
     {
-      ...buildConsumedAwuCreditsColumn(creditsResetAt),
+      ...buildPoolCreditUsageColumn(creditsResetAt, variant),
       meta: { className: "w-64" },
     },
     actionsColumn,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -262,11 +262,6 @@ export function AwuUsageBar({
   if (poolOnly) {
     const isOverPoolLimit = consumedFromPool > poolLimit;
     const isAtPoolLimit = poolLimit > 0 && consumedFromPool === poolLimit;
-    const fillClassName = isOverPoolLimit
-      ? OVER_POOL_LIMIT_BAR_CLASSES.fill
-      : isAtPoolLimit
-        ? AT_POOL_LIMIT_BAR_CLASSES.fill
-        : MUTED_BAR_CLASSES.fill;
     const percentage =
       poolLimit > 0
         ? Math.min(100, (consumedFromPool / poolLimit) * 100)
@@ -287,7 +282,14 @@ export function AwuUsageBar({
             aria-valuetext={`${formatCredits(consumedFromPool)} of ${limitLabel} pool credits used`}
             className="h-1 w-full gap-px bg-transparent"
             values={[
-              { value: percentage, className: fillClassName },
+              {
+                value: percentage,
+                className: isOverPoolLimit
+                  ? OVER_POOL_LIMIT_BAR_CLASSES.fill
+                  : isAtPoolLimit
+                    ? AT_POOL_LIMIT_BAR_CLASSES.fill
+                    : MUTED_BAR_CLASSES.fill,
+              },
               { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
             ]}
           />

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -180,7 +180,9 @@ interface AwuUsageBarProps {
   seatBalanceAwu?: number | null;
   // The fully-resolved spend cap from `spendLimitAwuCredits` (member override,
   // group cap or workspace default, all including seat allowance). `null`
-  // means uncapped
+  // means no cap could be resolved and is treated as no pool access (capped
+  // at the seat allowance) — unlimited/uncapped is not a supported product
+  // state right now.
   effectiveLimit: number | null;
   // Where `effectiveLimit` comes from — shown as a tooltip on the limit figure.
   spendLimitSource: EffectiveSpendLimitSource;
@@ -234,49 +236,44 @@ export function AwuUsageBar({
   const lifetimeConsumed = isFreeWithBalance
     ? Math.max(0, memberUsageLimit - seatBalanceAwu!)
     : null;
-  // Uncapped is not a real product state: fall back to seat allowance when no
-  // explicit spend limit is configured (no pool access).
+  // Unlimited/uncapped is not a supported product state right now: a `null`
+  // effective limit is treated as no pool access (capped at the seat
+  // allowance), same as an explicit "none" seat.
   // The bar splits consumption into seat → pool → overage:
   //   seat consumed · seat remaining · pool consumed · pool remaining · overage
   // `poolLimit` is the headroom above the seat allowance (0 = seat-only, e.g. free).
   // A seat with no pool (poolLimit === 0) shows no pool section —
   // any spend beyond the seat allowance is overage. Zero-width sections are
-  // skipped. `pool remaining` is omitted when uncapped (no finite headroom).
+  // skipped.
   const seatConsumed = isFreeWithBalance
     ? lifetimeConsumed!
     : consumedFromAllowance;
   const seatRemaining = isFreeWithBalance
     ? seatBalanceAwu!
     : Math.max(0, allowance - seatConsumed);
-  const poolLimit =
-    effectiveLimit !== null ? Math.max(0, effectiveLimit - allowance) : null;
+  const resolvedEffectiveLimit = effectiveLimit ?? allowance;
+  const poolLimit = Math.max(0, resolvedEffectiveLimit - allowance);
   // Of the pool consumption, the part within the pool limit vs. the overage
-  // beyond it (only capped seats can have overage).
-  const poolConsumed =
-    poolLimit !== null
-      ? Math.min(consumedFromPool, poolLimit)
-      : consumedFromPool;
-  const poolRemaining =
-    poolLimit !== null ? Math.max(0, poolLimit - poolConsumed) : null;
-  const overage =
-    poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
+  // beyond it.
+  const poolConsumed = Math.min(consumedFromPool, poolLimit);
+  const poolRemaining = Math.max(0, poolLimit - poolConsumed);
+  const overage = Math.max(0, consumedFromPool - poolLimit);
 
   if (poolOnly) {
-    const isOverPoolLimit = poolLimit !== null && consumedFromPool > poolLimit;
-    const isAtPoolLimit =
-      poolLimit !== null && poolLimit > 0 && consumedFromPool === poolLimit;
+    const isOverPoolLimit = consumedFromPool > poolLimit;
+    const isAtPoolLimit = poolLimit > 0 && consumedFromPool === poolLimit;
     const fillClassName = isOverPoolLimit
       ? OVER_POOL_LIMIT_BAR_CLASSES.fill
       : isAtPoolLimit
         ? AT_POOL_LIMIT_BAR_CLASSES.fill
         : MUTED_BAR_CLASSES.fill;
     const percentage =
-      poolLimit !== null && poolLimit > 0
+      poolLimit > 0
         ? Math.min(100, (consumedFromPool / poolLimit) * 100)
         : consumedFromPool > 0
           ? 100
           : 0;
-    const limitLabel = poolLimit === null ? "∞" : formatCredits(poolLimit);
+    const limitLabel = formatCredits(poolLimit);
     return (
       <div className="flex w-full flex-col gap-1">
         <div className="flex justify-between text-xs tabular-nums text-foreground">
@@ -326,7 +323,7 @@ export function AwuUsageBar({
       label: `${formatCredits(poolConsumed)} credits used from the workspace pool`,
     });
   }
-  if (poolRemaining !== null && poolRemaining > 0) {
+  if (poolRemaining > 0) {
     sections.push({
       value: poolRemaining,
       className: MUTED_BAR_CLASSES.track,
@@ -344,11 +341,10 @@ export function AwuUsageBar({
       : 0;
 
   const hasSeatSections = seatConsumed > 0 || seatRemaining > 0;
-  // Only surface the pool when there's actually a pool to spend from: a finite
-  // positive limit, or uncapped (null). A zero pool limit (free) has no pool.
+  // Only surface the pool when there's actually a pool to spend from (a
+  // zero pool limit, e.g. free/none, has no pool).
   const hasPoolSections =
-    (poolLimit === null || poolLimit > 0) &&
-    (poolConsumed > 0 || (poolRemaining !== null && poolRemaining > 0));
+    poolLimit > 0 && (poolConsumed > 0 || poolRemaining > 0);
 
   const tooltipLines: Array<{
     track: string;
@@ -369,10 +365,7 @@ export function AwuUsageBar({
       track: MUTED_BAR_CLASSES.track,
       fill: MUTED_BAR_CLASSES.fill,
       legend: "Pool usage",
-      usage:
-        poolLimit !== null
-          ? `${formatCredits(poolConsumed)} credits used out of ${formatCredits(poolLimit)}`
-          : `${formatCredits(poolConsumed)} credits used`,
+      usage: `${formatCredits(poolConsumed)} credits used out of ${formatCredits(poolLimit)}`,
     });
   }
   if (overage > 0) {
@@ -429,13 +422,9 @@ export function AwuUsageBar({
 
   const headlineConsumed = isFreeWithBalance
     ? Math.min(lifetimeConsumed! + overage, allowance)
-    : effectiveLimit !== null
-      ? Math.min(consumed, effectiveLimit)
-      : consumed;
-  // null means uncapped
-  const headlineLimit = isFreeWithBalance ? allowance : effectiveLimit;
-  const headlineLimitLabel =
-    headlineLimit === null ? "Unlimited" : formatCredits(headlineLimit);
+    : Math.min(consumed, resolvedEffectiveLimit);
+  const headlineLimit = isFreeWithBalance ? allowance : resolvedEffectiveLimit;
+  const headlineLimitLabel = formatCredits(headlineLimit);
   return (
     <div className="flex w-full flex-col gap-1">
       <div className="flex justify-between text-xs tabular-nums text-foreground">

--- a/front/components/workspace/seat_styles.ts
+++ b/front/components/workspace/seat_styles.ts
@@ -33,6 +33,17 @@ export const OVERAGE_BAR_CLASSES = {
   fill: "bg-warning-700",
 };
 
+// Pool credit bar fill exactly at its limit — a warning ahead of the overage
+// (red) color used once consumption exceeds it.
+export const AT_POOL_LIMIT_BAR_CLASSES = {
+  fill: "bg-warning-500",
+};
+
+// Pool credit bar fill once consumption exceeds its limit.
+export const OVER_POOL_LIMIT_BAR_CLASSES = {
+  fill: "bg-red-500",
+};
+
 // Seat icon text color: golden for max, highlight blue for pro, muted grey
 // otherwise (free / none / workspace).
 export function getSeatIconColorClass(seatType: MembershipSeatType): string {

--- a/front/components/workspace/seat_styles.ts
+++ b/front/components/workspace/seat_styles.ts
@@ -26,8 +26,8 @@ export const MUTED_BAR_CLASSES = {
   fill: SEAT_TIER_STYLES.muted.barFill,
 };
 
-// Overage bar colors (spend beyond the seat allowance + pool limit) — red, to
-// signal the user is over their cap.
+// Overage bar colors (spend beyond the seat allowance + pool limit) —
+// warning/orange, to signal the user is over their cap.
 export const OVERAGE_BAR_CLASSES = {
   track: "bg-warning-200",
   fill: "bg-warning-700",

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1566,9 +1566,14 @@ export async function getMemberUsage({
   // allowance, it just has no pool headroom on top. There's no default cap alert
   // for free (normalizeToPoolLimitSeatType is null), so we supply it explicitly.
   // Use the member's real free-credit total (which a rep may have raised) rather
-  // than the constant.
+  // than the constant. "none" seats have no seat and no pool access, so their
+  // cap is explicitly 0 rather than falling through to an unlimited `null`.
   const effectiveDefaultAwuCredits =
-    membership.seatType === "free" ? effectiveAllocationAwu : defaultAwuCredits;
+    membership.seatType === "free"
+      ? effectiveAllocationAwu
+      : membership.seatType === "none"
+        ? 0
+        : defaultAwuCredits;
 
   // Max group cap (pool-only) + seat allowance, matching override/default units.
   // Only pool-bearing seats (pro/max/workspace) get a group cap.
@@ -2334,10 +2339,14 @@ export async function getMembersUsage({
     // allowance (allowance + 0 pool) — the cap includes the allowance like every
     // other seat, it just has no pool headroom on top. Use the member's real
     // free-credit total (which a rep may have raised) rather than the constant.
+    // "none" seats have no seat and no pool access, so their cap is explicitly
+    // 0 rather than falling through to an unlimited `null`.
     const effectiveDefaultAwuCredits =
       membership.seatType === "free"
         ? effectiveAllocationAwu
-        : defaultAwuCredits;
+        : membership.seatType === "none"
+          ? 0
+          : defaultAwuCredits;
 
     // Max group cap (pool-only, stored on the group) + seat allowance, to match
     // the units of override/default above. Only pool-bearing seats

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -889,15 +889,13 @@ export async function sumActiveMembersPoolConsumedCredits({
   // alongside pure external calls, so the three fetchers below must stay Metronome/Redis-only.
   // If one of them ever needs a DB read, pull it out and sequence it before this Promise.all
   // instead of adding it here.
-  const [usageByMetronomeUserId, { freeStartingByUserId }, seatDataByUserId] =
+  const [consumedByUserId, { freeStartingByUserId }, seatDataByUserId] =
     await Promise.all([
-      fetchPerUserUsageCreditsForMembersTable({
+      fetchConsumedAwuCreditsFromMetronomeByUserId({
         workspaceId: auth.getNonNullableWorkspace().sId,
         metronomeCustomerId,
         metronomeContractId,
-        userIds: members.map((m) =>
-          m.seatType === "free" ? toFreeMetronomeUserId(m.sId) : m.sId
-        ),
+        users: members,
       }),
       fetchFreeSeatCreditsForMembersTable({ metronomeCustomerId }),
       fetchSeatDataForMembersTable({
@@ -908,12 +906,7 @@ export async function sumActiveMembersPoolConsumedCredits({
 
   let sumConsumedFromPoolAwuCredits = 0;
   for (const member of members) {
-    const metronomeUserId =
-      member.seatType === "free"
-        ? toFreeMetronomeUserId(member.sId)
-        : member.sId;
-    const totalConsumedCredits =
-      usageByMetronomeUserId.get(metronomeUserId) ?? 0;
+    const totalConsumedCredits = consumedByUserId.get(member.sId) ?? 0;
     const freeStartingBalanceAwu =
       member.seatType === "free"
         ? (freeStartingByUserId.get(member.sId) ?? null)
@@ -2234,21 +2227,17 @@ export async function getMembersUsage({
   // Bulk-fetch each user's Metronome-side per-user AWU consumption (poke-only),
   // shown next to the ES and rate-limiter figures to spot divergence. Reuses the
   // resilient wrapper (empty map when Metronome isn't configured or on error).
-  const metronomeConsumedByUserId = new Map<string, number>();
-  if (includeAlertLinks) {
-    const usage = await fetchPerUserUsageCreditsForMembersTable({
-      workspaceId: workspace.sId,
-      metronomeCustomerId: metronomeCustomerId ?? null,
-      metronomeContractId,
-      userIds: users.flatMap((u) => [u.sId, toFreeMetronomeUserId(u.sId)]),
-    });
-    for (const u of users) {
-      const membership = membershipByUserId.get(u.id);
-      const metronomeUserId =
-        membership?.seatType === "free" ? toFreeMetronomeUserId(u.sId) : u.sId;
-      metronomeConsumedByUserId.set(u.sId, usage.get(metronomeUserId) ?? 0);
-    }
-  }
+  const metronomeConsumedByUserId = includeAlertLinks
+    ? await fetchConsumedAwuCreditsFromMetronomeByUserId({
+        workspaceId: workspace.sId,
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        metronomeContractId,
+        users: users.map((u) => ({
+          sId: u.sId,
+          seatType: membershipByUserId.get(u.id)?.seatType ?? null,
+        })),
+      })
+    : new Map<string, number>();
 
   // Bulk-fetch each user's fair-use AWU credit usage (poke-only). This is a
   // bounded page (≤ 150) of Redis reads, so batch with `concurrentExecutor`.

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -718,7 +718,7 @@ async function fetchConsumedAwuCreditsFromMetronomeByUserId({
   if (users.length === 0) {
     return new Map();
   }
-  const metronomeUserIdBySId = new Map(
+  const metronomeUserIdById = new Map(
     users.map((u) => [
       u.sId,
       u.seatType === "free" ? toFreeMetronomeUserId(u.sId) : u.sId,
@@ -728,11 +728,11 @@ async function fetchConsumedAwuCreditsFromMetronomeByUserId({
     workspaceId,
     metronomeCustomerId,
     metronomeContractId,
-    userIds: [...metronomeUserIdBySId.values()],
+    userIds: [...metronomeUserIdById.values()],
   });
   const consumedByUserId = new Map<string, number>();
   for (const u of users) {
-    const metronomeUserId = metronomeUserIdBySId.get(u.sId)!;
+    const metronomeUserId = metronomeUserIdById.get(u.sId)!;
     consumedByUserId.set(
       u.sId,
       usageByMetronomeUserId.get(metronomeUserId) ?? 0
@@ -1863,7 +1863,6 @@ async function resolveMembersUsagePageUsers({
         consumedByUserId,
         { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
         freeSeatCredits,
-        groupCapByUserModelId,
       ] = await Promise.all([
         fetchConsumedAwuCreditsFromMetronomeByUserId({
           workspaceId: workspace.sId,
@@ -1889,11 +1888,12 @@ async function resolveMembersUsagePageUsers({
               freeBalanceByUserId: new Map<string, number>(),
               freeStartingByUserId: new Map<string, number>(),
             }),
-        GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      ]);
+      const groupCapByUserModelId =
+        await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
           workspace,
           userModelIds: allUsers.map((u) => u.id),
-        }),
-      ]);
+        });
       const { freeStartingByUserId } = freeSeatCredits;
       for (const u of allUsers) {
         const membership = membershipByUserModelId.get(u.id);

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -229,7 +229,17 @@ export const MembersUsagePaginationSchema = z.object({
   // the search index; every other column is sorted in-app over the full
   // matching set (see resolveMembersUsagePageUsers).
   orderColumn: z
-    .enum(["name", "email", "consumedAwuCredits", "seatType", "creditState"])
+    .enum([
+      "name",
+      "email",
+      // Legacy usage page only: sorts by total consumed credits. Kept
+      // alongside `consumedFromPoolAwuCredits`, which sorts by pool-only
+      // consumption for the compact (Poke) variant.
+      "consumedAwuCredits",
+      "consumedFromPoolAwuCredits",
+      "seatType",
+      "creditState",
+    ])
     .catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
   // Optional seat-type filter. A base seat type (e.g. "pro") matches its
@@ -691,6 +701,43 @@ async function fetchPerUserUsageCreditsForMembersTable({
     );
     return new Map();
   }
+}
+
+async function fetchConsumedAwuCreditsFromMetronomeByUserId({
+  workspaceId,
+  metronomeCustomerId,
+  metronomeContractId,
+  users,
+}: {
+  workspaceId: string;
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+  users: { sId: string; seatType: MembershipSeatType | null }[];
+}): Promise<Map<string, number>> {
+  if (users.length === 0) {
+    return new Map();
+  }
+  const metronomeUserIdBySId = new Map(
+    users.map((u) => [
+      u.sId,
+      u.seatType === "free" ? toFreeMetronomeUserId(u.sId) : u.sId,
+    ])
+  );
+  const usageByMetronomeUserId = await fetchPerUserUsageCreditsForMembersTable({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId,
+    userIds: [...metronomeUserIdBySId.values()],
+  });
+  const consumedByUserId = new Map<string, number>();
+  for (const u of users) {
+    const metronomeUserId = metronomeUserIdBySId.get(u.sId)!;
+    consumedByUserId.set(
+      u.sId,
+      usageByMetronomeUserId.get(metronomeUserId) ?? 0
+    );
+  }
+  return consumedByUserId;
 }
 
 /** Exported for testing. */
@@ -1788,6 +1835,7 @@ async function resolveMembersUsagePageUsers({
   );
 
   const sortKeyByUserId = new Map<string, number | string>();
+  const overageLimitByUserId = new Map<string, number>();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -1803,6 +1851,94 @@ async function resolveMembersUsagePageUsers({
       });
       for (const u of allUsers) {
         sortKeyByUserId.set(u.sId, creditsByUserId.get(u.sId) ?? 0);
+      }
+      break;
+    }
+    case "consumedFromPoolAwuCredits": {
+      const freeSeatUserIds = allUsers.flatMap((u) =>
+        membershipByUserModelId.get(u.id)?.seatType === "free" ? [u.sId] : []
+      );
+      const creditUsageConfig =
+        await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+      const [
+        consumedByUserId,
+        { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
+        freeSeatCredits,
+        groupCapByUserModelId,
+      ] = await Promise.all([
+        fetchConsumedAwuCreditsFromMetronomeByUserId({
+          workspaceId: workspace.sId,
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
+          users: allUsers.map((u) => ({
+            sId: u.sId,
+            seatType: membershipByUserModelId.get(u.id)?.seatType ?? null,
+          })),
+        }),
+        fetchEffectivePerUserSpendLimits({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+          defaultPoolCapAwuCredits:
+            creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
+          includeAlertLinks: false,
+        }),
+        freeSeatUserIds.length > 0
+          ? fetchFreeSeatCreditsForMembersTable({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+            })
+          : Promise.resolve({
+              freeBalanceByUserId: new Map<string, number>(),
+              freeStartingByUserId: new Map<string, number>(),
+            }),
+        GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+          workspace,
+          userModelIds: allUsers.map((u) => u.id),
+        }),
+      ]);
+      const { freeStartingByUserId } = freeSeatCredits;
+      for (const u of allUsers) {
+        const membership = membershipByUserModelId.get(u.id);
+        const seatType = membership?.seatType ?? null;
+        const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+        const seatAllowance = normalizedSeatType
+          ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+          : 0;
+        const totalConsumed = consumedByUserId.get(u.sId) ?? 0;
+        const freeStartingBalanceAwu =
+          seatType === "free"
+            ? (freeStartingByUserId.get(u.sId) ?? null)
+            : null;
+        const effectiveAllocationAwu = freeStartingBalanceAwu ?? seatAllowance;
+        const consumedFromPoolAwuCredits = Math.max(
+          0,
+          totalConsumed - effectiveAllocationAwu
+        );
+        sortKeyByUserId.set(u.sId, consumedFromPoolAwuCredits);
+
+        const overrideAwuCredits =
+          membership?.poolCapOverrideAwuCredits !== null &&
+          membership?.poolCapOverrideAwuCredits !== undefined &&
+          seatType !== "none"
+            ? membership.poolCapOverrideAwuCredits + seatAllowance
+            : null;
+        const groupPoolCapAwuCredits = groupCapByUserModelId.get(u.id) ?? null;
+        const groupCapAwuCredits =
+          groupPoolCapAwuCredits !== null && normalizedSeatType !== null
+            ? groupPoolCapAwuCredits + seatAllowance
+            : null;
+        const defaultAwuCredits = normalizedSeatType
+          ? (defaultCapAwuCreditsBySeatType[normalizedSeatType] ?? 0)
+          : 0;
+        const effectiveSpendLimitAwuCredits =
+          resolveEffectiveSpendLimitAwuCredits({
+            overrideAwuCredits,
+            groupCapAwuCredits,
+            defaultAwuCredits,
+          });
+        overageLimitByUserId.set(
+          u.sId,
+          effectiveSpendLimitAwuCredits - seatAllowance
+        );
       }
       break;
     }
@@ -1838,6 +1974,12 @@ async function resolveMembersUsagePageUsers({
         : String(keyA).localeCompare(String(keyB));
     if (cmp !== 0) {
       return cmp * directionFactor;
+    }
+    // Tiebreak on the highest overage limit, always descending
+    const overageLimitA = overageLimitByUserId.get(a.sId) ?? 0;
+    const overageLimitB = overageLimitByUserId.get(b.sId) ?? 0;
+    if (overageLimitA !== overageLimitB) {
+      return overageLimitB - overageLimitA;
     }
     // Stable, direction-independent tiebreaker so pages don't reshuffle.
     const nameA = (a.fullName() || a.name).toLowerCase();

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -235,6 +235,7 @@ export const MembersUsagePaginationSchema = z.object({
       // Legacy usage page only: sorts by total consumed credits. Kept
       // alongside `consumedFromPoolAwuCredits`, which sorts by pool-only
       // consumption for the compact (Poke) variant.
+      // TODO(avervaet, 2026-09-01): remove once the app page and Poke page usage tables are uniformized.
       "consumedAwuCredits",
       "consumedFromPoolAwuCredits",
       "seatType",

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -458,7 +458,11 @@ export function useMembersUsage({
   searchTerm?: string;
   pageIndex: number;
   pageSize: number;
-  orderColumn?: "name" | "email" | "consumedFromPoolAwuCredits";
+  orderColumn?:
+    | "name"
+    | "email"
+    | "consumedAwuCredits"
+    | "consumedFromPoolAwuCredits";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType | "none";
   groupId?: string;

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -458,7 +458,7 @@ export function useMembersUsage({
   searchTerm?: string;
   pageIndex: number;
   pageSize: number;
-  orderColumn?: "name" | "email" | "consumedAwuCredits";
+  orderColumn?: "name" | "email" | "consumedFromPoolAwuCredits";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType | "none";
   groupId?: string;

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -259,6 +259,7 @@ export function usePokeMembersUsage({
     | "name"
     | "email"
     | "consumedAwuCredits"
+    | "consumedFromPoolAwuCredits"
     | "seatType"
     | "creditState";
   orderDirection?: "asc" | "desc";


### PR DESCRIPTION
## Description

For the compact layout, the pool credit column now hides the seat-allowance section (shown separately in the seat usage column) and shows only pool consumption — left number is credits consumed beyond the seat allowance, right is the pool limit. Bar turns orange/warning on overage, both in the no-pool-access edge case and the general case. Renames the shared column id to consumedFromPoolAwuCredits with backend sort support (kept alongside the existing consumedAwuCredits sort); legacy variant is otherwise unchanged.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. **#31605 (this PR)** — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked (front, front-api). Elasticsearch-backed functional tests (members_usage) couldn't be run locally (no local ES); relied on type-checking and manual code review.

## Risk

Medium. Touches the shared AwuUsageBar/pool-credit column used by the legacy customer page too, and renames a sort key consumed by both the legacy and Poke pages — reviewed carefully to confirm legacy rendering is unaffected, but flagging for extra scrutiny given the shared surface.

## Deploy Plan

Deploy front and front-api.
