### PR TITLE
feat(poke): add Change Subscription Plan plugin

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/change_subscription_plan.ts
+++ b/front/lib/api/poke/plugins/workspaces/change_subscription_plan.ts
@@ -1,0 +1,110 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { PlanModel } from "@app/lib/models/plan";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+
+const ChangeSubscriptionPlanArgsSchema = z
+  .object({
+    planCode: z.array(z.string()).length(1, "Please select a plan"),
+    confirm: z.boolean(),
+  })
+  .refine((data) => data.confirm === true, {
+    message: "Please confirm before changing the plan",
+  });
+
+// Narrows the selectable plans to those that match the workspace's current
+// billing setup:
+// - Metronome-billed (has a contract): only credit-priced (CP_) plans.
+// - Stripe-billed (no contract): the legacy, non credit-priced plans.
+// - No billing (no contract, no Stripe): only FREE plans.
+function allowedPlanFilter(
+  subscription: SubscriptionResource | null
+): (planCode: string) => boolean {
+  if (subscription?.metronomeContractId) {
+    return isCreditPricedPlanPrefix;
+  }
+  if (subscription?.stripeSubscriptionId) {
+    return (planCode) => !isCreditPricedPlanPrefix(planCode);
+  }
+  return (planCode) => planCode.startsWith("FREE_");
+}
+
+export const changeSubscriptionPlanPlugin = createPlugin({
+  manifest: {
+    id: "change-subscription-plan",
+    name: "Change Subscription Plan",
+    description:
+      "Repoint this workspace's active subscription to a different plan. " +
+      "Updates the subscription row, mirrors the plan code onto the Metronome " +
+      "contract when the workspace is Metronome-billed, and flushes the caches. " +
+      "The plan list is narrowed to match the workspace's billing setup: " +
+      "credit-priced (CP_) plans for Metronome contracts, legacy plans for " +
+      "Stripe subscriptions, and FREE plans when there is no billing.",
+    explanation:
+      "This is a low-level override: it does NOT create or end a subscription, " +
+      "touch Stripe, adjust seats/credits, or run the usual upgrade/downgrade " +
+      "guardrails. Use it to fix up which plan an existing subscription points " +
+      "to, not to move a customer between billing tiers.",
+    warning:
+      "Only changes the plan the active subscription references and the " +
+      "Metronome plan-code custom field. It does not reconcile billing.",
+    resourceTypes: ["workspaces"],
+    args: {
+      planCode: {
+        type: "enum",
+        label: "Plan",
+        description: "The plan to switch the subscription to.",
+        async: true,
+        values: [],
+        multiple: false,
+      },
+      confirm: {
+        type: "boolean",
+        label: "Confirm",
+        description: "I confirm I want to change this workspace's plan.",
+      },
+    },
+    requiredRoles: ["billing"],
+  },
+  populateAsyncArgs: async (auth) => {
+    const subscription = auth.subscriptionResource();
+    const currentPlanCode = subscription?.getPlan().code;
+    const isAllowed = allowedPlanFilter(subscription);
+
+    const plans = await PlanModel.findAll({ order: [["name", "ASC"]] });
+    return new Ok({
+      planCode: plans
+        .filter((plan) => isAllowed(plan.code))
+        .map((plan) => ({
+          label: `${plan.name} (${plan.code})`,
+          value: plan.code,
+          checked: plan.code === currentPlanCode,
+        })),
+    });
+  },
+  execute: async (auth, _, args) => {
+    const validationResult = ChangeSubscriptionPlanArgsSchema.safeParse(args);
+    if (!validationResult.success) {
+      return new Err(new Error(fromZodError(validationResult.error).message));
+    }
+
+    const planCode = validationResult.data.planCode[0];
+
+    const res = await SubscriptionResource.pokeChangePlan({ auth, planCode });
+    if (res.isErr()) {
+      return res;
+    }
+
+    const { previousPlanCode, metronomeContractUpdated } = res.value;
+
+    return new Ok({
+      display: "text",
+      value:
+        `Plan changed from "${previousPlanCode}" to "${planCode}".\n` +
+        `Metronome contract updated: ${metronomeContractUpdated ? "yes" : "no (not Metronome-billed)"}.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -4,6 +4,7 @@ export * from "./apply_coupon";
 export * from "./apply_group_roles";
 export * from "./batch_update_members";
 export * from "./buy_programmatic_usage_credits";
+export * from "./change_subscription_plan";
 export * from "./check_message_usage";
 export * from "./check_seat_count";
 export * from "./clean_outdated_directory_sync_groups";

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -4,7 +4,11 @@ import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
+import {
+  scheduleMetronomeContractEnd,
+  setMetronomeContractCustomFields,
+} from "@app/lib/metronome/client";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -1178,6 +1182,89 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     }
 
     return new Ok(undefined);
+  }
+
+  /**
+   * Low-level plan change for Poke: repoints the active subscription row to a
+   * different plan, mirrors the new plan code onto the Metronome contract (when
+   * the workspace is Metronome-billed) and flushes the subscription + contract
+   * caches. Unlike `pokeUpgradeWorkspaceToPlan` this does not create or end any
+   * subscription, touch Stripe, or run any plan-family guardrails — it is a raw
+   * override for fixing up a workspace's plan.
+   */
+  static async pokeChangePlan({
+    auth,
+    planCode,
+  }: {
+    auth: Authenticator;
+    planCode: string;
+  }): Promise<
+    Result<
+      { previousPlanCode: string; metronomeContractUpdated: boolean },
+      Error
+    >
+  > {
+    const owner = auth.getNonNullableWorkspace();
+
+    if (!auth.isDustSuperUser()) {
+      throw new Error("Cannot change workspace plan: not allowed.");
+    }
+
+    const newPlan = await this.findPlanOrThrow(planCode);
+
+    const activeSubscription = auth.subscriptionResource();
+    if (!activeSubscription) {
+      return new Err(
+        new Error("Workspace has no active subscription to change.")
+      );
+    }
+
+    const previousPlanCode = activeSubscription.plan.code;
+    if (previousPlanCode === newPlan.code) {
+      return new Err(
+        new Error(`Workspace is already on plan ${newPlan.code}.`)
+      );
+    }
+
+    // Repoint the subscription row to the new plan.
+    await SubscriptionModel.update(
+      { planId: newPlan.id },
+      {
+        where: { sId: activeSubscription.sId },
+      }
+    );
+
+    // Mirror the plan code onto the Metronome contract when the workspace is
+    // Metronome-billed, so billing stays consistent with the DB.
+    let metronomeContractUpdated = false;
+    const { metronomeContractId } = activeSubscription;
+    if (metronomeContractId) {
+      const res = await setMetronomeContractCustomFields({
+        contractId: metronomeContractId,
+        customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: newPlan.code },
+      });
+      if (res.isErr()) {
+        return res;
+      }
+      metronomeContractUpdated = true;
+    }
+
+    // Flush both the active-subscription cache and the Metronome contract cache.
+    await SubscriptionResource.invalidateSubscriptionCache(owner.id);
+    await invalidateContractCache(owner.sId);
+
+    logger.info(
+      {
+        workspaceId: owner.sId,
+        previousPlanCode,
+        newPlanCode: newPlan.code,
+        metronomeContractUpdated,
+        method: "SubscriptionResource.pokeChangePlan",
+      },
+      "Changed workspace subscription plan via Poke"
+    );
+
+    return new Ok({ previousPlanCode, metronomeContractUpdated });
   }
 
   /**


### PR DESCRIPTION
## Description

Adds a Poke plugin (**Change Subscription Plan**) to repoint a workspace's active subscription to a different plan without going through the full upgrade/downgrade flow.

- New `SubscriptionResource.pokeChangePlan({ auth, planCode })`: updates the active subscription row's `planId`, mirrors the plan code onto the Metronome contract's `DUST_PLAN_CODE` custom field when the workspace is Metronome-billed, and flushes both the subscription cache and the Metronome contract cache.
- New `SubscriptionResource.listAllPlans()` to populate the plan picker.
- The plan dropdown is narrowed to the workspace's billing setup: credit-priced (`CP_`) plans for Metronome contracts, legacy non-`CP_` plans for Stripe subscriptions, and `FREE_` plans when there is no billing. The current plan is pre-selected.
- Gated to super-users with the `billing` poke role; requires an explicit confirm toggle.

This is a low-level override: it does not create/end subscriptions, touch Stripe, adjust seats/credits, or reconcile billing.

## Risk

Low. New Poke-only plugin behind `requiredRoles: ["billing"]`. The `pokeChangePlan` path is additive and mirrors the existing `pokeUpgradeWorkspaceToPlan` mutation + cache-invalidation pattern. Misuse could leave DB and billing inconsistent, hence the raw-override framing in the plugin description/warning and the billing-aware plan filtering.

## Tests

- `npx tsgo --noEmit` passes.
- Biome check passes on the changed files.
- No functional test added (Poke plugin runs through the generic plugin run endpoint); manual verification via Poke.

## Deploy Plan

Standard deploy. No migration, no config, no feature flag.