### PR TITLE
[front] Show confirmation content in ask_user_question (Forms) card

### DIFF
--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -3,7 +3,7 @@ import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/deta
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { UserQuestionSchema } from "@app/lib/actions/types";
 import { parseUserQuestionAnswer } from "@app/lib/actions/user_question";
-import { Check, Icon, MessageCircle01 } from "@dust-tt/sparkle";
+import { Check, Icon, Markdown, MessageCircle01 } from "@dust-tt/sparkle";
 
 export function MCPAskUserQuestionActionDetails({
   toolOutput,
@@ -31,6 +31,15 @@ export function MCPAskUserQuestionActionDetails({
     >
       {displayContext !== "conversation" && userQuestion && outputText && (
         <div className="flex flex-col gap-3 pl-6 pt-4">
+          {userQuestion.content && (
+            <div className="max-h-96 overflow-y-auto rounded-xl bg-muted-background p-4">
+              <Markdown
+                content={userQuestion.content}
+                forcedTextSize="text-sm"
+                isLastMessage={false}
+              />
+            </div>
+          )}
           <div className="text-sm font-medium text-foreground">
             {userQuestion.question}
           </div>

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -181,6 +181,7 @@ vi.mock("@dust-tt/sparkle", () => {
 
   const Spinner = () => <div>Loading</div>;
   const ArrowUp = () => null;
+  const Markdown = ({ content }: { content: string }) => <div>{content}</div>;
 
   return {
     ArrowUp,
@@ -189,6 +190,7 @@ vi.mock("@dust-tt/sparkle", () => {
     Counter,
     cn,
     Input,
+    Markdown,
     OptionCard,
     Spinner,
   };
@@ -209,8 +211,10 @@ const owner: LightWorkspaceType = {
 
 function makeBlockedAction({
   multiSelect = false,
+  content,
 }: {
   multiSelect?: boolean;
+  content?: string | null;
 } = {}): AgentLoopBlockedToolExecution & {
   status: "blocked_user_answer_required";
 } {
@@ -231,6 +235,7 @@ function makeBlockedAction({
     authorizationInfo: null,
     question: {
       question: "Choose an option",
+      content,
       multiSelect,
       options: [
         {
@@ -275,6 +280,38 @@ describe("UserAnswerRequired", () => {
     vi.clearAllMocks();
     shouldReduceMotionMock = false;
     answerQuestionMock.mockResolvedValue({ success: true });
+  });
+
+  it("renders the content being confirmed when provided", () => {
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction({
+          content: "Here is the draft message to confirm.",
+        })}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+      />
+    );
+
+    expect(
+      screen.getByText("Here is the draft message to confirm.")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a content block when content is absent", () => {
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+      />
+    );
+
+    expect(
+      screen.queryByText("Here is the draft message to confirm.")
+    ).not.toBeInTheDocument();
   });
 
   it("highlights the first option by default and moves the highlight with arrow keys", async () => {

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -6,7 +6,14 @@ import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { ArrowUp, Button, cn, OptionCard, Spinner } from "@dust-tt/sparkle";
+import {
+  ArrowUp,
+  Button,
+  cn,
+  Markdown,
+  OptionCard,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useReducedMotion } from "framer-motion";
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -295,6 +302,15 @@ export function UserAnswerRequired({
         isKeyboardNavigating && "cursor-none"
       )}
     >
+      {question.content && (
+        <div className="max-h-96 overflow-y-auto rounded-xl bg-muted-background p-4">
+          <Markdown
+            content={question.content}
+            forcedTextSize="text-sm"
+            isLastMessage={false}
+          />
+        </div>
+      )}
       <div className="text-base font-medium leading-tight text-foreground">
         {question.question}
       </div>

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -65,6 +65,18 @@ export const UserQuestionSchema = z.object({
   question: z
     .string()
     .describe("The question text. Should be clear and specific."),
+  content: z
+    .string()
+    .nullish()
+    .describe(
+      "The exact content this question is about, rendered as markdown, so " +
+        "the user can review it before answering. Set this whenever the " +
+        "question asks the user to review, confirm, or validate specific " +
+        "content you have prepared (e.g. a draft message, email, post, or " +
+        "payload) — put the full content here rather than only referring to " +
+        "it in the question. Leave null for pure clarification questions " +
+        "that have no content to show."
+    ),
   options: z
     .array(UserQuestionOptionSchema)
     .describe(

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -25,7 +25,11 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = [
       "- The user always gets an automatic option for free-text input\n" +
       "- Use multiSelect: true to allow multiple answers to be selected for a question\n" +
       '- If a specific option is recommended, it should be the first option in the list and have "(Recommended)" ' +
-      "at the end of its label",
+      "at the end of its label\n" +
+      "- When the question asks the user to review, confirm, or validate specific content you have " +
+      "prepared (e.g. a draft message, email, Slack post, or payload), you MUST put that full content in " +
+      'the "content" field (as markdown) so it is displayed to the user before they answer. Do not ask the ' +
+      'user to confirm something (e.g. "Does this look right?") without providing the content it refers to.',
     schema: {
       ...UserQuestionSchema.shape,
     },

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -16,7 +16,7 @@ import assert from "assert";
 
 const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
   ask_user_question: async (
-    { question, options, multiSelect },
+    { question, content, options, multiSelect },
     { runContext }
   ) => {
     assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
@@ -52,7 +52,7 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
         resource: {
           mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
           type: "tool_user_answer_required",
-          question: { question, options, multiSelect },
+          question: { question, content, options, multiSelect },
           text: `Asking user: ${question}`,
           uri: "",
         },


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10196.

When an agent uses the `ask_user_question` (Forms) tool to confirm something ("Does this look right? Any corrections before I post?"), the content being confirmed was frequently never shown to the user. The tool had no field for it, so the subject lived only in the model's reasoning (collapsed/hidden) or was materialized *after* the answer — the confirmation card showed just the question and its options, so "this" had no visible referent.


This adds an optional `content` field to `UserQuestionSchema`. The tool description now instructs the model to put the exact content it asks the user to review/confirm (draft message, email, Slack post, payload) into that field. The live answer card (`UserAnswerRequired`) and the read-only action details (`MCPAskUserQuestionActionDetails`) render it as markdown, in a scrollable muted block above the question. The field flows through the pause resource, resume state, SSE event and the blocked-actions reload endpoint automatically, since they pass the whole `question` object through.

<img width="852" height="677" alt="Screenshot 2026-09-01 at 14 57 22" src="https://github.com/user-attachments/assets/0db595d6-ccf2-44c5-9980-550303dd83cf" />



## Tests

- `npm run test -- UserAnswerRequired` — added two tests (renders the content block when present; no block when absent). 14/14 pass.
- `npx tsgo --noEmit` clean.

## Risk

Low. `content` is optional (`.nullish()`) and append-only: old stored tool params and older clients are unaffected, and `UserQuestionSchema.safeParse` on historical actions still succeeds. Purely additive, no breaking API/schema change. Safe to roll back.

## Deploy Plan

Standard front deploy. No migration and no ordering constraints.