### PR TITLE
[front] Add cleanup script for orphaned Pod groups

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -966,22 +966,13 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchByName(
     auth: Authenticator,
-    name: string,
-    {
-      forUpdate = false,
-      transaction,
-    }: { forUpdate?: boolean; transaction?: Transaction } = {}
+    name: string
   ): Promise<GroupResource | null> {
-    const [group] = await this.baseFetch(
-      auth,
-      {
-        where: {
-          name,
-        },
-        ...(transaction && forUpdate ? { lock: transaction.LOCK.UPDATE } : {}),
+    const [group] = await this.baseFetch(auth, {
+      where: {
+        name,
       },
-      transaction
-    );
+    });
     if (group && !group.canRead(auth)) {
       return null;
     }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -966,13 +966,18 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchByName(
     auth: Authenticator,
-    name: string
+    name: string,
+    transaction?: Transaction
   ): Promise<GroupResource | null> {
-    const [group] = await this.baseFetch(auth, {
-      where: {
-        name,
+    const [group] = await this.baseFetch(
+      auth,
+      {
+        where: {
+          name,
+        },
       },
-    });
+      transaction
+    );
     if (group && !group.canRead(auth)) {
       return null;
     }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -967,7 +967,10 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async fetchByName(
     auth: Authenticator,
     name: string,
-    transaction?: Transaction
+    {
+      forUpdate = false,
+      transaction,
+    }: { forUpdate?: boolean; transaction?: Transaction } = {}
   ): Promise<GroupResource | null> {
     const [group] = await this.baseFetch(
       auth,
@@ -975,6 +978,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         where: {
           name,
         },
+        ...(transaction && forUpdate ? { lock: transaction.LOCK.UPDATE } : {}),
       },
       transaction
     );

--- a/front/scripts/cleanup_orphaned_pod_groups.ts
+++ b/front/scripts/cleanup_orphaned_pod_groups.ts
@@ -1,0 +1,155 @@
+/**
+ * Delete the auto-created groups left behind by the Pod deletion bug fixed in
+ * https://github.com/dust-tt/tasks/issues/10245.
+ *
+ * Dry run:
+ *   npx tsx scripts/cleanup_orphaned_pod_groups.ts \
+ *     --workspaceId WORKSPACE_SID \
+ *     --podName "Deleted Pod Name"
+ *
+ * Execute:
+ *   npx tsx scripts/cleanup_orphaned_pod_groups.ts \
+ *     --workspaceId WORKSPACE_SID \
+ *     --podName "Deleted Pod Name" \
+ *     --execute
+ */
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { makeScript } from "@app/scripts/helpers";
+import {
+  PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+} from "@app/types/groups";
+
+type CleanupResult = {
+  deletedCount: number;
+  groups: { name: string; sId: string }[];
+  mode: "dry_run" | "execution";
+};
+
+export async function cleanupOrphanedPodGroups(
+  auth: Authenticator,
+  {
+    execute,
+    podName: rawPodName,
+  }: {
+    execute: boolean;
+    podName: string;
+  }
+): Promise<CleanupResult> {
+  const podName = rawPodName.trim();
+  if (!podName) {
+    throw new Error("Pod name must not be empty.");
+  }
+
+  return withTransaction(async (transaction) => {
+    const existingSpace = await SpaceResource.fetchByName(
+      auth,
+      podName,
+      transaction
+    );
+    if (existingSpace) {
+      throw new Error(
+        `A Space or Pod named "${podName}" still exists. Archived Pods must not be cleaned up.`
+      );
+    }
+
+    const expectedGroupNames = [
+      `${PROJECT_GROUP_PREFIX} ${podName}`,
+      `${PROJECT_EDITOR_GROUP_PREFIX} ${podName}`,
+    ];
+    const groups: GroupResource[] = [];
+
+    for (const groupName of expectedGroupNames) {
+      const group = await GroupResource.fetchByName(
+        auth,
+        groupName,
+        transaction
+      );
+      if (!group) {
+        continue;
+      }
+      if (!group.isRegularAuto()) {
+        throw new Error(
+          `Group "${groupName}" is not an auto-created group. Refusing to delete it.`
+        );
+      }
+
+      const grants = await GroupPermissionResource.listForGroup(
+        auth,
+        group,
+        transaction
+      );
+      if (grants.length > 0) {
+        throw new Error(
+          `Group "${groupName}" still has grants. Refusing to delete it.`
+        );
+      }
+
+      groups.push(group);
+    }
+
+    if (execute) {
+      for (const group of groups) {
+        const deleteResult = await group.delete(auth, { transaction });
+        if (deleteResult.isErr()) {
+          throw deleteResult.error;
+        }
+      }
+    }
+
+    return {
+      deletedCount: execute ? groups.length : 0,
+      groups: groups.map(({ name, sId }) => ({ name, sId })),
+      mode: execute ? "execution" : "dry_run",
+    };
+  });
+}
+
+function runScript() {
+  makeScript(
+    {
+      workspaceId: {
+        type: "string",
+        description: "Workspace sID",
+        demandOption: true,
+      },
+      podName: {
+        type: "string",
+        description: "Name of the deleted Pod",
+        demandOption: true,
+      },
+    },
+    async ({ execute, podName, workspaceId }, logger) => {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        throw new Error(`Workspace "${workspaceId}" not found.`);
+      }
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const result = await cleanupOrphanedPodGroups(auth, {
+        execute,
+        podName,
+      });
+
+      logger.info(
+        {
+          ...result,
+          podName: podName.trim(),
+          workspaceId: workspace.sId,
+        },
+        execute
+          ? "Orphaned Pod group cleanup completed"
+          : "Orphaned Pod group cleanup dry run completed"
+      );
+    }
+  );
+}
+
+if (process.argv[1]?.endsWith("cleanup_orphaned_pod_groups.ts")) {
+  runScript();
+}

--- a/front/scripts/cleanup_orphaned_pod_groups.ts
+++ b/front/scripts/cleanup_orphaned_pod_groups.ts
@@ -47,6 +47,8 @@ export async function cleanupOrphanedPodGroups(
   }
 
   return withTransaction(async (transaction) => {
+    // Archiving only sets ProjectMetadata.archivedAt, so archived Pods still have an active Space
+    // row and are returned here.
     const existingSpace = await SpaceResource.fetchByName(
       auth,
       podName,
@@ -65,11 +67,10 @@ export async function cleanupOrphanedPodGroups(
     const groups: GroupResource[] = [];
 
     for (const groupName of expectedGroupNames) {
-      const group = await GroupResource.fetchByName(
-        auth,
-        groupName,
-        transaction
-      );
+      const group = await GroupResource.fetchByName(auth, groupName, {
+        forUpdate: execute,
+        transaction,
+      });
       if (!group) {
         continue;
       }

--- a/front/scripts/cleanup_orphaned_pod_groups.ts
+++ b/front/scripts/cleanup_orphaned_pod_groups.ts
@@ -67,10 +67,7 @@ export async function cleanupOrphanedPodGroups(
     const groups: GroupResource[] = [];
 
     for (const groupName of expectedGroupNames) {
-      const group = await GroupResource.fetchByName(auth, groupName, {
-        forUpdate: execute,
-        transaction,
-      });
+      const group = await GroupResource.fetchByName(auth, groupName);
       if (!group) {
         continue;
       }


### PR DESCRIPTION
## Description

- Add a dry-run-by-default script to clean up the two auto-created groups left by Pod deletions affected by dust-tt/tasks#10245.
- Scope cleanup to one workspace and Pod name.
- Refuse cleanup when the Space still exists, including archived Pods, or when a matching group is not auto-created or still has grants.
- Delete through `GroupResource.delete` in a transaction so associated memberships and references are cleaned up.

## Usage

```sh
npx tsx scripts/cleanup_orphaned_pod_groups.ts --workspaceId WORKSPACE_SID --podName "Deleted Pod Name"
npx tsx scripts/cleanup_orphaned_pod_groups.ts --workspaceId WORKSPACE_SID --podName "Deleted Pod Name" --execute
```

## Validation

- `npx biome check scripts/cleanup_orphaned_pod_groups.ts`
- `npx tsgo --noEmit`
- `npx tsx scripts/cleanup_orphaned_pod_groups.ts --help`
- No automated tests added for this one-off operational script.