### PR TITLE
Add: cell in webhook routing config

### DIFF
--- a/connectors/migrations/20251120_migrate_slack_connection_credentials.ts
+++ b/connectors/migrations/20251120_migrate_slack_connection_credentials.ts
@@ -124,7 +124,7 @@ async function migrateSlackConnectionCredential(
 
   // Configure webhook router
   const webhookService = new WebhookRouterConfigService();
-  const currentRegion = connectorsConfig.getCurrentRegion();
+  const currentCell = connectorsConfig.getCurrentCell();
 
   // Get all connectors for this team to build the connector IDs list
   const allTeamSlackConfigs = await SlackConfigurationResource.listForTeamId(
@@ -137,12 +137,12 @@ async function migrateSlackConnectionCredential(
     PROVIDER,
     teamId,
     slackSigningSecret,
-    currentRegion,
+    currentCell,
     connectorIds
   );
 
   logger.info(
-    { teamId, region: currentRegion, connectorIds },
+    { teamId, cell: currentCell, connectorIds },
     `Updated webhook router configuration for team ${teamId} with ${connectorIds.length} connector(s).`
   );
 

--- a/connectors/migrations/20251204_migrate_slack_connection_credentials_manual_mapping.ts
+++ b/connectors/migrations/20251204_migrate_slack_connection_credentials_manual_mapping.ts
@@ -172,7 +172,7 @@ async function migrateSlackConnectionCredential(
 
   // Configure webhook router
   const webhookService = new WebhookRouterConfigService();
-  const currentRegion = connectorsConfig.getCurrentRegion();
+  const currentCell = connectorsConfig.getCurrentCell();
 
   // Get all connectors for this team to build the connector IDs list
   const allTeamSlackConfigs = await SlackConfigurationResource.listForTeamId(
@@ -185,12 +185,12 @@ async function migrateSlackConnectionCredential(
     PROVIDER,
     teamId,
     slackSigningSecret,
-    currentRegion,
+    currentCell,
     connectorIds
   );
 
   logger.info(
-    { teamId, region: currentRegion, connectorIds },
+    { teamId, cell: currentCell, connectorIds },
     `Updated webhook router configuration for team ${teamId} with ${connectorIds.length} connector(s).`
   );
 

--- a/connectors/migrations/20260901_backfill_webhook_router_config_cells.ts
+++ b/connectors/migrations/20260901_backfill_webhook_router_config_cells.ts
@@ -1,0 +1,25 @@
+import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
+import type { Logger } from "@connectors/logger/logger";
+import { makeScript } from "scripts/helpers";
+
+makeScript({}, async ({ execute }, logger: Logger) => {
+  const service = new WebhookRouterConfigService();
+  const { entriesUpdated } = await service.backfillMissingCells(execute);
+
+  if (entriesUpdated === 0) {
+    logger.info("No webhook router entries need cells backfill.");
+    return;
+  }
+
+  if (execute) {
+    logger.info(
+      { entriesUpdated },
+      "Backfilled cells from regions in webhook router config."
+    );
+  } else {
+    logger.info(
+      { entriesUpdated },
+      "[DRY RUN] Would backfill cells from regions in webhook router config."
+    );
+  }
+});

--- a/connectors/src/api/sync_webhook_router_config.ts
+++ b/connectors/src/api/sync_webhook_router_config.ts
@@ -29,7 +29,7 @@ type SyncWebhookRouterEntryReqBody = t.TypeOf<
 
 /**
  * POST /webhooks_router_entries/:webhook_secret/:provider/:providerWorkspaceId
- * Sync webhook router configuration entry for this region.
+ * Sync webhook router configuration entry for this cell.
  * Looks up all connectors for the given providerWorkspaceId and updates the entry.
  */
 const _syncWebhookRouterEntryHandler = async (
@@ -56,7 +56,7 @@ const _syncWebhookRouterEntryHandler = async (
   }
 
   const { signingSecret } = bodyValidation.right;
-  const region = connectorsConfig.getCurrentRegion();
+  const cell = connectorsConfig.getCurrentCell();
 
   let connectorIds: number[] = [];
 
@@ -72,7 +72,7 @@ const _syncWebhookRouterEntryHandler = async (
 
       logger.info(
         { notionWorkspaceId: providerWorkspaceId, connectorIds },
-        `Found ${connectorIds.length} Notion connectors in region ${region}`
+        `Found ${connectorIds.length} Notion connectors in cell ${cell}`
       );
     } else {
       logger.info(
@@ -95,12 +95,12 @@ const _syncWebhookRouterEntryHandler = async (
 
       logger.info(
         { slackTeamId: providerWorkspaceId, connectorIds },
-        `Found ${connectorIds.length} Slack connectors in region ${region}`
+        `Found ${connectorIds.length} Slack connectors in cell ${cell}`
       );
     } else {
       logger.info(
         { slackTeamId: providerWorkspaceId },
-        "No Slack configuration found in this region"
+        "No Slack configuration found in this cell"
       );
     }
   } else {
@@ -119,7 +119,7 @@ const _syncWebhookRouterEntryHandler = async (
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `No connectors found for provider '${provider}' and providerWorkspaceId '${providerWorkspaceId}' in region '${region}'. Cannot sync with provided signing secret.`,
+        message: `No connectors found for provider '${provider}' and providerWorkspaceId '${providerWorkspaceId}' in cell '${cell}'. Cannot sync with provided signing secret.`,
       },
     });
   }
@@ -139,17 +139,17 @@ const _syncWebhookRouterEntryHandler = async (
     }
   }
 
-  // Sync the entry for this region
+  // Sync the entry for this cell
   await service.syncEntry(
     provider,
     providerWorkspaceId,
     signingSecret,
-    region,
+    cell,
     connectorIds
   );
 
   logger.info(
-    { provider, providerWorkspaceId, region, connectorIds },
+    { provider, providerWorkspaceId, cell, connectorIds },
     `Successfully synced webhook router entry`
   );
 

--- a/connectors/src/connectors/shared/config.ts
+++ b/connectors/src/connectors/shared/config.ts
@@ -3,6 +3,13 @@ import { EnvironmentConfig } from "@connectors/types";
 export const SUPPORTED_REGIONS = ["europe-west1", "us-central1"] as const;
 export type RegionType = (typeof SUPPORTED_REGIONS)[number];
 
+export const SUPPORTED_CELLS = ["cell-00000", "cell-00001"] as const;
+export type CellType = (typeof SUPPORTED_CELLS)[number];
+export const CELL_TO_REGION: Record<CellType, RegionType> = {
+  "cell-00000": "us-central1",
+  "cell-00001": "europe-west1",
+};
+
 export const connectorsConfig = {
   getDustTmpSyncBucketName: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_TMP_SYNC_BUCKET_NAME");
@@ -15,5 +22,8 @@ export const connectorsConfig = {
   },
   getCurrentRegion: (): RegionType => {
     return EnvironmentConfig.getEnvVariable("REGION") as RegionType;
+  },
+  getCurrentCell: (): CellType => {
+    return EnvironmentConfig.getEnvVariable("CELL") as CellType;
   },
 };

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -823,7 +823,7 @@ async function resyncWebhookRouterConfig(
 ): Promise<Result<undefined, Error>> {
   try {
     const webhookService = new WebhookRouterConfigService();
-    const currentRegion = connectorsConfig.getCurrentRegion();
+    const currentCell = connectorsConfig.getCurrentCell();
 
     const remainingConnectorIds = configurations
       .filter((c) => c.connectorId !== connectorId)
@@ -833,7 +833,7 @@ async function resyncWebhookRouterConfig(
       "slack",
       slackTeamId,
       undefined,
-      currentRegion,
+      currentCell,
       remainingConnectorIds
     );
 
@@ -841,12 +841,12 @@ async function resyncWebhookRouterConfig(
       {
         connectorId,
         slackTeamId,
-        region: currentRegion,
+        cell: currentCell,
         remainingConnectors: remainingConnectorIds.length,
         isLastConnector: remainingConnectorIds.length === 0,
       },
       remainingConnectorIds.length === 0
-        ? "Resynced webhook router: removed region entry (last connector)"
+        ? "Resynced webhook router: removed cell entry (last connector)"
         : "Resynced webhook router: updated with remaining connectors"
     );
 

--- a/connectors/src/lib/webhook_router_config.ts
+++ b/connectors/src/lib/webhook_router_config.ts
@@ -1,42 +1,35 @@
-import { connectorsConfig } from "@connectors/connectors/shared/config";
+import {
+  CELL_TO_REGION,
+  type CellType,
+  connectorsConfig,
+  SUPPORTED_CELLS,
+  SUPPORTED_REGIONS,
+} from "@connectors/connectors/shared/config";
 import logger from "@connectors/logger/logger";
 import { isDevelopment } from "@connectors/types";
 import { Storage } from "@google-cloud/storage";
+import { z } from "zod";
 
 const WEBHOOK_ROUTER_CONFIG_FILE = "webhook-router-config.json";
 
-export interface WebhookRouterEntry {
-  signingSecret: string;
-  regions: {
-    [region: string]: number[]; // region name -> connector IDs
-  };
-}
+const WebhookRouterEntrySchema = z.object({
+  signingSecret: z.string(),
+  regions: z.record(z.enum(SUPPORTED_REGIONS), z.array(z.number())),
+  cells: z.record(z.enum(SUPPORTED_CELLS), z.array(z.number())).optional(),
+});
 
-export interface WebhookRouterConfig {
-  [provider: string]: {
-    [providerWorkspaceId: string]: WebhookRouterEntry;
-  };
-}
+const WebhookRouterConfigSchema = z.record(
+  z.enum(["slack", "notion"]),
+  z.record(z.string(), WebhookRouterEntrySchema)
+);
 
-/**
- * Error thrown when a webhook router entry is not found.
- */
-export class WebhookRouterEntryNotFoundError extends Error {
-  constructor(
-    public readonly provider: string,
-    public readonly providerWorkspaceId: string
-  ) {
-    super(
-      `Webhook router entry not found for provider '${provider}' and providerWorkspaceId '${providerWorkspaceId}'`
-    );
-    this.name = "WebhookRouterEntryNotFoundError";
-  }
-}
+type WebhookRouterEntry = z.infer<typeof WebhookRouterEntrySchema>;
+type WebhookRouterConfig = z.infer<typeof WebhookRouterConfigSchema>;
 
 /**
  * Error thrown when a concurrent modification is detected during a write operation.
  */
-export class ConcurrentModificationError extends Error {
+class ConcurrentModificationError extends Error {
   constructor(message: string = "Concurrent modification detected") {
     super(message);
     this.name = "ConcurrentModificationError";
@@ -89,14 +82,8 @@ export class WebhookRouterConfigService {
       const [contents] = await file.download();
       const [metadata] = await file.getMetadata();
 
-      const config = JSON.parse(contents.toString("utf-8"));
-
-      // Validate the structure
-      if (typeof config !== "object" || config === null) {
-        throw new Error(
-          "Invalid webhook router configuration format. Expected an object."
-        );
-      }
+      const parsed = JSON.parse(contents.toString("utf-8"));
+      const config = WebhookRouterConfigSchema.parse(parsed);
 
       return {
         config,
@@ -260,13 +247,14 @@ export class WebhookRouterConfigService {
    * @param maxRetries - Maximum number of retries on concurrent modification (default: 5)
    */
   async syncEntry(
-    provider: string,
+    provider: "slack" | "notion",
     providerWorkspaceId: string,
     signingSecret: string | undefined,
-    region: string,
+    cell: CellType,
     connectorIds: number[],
     maxRetries: number = 5
   ): Promise<void> {
+    const region = CELL_TO_REGION[cell];
     return this.executeWithRetry(
       async (config) => {
         // Initialize provider object if it doesn't exist
@@ -278,12 +266,18 @@ export class WebhookRouterConfigService {
         const existingEntry = config[provider]![providerWorkspaceId];
 
         if (connectorIds.length === 0) {
-          // No connectors for this region - remove the region
+          // No connectors for this cell - remove the region & cell
           if (existingEntry) {
             delete existingEntry.regions[region];
+            if (existingEntry.cells) {
+              delete existingEntry.cells[cell];
+            }
 
-            // If no regions left, delete the entire entry
-            if (Object.keys(existingEntry.regions).length === 0) {
+            // If no regions & cells left, delete the entire entry
+            const cellsEmpty =
+              !existingEntry.cells ||
+              Object.keys(existingEntry.cells).length === 0;
+            if (Object.keys(existingEntry.regions).length === 0 && cellsEmpty) {
               delete config[provider]![providerWorkspaceId];
             }
           }
@@ -295,6 +289,10 @@ export class WebhookRouterConfigService {
               existingEntry.signingSecret = signingSecret;
             }
             existingEntry.regions[region] = connectorIds;
+            existingEntry.cells = {
+              ...(existingEntry.cells ?? {}),
+              [cell]: connectorIds,
+            };
           } else {
             // Create new entry - signingSecret must be provided for new entries
             if (!signingSecret) {
@@ -306,6 +304,9 @@ export class WebhookRouterConfigService {
               signingSecret,
               regions: {
                 [region]: connectorIds,
+              },
+              cells: {
+                [cell]: connectorIds,
               },
             };
           }
@@ -328,10 +329,73 @@ export class WebhookRouterConfigService {
    * @returns The entry if found, null otherwise
    */
   async getEntry(
-    provider: string,
+    provider: "slack" | "notion",
     providerWorkspaceId: string
   ): Promise<WebhookRouterEntry | null> {
     const { config } = await this.readConfig();
     return config[provider]?.[providerWorkspaceId] || null;
+  }
+
+  /**
+   * Backfill missing `cells` fields from `regions` in the GCS config file.
+   */
+  async backfillMissingCells(
+    execute: boolean
+  ): Promise<{ entriesUpdated: number }> {
+    const bucket = this.storage.bucket(this.bucketName);
+    const file = bucket.file(WEBHOOK_ROUTER_CONFIG_FILE);
+    const [exists] = await file.exists();
+
+    if (!exists) {
+      return { entriesUpdated: 0 };
+    }
+
+    const [contents] = await file.download();
+    const [metadata] = await file.getMetadata();
+    const raw = JSON.parse(contents.toString("utf-8"));
+
+    let entriesUpdated = 0;
+    if (typeof raw === "object" && raw !== null) {
+      for (const providerConfig of Object.values(raw)) {
+        if (typeof providerConfig !== "object" || providerConfig === null) {
+          continue;
+        }
+        for (const entry of Object.values(providerConfig)) {
+          if (
+            typeof entry === "object" &&
+            entry !== null &&
+            !("cells" in entry)
+          ) {
+            entriesUpdated++;
+          }
+        }
+      }
+    }
+
+    if (entriesUpdated === 0) {
+      return { entriesUpdated: 0 };
+    }
+
+    const config = WebhookRouterConfigSchema.parse(raw);
+
+    for (const providerConfig of Object.values(config)) {
+      for (const entry of Object.values(providerConfig)) {
+        if (entry.cells === undefined) {
+          entry.cells = Object.fromEntries(
+            SUPPORTED_CELLS.flatMap((cell) => {
+              const region = CELL_TO_REGION[cell];
+              const connectorIds = entry.regions[region];
+              return connectorIds !== undefined ? [[cell, connectorIds]] : [];
+            })
+          );
+        }
+      }
+    }
+
+    if (execute) {
+      await this.writeConfig(config, metadata.generation?.toString() || null);
+    }
+
+    return { entriesUpdated };
   }
 }

--- a/firebase-functions/webhook-router/src/firebase.ts
+++ b/firebase-functions/webhook-router/src/firebase.ts
@@ -9,6 +9,7 @@ import { onRequest } from "firebase-functions/v2/https";
 
 import { createApp } from "./app.js";
 import { CONFIG } from "./config.js";
+import { normalizeWebhookRouterConfig } from "./webhook-router-config.js";
 
 const serviceAccount = defineString("SERVICE_ACCOUNT");
 const bucket = defineString("GCP_WEBHOOK_ROUTER_CONFIG_BUCKET");
@@ -48,14 +49,10 @@ export const syncWebhookRouterConfig = onObjectFinalized(
       const [rawConfig] = await webhookRouterConfigFile.download();
 
       const parsedConfig = JSON.parse(rawConfig.toString("utf-8"));
-      if (parsedConfig === null || typeof parsedConfig !== "object") {
-        throw new Error(
-          "Invalid webhook configuration format. Expected an object."
-        );
-      }
+      const normalizedConfig = normalizeWebhookRouterConfig(parsedConfig);
 
       // We set the updated webhook router configuration at the root of Firebase Realtime Database
-      await getDatabase(firebaseApp).ref().set(parsedConfig);
+      await getDatabase(firebaseApp).ref().set(normalizedConfig);
 
       log("Webhook router configuration sync succeeded", {
         component: "webhook-router-config-sync",

--- a/firebase-functions/webhook-router/src/webhook-router-config.ts
+++ b/firebase-functions/webhook-router/src/webhook-router-config.ts
@@ -1,45 +1,37 @@
 import type { Database } from "firebase-admin/database";
+import { z } from "zod";
 
 export const ALL_REGIONS = ["us-central1", "europe-west1"] as const;
 export type Region = (typeof ALL_REGIONS)[number];
 
-type ProviderWithSigningSecret = "slack" | "notion";
+export const ALL_CELLS = ["cell-00000", "cell-00001"] as const;
+export type Cell = (typeof ALL_CELLS)[number];
 
-type WebhookRouterConfigEntry = {
-  signingSecret: string;
-  regions: {
-    [region in Region]: number[];
-  };
+export const CELL_TO_REGION: Record<Cell, Region> = {
+  "cell-00000": "us-central1",
+  "cell-00001": "europe-west1",
 };
 
-/**
- * Type guard to validate webhook router configuration entries.
- *
- * Example valid object:
- * {
- *   signingSecret: "abc123def456",
- *   regions: {
- *     "us-central1": [123, 456],
- *     "europe-west1": [789]
- *   }
- * }
- */
-function isValidWebhookRouterConfigEntry(
-  value: unknown
-): value is WebhookRouterConfigEntry {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "signingSecret" in value &&
-    typeof value.signingSecret === "string" &&
-    "regions" in value &&
-    typeof value.regions === "object" &&
-    value.regions !== null &&
-    Object.keys(value.regions).every(
-      (region: unknown) =>
-        typeof region === "string" && ALL_REGIONS.includes(region as Region)
-    )
-  );
+type ProviderWithSigningSecret = "slack" | "notion";
+
+const WebhookRouterEntrySchema = z.object({
+  signingSecret: z.string(),
+  regions: z.record(z.enum(ALL_REGIONS), z.array(z.number())),
+  cells: z.record(z.enum(ALL_CELLS), z.array(z.number())).optional(),
+});
+
+const WebhookRouterConfigSchema = z.record(
+  z.enum(["slack", "notion"]),
+  z.record(z.string(), WebhookRouterEntrySchema)
+);
+
+export type WebhookRouterConfigEntry = z.infer<typeof WebhookRouterEntrySchema>;
+type WebhookRouterConfig = z.infer<typeof WebhookRouterConfigSchema>;
+
+export function normalizeWebhookRouterConfig(
+  raw: unknown
+): WebhookRouterConfig {
+  return WebhookRouterConfigSchema.parse(raw);
 }
 
 export class WebhookRouterConfigManager {
@@ -58,16 +50,15 @@ export class WebhookRouterConfigManager {
       );
     }
 
-    const configEntry = configSnapshot.val();
-    if (!isValidWebhookRouterConfigEntry(configEntry)) {
+    const parsedEntry = WebhookRouterEntrySchema.safeParse(
+      configSnapshot.val()
+    );
+    if (!parsedEntry.success) {
       throw new Error(
         `Invalid ${provider} webhook router configuration found for providerWorkspaceId ${providerWorkspaceId}`
       );
     }
 
-    return {
-      signingSecret: configEntry.signingSecret,
-      regions: configEntry.regions,
-    };
+    return parsedEntry.data;
   }
 }


### PR DESCRIPTION
## Description

Add `CELL`-based webhook routing configuration alongside the existing region mapping. `WebhookRouterConfigService` now writes `cells`, derives cell-to-region mappings from `CELL_TO_REGION`, and provides a backfill script for existing GCS entries; the Firebase sync path validates the expanded schema while retaining region compatibility.

## Tests

No automated tests were added. The backfill script supports dry-run validation before writing existing entries.

## Risk

Low-to-medium risk. Webhook synchronization now depends on a valid `CELL` environment variable, and malformed configuration can block routing. The legacy `regions` data remains populated, `cells` is backward-compatible and optional, and the backfill can be dry-run before execution.

## Deploy Plan

Deploy `connectors` with `CELL` configured to a supported value, then run `20260901_backfill_webhook_router_config_cells` in dry-run mode and execute it to backfill existing GCS entries. Deploy `firebase-functions/webhook-router` afterward. No SQL migration or infrastructure change is required.