### PR TITLE
Fix Frames v2 authoring and standalone execution

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.53"
+version = "0.1.54"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/frame/create.rs
+++ b/cli/dust-sandbox/src/commands/frame/create.rs
@@ -15,7 +15,6 @@ const DEFAULT_FRAME_SOURCE: &str = r#"export default function Frame() {
 
 pub async fn run(directory: &Path, name: Option<&str>, description: &str) -> anyhow::Result<()> {
     let manifest_path = directory.join(FRAME_MANIFEST_FILE);
-    let scoped_manifest_path = scoped_manifest_path(&manifest_path)?;
     let frame_name = match name {
         Some(name) => name.to_owned(),
         None => directory
@@ -29,6 +28,9 @@ pub async fn run(directory: &Path, name: Option<&str>, description: &str) -> any
     }
 
     scaffold(directory, &frame_name, description)?;
+    // Scaffold first so canonicalization can follow `/files/conversation` and `/files/pod`
+    // symlinks even when the new Frame directory did not exist before this command.
+    let scoped_manifest_path = scoped_manifest_path(&manifest_path)?;
 
     let client = DustApiClient::from_env()?;
     let response = client.register_frame(&scoped_manifest_path).await?;

--- a/cli/dust-sandbox/src/commands/frame/create.rs
+++ b/cli/dust-sandbox/src/commands/frame/create.rs
@@ -5,7 +5,7 @@ use anyhow::{bail, Context};
 
 use crate::api::DustApiClient;
 
-use super::{print_response, scoped_manifest_path, FRAME_MANIFEST_FILE};
+use super::{print_response, scoped_manifest_path, validate_scoped_path, FRAME_MANIFEST_FILE};
 
 const FRAME_UI_ENTRY_POINT: &str = "index.tsx";
 const DEFAULT_FRAME_SOURCE: &str = r#"export default function Frame() {
@@ -15,6 +15,7 @@ const DEFAULT_FRAME_SOURCE: &str = r#"export default function Frame() {
 
 pub async fn run(directory: &Path, name: Option<&str>, description: &str) -> anyhow::Result<()> {
     let manifest_path = directory.join(FRAME_MANIFEST_FILE);
+    validate_scoped_path(&manifest_path)?;
     let frame_name = match name {
         Some(name) => name.to_owned(),
         None => directory

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -50,6 +50,13 @@ fn scoped_path(path: &Path) -> anyhow::Result<String> {
     scoped_path_under(path, Path::new(FILES_ROOT))
 }
 
+fn validate_scoped_path(path: &Path) -> anyhow::Result<()> {
+    let relative = path
+        .strip_prefix(FILES_ROOT)
+        .with_context(|| format!("path must be under {FILES_ROOT}: {}", path.display()))?;
+    validate_relative_scoped_path(relative).map(|_| ())
+}
+
 fn scoped_path_under(path: &Path, files_root: &Path) -> anyhow::Result<String> {
     let canonical_root = files_root
         .canonicalize()
@@ -60,6 +67,11 @@ fn scoped_path_under(path: &Path, files_root: &Path) -> anyhow::Result<String> {
     let relative = canonical_path
         .strip_prefix(&canonical_root)
         .with_context(|| format!("path must be under /files: {}", path.display()))?;
+
+    validate_relative_scoped_path(relative)
+}
+
+fn validate_relative_scoped_path(relative: &Path) -> anyhow::Result<String> {
     if relative.as_os_str().is_empty()
         || relative
             .components()
@@ -148,5 +160,7 @@ mod tests {
 
         assert!(scoped_path_under(&outside, &files_root).is_err());
         assert!(scoped_path_under(&files_root.join("missing.json"), &files_root).is_err());
+        assert!(validate_scoped_path(Path::new("/tmp/manifest.json")).is_err());
+        assert!(validate_scoped_path(Path::new("/files/../tmp/manifest.json")).is_err());
     }
 }

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -14,6 +14,7 @@ pub use register::run as cmd_frame_register;
 pub use share_link::run as cmd_frame_share_link;
 
 const FRAME_MANIFEST_FILE: &str = "manifest.json";
+const FILES_ROOT: &str = "/files";
 
 #[derive(Subcommand)]
 pub enum FrameCommand {
@@ -46,8 +47,18 @@ pub enum FrameCommand {
 }
 
 fn scoped_path(path: &Path) -> anyhow::Result<String> {
-    let relative = path
-        .strip_prefix("/files")
+    scoped_path_under(path, Path::new(FILES_ROOT))
+}
+
+fn scoped_path_under(path: &Path, files_root: &Path) -> anyhow::Result<String> {
+    let canonical_root = files_root
+        .canonicalize()
+        .with_context(|| format!("failed to resolve {}", files_root.display()))?;
+    let canonical_path = path
+        .canonicalize()
+        .with_context(|| format!("path must exist under {FILES_ROOT}: {}", path.display()))?;
+    let relative = canonical_path
+        .strip_prefix(&canonical_root)
         .with_context(|| format!("path must be under /files: {}", path.display()))?;
     if relative.as_os_str().is_empty()
         || relative
@@ -77,26 +88,65 @@ fn print_response(response: &impl serde::Serialize) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
     use super::*;
 
     #[test]
     fn converts_sandbox_frame_source_paths_to_scoped_paths() {
-        let manifest_path = Path::new("/files/pod-vlt_123/MyFrame/manifest.json");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let files_root = temp.path().join("files");
+        let manifest_path = files_root.join("pod-vlt_123/MyFrame/manifest.json");
+        let legacy_entry_path = files_root.join("conversation-conv_123/Legacy.tsx");
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create manifest parent");
+        fs::create_dir_all(legacy_entry_path.parent().expect("legacy parent"))
+            .expect("create legacy parent");
+        fs::write(&manifest_path, "{}").expect("write manifest");
+        fs::write(&legacy_entry_path, "export default null").expect("write entry");
+
         assert_eq!(
-            scoped_path(manifest_path).expect("valid path"),
+            scoped_path_under(&manifest_path, &files_root).expect("valid path"),
             "pod-vlt_123/MyFrame/manifest.json"
         );
-
-        let legacy_entry_path = Path::new("/files/conversation-conv_123/Legacy.tsx");
         assert_eq!(
-            scoped_path(legacy_entry_path).expect("valid path"),
+            scoped_path_under(&legacy_entry_path, &files_root).expect("valid path"),
             "conversation-conv_123/Legacy.tsx"
         );
     }
 
     #[test]
+    fn resolves_legacy_mount_aliases_to_canonical_scoped_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let files_root = temp.path().join("files");
+        let conversation_root = files_root.join("conversation-conv_123");
+        let manifest_path = conversation_root.join("Status/manifest.json");
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create manifest parent");
+        fs::write(&manifest_path, "{}").expect("write manifest");
+        symlink("conversation-conv_123", files_root.join("conversation"))
+            .expect("create conversation alias");
+
+        assert_eq!(
+            scoped_path_under(
+                &files_root.join("conversation/Status/manifest.json"),
+                &files_root
+            )
+            .expect("valid alias path"),
+            "conversation-conv_123/Status/manifest.json"
+        );
+    }
+
+    #[test]
     fn rejects_paths_outside_the_mount() {
-        assert!(scoped_path(Path::new("/tmp/manifest.json")).is_err());
-        assert!(scoped_path(Path::new("/files/../tmp/manifest.json")).is_err());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let files_root = temp.path().join("files");
+        let outside = temp.path().join("manifest.json");
+        fs::create_dir(&files_root).expect("create files root");
+        fs::write(&outside, "{}").expect("write outside file");
+
+        assert!(scoped_path_under(&outside, &files_root).is_err());
+        assert!(scoped_path_under(&files_root.join("missing.json"), &files_root).is_err());
     }
 }

--- a/front-api/lib/api/sandbox_function_invocation_errors.ts
+++ b/front-api/lib/api/sandbox_function_invocation_errors.ts
@@ -1,0 +1,15 @@
+import type { SandboxFunctionInvocationErrorCode } from "@app/lib/api/sandbox_functions/errors";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export function getSandboxFunctionInvocationErrorStatusCode(
+  code: SandboxFunctionInvocationErrorCode
+): 401 | 409 {
+  switch (code) {
+    case "user_authentication_required":
+      return 401;
+    case "frame_runtime_unavailable":
+      return 409;
+    default:
+      return assertNever(code);
+  }
+}

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.test.ts
@@ -1,5 +1,7 @@
+import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { makeTestFrameFunction } from "@app/tests/utils/FrameFunctionFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -63,5 +65,31 @@ describe("POST /api/w/:wId/frames/:frameId/functions/:name/invocations", () => {
         }),
       })
     );
