### PR TITLE
[front] chore: read agent usage from consumption analytics

### DIFF
--- a/front/lib/api/assistant/agent_usage.test.ts
+++ b/front/lib/api/assistant/agent_usage.test.ts
@@ -1,16 +1,18 @@
 import { agentMentionsCount } from "@app/lib/api/assistant/agent_usage";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/elasticsearch", () => ({
-  searchAnalytics: vi.fn(),
+  searchConsumptionAnalytics: vi.fn(),
 }));
 
 describe("agentMentionsCount", () => {
   it("should return aggregated mentions from Elasticsearch", async () => {
-    const mockSearchAnalytics = vi.mocked(searchAnalytics);
-    mockSearchAnalytics.mockResolvedValue(
+    const mockSearchConsumptionAnalytics = vi.mocked(
+      searchConsumptionAnalytics
+    );
+    mockSearchConsumptionAnalytics.mockResolvedValue(
       new Ok({
         took: 1,
         timed_out: false,
@@ -21,13 +23,15 @@ describe("agentMentionsCount", () => {
             buckets: [
               {
                 key: "agent-123",
-                doc_count: 5,
+                doc_count: 8,
+                message_count: { value: 5 },
                 conversation_count: { value: 3 },
                 user_count: { value: 2 },
               },
               {
                 key: "agent-456",
-                doc_count: 2,
+                doc_count: 4,
+                message_count: { value: 2 },
                 conversation_count: { value: 1 },
                 user_count: { value: 1 },
               },
@@ -53,25 +57,50 @@ describe("agentMentionsCount", () => {
     expect(result.value[1].messageCount).toBe(2);
 
     // Verify the query structure
-    expect(mockSearchAnalytics).toHaveBeenCalledWith(
+    expect(mockSearchConsumptionAnalytics).toHaveBeenCalledWith(
       expect.objectContaining({
         bool: {
           filter: expect.arrayContaining([
             { term: { workspace_id: "workspace-sId" } },
-            { exists: { field: "agent_id" } },
+            { exists: { field: "agent.attributed_id" } },
+            {
+              range: {
+                completed_at: {
+                  gte: "now-30d/d",
+                },
+              },
+            },
           ]),
         },
       }),
       expect.objectContaining({
-        aggregations: expect.any(Object),
+        aggregations: {
+          by_agent: {
+            terms: {
+              field: "agent.attributed_id",
+              order: { message_count: "desc" },
+              size: 1000,
+            },
+            aggs: expect.objectContaining({
+              message_count: {
+                cardinality: {
+                  field: "agent_message_id",
+                  precision_threshold: 40000,
+                },
+              },
+            }),
+          },
+        },
         size: 0,
       })
     );
   });
 
   it("should return empty array when no aggregations", async () => {
-    const mockSearchAnalytics = vi.mocked(searchAnalytics);
-    mockSearchAnalytics.mockResolvedValue(
+    const mockSearchConsumptionAnalytics = vi.mocked(
+      searchConsumptionAnalytics
+    );
+    mockSearchConsumptionAnalytics.mockResolvedValue(
       new Ok({
         took: 1,
         timed_out: false,

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,4 +1,11 @@
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CONVERSATION_ID_FIELD,
+  uniqueMessagesCardinalityAgg,
+} from "@app/lib/api/analytics/consumption/scope";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { USER_USAGE_ORIGINS } from "@app/lib/api/programmatic_usage/common";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
@@ -140,6 +147,7 @@ type MentionsCountAggs = {
   by_agent: estypes.AggregationsTermsAggregateBase<{
     key: string;
     doc_count: number;
+    message_count?: estypes.AggregationsCardinalityAggregate;
     conversation_count: estypes.AggregationsCardinalityAggregate;
     user_count: estypes.AggregationsCardinalityAggregate;
   }>;
@@ -153,10 +161,10 @@ export async function agentMentionsCount(
   const filters: estypes.QueryDslQueryContainer[] = [
     { term: { workspace_id: workspaceId } },
     { terms: { context_origin: USER_USAGE_ORIGINS } },
-    { exists: { field: "agent_id" } },
+    { exists: { field: CONSUMPTION_DIMENSION_FIELDS.agent } },
     {
       range: {
-        timestamp: {
+        [COMPLETED_AT_FIELD]: {
           gte: `now-${rankingUsageDays}d/d`,
         },
       },
@@ -164,7 +172,11 @@ export async function agentMentionsCount(
   ];
 
   if (agentConfiguration) {
-    filters.push({ term: { agent_id: agentConfiguration.sId } });
+    filters.push({
+      term: {
+        [CONSUMPTION_DIMENSION_FIELDS.agent]: agentConfiguration.sId,
+      },
+    });
   }
 
   const query: estypes.QueryDslQueryContainer = {
@@ -175,20 +187,35 @@ export async function agentMentionsCount(
     {
       by_agent: {
         terms: {
-          field: "agent_id",
+          field: CONSUMPTION_DIMENSION_FIELDS.agent,
           size: 1000,
+          order: { message_count: "desc" },
         },
         aggs: {
-          conversation_count: { cardinality: { field: "conversation_id" } },
-          user_count: { cardinality: { field: "user_id" } },
+          message_count: uniqueMessagesCardinalityAgg(),
+          conversation_count: {
+            cardinality: {
+              field: CONVERSATION_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          user_count: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
         },
       },
     };
 
-  const result = await searchAnalytics<never, MentionsCountAggs>(query, {
-    aggregations,
-    size: 0,
-  });
+  const result = await searchConsumptionAnalytics<never, MentionsCountAggs>(
+    query,
+    {
+      aggregations,
+      size: 0,
+    }
+  );
 
   if (result.isErr()) {
     return new Err(
@@ -205,7 +232,7 @@ export async function agentMentionsCount(
     buckets
       .map((bucket) => ({
         agentId: bucket.key,
-        messageCount: bucket.doc_count,
+        messageCount: Math.round(bucket.message_count?.value ?? 0),
         conversationCount: bucket.conversation_count?.value ?? 0,
         userCount: bucket.user_count?.value ?? 0,
         timePeriodSec: rankingUsageDays * 24 * 60 * 60,


### PR DESCRIPTION
## Description

Agent usage in the Manage Agents page reads from the legacy `front.agent_message_analytics`. This PR moves it to `front.agent_message_consumption_analytics` instead.

Consumption analytics stores several documents per message, so the query counts distinct agent message IDs where the old index could just count the total number of documents.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
