### PR TITLE
Route spend-cap access control through flag-aware access_control

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -11,6 +11,11 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isUserMessageContextOverflowing } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import {
+  isApiBlocked,
+  isApiKeyBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/api/credits/access_control";
+import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
@@ -19,11 +24,6 @@ import {
   addBackwardCompatibleConversationWithoutContentFields,
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
-import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -169,9 +169,14 @@ app.post(
               },
             });
           }
+          // Mirrors the authoritative gate in postUserMessage, checked here to
+          // avoid creating an empty conversation when the initial message is
+          // blocked. `isProgrammaticApiBlocked` / `isApiKeyBlocked` are
+          // flag-aware (Redis rate-limiter counters when the flag is on, the
+          // Metronome-driven credit state otherwise).
           if (
             workspace.metronomeCustomerId &&
-            (await isProgrammaticApiBlocked(workspace.sId))
+            (await isProgrammaticApiBlocked(auth))
           ) {
             return apiError(ctx, {
               status_code: 429,
@@ -182,10 +187,8 @@ app.post(
               },
             });
           }
-          // Per-API-key credit cap: block when this key's credit state is
-          // "capped" (driven by the Metronome per-key cap alert / reconcile).
           const key = auth.key();
-          if (key && (await isApiKeyCapped(workspace.sId, key.id))) {
+          if (key && (await isApiKeyBlocked(auth, { keyModelId: key.id }))) {
             return apiError(ctx, {
               status_code: 429,
               api_error: {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -156,10 +156,7 @@ app.post(
         const workspace = auth.getNonNullableWorkspace();
         const plan = auth.subscription()?.plan;
         if (plan && isCreditPricedPlan(plan)) {
-          if (
-            workspace.metronomeCustomerId &&
-            (await isApiBlocked(workspace.sId))
-          ) {
+          if (workspace.metronomeCustomerId && (await isApiBlocked(auth))) {
             return apiError(ctx, {
               status_code: 429,
               api_error: {

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -1,3 +1,8 @@
+import {
+  isUserAwuWarned,
+  isUserBlocked,
+  isWorkspaceProgrammaticWarningReached,
+} from "@app/lib/api/credits/access_control";
 import { getUpgradeRequestAvailabilityForUser } from "@app/lib/api/credits/upgrade_requests";
 import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -8,10 +13,7 @@ import type {
 import {
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
-  isUserAwuWarned,
-  isUserBlocked,
   isWorkspaceBalanceThresholdReached,
-  isWorkspaceProgrammaticWarningReached,
 } from "@app/lib/metronome/user_block";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -60,14 +62,17 @@ app.get(
       balanceThresholdReached,
     ] = await Promise.all([
       getWorkspaceCreditPoolStatus(workspace.sId),
-      isUserBlocked(workspace, user),
+      isUserBlocked(auth, user),
       getWorkspaceProgrammaticCreditStatus(workspace.sId),
-      isWorkspaceProgrammaticWarningReached(workspace.sId),
+      isWorkspaceProgrammaticWarningReached(auth),
       isWorkspaceBalanceThresholdReached(workspace.sId),
     ]);
 
+    // `isUserAwuWarned` is flag-aware: the Redis rate-limiter warning (80% of
+    // the effective cap) when the flag is on, the Metronome near-limit flag
+    // otherwise.
     const userNearCreditLimit =
-      !userBlockedReason && (await isUserAwuWarned(workspace.sId, user.sId));
+      !userBlockedReason && (await isUserAwuWarned(auth, { user }));
 
     const programmaticCreditStatus: ProgrammaticCreditStatus =
       programmaticState === "depleted" ? "depleted" : "active";

--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -33,7 +33,7 @@ const { mockIsUserBlocked, mockIsNonCreditPricedUserSpendLimitReached } =
     mockIsNonCreditPricedUserSpendLimitReached: vi.fn(),
   }));
 
-vi.mock("@app/lib/metronome/user_block", () => ({
+vi.mock("@app/lib/api/credits/access_control", () => ({
   isUserBlocked: mockIsUserBlocked,
 }));
 

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -3,10 +3,10 @@ import {
   createConversation,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import { isUserBlocked } from "@app/lib/api/credits/access_control";
 import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
-import { isUserBlocked } from "@app/lib/metronome/user_block";
 import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -16,7 +16,6 @@ import { jobSkill } from "@app/lib/resources/skill/code_defined/global/job";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { serializeSkillTag } from "@app/lib/skills/format";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
   DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
@@ -151,10 +150,7 @@ export async function isEligibleForNudge(
 
   if (user) {
     if (isCreditPricedWorkspace(auth)) {
-      const workspace = renderLightWorkspaceType({
-        workspace: auth.getNonNullableWorkspace(),
-      });
-      if (await isUserBlocked(workspace, user)) {
+      if (await isUserBlocked(auth, user)) {
         return false;
       }
     } else {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2560,7 +2560,7 @@ export async function checkMessagesLimit(
     // from the Metronome credit state (see `user_block.ts`).
     const blockedReason = user
       ? await isUserBlocked(auth, user)
-      : (await isApiBlocked(owner.sId))
+      : (await isApiBlocked(auth))
         ? ("credits_exhausted" as const)
         : null;
     if (blockedReason === "no_seat") {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -65,10 +65,14 @@ import {
   deriveAgentTriggerType,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import {
+  isApiBlocked,
+  isApiKeyBlocked,
+  isProgrammaticApiBlocked,
+  isUserBlocked,
+} from "@app/lib/api/credits/access_control";
 import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
-import { isProgrammaticSpendLimitRateCapReached } from "@app/lib/api/credits/programmatic_usage_limit";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
-import { isApiKeySpendLimitRateCapReached } from "@app/lib/api/keys/spend_limit";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import {
   checkProgrammaticUsageLimits,
@@ -76,24 +80,17 @@ import {
 } from "@app/lib/api/programmatic_usage/tracking";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects/context";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import {
-  isNonCreditPricedUserSpendLimitReached,
-  isUserSpendLimitRateCapReached,
-} from "@app/lib/api/users/spend_limit";
+import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
-import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
 import { isFreeOrigin } from "@app/lib/metronome/events";
 import {
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-  isUserBlocked,
 } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
@@ -2558,8 +2555,11 @@ export async function checkMessagesLimit(
   );
 
   if (isCreditPricedWorkspace) {
+    // `isUserBlocked` / `isApiBlocked` are flag-aware: with the rate-cap flag on
+    // the per-user cap comes from the Redis fixed-window counters, with it off
+    // from the Metronome credit state (see `user_block.ts`).
     const blockedReason = user
-      ? await isUserBlocked(owner, user)
+      ? await isUserBlocked(auth, user)
       : (await isApiBlocked(owner.sId))
         ? ("credits_exhausted" as const)
         : null;
@@ -2602,27 +2602,6 @@ export async function checkMessagesLimit(
           },
         });
       }
-      // Redis fixed-window per-user spend cap: a synchronous backup of the
-      // Metronome per-user cap over the current contract billing cycle. Only
-      // applies to real users (API keys are gated by pool / programmatic caps
-      // instead). Enforcement is gated behind a feature flag while we validate
-      // the counter; usage is recorded regardless (in credit_cost), so the flag
-      // only controls blocking.
-      if (user) {
-        const featureFlags = await getFeatureFlags(auth);
-        if (
-          featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
-          (await isUserSpendLimitRateCapReached(auth, { user }))
-        ) {
-          return new Err({
-            status_code: 403,
-            api_error: {
-              type: "user_cap_reached",
-              message: "You have reached your personal usage cap.",
-            },
-          });
-        }
-      }
       if (blockedReason === "credits_exhausted") {
         return new Err({
           status_code: 403,
@@ -2653,26 +2632,11 @@ export async function checkMessagesLimit(
 
     // Programmatic monthly cap: block programmatic calls when the cap is reached.
     if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
-      // The Redis fixed-window backups are flag-gated while we validate the
-      // counters; usage is recorded regardless (in credit_cost), so the flag
-      // only controls blocking.
-      const featureFlags = await getFeatureFlags(auth);
-      const spendCapEnabled = featureFlags.includes(
-        "enforce_user_spend_limit_rate_cap"
-      );
-
-      // Per-API-key credit cap: block when this key's credit state is "capped"
-      // (driven by the Metronome per-key cap alert / reconcile), or when the
-      // Redis fixed-window backup reports the cap reached.
+      // Per-API-key credit cap. `isApiKeyBlocked` is flag-aware (rate-limiter
+      // counter when the flag is on, Metronome per-key credit state otherwise).
       const key = auth.key();
       if (key) {
-        const capReached =
-          (await isApiKeyCapped(owner.sId, key.id)) ||
-          (spendCapEnabled &&
-            (await isApiKeySpendLimitRateCapReached(auth, {
-              keyModelId: key.id,
-            })));
-        if (capReached) {
+        if (await isApiKeyBlocked(auth, { keyModelId: key.id })) {
           return new Err({
             status_code: 429,
             api_error: {
@@ -2684,13 +2648,10 @@ export async function checkMessagesLimit(
         }
       }
 
-      // Workspace programmatic monthly cap: the Metronome-driven state
-      // (`isProgrammaticApiBlocked`) OR the Redis fixed-window backup.
-      const programmaticBlocked =
-        (await isProgrammaticApiBlocked(owner.sId)) ||
-        (spendCapEnabled &&
-          (await isProgrammaticSpendLimitRateCapReached(auth)));
-      if (programmaticBlocked) {
+      // Workspace programmatic monthly cap. `isProgrammaticApiBlocked` is
+      // flag-aware (rate-limiter counter when the flag is on, Metronome
+      // programmatic credit state otherwise).
+      if (await isProgrammaticApiBlocked(auth)) {
         return new Err({
           status_code: 429,
           api_error: {

--- a/front/lib/api/assistant/credit_check.test.ts
+++ b/front/lib/api/assistant/credit_check.test.ts
@@ -15,7 +15,7 @@ const {
   mockIsProgrammaticUsage: vi.fn(),
 }));
 
-vi.mock("@app/lib/metronome/user_block", () => ({
+vi.mock("@app/lib/api/credits/access_control", () => ({
   isUserBlocked: mockIsUserBlocked,
   isApiBlocked: mockIsApiBlocked,
   isProgrammaticApiBlocked: mockIsProgrammaticApiBlocked,

--- a/front/lib/api/assistant/credit_check.test.ts
+++ b/front/lib/api/assistant/credit_check.test.ts
@@ -109,7 +109,7 @@ describe("checkPoolCreditGate", () => {
     const auth = makeAuth({ hasUser: false });
     await callGate(auth);
     expect(mockIsUserBlocked).not.toHaveBeenCalled();
-    expect(mockIsApiBlocked).toHaveBeenCalledWith("ws_test");
+    expect(mockIsApiBlocked).toHaveBeenCalledWith(auth);
   });
 
   it("stops when isApiBlocked is true (no human user)", async () => {

--- a/front/lib/api/assistant/credit_check.ts
+++ b/front/lib/api/assistant/credit_check.ts
@@ -38,7 +38,7 @@ export async function checkPoolCreditGate(
   const user = auth.user();
   const blocked = user
     ? (await isUserBlocked(auth, user)) !== null
-    : await isApiBlocked(owner.sId);
+    : await isApiBlocked(auth);
   if (blocked) {
     return { shouldStop: true, reason: "credits_exhausted" };
   }

--- a/front/lib/api/assistant/credit_check.ts
+++ b/front/lib/api/assistant/credit_check.ts
@@ -1,10 +1,10 @@
-import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
-import type { Authenticator } from "@app/lib/auth";
 import {
   isApiBlocked,
   isProgrammaticApiBlocked,
   isUserBlocked,
-} from "@app/lib/metronome/user_block";
+} from "@app/lib/api/credits/access_control";
+import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
+import type { Authenticator } from "@app/lib/auth";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isCreditPricedPlan } from "@app/types/plan";
 
@@ -37,7 +37,7 @@ export async function checkPoolCreditGate(
 
   const user = auth.user();
   const blocked = user
-    ? (await isUserBlocked(owner, user)) !== null
+    ? (await isUserBlocked(auth, user)) !== null
     : await isApiBlocked(owner.sId);
   if (blocked) {
     return { shouldStop: true, reason: "credits_exhausted" };
@@ -46,7 +46,7 @@ export async function checkPoolCreditGate(
   if (
     userMessageOrigin &&
     isProgrammaticUsage(auth, { userMessageOrigin }) &&
-    (await isProgrammaticApiBlocked(owner.sId))
+    (await isProgrammaticApiBlocked(auth))
   ) {
     return { shouldStop: true, reason: "credits_exhausted" };
   }

--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -1,0 +1,123 @@
+// Flag-aware access-control readers.
+//
+// Each reader switches on the `enforce_user_spend_limit_rate_cap` feature flag:
+// when enabled it enforces from the Redis fixed-window rate-limiter counters,
+// when disabled it falls back to the Metronome credit state in
+// `lib/metronome/user_block.ts`. Usage is recorded into the counters regardless
+// (in credit_cost), so the flag only controls which signal blocks.
+//
+// Callers doing access-control decisions should import from here. The low-level
+// Redis cache getters/setters and the fine-grained status reads still live in
+// `lib/metronome/user_block.ts`.
+import {
+  isProgrammaticSpendLimitRateCapReached,
+  isProgrammaticSpendLimitRateWarningReached,
+} from "@app/lib/api/credits/programmatic_usage_limit";
+import { isApiKeySpendLimitRateCapReached } from "@app/lib/api/keys/spend_limit";
+import {
+  isUserSpendLimitRateCapReached,
+  isUserSpendLimitRateWarningReached,
+} from "@app/lib/api/users/spend_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
+import type { UserBlockedReason } from "@app/lib/metronome/user_block";
+import {
+  isProgrammaticApiBlocked as isProgrammaticApiBlockedByMetronome,
+  isUserAwuWarned as isUserAwuWarnedByMetronome,
+  isUserBlocked as isUserBlockedByMetronome,
+  isWorkspaceProgrammaticWarningReached as isWorkspaceProgrammaticWarningReachedByMetronome,
+} from "@app/lib/metronome/user_block";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+
+// Pool-only read (no per-user cap, no rate-limiter dimension): re-exported so
+// access-control callers have a single import site.
+export { isApiBlocked } from "@app/lib/metronome/user_block";
+
+async function spendLimitRateCapEnabled(auth: Authenticator): Promise<boolean> {
+  const featureFlags = await getFeatureFlags(auth);
+  return featureFlags.includes("enforce_user_spend_limit_rate_cap");
+}
+
+/**
+ * Whether the user is blocked from sending billable messages, and why. With the
+ * rate-cap flag on, the per-user cap comes from the Redis fixed-window counter;
+ * the pool part (no_seat, pool depletion, personal-seat carve-out) always comes
+ * from the Metronome pool state. With the flag off, both come from Metronome.
+ */
+export async function isUserBlocked(
+  auth: Authenticator,
+  user: UserResource
+): Promise<UserBlockedReason | null> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!(await spendLimitRateCapEnabled(auth))) {
+    return isUserBlockedByMetronome(workspace, user);
+  }
+  const userCapBlockedOverride = await isUserSpendLimitRateCapReached(auth, {
+    user,
+  });
+  return isUserBlockedByMetronome(workspace, user, { userCapBlockedOverride });
+}
+
+/**
+ * Whether the workspace programmatic monthly cap is reached. With the rate-cap
+ * flag on, from the Redis fixed-window counter; with it off, from the
+ * Metronome-driven programmatic credit state.
+ */
+export async function isProgrammaticApiBlocked(
+  auth: Authenticator
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!(await spendLimitRateCapEnabled(auth))) {
+    return isProgrammaticApiBlockedByMetronome(workspace.sId);
+  }
+  return isProgrammaticSpendLimitRateCapReached(auth);
+}
+
+/**
+ * Whether the API key has reached its per-key credit spend cap. With the
+ * rate-cap flag on, from the Redis fixed-window counter; with it off, from the
+ * Metronome-driven per-key credit state.
+ */
+export async function isApiKeyBlocked(
+  auth: Authenticator,
+  { keyModelId }: { keyModelId: ModelId }
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!(await spendLimitRateCapEnabled(auth))) {
+    return isApiKeyCapped(workspace.sId, keyModelId);
+  }
+  return isApiKeySpendLimitRateCapReached(auth, { keyModelId });
+}
+
+/**
+ * Whether the user has consumed ≥ 80% of their per-user cap (soft warning). With
+ * the rate-cap flag on, from the Redis fixed-window counter; with it off, from
+ * the Metronome-driven near-limit flag.
+ */
+export async function isUserAwuWarned(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!(await spendLimitRateCapEnabled(auth))) {
+    return isUserAwuWarnedByMetronome(workspace.sId, user.sId);
+  }
+  return isUserSpendLimitRateWarningReached(auth, { user });
+}
+
+/**
+ * Whether workspace programmatic usage has crossed 80% of the monthly cap (soft
+ * warning). With the rate-cap flag on, from the Redis fixed-window counter; with
+ * it off, from the Metronome-driven programmatic warning flag.
+ */
+export async function isWorkspaceProgrammaticWarningReached(
+  auth: Authenticator
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!(await spendLimitRateCapEnabled(auth))) {
+    return isWorkspaceProgrammaticWarningReachedByMetronome(workspace.sId);
+  }
+  return isProgrammaticSpendLimitRateWarningReached(auth);
+}

--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -101,17 +101,22 @@ export async function isApiKeyBlocked(
 /**
  * Whether the user has consumed ≥ 80% of their per-user cap (soft warning). With
  * the rate-cap flag on, from the Redis fixed-window counter; with it off, from
- * the Metronome-driven near-limit flag.
+ * the Metronome-driven near-limit flag. Free/none seats have no cycle cap for
+ * the counter to model, so they always fall back to the Metronome near-limit
+ * flag (driven by their lifetime credit-balance alert).
  */
 export async function isUserAwuWarned(
   auth: Authenticator,
   { user }: { user: UserResource }
 ): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
-  if (!(await spendLimitRateCapEnabled(auth))) {
-    return isUserAwuWarnedByMetronome(workspace.sId, user.sId);
+  if (await spendLimitRateCapEnabled(auth)) {
+    const rateWarned = await isUserSpendLimitRateWarningReached(auth, { user });
+    if (rateWarned !== null) {
+      return rateWarned;
+    }
   }
-  return isUserSpendLimitRateWarningReached(auth, { user });
+  return isUserAwuWarnedByMetronome(workspace.sId, user.sId);
 }
 
 /**

--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -20,24 +20,31 @@ import {
 } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
+import { isApiKeyCappedByMetronome } from "@app/lib/metronome/api_key_block";
 import type { UserBlockedReason } from "@app/lib/metronome/user_block";
 import {
-  isProgrammaticApiBlocked as isProgrammaticApiBlockedByMetronome,
-  isUserAwuWarned as isUserAwuWarnedByMetronome,
-  isUserBlocked as isUserBlockedByMetronome,
-  isWorkspaceProgrammaticWarningReached as isWorkspaceProgrammaticWarningReachedByMetronome,
+  isApiBlockedByMetronome,
+  isProgrammaticApiBlockedByMetronome,
+  isUserAwuWarnedByMetronome,
+  isUserBlockedByMetronome,
+  isWorkspaceProgrammaticWarningReachedByMetronome,
 } from "@app/lib/metronome/user_block";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { ModelId } from "@app/types/shared/model_id";
 
-// Pool-only read (no per-user cap, no rate-limiter dimension): re-exported so
-// access-control callers have a single import site.
-export { isApiBlocked } from "@app/lib/metronome/user_block";
-
 async function spendLimitRateCapEnabled(auth: Authenticator): Promise<boolean> {
   const featureFlags = await getFeatureFlags(auth);
   return featureFlags.includes("enforce_user_spend_limit_rate_cap");
+}
+
+/**
+ * Whether the workspace credit pool is depleted (API calls with no per-user
+ * cap). Pool depletion is a credit-balance signal with no rate-limiter
+ * dimension, so this always reads the Metronome pool state; it lives here only
+ * so access-control callers have a single, `auth`-based import site.
+ */
+export async function isApiBlocked(auth: Authenticator): Promise<boolean> {
+  return isApiBlockedByMetronome(auth.getNonNullableWorkspace().sId);
 }
 
 /**
@@ -86,7 +93,7 @@ export async function isApiKeyBlocked(
 ): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
   if (!(await spendLimitRateCapEnabled(auth))) {
-    return isApiKeyCapped(workspace.sId, keyModelId);
+    return isApiKeyCappedByMetronome(workspace.sId, keyModelId);
   }
   return isApiKeySpendLimitRateCapReached(auth, { keyModelId });
 }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -45,7 +45,7 @@ import { getCachedSeatDataByUserId } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   getFairUseAwuCreditsStatus,
-  isUserAwuWarned,
+  isUserAwuWarnedByMetronome,
 } from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -1896,7 +1896,10 @@ export async function getMembersUsage({
           await concurrentExecutor(
             users,
             async (u) =>
-              [u.sId, await isUserAwuWarned(workspace.sId, u.sId)] as const,
+              [
+                u.sId,
+                await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
+              ] as const,
             { concurrency: 8 }
           )
         )

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -10,6 +10,7 @@ import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
 import {
   microCreditsToCredits,
@@ -23,6 +24,7 @@ import type {
 import {
   getCachedDefaultCapThresholdsBySeatType,
   getCachedPerUserCapAlertIds,
+  USER_AWU_WARNING_PERCENTAGE,
 } from "@app/lib/metronome/alerts/spend_limits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import {
@@ -155,8 +157,9 @@ export type MemberUsageType = {
   // Per-user credit state machine state (personal-credits → pool → capped
   // progression) persisted on the membership. Surfaced for debugging.
   creditState: UserCreditState;
-  // Whether the user has consumed ≥ 80% of their effective limit. Driven by
-  // the nearLimit Redis flag (see user_block.ts). Poke-only.
+  // Whether the user has consumed ≥ 80% of their effective limit. With the
+  // rate-cap flag on, derived from the Redis rate-limiter counter; with it off,
+  // from the Metronome nearLimit flag (see user_block.ts). Poke-only.
   nearLimit: boolean;
   // Per-user fair-use AWU credit usage (credits, with decimals) backed by the
   // microCredit rate-limit counter. Applies to non-credit-based plans
@@ -1876,17 +1879,28 @@ export async function getMembersUsage({
       userIds: memberships.map((m) => m.userId),
     });
 
-  // Bulk-fetch near-limit flags from Redis (poke-only, gated on includeAlertLinks).
-  const nearLimitByUserId = includeAlertLinks
-    ? new Map(
-        await concurrentExecutor(
-          users,
-          async (u) =>
-            [u.sId, await isUserAwuWarned(workspace.sId, u.sId)] as const,
-          { concurrency: 8 }
+  // With the rate-cap flag on, the per-user "near limit" (≥ 80% of the effective
+  // cap) is derived from the Redis rate-limiter counter below; with it off, from
+  // the Metronome near-limit flag. Matches the flag-aware enforcement in
+  // `lib/api/credits/access_control.ts`.
+  const featureFlags = await getFeatureFlags(auth);
+  const spendCapEnabled = featureFlags.includes(
+    "enforce_user_spend_limit_rate_cap"
+  );
+
+  // Bulk-fetch Metronome near-limit flags from Redis (poke-only, and only when
+  // the rate-cap flag is off — otherwise the rate-limiter counter drives it).
+  const nearLimitByUserId =
+    includeAlertLinks && !spendCapEnabled
+      ? new Map(
+          await concurrentExecutor(
+            users,
+            async (u) =>
+              [u.sId, await isUserAwuWarned(workspace.sId, u.sId)] as const,
+            { concurrency: 8 }
+          )
         )
-      )
-    : new Map<string, boolean>();
+      : new Map<string, boolean>();
 
   // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
   // display beside the Elasticsearch-derived usage. The counter is bucketed on
@@ -2061,6 +2075,11 @@ export async function getMembersUsage({
       groupCapAwuCredits,
       defaultAwuCredits: effectiveDefaultAwuCredits,
     });
+    const effectiveSpendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
+      overrideAwuCredits,
+      groupCapAwuCredits,
+      defaultAwuCredits: effectiveDefaultAwuCredits,
+    });
     const effectiveCapAlert =
       spendLimitSource === "override"
         ? (perUserOverrideAlerts.get(userId) ?? null)
@@ -2081,6 +2100,20 @@ export async function getMembersUsage({
       membership.seatType === "free"
         ? (freeCreditAlertIds?.get(metronomeUserId) ?? null)
         : null;
+
+    const rateLimiterSpendAwuCredits = includeAlertLinks
+      ? (rateLimiterSpendByUserId.get(userId) ?? 0)
+      : null;
+    // Poke-only near-limit: with the rate-cap flag on, the rate-limiter counter
+    // ≥ 80% of the effective cap; with it off, the Metronome near-limit flag.
+    const nearLimit =
+      includeAlertLinks &&
+      (spendCapEnabled
+        ? effectiveSpendLimitAwuCredits !== null &&
+          effectiveSpendLimitAwuCredits > 0 &&
+          (rateLimiterSpendAwuCredits ?? 0) >=
+            USER_AWU_WARNING_PERCENTAGE * effectiveSpendLimitAwuCredits
+        : (nearLimitByUserId.get(userId) ?? false));
 
     return [
       {
@@ -2109,14 +2142,8 @@ export async function getMembersUsage({
         nextCreditResetAt: seatData?.nextCreditResetAt ?? null,
         scheduledSeatType: scheduled?.seatType ?? null,
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
-        spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
-          overrideAwuCredits,
-          groupCapAwuCredits,
-          defaultAwuCredits: effectiveDefaultAwuCredits,
-        }),
-        rateLimiterSpendAwuCredits: includeAlertLinks
-          ? (rateLimiterSpendByUserId.get(userId) ?? 0)
-          : null,
+        spendLimitAwuCredits: effectiveSpendLimitAwuCredits,
+        rateLimiterSpendAwuCredits,
         metronomeConsumedAwuCredits: includeAlertLinks
           ? (metronomeConsumedByUserId.get(userId) ?? 0)
           : null,
@@ -2126,7 +2153,7 @@ export async function getMembersUsage({
         freeCreditLowAlert: freeCreditAlerts?.low ?? null,
         freeCreditEmptyAlert: freeCreditAlerts?.empty ?? null,
         creditState: membership.creditState,
-        nearLimit: nearLimitByUserId.get(userId) ?? false,
+        nearLimit,
         fairUse: fairUseByUserId.get(userId) ?? null,
       },
     ];

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1888,22 +1888,23 @@ export async function getMembersUsage({
     "enforce_user_spend_limit_rate_cap"
   );
 
-  // Bulk-fetch Metronome near-limit flags from Redis (poke-only, and only when
-  // the rate-cap flag is off — otherwise the rate-limiter counter drives it).
-  const nearLimitByUserId =
-    includeAlertLinks && !spendCapEnabled
-      ? new Map(
-          await concurrentExecutor(
-            users,
-            async (u) =>
-              [
-                u.sId,
-                await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
-              ] as const,
-            { concurrency: 8 }
-          )
+  // Bulk-fetch Metronome near-limit flags from Redis (poke-only). Still needed
+  // when the rate-cap flag is on: free/none seats have no cycle cap for the
+  // rate-limiter counter to model, so they fall back to this flag (driven by
+  // their lifetime credit-balance alert).
+  const nearLimitByUserId = includeAlertLinks
+    ? new Map(
+        await concurrentExecutor(
+          users,
+          async (u) =>
+            [
+              u.sId,
+              await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
+            ] as const,
+          { concurrency: 8 }
         )
-      : new Map<string, boolean>();
+      )
+    : new Map<string, boolean>();
 
   // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
   // display beside the Elasticsearch-derived usage. The counter is bucketed on
@@ -2107,15 +2108,19 @@ export async function getMembersUsage({
     const rateLimiterSpendAwuCredits = includeAlertLinks
       ? (rateLimiterSpendByUserId.get(userId) ?? 0)
       : null;
-    // Poke-only near-limit: with the rate-cap flag on, the rate-limiter counter
-    // ≥ 80% of the effective cap; with it off, the Metronome near-limit flag.
+    // Poke-only near-limit. With the rate-cap flag on, use the rate-limiter
+    // counter ≥ 80% of the effective cap — but only for seats that actually
+    // have a cycle cap. Free/none seats (no effective cap) have no counter to
+    // model their lifetime balance, so they fall back to the Metronome
+    // near-limit flag, same as when the flag is off.
+    const hasCycleCap =
+      effectiveSpendLimitAwuCredits !== null &&
+      effectiveSpendLimitAwuCredits > 0;
     const nearLimit =
       includeAlertLinks &&
-      (spendCapEnabled
-        ? effectiveSpendLimitAwuCredits !== null &&
-          effectiveSpendLimitAwuCredits > 0 &&
-          (rateLimiterSpendAwuCredits ?? 0) >=
-            USER_AWU_WARNING_PERCENTAGE * effectiveSpendLimitAwuCredits
+      (spendCapEnabled && hasCycleCap
+        ? (rateLimiterSpendAwuCredits ?? 0) >=
+          USER_AWU_WARNING_PERCENTAGE * effectiveSpendLimitAwuCredits
         : (nearLimitByUserId.get(userId) ?? false));
 
     return [

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -11,6 +11,7 @@ import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import {
   clearMetronomeProgrammaticCapAlerts,
   upsertMetronomeProgrammaticCapAlerts,
+  WARNING_BALANCE_RATIO,
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -188,12 +189,43 @@ async function readProgrammaticSpendLimitCountWithLazySeed(
 export async function isProgrammaticSpendLimitRateCapReached(
   auth: Authenticator
 ): Promise<boolean> {
+  return isProgrammaticSpendLimitRateThresholdReached(auth, { ratio: 1 });
+}
+
+/**
+ * "Near limit" (soft warning) counterpart of
+ * `isProgrammaticSpendLimitRateCapReached`: the same Redis fixed-window counter
+ * compared against `WARNING_BALANCE_RATIO` (80%) of the monthly cap instead of
+ * the full cap. Rate-limiter counterpart of the Metronome-driven
+ * `isWorkspaceProgrammaticWarningReached`. Returns `false` with no positive cap,
+ * no billing period, or on a Redis read error (fail-open).
+ */
+export async function isProgrammaticSpendLimitRateWarningReached(
+  auth: Authenticator
+): Promise<boolean> {
+  return isProgrammaticSpendLimitRateThresholdReached(auth, {
+    ratio: WARNING_BALANCE_RATIO,
+  });
+}
+
+/**
+ * Reads the workspace programmatic spend-cap counter over the current contract
+ * billing cycle and compares it against `ratio × monthly cap`. Only enforces a
+ * *positive* cap: a cap of 0 means "always depleted", owned by the programmatic
+ * credit-state machine (`isProgrammaticApiBlocked`), so this defers there.
+ * Returns `false` with no positive cap, no billing period, or on a Redis read
+ * error (fail-open).
+ */
+async function isProgrammaticSpendLimitRateThresholdReached(
+  auth: Authenticator,
+  { ratio }: { ratio: number }
+): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
 
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  const threshold = config?.programmaticMonthlyCapAwuCredits ?? 0;
-  if (threshold <= 0) {
+  const cap = config?.programmaticMonthlyCapAwuCredits ?? 0;
+  if (cap <= 0) {
     return false;
   }
 
@@ -217,7 +249,7 @@ export async function isProgrammaticSpendLimitRateCapReached(
 
   // The counter stores microCredits; scale the credit threshold up so the
   // comparison stays integer-on-integer.
-  return count >= roundCreditsToMicroCredits(threshold);
+  return count >= roundCreditsToMicroCredits(cap * ratio);
 }
 
 /**

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -381,7 +381,7 @@ async function readApiKeySpendLimitCountWithLazySeed(
  * read at message-send time from the Redis fixed-window counter over the current
  * contract billing cycle. The threshold is the key's admin-configured
  * `monthlyCapAwuCredits`. Runs alongside the Metronome per-key cap
- * (`isApiKeyCapped`) as a faster, independent backup. Returns `false` (does not
+ * (`isApiKeyCappedByMetronome`) as a faster, independent backup. Returns `false` (does not
  * block) when the key is gone, has no cap, the billing period can't be resolved,
  * or on a Redis read error (fail-open).
  */

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -1,5 +1,6 @@
 import { makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace } from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
+import { isWorkspaceProgrammaticWarningReached } from "@app/lib/api/credits/access_control";
 import { getEsConsumedProgrammaticAwuCredits } from "@app/lib/api/credits/members_usage";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
@@ -14,7 +15,6 @@ import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getCachedWorkspaceMetronomeAlerts } from "@app/lib/metronome/alerts/workspace_alerts";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
 import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
-import { isWorkspaceProgrammaticWarningReached } from "@app/lib/metronome/user_block";
 import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
 import { getCustomerId, getStripeSubscription } from "@app/lib/plans/stripe";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
@@ -291,9 +291,8 @@ export async function getPokeWorkspaceInfo(
     usageCapAlert,
     defaultAlerts,
     programmaticCreditState: workspaceResource.programmaticCreditState,
-    programmaticWarningReached: await isWorkspaceProgrammaticWarningReached(
-      owner.sId
-    ),
+    programmaticWarningReached:
+      await isWorkspaceProgrammaticWarningReached(auth),
     programmaticSpendLimitRateCapCount,
     programmaticEsConsumedAwuCredits,
     programmaticMetronomeConsumedAwuCredits,

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -596,18 +596,23 @@ async function isSpendCapCounterReached(
  * the standard way (per-user override > group cap > seat-type/workspace
  * default, each incl. the seat allowance) — the same resolution the usage table
  * uses. Runs alongside the Metronome per-user cap (`isUserBlocked`) as a faster,
- * independent backup. Returns `false` (does not block) when there is no cap, the
- * billing period can't be resolved, or on a Redis read error (fail-open).
+ * independent backup.
+ *
+ * Returns `null` when the user has no cycle spend cap at all (e.g. free/none
+ * seats, whose lifetime credit balance is not modeled by this cycle counter) —
+ * the caller must fall back to the Metronome credit state for those. Returns
+ * `false` (does not block) when the billing period can't be resolved or on a
+ * Redis read error (fail-open).
  */
 export async function isUserSpendLimitRateCapReached(
   auth: Authenticator,
   { user }: { user: UserResource }
-): Promise<boolean> {
+): Promise<boolean | null> {
   const workspace = auth.getNonNullableWorkspace();
 
   const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
   if (threshold === null) {
-    return false;
+    return null;
   }
 
   const bounds = await resolveSpendLimitCycleBounds(workspace);
@@ -628,18 +633,22 @@ export async function isUserSpendLimitRateCapReached(
  * resolution as `isUserSpendLimitRateCapReached`, but compares against
  * `USER_AWU_WARNING_PERCENTAGE` (80%) of the cap instead of the full cap. This
  * is the rate-limiter counterpart of the Metronome-driven `isUserAwuWarned`
- * flag. Returns `false` when there is no cap, the billing period can't be
- * resolved, or on a Redis read error (fail-open).
+ * flag.
+ *
+ * Returns `null` when the user has no cycle spend cap at all (e.g. free/none
+ * seats — the caller must fall back to the Metronome near-limit flag). Returns
+ * `false` when the billing period can't be resolved or on a Redis read error
+ * (fail-open).
  */
 export async function isUserSpendLimitRateWarningReached(
   auth: Authenticator,
   { user }: { user: UserResource }
-): Promise<boolean> {
+): Promise<boolean | null> {
   const workspace = auth.getNonNullableWorkspace();
 
   const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
   if (threshold === null) {
-    return false;
+    return null;
   }
 
   const bounds = await resolveSpendLimitCycleBounds(workspace);

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -21,6 +21,7 @@ import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import {
   clearMetronomePerUserCapAlert,
   clearMetronomePerUserWarningAlert,
+  USER_AWU_WARNING_PERCENTAGE,
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
@@ -617,6 +618,38 @@ export async function isUserSpendLimitRateCapReached(
   return isSpendCapCounterReached(auth, {
     user,
     thresholdAwuCredits: threshold,
+    bounds,
+  });
+}
+
+/**
+ * Synchronous, Metronome-independent "near limit" (warning) signal for the
+ * per-user spend cap. Same Redis fixed-window counter and effective-cap
+ * resolution as `isUserSpendLimitRateCapReached`, but compares against
+ * `USER_AWU_WARNING_PERCENTAGE` (80%) of the cap instead of the full cap. This
+ * is the rate-limiter counterpart of the Metronome-driven `isUserAwuWarned`
+ * flag. Returns `false` when there is no cap, the billing period can't be
+ * resolved, or on a Redis read error (fail-open).
+ */
+export async function isUserSpendLimitRateWarningReached(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
+  if (threshold === null) {
+    return false;
+  }
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return false;
+  }
+
+  return isSpendCapCounterReached(auth, {
+    user,
+    thresholdAwuCredits: threshold * USER_AWU_WARNING_PERCENTAGE,
     bounds,
   });
 }

--- a/front/lib/metronome/api_key_block.ts
+++ b/front/lib/metronome/api_key_block.ts
@@ -73,7 +73,7 @@ async function getApiKeyCreditState(
   return state;
 }
 
-export async function isApiKeyCapped(
+export async function isApiKeyCappedByMetronome(
   workspaceId: string,
   keyModelId: ModelId
 ): Promise<boolean> {

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -1,6 +1,6 @@
 import {
   getWorkspaceCreditPoolStatus,
-  isUserBlocked,
+  isUserBlockedByMetronome,
 } from "@app/lib/metronome/user_block";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -74,7 +74,7 @@ vi.mock("@app/logger/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-describe("isUserBlocked", () => {
+describe("isUserBlockedByMetronome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // `clearAllMocks` resets call history but not implementations, so reset the
@@ -87,7 +87,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
     redisValues.set("metronome:pool_credit_status:ws_test", "active");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
     expect(mockFetchWorkspaceById).not.toHaveBeenCalled();
@@ -99,7 +99,7 @@ describe("isUserBlocked", () => {
       seatType: "none",
     });
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("no_seat");
     expect(mockRunOnRedis).not.toHaveBeenCalled();
@@ -109,7 +109,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
   });
@@ -118,7 +118,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
     redisValues.set("metronome:pool_credit_status:ws_test", "active");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -127,7 +127,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "user_seat");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -139,7 +139,7 @@ describe("isUserBlocked", () => {
     );
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -148,7 +148,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("credits_exhausted");
   });
@@ -160,7 +160,7 @@ describe("isUserBlocked", () => {
     );
     redisValues.set("metronome:pool_credit_status:ws_test", "active");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -172,7 +172,7 @@ describe("isUserBlocked", () => {
     );
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("credits_exhausted");
   });
@@ -185,7 +185,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
     redisValues.set("metronome:pool_credit_status:ws_test", poolState);
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -207,7 +207,7 @@ describe("isUserBlocked", () => {
       creditState: "capped",
     });
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
     expect(mockFetchUserById).toHaveBeenCalled();
@@ -221,7 +221,7 @@ describe("isUserBlocked", () => {
       poolCreditState: "active",
     });
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
     expect(redisValues.get("metronome:pool_credit_status:ws_test")).toBe(
@@ -238,7 +238,7 @@ describe("isUserBlocked", () => {
     });
     mockGetActiveMembershipOfUserInWorkspace.mockResolvedValue(null);
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -254,7 +254,7 @@ describe("isUserBlocked", () => {
       creditState: "capped",
     });
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
     expect(redisValues.get("metronome:user_credit_state:ws_test:u_test")).toBe(
@@ -274,7 +274,7 @@ describe("isUserBlocked", () => {
       poolCreditState: "depleted",
     });
 
-    const blocked = await isUserBlocked(workspace, user);
+    const blocked = await isUserBlockedByMetronome(workspace, user);
 
     expect(blocked).toBe("credits_exhausted");
     expect(redisValues.get("metronome:user_credit_state:ws_test:u_test")).toBe(

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -123,6 +123,39 @@ describe("isUserBlockedByMetronome", () => {
     expect(blocked).toBeNull();
   });
 
+  it("userCapBlockedOverride=true blocks even when the credit state is on_pool", async () => {
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
+    redisValues.set("metronome:pool_credit_status:ws_test", "active");
+
+    const blocked = await isUserBlockedByMetronome(workspace, user, {
+      userCapBlockedOverride: true,
+    });
+
+    expect(blocked).toBe("user_cap_reached");
+  });
+
+  it("userCapBlockedOverride=false ignores a 'capped' credit state (rate limiter governs)", async () => {
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
+    redisValues.set("metronome:pool_credit_status:ws_test", "active");
+
+    const blocked = await isUserBlockedByMetronome(workspace, user, {
+      userCapBlockedOverride: false,
+    });
+
+    expect(blocked).toBeNull();
+  });
+
+  it("userCapBlockedOverride=null falls back to the 'capped' credit state (free-seat case)", async () => {
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
+    redisValues.set("metronome:pool_credit_status:ws_test", "active");
+
+    const blocked = await isUserBlockedByMetronome(workspace, user, {
+      userCapBlockedOverride: null,
+    });
+
+    expect(blocked).toBe("user_cap_reached");
+  });
+
   it("does not block a 'user_seat' user when the pool is depleted", async () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "user_seat");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -328,12 +328,14 @@ function deriveBlockedReason({
 export async function isUserBlockedByMetronome(
   workspace: LightWorkspaceType,
   user: UserResource,
-  // When set, overrides the Metronome-credit-state user-cap signal
-  // (`userCreditState === "capped"`). The flag-aware wrapper in
-  // `lib/api/credits/access_control.ts` passes the Redis rate-limiter result
-  // here so the pool/seat logic (no_seat, pool depletion, personal-seat
-  // carve-out) stays defined in one place.
-  opts?: { userCapBlockedOverride?: boolean }
+  // Overrides the Metronome-credit-state user-cap signal
+  // (`userCreditState === "capped"`) when set to a boolean. The flag-aware
+  // wrapper in `lib/api/credits/access_control.ts` passes the Redis rate-limiter
+  // result here so the pool/seat logic (no_seat, pool depletion, personal-seat
+  // carve-out) stays defined in one place. `null`/`undefined` means "no
+  // override" — the Metronome credit state is used (e.g. free/none seats, whose
+  // lifetime balance the rate limiter does not model).
+  opts?: { userCapBlockedOverride?: boolean | null }
 ): Promise<UserBlockedReason | null> {
   const workspaceId = workspace.sId;
   const userId = user.sId;

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,5 +1,11 @@
 // Redis fast-path cache for credit-state-driven access control.
 //
+// This is the Metronome-credit-state layer. When the
+// `enforce_user_spend_limit_rate_cap` flag is on, callers should instead go
+// through the flag-aware readers in `lib/api/credits/access_control.ts`, which
+// enforce from the Redis rate-limiter counters and fall back to the functions
+// here when the flag is off.
+//
 // Four keys back the credit state machines:
 //   - `metronome:user_credit_state:<ws>:<user>`: fine-grained user credit state
 //     (mirrors `memberships.creditState`). Replaces the legacy boolean cap and
@@ -320,7 +326,13 @@ function deriveBlockedReason({
 
 export async function isUserBlocked(
   workspace: LightWorkspaceType,
-  user: UserResource
+  user: UserResource,
+  // When set, overrides the Metronome-credit-state user-cap signal
+  // (`userCreditState === "capped"`). The flag-aware wrapper in
+  // `lib/api/credits/access_control.ts` passes the Redis rate-limiter result
+  // here so the pool/seat logic (no_seat, pool depletion, personal-seat
+  // carve-out) stays defined in one place.
+  opts?: { userCapBlockedOverride?: boolean }
 ): Promise<UserBlockedReason | null> {
   const workspaceId = workspace.sId;
   const userId = user.sId;
@@ -364,7 +376,8 @@ export async function isUserBlocked(
   }
 
   return deriveBlockedReason({
-    userCapBlocked: userCreditState === "capped",
+    userCapBlocked:
+      opts?.userCapBlockedOverride ?? userCreditState === "capped",
     workspacePoolDepleted,
   });
 }

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -12,12 +12,13 @@
 //     warning flags — "capped" means blocked, "*_low_balance" means warned.
 //   - `metronome:pool_credit_status:<ws>`: fine-grained workspace pool state
 //     (mirrors `workspaces.poolCreditState`).
-//   - `metronome:pool_depleted:<ws>`: boolean shortcut for isUserBlocked /
-//     isApiBlocked hot paths (still maintained alongside pool_credit_status).
+//   - `metronome:pool_depleted:<ws>`: boolean shortcut for
+//     isUserBlockedByMetronome / isApiBlockedByMetronome hot paths (still
+//     maintained alongside pool_credit_status).
 //   - `metronome:programmatic_credit_status:<ws>` / `metronome:programmatic_depleted:<ws>`:
 //     programmatic (API) cap state.
 //
-// `isUserBlocked` is the unified read: a user is blocked iff the pool is
+// `isUserBlockedByMetronome` is the unified read: a user is blocked iff the pool is
 // depleted or the user's credit state is "capped". It returns the reason
 // ("credits_exhausted" / "user_cap_reached") so callers can surface a tailored
 // message. When both conditions hold, "user_cap_reached" wins: the per-user cap
@@ -84,7 +85,7 @@ export type GetWorkspaceUsageStatusResponseBody = {
   // Redis-only flag, independent of the throttling states (active_low_balance etc.).
   programmaticWarningReached: boolean;
   balanceThresholdReached: boolean;
-  // Authoritative block reason from isUserBlocked — null means the user can
+  // Authoritative block reason from access_control's isUserBlocked — null means the user can
   // send messages. Replaces the old client-side derivations (noSeat,
   // awuStatus === "blocked", poolCreditState === "depleted").
   userBlockedReason: UserBlockedReason | null;
@@ -173,7 +174,7 @@ async function getUserNearLimit(
   return state === "on_pool_low_balance" || state === "user_seat_low_balance";
 }
 
-export async function isUserAwuWarned(
+export async function isUserAwuWarnedByMetronome(
   workspaceId: string,
   userId: string
 ): Promise<boolean> {
@@ -228,7 +229,7 @@ export async function clearWorkspaceProgrammaticWarningReached(
   await setFlag(buildWorkspaceProgrammaticWarningKey(workspaceId), "0");
 }
 
-export async function isWorkspaceProgrammaticWarningReached(
+export async function isWorkspaceProgrammaticWarningReachedByMetronome(
   workspaceId: string
 ): Promise<boolean> {
   const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
@@ -324,7 +325,7 @@ function deriveBlockedReason({
   return null;
 }
 
-export async function isUserBlocked(
+export async function isUserBlockedByMetronome(
   workspace: LightWorkspaceType,
   user: UserResource,
   // When set, overrides the Metronome-credit-state user-cap signal
@@ -526,7 +527,7 @@ export async function getWorkspaceProgrammaticCreditStatus(
   return status;
 }
 
-export async function isProgrammaticApiBlocked(
+export async function isProgrammaticApiBlockedByMetronome(
   workspaceId: string
 ): Promise<boolean> {
   // getWorkspaceProgrammaticCreditStatus has its own DB fallback and cache repopulation.
@@ -535,7 +536,9 @@ export async function isProgrammaticApiBlocked(
 }
 
 // Workspace-pool-only read for API calls (no per-user cap).
-export async function isApiBlocked(workspaceId: string): Promise<boolean> {
+export async function isApiBlockedByMetronome(
+  workspaceId: string
+): Promise<boolean> {
   // getWorkspaceCreditPoolStatus has its own DB fallback and cache repopulation.
   const poolStatus = await getWorkspaceCreditPoolStatus(workspaceId);
   return poolStatus === "depleted";

--- a/front/lib/triggers/webhook.test.ts
+++ b/front/lib/triggers/webhook.test.ts
@@ -24,8 +24,10 @@ const { mockIsApiBlocked, mockCheckWebhookRequestForRateLimit } = vi.hoisted(
   })
 );
 
-vi.mock("@app/lib/metronome/user_block", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@app/lib/metronome/user_block")>()),
+vi.mock("@app/lib/api/credits/access_control", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@app/lib/api/credits/access_control")
+  >()),
   isApiBlocked: mockIsApiBlocked,
 }));
 

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -293,7 +293,7 @@ async function checkWorkspaceRateLimit({
   // depleted, no downstream message can be posted, so reject early instead of
   // spinning up the trigger workflow only to fail in `checkMessagesLimit`.
   if (plan && isCreditPricedPlan(plan)) {
-    if (owner.metronomeCustomerId && (await isApiBlocked(owner.sId))) {
+    if (owner.metronomeCustomerId && (await isApiBlocked(auth))) {
       block = {
         status: "credits_exhausted",
         message:

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -1,3 +1,7 @@
+import {
+  isApiBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/api/credits/access_control";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { FathomClient } from "@app/lib/api/triggers/built-in-webhooks/fathom/fathom_client";
 import type { Authenticator } from "@app/lib/auth";
@@ -5,10 +9,6 @@ import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -307,7 +307,7 @@ async function checkWorkspaceRateLimit({
       !block &&
       owner.metronomeCustomerId &&
       trigger.executionMode === "workspace_pool" &&
-      (await isProgrammaticApiBlocked(owner.sId))
+      (await isProgrammaticApiBlocked(auth))
     ) {
       block = {
         status: "credits_exhausted",

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -2,6 +2,10 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  isApiBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/api/credits/access_control";
 import { getStreamLLM } from "@app/lib/api/llm";
 import type { LlmConversationOptions } from "@app/lib/api/llm/batch_llm";
 import {
@@ -26,10 +30,6 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { intelligenceAwuFromRunUsages } from "@app/lib/metronome/events";
 import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { getRemainingProgrammaticUsageFromMetronome } from "@app/lib/metronome/programmatic_awu_usage";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
 import {
   AgentMessageModel,
   MessageModel,
@@ -727,10 +727,11 @@ export async function getReinforcementSettingsActivity({
       break;
     }
     case "awu_credits": {
-      // Pool + programmatic cap via Metronome state (alert/webhook driven).
+      // Pool + programmatic cap. `isProgrammaticApiBlocked` is flag-aware (Redis
+      // rate-limiter counter when the flag is on, Metronome state otherwise).
       programmaticUsageLimitReached =
         (await isApiBlocked(workspace.sId)) ||
-        (await isProgrammaticApiBlocked(workspace.sId));
+        (await isProgrammaticApiBlocked(auth));
 
       // Both clamps fail-open on errors: the reinforcement cap stays the only
       // constraint.

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -730,8 +730,7 @@ export async function getReinforcementSettingsActivity({
       // Pool + programmatic cap. `isProgrammaticApiBlocked` is flag-aware (Redis
       // rate-limiter counter when the flag is on, Metronome state otherwise).
       programmaticUsageLimitReached =
-        (await isApiBlocked(workspace.sId)) ||
-        (await isProgrammaticApiBlocked(auth));
+        (await isApiBlocked(auth)) || (await isProgrammaticApiBlocked(auth));
 
       // Both clamps fail-open on errors: the reinforcement cap stays the only
       // constraint.


### PR DESCRIPTION
## Description

Introduces `front/lib/api/credits/access_control.ts` as the single access-control decision layer for the spend caps. Each reader switches on the `enforce_user_spend_limit_rate_cap` feature flag: when enabled it enforces from the Redis fixed-window rate-limiter counters; when disabled it falls back to the Metronome credit state in `metronome/user_block.ts` (kept as the low-level Redis cache).

- Blocking readers: `isUserBlocked`, `isProgrammaticApiBlocked`, `isApiKeyBlocked` — the per-user cap comes from the counter; the pool/seat logic (no_seat, pool depletion, personal-seat carve-out) is unchanged via a `userCapBlockedOverride` seam into the Metronome reader.
- Near-limit readers: `isUserAwuWarned` (user 80%) and `isWorkspaceProgrammaticWarningReached` (programmatic 80%).
- The poke members table near-limit is computed inline from the rate-limiter counter it already reads, avoiding an import cycle.
- Callers repointed to the flag-aware readers: `conversation`, the v1 conversations pre-check, `usage-status`, `credit_check`, activation `nudge`, the webhook trigger, the reinforcement activity, and poke `workspace_info`.

Net: under the flag, per-user / per-API-key / programmatic blocking and both near-limit surfaces (usage banner + poke) read the rate limiter; with the flag off, behavior is unchanged (Metronome).

## Tests

- tsgo --noEmit clean on front and front-api.
- Passing suites: credit_check, nudge, webhook, metronome/user_block, members_usage, programmatic_usage_limit (test mocks repointed to access_control).

## Risk

Low–moderate and flag-gated. With the flag off, every reader falls through to the existing Metronome path (no behavior change). With it on, enforcement and reporting move to the Redis counters (usage is already recorded there today). No schema or API-contract changes.

## Deploy Plan

Standard deploy, no migrations. Roll out behind the existing enforce_user_spend_limit_rate_cap feature flag.