### PR TITLE
Improve sign-in flow for shared Frames

### DIFF
--- a/front/components/pages/share/SharedFramePage.test.tsx
+++ b/front/components/pages/share/SharedFramePage.test.tsx
@@ -1,0 +1,196 @@
+import { SharedFramePage } from "@app/components/pages/share/SharedFramePage";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  frameError: null as unknown,
+  hasSession: false,
+  isUserError: null as unknown,
+  isUserLoading: false,
+  requiresEmailVerification: false,
+  user: null as { sId: string } | null,
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer",
+  () => ({
+    PublicInteractiveContentContainer: () => <div>frame content</div>,
+  })
+);
+
+vi.mock("@app/components/pages/Custom404", () => ({
+  default: () => <div>404</div>,
+}));
+
+vi.mock("@app/components/pages/CustomErrorPage", () => ({
+  default: ({
+    title,
+    description,
+    href,
+    label,
+  }: {
+    title: string;
+    description: string;
+    href: string;
+    label: string;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <a href={href}>{label}</a>
+    </div>
+  ),
+}));
+
+vi.mock("@app/components/pages/share/EmailVerificationFlow", () => ({
+  EmailVerificationFlow: () => <div>email verification</div>,
+}));
+
+vi.mock("@app/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => undefined,
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getApiBaseUrl: () => "https://dust.tt",
+  },
+}));
+
+vi.mock("@app/lib/cookies", () => ({
+  DUST_HAS_SESSION: "dust-has-session",
+  hasSessionIndicator: () => mocks.hasSession,
+}));
+
+vi.mock("@app/lib/files", () => ({
+  formatFilenameForDisplay: (name: string) => name,
+}));
+
+vi.mock("@app/lib/platform", () => ({
+  usePathParam: () => "share-token",
+}));
+
+vi.mock("@app/lib/swr/frames", () => ({
+  usePublicFrame: () => ({
+    error: mocks.frameError,
+    frameMetadata: null,
+    mutateFrame: vi.fn(),
+  }),
+}));
+
+vi.mock("@app/lib/swr/share", () => ({
+  useShareFrameMetadata: () => ({
+    isShareMetadataLoading: false,
+    shareMetadata: {
+      faviconUrl: null,
+      logoUrl: null,
+      ogImageUrl: null,
+      requiresEmailVerification: mocks.requiresEmailVerification,
+      shareUrl: "https://dust.tt/share/frame/share-token",
+      showSignUpCta: false,
+      title: "Quarterly review",
+      vizUrl: "https://viz.dust.tt",
+      workspaceId: "w_123",
+      workspaceName: "Acme",
+    },
+    shareMetadataError: null,
+  }),
+}));
+
+vi.mock("@app/lib/swr/user", () => ({
+  useUser: () => ({
+    isUserError: mocks.isUserError,
+    isUserLoading: mocks.isUserLoading,
+    user: mocks.user,
+  }),
+}));
+
+vi.mock("@app/lib/utils", () => ({
+  getFaviconPath: () => "/favicon.png",
+}));
+
+vi.mock("@dust-tt/sparkle", () => ({
+  LogIn01: () => null,
+  Spinner: () => <div>loading</div>,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+vi.mock("react-cookie", () => ({
+  useCookies: () => [{}],
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.frameError = null;
+  mocks.hasSession = false;
+  mocks.isUserError = null;
+  mocks.isUserLoading = false;
+  mocks.requiresEmailVerification = false;
+  mocks.user = null;
+  window.history.replaceState({}, "", "/");
+});
+
+describe("SharedFramePage", () => {
+  it("prompts a logged-out viewer to sign in and preserves the Frame URL", () => {
+    mocks.frameError = new Error("not found");
+    window.history.replaceState(
+      {},
+      "",
+      "/share/frame/share-token?source=email#section"
+    );
+
+    render(<SharedFramePage />);
+
+    expect(screen.getByText("Sign in to open this Frame")).toBeDefined();
+    expect(
+      screen.getByText(
+        "Sign in with an account that has access. We’ll bring you back here."
+      )
+    ).toBeDefined();
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "https://dust.tt/api/workos/login?returnTo=%2Fshare%2Fframe%2Fshare-token%3Fsource%3Demail%23section"
+    );
+    expect(screen.queryByText("frame content")).toBeNull();
+  });
+
+  it("keeps the non-enumerating 404 for a signed-in viewer without access", () => {
+    mocks.frameError = new Error("not found");
+    mocks.hasSession = true;
+    mocks.user = { sId: "usr_123" };
+
+    render(<SharedFramePage />);
+
+    expect(screen.getByText("404")).toBeDefined();
+    expect(screen.queryByText("Sign in to open this Frame")).toBeNull();
+  });
+
+  it("treats a stale session indicator as logged out", () => {
+    mocks.frameError = new Error("not found");
+    mocks.hasSession = true;
+    mocks.isUserError = new Error("not authenticated");
+
+    render(<SharedFramePage />);
+
+    expect(screen.getByText("Sign in to open this Frame")).toBeDefined();
+  });
+
+  it("preserves the email verification flow for invited viewers", () => {
+    mocks.frameError = new Error("not found");
+    mocks.requiresEmailVerification = true;
+
+    render(<SharedFramePage />);
+
+    expect(screen.getByText("email verification")).toBeDefined();
+    expect(screen.queryByText("Sign in to open this Frame")).toBeNull();
+  });
+
+  it("renders a public Frame without asking the viewer to sign in", () => {
+    render(<SharedFramePage />);
+
+    expect(screen.getByText("frame content")).toBeDefined();
+    expect(screen.queryByText("Sign in to open this Frame")).toBeNull();
+  });
+});

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -1,15 +1,20 @@
 import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
 import Custom404 from "@app/components/pages/Custom404";
+import CustomErrorPage from "@app/components/pages/CustomErrorPage";
 import { EmailVerificationFlow } from "@app/components/pages/share/EmailVerificationFlow";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
+import config from "@app/lib/api/config";
+import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
 import { formatFilenameForDisplay } from "@app/lib/files";
 import { usePathParam } from "@app/lib/platform";
 import { usePublicFrame } from "@app/lib/swr/frames";
 import { useShareFrameMetadata } from "@app/lib/swr/share";
+import { useUser } from "@app/lib/swr/user";
 import { getFaviconPath } from "@app/lib/utils";
-import { Spinner } from "@dust-tt/sparkle";
+import { LogIn01, Spinner } from "@dust-tt/sparkle";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useMemo, useState } from "react";
+import { useCookies } from "react-cookie";
 
 // Origins from which the share frame is considered as embedded.
 // We hide the header for embedded origins.
@@ -20,6 +25,16 @@ export function SharedFramePage() {
   const posthog = usePostHog();
 
   const [isVerified, setIsVerified] = useState(false);
+  const [cookies] = useCookies([DUST_HAS_SESSION]);
+  const hasSession = hasSessionIndicator(cookies[DUST_HAS_SESSION]);
+  const {
+    user,
+    isUserLoading,
+    isUserError: userError,
+  } = useUser({
+    disabled: !hasSession,
+    redirectOnUnauthenticated: false,
+  });
 
   const hideHeader = useMemo(() => {
     if (typeof window === "undefined" || !document.referrer) {
@@ -160,6 +175,35 @@ export function SharedFramePage() {
     return (
       <EmailVerificationFlow shareToken={token} onVerified={handleVerified} />
     );
+  }
+
+  if (frameError) {
+    if (hasSession && isUserLoading && !userError) {
+      return (
+        <div className="flex h-dvh w-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      );
+    }
+
+    if (!hasSession || userError || !user) {
+      const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const loginUrl = `${config.getApiBaseUrl()}/api/workos/login?returnTo=${encodeURIComponent(returnTo)}`;
+
+      return (
+        <CustomErrorPage
+          title="Sign in to open this Frame"
+          description="Sign in with an account that has access. We’ll bring you back here."
+          href={loginUrl}
+          label="Sign in"
+          icon={LogIn01}
+        />
+      );
+    }
+
+    // Keep the existing non-enumerating response for authenticated users who
+    // do not have access (or whose link no longer resolves).
+    return <Custom404 />;
   }
 
   return (


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/10171.

Workspace-shared Frames return a 404 to unauthenticated users to prevent resource enumeration. This creates a poor experience for users who simply need to sign in. This PR detects that logged-out state and shows a sign-in prompt while preserving the existing 404 behavior for authenticated users without access.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
