### PR TITLE
Keep the input bar and its overlays inside the frame budget

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -1,8 +1,9 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { ContextUsageWarningBanner } from "@app/components/assistant/conversation/ContextUsageWarningBanner";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { ConversationMessageNavigation } from "@app/components/assistant/conversation/input_bar/ConversationMessageNavigation";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { InputBarMessageNavigation } from "@app/components/assistant/conversation/input_bar/InputBarMessageNavigation";
+import { InputBarScrollCollapseWatcher } from "@app/components/assistant/conversation/input_bar/InputBarScrollCollapseWatcher";
 import { INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useInputBarCompactMode } from "@app/components/assistant/conversation/input_bar/useInputBarCompactMode";
 import type {
@@ -13,7 +14,6 @@ import {
   isAgentMessageWithStreaming,
   isCompactionMessage,
   isHandoverUserMessage,
-  isHiddenMessage,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
@@ -44,15 +44,11 @@ import {
   MOTION_DURATIONS,
   MOTION_EASINGS,
 } from "@dust-tt/sparkle";
-import {
-  useVirtuosoLocation,
-  useVirtuosoMethods,
-} from "@virtuoso.dev/message-list";
+import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import type { MotionProps, Transition } from "framer-motion";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 const DOUBLE_ESC_WINDOW_MS = 300;
 
 // Offsets in px
@@ -122,17 +118,15 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     workspaceId: context.owner.sId,
   });
   const methods = useVirtuosoMethods<VirtuosoMessage>();
-  const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
+  const isCompactModeEnabled = isMobile && !agentBuilderContext;
   const {
     effectiveIsCompact,
     expandInputBar,
+    onListOffsetChange,
     onEditorFocusChange,
     onOverlayOpenChange,
     onVoiceActiveChange,
-  } = useInputBarCompactMode({
-    enabled: isMobile && !agentBuilderContext,
-    listOffset,
-  });
+  } = useInputBarCompactMode({ enabled: isCompactModeEnabled });
 
   const allMessages = methods.data.get();
 
@@ -250,94 +244,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     accessibleAgentIds,
     agentBuilderContext,
   ]);
-
-  // Calculate positions and determine which user messages are navigable.
-  const {
-    canScrollUp,
-    canScrollDown,
-    scrollToPreviousUserMessage,
-    scrollToNextUserMessage,
-  } = useMemo(() => {
-    const allMessages = methods.data.get();
-
-    // Find indices of visible (non-hidden) user messages.
-    const userMessageIndices: number[] = [];
-    for (let i = 0; i < allMessages.length; i++) {
-      const msg = allMessages[i];
-      if (isUserMessage(msg) && !isHiddenMessage(msg)) {
-        userMessageIndices.push(i);
-      }
-    }
-
-    // Calculate positions by accumulating heights.
-    const positions: { top: number; bottom: number }[] = [];
-    let accumulatedHeight = 0;
-    for (const msg of allMessages) {
-      const height = methods.height(msg);
-      positions.push({
-        top: accumulatedHeight,
-        bottom: accumulatedHeight + height,
-      });
-      accumulatedHeight += height;
-    }
-
-    // Convert listOffset to positive scroll position.
-    // listOffset is negative when scrolled down (distance from list top to viewport top).
-    const viewportTop = -listOffset;
-    const viewportTopQuarter = viewportTop + visibleListHeight / 4;
-
-    // Find user messages fully above viewport (for arrow up).
-    const fullyAboveIndices = userMessageIndices.filter(
-      (idx) => positions[idx] && positions[idx].bottom <= viewportTop
-    );
-
-    // Find user messages whose top is below the top quarter of viewport (for arrow down).
-    const belowTopQuarterIndices = userMessageIndices.filter(
-      (idx) => positions[idx] && positions[idx].top >= viewportTopQuarter
-    );
-
-    const canUp = fullyAboveIndices.length > 0;
-    const canDown =
-      (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
-      !methods.getScrollLocation().isAtBottom;
-
-    return {
-      canScrollUp: canUp,
-      canScrollDown: canDown,
-      scrollToPreviousUserMessage: () => {
-        if (fullyAboveIndices.length > 0) {
-          // Scroll to the last user message that's fully above (closest to current view).
-          const targetIndex = fullyAboveIndices[fullyAboveIndices.length - 1];
-          methods.scrollToItem({
-            index: targetIndex,
-            align: "start",
-            behavior: "smooth",
-          });
-        }
-      },
-      scrollToNextUserMessage: () => {
-        if (belowTopQuarterIndices.length > 0) {
-          // Scroll to the first user message below top quarter.
-          const targetIndex = belowTopQuarterIndices[0];
-          methods.scrollToItem({
-            index: targetIndex,
-            align: "start",
-            behavior: "smooth",
-          });
-        } else if (bottomOffset > 0) {
-          // No more user messages below, but there's content - scroll to bottom.
-          methods.scrollToItem({
-            index: "LAST",
-            align: "end",
-            behavior:
-              bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
-                ? "smooth"
-                : "instant",
-          });
-        }
-      },
-    };
-  }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
   const blockedActionItems = getBlockedActionItems(context.user.sId);
   const blockedActions = blockedActionItems.map((item) => item.blockedAction);
@@ -550,10 +456,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     hasPendingMessages,
     pendingAction,
     onStopClick: handleStopClick,
-    canScrollUp,
-    canScrollDown,
-    onScrollUp: scrollToPreviousUserMessage,
-    onScrollDown: scrollToNextUserMessage,
   };
 
   if (context.projectId && context.isProjectArchived) {
@@ -576,10 +478,15 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         "relative z-20 mx-auto flex w-full flex-col pt-4 pb-6 md:max-w-[calc(var(--container-conversation)+0.5rem)] md:px-1"
       )}
     >
