### PR TITLE
[front] perf: cache Metronome seat balances with Redis

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -33,7 +33,6 @@ const MEMBER_USAGE = {
   scheduledSeatChangeAt: null,
   scheduledSeatType: null,
   seatType: "max" as const,
-  seatUsageTarget: null,
   seatBalanceAwu: 100,
   seatUsageTarget: null,
   spendLimitAlertId: null,

--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -35,6 +35,7 @@ const MEMBER_USAGE = {
   seatType: "max" as const,
   seatUsageTarget: null,
   seatBalanceAwu: 100,
+  seatUsageTarget: null,
   spendLimitAlertId: null,
   spendLimitAwuCredits: null,
   rateLimiterSpendAwuCredits: null,

--- a/front/lib/api/credits/members_usage.test.ts
+++ b/front/lib/api/credits/members_usage.test.ts
@@ -8,7 +8,7 @@ import {
   getCachedSeatDataByUserId,
 } from "@app/lib/metronome/seats";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
@@ -106,8 +106,8 @@ describe("fetchSeatDataForMembersTable", () => {
   });
 
   it("degrades to an empty map when the cached read fails, without an uncached refetch", async () => {
-    vi.mocked(getCachedSeatDataByUserId).mockRejectedValue(
-      new Error("429 rate limit exceeded")
+    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue(
+      new Err(new Error("429 rate limit exceeded"))
     );
 
     const result = await fetchSeatDataForMembersTable({
@@ -120,7 +120,7 @@ describe("fetchSeatDataForMembersTable", () => {
   });
 
   it("degrades to an empty map when another process holds the fetch lock", async () => {
-    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue(null);
+    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue(new Ok(null));
 
     const result = await fetchSeatDataForMembersTable({
       metronomeCustomerId: "cust_1",
@@ -132,13 +132,15 @@ describe("fetchSeatDataForMembersTable", () => {
   });
 
   it("returns the cached seat data keyed by user id", async () => {
-    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue({
-      user_1: {
-        awuAllocation: 5000,
-        billingFrequency: "MONTHLY",
-        nextCreditResetAt: "2026-09-01T00:00:00.000Z",
-      },
-    });
+    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue(
+      new Ok({
+        user_1: {
+          awuAllocation: 5000,
+          billingFrequency: "MONTHLY",
+          nextCreditResetAt: "2026-09-01T00:00:00.000Z",
+        },
+      })
+    );
 
     const result = await fetchSeatDataForMembersTable({
       metronomeCustomerId: "cust_1",

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -31,10 +31,7 @@ import {
   USER_AWU_WARNING_PERCENTAGE,
 } from "@app/lib/metronome/alerts/spend_limits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
-import {
-  getCachedCustomerPerUserCreditBalances,
-  listMetronomeSeatBalances,
-} from "@app/lib/metronome/client";
+import { getCachedCustomerPerUserCreditBalances } from "@app/lib/metronome/client";
 import {
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   getCreditTypeAwuId,
@@ -45,7 +42,10 @@ import { getPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import type { SeatData } from "@app/lib/metronome/seats";
-import { getCachedSeatDataByUserId } from "@app/lib/metronome/seats";
+import {
+  getCachedSeatBalances,
+  getCachedSeatDataByUserId,
+} from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   getFairUseAwuCreditsStatus,
@@ -792,21 +792,26 @@ async function fetchSeatBalancesForMembersTable({
   if (!metronomeCustomerId || !metronomeContractId || userIds.length === 0) {
     return new Map();
   }
-  const result = await listMetronomeSeatBalances({
-    metronomeCustomerId,
-    metronomeContractId,
-    seatIds: userIds,
-  });
   const balanceByUserId = new Map<string, number>();
-  if (result.isErr()) {
+  let balances;
+  try {
+    balances = await getCachedSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+      seatIds: userIds,
+    });
+  } catch (err) {
     logger.warn(
-      { err: result.error, metronomeCustomerId },
+      { err: normalizeError(err), metronomeCustomerId },
       "[MembersUsage] Failed to fetch seat balances, degrading to empty map"
     );
     return balanceByUserId;
   }
+  if (balances === null) {
+    return balanceByUserId;
+  }
   const awuCreditTypeId = getCreditTypeAwuId();
-  for (const seat of result.value) {
+  for (const seat of balances) {
     const awu = seat.balances.find((b) => b.credit_type_id === awuCreditTypeId);
     if (awu) {
       balanceByUserId.set(seat.seat_id, awu.balance);

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -752,26 +752,26 @@ export async function fetchSeatDataForMembersTable({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-  try {
-    const seatData = await getCachedSeatDataByUserId({
-      metronomeCustomerId,
-      contractId: metronomeContractId,
-    });
-    // null: another process holds the fetch lock (skipIfLocked). Degrade
-    // rather than piling a duplicate Metronome fan-out on top.
-    if (!seatData) {
-      return new Map();
-    }
-    return new Map(Object.entries(seatData));
-  } catch (err) {
+  const seatDataResult = await getCachedSeatDataByUserId({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+  });
+  if (seatDataResult.isErr()) {
     // No uncached fallback: a failing loader means Metronome is already under
     // pressure, and refetching would amplify it (see the 429 storm of 2026-08).
     logger.warn(
-      { err: normalizeError(err), metronomeCustomerId },
+      { err: seatDataResult.error, metronomeCustomerId },
       "[MembersUsage] Failed to read cached seat data, degrading to empty map"
     );
     return new Map();
   }
+  const seatData = seatDataResult.value;
+  // null: another process holds the fetch lock (skipIfLocked). Degrade
+  // rather than piling a duplicate Metronome fan-out on top.
+  if (!seatData) {
+    return new Map();
+  }
+  return new Map(Object.entries(seatData));
 }
 
 // Live per-seat AWU balance remaining for paid (seat-managed) seats, keyed by
@@ -793,20 +793,19 @@ async function fetchSeatBalancesForMembersTable({
     return new Map();
   }
   const balanceByUserId = new Map<string, number>();
-  let balances;
-  try {
-    balances = await getCachedSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId,
-      seatIds: userIds,
-    });
-  } catch (err) {
+  const balancesResult = await getCachedSeatBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+    seatIds: userIds,
+  });
+  if (balancesResult.isErr()) {
     logger.warn(
-      { err: normalizeError(err), metronomeCustomerId },
+      { err: balancesResult.error, metronomeCustomerId },
       "[MembersUsage] Failed to fetch seat balances, degrading to empty map"
     );
     return balanceByUserId;
   }
+  const balances = balancesResult.value;
   if (balances === null) {
     return balanceByUserId;
   }

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import type { Result } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
 // Replace the Redis-backed subscription cache with an in-memory map so the
@@ -25,6 +26,19 @@ vi.mock("@app/lib/utils/cache", () => ({
           const result = await fn(...args);
           inMemoryCache.set(key, JSON.stringify(result));
           return result;
+        };
+      }
+    ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ) => {
+        return async (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> => {
+          return fn(...args);
         };
       }
     ),

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1160,23 +1160,23 @@ describe("computeSeatCreditTransfers", () => {
 // Regression tests for the Metronome 429 storm of 2026-08: the seat-data cache
 // must dedupe fetches fleet-wide (distributed lock + skipIfLocked) and surface
 // loader failures instead of returning empty data. The lock/skip semantics of
-// cacheWithRedis itself are covered by lib/utils/cache.test.ts; vite.setup.ts
-// replaces cacheWithRedis with a passthrough here, so we pin the registration
-// options rather than the runtime behavior.
+// cacheWithRedisResult itself are covered by lib/utils/cache.test.ts;
+// vite.setup.ts replaces cacheWithRedisResult with a passthrough here, so we
+// pin the registration options rather than the runtime behavior.
 describe("getCachedSeatDataByUserId", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("registers the seat-data cache with fleet-wide fetch dedup", async () => {
-    // Re-import so the module-level cacheWithRedis registration call is
+    // Re-import so the module-level cacheWithRedisResult registration call is
     // recorded on a fresh mock (earlier clearAllMocks wiped the original).
     vi.resetModules();
     const cache = await import("@app/lib/utils/cache");
     await import("@app/lib/metronome/seats");
 
     const registration = vi
-      .mocked(cache.cacheWithRedis)
+      .mocked(cache.cacheWithRedisResult)
       .mock.calls.find((call) => call[0]?.name === "fetchSeatDataRecord");
     // Coupled to the loader's function name: if this is undefined after a
     // rename in seats.ts, update the string above (the dedup is likely fine).
@@ -1192,11 +1192,14 @@ describe("getCachedSeatDataByUserId", () => {
       new Err(new Error("429 rate limit exceeded"))
     );
 
-    await expect(
-      getCachedSeatDataByUserId({
-        metronomeCustomerId: "cust_err",
-        contractId: "contract_1",
-      })
-    ).rejects.toThrow("429");
+    const result = await getCachedSeatDataByUserId({
+      metronomeCustomerId: "cust_err",
+      contractId: "contract_1",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("429");
+    }
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -53,7 +53,7 @@ import { heartbeat } from "@app/lib/temporal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   bestEffortInvalidateCacheWithRedis,
-  cacheWithRedis,
+  cacheWithRedisResult,
 } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -2447,13 +2447,12 @@ const seatDataCacheResolver = ({
 async function fetchSeatDataRecord(args: {
   metronomeCustomerId: string;
   contractId: string;
-}): Promise<Record<string, SeatData>> {
+}): Promise<Result<Record<string, SeatData>, Error>> {
   const seatDataResult = await buildSeatDataByUserId(args);
-  // Throw at the cache boundary so a transient fetch failure is not cached.
   if (seatDataResult.isErr()) {
-    throw seatDataResult.error;
+    return new Err(seatDataResult.error);
   }
-  return Object.fromEntries(seatDataResult.value);
+  return new Ok(Object.fromEntries(seatDataResult.value));
 }
 
 // At most one Metronome fan-out in flight per contract fleet-wide: concurrent
@@ -2461,10 +2460,11 @@ async function fetchSeatDataRecord(args: {
 // their own contract + per-subscription seat reads. Best-effort past the
 // distributed lock's 5s TTL: a fan-out slower than that lets a second fetcher
 // start, so the bound is "a couple in flight", never a storm.
-export const getCachedSeatDataByUserId = cacheWithRedis(
+export const getCachedSeatDataByUserId = cacheWithRedisResult(
   fetchSeatDataRecord,
   seatDataCacheResolver,
   {
+    cacheId: fetchSeatDataRecord.name,
     ttlMs: SEAT_DATA_CACHE_TTL_MS,
     useDistributedLock: true,
     skipIfLocked: true,
@@ -2494,22 +2494,22 @@ async function fetchSeatBalances(args: {
   metronomeCustomerId: string;
   metronomeContractId: string;
   seatIds: string[];
-}): Promise<MetronomeSeatBalance[]> {
+}): Promise<Result<MetronomeSeatBalance[], Error>> {
   const balancesResult = await listMetronomeSeatBalances(args);
-  // Throw at the cache boundary so a transient fetch failure is not cached.
   if (balancesResult.isErr()) {
-    throw balancesResult.error;
+    return new Err(balancesResult.error);
   }
-  return balancesResult.value;
+  return new Ok(balancesResult.value);
 }
 
 // Same fleet-wide single-flight rationale as `getCachedSeatDataByUserId`: concurrent
 // misses on other processes get null (callers degrade) instead of each firing their
 // own Metronome seat-balances fan-out for the same page of members.
-export const getCachedSeatBalances = cacheWithRedis(
+export const getCachedSeatBalances = cacheWithRedisResult(
   fetchSeatBalances,
   seatBalancesCacheResolver,
   {
+    cacheId: fetchSeatBalances.name,
     ttlMs: SEAT_BALANCES_CACHE_TTL_MS,
     useDistributedLock: true,
     skipIfLocked: true,

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -40,7 +40,10 @@ import {
   PRO_SEAT_CREDIT_NAME,
   USAGE_TAG,
 } from "@app/lib/metronome/setup_common";
-import type { BillingFrequency } from "@app/lib/metronome/types";
+import type {
+  BillingFrequency,
+  MetronomeSeatBalance,
+} from "@app/lib/metronome/types";
 import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -2431,7 +2434,7 @@ export async function buildSeatDataByUserId({
   return new Ok(seatDataByUserId);
 }
 
-const SEAT_DATA_CACHE_TTL_MS = 60 * 1000;
+const SEAT_DATA_CACHE_TTL_MS = 10 * 60 * 1000;
 
 const seatDataCacheResolver = ({
   metronomeCustomerId,
@@ -2472,4 +2475,43 @@ const invalidateCachedSeatDataByUserId = bestEffortInvalidateCacheWithRedis(
   fetchSeatDataRecord,
   seatDataCacheResolver,
   "members-usage seat data"
+);
+
+const SEAT_BALANCES_CACHE_TTL_MS = 10 * 60 * 1000;
+
+const seatBalancesCacheResolver = ({
+  metronomeCustomerId,
+  metronomeContractId,
+  seatIds,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  seatIds: string[];
+}) =>
+  `${metronomeCustomerId}-${metronomeContractId}-${[...seatIds].sort().join(",")}`;
+
+async function fetchSeatBalances(args: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  seatIds: string[];
+}): Promise<MetronomeSeatBalance[]> {
+  const balancesResult = await listMetronomeSeatBalances(args);
+  // Throw at the cache boundary so a transient fetch failure is not cached.
+  if (balancesResult.isErr()) {
+    throw balancesResult.error;
+  }
+  return balancesResult.value;
+}
+
+// Same fleet-wide single-flight rationale as `getCachedSeatDataByUserId`: concurrent
+// misses on other processes get null (callers degrade) instead of each firing their
+// own Metronome seat-balances fan-out for the same page of members.
+export const getCachedSeatBalances = cacheWithRedis(
+  fetchSeatBalances,
+  seatBalancesCacheResolver,
+  {
+    ttlMs: SEAT_BALANCES_CACHE_TTL_MS,
+    useDistributedLock: true,
+    skipIfLocked: true,
+  }
 );

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -87,6 +87,7 @@ function activeSchedule(minSeats: number, maxSeats: number | null = null) {
 // finally block — stub them so the test never touches Redis.
 vi.mock("@app/lib/utils/cache", () => ({
   cacheWithRedis: (fn: unknown) => fn,
+  cacheWithRedisResult: (fn: unknown) => fn,
   invalidateCacheWithRedis: () => async () => {},
   bestEffortInvalidateCacheWithRedis: () => async () => {},
 }));

--- a/front/lib/resources/key_resource.test.ts
+++ b/front/lib/resources/key_resource.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import type { Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // In-memory cache that replaces the global no-op mock, so we can
@@ -24,6 +25,19 @@ vi.mock("@app/lib/utils/cache", () => ({
           const result = await fn(...args);
           inMemoryCache.set(key, JSON.stringify(result));
           return result;
+        };
+      }
+    ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ) => {
+        return async (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> => {
+          return fn(...args);
         };
       }
     ),

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import type { Result } from "@app/types/shared/result";
 import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -25,6 +26,19 @@ vi.mock("@app/lib/utils/cache", () => ({
           const result = await fn(...args);
           inMemoryCache.set(key, JSON.stringify(result));
           return result;
+        };
+      }
+    ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ) => {
+        return async (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> => {
+          return fn(...args);
         };
       }
     ),

--- a/front/lib/resources/subscription_resource.test.ts
+++ b/front/lib/resources/subscription_resource.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import type { Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
@@ -23,6 +24,19 @@ vi.mock("@app/lib/utils/cache", () => ({
           const result = await fn(...args);
           inMemoryCache.set(key, JSON.stringify(result));
           return result;
+        };
+      }
+    ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ) => {
+        return async (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> => {
+          return fn(...args);
         };
       }
     ),

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import type { Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
@@ -32,6 +33,19 @@ vi.mock("@app/lib/utils/cache", () => ({
           const result = await fn(...args);
           inMemoryCache.set(key, JSON.stringify(result));
           return result;
+        };
+      }
+    ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ) => {
+        return async (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> => {
+          return fn(...args);
         };
       }
     ),

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -2,6 +2,7 @@ import { CONVERSATIONS_RETENTION_MIN_DAYS } from "@app/lib/conversations_retenti
 import { EMPTY_PLAN_LIMIT_OVERRIDE } from "@app/lib/plans/plan_limit_overrides";
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { getNamespace } from "@app/tests/utils/test_cls";
+import type { Result } from "@app/types/shared/result";
 import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -65,6 +66,19 @@ vi.mock("@app/lib/utils/cache", () => ({
       };
     }
   ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ) => {
+        return async (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> => {
+          return fn(...args);
+        };
+      }
+    ),
   invalidateCacheWithRedis: vi.fn().mockImplementation(
     <T, Args extends unknown[]>(
       fn: CacheableFunction<JsonSerializable<T>, Args>,

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -1,6 +1,8 @@
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Transaction } from "sequelize";
 
@@ -245,6 +247,58 @@ export function cacheWithRedis<T, Args extends unknown[]>(
       } else {
         unlock(readKey);
       }
+    }
+  };
+}
+
+// Wraps cacheWithRedisResult's error so it can round-trip through
+// cacheWithRedis's throw-to-skip-caching contract without ever escaping to a
+// caller of cacheWithRedisResult.
+class CacheResultError<E> extends Error {
+  constructor(public readonly original: E) {
+    super("cacheWithRedisResult: wrapped domain error");
+  }
+}
+
+// Same fetch-dedup semantics as cacheWithRedis (fleet-wide single-flight via
+// the distributed lock), but for loaders that report failure through Result<>
+// instead of throwing. The loader's Err is never cached and is returned to
+// the caller as a Result, so callers can use `.isErr()` instead of try/catch.
+export function cacheWithRedisResult<T, E, Args extends unknown[]>(
+  fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>,
+  resolver: KeyResolver<Args>,
+  options: {
+    cacheId?: string;
+    ttlMs?: number | ((...args: Args) => number);
+    useDistributedLock: true;
+    skipIfLocked: true;
+    cacheNullValues?: boolean;
+    migration?: CacheKeyMigration<Args>;
+  }
+): (...args: Args) => Promise<Result<JsonSerializable<T> | null, E>> {
+  const cacheId = options.cacheId ?? fn.name;
+
+  const cachedFn = cacheWithRedis<T, Args>(
+    async (...args: Args) => {
+      const result = await fn(...args);
+      if (result.isErr()) {
+        throw new CacheResultError(result.error);
+      }
+      return result.value;
+    },
+    resolver,
+    { ...options, cacheId }
+  );
+
+  return async function (...args: Args) {
+    try {
+      const value = await cachedFn(...args);
+      return new Ok(value);
+    } catch (err) {
+      if (err instanceof CacheResultError) {
+        return new Err(err.original as E);
+      }
+      throw err;
     }
   };
 }

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -6,6 +6,7 @@ import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { redisMock } from "@app/tests/utils/mocks/redis";
 import { createNamespace } from "@app/tests/utils/test_cls";
+import type { Result } from "@app/types/shared/result";
 import { cleanup } from "@testing-library/react";
 import { Sequelize } from "sequelize";
 import { afterEach, beforeEach, vi } from "vitest";
@@ -28,6 +29,19 @@ vi.mock("@app/lib/utils/cache", () => ({
         return async function (...args: Args): Promise<JsonSerializable<T>> {
           const result = await fn(...args);
           return result;
+        };
+      }
+    ),
+  cacheWithRedisResult: vi
+    .fn()
+    .mockImplementation(
+      <T, E, Args extends unknown[]>(
+        fn: (...args: Args) => Promise<Result<JsonSerializable<T>, E>>
+      ): ((...args: Args) => Promise<Result<JsonSerializable<T>, E>>) => {
+        return async function (
+          ...args: Args
+        ): Promise<Result<JsonSerializable<T>, E>> {
+          return fn(...args);
         };
       }
     ),


### PR DESCRIPTION
## Description

Wraps the existing per-page Metronome seat-balances read in a fleet-wide single-flight Redis cache (same pattern as the existing seat-data cache, whose TTL is also bumped to 10 minutes here).

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. **#31606 (this PR)** — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. #31611 — default-sort by pool credit usage

## Tests

Type-checked. Elasticsearch/Metronome-backed functional tests couldn't be run locally; relied on type-checking and manual review.

## Risk

Low-medium. Touches a function used by both the legacy and Poke members tables; behavior (returned balances) is unchanged, only caching.

## Deploy Plan

Deploy front.
