### PR TITLE
[Admin Governance] Add agent permission resource

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -32,6 +32,7 @@ import {
   O3_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { RoleType } from "@app/types/user";
 
 // Audiences are role-hierarchical: `managers` means managers and admins.
 const GLOBAL_AGENT_AUDIENCES = ["everyone", "managers", "admins"] as const;
@@ -45,28 +46,36 @@ type AgentMetadata = {
   audience?: GlobalAgentAudience;
 };
 
+function readerRolesForAudience(audience: GlobalAgentAudience): RoleType[] {
+  switch (audience) {
+    case "everyone":
+      return ["admin", "manager", "builder", "user", "none"];
+    case "managers":
+      return ["admin", "manager"];
+    case "admins":
+      return ["admin"];
+    default:
+      return assertNever(audience);
+  }
+}
+
 export function canRoleSeeAudience(
   audience: GlobalAgentAudience,
   auth: Authenticator
 ): boolean {
-  switch (audience) {
-    case "everyone":
-      return true;
-    case "managers":
-      return auth.isManager();
-    case "admins":
-      return auth.isAdmin();
-    default:
-      return assertNever(audience);
-  }
+  return readerRolesForAudience(audience).includes(auth.role());
+}
+
+export function globalAgentReaderRoles(sId: GLOBAL_AGENTS_SID): RoleType[] {
+  const { audience = "everyone" } = getGlobalAgentMetadata(sId);
+  return readerRolesForAudience(audience);
 }
 
 export function canRoleSeeGlobalAgent(
   sId: GLOBAL_AGENTS_SID,
   auth: Authenticator
 ): boolean {
-  const { audience = "everyone" } = getGlobalAgentMetadata(sId);
-  return canRoleSeeAudience(audience, auth);
+  return globalAgentReaderRoles(sId).includes(auth.role());
 }
 
 export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -1,0 +1,137 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { AgentResource } from "@app/lib/resources/agent_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("AgentResource", () => {
+  let testContext: Awaited<ReturnType<typeof createResourceTest>>;
+
+  beforeEach(async () => {
+    testContext = await createResourceTest({ role: "user" });
+  });
+
+  it("uses the stable id for custom-agent editor permissions", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator,
+      { scope: "hidden" }
+    );
+    const configuration = await AgentConfigurationModel.findOne({
+      where: { id: agent.id, workspaceId: testContext.workspace.id },
+    });
+    assert(configuration);
+    const resource = AgentResource.fromAgentConfiguration(configuration);
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, otherUser, {
+      role: "user",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      testContext.workspace.sId
+    );
+
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, admin, {
+      role: "admin",
+    });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      testContext.workspace.sId
+    );
+
+    expect(resource.id).toBe(configuration.agentId);
+    expect([
+      resource.canRead(testContext.authenticator),
+      resource.canWrite(testContext.authenticator),
+      resource.canAdministrate(testContext.authenticator),
+    ]).toEqual([true, true, true]);
+    expect([
+      resource.canRead(otherAuth),
+      resource.canWrite(otherAuth),
+      resource.canAdministrate(otherAuth),
+    ]).toEqual([false, false, false]);
+    expect([
+      resource.canRead(adminAuth),
+      resource.canWrite(adminAuth),
+      resource.canAdministrate(adminAuth),
+    ]).toEqual([true, true, true]);
+
+    const grantResult = await GroupPermissionResource.grantToUser(
+      testContext.authenticator,
+      {
+        user: otherUser.toJSON(),
+        grantType: "editor",
+        resourceType: "agent",
+        resourceId: configuration.agentId,
+      }
+    );
+    expect(grantResult.isOk()).toBe(true);
+    await otherAuth.refresh();
+
+    expect([
+      resource.canRead(otherAuth),
+      resource.canWrite(otherAuth),
+      resource.canAdministrate(otherAuth),
+    ]).toEqual([true, true, true]);
+  });
+
+  it("lets workspace members read visible agents without editing them", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator,
+      { scope: "visible" }
+    );
+    const configuration = await AgentConfigurationModel.findOne({
+      where: { id: agent.id, workspaceId: testContext.workspace.id },
+    });
+    assert(configuration);
+    const resource = AgentResource.fromAgentConfiguration(configuration);
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, otherUser, {
+      role: "user",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      testContext.workspace.sId
+    );
+
+    expect(resource.canRead(otherAuth)).toBe(true);
+    expect(resource.canWrite(otherAuth)).toBe(false);
+    expect(resource.canAdministrate(otherAuth)).toBe(false);
+  });
+
+  it("keeps code-defined global agents read-only and audience-scoped", async () => {
+    const helper = AgentResource.fromGlobalAgent({
+      agentId: GLOBAL_AGENTS_SID.HELPER,
+      workspaceModelId: testContext.workspace.id,
+    });
+    const analyst = AgentResource.fromGlobalAgent({
+      agentId: GLOBAL_AGENTS_SID.ANALYST,
+      workspaceModelId: testContext.workspace.id,
+    });
+
+    const manager = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, manager, {
+      role: "manager",
+    });
+    const managerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      manager.sId,
+      testContext.workspace.sId
+    );
+
+    expect(helper.canRead(testContext.authenticator)).toBe(true);
+    expect(helper.canWrite(testContext.authenticator)).toBe(false);
+    expect(helper.canAdministrate(testContext.authenticator)).toBe(false);
+    expect(analyst.canRead(testContext.authenticator)).toBe(false);
+    expect(analyst.canRead(managerAuth)).toBe(true);
+    expect(analyst.canWrite(managerAuth)).toBe(false);
+    expect(analyst.canAdministrate(managerAuth)).toBe(false);
+  });
+});

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -16,7 +16,7 @@ describe("AgentResource", () => {
     testContext = await createResourceTest({ role: "user" });
   });
 
