### PR TITLE
[front] Render persisted content for messages paused on a user question

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1473,7 +1473,8 @@ function AgentMessageContent({
 
         {agentMessage.content !== null &&
           agentMessage.content !== "" &&
-          agentMessage.streaming.agentState === "done" && (
+          (agentMessage.streaming.agentState === "done" ||
+            blockedAction !== null) && (
             <div>
               <AgentMessageMarkdown
                 content={sanitizeVisualizationContent(agentMessage.content)}

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -239,9 +239,15 @@ export const makeInitialMessageStreamState = (
     streaming: {
       actionProgress: new Map(),
       agentState: message.status === "created" ? "thinking" : "done",
-      // Live messages rebuild inline steps from the SSE replay on mount.
-      inlineActivitySteps:
-        message.status === "created" ? [] : (message.activitySteps ?? []),
+      // Hydrate the persisted steps for every message, including "created"
+      // (paused/blocked) ones. When a live SSE stream is still available it
+      // replays from the start and rebuilds these steps (the fresh-mount reset
+      // in useAgentMessageStream clears the hydrated steps on the first replayed
+      // event to avoid duplication). When the stream has expired — e.g. a
+      // message paused on a user question for longer than the Redis stream TTL —
+      // the persisted steps are the only source, so we keep them instead of
+      // dropping the content the user was meant to see.
+      inlineActivitySteps: message.activitySteps ?? [],
       isRetrying: false,
       lastUpdated: new Date(),
       pendingToolCalls: [],

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -289,6 +289,23 @@ describe("appendThinkingStep", () => {
   });
 });
 
+describe("makeInitialMessageStreamState", () => {
+  it("hydrates persisted activity steps for a paused (created) message", () => {
+    const step = {
+      type: "content" as const,
+      content: "Draft to confirm",
+      id: "content-1-0",
+      step: 1,
+    };
+    const message = makeInitialMessageStreamState(
+      makeLightAgentMessage({ status: "created", activitySteps: [step] })
+    );
+
+    expect(message.streaming.agentState).toBe("thinking");
+    expect(message.streaming.inlineActivitySteps).toEqual([step]);
+  });
+});
+
 describe("useAgentMessageStream", () => {
   it("clears stale database content before replaying fresh-mount tokens", () => {
     let currentMessage = makeInitialMessageStreamState(makeLightAgentMessage());
@@ -358,6 +375,80 @@ describe("useAgentMessageStream", () => {
     });
     expect(currentMessage.content).toBe("Hello ");
     expect(currentMessage.chainOfThought).toBe("");
+  });
+
+  it("clears hydrated activity steps on the first replayed event to avoid duplication", () => {
+    const hydratedStep = {
+      type: "content" as const,
+      content: "Old draft",
+      id: "content-0-0",
+      step: 0,
+    };
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({
+        status: "created",
+        content: null,
+        chainOfThought: null,
+        activitySteps: [hydratedStep],
+      })
+    );
+
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      hydratedStep,
+    ]);
+
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Fresh ",
+            classification: "tokens",
+          },
+        })
+      );
+    });
+
+    // The hydrated step is dropped so the live replay rebuilds without
+    // duplicating it.
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([]);
   });
 
   it("does not restore stale thinking text from a pending throttled update after tool_params", () => {

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -371,6 +371,16 @@ export function useAgentMessageStream({
     shouldStream && (!!agentMessage.content || !!agentMessage.chainOfThought)
   );
 
+  // When a "created" message is reloaded, its persisted activity steps are
+  // hydrated into streaming.inlineActivitySteps (see makeInitialMessageStreamState).
+  // If a live SSE stream is still available it replays from the start and would
+  // rebuild those same steps, so we clear the hydrated steps once, on the first
+  // replayed step-bearing event (tokens or tool_params). An expired stream
+  // never emits such an event, so the hydrated steps are preserved.
+  const isFreshMountWithSteps = useRef(
+    shouldStream && agentMessage.streaming.inlineActivitySteps.length > 0
+  );
+
   const chainOfThought = useRef(agentMessage.chainOfThought ?? "");
   // content.current tracks the current text segment only
   // (cleared on each flush to inline activity steps).
@@ -426,6 +436,21 @@ export function useAgentMessageStream({
         }
         seenEventIds.current.add(eventPayload.eventId);
       }
+      // On a fresh mount the persisted activity steps were hydrated into
+      // streaming.inlineActivitySteps. The live replay is about to rebuild them,
+      // so clear the hydrated copy exactly once, on the first replayed
+      // step-bearing event, to avoid duplicated steps.
+      const clearHydratedStepsOnce = () => {
+        if (!isFreshMountWithSteps.current) {
+          return;
+        }
+        isFreshMountWithSteps.current = false;
+        mapMessagesWithAutoScroll((m) =>
+          isAgentMessageWithStreaming(m) && m.sId === sId
+            ? { ...m, streaming: { ...m.streaming, inlineActivitySteps: [] } }
+            : m
+        );
+      };
       const eventType = eventPayload.data.type;
       switch (eventType) {
         case "end-of-stream":
@@ -441,6 +466,12 @@ export function useAgentMessageStream({
           break;
 
         case "generation_tokens":
+          if (
+            eventPayload.data.classification === "tokens" ||
+            eventPayload.data.classification === "chain_of_thought"
+          ) {
+            clearHydratedStepsOnce();
+          }
           if (
             isFreshMountWithContent.current &&
             (eventPayload.data.classification === "tokens" ||
@@ -644,6 +675,7 @@ export function useAgentMessageStream({
           break;
 
         case "tool_params":
+          clearHydratedStepsOnce();
           updateMessageThrottled.cancel();
           const toolParams = eventPayload.data;
           mapMessagesWithAutoScroll((m) => {


### PR DESCRIPTION
## Description

Follow-up to #31614 (independent). Fixes the reload/hydration half of dust-tt/tasks#10196.

A message paused on `ask_user_question` (Forms) has message status `created` — the blocked status lives on the action, not the message. On a fresh load, `makeInitialMessageStreamState` deliberately discarded the persisted `activitySteps` (setting `inlineActivitySteps: []`) and marked the message `agentState: "thinking"`, delegating all reconstruction to the live SSE replay. The message body is additionally gated on `agentState === "done"`.

That replay only exists for the Redis stream TTL (10 min). A message paused waiting for a user answer stops publishing, so once the stream expires a reload rebuilds nothing: empty timeline, non-`done` state, gated body → the content the user was meant to review renders nowhere (while it is intact server-side / in poke).

This change:
- **Hydrates persisted `activitySteps` for `created` messages too** (`types.ts`), so a reloaded paused message shows its steps even with no live stream.
- **De-dupes against the live replay** (`useAgentMessageStream.ts`): when a stream *is* available it replays from the start and would rebuild the same steps, so the hydrated copy is cleared exactly once, on the first replayed step-bearing event (`generation_tokens` tokens/CoT, or `tool_params`). An expired stream never emits such an event, so the hydrated steps are preserved. This mirrors the existing fresh-mount content/CoT reset.
- **Renders the body when the message is blocked** (`AgentMessage.tsx`): the body gate now also opens when a blocked action is present, so a paused message's persisted body (the last text fragment) shows even though `agentState !== "done"`.

## Tests

- `npm run test -- useAgentMessageStream` — added two tests: `makeInitialMessageStreamState` hydrates steps for a paused `created` message, and the hook clears hydrated steps on the first replayed event (de-dup). 18/18 pass.
- Existing `AgentMessage.compactUIView` + stream + markdown suites still green (63 tests).
- `npx tsgo --noEmit` clean.

## Risk

Low–moderate; the de-dup touches the live streaming reducer. The reset is guarded by a fresh-mount ref that is only true when persisted steps were hydrated on a `created` message (i.e. a reload of an existing message) — a brand-new live message has empty `activitySteps`, so behavior there is unchanged. The body-gate change is additive (blocked messages only). Safe to roll back.

## Deploy Plan

Standard front deploy. No migration, no ordering constraints.