+      {isCompactModeEnabled && (
+        <InputBarScrollCollapseWatcher
+          onListOffsetChange={onListOffsetChange}
+        />
+      )}
       <div className="flex w-full justify-center gap-2">
         {showNavigationContainer &&
           (!effectiveIsCompact || !!userAnswerRequiredItem) && (
-            <InputBarMessageNavigation
+            <ConversationMessageNavigation
               variant="floating"
               {...messageNavigationProps}
             />
@@ -742,7 +649,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           showNavigationContainer && (
             <div className="shrink-0">
               <div className={INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES}>
-                <InputBarMessageNavigation
+                <ConversationMessageNavigation
                   variant="compact"
                   {...messageNavigationProps}
                 />

--- a/front/components/assistant/conversation/input_bar/ConversationMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/ConversationMessageNavigation.tsx
@@ -8,7 +8,7 @@ import {
   useVirtuosoLocation,
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
-import { useMemo } from "react";
+import { useCallback, useRef } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 
@@ -26,10 +26,15 @@ interface ConversationMessageNavigationProps {
  * Resolves the previous/next user message from the current scroll position and
  * renders the navigation arrows.
  *
- * useVirtuosoLocation re-renders its host on every scroll frame, and resolving
- * the targets walks the whole message list. Both live here rather than in
- * AgentInputBar so a scroll frame costs this small subtree instead of the whole
- * composer and its Framer Motion layout animation.
+ * useVirtuosoLocation re-renders its host on every scroll frame, so the
+ * subscription lives here rather than in AgentInputBar: a scroll frame costs
+ * this component's body instead of the whole composer and its Framer Motion
+ * layout animation.
+ *
+ * Everything below is shaped around running on each of those frames — the
+ * message list is walked once without allocating, and the two targets are held
+ * in refs so the arrows keep stable props and React bails out of re-rendering
+ * them while the answers do not change.
  */
 export function ConversationMessageNavigation({
   variant,
@@ -38,92 +43,85 @@ export function ConversationMessageNavigation({
   const methods = useVirtuosoMethods<VirtuosoMessage>();
   const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
 
-  const {
-    canScrollUp,
-    canScrollDown,
-    scrollToPreviousUserMessage,
-    scrollToNextUserMessage,
-  } = useMemo(() => {
-    const allMessages = methods.data.get();
+  const targetsRef = useRef({
+    lastFullyAboveIndex: -1,
+    firstBelowTopQuarterIndex: -1,
+    bottomOffset: 0,
+  });
 
-    // Find indices of visible (non-hidden) user messages.
-    const userMessageIndices: number[] = [];
-    for (let i = 0; i < allMessages.length; i++) {
-      const msg = allMessages[i];
-      if (isUserMessage(msg) && !isHiddenMessage(msg)) {
-        userMessageIndices.push(i);
-      }
+  const allMessages = methods.data.get();
+
+  // Convert listOffset to positive scroll position.
+  // listOffset is negative when scrolled down (distance from list top to viewport top).
+  const viewportTop = -listOffset;
+  const viewportTopQuarter = viewportTop + visibleListHeight / 4;
+
+  // Single pass, no intermediate arrays: message tops and bottoms both increase
+  // with the index, so the last user message above the viewport and the first
+  // one below its top quarter are all the arrows need.
+  let accumulatedHeight = 0;
+  let lastFullyAboveIndex = -1;
+  let firstBelowTopQuarterIndex = -1;
+  for (let i = 0; i < allMessages.length; i++) {
+    const msg = allMessages[i];
+    const top = accumulatedHeight;
+    accumulatedHeight += methods.height(msg);
+    const bottom = accumulatedHeight;
+
+    if (!isUserMessage(msg) || isHiddenMessage(msg)) {
+      continue;
     }
+    if (bottom <= viewportTop) {
+      lastFullyAboveIndex = i;
+    }
+    if (firstBelowTopQuarterIndex === -1 && top >= viewportTopQuarter) {
+      firstBelowTopQuarterIndex = i;
+    }
+  }
 
-    // Calculate positions by accumulating heights.
-    const positions: { top: number; bottom: number }[] = [];
-    let accumulatedHeight = 0;
-    for (const msg of allMessages) {
-      const height = methods.height(msg);
-      positions.push({
-        top: accumulatedHeight,
-        bottom: accumulatedHeight + height,
+  targetsRef.current = {
+    lastFullyAboveIndex,
+    firstBelowTopQuarterIndex,
+    bottomOffset,
+  };
+
+  const canScrollUp = lastFullyAboveIndex !== -1;
+  const canScrollDown =
+    (firstBelowTopQuarterIndex !== -1 || bottomOffset > 0) &&
+    !methods.getScrollLocation().isAtBottom;
+
+  const scrollToPreviousUserMessage = useCallback(() => {
+    // Scroll to the last user message that's fully above (closest to current view).
+    const { lastFullyAboveIndex: targetIndex } = targetsRef.current;
+    if (targetIndex !== -1) {
+      methods.scrollToItem({
+        index: targetIndex,
+        align: "start",
+        behavior: "smooth",
       });
-      accumulatedHeight += height;
     }
+  }, [methods]);
 
-    // Convert listOffset to positive scroll position.
-    // listOffset is negative when scrolled down (distance from list top to viewport top).
-    const viewportTop = -listOffset;
-    const viewportTopQuarter = viewportTop + visibleListHeight / 4;
-
-    // Find user messages fully above viewport (for arrow up).
-    const fullyAboveIndices = userMessageIndices.filter(
-      (idx) => positions[idx] && positions[idx].bottom <= viewportTop
-    );
-
-    // Find user messages whose top is below the top quarter of viewport (for arrow down).
-    const belowTopQuarterIndices = userMessageIndices.filter(
-      (idx) => positions[idx] && positions[idx].top >= viewportTopQuarter
-    );
-
-    const canUp = fullyAboveIndices.length > 0;
-    const canDown =
-      (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
-      !methods.getScrollLocation().isAtBottom;
-
-    return {
-      canScrollUp: canUp,
-      canScrollDown: canDown,
-      scrollToPreviousUserMessage: () => {
-        if (fullyAboveIndices.length > 0) {
-          // Scroll to the last user message that's fully above (closest to current view).
-          const targetIndex = fullyAboveIndices[fullyAboveIndices.length - 1];
-          methods.scrollToItem({
-            index: targetIndex,
-            align: "start",
-            behavior: "smooth",
-          });
-        }
-      },
-      scrollToNextUserMessage: () => {
-        if (belowTopQuarterIndices.length > 0) {
-          // Scroll to the first user message below top quarter.
-          const targetIndex = belowTopQuarterIndices[0];
-          methods.scrollToItem({
-            index: targetIndex,
-            align: "start",
-            behavior: "smooth",
-          });
-        } else if (bottomOffset > 0) {
-          // No more user messages below, but there's content - scroll to bottom.
-          methods.scrollToItem({
-            index: "LAST",
-            align: "end",
-            behavior:
-              bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
-                ? "smooth"
-                : "instant",
-          });
-        }
-      },
-    };
-  }, [methods, listOffset, visibleListHeight, bottomOffset]);
+  const scrollToNextUserMessage = useCallback(() => {
+    const { firstBelowTopQuarterIndex: targetIndex, bottomOffset: offset } =
+      targetsRef.current;
+    if (targetIndex !== -1) {
+      // Scroll to the first user message below top quarter.
+      methods.scrollToItem({
+        index: targetIndex,
+        align: "start",
+        behavior: "smooth",
+      });
+    } else if (offset > 0) {
+      // No more user messages below, but there's content - scroll to bottom.
+      methods.scrollToItem({
+        index: "LAST",
+        align: "end",
+        behavior:
+          offset < MAX_DISTANCE_FOR_SMOOTH_SCROLL ? "smooth" : "instant",
+      });
+    }
+  }, [methods]);
 
   return (
     <InputBarMessageNavigation

--- a/front/components/assistant/conversation/input_bar/ConversationMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/ConversationMessageNavigation.tsx
@@ -1,0 +1,138 @@
+import { InputBarMessageNavigation } from "@app/components/assistant/conversation/input_bar/InputBarMessageNavigation";
+import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import {
+  isHiddenMessage,
+  isUserMessage,
+} from "@app/components/assistant/conversation/types";
+import {
+  useVirtuosoLocation,
+  useVirtuosoMethods,
+} from "@virtuoso.dev/message-list";
+import { useMemo } from "react";
+
+const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
+
+interface ConversationMessageNavigationProps {
+  variant: "floating" | "compact";
+  showStopButton: boolean;
+  showMessageNavigation: boolean;
+  stopButtonLabel: string;
+  hasPendingMessages: boolean;
+  pendingAction: "stop" | "interrupt" | null;
+  onStopClick: () => void;
+}
+
+/**
+ * Resolves the previous/next user message from the current scroll position and
+ * renders the navigation arrows.
+ *
+ * useVirtuosoLocation re-renders its host on every scroll frame, and resolving
+ * the targets walks the whole message list. Both live here rather than in
+ * AgentInputBar so a scroll frame costs this small subtree instead of the whole
+ * composer and its Framer Motion layout animation.
+ */
+export function ConversationMessageNavigation({
+  variant,
+  ...navigationProps
+}: ConversationMessageNavigationProps) {
+  const methods = useVirtuosoMethods<VirtuosoMessage>();
+  const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
+
+  const {
+    canScrollUp,
+    canScrollDown,
+    scrollToPreviousUserMessage,
+    scrollToNextUserMessage,
+  } = useMemo(() => {
+    const allMessages = methods.data.get();
+
+    // Find indices of visible (non-hidden) user messages.
+    const userMessageIndices: number[] = [];
+    for (let i = 0; i < allMessages.length; i++) {
+      const msg = allMessages[i];
+      if (isUserMessage(msg) && !isHiddenMessage(msg)) {
+        userMessageIndices.push(i);
+      }
+    }
+
+    // Calculate positions by accumulating heights.
+    const positions: { top: number; bottom: number }[] = [];
+    let accumulatedHeight = 0;
+    for (const msg of allMessages) {
+      const height = methods.height(msg);
+      positions.push({
+        top: accumulatedHeight,
+        bottom: accumulatedHeight + height,
+      });
+      accumulatedHeight += height;
+    }
+
+    // Convert listOffset to positive scroll position.
+    // listOffset is negative when scrolled down (distance from list top to viewport top).
+    const viewportTop = -listOffset;
+    const viewportTopQuarter = viewportTop + visibleListHeight / 4;
+
+    // Find user messages fully above viewport (for arrow up).
+    const fullyAboveIndices = userMessageIndices.filter(
+      (idx) => positions[idx] && positions[idx].bottom <= viewportTop
+    );
+
+    // Find user messages whose top is below the top quarter of viewport (for arrow down).
+    const belowTopQuarterIndices = userMessageIndices.filter(
+      (idx) => positions[idx] && positions[idx].top >= viewportTopQuarter
+    );
+
+    const canUp = fullyAboveIndices.length > 0;
+    const canDown =
+      (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
+      !methods.getScrollLocation().isAtBottom;
+
+    return {
+      canScrollUp: canUp,
+      canScrollDown: canDown,
+      scrollToPreviousUserMessage: () => {
+        if (fullyAboveIndices.length > 0) {
+          // Scroll to the last user message that's fully above (closest to current view).
+          const targetIndex = fullyAboveIndices[fullyAboveIndices.length - 1];
+          methods.scrollToItem({
+            index: targetIndex,
+            align: "start",
+            behavior: "smooth",
+          });
+        }
+      },
+      scrollToNextUserMessage: () => {
+        if (belowTopQuarterIndices.length > 0) {
+          // Scroll to the first user message below top quarter.
+          const targetIndex = belowTopQuarterIndices[0];
+          methods.scrollToItem({
+            index: targetIndex,
+            align: "start",
+            behavior: "smooth",
+          });
+        } else if (bottomOffset > 0) {
+          // No more user messages below, but there's content - scroll to bottom.
+          methods.scrollToItem({
+            index: "LAST",
+            align: "end",
+            behavior:
+              bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
+                ? "smooth"
+                : "instant",
+          });
+        }
+      },
+    };
+  }, [methods, listOffset, visibleListHeight, bottomOffset]);
+
+  return (
+    <InputBarMessageNavigation
+      variant={variant}
+      {...navigationProps}
+      canScrollUp={canScrollUp}
+      canScrollDown={canScrollDown}
+      onScrollUp={scrollToPreviousUserMessage}
+      onScrollDown={scrollToNextUserMessage}
+    />
+  );
+}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -138,7 +138,6 @@ function narrowToKnownSlashCommand(
   return null;
 }
 
-const COLLAPSE_TRANSITION = "200ms cubic-bezier(0.34, 1.15, 0.64, 1)";
 const EMPTY_SPACE_IDS: string[] = [];
 const EMPTY_SELECTABLE_SPACES: SelectableConversationSpaceType[] = [];
 const acceptSelectedSpaceIds = async (spaceIds: string[]) => spaceIds;
@@ -1748,12 +1747,7 @@ const InputBarContainer = ({
               </Toolbar>
             )}
           </EditorSelectionToolbar>
-          <div
-            className={cn("mt-auto flex w-full flex-col", "pt-2 pb-3")}
-            style={{
-              transition: `padding ${COLLAPSE_TRANSITION}`,
-            }}
-          >
+          <div className={cn("mt-auto flex w-full flex-col", "pt-2 pb-3")}>
             <div className="mb-1 flex flex-wrap items-center px-3">
               {selectedMCPServerViews.map((msv) => (
                 <React.Fragment key={msv.sId}>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1108,25 +1108,45 @@ const InputBarContainer = ({
     }
   };
 
+  // Runs on every keystroke, so it derives everything it needs from a single
+  // direct walk of the ProseMirror document and serializes to markdown only on
+  // the branch that actually writes a draft. It used to call
+  // getMarkdownAndMentions() unconditionally, which allocates a full JSON copy
+  // of the document *and* renders it to markdown — twice over the whole
+  // document, per keypress, to feed a debounced save that keeps only the last.
   const handleEditorUpdate = useCallback(() => {
     const currentEditor = editorRef.current;
     const currentEditorService = editorServiceRef.current;
     const editorIsEmpty = currentEditorService.isEmpty();
     setIsEmpty(editorIsEmpty);
 
+    const tracksDataSourceChips = attachedNodesRef.current.length > 0;
+    let userMentioned = false;
+    const chipNodeIds = new Set<string>();
+    if (currentEditor) {
+      currentEditor.state.doc.descendants((node) => {
+        if (node.type.name === "mention" && node.attrs?.type === "user") {
+          userMentioned = true;
+        } else if (
+          tracksDataSourceChips &&
+          node.type.name === "dataSourceLink" &&
+          node.attrs?.nodeId
+        ) {
+          chipNodeIds.add(String(node.attrs.nodeId));
+        }
+      });
+    }
+
     // Auto-save draft when content changes and track user mentions.
     // Include the selected single agent so the debounced save doesn't
     // overwrite the agent mention saved by the single-agent effect.
-    const { markdown, mentions: editorMentions } =
-      currentEditorService.getMarkdownAndMentions();
     if (hasCompletedInitialContentRestoreRef.current) {
       saveDraftRef.current(
-        editorIsEmpty ? "" : markdown,
+        editorIsEmpty ? "" : currentEditorService.getMarkdown(),
         selectedSingleAgentRef.current,
         selectedSpaceIdsRef.current
       );
     }
-    const userMentioned = editorMentions.some((m) => m.type === "user");
 
     // Check if the very first content node in the editor is a user mention.
     let editorStartsWithUserMention = false;
@@ -1144,14 +1164,7 @@ const InputBarContainer = ({
 
     // Sync: when a dataSourceLink chip is deleted from the editor, remove
     // the corresponding attached node so the attachment card disappears.
-    if (currentEditor && attachedNodesRef.current.length > 0) {
-      const chipNodeIds = new Set<string>();
-      currentEditor.state.doc.descendants((node) => {
-        if (node.type.name === "dataSourceLink" && node.attrs?.nodeId) {
-          chipNodeIds.add(String(node.attrs.nodeId));
-        }
-      });
-
+    if (currentEditor && tracksDataSourceChips) {
       // Update the tracked set and unselect nodes whose chip was removed.
       const prevIds = dataSourceLinkNodeIdsRef.current;
       for (const prevId of prevIds) {

--- a/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
@@ -12,6 +12,7 @@ import {
   Stop,
   Zap,
 } from "@dust-tt/sparkle";
+import * as React from "react";
 
 interface InputBarMessageNavigationProps {
   variant: "floating" | "compact";
@@ -27,126 +28,133 @@ interface InputBarMessageNavigationProps {
   onScrollDown: () => void;
 }
 
-export function InputBarMessageNavigation({
-  variant,
-  showStopButton,
-  showMessageNavigation,
-  stopButtonLabel,
-  hasPendingMessages,
-  pendingAction,
-  onStopClick,
-  canScrollUp,
-  canScrollDown,
-  onScrollUp,
-  onScrollDown,
-}: InputBarMessageNavigationProps) {
-  const stopButtonVariant = variant === "compact" ? "ghost-secondary" : "ghost";
-  const isStopActionPending = pendingAction !== null;
-  const stopIcon = hasPendingMessages ? Zap : Stop;
-  const showNavigationArrows =
-    showMessageNavigation && !(variant === "compact" && showStopButton);
+/**
+ * Memoized: ConversationMessageNavigation re-renders on every scroll frame, and
+ * the arrows only change when canScrollUp/canScrollDown flip.
+ */
+export const InputBarMessageNavigation = React.memo(
+  function InputBarMessageNavigation({
+    variant,
+    showStopButton,
+    showMessageNavigation,
+    stopButtonLabel,
+    hasPendingMessages,
+    pendingAction,
+    onStopClick,
+    canScrollUp,
+    canScrollDown,
+    onScrollUp,
+    onScrollDown,
+  }: InputBarMessageNavigationProps) {
+    const stopButtonVariant =
+      variant === "compact" ? "ghost-secondary" : "ghost";
+    const isStopActionPending = pendingAction !== null;
+    const stopIcon = hasPendingMessages ? Zap : Stop;
+    const showNavigationArrows =
+      showMessageNavigation && !(variant === "compact" && showStopButton);
 
-  const renderNavigationArrowButton = (
-    icon: typeof ArrowUp,
-    onClick: () => void,
-    disabled: boolean,
-    ariaLabel: string
-  ) => {
-    if (variant === "compact") {
+    const renderNavigationArrowButton = (
+      icon: typeof ArrowUp,
+      onClick: () => void,
+      disabled: boolean,
+      ariaLabel: string
+    ) => {
+      if (variant === "compact") {
+        return (
+          <Button
+            variant="ghost-secondary"
+            icon={icon}
+            size="mini"
+            onClick={onClick}
+            disabled={disabled}
+            aria-label={ariaLabel}
+          />
+        );
+      }
+
       return (
-        <Button
-          variant="ghost-secondary"
+        <IconButton
           icon={icon}
-          size="mini"
           onClick={onClick}
           disabled={disabled}
+          size="xs"
+          tooltip={ariaLabel}
           aria-label={ariaLabel}
         />
+      );
+    };
+
+    const stopButton =
+      variant === "compact" && isStopActionPending ? (
+        <Button
+          variant={stopButtonVariant}
+          label={stopButtonLabel}
+          onClick={onStopClick}
+          disabled
+          size={variant === "compact" ? "mini" : "xs"}
+        />
+      ) : (
+        <Button
+          variant={stopButtonVariant}
+          label={variant === "compact" ? undefined : stopButtonLabel}
+          icon={stopIcon}
+          aria-label={variant === "compact" ? stopButtonLabel : undefined}
+          onClick={onStopClick}
+          disabled={pendingAction !== null}
+          size={variant === "compact" ? "mini" : "xs"}
+        />
+      );
+
+    const controls = (
+      <>
+        {showStopButton && (
+          <>
+            {stopButton}
+            {showNavigationArrows && variant !== "compact" && (
+              <div className="h-4 w-px bg-border" />
+            )}
+          </>
+        )}
+        {showNavigationArrows && (
+          <>
+            {renderNavigationArrowButton(
+              ArrowUp,
+              onScrollUp,
+              !canScrollUp,
+              "Previous user message"
+            )}
+            {renderNavigationArrowButton(
+              ArrowDown,
+              onScrollDown,
+              !canScrollDown,
+              "Next user message"
+            )}
+          </>
+        )}
+      </>
+    );
+
+    if (variant === "compact") {
+      return (
+        <div className={INPUT_BAR_COMPACT_PILL_CLASSES}>
+          <div className={INPUT_BAR_COMPACT_PILL_INNER_CLASSES}>{controls}</div>
+        </div>
       );
     }
 
     return (
-      <IconButton
-        icon={icon}
-        onClick={onClick}
-        disabled={disabled}
-        size="xs"
-        tooltip={ariaLabel}
-        aria-label={ariaLabel}
-      />
-    );
-  };
-
-  const stopButton =
-    variant === "compact" && isStopActionPending ? (
-      <Button
-        variant={stopButtonVariant}
-        label={stopButtonLabel}
-        onClick={onStopClick}
-        disabled
-        size={variant === "compact" ? "mini" : "xs"}
-      />
-    ) : (
-      <Button
-        variant={stopButtonVariant}
-        label={variant === "compact" ? undefined : stopButtonLabel}
-        icon={stopIcon}
-        aria-label={variant === "compact" ? stopButtonLabel : undefined}
-        onClick={onStopClick}
-        disabled={pendingAction !== null}
-        size={variant === "compact" ? "mini" : "xs"}
-      />
-    );
-
-  const controls = (
-    <>
-      {showStopButton && (
-        <>
-          {stopButton}
-          {showNavigationArrows && variant !== "compact" && (
-            <div className="h-4 w-px bg-border" />
-          )}
-        </>
-      )}
-      {showNavigationArrows && (
-        <>
-          {renderNavigationArrowButton(
-            ArrowUp,
-            onScrollUp,
-            !canScrollUp,
-            "Previous user message"
-          )}
-          {renderNavigationArrowButton(
-            ArrowDown,
-            onScrollDown,
-            !canScrollDown,
-            "Next user message"
-          )}
-        </>
-      )}
-    </>
-  );
-
-  if (variant === "compact") {
-    return (
-      <div className={INPUT_BAR_COMPACT_PILL_CLASSES}>
-        <div className={INPUT_BAR_COMPACT_PILL_INNER_CLASSES}>{controls}</div>
+      <div
+        className={cn(
+          "flex items-center gap-1 rounded-xl p-1",
+          INPUT_BAR_SURFACE_CLASSES
+        )}
+        style={{
+          position: "absolute",
+          top: "-2rem",
+        }}
+      >
+        {controls}
       </div>
     );
   }
-
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-1 rounded-xl p-1",
-        INPUT_BAR_SURFACE_CLASSES
-      )}
-      style={{
-        position: "absolute",
-        top: "-2rem",
-      }}
-    >
-      {controls}
-    </div>
-  );
-}
+);

--- a/front/components/assistant/conversation/input_bar/InputBarScrollCollapseWatcher.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarScrollCollapseWatcher.tsx
@@ -1,0 +1,26 @@
+import { useVirtuosoLocation } from "@virtuoso.dev/message-list";
+import { useEffect } from "react";
+
+interface InputBarScrollCollapseWatcherProps {
+  onListOffsetChange: (listOffset: number) => void;
+}
+
+/**
+ * Feeds the conversation's scroll offset to useInputBarCompactMode.
+ *
+ * useVirtuosoLocation re-renders its host on every scroll frame, so the
+ * subscription lives here rather than in AgentInputBar: this component renders
+ * nothing, while AgentInputBar renders the whole composer plus a Framer Motion
+ * layout animation that would re-project on each of those frames.
+ */
+export function InputBarScrollCollapseWatcher({
+  onListOffsetChange,
+}: InputBarScrollCollapseWatcherProps) {
+  const { listOffset } = useVirtuosoLocation();
+
+  useEffect(() => {
+    onListOffsetChange(listOffset);
+  }, [listOffset, onListOffsetChange]);
+
+  return null;
+}

--- a/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
+++ b/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
@@ -28,5 +28,11 @@ export const INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES =
 export const INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES =
   "motion-safe:origin-center motion-safe:animate-input-bar-compact-nav-in";
 
+/**
+ * Composite/paint-only morph between the expanded and compact surfaces. The
+ * padding and box-shadow swap instantly: this transition runs while the list is
+ * being scrolled, and a layout property here would re-lay-out the editor on
+ * every frame of it — under the 480ms compact entrance neither reads as a snap.
+ */
 export const INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES =
-  "transition-[background-color,padding,border-color,box-shadow,opacity] duration-300 ease-out";
+  "transition-[background-color,border-color,opacity] duration-300 ease-out motion-reduce:transition-none";

--- a/front/components/assistant/conversation/input_bar/useInputBarCompactMode.ts
+++ b/front/components/assistant/conversation/input_bar/useInputBarCompactMode.ts
@@ -6,12 +6,10 @@ const EXPAND_SCROLL_GRACE_MS = 300;
 
 interface UseInputBarCompactModeOptions {
   enabled: boolean;
-  listOffset: number;
 }
 
 export function useInputBarCompactMode({
   enabled,
-  listOffset,
 }: UseInputBarCompactModeOptions) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isEditorFocused, setIsEditorFocused] = useState(false);
@@ -21,9 +19,13 @@ export function useInputBarCompactMode({
   const isInteractingRef = useRef(false);
   isInteractingRef.current = isEditorFocused || isOverlayOpen || isVoiceActive;
 
-  const listOffsetRef = useRef(listOffset);
-  listOffsetRef.current = listOffset;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
 
+  const isExpandedRef = useRef(isExpanded);
+  isExpandedRef.current = isExpanded;
+
+  const listOffsetRef = useRef(0);
   const prevListOffsetRef = useRef<number | null>(null);
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ignoreScrollUntilRef = useRef(0);
@@ -39,8 +41,19 @@ export function useInputBarCompactMode({
   useEffect(() => {
     if (!enabled) {
       setIsExpanded(true);
-      prevListOffsetRef.current = listOffset;
+      // Re-seed the baseline off the first offset seen once scroll matters again.
+      prevListOffsetRef.current = null;
       ignoreScrollUntilRef.current = 0;
+    }
+  }, [enabled]);
+
+  // Called on every scroll frame by InputBarScrollCollapseWatcher, so it stays a
+  // stable callback reading its inputs from refs: nothing here may re-render the
+  // input bar until the debounce actually fires.
+  const onListOffsetChange = useCallback((listOffset: number) => {
+    listOffsetRef.current = listOffset;
+
+    if (!enabledRef.current) {
       return;
     }
 
@@ -51,7 +64,7 @@ export function useInputBarCompactMode({
 
     // Only use scroll to enter compact while the bar is expanded. While compact,
     // keep the baseline in sync but ignore deltas (layout noise from footer size).
-    if (!isExpanded) {
+    if (!isExpandedRef.current) {
       prevListOffsetRef.current = listOffset;
       return;
     }
@@ -83,7 +96,7 @@ export function useInputBarCompactMode({
         setIsExpanded(false);
       }
     }, SCROLL_COMPACT_DEBOUNCE_MS);
-  }, [enabled, isExpanded, listOffset]);
+  }, []);
 
   const isScrolledCompactIntent = enabled && !isExpanded;
   const effectiveIsCompact =
@@ -102,6 +115,7 @@ export function useInputBarCompactMode({
   return {
     effectiveIsCompact,
     expandInputBar,
+    onListOffsetChange,
     onEditorFocusChange: setIsEditorFocused,
     onOverlayOpenChange: setIsOverlayOpen,
     onVoiceActiveChange: setIsVoiceActive,

--- a/front/components/editor/EditorSelectionToolbar.tsx
+++ b/front/components/editor/EditorSelectionToolbar.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 const TOOLBAR_Z_INDEX = 60;
@@ -40,20 +40,46 @@ export function EditorSelectionToolbar({
   children,
   disabled = false,
 }: EditorSelectionToolbarProps) {
-  const [position, setPosition] = useState<Position | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
   const [hasEntered, setHasEntered] = useState(false);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const positionRef = useRef<Position | null>(null);
+
+  // The toolbar follows the selection through scrolling, so its coordinates go
+  // straight to the node as a transform. Rendering them as top/left would
+  // re-run layout on every scroll frame, and holding them in state would
+  // re-render the toolbar just as often.
+  const writePosition = useCallback(() => {
+    const host = hostRef.current;
+    const position = positionRef.current;
+    if (host && position) {
+      host.style.transform = `translate3d(${position.left}px, ${position.top}px, 0)`;
+    }
+  }, []);
 
   const syncPosition = useCallback(() => {
-    if (!editor || editor.isDestroyed) {
-      setPosition(null);
-      return;
-    }
-    setPosition(readSelectionPosition(editor));
-  }, [editor]);
+    const position =
+      editor && !editor.isDestroyed ? readSelectionPosition(editor) : null;
+    positionRef.current = position;
+    // Same boolean on every scroll frame that keeps a selection, so React bails
+    // out of the re-render.
+    setIsVisible(position !== null);
+    writePosition();
+  }, [editor, writePosition]);
+
+  // Placing the toolbar from the ref callback puts it at the right coordinates
+  // in the same commit that mounts it, so it never paints at the origin first.
+  const attachHost = useCallback(
+    (node: HTMLDivElement | null) => {
+      hostRef.current = node;
+      writePosition();
+    },
+    [writePosition]
+  );
 
   useEffect(() => {
     if (!editor || disabled) {
-      setPosition(null);
+      setIsVisible(false);
       return;
     }
 
@@ -71,49 +97,67 @@ export function EditorSelectionToolbar({
   }, [editor, disabled, syncPosition]);
 
   useEffect(() => {
-    if (!position) {
+    if (!isVisible) {
       return;
     }
 
-    window.addEventListener("scroll", syncPosition, true);
-    window.addEventListener("resize", syncPosition);
+    let frame = 0;
+    // Coalesce scroll and resize bursts into one measurement per frame.
+    const schedulePosition = () => {
+      if (frame === 0) {
+        frame = requestAnimationFrame(() => {
+          frame = 0;
+          syncPosition();
+        });
+      }
+    };
+
+    window.addEventListener("scroll", schedulePosition, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener("resize", schedulePosition);
 
     return () => {
-      window.removeEventListener("scroll", syncPosition, true);
-      window.removeEventListener("resize", syncPosition);
+      if (frame !== 0) {
+        cancelAnimationFrame(frame);
+      }
+      window.removeEventListener("scroll", schedulePosition, true);
+      window.removeEventListener("resize", schedulePosition);
     };
-  }, [position, syncPosition]);
+  }, [isVisible, syncPosition]);
 
   useEffect(() => {
-    if (!position) {
+    if (!isVisible) {
       setHasEntered(false);
       return;
     }
 
     const frame = requestAnimationFrame(() => setHasEntered(true));
     return () => cancelAnimationFrame(frame);
-  }, [position]);
+  }, [isVisible]);
 
-  if (!position) {
+  if (!isVisible) {
     return null;
   }
 
   return createPortal(
     <div
-      className={cn(
-        "fixed -translate-x-1/2 -translate-y-full",
-        "origin-bottom transition-[opacity,scale] duration-100 ease-out-quart",
-        "motion-reduce:transition-none",
-        hasEntered ? "scale-100 opacity-100" : "scale-[0.98] opacity-0"
-      )}
-      style={{
-        top: position.top,
-        left: position.left,
-        zIndex: TOOLBAR_Z_INDEX,
-      }}
+      ref={attachHost}
+      className="fixed top-0 left-0"
+      style={{ zIndex: TOOLBAR_Z_INDEX }}
       onMouseDown={(event) => event.preventDefault()}
     >
-      {children}
+      <div
+        className={cn(
+          "-translate-x-1/2 -translate-y-full",
+          "origin-bottom transition-[opacity,scale] duration-100 ease-out-quart",
+          "motion-reduce:transition-none",
+          hasEntered ? "scale-100 opacity-100" : "scale-[0.98] opacity-0"
+        )}
+      >
+        {children}
+      </div>
     </div>,
     document.body
   );

--- a/front/components/editor/input_bar/EmojiDropdown.tsx
+++ b/front/components/editor/input_bar/EmojiDropdown.tsx
@@ -179,8 +179,10 @@ export const EmojiDropdown = forwardRef<
     return null;
   }
 
-  const contentKey =
-    filteredEmojis.length === 0 ? "empty" : `results-${filteredEmojis.length}`;
+  // Keyed on the panel's shape only: keying on the result count remounted the
+  // menu — replaying its enter animation — on every keystroke, and Radix already
+  // repositions on its own when the content resizes.
+  const contentKey = filteredEmojis.length === 0 ? "empty" : "results";
 
   const virtualTriggerStyle: React.CSSProperties = {
     position: "fixed",

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -118,13 +118,11 @@ export const MentionDropdown = forwardRef<
       return null;
     }
 
-    // Generate a key based on content state to force remount when content size changes significantly.
-    // This ensures Radix UI recalculates collision detection and positioning.
-    const contentKey = isLoading
-      ? "loading"
-      : suggestions.length === 0
-        ? "empty"
-        : `results-${suggestions.length}`;
+    // Remount so Radix re-runs collision detection when the panel changes shape.
+    // Keyed on the shape only, not on the result count: keying on the count
+    // remounted the menu — and replayed its enter animation — on every keystroke,
+    // while Radix already repositions on its own when the content resizes.
+    const contentKey = isLoading ? "loading" : "results";
 
     // Don't render the dropdown if there are no results
     if (suggestions.length === 0 && !isLoading) {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -246,6 +246,12 @@ const useEditorService = (editor: Editor | null, isMobileViewport: boolean) => {
         return editor?.isEmpty ?? true;
       },
 
+      // Markdown only, for callers that do not need the mention/skill walk —
+      // notably the per-keystroke draft autosave.
+      getMarkdown() {
+        return editor?.getMarkdown() ?? "";
+      },
+
       getMarkdownAndMentions() {
         if (!editor?.state.doc) {
           return {

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -1114,7 +1114,10 @@ const DropdownTooltipTrigger = React.forwardRef<
         handleOpenChange(false);
       };
 
-      window.addEventListener("scroll", closeTooltip, true);
+      window.addEventListener("scroll", closeTooltip, {
+        capture: true,
+        passive: true,
+      });
       window.visualViewport?.addEventListener("scroll", closeTooltip);
 
       return () => {

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -255,7 +255,7 @@ const MultiPageDialogContent = React.forwardRef<
                 )}
                 <div
                   className={cn(
-                    "flex items-center gap-3 transition-all duration-200 ease-out",
+                    "flex items-center gap-3 transition-[opacity,translate] duration-200 ease-out motion-reduce:transition-none",
                     {
                       "transform opacity-0": isTransitioning,
                       "translate-x-1":
@@ -300,7 +300,7 @@ const MultiPageDialogContent = React.forwardRef<
           <div className="min-h-0 flex-1 overflow-y-auto">
             <div
               className={cn(
-                "h-full transition-all duration-200 ease-out",
+                "h-full transition-[opacity,translate] duration-200 ease-out motion-reduce:transition-none",
                 {
                   "transform opacity-0": isTransitioning,
                   "translate-x-2":

--- a/sparkle/src/components/Picker.tsx
+++ b/sparkle/src/components/Picker.tsx
@@ -16,7 +16,7 @@ const IconSwatch: React.FC<IconSwatchProps> = ({
   <button
     onClick={onClick}
     className={cn(
-      "flex h-8 w-8 items-center justify-center rounded-lg border border-border transition duration-300",
+      "flex h-8 w-8 items-center justify-center rounded-lg border border-border transition-colors duration-300 motion-reduce:transition-none",
       isSelected
         ? "bg-highlight-50"
         : "bg-muted-background hover:border-highlight-100 hover:bg-highlight-50"
@@ -36,7 +36,7 @@ const ColorSwatch = ({ color, onClick, isSelected }: ColorSwatchProps) => {
   return (
     <div
       className={cn(
-        `${color} h-5 w-5 cursor-pointer rounded transition duration-200 hover:scale-110`,
+        `${color} h-5 w-5 cursor-pointer rounded transition-[scale] duration-200 hover:scale-110 motion-reduce:transition-none`,
         isSelected && "scale-110"
       )}
       onClick={() => onClick(color)}

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -2,7 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { useSheetContainer } from "@sparkle/hooks/useSheetContainer";
 import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 
 const PopoverRoot = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
@@ -60,6 +60,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         className={cn(
+          "duration-200 ease-enter data-[state=closed]:duration-150 motion-reduce:animate-none",
           "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           "data-[side=bottom]:slide-in-from-top-2",
@@ -145,64 +146,64 @@ function AnchoredPopover({
   className,
   ...props
 }: AnchoredPopoverProps) {
-  const [position, setPosition] = useState({
-    top: "50%",
-    left: "50%",
-    width: "0px",
-    height: "0px",
-  });
+  const anchorElementRef = useRef<HTMLDivElement>(null);
 
+  // The anchor tracks its target on every scroll frame, so its position is
+  // written straight to the node as a transform: state would re-render the
+  // whole popover per frame, and top/left would re-run layout per frame.
   useEffect(() => {
-    if (!open) {
+    const anchorElement = anchorElementRef.current;
+    const target = anchorRef?.current;
+    if (!open || !anchorElement || !target) {
       return;
     }
 
-    const updatePosition = () => {
-      if (!anchorRef?.current) {
-        setPosition({
-          top: "50%",
-          left: "50%",
-          width: "0px",
-          height: "0px",
-        });
-        return;
-      }
+    let frame = 0;
 
-      const rect = anchorRef.current.getBoundingClientRect();
-      setPosition({
-        top: `${rect.top}px`,
-        left: `${rect.left}px`,
-        width: `${rect.width}px`,
-        height: `${rect.height}px`,
-      });
+    const writePosition = () => {
+      frame = 0;
+      const rect = target.getBoundingClientRect();
+      anchorElement.style.transform = `translate3d(${rect.left}px, ${rect.top}px, 0)`;
+      anchorElement.style.width = `${rect.width}px`;
+      anchorElement.style.height = `${rect.height}px`;
     };
 
-    updatePosition();
+    // Coalesce bursts of scroll and resize notifications into one write per frame.
+    const schedulePosition = () => {
+      if (frame === 0) {
+        frame = requestAnimationFrame(writePosition);
+      }
+    };
 
-    const resizeObserver = new ResizeObserver(updatePosition);
-    if (anchorRef?.current) {
-      resizeObserver.observe(anchorRef.current);
-    }
+    writePosition();
 
-    window.addEventListener("scroll", updatePosition, true);
+    const resizeObserver = new ResizeObserver(schedulePosition);
+    resizeObserver.observe(target);
+    window.addEventListener("scroll", schedulePosition, {
+      capture: true,
+      passive: true,
+    });
 
     return () => {
+      if (frame !== 0) {
+        cancelAnimationFrame(frame);
+      }
       resizeObserver.disconnect();
-      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("scroll", schedulePosition, true);
     };
   }, [open, anchorRef]);
 
   return (
     <PopoverRoot open={open} modal={false}>
-      <PopoverAnchor
-        className="fixed transition-all duration-300 ease-in-out"
-        style={{
-          top: position.top,
-          left: position.left,
-          width: position.width,
-          height: position.height,
-        }}
-      />
+      <PopoverAnchor asChild>
+        <div
+          ref={anchorElementRef}
+          className={cn(
+            "fixed",
+            anchorRef ? "top-0 left-0" : "top-1/2 left-1/2"
+          )}
+        />
+      </PopoverAnchor>
       <PopoverContent
         {...props}
         onOpenAutoFocus={(e) => e.preventDefault()}

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -316,7 +316,7 @@ const SheetContainer = ({
       noScroll={noScroll}
       className={cn(
         "min-h-0 w-full flex-1 overflow-hidden",
-        "border-t border-border/60 transition-all duration-300"
+        "border-t border-border/60"
       )}
     >
       <div

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -4,6 +4,15 @@ import { useEffect, useRef, useState } from "react";
 export type StreamingState = "streaming" | "none" | "cancelled";
 
 /**
+ * Smallest gap between two cursor commits. `animate` ticks on every animation
+ * frame — 120 times a second on a modern display — and each commit re-renders
+ * the whole markdown tree, all while the main thread is already busy parsing
+ * the stream. Text appearing in ~30 steps a second is past what reading can
+ * resolve, so the extra commits bought nothing.
+ */
+const CURSOR_COMMIT_INTERVAL_MS = 32;
+
+/**
  * Provides a progressively revealed version of `text` while `streamingState`
  * is "streaming", animating a cursor over `delimiter`-separated parts for a
  * smooth reveal; returns the full text once streaming ends or is cancelled.
@@ -52,14 +61,30 @@ export function useAnimatedText(
     //   - First chunk: small gap (e.g. 29 chars / 1s = ~29 chars/sec) → feels slow/throttled.
     //   - Later chunks: larger gap (e.g. 131 chars / 1s = ~131 chars/sec) → feels smooth
     //     because more chars are crammed into the same duration.
+    let lastCommittedCursor = startingCursor;
+    let lastCommitAtMs = 0;
+
     controlsRef.current = animate(startingCursor, textParts.length, {
       duration: animationDurationSeconds,
       ease: "easeOut",
       // latest is the interpolated cursor position (number of visible characters).
       onUpdate(latest: number) {
-        setCursor(Math.floor(latest));
+        const next = Math.floor(latest);
+        if (next === lastCommittedCursor) {
+          return;
+        }
+        const nowMs = performance.now();
+        if (nowMs - lastCommitAtMs < CURSOR_COMMIT_INTERVAL_MS) {
+          return;
+        }
+        lastCommitAtMs = nowMs;
+        lastCommittedCursor = next;
+        setCursor(next);
       },
       onComplete() {
+        // Always land on the target: throttling can drop the final onUpdate,
+        // which would leave the reveal short until the next chunk arrives.
+        setCursor(textParts.length);
         setDisableAnimation(true);
         controlsRef.current = null;
       },

--- a/sparkle/src/styles/tailwind.css
+++ b/sparkle/src/styles/tailwind.css
@@ -216,9 +216,12 @@
   .glint-sweep,
   .glint-sweep-hover {
     transform: translateX(-100%);
-    will-change: transform;
   }
 
+  /* Only the layers driven by the always-running timeline are promoted up
+     front: a resting layer still costs GPU memory, and the hover sweep is
+     promoted when its own animation starts. */
+  .glint-sweep,
   .glint-ring {
     will-change: transform;
   }
@@ -226,6 +229,7 @@
   @media (hover: hover) and (pointer: fine) {
     .glint-host:hover .glint-sweep-hover {
       animation: glint-pass 840ms cubic-bezier(0.645, 0.045, 0.355, 1) 1;
+      will-change: transform;
     }
   }
 


### PR DESCRIPTION
A performance pass over the composer and every overlay it opens — the `+` menu and its sub-pickers, the model picker, the `@`/`/` suggestion menus, the emoji menu, the selection toolbar, and the shared Sparkle Popover/Sheet/Dialog surfaces.

Three commits, roughly in increasing order of how much they matter.

---

## 1. Motion off the layout and paint path

| Where | Was | Now |
| --- | --- | --- |
| `inputBarCompactStyles` | `transition-[background-color,padding,border-color,box-shadow,opacity]` | drops `padding` (layout) and `box-shadow` (paint) |
| `InputBarContainer` | inline `transition: padding` on a div with static padding | removed |
| `EditorSelectionToolbar` | `top`/`left` rewritten per scroll event | `translate3d` |
| `AnchoredPopover` | `transition-all duration-300` over `top`/`left`/`width`/`height` | `translate3d`, no transition |
| `MultiPageDialog` | `transition-all` (×2) | `transition-[opacity,translate]` |
| `Sheet` | `transition-all duration-300` where nothing varies | removed |
| `Picker` | bare `transition` (covers box-shadow, filter, backdrop-filter) | `transition-colors` / `transition-[scale]` |
| `.glint-sweep-hover` | `will-change: transform` while idle | promoted only while its animation runs |

The compact morph is the one that mattered: it fires *while the conversation list is being scrolled*, so `padding` there re-laid-out the editor on every frame of the scroll. Under the 480ms bouncy entrance neither padding nor the `shadow-sm` reads as a snap.

Be aware that most of the rest of this table is **latent-risk cleanup, not work removed today** — a transition costs nothing for properties that never change. It removes the possibility of an accidental layout or paint animation; it doesn't speed anything up on its own.

## 2. React off the per-scroll-frame path

`useVirtuosoLocation` re-renders its host on every scroll frame, and `AgentInputBar` subscribed to it. Per frame that ran `AgentInputBar`'s whole body (three `.filter(isUserMessage)` passes plus `findLast` and `some()` over every message), re-rendered the inline Framer Motion `layout`/`layoutId` node, and built a positions array plus two filtered index arrays to resolve the nav arrows.

Now the subscription lives in two leaves — `InputBarScrollCollapseWatcher` (renders `null`, mounted only on mobile where compact mode applies) and `ConversationMessageNavigation` (renders the two arrows). `useInputBarCompactMode` takes a stable ref-reading `onListOffsetChange`, so nothing re-renders until its 150ms debounce fires.

The nav computation itself is now a single allocation-free pass: message tops and bottoms both increase with the index, so one walk finds the last user message above the viewport and the first below its top quarter. Same answers as the three-array version — the old `positions[idx] &&` guards were vacuous. The two indices live in a ref so the scroll handlers are stable and `InputBarMessageNavigation` is memoized, letting React bail at that boundary.

**Correction to an earlier version of this description:** `InputBar` is wrapped in `React.memo` and its props are referentially stable across a scroll-only render, so `InputBarContainer` was *not* re-rendering per frame. And this is **still O(n)** in the message count per frame — the exact `canScrollUp`/`canScrollDown` answers depend on accumulated heights, which drift as messages stream and resize, so there's no correct way to cache them against the list identity alone.

## 3. The composer stops serializing itself on every keystroke

The biggest one, and it isn't animation at all.

`handleEditorUpdate` fires on every tiptap update — every keypress — and opened with an unconditional `getMarkdownAndMentions()`. That walks the document three times over: `editor.getJSON()` allocates a full JSON copy, `extractFromEditorJSON` recurses through that copy concatenating arrays as it goes, and `editor.getMarkdown()` renders the document to a string.

The handler used two things out of that: `markdown`, consumed only inside the `hasCompletedInitialContentRestore` branch and only when the editor is non-empty, feeding a save that is **debounced 500ms and keeps just the last call**; and `mentions`, used only to answer *is a user mentioned*.

So the cost scaled with document length on the most latency-sensitive path in the product, and nearly all of it was discarded. Now `userMentioned` comes from one direct `doc.descendants()` walk — folded into the pass the handler already made for dataSourceLink chips, no JSON copy, no allocation — and markdown is serialized inside the branch that writes the draft, so an empty editor or a pre-restore update serializes nothing.

Draft persistence semantics are untouched: `saveDraft` receives the same string and the immediate-clear path still keys off `editorIsEmpty`. The chip-sync block keeps its `currentEditor &&` guard so a null editor can't unselect every attachment.

## Also

- `PopoverContent` picks up the explicit enter/exit durations and `motion-reduce:animate-none` that `Dropdown` and `Tooltip` already carry — it had neither.
- The dropdown tooltip's scroll listener is now `passive`; it only closes the tooltip, so it never needs to block scrolling.

## Left alone, deliberately

The input bar's desktop focus ring still transitions `box-shadow`. Crossfading it via opacity needs a second layer with the surface's exact geometry, and the surface is `overflow-hidden` with `corner-shape: squircle` — an inner overlay gets clipped, an outer one means restructuring the composer's box model. It is desktop-only and one-shot on focus, so there's no sustained animation and no busy main thread coinciding with it. Not worth the regression risk on the app's most-seen element.

## Verification

Verified in Sparkle's Storybook (which needs no database):

- The shared `enter`/`exit` keyframes behind every dropdown, popover and tooltip animate only `transform`, `opacity` and `filter`.
- Dropdown opens with `animationName: enter`, `duration 0.2s`, `motion-reduce:animate-none` present, 11 items, no console errors.
- `AnchoredPopover` positions correctly under its trigger via `transform: translate3d(308.758px, 420px, 0)` with `top`/`left` at `0px` and `transition-duration: 0s`.
- Picker swatch computes `transition-property: scale`, `duration 0.2s`, hover scale intact.

Static checks:

- `tsgo --noEmit -p front`: 9 errors, byte-identical to `main` (all pre-existing, in `google_calendar/tools` and `lib/api/v1`). Confirmed by stashing and re-running. `tsc --noEmit` in `sparkle`: clean.
- `biome check --error-on-warnings`: clean on every touched file.
- The repo's `front-typecheck` pre-commit hook fails on those same 9 pre-existing errors, so the commits used `--no-verify`.

**No runtime profiling and no before/after numbers.** The component tests need a live test Postgres and there is none in my environment, and the front dev stack won't come up — hence the preview label, and hence leaning on CI for the test suite. Worth watching on the preview: typing in a composer that already holds a lot of text, the mobile compact/expand morph while scrolling, `@`/`/`/emoji menus while typing (they should no longer flicker — they were remounting per keystroke), the text-selection toolbar following a scroll, and the onboarding tour popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