-  it("uses the stable id for custom-agent editor permissions", async () => {
+  it("applies author, admin, and editor permissions to custom agents", async () => {
     const resource = AgentResource.fromAgentConfiguration({
       agentId: AGENT_MODEL_ID,
       authorId: testContext.user.id,
@@ -45,20 +45,20 @@ describe("AgentResource", () => {
 
     expect(resource.id).toBe(AGENT_MODEL_ID);
     expect([
-      resource.canRead(testContext.authenticator),
-      resource.canWrite(testContext.authenticator),
-      resource.canAdministrate(testContext.authenticator),
+      testContext.authenticator.hasPermission("read", resource),
+      testContext.authenticator.hasPermission("write", resource),
+      testContext.authenticator.hasPermission("admin", resource),
     ]).toEqual([true, true, true]);
     expect([
-      resource.canRead(otherAuth),
-      resource.canWrite(otherAuth),
-      resource.canAdministrate(otherAuth),
+      otherAuth.hasPermission("read", resource),
+      otherAuth.hasPermission("write", resource),
+      otherAuth.hasPermission("admin", resource),
     ]).toEqual([false, false, false]);
     expect([
-      resource.canRead(adminAuth),
-      resource.canWrite(adminAuth),
-      resource.canAdministrate(adminAuth),
-    ]).toEqual([true, true, true]);
+      adminAuth.hasPermission("read", resource),
+      adminAuth.hasPermission("write", resource),
+      adminAuth.hasPermission("admin", resource),
+    ]).toEqual([true, false, true]);
 
     const grantResult = await GroupPermissionResource.grantToUser(
       testContext.authenticator,
@@ -73,9 +73,9 @@ describe("AgentResource", () => {
     await otherAuth.refresh();
 
     expect([
-      resource.canRead(otherAuth),
-      resource.canWrite(otherAuth),
-      resource.canAdministrate(otherAuth),
+      otherAuth.hasPermission("read", resource),
+      otherAuth.hasPermission("write", resource),
+      otherAuth.hasPermission("admin", resource),
     ]).toEqual([true, true, true]);
   });
 
@@ -97,9 +97,9 @@ describe("AgentResource", () => {
       testContext.workspace.sId
     );
 
-    expect(resource.canRead(otherAuth)).toBe(true);
-    expect(resource.canWrite(otherAuth)).toBe(false);
-    expect(resource.canAdministrate(otherAuth)).toBe(false);
+    expect(otherAuth.hasPermission("read", resource)).toBe(true);
+    expect(otherAuth.hasPermission("write", resource)).toBe(false);
+    expect(otherAuth.hasPermission("admin", resource)).toBe(false);
   });
 
   it("keeps code-defined global agents read-only and audience-scoped", async () => {
@@ -121,12 +121,18 @@ describe("AgentResource", () => {
       testContext.workspace.sId
     );
 
-    expect(helper.canRead(testContext.authenticator)).toBe(true);
-    expect(helper.canWrite(testContext.authenticator)).toBe(false);
-    expect(helper.canAdministrate(testContext.authenticator)).toBe(false);
-    expect(analyst.canRead(testContext.authenticator)).toBe(false);
-    expect(analyst.canRead(managerAuth)).toBe(true);
-    expect(analyst.canWrite(managerAuth)).toBe(false);
-    expect(analyst.canAdministrate(managerAuth)).toBe(false);
+    expect(testContext.authenticator.hasPermission("read", helper)).toBe(true);
+    expect(testContext.authenticator.hasPermission("write", helper)).toBe(
+      false
+    );
+    expect(testContext.authenticator.hasPermission("admin", helper)).toBe(
+      false
+    );
+    expect(testContext.authenticator.hasPermission("read", analyst)).toBe(
+      false
+    );
+    expect(managerAuth.hasPermission("read", analyst)).toBe(true);
+    expect(managerAuth.hasPermission("write", analyst)).toBe(false);
+    expect(managerAuth.hasPermission("admin", analyst)).toBe(false);
   });
 });

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -1,14 +1,13 @@
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import assert from "assert";
 import { beforeEach, describe, expect, it } from "vitest";
+
+const AGENT_MODEL_ID = 42;
 
 describe("AgentResource", () => {
   let testContext: Awaited<ReturnType<typeof createResourceTest>>;
@@ -18,15 +17,13 @@ describe("AgentResource", () => {
   });
 
   it("uses the stable id for custom-agent editor permissions", async () => {
-    const agent = await AgentConfigurationFactory.createTestAgent(
-      testContext.authenticator,
-      { scope: "hidden" }
-    );
-    const configuration = await AgentConfigurationModel.findOne({
-      where: { id: agent.id, workspaceId: testContext.workspace.id },
+    const resource = AgentResource.fromAgentConfiguration({
+      agentId: AGENT_MODEL_ID,
+      authorId: testContext.user.id,
+      sId: "custom-agent",
+      scope: "hidden",
+      workspaceId: testContext.workspace.id,
     });
-    assert(configuration);
-    const resource = AgentResource.fromAgentConfiguration(configuration);
 
     const otherUser = await UserFactory.basic();
     await MembershipFactory.associate(testContext.workspace, otherUser, {
@@ -46,7 +43,7 @@ describe("AgentResource", () => {
       testContext.workspace.sId
     );
 
-    expect(resource.id).toBe(configuration.agentId);
+    expect(resource.id).toBe(AGENT_MODEL_ID);
     expect([
       resource.canRead(testContext.authenticator),
       resource.canWrite(testContext.authenticator),
@@ -69,7 +66,7 @@ describe("AgentResource", () => {
         user: otherUser.toJSON(),
         grantType: "editor",
         resourceType: "agent",
-        resourceId: configuration.agentId,
+        resourceId: AGENT_MODEL_ID,
       }
     );
     expect(grantResult.isOk()).toBe(true);
@@ -83,15 +80,13 @@ describe("AgentResource", () => {
   });
 
   it("lets workspace members read visible agents without editing them", async () => {
-    const agent = await AgentConfigurationFactory.createTestAgent(
-      testContext.authenticator,
-      { scope: "visible" }
-    );
-    const configuration = await AgentConfigurationModel.findOne({
-      where: { id: agent.id, workspaceId: testContext.workspace.id },
+    const resource = AgentResource.fromAgentConfiguration({
+      agentId: AGENT_MODEL_ID,
+      authorId: testContext.user.id,
+      sId: "custom-agent",
+      scope: "visible",
+      workspaceId: testContext.workspace.id,
     });
-    assert(configuration);
-    const resource = AgentResource.fromAgentConfiguration(configuration);
 
     const otherUser = await UserFactory.basic();
     await MembershipFactory.associate(testContext.workspace, otherUser, {

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -1,0 +1,134 @@
+import { globalAgentReaderRoles } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import type { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { GrantVerb } from "@app/types/group_permissions";
+import type {
+  AccessControlList,
+  RoleGrant,
+  WithAccessControl,
+} from "@app/types/resource_permissions";
+import type { ModelId } from "@app/types/shared/model_id";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+// Legacy `canEdit` also allows changing the editor set, so the author fallback mirrors the full
+// editor role rather than granting write alone.
+const AGENT_EDITOR_VERBS: GrantVerb[] = ["read", "write", "admin"];
+
+const HIDDEN_AGENT_ROLE_GRANTS: RoleGrant[] = [
+  { role: "admin", permissions: AGENT_EDITOR_VERBS },
+];
+
+const VISIBLE_AGENT_ROLE_GRANTS: RoleGrant[] = [
+  ...HIDDEN_AGENT_ROLE_GRANTS,
+  { role: "manager", permissions: ["read"] },
+  { role: "builder", permissions: ["read"] },
+  { role: "user", permissions: ["read"] },
+  { role: "none", permissions: ["read"] },
+];
+
+type CustomAgentAccess = {
+  kind: "custom";
+  agentModelId: ModelId;
+  authorModelId: ModelId;
+  scope: Exclude<AgentConfigurationScope, "global">;
+};
+
+type GlobalAgentAccess = {
+  kind: "global";
+  agentId: GLOBAL_AGENTS_SID;
+};
+
+type AgentAccess = CustomAgentAccess | GlobalAgentAccess;
+
+type AgentConfigurationAccess = Pick<
+  AgentConfigurationModel,
+  "agentId" | "authorId" | "sId" | "scope" | "workspaceId"
+>;
+
+export class AgentResource implements WithAccessControl {
+  private constructor(
+    readonly id: ModelId | null,
+    readonly sId: string,
+    readonly workspaceId: ModelId,
+    private readonly access: AgentAccess
+  ) {}
+
+  static fromAgentConfiguration(
+    configuration: AgentConfigurationAccess
+  ): AgentResource {
+    return new AgentResource(
+      configuration.agentId,
+      configuration.sId,
+      configuration.workspaceId,
+      {
+        kind: "custom",
+        agentModelId: configuration.agentId,
+        authorModelId: configuration.authorId,
+        scope: configuration.scope,
+      }
+    );
+  }
+
+  static fromGlobalAgent({
+    agentId,
+    workspaceModelId,
+  }: {
+    agentId: GLOBAL_AGENTS_SID;
+    workspaceModelId: ModelId;
+  }): AgentResource {
+    return new AgentResource(null, agentId, workspaceModelId, {
+      kind: "global",
+      agentId,
+    });
+  }
+
+  getAccessControlLists(auth: Authenticator): AccessControlList[] {
+    switch (this.access.kind) {
+      case "custom": {
+        const grants = auth.getGrantedVerbs("agent", this.access.agentModelId);
+        const isAuthor =
+          auth.workspace()?.id === this.workspaceId &&
+          auth.user()?.id === this.access.authorModelId;
+
+        return [
+          {
+            roles:
+              this.access.scope === "visible"
+                ? VISIBLE_AGENT_ROLE_GRANTS
+                : HIDDEN_AGENT_ROLE_GRANTS,
+            grantedVerbs: isAuthor
+              ? [...new Set([...grants, ...AGENT_EDITOR_VERBS])]
+              : grants,
+            workspaceId: this.workspaceId,
+          },
+        ];
+      }
+      case "global":
+        return [
+          {
+            roles: globalAgentReaderRoles(this.access.agentId).map((role) => ({
+              role,
+              permissions: ["read"],
+            })),
+            workspaceId: this.workspaceId,
+          },
+        ];
+      default:
+        return assertNever(this.access);
+    }
+  }
+
+  canRead(auth: Authenticator): boolean {
+    return auth.hasPermission("read", this);
+  }
+
+  canWrite(auth: Authenticator): boolean {
+    return auth.hasPermission("write", this);
+  }
+
+  canAdministrate(auth: Authenticator): boolean {
+    return auth.hasPermission("admin", this);
+  }
+}

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -1,8 +1,8 @@
 import { globalAgentReaderRoles } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import type { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { GrantVerb } from "@app/types/group_permissions";
 import type {
   AccessControlList,
@@ -11,13 +11,15 @@ import type {
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import assert from "assert";
 
 // Legacy `canEdit` also allows changing the editor set, so the author fallback mirrors the full
 // editor role rather than granting write alone.
 const AGENT_EDITOR_VERBS: GrantVerb[] = ["read", "write", "admin"];
 
+// Workspace admins manage editors but must grant themselves editor access to change the agent.
 const HIDDEN_AGENT_ROLE_GRANTS: RoleGrant[] = [
-  { role: "admin", permissions: AGENT_EDITOR_VERBS },
+  { role: "admin", permissions: ["read", "admin"] },
 ];
 
 const VISIBLE_AGENT_ROLE_GRANTS: RoleGrant[] = [
@@ -28,46 +30,32 @@ const VISIBLE_AGENT_ROLE_GRANTS: RoleGrant[] = [
   { role: "none", permissions: ["read"] },
 ];
 
-type CustomAgentAccess = {
-  kind: "custom";
-  agentModelId: ModelId;
-  authorModelId: ModelId;
-  scope: Exclude<AgentConfigurationScope, "global">;
-};
-
-type GlobalAgentAccess = {
-  kind: "global";
-  agentId: GLOBAL_AGENTS_SID;
-};
-
-type AgentAccess = CustomAgentAccess | GlobalAgentAccess;
-
-type AgentConfigurationAccess = Pick<
-  AgentConfigurationModel,
-  "agentId" | "authorId" | "sId" | "scope" | "workspaceId"
->;
-
 export class AgentResource implements WithAccessControl {
   private constructor(
     readonly id: ModelId | null,
     readonly sId: string,
     readonly workspaceId: ModelId,
-    private readonly access: AgentAccess
+    readonly kind: "custom" | "global",
+    private readonly authorId: ModelId | null,
+    private readonly scope: AgentConfigurationScope
   ) {}
 
-  static fromAgentConfiguration(
-    configuration: AgentConfigurationAccess
-  ): AgentResource {
+  static fromAgentConfiguration(configuration: {
+    agentId: ModelId;
+    authorId: ModelId;
+    sId: string;
+    scope: AgentConfigurationScope;
+    workspaceId: ModelId;
+  }): AgentResource {
+    assert(configuration.scope !== "global");
+
     return new AgentResource(
       configuration.agentId,
       configuration.sId,
       configuration.workspaceId,
-      {
-        kind: "custom",
-        agentModelId: configuration.agentId,
-        authorModelId: configuration.authorId,
-        scope: configuration.scope,
-      }
+      "custom",
+      configuration.authorId,
+      configuration.scope
     );
   }
 
@@ -78,24 +66,43 @@ export class AgentResource implements WithAccessControl {
     agentId: GLOBAL_AGENTS_SID;
     workspaceModelId: ModelId;
   }): AgentResource {
-    return new AgentResource(null, agentId, workspaceModelId, {
-      kind: "global",
+    return new AgentResource(
+      null,
       agentId,
-    });
+      workspaceModelId,
+      "global",
+      null,
+      "global"
+    );
   }
 
   getAccessControlLists(auth: Authenticator): AccessControlList[] {
-    switch (this.access.kind) {
+    switch (this.kind) {
+      case "global":
+        assert(isGlobalAgentId(this.sId));
+
+        return [
+          {
+            roles: globalAgentReaderRoles(this.sId).map((role) => ({
+              role,
+              permissions: ["read"],
+            })),
+            workspaceId: this.workspaceId,
+          },
+        ];
       case "custom": {
-        const grants = auth.getGrantedVerbs("agent", this.access.agentModelId);
+        assert(this.id !== null);
+        assert(this.authorId !== null);
+
+        const grants = auth.getGrantedVerbs("agent", this.id);
         const isAuthor =
           auth.workspace()?.id === this.workspaceId &&
-          auth.user()?.id === this.access.authorModelId;
+          auth.user()?.id === this.authorId;
 
         return [
           {
             roles:
-              this.access.scope === "visible"
+              this.scope === "visible"
                 ? VISIBLE_AGENT_ROLE_GRANTS
                 : HIDDEN_AGENT_ROLE_GRANTS,
             grantedVerbs: isAuthor
@@ -105,30 +112,8 @@ export class AgentResource implements WithAccessControl {
           },
         ];
       }
-      case "global":
-        return [
-          {
-            roles: globalAgentReaderRoles(this.access.agentId).map((role) => ({
-              role,
-              permissions: ["read"],
-            })),
-            workspaceId: this.workspaceId,
-          },
-        ];
       default:
-        return assertNever(this.access);
+        return assertNever(this.kind);
     }
-  }
-
-  canRead(auth: Authenticator): boolean {
-    return auth.hasPermission("read", this);
-  }
-
-  canWrite(auth: Authenticator): boolean {
-    return auth.hasPermission("write", this);
-  }
-
-  canAdministrate(auth: Authenticator): boolean {
-    return auth.hasPermission("admin", this);
   }
 }


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48

Today, editor access for an agent is represented by membership in a dedicated group. The governance migration will instead store editor access in `group_permissions`. A permission must target the logical agent, while each saved version currently has a different `agent_configurations.id`.

This PR introduces `AgentResource`, a common interface for checking whether a user may read an agent, edit it, or manage its editors. For custom agents, permissions target the new stable `agents.id` shared by all versions.

The resource represents the current permission behavior:

- workspace admins can read any custom agent and manage its editors, but must add themselves as an editor before changing the agent;
- the user who created a custom agent keeps the same access while the legacy permission checks are being migrated;
- users with an editor grant can read, edit, and manage editors for that agent;
- agents shared with the workspace can be read by all workspace members, but sharing alone does not grant edit access;
- built-in global agents cannot be edited, and can be read by the roles configured for each agent: everyone, managers and admins, or admins only.

This PR only adds the permission abstraction and its tests. Existing agent endpoints do not use it yet, so it does not change end-user behavior by itself.

## Risks

Blast radius: the new agent permission abstraction and the existing global-agent visibility check; no production agent endpoint uses `AgentResource` yet.
Risk: low

## Deploy Plan

- deploy front; no migration required

## Tests

- [x] `cd front && NODE_ENV=test npm test lib/resources/agent_resource.test.ts lib/api/assistant/global_agents/global_agent_metadata.test.ts`