### PR TITLE
Add Shopify compliance webhook handling

### DIFF
--- a/firebase-functions/webhook-router/README.md
+++ b/firebase-functions/webhook-router/README.md
@@ -1,12 +1,13 @@
 # Unified Webhook Router
 
-A secure Firebase Function that routes webhooks from Slack and Microsoft Teams to multiple regional endpoints with platform-specific verification.
+A secure Firebase Function that receives and routes platform webhooks with platform-specific
+verification.
 
 ## Features
 
-- ✅ **Multi-platform support** - Handles Slack and Microsoft Teams webhooks
-- ✅ **Platform-specific verification** - Slack HMAC signatures + Teams JWT validation
-- ✅ **Webhook secret validation** - Double security layer for both platforms
+- ✅ **Multi-platform support** - Handles Slack, Microsoft Teams, Notion, and Shopify webhooks
+- ✅ **Platform-specific verification** - HMAC signatures and Teams JWT validation
+- ✅ **Webhook secret validation** - Additional URL secret on standard platform routes
 - ✅ **Multi-region forwarding** - Routes to US and EU endpoints
 - ✅ **URL verification** - Handles Slack's URL verification challenges
 - ✅ **Form-data preservation** - Maintains original webhook formats
@@ -78,6 +79,7 @@ GCP_WEBHOOK_ROUTER_CONFIG_BUCKET=dust-infra.firebasestorage.app
 SLACK_SIGNING_SECRET="your-slack-signing-secret"
 MICROSOFT_BOT_ID_SECRET="your-bot-app-id"
 NOTION_SIGNING_SECRET="your-notion-signing-secret"
+OAUTH_SHOPIFY_CLIENT_SECRET="your-shopify-client-secret"
 US_CONNECTOR_URL=http://localhost:3002
 EU_CONNECTOR_URL=http://localhost:3002
 ```
@@ -93,6 +95,7 @@ http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/s
 http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/slack/interactions
 http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/microsoft/teams/messages
 http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/notion
+http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/shopify
 ```
 
 ### Production
@@ -104,6 +107,7 @@ https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SEC
 https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/slack/interactions
 https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/microsoft/teams/messages
 https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/notion
+https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/shopify
 ```
 
 **Custom Domain (via Firebase Hosting):**
@@ -113,12 +117,13 @@ https://webhook-router.dust.tt/YOUR_WEBHOOK_SECRET/slack/events
 https://webhook-router.dust.tt/YOUR_WEBHOOK_SECRET/slack/interactions
 https://webhook-router.dust.tt/YOUR_WEBHOOK_SECRET/microsoft/teams/messages
 https://webhook-router.dust.tt/YOUR_WEBHOOK_SECRET/notion
+https://webhook-router.dust.tt/YOUR_WEBHOOK_SECRET/shopify
 ```
 
 ## Architecture
 
 ```
-Slack/Teams → Firebase Hosting → Firebase Function → [US Endpoint, EU Endpoint]
+Platforms → Firebase Hosting → Firebase Function → [US Endpoint, EU Endpoint]
                                            ↓
                               Firebase Realtime Database
                                            ↑
@@ -127,10 +132,12 @@ Slack/Teams → Firebase Hosting → Firebase Function → [US Endpoint, EU Endp
 
 **Security Flow:**
 
-1. Validates webhook secret from URL parameter (standard routes) or fetches from config (data sync routes)
+1. Validates the webhook secret from the URL on standard routes
 2. Platform-specific verification:
    - **Slack**: HMAC signature validation using Dust secret (standard) or client secret (data sync)
    - **Teams**: Bot Framework JWT token validation
+   - **Notion**: HMAC signature validation
+   - **Shopify**: Raw-body HMAC validation using the Shopify app client secret
 3. Handles platform-specific challenges (Slack URL verification)
 4. Forwards to regional endpoints based on configuration
 
@@ -153,6 +160,10 @@ Uses GCP Secret Manager for production:
 - `connectors-DUST_CONNECTORS_WEBHOOKS_SECRET` - Webhook secret
 - `SLACK_SIGNING_SECRET` - Slack app signing secret
 - `MICROSOFT_BOT_ID_SECRET` - Microsoft Bot Framework App ID
+- `NOTION_SIGNING_SECRET` - Notion integration signing secret
+- `OAUTH_SHOPIFY_CLIENT_SECRET` - Shopify app client secret
+
+The Shopify client secret must exist in the global GCP project before deploying the router.
 
 For local development, set environment variables:
 
@@ -161,6 +172,7 @@ export DUST_CONNECTORS_WEBHOOKS_SECRET="your-webhook-secret"
 export SLACK_SIGNING_SECRET="your-slack-signing-secret"
 export MICROSOFT_BOT_ID_SECRET="your-bot-app-id"
 export NOTION_SIGNING_SECRET="your-notion-signing-secret"
+export OAUTH_SHOPIFY_CLIENT_SECRET="your-shopify-client-secret"
 ```
 
 ## Firebase Services Used
