### PR TITLE
[Admin Governance] Resume agent editor restoration

### DIFF
--- a/front/migrations/20260828_restore_agent_editor_memberships.ts
+++ b/front/migrations/20260828_restore_agent_editor_memberships.ts
@@ -100,15 +100,24 @@ async function restoreWorkspaceAgentEditors(
 makeScript(
   {
     wId: { type: "string", required: false },
+    fromWorkspace: {
+      type: "number",
+      required: false,
+      description: "Resume from this numeric workspace model ID",
+    },
   },
-  async ({ wId, execute }, logger) => {
+  async ({ wId, fromWorkspace, execute }, logger) => {
     logger.info("Starting agent editor membership restoration");
 
     await runOnAllWorkspaces(
       async (workspace) => {
         await restoreWorkspaceAgentEditors(execute, logger, workspace);
       },
-      { concurrency: WORKSPACE_CONCURRENCY, wId }
+      {
+        concurrency: WORKSPACE_CONCURRENCY,
+        wId,
+        fromWorkspaceId: fromWorkspace,
+      }
     );
 
     logger.info("Agent editor membership restoration completed");


### PR DESCRIPTION
## Description

Follow-up to #31327.

Adds an optional, inclusive numeric `--fromWorkspace` cursor to the agent editor membership restoration script. This lets an interrupted production run resume at a known workspace instead of replaying every earlier workspace query.

## Risks

Blast radius: the one-off agent editor membership restoration script.

Risk is low. Existing invocations are unchanged; the cursor only applies when explicitly provided.

## Deploy Plan

- Merge this PR.
- On the US prodbox, pull the merged code and run `npx tsx migrations/20260828_restore_agent_editor_memberships.ts --fromWorkspace 381307 --execute`.
- Verify that the script logs `Agent editor membership restoration completed`.

## Test

- [x] Verified that CLI help exposes `--fromWorkspace` as a numeric option.