### PR TITLE
Fixed padding/line clamps

### DIFF
--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -101,7 +101,7 @@ export function AgentTriggersTab({
 
   return (
     <>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between mb-2">
         <h3 className="text-sm font-semibold">My triggers</h3>
         <Button
           label="Add trigger"
@@ -138,9 +138,7 @@ export function AgentTriggersTab({
                 )
               }
               // The chip counts as a clamped line: leave room for it.
-              descriptionLineClamp={
-                trigger.status === "enabled" ? undefined : 3
-              }
+              descriptionLineClamp={6}
               canAdd={false}
               disabled={trigger.status !== "enabled"}
               onClick={() => onEditTrigger(trigger)}


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/10242

## Description

Increased line clamp for long cron schedule, inconditionally set it (no impact when status badge is not displayed) and add a margin between button and cards.

<img width="753" height="265" alt="Screenshot 2026-09-01 at 16 14 11" src="https://github.com/user-attachments/assets/e8f539b8-3f8c-4f1a-b079-c5c93ef80b10" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
