### PR TITLE
feat: move version-markers to new es index

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { fetchVersionMarkers } from "@app/lib/api/assistant/observability/version_markers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -42,15 +41,12 @@ app.get(
     }
 
     const { days } = ctx.req.valid("query");
-    const owner = auth.getNonNullableWorkspace();
 
-    const baseQuery = buildAgentAnalyticsBaseQuery({
-      workspaceId: owner.sId,
+    const versionMarkersResult = await fetchVersionMarkers({
+      auth,
       agentId: assistant.sId,
       days,
     });
-
-    const versionMarkersResult = await fetchVersionMarkers(baseQuery);
     if (versionMarkersResult.isErr()) {
       return apiError(ctx, {
         status_code: 500,

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -17,13 +17,6 @@ type OverviewAggs = {
   active_users?: { value?: number };
   conversations?: { value?: number };
   total_messages?: { value?: number };
-  feedbacks?: {
-    recent?: {
-      doc_count: number;
-      up?: { doc_count: number };
-      down?: { doc_count: number };
-    };
-  };
 };
 
 export async function fetchAgentOverview(

--- a/front/lib/api/assistant/observability/version_markers.test.ts
+++ b/front/lib/api/assistant/observability/version_markers.test.ts
@@ -1,0 +1,136 @@
+import { fetchVersionMarkers } from "@app/lib/api/assistant/observability/version_markers";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
+});
+
+function mockVersionBuckets(
+  buckets: { key: string; doc_count: number; first_seen: { value: number } }[]
+) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: { total: { value: 0, relation: "eq" as const }, hits: [] },
+      aggregations: {
+        by_version: { buckets },
+      },
+    })
+  );
+}
+
+describe("fetchVersionMarkers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns version markers sorted by timestamp", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    mockVersionBuckets([
+      { key: "3", doc_count: 5, first_seen: { value: 3000 } },
+      { key: "1", doc_count: 10, first_seen: { value: 1000 } },
+      { key: "2", doc_count: 3, first_seen: { value: 2000 } },
+    ]);
+
+    const result = await fetchVersionMarkers({
+      auth: authenticator,
+      agentId: "agent-abc",
+      days: 30,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toEqual([
+      { version: "1", timestamp: 1000 },
+      { version: "2", timestamp: 2000 },
+      { version: "3", timestamp: 3000 },
+    ]);
+  });
+
+  it("returns an empty array when no versions exist", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    mockVersionBuckets([]);
+
+    const result = await fetchVersionMarkers({
+      auth: authenticator,
+      agentId: "agent-abc",
+      days: 7,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toEqual([]);
+  });
+
+  it("passes the agent filter and aggregation to searchConsumptionAnalytics", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    mockVersionBuckets([]);
+
+    await fetchVersionMarkers({
+      auth: authenticator,
+      agentId: "agent-xyz",
+      days: 14,
+    });
+
+    expect(searchConsumptionAnalytics).toHaveBeenCalledOnce();
+
+    const [query, options] = vi.mocked(searchConsumptionAnalytics).mock
+      .calls[0];
+
+    const filters = (query as { bool: { filter: unknown[] } }).bool.filter;
+    const hasAgentFilter = filters.some(
+      (f: any) =>
+        f?.term?.["agent.attributed_id"] === "agent-xyz" ||
+        f?.terms?.["agent.attributed_id"]?.includes("agent-xyz")
+    );
+    expect(hasAgentFilter).toBe(true);
+
+    expect(options?.size).toBe(0);
+    expect(options?.aggregations?.by_version).toBeDefined();
+  });
+
+  it("defaults timestamp to 0 when first_seen is missing", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" as const }, hits: [] },
+        aggregations: {
+          by_version: {
+            buckets: [{ key: "1", doc_count: 1 }],
+          },
+        },
+      })
+    );
+
+    const result = await fetchVersionMarkers({
+      auth: authenticator,
+      agentId: "agent-abc",
+      days: 7,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toEqual([{ version: "1", timestamp: 0 }]);
+  });
+});

--- a/front/lib/api/assistant/observability/version_markers.test.ts
+++ b/front/lib/api/assistant/observability/version_markers.test.ts
@@ -89,19 +89,23 @@ describe("fetchVersionMarkers", () => {
 
     expect(searchConsumptionAnalytics).toHaveBeenCalledOnce();
 
-    const [query, options] = vi.mocked(searchConsumptionAnalytics).mock
-      .calls[0];
-
-    const filters = (query as { bool: { filter: unknown[] } }).bool.filter;
-    const hasAgentFilter = filters.some(
-      (f: any) =>
-        f?.term?.["agent.attributed_id"] === "agent-xyz" ||
-        f?.terms?.["agent.attributed_id"]?.includes("agent-xyz")
+    expect(searchConsumptionAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bool: expect.objectContaining({
+          filter: expect.arrayContaining([
+            expect.objectContaining({
+              term: { "agent.attributed_id": "agent-xyz" },
+            }),
+          ]),
+        }),
+      }),
+      expect.objectContaining({
+        size: 0,
+        aggregations: expect.objectContaining({
+          by_version: expect.anything(),
+        }),
+      })
     );
-    expect(hasAgentFilter).toBe(true);
-
-    expect(options?.size).toBe(0);
-    expect(options?.aggregations?.by_version).toBeDefined();
   });
 
   it("defaults timestamp to 0 when first_seen is missing", async () => {

--- a/front/lib/api/assistant/observability/version_markers.ts
+++ b/front/lib/api/assistant/observability/version_markers.ts
@@ -1,4 +1,13 @@
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  buildConsumptionScopeQuery,
+  COMPLETED_AT_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -21,27 +30,45 @@ type VersionMarkersAggs = {
   by_version?: estypes.AggregationsMultiBucketAggregateBase<VersionBucket>;
 };
 
-export async function fetchVersionMarkers(
-  baseQuery: estypes.QueryDslQueryContainer
-): Promise<Result<AgentVersionMarker[], Error>> {
+export async function fetchVersionMarkers({
+  auth,
+  agentId,
+  days,
+}: {
+  auth: Authenticator;
+  agentId: string;
+  days: number;
+}): Promise<Result<AgentVersionMarker[], Error>> {
+  const period = await resolveConsumptionPeriod(auth, { kind: "days", days });
+
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter: { agents: [agentId] },
+  });
+
   const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
     by_version: {
       terms: {
-        field: "agent_version",
+        field: "agent.version",
         size: MAX_VERSIONS_TO_FETCH,
       },
       aggs: {
         first_seen: {
-          min: { field: "timestamp" },
+          min: { field: COMPLETED_AT_FIELD },
         },
       },
     },
   };
 
-  const result = await searchAnalytics<never, VersionMarkersAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
-  });
+  const result = await searchConsumptionAnalytics<never, VersionMarkersAggs>(
+    query,
+    {
+      aggregations: aggs,
+      size: 0,
+    }
+  );
 
   if (result.isErr()) {
     return new Err(new Error(result.error.message));


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/10185

Migrate `/api/w/:wId/assistant/agent_configurations/:aId/observability/version-markers` to `searchConsumptionAnalytics`.

## Tests

- added tests
- tested locally by navigating to an agent > insights > feedback > by version and see the dropdown correctly populated

## Risk

Low. Safe to rollback while the legacy es index still exists.

## Deploy Plan

Front only