### PR TITLE
[front] Run @help, dust-task and dust-planning on the @dust default stream

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -36,10 +36,8 @@ import {
   CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
-import {
-  GPT_5_6_LUNA_MODEL_CONFIG,
-  GPT_5_6_SOL_MODEL_CONFIG,
-} from "@app/types/assistant/models/openai";
+import { AUTO_FAST_MODEL_CONFIG } from "@app/types/assistant/models/auto";
+import { GPT_5_6_SOL_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -415,54 +413,6 @@ function getDeepDiveModelConfig(
   );
 }
 
-function getDustTaskModelConfig(
-  auth: Authenticator,
-  featureFlags: WhitelistableFeature[],
-  excludeProviders: ReadonlySet<ModelProviderIdType>
-): ModelConfigWithReasoning | null {
-  return (
-    getEnabledModelConfig(
-      auth,
-      GPT_5_6_LUNA_MODEL_CONFIG,
-      "high",
-      featureFlags,
-      excludeProviders
-    ) ??
-    getEnabledModelConfig(
-      auth,
-      CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
-      "light",
-      featureFlags,
-      excludeProviders
-    ) ??
-    getLargeModelFallback(auth, featureFlags, excludeProviders)
-  );
-}
-
-function getPlanningModelConfig(
-  auth: Authenticator,
-  featureFlags: WhitelistableFeature[],
-  excludeProviders: ReadonlySet<ModelProviderIdType>
-): ModelConfigWithReasoning | null {
-  return (
-    getEnabledModelConfig(
-      auth,
-      GPT_5_6_SOL_MODEL_CONFIG,
-      "high",
-      featureFlags,
-      excludeProviders
-    ) ??
-    getEnabledModelConfig(
-      auth,
-      CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
-      "high",
-      featureFlags,
-      excludeProviders
-    ) ??
-    getLargeModelFallback(auth, featureFlags, excludeProviders)
-  );
-}
-
 export function _getDeepDiveGlobalAgent(
   auth: Authenticator,
   {
@@ -627,22 +577,19 @@ export function _getDeepDiveGlobalAgent(
   };
 }
 
-export function _getDustTaskGlobalAgent(
-  auth: Authenticator,
-  {
-    settings,
-    preFetchedDataSources,
-    mcpServerViews,
-    excludeProviders,
-    featureFlags,
-  }: {
-    settings: GlobalAgentSettingsModel | null;
-    preFetchedDataSources: PrefetchedDataSourcesType | null;
-    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    excludeProviders: ReadonlySet<ModelProviderIdType>;
-    featureFlags: WhitelistableFeature[];
-  }
-): AgentConfigurationType | null {
+export function _getDustTaskGlobalAgent({
+  settings,
+  preFetchedDataSources,
+  mcpServerViews,
+  autoDefaultModelConfig,
+}: {
+  settings: GlobalAgentSettingsModel | null;
+  preFetchedDataSources: PrefetchedDataSourcesType | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+  // The stream meta-model the @dust agent defaults to: the highest one the
+  // member's model-tier cap allows (Standard, or Basic when capped).
+  autoDefaultModelConfig: ModelConfigurationType | null;
+}): AgentConfigurationType | null {
   const name = "dust-task";
   const description = `Focused research sub-agent. Same data/web tools as ${DEEP_DIVE_NAME}, without Interactive Content or spawning sub-agents.`;
 
@@ -674,13 +621,7 @@ export function _getDustTaskGlobalAgent(
     canEdit: false,
   };
 
-  const modelConfig = getDustTaskModelConfig(
-    auth,
-    featureFlags,
-    excludeProviders
-  );
-
-  if (!modelConfig || settings?.status === "disabled_by_admin") {
+  if (settings?.status === "disabled_by_admin") {
     return {
       ...dustTaskAgent,
       status: "disabled_by_admin",
@@ -689,11 +630,15 @@ export function _getDustTaskGlobalAgent(
     };
   }
 
+  // Same default stream as the @dust agent. The sentinel is resolved to a
+  // concrete model + effort at message-send time by resolveModel().
+  const modelConfiguration = autoDefaultModelConfig ?? AUTO_FAST_MODEL_CONFIG;
+
   const model: AgentModelConfigurationType = {
-    providerId: modelConfig.modelConfiguration.providerId,
-    modelId: modelConfig.modelConfiguration.modelId,
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
     temperature: 1.0,
-    reasoningEffort: modelConfig.reasoningEffort,
+    reasoningEffort: modelConfiguration.defaultReasoningEffort,
   };
 
   dustTaskAgent.model = model;
@@ -751,18 +696,15 @@ export function _getDustTaskGlobalAgent(
   };
 }
 
-export function _getPlanningAgent(
-  auth: Authenticator,
-  {
-    settings,
-    excludeProviders,
-    featureFlags,
-  }: {
-    settings: GlobalAgentSettingsModel | null;
-    excludeProviders: ReadonlySet<ModelProviderIdType>;
-    featureFlags: WhitelistableFeature[];
-  }
-): AgentConfigurationType | null {
+export function _getPlanningAgent({
+  settings,
+  autoDefaultModelConfig,
+}: {
+  settings: GlobalAgentSettingsModel | null;
+  // The stream meta-model the @dust agent defaults to: the highest one the
+  // member's model-tier cap allows (Standard, or Basic when capped).
+  autoDefaultModelConfig: ModelConfigurationType | null;
+}): AgentConfigurationType | null {
   const name = "dust-planning";
   const description = "A agent that plans research tasks.";
 
@@ -794,12 +736,7 @@ export function _getPlanningAgent(
     canEdit: false,
   };
 
-  const modelConfig = getPlanningModelConfig(
-    auth,
-    featureFlags,
-    excludeProviders
-  );
-  if (!modelConfig || settings?.status === "disabled_by_admin") {
+  if (settings?.status === "disabled_by_admin") {
     return {
       ...planningAgent,
       status: "disabled_by_admin",
@@ -808,11 +745,15 @@ export function _getPlanningAgent(
     };
   }
 
+  // Same default stream as the @dust agent. The sentinel is resolved to a
+  // concrete model + effort at message-send time by resolveModel().
+  const modelConfiguration = autoDefaultModelConfig ?? AUTO_FAST_MODEL_CONFIG;
+
   const model: AgentModelConfigurationType = {
-    providerId: modelConfig.modelConfiguration.providerId,
-    modelId: modelConfig.modelConfiguration.modelId,
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
     temperature: 1.0,
-    reasoningEffort: modelConfig.reasoningEffort,
+    reasoningEffort: modelConfiguration.defaultReasoningEffort,
   };
   planningAgent.model = model;
 

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -6,11 +6,6 @@ import {
   _getAgentRouterToolsConfiguration,
   _getDefaultWebActionsForGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
@@ -18,15 +13,18 @@ import type {
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { AUTO_FAST_MODEL_CONFIG } from "@app/types/assistant/models/auto";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
 export function _getHelperGlobalAgent({
   auth,
-  featureFlags,
+  autoDefaultModelConfig,
   mcpServerViews,
 }: {
   auth: Authenticator;
-  featureFlags: WhitelistableFeature[];
+  // The stream meta-model the @dust agent defaults to: the highest one the
+  // member's model-tier cap allows (Standard, or Basic when capped).
+  autoDefaultModelConfig: ModelConfigurationType | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let prompt = `<primary_goal>
@@ -64,19 +62,16 @@ The user you're interacting with is granted with the role ${role}. Their name is
 </user_context>`;
   }
 
-  const modelConfiguration = auth.isUpgraded()
-    ? getLargeWhitelistedModel(auth, undefined, { featureFlags })
-    : getSmallWhitelistedModel(auth, undefined, { featureFlags });
+  // Same default stream as the @dust agent. The sentinel is resolved to a
+  // concrete model + effort at message-send time by resolveModel().
+  const modelConfiguration = autoDefaultModelConfig ?? AUTO_FAST_MODEL_CONFIG;
 
-  const model: AgentModelConfigurationType = modelConfiguration
-    ? {
-        providerId: modelConfiguration?.providerId,
-        modelId: modelConfiguration?.modelId,
-        temperature: 0.2,
-        reasoningEffort: modelConfiguration?.defaultReasoningEffort,
-      }
-    : dummyModelConfiguration;
-  const status = modelConfiguration ? "active" : "disabled_by_admin";
+  const model: AgentModelConfigurationType = {
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
+    temperature: 0.2,
+    reasoningEffort: modelConfiguration.defaultReasoningEffort,
+  };
 
   const sId = GLOBAL_AGENTS_SID.HELPER;
   const metadata = getGlobalAgentMetadata(sId);
@@ -103,7 +98,7 @@ The user you're interacting with is granted with the role ${role}. Their name is
     instructions: prompt + globalAgentGuidelines,
     instructionsHtml: null,
     pictureUrl: metadata.pictureUrl,
-    status: status,
+    status: "active",
     userFavorite: false,
     scope: "global",
     model: model,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -176,7 +176,7 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.HELPER:
       agentConfiguration = _getHelperGlobalAgent({
         auth,
-        featureFlags,
+        autoDefaultModelConfig,
         mcpServerViews,
       });
       break;
@@ -880,22 +880,20 @@ function getGlobalAgent({
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
-      agentConfiguration = _getDustTaskGlobalAgent(auth, {
+      agentConfiguration = _getDustTaskGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        excludeProviders,
-        featureFlags,
+        autoDefaultModelConfig,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY:
       agentConfiguration = _getArchivedBrowserSummaryAgent();
       break;
     case GLOBAL_AGENTS_SID.DUST_PLANNING:
-      agentConfiguration = _getPlanningAgent(auth, {
+      agentConfiguration = _getPlanningAgent({
         settings,
-        excludeProviders,
-        featureFlags,
+        autoDefaultModelConfig,
       });
       break;
     case GLOBAL_AGENTS_SID.SIDEKICK:


### PR DESCRIPTION
## Description

`@help`, `dust-task` and `dust-planning` each picked a concrete model through their own
`getLargeWhitelistedModel` / `selectEnabledModel` chain. They now use the same stream
meta-model the `@dust` agent defaults to — `autoDefaultModelConfig`, i.e. the highest
stream the member's model-tier cap allows (Standard, or Basic when capped) — so the
sentinel is resolved to a concrete model + effort at message-send time by `resolveModel()`.

Before → after:

| Agent | Before | After |
| --- | --- | --- |
| `@help` | large whitelisted model (upgraded) / small whitelisted model | `autoDefaultModelConfig` |
| `dust-task` | Luna high → Sonnet 5 light → large fallback | `autoDefaultModelConfig` |
| `dust-planning` | Sol high → Opus 5 high → large fallback | `autoDefaultModelConfig` |

`@analyst` and `@sidekick` already run on the auto streams, so this is the existing
pattern rather than a new one. `_getDeepDiveGlobalAgent` and `getDeepDiveModelConfig`
are deliberately **not** touched — Deep Dive itself still pins Sol at medium.

Two consequences of dropping the whitelisted-model lookups:

- `featureFlags` / `excludeProviders` (and `auth` for `_getPlanningAgent`) only fed model
  selection, so they leave those signatures. `getDustTaskModelConfig` and
  `getPlanningModelConfig` are removed.
- The `no whitelisted model found` branches are gone: a sentinel always exists, and
  provider availability is handled inside stream resolution (`isProviderWhitelisted`
  short-circuits on stream ids, and `resolveStreamModel` filters the candidate pool by
  real availability). `@help` is now always `active`, matching `@analyst` and `@sidekick`;
  the two sub-agents only report `disabled_by_admin` from their settings row.

Incidentally this fixes a tier-cap failure: `dust-planning` ran Sol at `high`, which is
`premium`-tiered, so a member capped below premium hit `model_tier_not_enabled` at
[`run_model.ts` step 0](https://github.com/dust-tt/dust/blob/main/front/temporal/agent_loop/lib/run_model.ts)
*inside the planning sub-agent* — a Deep Dive that failed partway. A stream is by
construction within the member's cap, so that can no longer happen. `dust-task` ran
Luna at `high` (`balanced`), so it only affected Basic-capped members.

## Tests

No new tests. Typechecked the three changed files with `npx tsgo --noEmit` and linted them
with biome — both clean.

Caveat worth flagging for the reviewer: this worktree has no `node_modules`, so a full
`tsgo` run (and the `front-typecheck` pre-commit hook) fails on unresolvable third-party
imports (`openai/resources/responses/responses`, `@novu/framework`, `@notionhq/client`).
None of those errors are in the changed files; CI on a properly installed tree is the real
check here.

No existing test asserts the helper's model. `analyst.test.ts` covers the equivalent
assertions for `@analyst` and is the template if we want the same for `@help` — it is
cheap there only because `_getAnalystGlobalAgent` takes no `mcpServerViews`.

## Risk

Low-to-moderate; behavioral, fully rollback-able by revert (no schema or data changes).

- **Non-upgraded workspaces**: `@help` used to get the *small* whitelisted model and now
  gets whatever the stream resolves to. Tier caps are grant-based rather than plan-based,
  so `auth.isUpgraded()` no longer gates this. `@analyst` still keeps an explicit
  `isUpgraded() ? auto : auto_fast` branch — happy to add the same floor to `@help` if we
  want the plan-based behaviour preserved.
- **Deep Dive quality**: `dust-planning` moves off Sol/Opus high onto the Standard stream
  for uncapped members. That is a deliberate tier reduction for the planning step; if we
  would rather keep planning on premium, `auto_complex` is the sentinel to use, but note
  it is tiered `premium` itself and would hard-refuse capped members rather than degrade.
- **Model resolution attribution**: `modelResolutionMethod` now reports the stream id
  (`auto` / `auto_fast`) for these agents instead of `agent`, which shows up in analytics.

## Deploy Plan

Standard deploy of `front`, no ordering constraints. No migration, no feature flag. Revert
the commit to restore the previous per-agent model chains.
