### PR TITLE
Sidekick: always run in standard even if user restricted to basics

### DIFF
--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -2,12 +2,16 @@ import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preference
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { Authenticator } from "@app/lib/auth";
+import { setWorkspaceMaxAllowedTierName } from "@app/lib/model_tiers/allowed_tiers";
 import * as enabledModels from "@app/lib/model_tiers/enabled_models";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { AUTO_MODEL_ID, MODEL_STREAMS } from "@app/types/assistant/models/auto";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import {
   GPT_5_4_MINI_MODEL_CONFIG,
   GPT_5_5_MODEL_CONFIG,
@@ -103,15 +107,17 @@ function makeAgentConfiguration({
   providerId,
   modelId,
   reasoningEffort,
+  sId = "agent_test",
 }: {
   providerId: ModelProviderIdType;
   modelId: ModelIdType;
   reasoningEffort?: ReasoningEffort;
+  sId?: string;
 }): LightAgentConfigurationType {
   return {
     id: 1,
     versionCreatedAt: null,
-    sId: "agent_test",
+    sId,
     version: 0,
     versionAuthorId: null,
     instructions: null,
@@ -296,6 +302,40 @@ describe("resolveModel", () => {
       modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
       reasoningEffort: "high",
     });
+  });
+
+  it("resolves the sidekick's auto stream above the member's tier cap", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await setWorkspaceMaxAllowedTierName(auth, "cost_efficient");
+
+    // A regular agent on `auto` stays within the workspace's Basic cap.
+    const regular = await resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+      }),
+      featureFlags: [],
+    });
+    expect(
+      getTierForModel(
+        regular.resolvedModel.modelId,
+        regular.resolvedModel.reasoningEffort
+      )
+    ).toBe("cost_efficient");
+
+    // The sidekick ignores the cap and resolves to the stream's first candidate.
+    const sidekick = await resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+        sId: GLOBAL_AGENTS_SID.SIDEKICK,
+      }),
+      featureFlags: [],
+    });
+    expect(sidekick.modelResolutionMethod).toBe(AUTO_MODEL_ID);
+    expect(sidekick.resolvedModel).toEqual(MODEL_STREAMS[AUTO_MODEL_ID][0]);
   });
 
   it("resolves an auto user selection to a concrete model", async () => {

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -1,6 +1,7 @@
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import { getAgentAllowedTierNamesOverride } from "@app/lib/model_tiers/agent_tier_overrides";
 import {
   getEnabledModelsForAuth,
   resolveStreamModel,
@@ -93,7 +94,11 @@ export async function resolveModel(
   // ordered candidate pool and pick the first one available to the workspace.
   if (enabled && isModelStreamId(enabled.modelId)) {
     const streamId = enabled.modelId;
-    const models = await getEnabledModelsForAuth(auth);
+    const models = await getEnabledModelsForAuth(auth, {
+      allowedTierNamesOverride: getAgentAllowedTierNamesOverride(
+        configuration.sId
+      ),
+    });
     const resolution = resolveStreamModel(models, streamId);
     enabled = resolution.model;
 

--- a/front/lib/model_tiers/access.test.ts
+++ b/front/lib/model_tiers/access.test.ts
@@ -131,7 +131,7 @@ describe("getModelTierAccessErrorForAgentConfiguration", () => {
 
     const error = await getModelTierAccessErrorForAgentConfiguration(auth, {
       agentSId,
-      agentName: "test-agent",
+      agentName: agentSId,
       model: streamModel,
       modelResolutionMethod: AUTO_MODEL_ID,
     });

--- a/front/lib/model_tiers/access.test.ts
+++ b/front/lib/model_tiers/access.test.ts
@@ -1,14 +1,18 @@
 import { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
 import { setUserMaxAllowedTier } from "@app/lib/model_tiers/allowed_tiers";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID, MODEL_STREAMS } from "@app/types/assistant/models/auto";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("getModelTierAccessErrorForAgentConfiguration", () => {
@@ -20,12 +24,16 @@ describe("getModelTierAccessErrorForAgentConfiguration", () => {
     adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
-  async function restrictedUserAuth() {
+  async function restrictedUserAuth({
+    tierName = "balanced",
+  }: {
+    tierName?: ModelsTierName;
+  } = {}) {
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
     await setUserMaxAllowedTier(adminAuth, {
       userId: user.sId,
-      tierName: "balanced",
+      tierName,
     });
 
     return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
@@ -102,6 +110,30 @@ describe("getModelTierAccessErrorForAgentConfiguration", () => {
       // any stream, and always within a `balanced` member's cap.
       model: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
       modelResolutionMethod,
+    });
+
+    expect(error?.code ?? null).toBe(expectedCode);
+  });
+  // Sidekick is free and picks its own model server-side, so it runs the
+  // Standard stream whatever the member's own cap is.
+  it.each([
+    [GLOBAL_AGENTS_SID.SIDEKICK, null],
+    ["agent_test", "model_tier_not_enabled"],
+  ] as const)("tier-checks the Standard stream for %s against a Basic-capped member", async (agentSId, expectedCode) => {
+    const auth = await restrictedUserAuth({ tierName: "cost_efficient" });
+    // The model the Standard stream resolves to for an uncapped member.
+    const streamModel = getModelConfigByModelId(
+      MODEL_STREAMS[AUTO_MODEL_ID][0].modelId
+    );
+    if (!streamModel) {
+      throw new Error("Standard stream's first candidate is not supported.");
+    }
+
+    const error = await getModelTierAccessErrorForAgentConfiguration(auth, {
+      agentSId,
+      agentName: "test-agent",
+      model: streamModel,
+      modelResolutionMethod: AUTO_MODEL_ID,
     });
 
     expect(error?.code ?? null).toBe(expectedCode);

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { getAgentAllowedTierNamesOverride } from "@app/lib/model_tiers/agent_tier_overrides";
 import { resolveAllowedTierNames } from "@app/lib/model_tiers/allowed_tiers";
 import type {
   AgentConfigurationScope,
@@ -34,12 +35,15 @@ function buildModelTierAccessDeniedError(
 export async function getModelTierAccessErrorForAgentConfiguration(
   auth: Authenticator,
   {
+    agentSId,
     agentName,
     model,
     reasoningEffort,
     agentScope,
     modelResolutionMethod,
   }: {
+    // Left out when the agent has no sId yet (creation): no agent override applies.
+    agentSId?: string;
     agentName: string;
     model: ModelConfigurationType;
     reasoningEffort?: ReasoningEffort;
@@ -73,7 +77,11 @@ export async function getModelTierAccessErrorForAgentConfiguration(
     return null;
   }
 
-  const { tiers: allowedTierNames } = await resolveAllowedTierNames(auth);
+  const allowedTierNamesOverride = agentSId
+    ? getAgentAllowedTierNamesOverride(agentSId)
+    : null;
+  const allowedTierNames =
+    allowedTierNamesOverride ?? (await resolveAllowedTierNames(auth)).tiers;
 
   if (allowedTierNames.includes(tierName)) {
     return null;

--- a/front/lib/model_tiers/agent_tier_overrides.ts
+++ b/front/lib/model_tiers/agent_tier_overrides.ts
@@ -1,0 +1,19 @@
+import { expandTiersUpTo } from "@app/lib/model_tiers/tier_order";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+
+// Sidekick is free and picks its own model server-side (user model selections are
+// ignored for it), so it always runs on the Standard stream whatever the member's
+// own tier cap is. The Standard stream's candidates never exceed the `balanced`
+// tier, so this can never hand a member a premium model.
+const SIDEKICK_MAX_MODEL_TIER: ModelsTierName = "balanced";
+
+// Tiers an agent may use regardless of the member's own tier grants, or null when
+// the member's grants apply as usual.
+export function getAgentAllowedTierNamesOverride(
+  agentSId: string
+): ModelsTierName[] | null {
+  return agentSId === GLOBAL_AGENTS_SID.SIDEKICK
+    ? expandTiersUpTo(SIDEKICK_MAX_MODEL_TIER)
+    : null;
+}

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -84,9 +84,17 @@ function restrictModelConfigToAllowedTiers(
 
 export async function withModelSelectability(
   auth: Authenticator,
-  { models }: { models: ModelConfigurationType[] }
+  {
+    models,
+    allowedTierNamesOverride,
+  }: {
+    models: ModelConfigurationType[];
+    // Set to bypass the member's own tier grants (see getAgentAllowedTierNamesOverride).
+    allowedTierNamesOverride?: ModelsTierName[] | null;
+  }
 ): Promise<EnabledModelConfigurationType[]> {
-  const { tiers: allowedTierNames } = await resolveAllowedTierNames(auth);
+  const allowedTierNames =
+    allowedTierNamesOverride ?? (await resolveAllowedTierNames(auth)).tiers;
   const allowedTierNamesSet = new Set(allowedTierNames);
 
   return models.map((model) =>
@@ -95,10 +103,16 @@ export async function withModelSelectability(
 }
 
 export async function getEnabledModelsForAuth(
-  auth: Authenticator
+  auth: Authenticator,
+  {
+    allowedTierNamesOverride,
+  }: { allowedTierNamesOverride?: ModelsTierName[] | null } = {}
 ): Promise<EnabledModelConfigurationType[]> {
   const availableModels = await getAvailableModelsForWorkspace(auth);
-  return withModelSelectability(auth, { models: availableModels });
+  return withModelSelectability(auth, {
+    models: availableModels,
+    allowedTierNamesOverride,
+  });
 }
 
 export async function getDefaultStreamConfigForAuth(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -446,6 +446,7 @@ export async function runModel(
     const accessError = await getModelTierAccessErrorForAgentConfiguration(
       auth,
       {
+        agentSId: agentConfiguration.sId,
         agentName: agentConfiguration.name,
         model: modelInfo.endpoint.modelConfig,
         reasoningEffort: modelInfo.reasoningEffort,


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/10246

Always allow standard tier for sidekick which is the harcoded tier.

sidekick is free for now so no impact for customers. 
Avoid downgrading to a lower tier where sidekick would not work.

## Tests

 - Added unit tests
 - tested locally: even when restricted to basics I can now use sidekick

## Risk

low
add new flags to bypass the model tier check but there are only usable from sidekick and sidekick does not allow to override model (blocked on purpose)

## Deploy Plan

deploy front