+  });
+
+  it("reports an unavailable Frame runtime as a state conflict", async () => {
+    const { workspace, frame } = await makeTestFrameFunction();
+    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValueOnce(
+      new Err(
+        new SandboxFunctionInvocationError(
+          "This Frame's runtime scope no longer exists.",
+          "frame_runtime_unavailable"
+        )
+      )
+    );
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/${frame.sId}/functions/run-function/invocations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { type: "frame_runtime_unavailable" },
+    });
   });
 });

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -47,7 +47,10 @@ app.post(
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
         return apiError(ctx, {
-          status_code: 401,
+          status_code:
+            invocationResult.error.code === "user_authentication_required"
+              ? 401
+              : 409,
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -5,11 +5,11 @@ import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
 } from "@app/types/api/sandbox_functions";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
   FrameFunctionInvocationParamsSchema,
   PostFrameFunctionInvocationBodySchema,
 } from "@front-api/lib/api/frame_function_invocation_schemas";
+import { getSandboxFunctionInvocationErrorStatusCode } from "@front-api/lib/api/sandbox_function_invocation_errors";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -47,19 +47,10 @@ app.post(
     });
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
-        let statusCode: 401 | 409;
-        switch (invocationResult.error.code) {
-          case "user_authentication_required":
-            statusCode = 401;
-            break;
-          case "frame_runtime_unavailable":
-            statusCode = 409;
-            break;
-          default:
-            assertNever(invocationResult.error.code);
-        }
         return apiError(ctx, {
-          status_code: statusCode,
+          status_code: getSandboxFunctionInvocationErrorStatusCode(
+            invocationResult.error.code
+          ),
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/functions/[name]/invocations.ts
@@ -5,6 +5,7 @@ import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
 } from "@app/types/api/sandbox_functions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
   FrameFunctionInvocationParamsSchema,
   PostFrameFunctionInvocationBodySchema,
@@ -46,11 +47,19 @@ app.post(
     });
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
+        let statusCode: 401 | 409;
+        switch (invocationResult.error.code) {
+          case "user_authentication_required":
+            statusCode = 401;
+            break;
+          case "frame_runtime_unavailable":
+            statusCode = 409;
+            break;
+          default:
+            assertNever(invocationResult.error.code);
+        }
         return apiError(ctx, {
-          status_code:
-            invocationResult.error.code === "user_authentication_required"
-              ? 401
-              : 409,
+          status_code: statusCode,
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -10,6 +10,7 @@ import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -209,15 +210,23 @@ async function createFramePublicationFunction({
 async function setupFrameV2Function({
   shareScope = "workspace_and_emails",
   featureFlag = "frames_v2",
+  standalone = false,
 }: {
   shareScope?: FileShareScope;
   featureFlag?: "frames_v2" | "sandbox_functions";
+  standalone?: boolean;
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
     role: "admin",
   });
   await FeatureFlagFactory.basic(adminAuth, featureFlag);
   const space = await SpaceFactory.project(workspace);
+  const conversation = standalone
+    ? await ConversationFactory.create(adminAuth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+      })
+    : null;
   const publicationId = "publication-1";
   const frame = await FileFactory.create(adminAuth, null, {
     contentType: frameV2ContentType,
@@ -226,7 +235,9 @@ async function setupFrameV2Function({
     status: "ready",
     useCase: "conversation",
     useCaseMetadata: {
-      spaceId: space.sId,
+      ...(conversation
+        ? { conversationId: conversation.sId }
+        : { spaceId: space.sId }),
       activePublicationId: publicationId,
     },
   });
@@ -514,6 +525,26 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         }),
       }
     );
+  });
+
+  it("invokes a Frame from a standalone conversation", async () => {
+    const { workspace, frame, sandboxFunction } = await setupFrameV2Function({
+      standalone: true,
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+      body: { input: { message: "hello" } },
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      invocation: {
+        functionId: sandboxFunction.sId,
+        status: "created",
+      },
+    });
   });
 
   it("keeps an in-flight Frame invocation streamable after a new publication activates", async () => {
@@ -849,6 +880,30 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         type: "user_authentication_required",
         message:
           "This Pod Function requires a logged-in user from its workspace.",
+      },
+    });
+  });
+
+  it("does not report an unavailable Frame runtime as an authentication error", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction();
+    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValueOnce(
+      new Err(
+        new SandboxFunctionInvocationError(
+          "This Frame's runtime scope no longer exists.",
+          "frame_runtime_unavailable"
+        )
+      )
+    );
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: {
+        type: "frame_runtime_unavailable",
       },
     });
   });

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -129,11 +129,19 @@ app.post(
     });
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
+        let statusCode: 401 | 409;
+        switch (invocationResult.error.code) {
+          case "user_authentication_required":
+            statusCode = 401;
+            break;
+          case "frame_runtime_unavailable":
+            statusCode = 409;
+            break;
+          default:
+            assertNever(invocationResult.error.code);
+        }
         return apiError(ctx, {
-          status_code:
-            invocationResult.error.code === "user_authentication_required"
-              ? 401
-              : 409,
+          status_code: statusCode,
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -10,6 +10,7 @@ import type {
 } from "@app/types/api/sandbox_functions";
 import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { getSandboxFunctionInvocationErrorStatusCode } from "@front-api/lib/api/sandbox_function_invocation_errors";
 import { redirectToSse } from "@front-api/lib/api/sse/redirect";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -129,19 +130,10 @@ app.post(
     });
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
-        let statusCode: 401 | 409;
-        switch (invocationResult.error.code) {
-          case "user_authentication_required":
-            statusCode = 401;
-            break;
-          case "frame_runtime_unavailable":
-            statusCode = 409;
-            break;
-          default:
-            assertNever(invocationResult.error.code);
-        }
         return apiError(ctx, {
-          status_code: statusCode,
+          status_code: getSandboxFunctionInvocationErrorStatusCode(
+            invocationResult.error.code
+          ),
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -130,7 +130,10 @@ app.post(
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
         return apiError(ctx, {
-          status_code: 401,
+          status_code:
+            invocationResult.error.code === "user_authentication_required"
+              ? 401
+              : 409,
           api_error: {
             type: invocationResult.error.code,
             message: invocationResult.error.message,

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -79,38 +79,6 @@ describe("editHandler", () => {
     );
   });
 
-  it("serializes concurrent edits to the same file", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-    mockStoredFile("const first = 1;\nconst second = 2;\n", "text/plain");
-    const path = `conversation-${conversation.sId}/notes.txt`;
-
-    const [firstResult, secondResult] = await Promise.all([
-      editHandler(
-        {
-          path,
-          old_string: "first = 1",
-          new_string: "first = 10",
-        },
-        makeExtra(auth, conversation)
-      ),
-      editHandler(
-        {
-          path,
-          old_string: "second = 2",
-          new_string: "second = 20",
-        },
-        makeExtra(auth, conversation)
-      ),
-    ]);
-
-    assert(firstResult.isOk());
-    assert(secondResult.isOk());
-    expect(fileStorageMock.saveFileCalls).toHaveLength(2);
-    expect(fileStorageMock.saveFileCalls.at(-1)?.content.toString("utf8")).toBe(
-      "const first = 10;\nconst second = 20;\n"
-    );
-  });
-
   it("appends a publish reminder when editing a Frame source file", async () => {
     const { auth, conversation } = await setupProjectConversation();
     mockStoredFile(

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -79,6 +79,38 @@ describe("editHandler", () => {
     );
   });
 
+  it("serializes concurrent edits to the same file", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("const first = 1;\nconst second = 2;\n", "text/plain");
+    const path = `conversation-${conversation.sId}/notes.txt`;
+
+    const [firstResult, secondResult] = await Promise.all([
+      editHandler(
+        {
+          path,
+          old_string: "first = 1",
+          new_string: "first = 10",
+        },
+        makeExtra(auth, conversation)
+      ),
+      editHandler(
+        {
+          path,
+          old_string: "second = 2",
+          new_string: "second = 20",
+        },
+        makeExtra(auth, conversation)
+      ),
+    ]);
+
+    assert(firstResult.isOk());
+    assert(secondResult.isOk());
+    expect(fileStorageMock.saveFileCalls).toHaveLength(2);
+    expect(fileStorageMock.saveFileCalls.at(-1)?.content.toString("utf8")).toBe(
+      "const first = 10;\nconst second = 20;\n"
+    );
+  });
+
   it("appends a publish reminder when editing a Frame source file", async () => {
     const { auth, conversation } = await setupProjectConversation();
     mockStoredFile(

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -32,7 +32,7 @@ import {
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 
-const FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS = 30_000;
+const FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS = 5_000;
 const FILE_EDIT_LOCK_TTL_MS = 30_000;
 const FILE_EDIT_LOCK_RETRY_INTERVAL_MS = 25;
 

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -21,7 +21,10 @@ import {
 import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
-import { executeWithLock, isLockAcquisitionTimeoutError } from "@app/lib/lock";
+import {
+  executeWithLockResult,
+  isLockAcquisitionTimeoutError,
+} from "@app/lib/lock";
 import {
   isInteractiveContentType,
   stripMimeParameters,
@@ -186,26 +189,30 @@ export async function editHandler(
     );
   }
 
-  try {
-    return await executeWithLock(
-      `file:edit:${extra.auth.getNonNullableWorkspace().sId}:${normalizedPath}`,
-      () => editHandlerUnlocked(args, extra),
-      FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS,
-      {
-        lockTtlMs: FILE_EDIT_LOCK_TTL_MS,
-        retryIntervalMs: FILE_EDIT_LOCK_RETRY_INTERVAL_MS,
-      }
-    );
-  } catch (error) {
-    if (isLockAcquisitionTimeoutError(error)) {
-      return new Err(
-        new MCPError(
-          `Another edit is still in progress for \`${normalizedPath}\`. Re-read the file and retry.`,
-          { tracked: false }
-        )
-      );
+  const editResult = await executeWithLockResult(
+    `file:edit:${extra.auth.getNonNullableWorkspace().sId}:${normalizedPath}`,
+    () => editHandlerUnlocked(args, extra),
+    FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS,
+    {
+      lockTtlMs: FILE_EDIT_LOCK_TTL_MS,
+      retryIntervalMs: FILE_EDIT_LOCK_RETRY_INTERVAL_MS,
     }
+  );
 
-    throw error;
+  if (editResult.isOk()) {
+    return new Ok(editResult.value);
   }
+  if (editResult.error instanceof MCPError) {
+    return new Err(editResult.error);
+  }
+  if (isLockAcquisitionTimeoutError(editResult.error)) {
+    return new Err(
+      new MCPError(
+        `Another edit is still in progress for \`${normalizedPath}\`. Re-read the file and retry.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  throw editResult.error;
 }

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -19,12 +19,7 @@ import {
   isReadableAsText,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
-import { DustFileSystem } from "@app/lib/api/file_system";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
-import {
-  executeWithLockResult,
-  isLockAcquisitionTimeoutError,
-} from "@app/lib/lock";
 import {
   isInteractiveContentType,
   stripMimeParameters,
@@ -32,19 +27,18 @@ import {
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 
-const FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS = 5_000;
-const FILE_EDIT_LOCK_TTL_MS = 30_000;
-const FILE_EDIT_LOCK_RETRY_INTERVAL_MS = 25;
-
-type EditHandlerArgs = {
-  path: string;
-  old_string: string;
-  new_string: string;
-  expected_replacements?: number;
-};
-
-async function editHandlerUnlocked(
-  { path, old_string, new_string, expected_replacements }: EditHandlerArgs,
+export async function editHandler(
+  {
+    path,
+    old_string,
+    new_string,
+    expected_replacements,
+  }: {
+    path: string;
+    old_string: string;
+    new_string: string;
+    expected_replacements?: number;
+  },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const conversationRes = requireAgentLoopConversation({ runContext });
@@ -62,6 +56,7 @@ async function editHandlerUnlocked(
   }
 
   const dustFs = fsResult.value;
+
   const statResult = await dustFs.stat(path);
   if (statResult.isErr()) {
     return new Err(new MCPError(statResult.error.message, { tracked: false }));
@@ -176,43 +171,4 @@ async function editHandlerUnlocked(
   }
 
   return new Ok([{ type: "text", text }]);
-}
-
-export async function editHandler(
-  args: EditHandlerArgs,
-  extra: ToolHandlerExtra
-): Promise<ToolHandlerResult> {
-  const normalizedPath = DustFileSystem.normalizeScopedPath(args.path);
-  if (!normalizedPath) {
-    return new Err(
-      new MCPError(`Invalid path: \`${args.path}\`.`, { tracked: false })
-    );
-  }
-
-  const editResult = await executeWithLockResult(
-    `file:edit:${extra.auth.getNonNullableWorkspace().sId}:${normalizedPath}`,
-    () => editHandlerUnlocked(args, extra),
-    FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS,
-    {
-      lockTtlMs: FILE_EDIT_LOCK_TTL_MS,
-      retryIntervalMs: FILE_EDIT_LOCK_RETRY_INTERVAL_MS,
-    }
-  );
-
-  if (editResult.isOk()) {
-    return new Ok(editResult.value);
-  }
-  if (editResult.error instanceof MCPError) {
-    return new Err(editResult.error);
-  }
-  if (isLockAcquisitionTimeoutError(editResult.error)) {
-    return new Err(
-      new MCPError(
-        `Another edit is still in progress for \`${normalizedPath}\`. Re-read the file and retry.`,
-        { tracked: false }
-      )
-    );
-  }
-
-  throw editResult.error;
 }

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -19,7 +19,9 @@ import {
   isReadableAsText,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import { executeWithLock, isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import {
   isInteractiveContentType,
   stripMimeParameters,
@@ -27,18 +29,19 @@ import {
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 
-export async function editHandler(
-  {
-    path,
-    old_string,
-    new_string,
-    expected_replacements,
-  }: {
-    path: string;
-    old_string: string;
-    new_string: string;
-    expected_replacements?: number;
-  },
+const FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS = 30_000;
+const FILE_EDIT_LOCK_TTL_MS = 30_000;
+const FILE_EDIT_LOCK_RETRY_INTERVAL_MS = 25;
+
+type EditHandlerArgs = {
+  path: string;
+  old_string: string;
+  new_string: string;
+  expected_replacements?: number;
+};
+
+async function editHandlerUnlocked(
+  { path, old_string, new_string, expected_replacements }: EditHandlerArgs,
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const conversationRes = requireAgentLoopConversation({ runContext });
@@ -56,7 +59,6 @@ export async function editHandler(
   }
 
   const dustFs = fsResult.value;
-
   const statResult = await dustFs.stat(path);
   if (statResult.isErr()) {
     return new Err(new MCPError(statResult.error.message, { tracked: false }));
@@ -171,4 +173,39 @@ export async function editHandler(
   }
 
   return new Ok([{ type: "text", text }]);
+}
+
+export async function editHandler(
+  args: EditHandlerArgs,
+  extra: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const normalizedPath = DustFileSystem.normalizeScopedPath(args.path);
+  if (!normalizedPath) {
+    return new Err(
+      new MCPError(`Invalid path: \`${args.path}\`.`, { tracked: false })
+    );
+  }
+
+  try {
+    return await executeWithLock(
+      `file:edit:${extra.auth.getNonNullableWorkspace().sId}:${normalizedPath}`,
+      () => editHandlerUnlocked(args, extra),
+      FILE_EDIT_LOCK_ACQUISITION_TIMEOUT_MS,
+      {
+        lockTtlMs: FILE_EDIT_LOCK_TTL_MS,
+        retryIntervalMs: FILE_EDIT_LOCK_RETRY_INTERVAL_MS,
+      }
+    );
+  } catch (error) {
+    if (isLockAcquisitionTimeoutError(error)) {
+      return new Err(
+        new MCPError(
+          `Another edit is still in progress for \`${normalizedPath}\`. Re-read the file and retry.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    throw error;
+  }
 }

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -34,7 +34,11 @@ const manifest = JSON.stringify({
 });
 const uiSource = "export default function Status() { return <p>Ready</p>; }";
 
-async function setup() {
+async function setup({
+  uiContentType = "text/typescript",
+}: {
+  uiContentType?: string;
+} = {}) {
   const { authenticator: auth, workspace } = await createResourceTest({
     role: "admin",
   });
@@ -68,7 +72,7 @@ async function setup() {
           name,
           metadata: {
             contentType: name.endsWith(".tsx")
-              ? "text/typescript"
+              ? uiContentType
               : frameV2ContentType,
             size: String(Buffer.byteLength(content)),
           },
@@ -226,6 +230,20 @@ describe("publishFrameV2FromSource", () => {
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       result.value.publicationId
     );
+  });
+
+  it("infers TSX source content type from its extension", async () => {
+    const { auth, conversation, frame, manifestPath } = await setup({
+      uiContentType: "application/x-tiled-tsx",
+    });
+
+    const result = await publishFrameV2FromSource(auth, {
+      conversation,
+      frame,
+      manifestPath,
+    });
+
+    expect(result.isOk()).toBe(true);
   });
 
   it("rejects a path that does not match the Frame identity", async () => {

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -22,6 +22,7 @@ import {
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
+  contentTypeFromFileName,
   isAllSupportedFileContentType,
   normalizeMimeType,
 } from "@app/types/files";
@@ -250,7 +251,11 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
       );
     }
 
-    const contentType = normalizeMimeType(entry.contentType);
+    // FUSE/GCS metadata is not authoritative for source code. In particular, `.tsx` can be
+    // reported as the unrelated `application/x-tiled-tsx`; the file extension is stable.
+    const contentType =
+      contentTypeFromFileName(relativePath) ??
+      normalizeMimeType(entry.contentType);
     if (!isAllSupportedFileContentType(contentType)) {
       return frameError(
         "invalid_source",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.102",
+      tag: "0.8.103",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.53/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.54/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.102";
-const DSBX_CLI_VERSION = "0.1.53";
+const DUST_BASE_IMAGE_VERSION = "0.8.103";
+const DSBX_CLI_VERSION = "0.1.54";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -20,10 +20,15 @@ export class SandboxFunctionError extends Error {
   }
 }
 
-export class SandboxFunctionInvocationError extends Error {
-  readonly code = "user_authentication_required";
+export type SandboxFunctionInvocationErrorCode =
+  | "user_authentication_required"
+  | "frame_runtime_unavailable";
 
-  constructor(message: string) {
+export class SandboxFunctionInvocationError extends Error {
+  constructor(
+    message: string,
+    readonly code: SandboxFunctionInvocationErrorCode = "user_authentication_required"
+  ) {
     super(message);
     this.name = "SandboxFunctionInvocationError";
   }

--- a/front/lib/api/sandbox_functions/workspace_user.test.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.test.ts
@@ -2,6 +2,7 @@ import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functio
 import { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -12,11 +13,13 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
 
 async function setup() {
-  const { workspace, authenticator: adminAuth } = await createResourceTest({
-    role: "admin",
-  });
+  const {
+    workspace,
+    authenticator: adminAuth,
+    globalSpace,
+  } = await createResourceTest({ role: "admin" });
   const space = await SpaceFactory.project(workspace);
-  return { workspace, adminAuth, space };
+  return { workspace, adminAuth, globalSpace, space };
 }
 
 async function makeWorkspaceMember(
@@ -179,6 +182,34 @@ describe("authorizeSandboxFunctionInvocation for Frames", () => {
       runtimeSpaceId: space.sId,
       pod: expect.objectContaining({ sId: space.sId }),
       user: expect.objectContaining({ sId: member.sId }),
+    });
+  });
+
+  it("uses the global space for a Frame in a standalone conversation", async () => {
+    const { adminAuth, globalSpace } = await setup();
+    const conversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const frame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: "tasks.frame.json",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const authorization = await authorizeSandboxFunctionInvocation(adminAuth, {
+      userIdentity: "optional",
+      origin: "interactive_session",
+      owner: { kind: "frame", frame },
+    });
+
+    expect(authorization).toMatchObject({
+      authorized: true,
+      runtimeSpaceId: globalSpace.sId,
+      pod: null,
     });
   });
 

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,3 +1,4 @@
+import type { SandboxFunctionInvocationErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { FrameSandboxScope } from "@app/lib/resources/frame_sandbox_adapter";
@@ -17,7 +18,18 @@ export type SandboxFunctionAuthorization =
       runtimeSpaceId: string;
       pod: SpaceResource | null;
     }
-  | { authorized: false; errorMessage: string };
+  | {
+      authorized: false;
+      errorCode: SandboxFunctionInvocationErrorCode;
+      errorMessage: string;
+    };
+
+function authorizationError(
+  errorMessage: string,
+  errorCode: SandboxFunctionInvocationErrorCode = "user_authentication_required"
+): SandboxFunctionAuthorization {
+  return { authorized: false, errorCode, errorMessage };
+}
 
 export async function getAuthenticatedWorkspaceUser(
   auth: Authenticator
@@ -62,29 +74,29 @@ export async function authorizeSandboxFunctionInvocation(
     // Frames are always workspace-member execution, even when a declaration's identity policy is
     // optional. Public and guest rendering may still work, but invocation fails before wakeup.
     if (!user) {
-      return {
-        authorized: false,
-        errorMessage:
-          "This Frame function requires a logged-in user from its workspace.",
-      };
+      return authorizationError(
+        "This Frame function requires a logged-in user from its workspace."
+      );
     }
     const scope =
       owner.scope ?? (await frame.resolveFrameScopedPathContext(auth));
-    if (!scope.spaceId) {
-      return {
-        authorized: false,
-        errorMessage: "This Frame has no valid runtime scope.",
-      };
+    if (scope.spaceId) {
+      const runtimeSpace = await SpaceResource.fetchById(auth, scope.spaceId);
+      if (!runtimeSpace) {
+        return authorizationError(
+          "This Frame's runtime scope no longer exists.",
+          "frame_runtime_unavailable"
+        );
+      }
+      runtimeSpaceId = runtimeSpace.sId;
+      pod = runtimeSpace.isProject() ? runtimeSpace : null;
+    } else {
+      // Standalone conversations have no space. Their functions still need a space claim so
+      // sandbox tokens can expose workspace-level MCP servers; the global space is that scope.
+      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+      runtimeSpaceId = globalSpace.sId;
+      pod = null;
     }
-    const runtimeSpace = await SpaceResource.fetchById(auth, scope.spaceId);
-    if (!runtimeSpace) {
-      return {
-        authorized: false,
-        errorMessage: "This Frame's runtime scope no longer exists.",
-      };
-    }
-    runtimeSpaceId = runtimeSpace.sId;
-    pod = runtimeSpace.isProject() ? runtimeSpace : null;
   } else {
     pod = owner.space;
     runtimeSpaceId = pod.sId;
@@ -98,10 +110,9 @@ export async function authorizeSandboxFunctionInvocation(
     case "workspace_user_required":
       return user
         ? { authorized: true, user, runtimeSpaceId, pod }
-        : {
-            authorized: false,
-            errorMessage: `This ${functionKind} requires a logged-in user from its workspace.`,
-          };
+        : authorizationError(
+            `This ${functionKind} requires a logged-in user from its workspace.`
+          );
     case "interactive_workspace_user_required": {
       const authorized =
         user !== null &&
@@ -109,10 +120,9 @@ export async function authorizeSandboxFunctionInvocation(
         auth.authMethod() === "session";
       return authorized
         ? { authorized: true, user, runtimeSpaceId, pod }
-        : {
-            authorized: false,
-            errorMessage: `This ${functionKind} requires a logged-in workspace member in a live Dust session.`,
-          };
+        : authorizationError(
+            `This ${functionKind} requires a logged-in workspace member in a live Dust session.`
+          );
     }
     case "pod_member_required": {
       // Membership means belonging to any of the pod's groups (member or editor — a user is never
@@ -123,10 +133,9 @@ export async function authorizeSandboxFunctionInvocation(
       const authorized = user !== null && pod?.isMember(auth) === true;
       return authorized
         ? { authorized: true, user, runtimeSpaceId, pod }
-        : {
-            authorized: false,
-            errorMessage: `This ${functionKind} requires a member of its Pod.`,
-          };
+        : authorizationError(
+            `This ${functionKind} requires a member of its Pod.`
+          );
     }
     default:
       // The policy is persisted as a plain string, so the store can hold a value this revision
@@ -137,9 +146,8 @@ export async function authorizeSandboxFunctionInvocation(
       // the value is cross-revision data, not internal control flow, and throwing would turn
       // these invocations into 500s instead of this clean denial.
       assertNeverAndIgnore(policy);
-      return {
-        authorized: false,
-        errorMessage: `This ${functionKind} uses an unsupported user identity policy.`,
-      };
+      return authorizationError(
+        `This ${functionKind} uses an unsupported user identity policy.`
+      );
   }
 }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -20,6 +20,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -209,11 +210,21 @@ async function setupExecutionTest(
   };
 }
 
-async function setupFrameExecutionTest() {
-  const { authenticator, workspace } = await createResourceTest({
+async function setupFrameExecutionTest({
+  standalone = false,
+}: {
+  standalone?: boolean;
+} = {}) {
+  const { authenticator, globalSpace, workspace } = await createResourceTest({
     role: "admin",
   });
   const space = await SpaceFactory.project(workspace);
+  const conversation = standalone
+    ? await ConversationFactory.create(authenticator, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+      })
+    : null;
   const publicationId = "publication-1";
   const frame = await FileFactory.create(authenticator, null, {
     contentType: frameV2ContentType,
@@ -221,7 +232,12 @@ async function setupFrameExecutionTest() {
     fileSize: 100,
     status: "ready",
     useCase: "conversation",
-    useCaseMetadata: { spaceId: space.sId, activePublicationId: publicationId },
+    useCaseMetadata: {
+      ...(conversation
+        ? { conversationId: conversation.sId }
+        : { spaceId: space.sId }),
+      activePublicationId: publicationId,
+    },
   });
   await withTransaction((transaction) =>
     SandboxFunctionResource.createForFramePublication(
@@ -260,7 +276,11 @@ async function setupFrameExecutionTest() {
     version: "0.0.0-test",
   });
   vi.mocked(ensureFrameSandboxReady).mockResolvedValue(
-    new Ok({ sandbox, freshlyCreated: false, scope: { spaceId: space.sId } })
+    new Ok({
+      sandbox,
+      freshlyCreated: false,
+      scope: { spaceId: standalone ? null : space.sId },
+    })
   );
   vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
     "sbt-frame-function-token"
@@ -273,6 +293,7 @@ async function setupFrameExecutionTest() {
   return {
     authenticator,
     frame,
+    globalSpace,
     invocation,
     publicationId,
     sandbox,
@@ -1040,6 +1061,35 @@ describe("SandboxFunctionInvocationResource", () => {
           kind: "frame",
           frameId: frame.sId,
           spaceId: movedSpace.sId,
+        },
+      })
+    );
+  });
+
+  it("uses the global space token scope for a standalone Frame", async () => {
+    const {
+      authenticator,
+      frame,
+      globalSpace,
+      invocation,
+      sandbox,
+      sandboxFunction,
+    } = await setupFrameExecutionTest({ standalone: true });
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: SUCCEEDED_STDOUT, stderr: "" })
+    );
+
+    const result = await invocation.execute(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
+      authenticator,
+      expect.objectContaining({
+        sandboxFunction,
+        owner: {
+          kind: "frame",
+          frameId: frame.sId,
+          spaceId: globalSpace.sId,
         },
       })
     );

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -17,6 +17,7 @@ import {
 } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { podDatabasePrefixFromSlug } from "@app/lib/api/sandbox_functions/db_naming";
+import type { SandboxFunctionInvocationErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import {
@@ -652,7 +653,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       const runFunctionCheck = async (): Promise<{
         persistedFunction: SandboxFunctionModel;
         podAuthorization: SandboxFunctionAuthorization | null;
-        errorMessage: string | null;
+        error: {
+          code: SandboxFunctionInvocationErrorCode;
+          message: string;
+        } | null;
       } | null> => {
         const persistedFunction = await SandboxFunctionModel.findOne({
           where: {
@@ -671,9 +675,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           return {
             persistedFunction,
             podAuthorization: null,
-            errorMessage: user
+            error: user
               ? null
-              : "This Frame function requires a logged-in user from its workspace.",
+              : {
+                  code: "user_authentication_required",
+                  message:
+                    "This Frame function requires a logged-in user from its workspace.",
+                },
           };
         }
         const authorization = await authorizeSandboxFunctionInvocation(auth, {
@@ -684,9 +692,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         return {
           persistedFunction,
           podAuthorization: authorization,
-          errorMessage: authorization.authorized
+          error: authorization.authorized
             ? null
-            : authorization.errorMessage,
+            : {
+                code: authorization.errorCode,
+                message: authorization.errorMessage,
+              },
         };
       };
       const runEnsure = async (): Promise<
@@ -707,7 +718,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         ]);
       } else {
         functionCheck = await runFunctionCheck();
-        if (functionCheck === null || functionCheck.errorMessage !== null) {
+        if (functionCheck === null || functionCheck.error !== null) {
           ensureResult = null;
         } else {
           ensureResult = await runEnsure();
@@ -717,9 +728,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         return new Err(new Error(`The ${functionKind} no longer exists.`));
       }
       const { persistedFunction } = functionCheck;
-      if (functionCheck.errorMessage !== null) {
+      if (functionCheck.error !== null) {
         return new Err(
-          new SandboxFunctionInvocationError(functionCheck.errorMessage)
+          new SandboxFunctionInvocationError(
+            functionCheck.error.message,
+            functionCheck.error.code
+          )
         );
       }
       if (!ensureResult) {
@@ -759,7 +773,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
       if (!authorization.authorized) {
         return new Err(
-          new SandboxFunctionInvocationError(authorization.errorMessage)
+          new SandboxFunctionInvocationError(
+            authorization.errorMessage,
+            authorization.errorCode
+          )
         );
       }
 

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -892,7 +892,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     });
     if (!authorization.authorized) {
       return new Err(
-        new SandboxFunctionInvocationError(authorization.errorMessage)
+        new SandboxFunctionInvocationError(
+          authorization.errorMessage,
+          authorization.errorCode
+        )
       );
     }
 

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -90,27 +90,16 @@ describe("framesSkill.fetchInstructions", () => {
       "Chat apps, task lists, trackers, forms, CRUD apps"
     );
     expect(instructions).toContain(
-      "Do not substitute in-memory arrays or seed data"
+      "Do not store durable application state in memory; use a Frame database"
     );
-    expect(instructions).toContain("Do not inspect installed");
     expect(instructions).toContain(
-      "`@dust/pod` or `@dust/react-hooks` package internals"
+      "Use the Computer to create and edit their source"
     );
     expect(instructions).toContain("Do not pass the convenience aliases");
     expect(instructions).toContain("`/files/conversation` or `/files/pod`");
     expect(instructions).toContain(
       "Never run concurrent file mutations against the same path"
     );
-    expect(instructions).toContain("Do not use Files MCP");
-    expect(instructions).toContain("mutation tools for Frame authoring");
-    expect(instructions).toContain(
-      "exercise at least one read and one representative mutation"
-    );
-    expect(instructions).toContain(
-      'Distinguish "the UI renders" from "the application works end to end"'
-    );
-    expect(instructions).toContain("Never claim completion");
-    expect(instructions).toContain("while a verification step failed");
     expect(instructions).toContain(
       "Other interactive-content tools remain available"
     );

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -101,6 +101,8 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(
       "Never run concurrent file mutations against the same path"
     );
+    expect(instructions).toContain("Do not use Files MCP");
+    expect(instructions).toContain("mutation tools for Frame authoring");
     expect(instructions).toContain(
       "exercise at least one read and one representative mutation"
     );

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -87,6 +87,29 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("legacy Frame");
     expect(instructions).toContain("<frame>.tsx");
     expect(instructions).toContain(
+      "Chat apps, task lists, trackers, forms, CRUD apps"
+    );
+    expect(instructions).toContain(
+      "Do not substitute in-memory arrays or seed data"
+    );
+    expect(instructions).toContain("Do not inspect installed");
+    expect(instructions).toContain(
+      "`@dust/pod` or `@dust/react-hooks` package internals"
+    );
+    expect(instructions).toContain("Do not pass the convenience aliases");
+    expect(instructions).toContain("`/files/conversation` or `/files/pod`");
+    expect(instructions).toContain(
+      "Never run concurrent file mutations against the same path"
+    );
+    expect(instructions).toContain(
+      "exercise at least one read and one representative mutation"
+    );
+    expect(instructions).toContain(
+      'Distinguish "the UI renders" from "the application works end to end"'
+    );
+    expect(instructions).toContain("Never claim completion");
+    expect(instructions).toContain("while a verification step failed");
+    expect(instructions).toContain(
       "Other interactive-content tools remain available"
     );
     expect(framesSkill.mcpServers).toEqual([{ name: "interactive_content" }]);

--- a/front/lib/resources/skill/code_defined/global/frames.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.ts
@@ -56,6 +56,6 @@ export const framesSkill = {
     });
   },
   mcpServers: [{ name: "interactive_content" }],
-  version: 4,
+  version: 5,
   icon: "ActionFrameIcon",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -19,6 +19,17 @@ Frames are interactive React applications. Use the Computer to edit their source
 - \`dsbx frame publish\` supports both formats. Edit and publish an existing legacy Frame in place;
   do not recreate it just to make it v2.
 
+## Before authoring
+
+Decide whether the Frame is a throwaway visualization or an application with durable state before
+writing source. Chat apps, task lists, trackers, forms, CRUD apps, and anything users can change
+default to durable: declare the database plus the read and mutation functions in the first
+manifest. Do not substitute in-memory arrays or seed data unless the user explicitly asked for a
+prototype.
+
+Treat the documented APIs and examples in this skill as authoritative. Do not inspect installed
+\`@dust/pod\` or \`@dust/react-hooks\` package internals to guess an API.
+
 ## Create a Frame
 
 Create and register a new Frame folder on the mounted file system:
@@ -30,6 +41,10 @@ dsbx frame create /files/conversation-<conversationId>/<frame-folder> --name "<n
 In a Pod, create it under \`/files/pod-<podId>/...\` instead. The command scaffolds
 \`manifest.json\` and \`index.tsx\`, then assigns the Frame's stable identity. Edit the generated
 source before publishing it.
+
+Always pass canonical \`/files/conversation-<conversationId>/...\` or
+\`/files/pod-<podId>/...\` paths to \`dsbx frame\`. Do not pass the convenience aliases
+\`/files/conversation\` or \`/files/pod\`.
 
 ## Register an existing Frame folder
 
@@ -336,5 +351,19 @@ yet. Use \`dsbx frame --help\` as the authority for available operations.
 
 Do not use \`mv\` or \`cp\` on a registered Frame folder: move and clone are not supported in this
 initial scope.
+
+## Editing and verification
+
+Never run concurrent file mutations against the same path. Read the current file, apply one edit,
+then start the next edit to that file.
+
+After publishing, verify the published Frame rather than only the source or build result:
+
+1. Open the Frame and inspect the rendered pixels, loading state, and errors.
+2. If it declares functions, exercise at least one read and one representative mutation through
+   the UI, then confirm the resulting state. A successful publish or screenshot capture does not
+   prove that function execution or persistence works.
+3. Distinguish "the UI renders" from "the application works end to end". Never claim completion
+   while a verification step failed; report exactly what remains unverified.
 
 ${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}`;

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -4,8 +4,8 @@ import { MAX_FRAME_DATABASE_COUNT } from "@app/types/api/frame_manifest";
 export const FRAMES_V2_INSTRUCTIONS = `\
 # Frames v2
 
-Frames are interactive React applications. Use \`bash\` on the Computer to create and edit their
-source on the mounted file system, and the \`dsbx frame\` CLI for their lifecycle.
+Frames are interactive React applications. Use the Computer to create and edit their source, and
+the \`dsbx frame\` CLI for their lifecycle.
 
 ## Frames v2 vs legacy Frames
 
@@ -23,16 +23,12 @@ source on the mounted file system, and the \`dsbx frame\` CLI for their lifecycl
 
 Decide whether the Frame is a throwaway visualization or an application with durable state before
 writing source. Chat apps, task lists, trackers, forms, CRUD apps, and anything users can change
-default to durable: declare the database plus the read and mutation functions in the first
-manifest. Do not substitute in-memory arrays or seed data unless the user explicitly asked for a
-prototype.
-
-Treat the documented APIs and examples in this skill as authoritative. Do not inspect installed
-\`@dust/pod\` or \`@dust/react-hooks\` package internals to guess an API.
+default to durable: declare the database plus the read and mutation functions in the
+manifest. Do not store durable application state in memory; use a Frame database.
 
 ## Create a Frame
 
-Create and register a new Frame folder on the mounted file system:
+Use the Computer to create and register a new Frame folder:
 
 \`\`\`bash
 dsbx frame create /files/conversation-<conversationId>/<frame-folder> --name "<name>"
@@ -352,19 +348,9 @@ yet. Use \`dsbx frame --help\` as the authority for available operations.
 Do not use \`mv\` or \`cp\` on a registered Frame folder: move and clone are not supported in this
 initial scope.
 
-## Editing and verification
+## Editing
 
-Edit Frame source through \`bash\` on the Computer's mounted file system. Do not use Files MCP
-mutation tools for Frame authoring. Never run concurrent file mutations against the same path:
+Use the Computer to edit Frame source. Never run concurrent file mutations against the same path:
 read the current file, apply one edit, then start the next edit to that file.
-
-After publishing, verify the published Frame rather than only the source or build result:
-
-1. Open the Frame and inspect the rendered pixels, loading state, and errors.
-2. If it declares functions, exercise at least one read and one representative mutation through
-   the UI, then confirm the resulting state. A successful publish or screenshot capture does not
-   prove that function execution or persistence works.
-3. Distinguish "the UI renders" from "the application works end to end". Never claim completion
-   while a verification step failed; report exactly what remains unverified.
 
 ${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}`;

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -4,8 +4,8 @@ import { MAX_FRAME_DATABASE_COUNT } from "@app/types/api/frame_manifest";
 export const FRAMES_V2_INSTRUCTIONS = `\
 # Frames v2
 
-Frames are interactive React applications. Use the Computer to edit their source and the
-\`dsbx frame\` CLI for their lifecycle.
+Frames are interactive React applications. Use \`bash\` on the Computer to create and edit their
+source on the mounted file system, and the \`dsbx frame\` CLI for their lifecycle.
 
 ## Frames v2 vs legacy Frames
 
@@ -354,8 +354,9 @@ initial scope.
 
 ## Editing and verification
 
-Never run concurrent file mutations against the same path. Read the current file, apply one edit,
-then start the next edit to that file.
+Edit Frame source through \`bash\` on the Computer's mounted file system. Do not use Files MCP
+mutation tools for Frame authoring. Never run concurrent file mutations against the same path:
+read the current file, apply one edit, then start the next edit to that file.
 
 After publishing, verify the published Frame rather than only the source or build result:
 

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -167,6 +167,7 @@ const API_ERROR_TYPES = [
   "skill_github_repository_not_found",
   "sandbox_function_not_found",
   "sandbox_function_invocation_not_found",
+  "frame_runtime_unavailable",
   "fast_function_called_tools",
   // Projects
   "project_metadata_not_found",


### PR DESCRIPTION
## Description

Fix the failures found during the first Frames v2 end-to-end run:

- Let standalone-conversation Frames invoke functions using the workspace global space as their token scope.
- Return a typed runtime error when a referenced scope no longer exists.
- Resolve convenience mount aliases to canonical Frame source paths in dsbx.
- Infer source MIME types from file extensions when GCS metadata is misleading.
- Teach the Frames skill to plan persistence up front, edit mounted source through bash without concurrent writes to one file, and verify functions and mutations end to end.
- Release the CLI changes as dsbx `0.1.54` and pin dust-base `0.8.103` to that release.

## Tests

- 85 focused front tests
- 56 focused front-api tests
- 4 dsbx frame tests
- 21 sandbox image registry tests
- front and front-api typechecks
- Biome, Swagger annotation lint, cargo fmt, Clippy

## Risk

Medium. Standalone Frames now use the workspace global space as their non-Pod runtime token scope. Frames v2 behavior remains feature-flagged. The private invocation endpoints distinguish unavailable runtime state from authentication failures.

The dust-base build downloads the pinned dsbx release from GitHub. Building dust-base before `dsbx-v0.1.54` is published will fail.

#31585 and its child #31603 also touch the dust-base pin on older bases. After this PR merges, #31585 must rebase and advance to `0.8.104`; #31603 must then rebase on it and advance to `0.8.105`.

## Deploy Plan

1. Merge this PR.
2. Publish `dsbx-v0.1.54` with the sandbox CLI release workflow.
3. Build and deploy dust-base `0.8.103` only after the dsbx release is available.
4. Open `/poke/kill` and recycle older dust-base sandboxes so existing conversations receive the fixed CLI.
5. Rebase #31585 and #31603 and advance their image tags as described above.
