### PR TITLE
[front] Complete sandbox child workflows after activity failures

### DIFF
--- a/front/temporal/agent_loop/workflows.test.ts
+++ b/front/temporal/agent_loop/workflows.test.ts
@@ -19,6 +19,7 @@ const {
   runModelAndCreateActionsActivity,
   runModelAndCreateActionsActivityWithExplicitCancellation,
   publishDeferredEventsActivity,
+  workflowLogError,
 } = vi.hoisted(() => ({
   deprecatePatch: vi.fn(),
   patched: vi.fn(),
@@ -32,6 +33,7 @@ const {
   runModelAndCreateActionsActivity: vi.fn(),
   runModelAndCreateActionsActivityWithExplicitCancellation: vi.fn(),
   publishDeferredEventsActivity: vi.fn(),
+  workflowLogError: vi.fn(),
 }));
 
 vi.mock("@temporalio/workflow", () => {
@@ -54,6 +56,9 @@ vi.mock("@temporalio/workflow", () => {
     },
     defineSignal: (name: string) => name,
     deprecatePatch,
+    log: {
+      error: workflowLogError,
+    },
     patched,
     proxyActivities: (options: {
       cancellationType?: unknown;
@@ -190,7 +195,7 @@ describe("runSandboxChildToolWorkflow", () => {
   it.each([
     "no_retry",
     "retry_on_interrupt",
-  ] as const)("finalizes and propagates terminal activity failures for %s", async (retryPolicy) => {
+  ] as const)("finalizes terminal activity failures without failing the workflow for %s", async (retryPolicy) => {
     const error = new Error("activity attempts exhausted");
     const runActivity =
       retryPolicy === "retry_on_interrupt"
@@ -204,6 +209,36 @@ describe("runSandboxChildToolWorkflow", () => {
         agentLoopArgs,
         authType,
         retryPolicy,
+        step: 1,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(finalizeErroredSandboxChildToolActivity).toHaveBeenCalledWith(
+      authType,
+      { actionModelId: 123 }
+    );
+    expect(workflowLogError).toHaveBeenCalledWith(
+      "Sandbox child tool activity failed.",
+      {
+        actionModelId: 123,
+        error,
+      }
+    );
+  });
+
+  it("preserves terminal activity failure propagation when replaying without the completion patch", async () => {
+    const error = new Error("activity attempts exhausted");
+    runToolActivity.mockRejectedValue(error);
+    patched.mockImplementation(
+      (patchId) => patchId === "sandbox-child-tool-retry-policy"
+    );
+
+    await expect(
+      runSandboxChildToolWorkflow({
+        actionModelId: 123,
+        agentLoopArgs,
+        authType,
+        retryPolicy: "no_retry",
         step: 1,
       })
     ).rejects.toBe(error);

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -47,6 +47,7 @@ import {
   ActivityCancellationType,
   CancellationScope,
   deprecatePatch,
+  log,
   patched,
   proxyActivities,
   proxySinks,
@@ -599,6 +600,17 @@ export async function runSandboxChildToolWorkflow({
           actionModelId,
         })
       );
+
+      // Preserve the recorded failed outcome when replaying histories created before terminal
+      // activity failures became action results.
+      if (patched("sandbox-child-tool-terminal-failure-as-result")) {
+        log.error("Sandbox child tool activity failed.", {
+          actionModelId,
+          error,
+        });
+        return;
+      }
+
       throw error;
     }
   } else {


### PR DESCRIPTION
## Description

Sandbox child tool workflows currently finalize the action as errored and then rethrow terminal activity failures. A worker-drain race can therefore leave a correctly finalized child action behind a failed Temporal workflow.

This change treats the errored action as the in-band result for new histories. It logs the activity failure, keeps finalization non-cancellable, and returns successfully. A new Temporal patch marker preserves the recorded failure outcome for older histories.

## Tests

- npm run test -- temporal/agent_loop/workflows.test.ts temporal/agent_loop/activities/finalize_sandbox_child_tool.test.ts
- npx tsgo --noEmit
- Pre-commit Biome and front type-check hooks

The full front test suite was started but not run to completion.

## Risk

Risk is low. The sandbox action status remains errored and stays the result consumed by polling clients. No-retry activities remain single-attempt. Workflow failure alerts become structured workflow error logs.

The patch marker makes forward replay safe. A rollback must keep patch-aware workers available until marked executions close. The marked branch completes immediately after logging.

## Deploy Plan

Use the standard forward rolling deploy. Monitor sandbox child workflow failures, the Sandbox child tool activity failed log, and child actions stuck in running. For a rollback, let marked executions close before removing patch-aware workers.