### PR TITLE
[CLI] Fix login for manager roles

### DIFF
--- a/cli/dust-cli/package.json
+++ b/cli/dust-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "engines": {
     "node": ">=24.16.0"
   },
@@ -27,7 +27,7 @@
     "directory": "cli/dust-cli"
   },
   "dependencies": {
-    "@dust-tt/client": "^1.2.6",
+    "@dust-tt/client": "^1.2.8",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.4.1",
     "clipboardy": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,10 @@
     },
     "cli/dust-cli": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
-        "@dust-tt/client": "^1.2.6",
+        "@dust-tt/client": "^1.2.8",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.4.1",
         "clipboardy": "^4.0.0",


### PR DESCRIPTION
## Description

The `/api/v1/me` endpoint can return the `manager` workspace role, but CLI 0.4.5 may use an older client schema that rejects it. This bumps the CLI to 0.4.6 and requires `@dust-tt/client` 1.2.8 or newer, whose schema supports `manager`.

## Risks

Blast radius: CLI installation, authentication, and workspace selection.
Risk: low

## Deploy Plan

- publish `@dust-tt/dust-cli` 0.4.6 with the Publish CLI workflow after merge