@@ -198,6 +210,23 @@ export NOTION_SIGNING_SECRET="your-notion-signing-secret"
 ### Notion Endpoint
 
 - `POST /:webhookSecret/notion` - Notion events
+
+### Shopify Compliance Endpoint
+
+- `POST /:webhookSecret/shopify` - Shopify compliance events
+
+The Shopify route accepts `customers/data_request`, `customers/redact`, and `shop/redact`. It
+verifies and acknowledges receipt without logging customer or order data. It currently emits an
+operational warning for the privacy team; fulfilling exports and redactions remains a separate
+privacy workflow.
+
+Configure the Shopify app with:
+
+```toml
+[[webhooks.subscriptions]]
+compliance_topics = ["customers/data_request", "customers/redact", "shop/redact"]
+uri = "https://webhook-router.dust.tt/YOUR_WEBHOOK_SECRET/shopify"
+```
 
 ## Development
 

--- a/firebase-functions/webhook-router/package-lock.json
+++ b/firebase-functions/webhook-router/package-lock.json
@@ -15,180 +15,17 @@
         "firebase-admin": "^13.4.0",
         "firebase-functions": "^6.3.2",
         "jose": "^5.0.0",
-        "raw-body": "^3.0.0"
+        "raw-body": "^3.0.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.14",
         "@types/express": "^5.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "22.19.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": "20.19.2"
-      }
-    },
-    "node_modules/@biomejs/biome": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.14.tgz",
-      "integrity": "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "bin": {
-        "biome": "bin/biome"
-      },
-      "engines": {
-        "node": ">=14.21.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/biome"
-      },
-      "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.14",
-        "@biomejs/cli-darwin-x64": "2.3.14",
-        "@biomejs/cli-linux-arm64": "2.3.14",
-        "@biomejs/cli-linux-arm64-musl": "2.3.14",
-        "@biomejs/cli-linux-x64": "2.3.14",
-        "@biomejs/cli-linux-x64-musl": "2.3.14",
-        "@biomejs/cli-win32-arm64": "2.3.14",
-        "@biomejs/cli-win32-x64": "2.3.14"
-      }
-    },
-    "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.14.tgz",
-      "integrity": "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.14.tgz",
-      "integrity": "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.14.tgz",
-      "integrity": "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.14.tgz",
-      "integrity": "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.14.tgz",
-      "integrity": "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.14.tgz",
-      "integrity": "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.14.tgz",
-      "integrity": "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.14.tgz",
-      "integrity": "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -680,9 +517,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1534,15 +1371,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.14.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/@types/node": {
-      "version": "22.15.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.34.tgz",
-      "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/firebase-admin/node_modules/uuid": {
@@ -3320,6 +3148,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/firebase-functions/webhook-router/package.json
+++ b/firebase-functions/webhook-router/package.json
@@ -12,7 +12,8 @@
     "build:watch": "tsc --watch",
     "start": "npm run build && firebase emulators:start --only functions,storage,database",
     "dev": "npm run start",
-    "deploy": "./deploy.sh"
+    "deploy": "./deploy.sh",
+    "test": "npm run build && node --test dist/shopify/verification.test.js"
   },
   "author": "Dust",
   "license": "ISC",
@@ -23,7 +24,8 @@
     "firebase-admin": "^13.4.0",
     "firebase-functions": "^6.3.2",
     "jose": "^5.0.0",
-    "raw-body": "^3.0.0"
+    "raw-body": "^3.0.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/firebase-functions/webhook-router/package.json
+++ b/firebase-functions/webhook-router/package.json
@@ -12,8 +12,7 @@
     "build:watch": "tsc --watch",
     "start": "npm run build && firebase emulators:start --only functions,storage,database",
     "dev": "npm run start",
-    "deploy": "./deploy.sh",
-    "test": "npm run build && node --test dist/shopify/verification.test.js"
+    "deploy": "./deploy.sh"
   },
   "author": "Dust",
   "license": "ISC",

