### PR TITLE
[front] fix: redirect legacy analytics page

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -4,10 +4,6 @@ import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
 import { Navigate } from "react-router-dom";
 
-const AnalyticsPage = withSuspense(
-  () => import("@dust-tt/front/components/pages/workspace/AnalyticsPage"),
-  "AnalyticsPage"
-);
 const AnalyticsConsumptionPage = withSuspense(
   () =>
     import(
@@ -117,9 +113,11 @@ export const adminRoutes: RouteObject[] = [
     element: <RequireRoleLayout requiredRole="manager" />,
     children: [
       { path: "members", element: <MembersPage /> },
-      // Legacy analytics page, kept for direct access but intentionally absent
-      // from the admin sidebar.
-      { path: "analytics", element: <AnalyticsPage /> },
+      // Legacy analytics page, now superseded by consumption analytics.
+      {
+        path: "analytics",
+        element: <Navigate to="../analytics/consumption" replace />,
+      },
       {
         path: "analytics/consumption",
         element: <AnalyticsConsumptionPage />,


### PR DESCRIPTION
## Description

The legacy analytics URL currently opens the legacy page. This PR changes that to instead redirect to the new `/analytics/consumption` page. We don't remove it entirely because some users may have kept bookmarks or shared direct links internally.

A follow up PR will remove the front-end component.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
