### PR TITLE
Sub-agent: allow role-restricted sub agent to be run

### DIFF
--- a/front-api/middlewares/public_api_auth.ts
+++ b/front-api/middlewares/public_api_auth.ts
@@ -175,12 +175,13 @@ export const publicApiAuth = createMiddleware<PublicApiCtx>(
     if (keyRes.isErr()) {
       return apiError(ctx, keyRes.error);
     }
+    const requestedRole = getRoleFromHeaders(headers);
 
     let workspaceAuth = await Authenticator.fromKey(
       keyRes.value,
       wId,
       getGroupIdsFromHeaders(headers),
-      getRoleFromHeaders(headers)
+      requestedRole
     );
 
     const workspaceError = validateWorkspaceFromAuth(workspaceAuth);
@@ -206,6 +207,7 @@ export const publicApiAuth = createMiddleware<PublicApiCtx>(
           workspaceAuth,
           {
             userEmail: userEmailFromHeader,
+            requestedRole,
           }
         )) ?? workspaceAuth;
     }

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -59,6 +59,7 @@ import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { CitationType } from "@app/types/assistant/conversation";
+import { getHeaderFromRole } from "@app/types/groups";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -90,6 +91,25 @@ function canRunChildAgent(agent: LightAgentConfigurationType): boolean {
     default:
       assertNever(agent.status);
   }
+}
+
+/**
+ * Headers for the public API calls that create and drive the sub-conversation.
+ *
+ * We use a system API key to override the user here (not the groups) so that the sub-agent can
+ * access the same spaces as the user but also as the sub-agent may rely on personal actions that
+ * have to be operated in the name of the user initiating the interaction.
+ *
+ * The role is forwarded too: the system-key exchange otherwise scopes the sub-conversation down to
+ * a plain member, and a sub-agent gated on `managers`/`admins` (e.g. `@analyst`) would then be
+ * invisible to it. The exchange caps the forwarded role by the user's own membership.
+ */
+function subAgentApiHeaders(auth: Authenticator): Record<string, string> {
+  return {
+    ...getHeaderFromUserEmail(auth.user()?.email),
+    ...getApiKeyNameHeader(auth),
+    ...getHeaderFromRole(auth.role()),
+  };
 }
 
 function makeChildAgentUnavailableError(childAgentName: string): MCPError {
@@ -212,8 +232,6 @@ export const runAgent = async (
   }
   const childAgentBlob = configuredChildAgentBlob ?? childAgentRes.value;
 
-  const user = auth.user();
-
   const prodCredentials = await prodAPICredentialsForOwner(
     auth.getNonNullableWorkspace()
   );
@@ -221,14 +239,7 @@ export const runAgent = async (
     config.getDustAPIConfig(),
     {
       ...prodCredentials,
-      extraHeaders: {
-        // We use a system API key to override the user here (not groups and role) so that the
-        // sub-agent can access the same spaces as the user but also as the sub-agent may rely
-        // on personal actions that have to be operated in the name of the user initiating the
-        // interaction.
-        ...getHeaderFromUserEmail(user?.email),
-        ...getApiKeyNameHeader(auth),
-      },
+      extraHeaders: subAgentApiHeaders(auth),
     },
     logger
   );

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -83,7 +83,13 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types/user";
-import { isAdmin, isBuilder, isManager, isUser } from "@app/types/user";
+import {
+  isAdmin,
+  isBuilder,
+  isManager,
+  isUser,
+  lowestRole,
+} from "@app/types/user";
 import assert from "assert";
 import { TokenExpiredError } from "jsonwebtoken";
 import type { Transaction } from "sequelize";
@@ -1173,13 +1179,22 @@ export class Authenticator {
    *
    * /!\ This function should only be used with Authenticators that are associated with a system key.
    *
+   * The exchanged authenticator is scoped down to a plain `user` role by default. An internal
+   * system-key caller that needs the impersonated user to keep their own role (e.g. the
+   * `run_agent` tool, so a sub-agent gated on `managers`/`admins` stays reachable) asks for it
+   * with the `X-Dust-Role` header; we then cap the requested role by the user's verified active
+   * membership, so the exchange can never grant more than the user actually has.
+   *
    * @param auth
    * @param param1
    * @returns
    */
   async exchangeSystemKeyForUserAuthByEmail(
     auth: Authenticator,
-    { userEmail }: { userEmail: string }
+    {
+      userEmail,
+      requestedRole,
+    }: { userEmail: string; requestedRole?: RoleType }
   ): Promise<Authenticator | null> {
     if (!auth.isSystemKey()) {
       logger.error(
@@ -1239,8 +1254,9 @@ export class Authenticator {
     return new Authenticator({
       authMethod: auth.authMethod(),
       key: auth._key,
-      // We limit scope to a user role.
-      role: "user",
+      role: requestedRole
+        ? lowestRole(requestedRole, activeMembership.role)
+        : "user",
       groupModelIds,
       globalGroupModelId,
       user,

--- a/front/types/user.test.ts
+++ b/front/types/user.test.ts
@@ -1,0 +1,23 @@
+import { lowestRole } from "@app/types/user";
+import { describe, expect, it } from "vitest";
+
+describe("lowestRole", () => {
+  it("returns the least privileged of the two roles", () => {
+    expect(lowestRole("admin", "manager")).toBe("manager");
+    expect(lowestRole("manager", "admin")).toBe("manager");
+    expect(lowestRole("admin", "user")).toBe("user");
+    expect(lowestRole("manager", "builder")).toBe("builder");
+    expect(lowestRole("builder", "user")).toBe("user");
+  });
+
+  it("treats `none` as the least privileged role", () => {
+    expect(lowestRole("admin", "none")).toBe("none");
+    expect(lowestRole("none", "user")).toBe("none");
+  });
+
+  it("returns the role itself when both are equal", () => {
+    expect(lowestRole("admin", "admin")).toBe("admin");
+    expect(lowestRole("user", "user")).toBe("user");
+    expect(lowestRole("none", "none")).toBe("none");
+  });
+});

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -44,6 +44,11 @@ export function isRoleType(role: string): role is RoleType {
   return ROLES.includes(role as RoleType);
 }
 
+// `ROLES` is ordered from most to least privileged.
+export function lowestRole(a: RoleType, b: RoleType): RoleType {
+  return ROLES.indexOf(a) >= ROLES.indexOf(b) ? a : b;
+}
+
 export const ActiveRoleSchema = z.enum(ACTIVE_ROLES);
 
 export type ActiveRoleType = z.infer<typeof ActiveRoleSchema>;


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/10198#issue-5257093684

Only when using system API key with an explicit role required, we try to grant the requested role (or less if the role cannot be granted).

This allow to run subagent which are gated behind roles, which is only the case of `@analyst` agent.

## Tests

tested locally: Analyst can be used as subagent now

## Risk

Only ask for escalated permission in one place (sub agent calls) to avoid upgrading all the API permissions for nothing.

## Deploy Plan

deploy front
