### PR TITLE
[front] Contain thrown errors from fire-and-forget notifications

### DIFF
--- a/front/lib/notifications/fire_and_forget.test.ts
+++ b/front/lib/notifications/fire_and_forget.test.ts
@@ -1,0 +1,29 @@
+import { fireAndForgetNotification } from "@app/lib/notifications/fire_and_forget";
+import logger from "@app/logger/logger";
+import { describe, expect, it, vi } from "vitest";
+
+describe("fireAndForgetNotification", () => {
+  const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+  it("logs a thrown error instead of leaving an unhandled rejection", async () => {
+    const onUnhandled = vi.fn();
+    process.once("unhandledRejection", onUnhandled);
+    const loggerSpy = vi
+      .spyOn(logger, "error")
+      .mockImplementation(() => logger);
+
+    fireAndForgetNotification(
+      Promise.reject(new Error("SequelizeConnectionAcquireTimeoutError")),
+      { message: "Failed to notify", context: { conversationId: "abc" } }
+    );
+    await flush();
+
+    expect(onUnhandled).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "abc" }),
+      "Failed to notify"
+    );
+    process.off("unhandledRejection", onUnhandled);
+    loggerSpy.mockRestore();
+  });
+});

--- a/front/lib/notifications/fire_and_forget.ts
+++ b/front/lib/notifications/fire_and_forget.ts
@@ -1,0 +1,24 @@
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export function fireAndForgetNotification<E>(
+  trigger: Promise<Result<void, E>>,
+  {
+    message,
+    context,
+  }: {
+    message: string;
+    context: Record<string, unknown>;
+  }
+): void {
+  void trigger
+    .then((res) => {
+      if (res.isErr()) {
+        logger.error({ ...context, error: res.error }, message);
+      }
+    })
+    .catch((err) => {
+      logger.error({ ...context, error: normalizeError(err) }, message);
+    });
+}

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -1,15 +1,16 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
+import { fireAndForgetNotification } from "@app/lib/notifications/fire_and_forget";
 import { triggerActivationNewConversationEmail } from "@app/lib/notifications/workflows/activation-new-conversation";
 import { shouldSkipConversationExternalNotification } from "@app/lib/notifications/workflows/conversation-unread";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
-import type { UserResource } from "@app/lib/resources/user_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
@@ -30,7 +31,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import uniqBy from "lodash/uniqBy";
 import { Op } from "sequelize";
 
 const NOTIFICATION_DELAY_MS = 15_000; // 15 seconds
@@ -141,22 +141,30 @@ const triggerProjectNewConversationNotifications = async (
     return new Ok(undefined);
   }
 
-  const { groupsToProcess } = await space.fetchManualGroupsMemberships(auth);
+  const { allGroupMemberships } =
+    await space.fetchManualGroupsMemberships(auth);
 
-  const projectMembers = uniqBy(
-    (
-      await concurrentExecutor(
-        groupsToProcess,
-        async (group) => {
-          return group.getActiveMembers(auth);
-        },
-        { concurrency: 8 }
-      )
-    ).flat(),
-    "sId"
+  const memberModelIds = [
+    ...new Set(allGroupMemberships.map((membership) => membership.userId)),
+  ];
+  if (memberModelIds.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const projectMembers = await UserResource.fetchByModelIds(memberModelIds);
+  const { memberships: workspaceMemberships } =
+    await MembershipResource.getActiveMemberships({
+      users: projectMembers,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+  const activeUserIds = new Set(
+    workspaceMemberships.map((membership) => membership.userId)
+  );
+  const activeProjectMembers = projectMembers.filter((member) =>
+    activeUserIds.has(member.id)
   );
 
-  const otherProjectMembers = projectMembers.filter(
+  const otherProjectMembers = activeProjectMembers.filter(
     (member) => member.sId !== userThatCreatedConversation.sId
   );
 
@@ -228,16 +236,13 @@ export function notifyNewProjectConversation(
     conversation: ConversationWithoutContentType;
   }
 ): void {
-  void triggerProjectNewConversationNotifications(auth, {
-    conversation,
-  }).then((notifRes) => {
-    if (notifRes.isErr()) {
-      logger.error(
-        { error: notifRes.error, conversationId: conversation.sId },
-        "Failed to trigger project new conversation notification"
-      );
+  fireAndForgetNotification(
+    triggerProjectNewConversationNotifications(auth, { conversation }),
+    {
+      message: "Failed to trigger project new conversation notification",
+      context: { conversationId: conversation.sId },
     }
-  });
+  );
 }
 
 export async function areForYouNotificationsEnabled(

--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -2,6 +2,7 @@ import { getEditors } from "@app/lib/api/assistant/editors";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
+import { fireAndForgetNotification } from "@app/lib/notifications/fire_and_forget";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -137,18 +138,14 @@ export function notifyAgentSuggestionsReady(
     suggestionCount: number;
   }
 ): void {
-  void triggerAgentSuggestionsReadyNotifications(auth, {
-    agentConfiguration,
-    suggestionCount,
-  }).then((notifRes) => {
-    if (notifRes.isErr()) {
-      logger.error(
-        {
-          error: notifRes.error,
-          agentConfigurationId: agentConfiguration.sId,
-        },
-        "Failed to trigger agent suggestions ready notification"
-      );
+  fireAndForgetNotification(
+    triggerAgentSuggestionsReadyNotifications(auth, {
+      agentConfiguration,
+      suggestionCount,
+    }),
+    {
+      message: "Failed to trigger agent suggestions ready notification",
+      context: { agentConfigurationId: agentConfiguration.sId },
     }
-  });
+  );
 }

--- a/front/lib/notifications/workflows/pod-added-as-member.ts
+++ b/front/lib/notifications/workflows/pod-added-as-member.ts
@@ -4,10 +4,10 @@ import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
 import { getNovuClient } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { fireAndForgetNotification } from "@app/lib/notifications/fire_and_forget";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { getPodRoute } from "@app/lib/utils/router";
-import logger from "@app/logger/logger";
 import { POD_ADDED_AS_MEMBER_TRIGGER_ID } from "@app/types/notification_preferences";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -268,15 +268,11 @@ export function notifyPodMembersAdded(
     addedUserIds: string[];
   }
 ): void {
-  void triggerPodAddedAsMemberNotifications(auth, {
-    pod: pod,
-    addedUserIds,
-  }).then((notifRes) => {
-    if (notifRes.isErr()) {
-      logger.error(
-        { error: notifRes.error, podId: pod.sId },
-        "Failed to trigger pod added as member notification"
-      );
+  fireAndForgetNotification(
+    triggerPodAddedAsMemberNotifications(auth, { pod, addedUserIds }),
+    {
+      message: "Failed to trigger pod added as member notification",
+      context: { podId: pod.sId },
     }
-  });
+  );
 }


### PR DESCRIPTION
## Summary
- Notification triggers that run after the response used `.then(if isErr)`, so a throw (Sequelize pool timeout, failed `fetch`) became an unhandled rejection with `panic: true`.
- `fireAndForgetNotification` logs both a returned `Err` and a thrown error, same contract as `emitAuditLogEvent`.
- Project new-conversation members are loaded from the group rows `fetchManualGroupsMemberships` already returns, then one `getActiveMemberships` call keeps the workspace-membership filter that `getActiveMembers` had. That avoids fanning out 8 concurrent connections against a pool of 10.

## Test plan
unit tests

## Risk
1. Low, no behavior change

## Deploy
1. Deploy front