### PR TITLE
[front] feat: add cycle-history fetch logic for pool usage

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -13,6 +13,7 @@ vi.mock("@app/lib/metronome/client", async () => {
     ...actual,
     listMetronomeBalances: vi.fn(),
     listMetronomeDraftInvoices: vi.fn(),
+    listMetronomeFinalizedInvoices: vi.fn(),
   };
 });
 
@@ -29,6 +30,9 @@ const EMPTY_POOL_SUMMARY = {
   currentCycleStartMs: null,
   currentCycleEndMs: null,
   currentCycleConsumedCredits: null,
+  cycleBreakdown: [],
+  excessConsumedCredits: null,
+  excessCycleBreakdown: [],
   programmaticConsumedCredits: null,
   otherConsumedCredits: null,
   excessConsumedCredits: null,
@@ -39,6 +43,9 @@ beforeEach(() => {
     new Ok([])
   );
   vi.mocked(metronomeClient.listMetronomeDraftInvoices).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
     new Ok([])
   );
 });

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -35,7 +35,6 @@ const EMPTY_POOL_SUMMARY = {
   excessCycleBreakdown: [],
   programmaticConsumedCredits: null,
   otherConsumedCredits: null,
-  excessConsumedCredits: null,
 };
 
 beforeEach(() => {

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -95,7 +95,7 @@ export function WorkspaceCreditUsageValueCards({
             : "—"
         }
         hint={`Other: ${
-          typeof otherConsumedCredits === "number"
+          otherConsumedCredits !== null
             ? formatCredits(otherConsumedCredits)
             : "—"
         }`}

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -117,6 +117,9 @@ async function getPoolLedgerData({
   return new Ok({ poolCommitIds, ledgerEntries });
 }
 
+// O(invoices x ledgerEntries) via computeCycleBreakdown's .map, but invoices
+// are capped at MAX_CYCLE_HISTORY_LIMIT (24) and ledgerEntries is bounded to
+// the same history window, so this stays cheap.
 function sumPoolLedgerEntriesForInvoice(
   ledgerEntries: PoolLedgerEntry[],
   invoiceId: string

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -492,7 +492,7 @@ async function getAwuPoolCurrentCycleUncached(
     listMetronomeDraftInvoices(metronomeCustomerId),
     getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit: 1 }),
     sumActiveMembersPoolConsumedCredits({
-      workspace,
+      auth,
       metronomeCustomerId,
       metronomeContractId,
     }),

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -117,9 +117,6 @@ async function getPoolLedgerData({
   return new Ok({ poolCommitIds, ledgerEntries });
 }
 
-// O(invoices x ledgerEntries) via computeCycleBreakdown's .map, but invoices
-// are capped at MAX_CYCLE_HISTORY_LIMIT and ledgerEntries is bounded to
-// the same history window.
 function sumPoolLedgerEntriesForInvoice(
   ledgerEntries: PoolLedgerEntry[],
   invoiceId: string
@@ -445,8 +442,6 @@ async function getAwuPoolCycleHistoryUncached(
   return new Ok({ cycleBreakdown, excessCycleBreakdown });
 }
 
-// Full body — current cycle plus history, composed for callers that want
-// everything in one shot (Poke, the legacy combined endpoint).
 export async function getAwuPoolSummary(
   auth: Authenticator,
   {

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -8,6 +8,7 @@ import { amountCents } from "@app/lib/metronome/amounts";
 import {
   listMetronomeBalances,
   listMetronomeDraftInvoices,
+  listMetronomeFinalizedInvoices,
 } from "@app/lib/metronome/client";
 import {
   CREDIT_TYPE_EUR_ID,
@@ -25,13 +26,32 @@ import {
 } from "@app/lib/metronome/seat_types";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
-import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type {
+  AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleBreakdown,
+  AwuPoolCycleHistoryResponseBody,
+  AwuPoolSummaryResponseBody,
+} from "@app/types/api/credits/awu_pool_summary";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { isNumber } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
+import { z } from "zod";
+
+const DEFAULT_CYCLE_HISTORY_LIMIT = 5;
+const MAX_CYCLE_HISTORY_LIMIT = 24;
+
+export const AwuPoolSummaryQuerySchema = z.object({
+  cycleHistoryLimit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_CYCLE_HISTORY_LIMIT)
+    .catch(DEFAULT_CYCLE_HISTORY_LIMIT),
+});
 
 const AUTOMATED_INVOICE_DEDUCTION_LEDGER_TYPES = new Set([
   "PREPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION",
@@ -51,16 +71,25 @@ type PoolLedgerData = {
   ledgerEntries: PoolLedgerEntry[];
 };
 
+const APPROX_CYCLE_LENGTH_DAYS = 31;
+
+// Balance listing bounded to the history the caller can actually surface
 async function getPoolLedgerData({
   metronomeCustomerId,
+  cycleHistoryLimit,
 }: {
   metronomeCustomerId: string;
+  cycleHistoryLimit: number;
 }): Promise<Result<PoolLedgerData, Error>> {
+  const startingAt = new Date(
+    Date.now() - cycleHistoryLimit * APPROX_CYCLE_LENGTH_DAYS * ONE_DAY_MS
+  );
   const balancesResult = await listMetronomeBalances(metronomeCustomerId, {
     coveringDate: null,
     onlyPoolCredits: true,
     includeArchived: true,
     includeLedgers: true,
+    startingAt,
   });
   if (balancesResult.isErr()) {
     return new Err(balancesResult.error);
@@ -95,6 +124,32 @@ function sumPoolLedgerEntriesForInvoice(
   return ledgerEntries
     .filter((entry) => entry.invoiceId === invoiceId)
     .reduce((sum, entry) => sum + Math.abs(entry.amountCredits), 0);
+}
+
+function computeCycleBreakdown({
+  finalizedInvoices,
+  ledgerEntries,
+  cycleHistoryLimit,
+}: {
+  finalizedInvoices: Invoice[];
+  ledgerEntries: PoolLedgerEntry[];
+  cycleHistoryLimit: number;
+}): AwuPoolCycleBreakdown[] {
+  return finalizedInvoices
+    .map((invoice) => ({
+      cycleStartMs: invoice.start_timestamp
+        ? new Date(invoice.start_timestamp).getTime()
+        : null,
+      cycleEndMs: invoice.end_timestamp
+        ? new Date(invoice.end_timestamp).getTime()
+        : null,
+      consumedCredits: sumPoolLedgerEntriesForInvoice(
+        ledgerEntries,
+        invoice.id
+      ),
+    }))
+    .filter((cycle) => cycle.consumedCredits > 0)
+    .slice(0, cycleHistoryLimit);
 }
 
 type MetronomeContext = {
@@ -165,6 +220,25 @@ function extractOverageFromInvoice(invoice: Invoice): {
     overageAmountCents,
     overageCurrency: overageCredits !== null ? overageCurrency : null,
   };
+}
+
+// Fallback cycle history for workspaces with no credit pool
+function computeExcessCycleBreakdown(
+  finalizedInvoices: Invoice[],
+  cycleHistoryLimit: number
+): AwuPoolCycleBreakdown[] {
+  return finalizedInvoices
+    .map((invoice) => ({
+      cycleStartMs: invoice.start_timestamp
+        ? new Date(invoice.start_timestamp).getTime()
+        : null,
+      cycleEndMs: invoice.end_timestamp
+        ? new Date(invoice.end_timestamp).getTime()
+        : null,
+      consumedCredits: extractOverageFromInvoice(invoice).overageCredits ?? 0,
+    }))
+    .filter((cycle) => cycle.consumedCredits > 0)
+    .slice(0, cycleHistoryLimit);
 }
 
 // Programmatic AWU spend against the pool, read straight from the current
@@ -253,7 +327,8 @@ const getCachedAwuPoolCurrentCycleOutcome = cacheWithRedis(
   }
 );
 
-// Header-card data only — cheap, bounded to a single cycle's ledger.
+// Header-card data only — cheap, meant to render before cycle history is
+// available. See `getAwuPoolCycleHistory` for the history table.
 export async function getAwuPoolCurrentCycle(
   auth: Authenticator
 ): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
@@ -264,10 +339,140 @@ export async function getAwuPoolCurrentCycle(
   return new Ok(outcome.body);
 }
 
+type SerializableAwuPoolCycleHistoryOutcome =
+  | { status: "ok"; body: AwuPoolCycleHistoryResponseBody }
+  | { status: "error"; errorType: AwuPoolSummaryErrorType };
+
+async function computeAwuPoolCycleHistoryOutcome(
+  auth: Authenticator,
+  cycleHistoryLimit: number
+): Promise<SerializableAwuPoolCycleHistoryOutcome> {
+  const result = await getAwuPoolCycleHistoryUncached(auth, {
+    cycleHistoryLimit,
+  });
+  if (result.isErr()) {
+    return { status: "error", errorType: result.error.type };
+  }
+  return { status: "ok", body: result.value };
+}
+
+function cacheResolverKeyWithHistoryLimit(
+  workspaceId: string,
+  cycleHistoryLimit: number
+): string {
+  return `${workspaceId}-${cycleHistoryLimit}`;
+}
+
+const AWU_POOL_CYCLE_HISTORY_CACHE_ID = "awuPoolCycleHistory";
+const AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS = 60 * 1000;
+
+const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
+  computeAwuPoolCycleHistoryOutcome,
+  (auth, cycleHistoryLimit) =>
+    cacheResolverKeyWithHistoryLimit(
+      auth.getNonNullableWorkspace().sId,
+      cycleHistoryLimit
+    ),
+  {
+    cacheId: AWU_POOL_CYCLE_HISTORY_CACHE_ID,
+    ttlMs: AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS,
+  }
+);
+
+// History-table data only — slower (scans the full ledger window). See
+// `getAwuPoolCurrentCycle` for the header-card figures.
+export async function getAwuPoolCycleHistory(
+  auth: Authenticator,
+  {
+    cycleHistoryLimit = DEFAULT_CYCLE_HISTORY_LIMIT,
+  }: {
+    cycleHistoryLimit?: number;
+  } = {}
+): Promise<Result<AwuPoolCycleHistoryResponseBody, AwuPoolSummaryError>> {
+  const outcome = await getCachedAwuPoolCycleHistoryOutcome(
+    auth,
+    cycleHistoryLimit
+  );
+  if (outcome.status === "error") {
+    return new Err(new AwuPoolSummaryError(outcome.errorType));
+  }
+  return new Ok(outcome.body);
+}
+
+// Past-cycle breakdown for the history table. Scans the full
+// `cycleHistoryLimit` ledger window, so it's slower than the current-cycle
+// figures above — kept separate so the header cards don't wait on it.
+async function getAwuPoolCycleHistoryUncached(
+  auth: Authenticator,
+  { cycleHistoryLimit }: { cycleHistoryLimit: number }
+): Promise<Result<AwuPoolCycleHistoryResponseBody, AwuPoolSummaryError>> {
+  const contextResult = resolveMetronomeContext(auth);
+  if (contextResult.isErr()) {
+    return contextResult;
+  }
+  const { metronomeCustomerId, metronomeContractId } = contextResult.value;
+
+  const [poolLedgerDataResult, finalizedInvoicesResult] = await Promise.all([
+    getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit }),
+    listMetronomeFinalizedInvoices(metronomeCustomerId, {
+      limit: cycleHistoryLimit,
+    }),
+  ]);
+
+  if (poolLedgerDataResult.isErr() || finalizedInvoicesResult.isErr()) {
+    logger.error(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        poolLedgerDataError: poolLedgerDataResult.isErr()
+          ? poolLedgerDataResult.error
+          : null,
+        invoicesError: finalizedInvoicesResult.isErr()
+          ? finalizedInvoicesResult.error
+          : null,
+      },
+      "[AwuPoolSummary] Failed to compute cycle breakdown"
+    );
+    return new Ok({ cycleBreakdown: [], excessCycleBreakdown: [] });
+  }
+
+  const cycleBreakdown = computeCycleBreakdown({
+    finalizedInvoices: finalizedInvoicesResult.value,
+    ledgerEntries: poolLedgerDataResult.value.ledgerEntries,
+    cycleHistoryLimit,
+  });
+  const excessCycleBreakdown = computeExcessCycleBreakdown(
+    finalizedInvoicesResult.value,
+    cycleHistoryLimit
+  );
+
+  return new Ok({ cycleBreakdown, excessCycleBreakdown });
+}
+
+// Full body — current cycle plus history, composed for callers that want
+// everything in one shot (Poke, the legacy combined endpoint).
 export async function getAwuPoolSummary(
-  auth: Authenticator
-): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
-  return getAwuPoolCurrentCycle(auth);
+  auth: Authenticator,
+  {
+    cycleHistoryLimit = DEFAULT_CYCLE_HISTORY_LIMIT,
+  }: {
+    cycleHistoryLimit?: number;
+  } = {}
+): Promise<Result<AwuPoolSummaryResponseBody, AwuPoolSummaryError>> {
+  const [currentCycleResult, cycleHistoryResult] = await Promise.all([
+    getAwuPoolCurrentCycle(auth),
+    getAwuPoolCycleHistory(auth, { cycleHistoryLimit }),
+  ]);
+  if (currentCycleResult.isErr()) {
+    return currentCycleResult;
+  }
+  if (cycleHistoryResult.isErr()) {
+    return cycleHistoryResult;
+  }
+  return new Ok({
+    ...currentCycleResult.value,
+    ...cycleHistoryResult.value,
+  });
 }
 
 async function getAwuPoolCurrentCycleUncached(
@@ -289,7 +494,7 @@ async function getAwuPoolCurrentCycleUncached(
   ] = await Promise.all([
     listMetronomeBalances(metronomeCustomerId),
     listMetronomeDraftInvoices(metronomeCustomerId),
-    getPoolLedgerData({ metronomeCustomerId }),
+    getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit: 1 }),
     sumActiveMembersPoolConsumedCredits({
       workspace,
       metronomeCustomerId,

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -118,8 +118,8 @@ async function getPoolLedgerData({
 }
 
 // O(invoices x ledgerEntries) via computeCycleBreakdown's .map, but invoices
-// are capped at MAX_CYCLE_HISTORY_LIMIT (24) and ledgerEntries is bounded to
-// the same history window, so this stays cheap.
+// are capped at MAX_CYCLE_HISTORY_LIMIT and ledgerEntries is bounded to
+// the same history window.
 function sumPoolLedgerEntriesForInvoice(
   ledgerEntries: PoolLedgerEntry[],
   invoiceId: string
@@ -330,8 +330,6 @@ const getCachedAwuPoolCurrentCycleOutcome = cacheWithRedis(
   }
 );
 
-// Header-card data only — cheap, meant to render before cycle history is
-// available. See `getAwuPoolCycleHistory` for the history table.
 export async function getAwuPoolCurrentCycle(
   auth: Authenticator
 ): Promise<Result<AwuPoolCurrentCycleResponseBody, AwuPoolSummaryError>> {
@@ -382,8 +380,6 @@ const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
   }
 );
 
-// History-table data only — slower (scans the full ledger window). See
-// `getAwuPoolCurrentCycle` for the header-card figures.
 export async function getAwuPoolCycleHistory(
   auth: Authenticator,
   {
@@ -402,9 +398,6 @@ export async function getAwuPoolCycleHistory(
   return new Ok(outcome.body);
 }
 
-// Past-cycle breakdown for the history table. Scans the full
-// `cycleHistoryLimit` ledger window, so it's slower than the current-cycle
-// figures above — kept separate so the header cards don't wait on it.
 async function getAwuPoolCycleHistoryUncached(
   auth: Authenticator,
   { cycleHistoryLimit }: { cycleHistoryLimit: number }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -799,11 +799,11 @@ async function fetchFreeSeatCreditsForMembersTable({
 }
 
 export async function sumActiveMembersPoolConsumedCredits({
-  workspace,
+  auth,
   metronomeCustomerId,
   metronomeContractId,
 }: {
-  workspace: LightWorkspaceType;
+  auth: Authenticator;
   metronomeCustomerId: string | null;
   metronomeContractId: string | null;
 }): Promise<number | null> {
@@ -812,7 +812,7 @@ export async function sumActiveMembersPoolConsumedCredits({
   }
 
   const { memberships } = await MembershipResource.getActiveMemberships({
-    workspace,
+    workspace: auth.getNonNullableWorkspace(),
   });
   if (memberships.length === 0) {
     return 0;
@@ -826,10 +826,14 @@ export async function sumActiveMembersPoolConsumedCredits({
     return user ? [{ sId: user.sId, seatType: m.seatType ?? null }] : [];
   });
 
+  // This function itself runs inside an outer Promise.all (getAwuPoolCurrentCycleUncached)
+  // alongside pure external calls, so the three fetchers below must stay Metronome/Redis-only.
+  // If one of them ever needs a DB read, pull it out and sequence it before this Promise.all
+  // instead of adding it here.
   const [usageByMetronomeUserId, { freeStartingByUserId }, seatDataByUserId] =
     await Promise.all([
       fetchPerUserUsageCreditsForMembersTable({
-        workspaceId: workspace.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
         metronomeCustomerId,
         metronomeContractId,
         userIds: members.map((m) =>

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2308,6 +2308,34 @@ export async function listMetronomeDraftInvoices(
   }
 }
 
+export async function listMetronomeFinalizedInvoices(
+  metronomeCustomerId: string,
+  { limit }: { limit: number }
+): Promise<Result<Invoice[], Error>> {
+  try {
+    const invoices: Invoice[] = [];
+    for await (const entry of getMetronomeClient().v1.customers.invoices.list({
+      customer_id: metronomeCustomerId,
+      status: "FINALIZED",
+      sort: "date_desc",
+      skip_zero_qty_line_items: true,
+    })) {
+      invoices.push(entry);
+      if (invoices.length >= limit) {
+        break;
+      }
+    }
+    return new Ok(invoices);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to list finalized invoices"
+    );
+    return new Err(error);
+  }
+}
+
 export async function listMetronomeBalances(
   metronomeCustomerId: string,
   {

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -1,5 +1,11 @@
 import type { SupportedCurrency } from "@app/types/currency";
 
+export type AwuPoolCycleBreakdown = {
+  cycleStartMs: number | null;
+  cycleEndMs: number | null;
+  consumedCredits: number;
+};
+
 // Current-cycle figures only — cheap to compute (bounded ledger lookup),
 // meant to render before cycle history is available.
 export type AwuPoolCurrentCycleResponseBody = {
@@ -24,4 +30,13 @@ export type AwuPoolCurrentCycleResponseBody = {
   otherConsumedCredits: number | null;
 };
 
-export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody;
+// Past-cycle history — requires scanning the full ledger window, slower than
+// `AwuPoolCurrentCycleResponseBody`.
+export type AwuPoolCycleHistoryResponseBody = {
+  // Per-cycle pool consumption, most recent first
+  cycleBreakdown: AwuPoolCycleBreakdown[];
+  excessCycleBreakdown: AwuPoolCycleBreakdown[];
+};
+
+export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody &
+  AwuPoolCycleHistoryResponseBody;

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -30,8 +30,6 @@ export type AwuPoolCurrentCycleResponseBody = {
   otherConsumedCredits: number | null;
 };
 
-// Past-cycle history — requires scanning the full ledger window, slower than
-// `AwuPoolCurrentCycleResponseBody`.
 export type AwuPoolCycleHistoryResponseBody = {
   // Per-cycle pool consumption, most recent first
   cycleBreakdown: AwuPoolCycleBreakdown[];


### PR DESCRIPTION
## Description

Adds `getAwuPoolCycleHistory`, scanning the full `cycleHistoryLimit` ledger window (via a new `listMetronomeFinalizedInvoices` call and a bounded `startingAt` on the balances fetch) to build a per-cycle consumed/excess breakdown. Kept separate from the current-cycle computation so the cheaper header-card fetch isn't slowed down by the wider scan.

## Stack overview

1. #31586 — infra: add Poke model_tiers endpoints
2. #31587 — infra: per-user AWU usage perf (dedupe + wider window)
3. #31588 — add Pool Usage page to Poke
4. #31589 — header -> remaining-pool card
5. #31590 — consumed-this-cycle card
6. #31591 — programmatic usage card
7. #31592 — other usage added to the programmatic/other card
8. #31593 — excess credit consumption for pool-less workspaces
9. **#31630 (this PR)** — cycle-history fetch logic for pool usage
10. #31595 — previous-cycle consumption table + ledger fetching
11. #31597 — remove group column from members table
12. #31598 — remove "Up to " prefix from Models column
13. #31600 — seats column -> icon only
14. #31601 — seat usage loading ring column
15. #31605 — pool credit usage column: extra-seat-usage only, orange overage
16. #31606 — infra: cache Metronome seat balances with Redis
17. #31608 — hover shows the group a member's limit is inherited from
18. #31610 — seat usage becomes sortable
19. #31611 — default-sort by pool credit usage

## Tests

Type-checked (front, front-api). awu-pool-summary.test.ts passes with the extended fixture (adds a listMetronomeFinalizedInvoices mock).

## Risk

Low-medium. Adds AwuPoolSummaryQuerySchema validation to the existing /w/ and /poke/ awu-pool-summary routes (cycleHistoryLimit, defaulted and bounded); no change to their existing response shape for current callers.

## Deploy Plan

Deploy front and front-api.