--- a/firebase-functions/webhook-router/src/config.ts
+++ b/firebase-functions/webhook-router/src/config.ts
@@ -20,6 +20,9 @@ export const CONFIG = {
   // Notion environment secrets.
   NOTION_SIGNING_SECRET: process.env.NOTION_SIGNING_SECRET,
 
+  // Shopify environment secrets.
+  OAUTH_SHOPIFY_CLIENT_SECRET: process.env.OAUTH_SHOPIFY_CLIENT_SECRET,
+
   // Endpoints.
   US_CONNECTOR_URL:
     process.env.US_CONNECTOR_URL ?? "https://connectors.dust.tt",
@@ -37,6 +40,9 @@ export const CONFIG = {
 
   // Notion related secrets.
   NOTION_SIGNING_SECRET_NAME: "NOTION_SIGNING_SECRET",
+
+  // Shopify related secrets.
+  OAUTH_SHOPIFY_CLIENT_SECRET_NAME: "OAUTH_SHOPIFY_CLIENT_SECRET",
 
   DUST_WEBHOOK_ROUTER_CONFIG_FILE_PATH: "webhook-router-config.json",
 } as const;

--- a/firebase-functions/webhook-router/src/routes.ts
+++ b/firebase-functions/webhook-router/src/routes.ts
@@ -5,6 +5,7 @@ import { createTeamsRoutes } from "./microsoft/routes.js";
 import { createTeamsVerificationMiddleware } from "./microsoft/verification.js";
 import { createNotionRoutes } from "./notion/routes.js";
 import type { SecretManager } from "./secrets.js";
+import { createShopifyRoutes } from "./shopify/routes.js";
 import {
   createSlackBotRoutes,
   createSlackDataSyncRoutes,
@@ -70,6 +71,9 @@ export function createRoutes(
     true
   );
   router.use("/notion/:providerWorkspaceId", notionInternalIntegrationRoutes);
+
+  const shopifyRoutes = createShopifyRoutes(secretManager);
+  router.use("/:webhookSecret/shopify", webhookSecretValidation, shopifyRoutes);
 
   const slackBotRoutes = createSlackBotRoutes(
     secretManager,

--- a/firebase-functions/webhook-router/src/secrets.ts
+++ b/firebase-functions/webhook-router/src/secrets.ts
@@ -10,6 +10,7 @@ export interface Secrets {
   webhookSecret: string;
   microsoftBotId?: string;
   notionSigningSecret: string;
+  shopifyClientSecret: string;
 }
 
 export class SecretManager {
@@ -47,6 +48,7 @@ export class SecretManager {
         microsoftBotId: CONFIG.MICROSOFT_BOT_ID_SECRET,
         slackSigningSecret: CONFIG.SLACK_SIGNING_SECRET ?? "",
         notionSigningSecret: CONFIG.NOTION_SIGNING_SECRET ?? "",
+        shopifyClientSecret: CONFIG.OAUTH_SHOPIFY_CLIENT_SECRET ?? "",
         usSecret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
         webhookSecret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
       };
@@ -76,6 +78,7 @@ export class SecretManager {
         slackSigningSecretResponse,
         microsoftBotIdResponse,
         notionSigningSecretResponse,
+        shopifyClientSecretResponse,
       ] = await Promise.all([
         this.client.accessSecretVersion({
           name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.SECRET_NAME}/versions/latest`,
@@ -95,6 +98,9 @@ export class SecretManager {
         this.client.accessSecretVersion({
           name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.NOTION_SIGNING_SECRET_NAME}/versions/latest`,
         }),
+        this.client.accessSecretVersion({
+          name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.OAUTH_SHOPIFY_CLIENT_SECRET_NAME}/versions/latest`,
+        }),
       ]);
 
       return {
@@ -107,6 +113,8 @@ export class SecretManager {
           slackSigningSecretResponse[0].payload?.data?.toString() || "",
         notionSigningSecret:
           notionSigningSecretResponse[0].payload?.data?.toString() || "",
+        shopifyClientSecret:
+          shopifyClientSecretResponse[0].payload?.data?.toString() || "",
       };
     } catch (e) {
       error("Failed to load secrets from Secret Manager", {

--- a/firebase-functions/webhook-router/src/shopify/routes.ts
+++ b/firebase-functions/webhook-router/src/shopify/routes.ts
@@ -1,0 +1,41 @@
+import express from "express";
+import { error, warn } from "firebase-functions/logger";
+
+import type { SecretManager } from "../secrets.js";
+import {
+  createShopifyVerificationMiddleware,
+  parseShopifyComplianceWebhookContext,
+} from "./verification.js";
+
+export function createShopifyRoutes(secretManager: SecretManager) {
+  const router = express.Router();
+  const shopifyVerification =
+    createShopifyVerificationMiddleware(secretManager);
+
+  router.post("/", shopifyVerification, (req, res) => {
+    const context = parseShopifyComplianceWebhookContext(
+      res.locals.shopifyComplianceWebhook
+    );
+    if (!context) {
+      error("Verified Shopify compliance webhook is missing context", {
+        component: "shopify-routes",
+      });
+      res.status(500).send();
+      return;
+    }
+
+    // This ingress intentionally avoids logging customer and order data from the payload.
+    warn(
+      "Shopify compliance webhook received and requires privacy processing",
+      {
+        component: "shopify-routes",
+        shopDomain: context.shopDomain,
+        topic: context.topic,
+        webhookId: context.webhookId,
+      }
+    );
+    res.status(200).send();
+  });
+
+  return router;
+}

--- a/firebase-functions/webhook-router/src/shopify/verification.test.ts
+++ b/firebase-functions/webhook-router/src/shopify/verification.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { describe, it } from "node:test";
+
+import {
+  type ShopifyComplianceTopic,
+  verifyShopifyComplianceWebhook,
+} from "./verification.js";
+
+const CLIENT_SECRET = "shopify-client-secret";
+const SHOP_DOMAIN = "dust-test.myshopify.com";
+
+function makeWebhook({
+  payload,
+  topic,
+}: {
+  payload: unknown;
+  topic: ShopifyComplianceTopic;
+}) {
+  const requestBody = Buffer.from(JSON.stringify(payload));
+  const hmac = crypto
+    .createHmac("sha256", CLIENT_SECRET)
+    .update(requestBody)
+    .digest("base64");
+
+  return {
+    headers: {
+      "x-shopify-hmac-sha256": hmac,
+      "x-shopify-shop-domain": SHOP_DOMAIN,
+      "x-shopify-topic": topic,
+      "x-shopify-webhook-id": "webhook-123",
+    },
+    requestBody,
+  };
+}
+
+describe("verifyShopifyComplianceWebhook", () => {
+  it("accepts each mandatory Shopify compliance topic", () => {
+    const webhooks: Array<{
+      payload: unknown;
+      topic: ShopifyComplianceTopic;
+    }> = [
+      {
+        topic: "customers/data_request",
+        payload: {
+          shop_id: 954889,
+          shop_domain: SHOP_DOMAIN,
+          orders_requested: [299938],
+          customer: { id: 191167, email: "customer@example.com" },
+          data_request: { id: 9999 },
+        },
+      },
+      {
+        topic: "customers/redact",
+        payload: {
+          shop_id: 954889,
+          shop_domain: SHOP_DOMAIN,
+          customer: { id: 191167, email: "customer@example.com" },
+          orders_to_redact: [299938],
+        },
+      },
+      {
+        topic: "shop/redact",
+        payload: {
+          shop_id: 954889,
+          shop_domain: SHOP_DOMAIN,
+        },
+      },
+    ];
+
+    for (const { payload, topic } of webhooks) {
+      const result = verifyShopifyComplianceWebhook({
+        clientSecret: CLIENT_SECRET,
+        ...makeWebhook({ payload, topic }),
+      });
+
+      assert.equal(result.status, 200);
+      if (result.status === 200) {
+        assert.deepEqual(result.context, {
+          shopDomain: SHOP_DOMAIN,
+          topic,
+          webhookId: "webhook-123",
+        });
+      }
+    }
+  });
+
+  it("rejects an invalid HMAC", () => {
+    const webhook = makeWebhook({
+      topic: "shop/redact",
+      payload: { shop_id: 954889, shop_domain: SHOP_DOMAIN },
+    });
+
+    assert.deepEqual(
+      verifyShopifyComplianceWebhook({
+        clientSecret: "wrong-secret",
+        ...webhook,
+      }),
+      { status: 401, error: "Invalid Shopify webhook signature" }
+    );
+  });
+
+  it("rejects a payload that does not match its topic", () => {
+    const webhook = makeWebhook({
+      topic: "customers/redact",
+      payload: { shop_id: 954889, shop_domain: SHOP_DOMAIN },
+    });
+
+    assert.deepEqual(
+      verifyShopifyComplianceWebhook({
+        clientSecret: CLIENT_SECRET,
+        ...webhook,
+      }),
+      { status: 400, error: "Invalid compliance webhook payload" }
+    );
+  });
+
+  it("rejects a store domain that differs from the signed payload", () => {
+    const webhook = makeWebhook({
+      topic: "shop/redact",
+      payload: { shop_id: 954889, shop_domain: SHOP_DOMAIN },
+    });
+
+    assert.deepEqual(
+      verifyShopifyComplianceWebhook({
+        clientSecret: CLIENT_SECRET,
+        requestBody: webhook.requestBody,
+        headers: {
+          ...webhook.headers,
+          "x-shopify-shop-domain": "another-store.myshopify.com",
+        },
+      }),
+      { status: 400, error: "Shopify store domain mismatch" }
+    );
+  });
+});

--- a/firebase-functions/webhook-router/src/shopify/verification.ts
+++ b/firebase-functions/webhook-router/src/shopify/verification.ts
@@ -110,6 +110,14 @@ function isValidPayloadForTopic(
       return CustomerRedactPayloadSchema.safeParse(payload).success;
     case "shop/redact":
       return BasePayloadSchema.safeParse(payload).success;
+    default: {
+      const exhaustiveTopic: never = topic;
+      error("Unhandled Shopify compliance webhook topic", {
+        component: "shopify-verification",
+        topic: exhaustiveTopic,
+      });
+      return false;
+    }
   }
 }
 

--- a/firebase-functions/webhook-router/src/shopify/verification.ts
+++ b/firebase-functions/webhook-router/src/shopify/verification.ts
@@ -1,0 +1,225 @@
+import crypto from "crypto";
+import type { Request, RequestHandler } from "express";
+import { error } from "firebase-functions/logger";
+import type { IncomingHttpHeaders } from "http";
+import rawBody from "raw-body";
+import { z } from "zod";
+
+import type { SecretManager } from "../secrets.js";
+
+const SHOPIFY_STORE_DOMAIN_RE =
+  /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.myshopify\.com$/;
+
+const ShopifyIdSchema = z.union([
+  z.number().int().nonnegative(),
+  z.string().regex(/^\d+$/),
+]);
+
+const BasePayloadSchema = z
+  .object({
+    shop_id: ShopifyIdSchema,
+    shop_domain: z.string().regex(SHOPIFY_STORE_DOMAIN_RE),
+  })
+  .passthrough();
+
+const CustomerDataRequestPayloadSchema = BasePayloadSchema.extend({
+  customer: z.object({ id: ShopifyIdSchema }).passthrough(),
+  data_request: z.object({ id: ShopifyIdSchema }).passthrough(),
+  orders_requested: z.array(ShopifyIdSchema),
+});
+
+const CustomerRedactPayloadSchema = BasePayloadSchema.extend({
+  customer: z.object({ id: ShopifyIdSchema }).passthrough(),
+  orders_to_redact: z.array(ShopifyIdSchema),
+});
+
+export const SHOPIFY_COMPLIANCE_TOPICS = [
+  "customers/data_request",
+  "customers/redact",
+  "shop/redact",
+] as const;
+
+const ShopifyComplianceTopicSchema = z.enum(SHOPIFY_COMPLIANCE_TOPICS);
+export type ShopifyComplianceTopic = z.infer<
+  typeof ShopifyComplianceTopicSchema
+>;
+
+const ShopifyComplianceWebhookContextSchema = z.object({
+  shopDomain: z.string().regex(SHOPIFY_STORE_DOMAIN_RE),
+  topic: ShopifyComplianceTopicSchema,
+  webhookId: z.string().min(1),
+});
+export type ShopifyComplianceWebhookContext = z.infer<
+  typeof ShopifyComplianceWebhookContextSchema
+>;
+
+type ShopifyComplianceWebhookVerificationResult =
+  | {
+      status: 200;
+      context: ShopifyComplianceWebhookContext;
+    }
+  | {
+      status: 400 | 401;
+      error: string;
+    };
+
+function getHeader(
+  headers: IncomingHttpHeaders,
+  name: string
+): string | undefined {
+  const value = headers[name.toLowerCase()];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function parseShopifyComplianceWebhookContext(
+  value: unknown
+): ShopifyComplianceWebhookContext | undefined {
+  const result = ShopifyComplianceWebhookContextSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}
+
+export function isValidShopifyWebhookHmac({
+  clientSecret,
+  hmac,
+  requestBody,
+}: {
+  clientSecret: string;
+  hmac: string;
+  requestBody: Buffer;
+}): boolean {
+  const receivedDigest = Buffer.from(hmac, "base64");
+  const expectedDigest = crypto
+    .createHmac("sha256", clientSecret)
+    .update(requestBody)
+    .digest();
+
+  return (
+    receivedDigest.length === expectedDigest.length &&
+    crypto.timingSafeEqual(receivedDigest, expectedDigest)
+  );
+}
+
+function isValidPayloadForTopic(
+  topic: ShopifyComplianceTopic,
+  payload: unknown
+): boolean {
+  switch (topic) {
+    case "customers/data_request":
+      return CustomerDataRequestPayloadSchema.safeParse(payload).success;
+    case "customers/redact":
+      return CustomerRedactPayloadSchema.safeParse(payload).success;
+    case "shop/redact":
+      return BasePayloadSchema.safeParse(payload).success;
+  }
+}
+
+export function verifyShopifyComplianceWebhook({
+  clientSecret,
+  headers,
+  requestBody,
+}: {
+  clientSecret: string;
+  headers: IncomingHttpHeaders;
+  requestBody: Buffer;
+}): ShopifyComplianceWebhookVerificationResult {
+  const hmac = getHeader(headers, "x-shopify-hmac-sha256");
+  if (
+    !hmac ||
+    !isValidShopifyWebhookHmac({ clientSecret, hmac, requestBody })
+  ) {
+    return { status: 401, error: "Invalid Shopify webhook signature" };
+  }
+
+  const topicResult = ShopifyComplianceTopicSchema.safeParse(
+    getHeader(headers, "x-shopify-topic")
+  );
+  if (!topicResult.success) {
+    return { status: 400, error: "Unsupported Shopify webhook topic" };
+  }
+
+  const webhookId = getHeader(headers, "x-shopify-webhook-id");
+  const headerShopDomain = getHeader(headers, "x-shopify-shop-domain");
+  if (!webhookId || !headerShopDomain) {
+    return { status: 400, error: "Missing Shopify webhook headers" };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(requestBody.toString("utf8"));
+  } catch {
+    return { status: 400, error: "Invalid JSON payload" };
+  }
+
+  const basePayloadResult = BasePayloadSchema.safeParse(payload);
+  if (
+    !basePayloadResult.success ||
+    !isValidPayloadForTopic(topicResult.data, payload)
+  ) {
+    return { status: 400, error: "Invalid compliance webhook payload" };
+  }
+
+  if (basePayloadResult.data.shop_domain !== headerShopDomain) {
+    return { status: 400, error: "Shopify store domain mismatch" };
+  }
+
+  return {
+    status: 200,
+    context: {
+      shopDomain: basePayloadResult.data.shop_domain,
+      topic: topicResult.data,
+      webhookId,
+    },
+  };
+}
+
+// On Firebase Functions and GCP, req.rawBody is provided for signature verification.
+async function parseExpressRequestRawBody(req: Request): Promise<Buffer> {
+  if (req !== null && "rawBody" in req && Buffer.isBuffer(req.rawBody)) {
+    return Promise.resolve(req.rawBody);
+  }
+
+  return rawBody(req);
+}
+
+export function createShopifyVerificationMiddleware(
+  secretManager: SecretManager
+): RequestHandler {
+  return async (req, res, next): Promise<void> => {
+    try {
+      const requestBody = await parseExpressRequestRawBody(req);
+      const secrets = await secretManager.getSecrets();
+      if (!secrets.shopifyClientSecret) {
+        error("Shopify client secret is not configured", {
+          component: "shopify-verification",
+        });
+        res.status(500).send();
+        return;
+      }
+
+      const result = verifyShopifyComplianceWebhook({
+        clientSecret: secrets.shopifyClientSecret,
+        headers: req.headers,
+        requestBody,
+      });
+
+      if (result.status !== 200) {
+        error("Shopify compliance webhook verification failed", {
+          component: "shopify-verification",
+          error: result.error,
+          status: result.status,
+        });
+        res.status(result.status).send();
+        return;
+      }
+
+      res.locals.shopifyComplianceWebhook = result.context;
+      return next();
+    } catch (e) {
+      error("Shopify compliance webhook verification failed", {
+        component: "shopify-verification",
+        error: e instanceof Error ? e.message : String(e),
+      });
+      res.status(500).send();
+    }
+  };
+}


### PR DESCRIPTION
## Description

- Add Shopify mandatory compliance webhook handling to the existing Firebase webhook router.
- Gate the endpoint with the shared webhook URL secret, then validate Shopify raw-body HMAC signatures, topics, and payloads.
- Load the Shopify app client secret from global Secret Manager and document the Shopify app configuration.
- Acknowledge verified requests while emitting a PII-minimized warning for the privacy workflow.

## Tests

- `cd firebase-functions/webhook-router && npm run build && node --test dist/shopify/verification.test.js`
- Firebase Functions emulator: valid webhook returns 200, invalid URL secret returns 404, and invalid Shopify HMAC returns 401.

## Risk

Low. The change adds an isolated endpoint protected by both the existing webhook secret and Shopify signature validation.

## Deploy Plan

- Ensure `OAUTH_SHOPIFY_CLIENT_SECRET` exists in the global GCP Secret Manager project.
- Deploy `firebase-functions/webhook-router`.
- Update Shopify `dust-mcp` app to point to `https://webhook-router.dust.tt/xxx/shopify`