### PR TITLE
[Admin Governance] Let agent editors administrate agents

### DIFF
--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -262,12 +262,14 @@ describe("Authenticator.fromKey permission resolution", () => {
     // Every verb the registry defines holds, on the granted agent and on one that carries no
     // grant at all (instance verbs and type-level capabilities alike).
     expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
+      "admin",
       "create",
       "publish",
       "read",
       "write",
     ]);
     expect([...workspaceAuth.getGrantedVerbs("agent", 99)].sort()).toEqual([
+      "admin",
       "create",
       "publish",
       "read",
@@ -309,6 +311,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     const workspaceAuth = await Authenticator.fromKey(key, workspace.sId);
 
     expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
+      "admin",
       "read",
       "write",
     ]);
@@ -382,7 +385,7 @@ describe("Authenticator.refresh permission resolution", () => {
     expect(workspaceAuth.getGrantedVerbs("agent", 42)).toEqual([]);
 
     // A grant lands on one of the key's groups AFTER the auth was built (mirrors a backfill or an
-    // updatePermissions write arriving mid-run). `editor` on `agent` confers read + write.
+    // updatePermissions write arriving mid-run). `editor` on `agent` confers read, write and admin.
     await GroupPermissionResource.grant(adminAuth, {
       group,
       grantType: "editor",
@@ -395,6 +398,7 @@ describe("Authenticator.refresh permission resolution", () => {
     await workspaceAuth.refresh();
 
     expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
+      "admin",
       "read",
       "write",
     ]);

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -213,6 +213,12 @@ describe("ROLE_REGISTRY invariants", () => {
     expect(grantTypesForVerb("skill", "admin", "instance")).toContain("editor");
   });
 
+  it("lets the agent editor role administrate its agent", () => {
+    // Agent editors can archive / restore agents and manage their editors. Keep those actions when
+    // group_permissions becomes the read source by granting `admin` through the editor role.
+    expect(grantTypesForVerb("agent", "admin", "instance")).toContain("editor");
+  });
+
   it("keeps every type-level role a singleton", () => {
     // The Governance page toggles capabilities one verb at a time, so a type-level role must carry
     // exactly one verb. The name is not required to be that verb: a governance capability is named
@@ -256,6 +262,7 @@ describe("verbsForGrantAtLevels", () => {
     expect(verbsForGrantAtLevels("editor", "agent", levels)).toEqual([
       "read",
       "write",
+      "admin",
     ]);
   });
 });
@@ -311,6 +318,7 @@ describe("GroupPermissions wildcard grant", () => {
     ]);
     // Type-level capabilities alongside the instance ones.
     expect(perms.resolvedVerbsForResource("agent", 42).sort()).toEqual([
+      "admin",
       "create",
       "publish",
       "read",
@@ -331,6 +339,7 @@ describe("GroupPermissions wildcard grant", () => {
       { grantType: "*", resourceType: "agent", resourceId: 42 },
     ]);
     expect(perms.resolvedVerbsForResource("agent", 42).sort()).toEqual([
+      "admin",
       "read",
       "write",
     ]);

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -63,7 +63,7 @@ export const ROLE_REGISTRY: Record<
     admin: { verbs: ["read", "write", "admin"], levels: ["instance"] },
   },
   agent: {
-    editor: { verbs: ["read", "write"], levels: ["instance"] },
+    editor: { verbs: ["read", "write", "admin"], levels: ["instance"] },
     create: { verbs: ["create"], levels: ["type"] },
     publish: { verbs: ["publish"], levels: ["type"] },
   },


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31331.

Agent editors can archive or restore agents and manage their editor lists today. Add admin to the agent editor registry role so the future grant-backed authorization path preserves those existing capabilities.
Consistency with skill (& space admins)

## Risks

Blast radius: resolution of instance-level agent editor grants.
Risk: low

## Deploy Plan

- deploy front

## Tests

- [x] npm test -- group_permission_registry.test.ts