### PR TITLE
[front] Agent loop: exit gracefully when the agent message row is gone

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -74,6 +74,7 @@ export async function ensureConversationTitleFromAgentLoop(
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
         {
+          reason: runAgentDataRes.error.type,
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
         },

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -12,7 +12,7 @@ import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
   getAgentLoopRuntimeData,
-  isAgentLoopDataSoftDeleteError,
+  isAgentLoopDataTerminalError,
 } from "@app/types/assistant/agent_run";
 import type {
   ConversationType,
@@ -71,7 +71,7 @@ export async function ensureConversationTitleFromAgentLoop(
     agentLoopArgs
   );
   if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+    if (isAgentLoopDataTerminalError(runAgentDataRes.error)) {
       logger.info(
         {
           reason: runAgentDataRes.error.type,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5082,6 +5082,48 @@ describe("Space Handling", () => {
         expect(result.error.message).toBe("Message not found");
       }
     });
+
+    it("enforces the version filter for version 0", async () => {
+      const conversationResource = await ConversationResource.fetchById(
+        ownerAuth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource not found");
+
+      const [messageRecord] = await MessageModel.findAll({
+        where: {
+          conversationId: conversationResource.id,
+          workspaceId: workspace.id,
+        },
+        limit: 1,
+      });
+      assert(messageRecord, "No message found");
+
+      // Make the stored version differ from 0: a falsy check on `version` would silently drop
+      // the filter for version 0 and return this row anyway.
+      await messageRecord.update({ version: 2 });
+
+      const wrongVersion =
+        await ConversationResource.getMessageByIdInConversation(
+          ownerAuth,
+          conversation,
+          messageRecord.sId,
+          0
+        );
+      expect(wrongVersion.isErr()).toBe(true);
+
+      const exactVersion =
+        await ConversationResource.getMessageByIdInConversation(
+          ownerAuth,
+          conversation,
+          messageRecord.sId,
+          2
+        );
+      expect(exactVersion.isOk()).toBe(true);
+      if (exactVersion.isOk()) {
+        expect(exactVersion.value.id).toBe(messageRecord.id);
+      }
+    });
   });
 
   describe("getPendingUserMessagesInConversation", () => {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -4234,7 +4234,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         conversationId: conversation.id,
         workspaceId: auth.getNonNullableWorkspace().id,
         sId: messageId,
-        ...(version ? { version } : {}),
+        // A truthiness check would silently drop the filter for version 0, matching an arbitrary
+        // version of the message instead of the first one.
+        ...(version !== undefined ? { version } : {}),
       },
       include: [
         {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -26,7 +26,7 @@ import type {
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
   getAgentLoopRuntimeData,
-  isAgentLoopDataSoftDeleteError,
+  isAgentLoopDataTerminalError,
 } from "@app/types/assistant/agent_run";
 import type {
   AgentMessageStatus,
@@ -527,8 +527,8 @@ function toUserFriendlyMessage(error: {
 }
 
 // Returns the errored agent message's model id (already resolved here) so the caller can
-// attribute the failure without refetching the conversation, or null when the conversation is
-// gone.
+// attribute the failure without refetching the conversation, or null when the conversation or
+// the message is gone.
 export async function notifyWorkflowError(
   authType: AuthenticatorType,
   { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
@@ -551,14 +551,25 @@ export async function notifyWorkflowError(
     agentMessageVersion
   );
 
+  // This runs on the workflow's error path: a failed lookup must degrade (no user-facing event)
+  // rather than throw, which would fail the finalize activity and skip its remaining side
+  // effects (billing, analytics, email).
   if (messageRes.isErr()) {
-    throw new Error(`Agent message not found: ${agentMessageId}`);
+    logger.warn(
+      { conversationId, agentMessageId, agentMessageVersion },
+      "Agent message not found while notifying a workflow error"
+    );
+    return null;
   }
 
   const messageRow = messageRes.value;
 
   if (!messageRow.agentMessage) {
-    throw new Error(`Agent message not found: ${agentMessageId}`);
+    logger.warn(
+      { conversationId, agentMessageId, agentMessageVersion },
+      "Agent message not found while notifying a workflow error"
+    );
+    return null;
   }
 
   const errorEvent: AgentMessageEvents = {
@@ -640,7 +651,7 @@ export async function finalizeCancellation(
     agentLoopArgs
   );
   if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+    if (isAgentLoopDataTerminalError(runAgentDataRes.error)) {
       logger.info(
         {
           reason: runAgentDataRes.error.type,
@@ -711,7 +722,7 @@ export async function finalizeInterruption(
     agentLoopArgs
   );
   if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+    if (isAgentLoopDataTerminalError(runAgentDataRes.error)) {
       logger.info(
         {
           reason: runAgentDataRes.error.type,
@@ -799,7 +810,7 @@ export async function finalizeGracefulStop(
     agentLoopArgs
   );
   if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+    if (isAgentLoopDataTerminalError(runAgentDataRes.error)) {
       logger.info(
         {
           reason: runAgentDataRes.error.type,
@@ -864,7 +875,7 @@ export async function finalizeCreditStop(
     agentLoopArgs
   );
   if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+    if (isAgentLoopDataTerminalError(runAgentDataRes.error)) {
       logger.info(
         {
           reason: runAgentDataRes.error.type,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -643,6 +643,7 @@ export async function finalizeCancellation(
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
         {
+          reason: runAgentDataRes.error.type,
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
         },
@@ -713,6 +714,7 @@ export async function finalizeInterruption(
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
         {
+          reason: runAgentDataRes.error.type,
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
         },
@@ -800,6 +802,7 @@ export async function finalizeGracefulStop(
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
         {
+          reason: runAgentDataRes.error.type,
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
         },
@@ -864,6 +867,7 @@ export async function finalizeCreditStop(
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
         {
+          reason: runAgentDataRes.error.type,
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
         },

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -138,6 +138,7 @@ async function _runModelAndCreateActionsActivity({
     if (isAgentLoopDataSoftDeleteError(contextProviderRes.error)) {
       logger.info(
         {
+          reason: contextProviderRes.error.type,
           conversationId: runAgentArgs.conversationId,
           agentMessageId: runAgentArgs.agentMessageId,
         },

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -30,7 +30,7 @@ import type {
   AgentLoopArgsWithTiming,
   AgentLoopRuntimeData,
 } from "@app/types/assistant/agent_run";
-import { isAgentLoopDataSoftDeleteError } from "@app/types/assistant/agent_run";
+import { isAgentLoopDataTerminalError } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation } from "@langfuse/tracing";
 import { Context, heartbeat } from "@temporalio/activity";
@@ -135,7 +135,7 @@ async function _runModelAndCreateActionsActivity({
       })
   );
   if (contextProviderRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(contextProviderRes.error)) {
+    if (isAgentLoopDataTerminalError(contextProviderRes.error)) {
       logger.info(
         {
           reason: contextProviderRes.error.type,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -26,7 +26,7 @@ import type {
 } from "@app/types/assistant/agent_run";
 import {
   getFullAgentLoopDataWithAuth,
-  isAgentLoopDataSoftDeleteError,
+  isAgentLoopDataTerminalError,
 } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -152,7 +152,7 @@ export async function runToolActivity(
     }
   );
   if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+    if (isAgentLoopDataTerminalError(runAgentDataRes.error)) {
       logger.info(
         {
           reason: runAgentDataRes.error.type,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -155,6 +155,7 @@ export async function runToolActivity(
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
         {
+          reason: runAgentDataRes.error.type,
           actionId,
           runIds,
         },

--- a/front/types/assistant/agent_run.test.ts
+++ b/front/types/assistant/agent_run.test.ts
@@ -1,7 +1,10 @@
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { getAgentLoopRuntimeDataWithAuth } from "@app/types/assistant/agent_run";
+import {
+  getAgentLoopRuntimeDataWithAuth,
+  isAgentLoopDataSoftDeleteError,
+} from "@app/types/assistant/agent_run";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { describe, expect, it } from "vitest";
 
@@ -57,5 +60,48 @@ describe("getAgentLoopRuntimeDataWithAuth", () => {
     expect(result.value.modelInfo.endpoint.modelConfig.modelId).not.toBe(
       AUTO_MODEL_ID
     );
+  });
+
+  it("returns a terminal error when the agent message version does not exist", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow, userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+      });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      auth,
+      {
+        workspace,
+        conversation,
+        agentConfig,
+        parentMessageModelId: userMessageRow.id,
+        rank: 1,
+      }
+    );
+
+    const result = await getAgentLoopRuntimeDataWithAuth(auth, {
+      agentMessageId: agentMessage.sId,
+      // A version that was never created: a workflow referencing it can never make progress.
+      agentMessageVersion: agentMessage.version + 1,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+      userMessageOrigin: userMessage.context.origin,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      // Terminal: callers exit gracefully instead of retrying an error that cannot resolve.
+      expect(isAgentLoopDataSoftDeleteError(result.error)).toBe(true);
+    }
   });
 });

--- a/front/types/assistant/agent_run.test.ts
+++ b/front/types/assistant/agent_run.test.ts
@@ -3,7 +3,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import {
   getAgentLoopRuntimeDataWithAuth,
-  isAgentLoopDataSoftDeleteError,
+  isAgentLoopDataTerminalError,
 } from "@app/types/assistant/agent_run";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { describe, expect, it } from "vitest";
@@ -101,7 +101,7 @@ describe("getAgentLoopRuntimeDataWithAuth", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       // Terminal: callers exit gracefully instead of retrying an error that cannot resolve.
-      expect(isAgentLoopDataSoftDeleteError(result.error)).toBe(true);
+      expect(isAgentLoopDataTerminalError(result.error)).toBe(true);
     }
   });
 });

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -44,7 +44,7 @@ import { ConversationError } from "./conversation";
  * Error types for getAgentLoopRuntimeData that indicate deleted or unavailable resources.
  * These are safe to ignore in callers since retrying won't make the data available.
  */
-const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
+const AGENT_LOOP_DATA_TERMINAL_ERROR_TYPES = [
   "conversation_deleted",
   "agent_message_deleted",
   "user_message_deleted",
@@ -56,24 +56,24 @@ const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
 // Cache for 200 seconds, which maps to P95 execution time of the agent loop.
 const AGENT_CONFIGURATION_CACHE_TTL_MS = 200 * 1000;
 
-type AgentLoopDataSoftDeleteErrorType =
-  (typeof AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES)[number];
+type AgentLoopDataTerminalErrorType =
+  (typeof AGENT_LOOP_DATA_TERMINAL_ERROR_TYPES)[number];
 
 class AgentLoopDataError extends Error {
-  readonly type: AgentLoopDataSoftDeleteErrorType;
+  readonly type: AgentLoopDataTerminalErrorType;
 
-  constructor(type: AgentLoopDataSoftDeleteErrorType) {
+  constructor(type: AgentLoopDataTerminalErrorType) {
     super(`Agent loop data unavailable: ${type}`);
     this.type = type;
   }
 }
 
-export function isAgentLoopDataSoftDeleteError(
+export function isAgentLoopDataTerminalError(
   error: Error
 ): error is AgentLoopDataError {
   return (
     error instanceof AgentLoopDataError &&
-    AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES.includes(error.type)
+    AGENT_LOOP_DATA_TERMINAL_ERROR_TYPES.includes(error.type)
   );
 }
 
@@ -220,8 +220,8 @@ export async function getAgentLoopRuntimeDataWithAuth(
       message.agentMessage
   );
   if (!agentMessageRow) {
-    // Direct lookup: the row is genuinely absent at this exact sId + version, retrying will not
-    // make it appear.
+    // Direct lookup: the row is absent or unreadable at this exact sId + version, retrying will
+    // not make it appear.
     return new Err(new AgentLoopDataError("agent_message_not_found"));
   }
   if (agentMessageRow.visibility === "deleted") {

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -15,6 +15,7 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { DustNoopNoopGlobalNoopStream } from "@app/lib/llms/stream/endpoints/noop_noop_global_noop";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { cacheWithRedis } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
   AgentConfigurationWithoutModelType,
@@ -47,6 +48,9 @@ const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
   "conversation_deleted",
   "agent_message_deleted",
   "user_message_deleted",
+  // The message row is absent at the exact sId + version the workflow references, verified with a
+  // direct lookup rather than just missing from a rendered conversation.
+  "agent_message_not_found",
 ] as const;
 
 // Cache for 200 seconds, which maps to P95 execution time of the agent loop.
@@ -216,7 +220,9 @@ export async function getAgentLoopRuntimeDataWithAuth(
       message.agentMessage
   );
   if (!agentMessageRow) {
-    return new Err(new Error("Agent message not found"));
+    // Direct lookup: the row is genuinely absent at this exact sId + version, retrying will not
+    // make it appear.
+    return new Err(new AgentLoopDataError("agent_message_not_found"));
   }
   if (agentMessageRow.visibility === "deleted") {
     return new Err(new AgentLoopDataError("agent_message_deleted"));
@@ -371,7 +377,33 @@ export async function buildAgentLoopDataFromConversation(
   }
 
   if (!agentMessage) {
-    return new Err(new Error("Agent message not found"));
+    // The rendered conversation does not contain the message. Either the row is genuinely gone,
+    // in which case retrying will not help, or rendering dropped a row that exists, which is
+    // retryable and worth a precise log since it means the conversation fetch lost a message.
+    const messageRes = await ConversationResource.getMessageByIdInConversation(
+      auth,
+      conversation,
+      agentMessageId,
+      agentMessageVersion
+    );
+    if (messageRes.isErr()) {
+      return new Err(new AgentLoopDataError("agent_message_not_found"));
+    }
+    logger.error(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        agentMessageId,
+        agentMessageVersion,
+        messageRank: messageRes.value.rank,
+        messageVisibility: messageRes.value.visibility,
+        renderedGroupCount: conversation.content.length,
+      },
+      "Agent message exists but is missing from the rendered conversation"
+    );
+    return new Err(
+      new Error("Agent message not found in rendered conversation")
+    );
   }
 
   // Check if the agent message was soft-deleted.


### PR DESCRIPTION
## Goal

Some agentLoopWorkflows fail with `Agent message not found` after burning all 15 retry attempts of `runModelAndCreateActionsActivity` (~70-500 attempt failures/day in Datadog, repeat pattern: one conversation had 8 workflows fail back to back). The referenced (sId, version) message row is absent, and since a message's sId and version are immutable once created, no retry can ever succeed: the workflow retries a permanently missing row for ~30 minutes, then goes FAILED.

## What it does

- `getAgentLoopRuntimeDataWithAuth` (direct row lookup path): an absent row at the exact sId + version now returns `AgentLoopDataError("agent_message_not_found")`, added to the terminal error family — callers already exit gracefully on those instead of retrying.
- `buildAgentLoopDataFromConversation` (full render path): a message missing from the rendered conversation is disambiguated with a direct lookup. Row absent → same terminal error. Row present → the render dropped an existing message: kept retryable, and logged (`"Agent message exists but is missing from the rendered conversation"` with rank/visibility/rendered-group-count) so the next occurrence tells us why.
- `getMessageByIdInConversation`: fixes a falsy check that silently dropped the version filter for version 0 (`version ? ... : ...`) — until now, version-0 lookups (the overwhelming majority) skipped version matching entirely.
- `notifyWorkflowError` no longer throws when the message lookup misses: it runs on the workflow's error path, and a throw there fails the finalize activity and skips its billing/analytics/email side effects (a risk the version-0 fix would have sharpened). It degrades to a warn log + null, like its existing conversation-gone branch.
- The terminal-error guard is renamed `isAgentLoopDataTerminalError` (was `isAgentLoopDataSoftDeleteError`): with `agent_message_not_found` in the family, the old name no longer matched its semantics. Its logs at the 7 call sites now include `reason` (the error type), so graceful exits are distinguishable in Datadog.

## Tests

`getAgentLoopRuntimeDataWithAuth` returns a terminal error for a nonexistent version; `getMessageByIdInConversation` enforces the version filter for version 0. `tsgo --noEmit` clean.

## Risk

A hypothetical race where the workflow starts before its message row is visible would now exit gracefully instead of succeeding on retry — but workflows launch after the creating transaction commits, and the production failures show the condition is always persistent (15/15 attempts over ~30 min). Worst case, a raced run ends silently, the same outcome the soft-delete family already accepts.

## Deploy Plan

- [ ] Deploy front.
- [ ] `"Activity failed" "Agent message not found"` drops to ~0 in Datadog.
- [ ] Watch for `"Agent message exists but is missing from the rendered conversation"`: any hit is a conversation-rendering bug with diagnostics attached.
