### PR TITLE
feat: fetch feedback counts from pg

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -6,6 +6,7 @@ import {
   getAgentCostStats,
 } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -59,8 +60,13 @@ app.get(
       version,
     });
 
-    const [overview, costStatsResult] = await Promise.all([
-      fetchAgentOverview(baseQuery, days),
+    const [feedbackCounts, overview, costStatsResult] = await Promise.all([
+      AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        assistant.sId,
+        days
+      ),
+      fetchAgentOverview(baseQuery),
       fetchAgentCostStats(auth, {
         agentIds: [assistant.sId],
         days,
@@ -82,13 +88,7 @@ app.get(
       });
     }
 
-    const {
-      activeUsers,
-      conversationCount,
-      messageCount,
-      positiveFeedbacks,
-      negativeFeedbacks,
-    } = overview.value;
+    const { activeUsers, conversationCount, messageCount } = overview.value;
 
     return ctx.json({
       activeUsers,
@@ -98,8 +98,8 @@ app.get(
         timePeriodSec: days * 24 * 60 * 60,
       },
       feedbacks: {
-        positiveFeedbacks,
-        negativeFeedbacks,
+        positiveFeedbacks: feedbackCounts.positive,
+        negativeFeedbacks: feedbackCounts.negative,
         timePeriodSec: days * 24 * 60 * 60,
       },
       costs,

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -48,6 +48,7 @@ import {
   DESCRIBE_MCP_TOOL_NAME,
   DESCRIBE_SKILL_TOOL_NAME,
 } from "@app/lib/reinforcement/types";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -859,7 +860,14 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       days: numberOfDays,
     });
 
-    const overviewResult = await fetchAgentOverview(baseQuery, numberOfDays);
+    const [feedbackCounts, overviewResult] = await Promise.all([
+      AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        agentConfigurationId,
+        numberOfDays
+      ),
+      fetchAgentOverview(baseQuery),
+    ]);
 
     if (overviewResult.isErr()) {
       return new Err(
@@ -883,9 +891,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         conversationCount: overview.conversationCount,
         messageCount: overview.messageCount,
         feedback: {
-          positive: overview.positiveFeedbacks,
-          negative: overview.negativeFeedbacks,
-          total: overview.positiveFeedbacks + overview.negativeFeedbacks,
+          positive: feedbackCounts.positive,
+          negative: feedbackCounts.negative,
+          total: feedbackCounts.positive + feedbackCounts.negative,
         },
       },
     };

--- a/front/lib/api/assistant/builder/sidekick_prompts.ts
+++ b/front/lib/api/assistant/builder/sidekick_prompts.ts
@@ -5,6 +5,7 @@ import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { TemplateResource } from "@app/lib/resources/template_resource";
@@ -198,7 +199,14 @@ async function fetchInsightsMarkdown(
     days: INSIGHTS_DAYS,
   });
 
-  const overviewResult = await fetchAgentOverview(baseQuery, INSIGHTS_DAYS);
+  const [feedbackCounts, overviewResult] = await Promise.all([
+    AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+      auth,
+      agentConfigurationId,
+      INSIGHTS_DAYS
+    ),
+    fetchAgentOverview(baseQuery),
+  ]);
 
   if (overviewResult.isErr()) {
     logger.warn(
@@ -215,7 +223,7 @@ async function fetchInsightsMarkdown(
     `Active users: ${o.activeUsers}`,
     `Conversations: ${o.conversationCount}`,
     `Messages: ${o.messageCount}`,
-    `Feedback: ${o.positiveFeedbacks} positive, ${o.negativeFeedbacks} negative`,
+    `Feedback: ${feedbackCounts.positive} positive, ${feedbackCounts.negative} negative`,
     "</insights>",
   ].join("\n");
 }

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -11,8 +11,6 @@ export type AgentOverview = {
   activeUsers: number;
   conversationCount: number;
   messageCount: number;
-  positiveFeedbacks: number;
-  negativeFeedbacks: number;
 };
 
 type OverviewAggs = {
@@ -29,30 +27,13 @@ type OverviewAggs = {
 };
 
 export async function fetchAgentOverview(
-  baseQuery: estypes.QueryDslQueryContainer,
-  days: number
+  baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<AgentOverview, Error>> {
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
     {
       active_users: { cardinality: { field: "user_id" } },
       conversations: { cardinality: { field: "conversation_id" } },
       total_messages: { value_count: { field: "message_id" } },
-      feedbacks: {
-        nested: { path: "feedbacks" },
-        aggs: {
-          recent: {
-            filter: {
-              range: { "feedbacks.created_at": { gte: `now-${days}d/d` } },
-            },
-            aggs: {
-              up: { filter: { term: { "feedbacks.thumb_direction": "up" } } },
-              down: {
-                filter: { term: { "feedbacks.thumb_direction": "down" } },
-              },
-            },
-          },
-        },
-      },
     };
 
   const result = await searchAnalytics<never, OverviewAggs>(baseQuery, {
@@ -70,10 +51,6 @@ export async function fetchAgentOverview(
     activeUsers: Math.round(aggs?.active_users?.value ?? 0),
     conversationCount: Math.round(aggs?.conversations?.value ?? 0),
     messageCount: Math.round(aggs?.total_messages?.value ?? 0),
-    positiveFeedbacks: Math.round(aggs?.feedbacks?.recent?.up?.doc_count ?? 0),
-    negativeFeedbacks: Math.round(
-      aggs?.feedbacks?.recent?.down?.doc_count ?? 0
-    ),
   });
 }
 

--- a/front/lib/resources/agent_message_feedback_resource.test.ts
+++ b/front/lib/resources/agent_message_feedback_resource.test.ts
@@ -25,6 +25,163 @@ async function createConvWithAgentMessage(
   return { conv, agentMessageId: messageRow.agentMessageId! };
 }
 
+describe("AgentMessageFeedbackResource.getFeedbackCountForAssistant", () => {
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "user" });
+    auth = setup.authenticator;
+  });
+
+  it("returns zeros when no feedback exists for the assistant", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        agent.sId
+      );
+
+    expect(result).toEqual({ positive: 0, negative: 0 });
+  });
+
+  it("counts positive and negative feedback correctly", async () => {
+    const workspace = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const { conv: conv1, agentMessageId: amId1 } =
+      await createConvWithAgentMessage(auth, agent.sId);
+    const { conv: conv2, agentMessageId: amId2 } =
+      await createConvWithAgentMessage(auth, agent.sId);
+    const { conv: conv3, agentMessageId: amId3 } =
+      await createConvWithAgentMessage(auth, agent.sId);
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv1.id,
+      agentMessageId: amId1,
+      userId,
+      thumbDirection: "up",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv2.id,
+      agentMessageId: amId2,
+      userId,
+      thumbDirection: "up",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv3.id,
+      agentMessageId: amId3,
+      userId,
+      thumbDirection: "down",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        agent.sId
+      );
+
+    expect(result).toEqual({ positive: 2, negative: 1 });
+  });
+
+  it("does not count feedback for other assistants", async () => {
+    const workspace = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+    const agent1 = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Agent One",
+    });
+    const agent2 = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Agent Two",
+    });
+
+    const { conv, agentMessageId: amId } = await createConvWithAgentMessage(
+      auth,
+      agent2.sId
+    );
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent2.sId,
+      agentConfigurationVersion: agent2.version,
+      conversationId: conv.id,
+      agentMessageId: amId,
+      userId,
+      thumbDirection: "up",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        agent1.sId
+      );
+
+    expect(result).toEqual({ positive: 0, negative: 0 });
+  });
+
+  it("includes recent feedback when daysOld covers the current day", async () => {
+    const workspace = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const { conv, agentMessageId: amId } = await createConvWithAgentMessage(
+      auth,
+      agent.sId
+    );
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv.id,
+      agentMessageId: amId,
+      userId,
+      thumbDirection: "up",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    // A 30-day window should include feedback created just now.
+    const resultWithinWindow =
+      await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        agent.sId,
+        30
+      );
+    expect(resultWithinWindow).toEqual({ positive: 1, negative: 0 });
+
+    // Omitting daysOld returns all feedback regardless of age.
+    const resultAllTime =
+      await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+        auth,
+        agent.sId
+      );
+    expect(resultAllTime).toEqual({ positive: 1, negative: 0 });
+  });
+});
+
 describe("AgentMessageFeedbackResource.getFeedbackCountsByConversationIds", () => {
   let auth: Authenticator;
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -361,6 +361,28 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     }[];
   }
 
+  static async getFeedbackCountForAssistant(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    daysOld?: number
+  ): Promise<{ positive: number; negative: number }> {
+    const feedbackCounts = await this.getFeedbackCountForAssistants(
+      auth,
+      [agentConfigurationId],
+      daysOld
+    );
+
+    const positive = feedbackCounts
+      .filter((f) => f.thumbDirection === "up")
+      .reduce((sum, f) => sum + f.count, 0);
+
+    const negative = feedbackCounts
+      .filter((f) => f.thumbDirection === "down")
+      .reduce((sum, f) => sum + f.count, 0);
+
+    return { positive, negative };
+  }
+
   /**
    * Returns feedback counts grouped by conversationId for the given
    * conversation model IDs.


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/10262

- Stop aggregating feedback counts from ES in `fetchAgentOverview()`, instead, rely on the already existing `AgentMessageResource.getFeedbackCountForAssistants`.
- Added a shortcut `AgentMessageResource.getFeedbackCountForAssistant`.

There should be no behavior change.

## Tests

- Added test for `AgentMessageResource.getFeedbackCountForAssistant`

## Risk

Low. Safe to rollback until the ES index `front.agent_message_analytics` is removed.

## Deploy Plan

Front only