### PR TITLE
[front] fix: default-sort Poke pool usage by pool credit usage

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -144,7 +144,7 @@ export function PoolUsagePage() {
     pageSize: DEFAULT_PAGE_SIZE,
   });
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "name", desc: false },
+    { id: "consumedFromPoolAwuCredits", desc: true },
   ]);
 
   // Debounce the search input, and reset to the first page on a new query.


### PR DESCRIPTION
## Description

One-line change: the Poke pool usage page's initial sort is now consumedFromPoolAwuCredits desc instead of name asc.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. #31595 — previous-cycle consumption table + ledger fetching
10. #31597 — remove group column from members table
11. #31598 — remove "Up to " prefix from Models column
12. #31600 — seats column -> icon only
13. #31601 — seat usage loading ring column
14. #31605 — pool credit usage column: extra-seat-usage only, orange overage
15. #31606 — infra: cache Metronome seat balances with Redis
16. #31608 — hover shows the group a member's limit is inherited from
17. #31610 — seat usage becomes sortable
18. **#31611 (this PR)** — default-sort by pool credit usage

## Tests

Type-checked. Not manually verified in a running browser.

## Risk

Very low. Single default-state change, Poke-only.

## Deploy Plan

Deploy front.
