### PR TITLE
[front] refactor: compute model picker availability on the backend

### DIFF
--- a/front-api/routes/w/[wId]/models.test.ts
+++ b/front-api/routes/w/[wId]/models.test.ts
@@ -1,0 +1,20 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { GetEnabledModelsResponseType } from "@app/types/api/assistant/models";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/w/:wId/models", () => {
+  it("returns backend-owned selection availability", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+
+    const response = await honoApp.request(`/api/w/${workspace.sId}/models`);
+
+    expect(response.status).toBe(200);
+    const body: GetEnabledModelsResponseType = await response.json();
+    expect(body.models.length).toBeGreaterThan(0);
+    expect(
+      body.models.every((model) => model.selectionAvailability !== undefined)
+    ).toBe(true);
+    expect(body.defaultModel.selectionAvailability).toBeDefined();
+  });
+});

--- a/front/components/assistant/SetModelAssistantsDialog.tsx
+++ b/front/components/assistant/SetModelAssistantsDialog.tsx
@@ -52,8 +52,10 @@ export function SetModelAssistantsDialog({
   const [pending, setPending] = useState<SelectionDisplay | null>(null);
   const [confirming, setConfirming] = useState<SelectionDisplay | null>(null);
 
-  const { modelProps, isModelsLoading, lockPremiumEfforts } =
-    useModelPickerModels({ owner, disabled: !isOpen });
+  const { modelProps, isModelsLoading } = useModelPickerModels({
+    owner,
+    disabled: !isOpen,
+  });
   const { menuStateProps, resetMenu } = useModelPickerMenuState();
 
   const { mutateRegardlessOfQueryParams: mutateAgentConfigurations } =
@@ -97,7 +99,7 @@ export function SetModelAssistantsDialog({
     setPending({
       kind: "model",
       model,
-      effort: getInitialEffort(model, { lockPremiumEfforts }),
+      effort: getInitialEffort(model),
     });
   };
 

--- a/front/components/editor/extensions/shared/slash_suggestion/PickModelSubMenuDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/PickModelSubMenuDropdown.tsx
@@ -6,11 +6,9 @@ import type { SlashMenuStackFrame } from "@app/components/editor/extensions/shar
 import type { Selection } from "@app/components/model_picker/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { useAuth } from "@app/lib/auth/AuthContext";
 import { useModels } from "@app/lib/swr/models";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import { getModelMaker } from "@app/types/assistant/models/providers";
-import { isCreditPricedPlan } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
@@ -42,8 +40,6 @@ export const PickModelSubMenuDropdown = forwardRef<
     const dropdownRef = useRef<{
       onKeyDown: (props: { event: KeyboardEvent }) => boolean;
     }>(null);
-    const { subscription } = useAuth();
-    const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
     const { isDark } = useTheme();
 
     const { models, streams, isModelsLoading } = useModels({ owner });
@@ -57,12 +53,11 @@ export const PickModelSubMenuDropdown = forwardRef<
       () =>
         buildPickModelSlashCommandItems({
           getModelIcon,
-          lockPremiumEfforts,
           models,
           query,
           streams,
         }),
-      [getModelIcon, lockPremiumEfforts, models, query, streams]
+      [getModelIcon, models, query, streams]
     );
 
     const handleSelect = (item: SlashCommand) => {

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
@@ -31,7 +31,7 @@ function asSelectable(
 
   return {
     ...model,
-    isSelectable: lockReason !== "model_access",
+    isSelectable: lockReason !== "tier_limit",
     selectionAvailability: {
       defaultReasoningEffort: model.defaultReasoningEffort,
       reasoningEfforts,
@@ -123,7 +123,7 @@ describe("buildPickModelSlashCommandItems", () => {
       getModelIcon: () => Icon,
       models: [
         asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
-        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "model_access"),
+        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "tier_limit"),
       ],
       query: "",
       streams: null,
@@ -136,14 +136,14 @@ describe("buildPickModelSlashCommandItems", () => {
     ).toEqual(["Basic", "Standard"]);
   });
 
-  it("omits efforts and tiers locked by the workspace plan", () => {
+  it("omits efforts and tiers without premium entitlement", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
       models: [
         asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, null, {
-          high: "workspace_plan",
+          high: "premium_entitlement",
         }),
-        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "workspace_plan"),
+        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "premium_entitlement"),
       ],
       query: "",
       streams: null,

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
@@ -4,22 +4,43 @@ import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/model
 import { AUTO_COMPLEX_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { GEMINI_3_1_FLASH_LITE_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_4_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 import { describe, expect, it } from "vitest";
 
 const Icon = () => null;
 
 function asSelectable(
-  model: ModelConfigurationType
+  model: ModelConfigurationType,
+  unavailabilityReason: "premium" | "model_tier" | null = null,
+  effortReasons: Partial<
+    Record<ReasoningEffort, "premium" | "model_tier" | "unsupported">
+  > = {}
 ): EnabledModelConfigurationType {
-  return { ...model, isSelectable: true };
+  const reasoningEfforts = (["light", "medium", "high"] as const)
+    .filter((effort) => model.supportedReasoningEfforts[effort])
+    .map((effort) => ({
+      effort,
+      unavailabilityReason: effortReasons[effort] ?? null,
+    }));
+
+  return {
+    ...model,
+    isSelectable: unavailabilityReason !== "model_tier",
+    selectionAvailability: {
+      defaultReasoningEffort: model.defaultReasoningEffort,
+      reasoningEfforts,
+      unavailabilityReason,
+    },
+  };
 }
 
 describe("buildPickModelSlashCommandItems", () => {
   it("lists tiers first, then one row per slider effort", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
-      lockPremiumEfforts: false,
       models: [asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)],
       query: "",
       streams: null,
@@ -43,7 +64,6 @@ describe("buildPickModelSlashCommandItems", () => {
   it("uses a single row for non-reasoning models", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
-      lockPremiumEfforts: false,
       models: [asSelectable(GPT_4_1_MODEL_CONFIG)],
       query: "",
       streams: null,
@@ -63,7 +83,6 @@ describe("buildPickModelSlashCommandItems", () => {
   it("uses display names for model makers", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
-      lockPremiumEfforts: false,
       models: [asSelectable(GEMINI_3_1_FLASH_LITE_MODEL_CONFIG)],
       query: "",
       streams: null,
@@ -82,7 +101,6 @@ describe("buildPickModelSlashCommandItems", () => {
     expect(
       buildPickModelSlashCommandItems({
         getModelIcon: () => Icon,
-        lockPremiumEfforts: false,
         models: [
           asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
           asSelectable(GPT_4_1_MODEL_CONFIG),
@@ -100,10 +118,9 @@ describe("buildPickModelSlashCommandItems", () => {
   it("omits a tier whose stream is above the member's model-tier cap", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
-      lockPremiumEfforts: false,
       models: [
         asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
-        { ...AUTO_COMPLEX_MODEL_CONFIG, isSelectable: false },
+        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "model_tier"),
       ],
       query: "",
       streams: null,
@@ -116,11 +133,15 @@ describe("buildPickModelSlashCommandItems", () => {
     ).toEqual(["Basic", "Standard"]);
   });
 
-  it("omits premium efforts and the Premium tier when gated", () => {
+  it("omits efforts and tiers the backend marks as premium", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
-      lockPremiumEfforts: true,
-      models: [asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)],
+      models: [
+        asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, null, {
+          high: "premium",
+        }),
+        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "premium"),
+      ],
       query: "",
       streams: null,
     });

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
@@ -1,5 +1,8 @@
 import { buildPickModelSlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems";
-import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type {
+  EnabledModelConfigurationType,
+  ModelSelectionLockReason,
+} from "@app/types/api/assistant/models";
 import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import { AUTO_COMPLEX_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { GEMINI_3_1_FLASH_LITE_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
@@ -14,9 +17,9 @@ const Icon = () => null;
 
 function asSelectable(
   model: ModelConfigurationType,
-  unavailabilityReason: "premium" | "model_tier" | null = null,
+  lockReason: ModelSelectionLockReason | null = null,
   effortReasons: Partial<
-    Record<ReasoningEffort, "premium" | "model_tier" | "unsupported">
+    Record<ReasoningEffort, ModelSelectionLockReason | "unsupported">
   > = {}
 ): EnabledModelConfigurationType {
   const reasoningEfforts = (["light", "medium", "high"] as const)
@@ -28,11 +31,11 @@ function asSelectable(
 
   return {
     ...model,
-    isSelectable: unavailabilityReason !== "model_tier",
+    isSelectable: lockReason !== "model_access",
     selectionAvailability: {
       defaultReasoningEffort: model.defaultReasoningEffort,
       reasoningEfforts,
-      unavailabilityReason,
+      lockReason,
     },
   };
 }
@@ -120,7 +123,7 @@ describe("buildPickModelSlashCommandItems", () => {
       getModelIcon: () => Icon,
       models: [
         asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
-        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "model_tier"),
+        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "model_access"),
       ],
       query: "",
       streams: null,
@@ -133,14 +136,14 @@ describe("buildPickModelSlashCommandItems", () => {
     ).toEqual(["Basic", "Standard"]);
   });
 
-  it("omits efforts and tiers the backend marks as premium", () => {
+  it("omits efforts and tiers locked by the workspace plan", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
       models: [
         asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, null, {
-          high: "premium",
+          high: "workspace_plan",
         }),
-        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "premium"),
+        asSelectable(AUTO_COMPLEX_MODEL_CONFIG, "workspace_plan"),
       ],
       query: "",
       streams: null,

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.ts
@@ -7,10 +7,11 @@ import {
   buildModelSelection,
   buildTierSelection,
   getEffortStops,
+  getInitialEffort,
+  getModelLockReason,
   getModelWithReasoningEffortLabel,
   getTierLockReason,
   getTierResolvedModelLabel,
-  isPremiumModel,
   MODEL_TIERS,
 } from "@app/components/model_picker/modelPickerUtils";
 import type {
@@ -29,14 +30,13 @@ import type { ComponentType } from "react";
 // a selectable effort row for reasoning models — it only appears as the single
 // row for non-reasoning models that have no slider stops.
 export function getSelectableEffortsForSlashMenu(
-  model: EnabledModelConfigurationType,
-  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
+  model: EnabledModelConfigurationType
 ): ReasoningEffort[] {
-  if (isPremiumModel(model, { lockPremiumEfforts })) {
+  if (getModelLockReason(model)) {
     return [];
   }
 
-  const selectableEfforts = getEffortStops(model, { lockPremiumEfforts })
+  const selectableEfforts = getEffortStops(model)
     .filter((stop) => stop.unavailabilityReason === null)
     .map((stop) => stop.effort);
 
@@ -44,7 +44,7 @@ export function getSelectableEffortsForSlashMenu(
     return selectableEfforts;
   }
 
-  return ["none"];
+  return [getInitialEffort(model)];
 }
 
 function matchesQuery(item: SlashCommand, normalizedQuery: string): boolean {
@@ -58,18 +58,16 @@ function matchesQuery(item: SlashCommand, normalizedQuery: string): boolean {
 }
 
 function buildTierSlashCommandItems({
-  lockPremiumEfforts,
   streamModels,
   streams,
 }: {
-  lockPremiumEfforts: boolean;
   streamModels: EnabledModelConfigurationType[];
   streams: ModelStreamResolutionsType | null;
 }): SelectModelSlashCommand[] {
   const items: SelectModelSlashCommand[] = [];
 
   for (const tier of MODEL_TIERS) {
-    if (getTierLockReason(tier.id, { lockPremiumEfforts, streamModels })) {
+    if (getTierLockReason(tier.id, streamModels)) {
       continue;
     }
 
@@ -93,13 +91,11 @@ function buildTierSlashCommandItems({
 
 export function buildPickModelSlashCommandItems({
   getModelIcon,
-  lockPremiumEfforts,
   models,
   query,
   streams,
 }: {
   getModelIcon: (model: EnabledModelConfigurationType) => ComponentType;
-  lockPremiumEfforts: boolean;
   models: EnabledModelConfigurationType[];
   query: string;
   streams: ModelStreamResolutionsType | null;
@@ -112,16 +108,13 @@ export function buildPickModelSlashCommandItems({
 
   const items: SelectModelSlashCommand[] = [
     ...buildTierSlashCommandItems({
-      lockPremiumEfforts,
       streamModels,
       streams,
     }),
   ];
 
   for (const model of selectableModels) {
-    const efforts = getSelectableEffortsForSlashMenu(model, {
-      lockPremiumEfforts,
-    });
+    const efforts = getSelectableEffortsForSlashMenu(model);
     const icon = getModelIcon(model);
 
     for (const effort of efforts) {

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -18,12 +18,13 @@ import {
   buildModelSelection,
   buildTierSelection,
   DEGRADED_MODEL_TOOLTIP,
+  getEffortStops,
   getInitialEffort,
+  getModelLockReason,
   getModelTier,
   getModelWithReasoningEffortLabel,
   getReasoningEffortLabel,
   getTierLockReason,
-  isPremiumModel,
   isSameSelection,
   resolveShownSelection,
 } from "@app/components/model_picker/modelPickerUtils";
@@ -33,7 +34,6 @@ import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useClientType } from "@app/lib/context/clientType";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
-import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -112,13 +112,8 @@ export function ModelPicker({
 
   const [userOverride, setUserOverride] = useState<Selection | null>(null);
 
-  const {
-    modelProps,
-    models,
-    streamModels,
-    lockPremiumEfforts,
-    degradedModelIds,
-  } = useModelPickerModels({ owner });
+  const { modelProps, models, streamModels, degradedModelIds } =
+    useModelPickerModels({ owner });
   const { menuStateProps, resetMenu } = useModelPickerMenuState();
 
   const { shown: baseSelection, agentDefault } = useMemo(
@@ -205,7 +200,7 @@ export function ModelPicker({
   }
 
   const onSelectTier = (tierId: ModelTierId) => {
-    if (getTierLockReason(tierId, { lockPremiumEfforts, streamModels })) {
+    if (getTierLockReason(tierId, streamModels)) {
       return;
     }
     commit(
@@ -218,10 +213,10 @@ export function ModelPicker({
   };
 
   const onSelectModel = (model: ModelConfigurationType) => {
-    if (isPremiumModel(model, { lockPremiumEfforts })) {
+    if (getModelLockReason(model)) {
       return;
     }
-    const effort = getInitialEffort(model, { lockPremiumEfforts });
+    const effort = getInitialEffort(model);
     commit(
       {
         display: { kind: "model", model, effort },
@@ -236,10 +231,10 @@ export function ModelPicker({
       return;
     }
     const { model } = shown.display;
-    if (
-      lockPremiumEfforts &&
-      getTierForModel(model.modelId, effort) === "premium"
-    ) {
+    const stop = getEffortStops(model).find(
+      (option) => option.effort === effort
+    );
+    if (!stop || stop.unavailabilityReason !== null) {
       return;
     }
     commit(

--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -36,7 +36,6 @@ import {
 interface ModelPickerContentProps {
   side: "top" | "bottom";
   selection: ModelPickerSelectionModel;
-  lockPremiumEfforts: boolean;
   ignoreTierRestrictions: boolean;
   tiers: ModelTierDefinition[];
   degradedModelIds: ReadonlySet<string>;
@@ -63,7 +62,6 @@ interface ModelPickerContentProps {
 export function ModelPickerContent({
   side,
   selection,
-  lockPremiumEfforts,
   ignoreTierRestrictions,
   tiers,
   degradedModelIds,
@@ -91,7 +89,7 @@ export function ModelPickerContent({
         const isSelected = isTierSelected(tier.id, selection);
         const lockReason = ignoreTierRestrictions
           ? null
-          : getTierLockReason(tier.id, { lockPremiumEfforts, streamModels });
+          : getTierLockReason(tier.id, streamModels);
         if (lockReason) {
           return (
             <DropdownMenuItem
@@ -156,7 +154,6 @@ export function ModelPickerContent({
           makerGroups={makerGroups}
           selection={selection}
           ignoreTierRestrictions={ignoreTierRestrictions}
-          lockPremiumEfforts={lockPremiumEfforts}
           degradedModelIds={degradedModelIds}
           onSelectModel={onSelectModel}
           onChangeEffort={onChangeEffort}

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -28,9 +28,6 @@ interface ModelPickerMakersViewProps {
   makerGroups: MakerGroup[];
   selection: ModelPickerSelectionModel;
   ignoreTierRestrictions: boolean;
-  // When true, premium (model, effort) picks are locked (workspace not on a
-  // credit-based plan).
-  lockPremiumEfforts: boolean;
   degradedModelIds: ReadonlySet<string>;
   onSelectModel: (model: ModelConfigurationType) => void;
   onChangeEffort?: (
@@ -43,7 +40,6 @@ export function ModelPickerMakersView({
   makerGroups,
   selection,
   ignoreTierRestrictions,
-  lockPremiumEfforts,
   degradedModelIds,
   onSelectModel,
   onChangeEffort,
@@ -67,10 +63,10 @@ export function ModelPickerMakersView({
                 isModelSelection(model, selection.agentDefault);
               const lockReason = ignoreTierRestrictions
                 ? null
-                : getModelLockReason(model, { lockPremiumEfforts });
+                : getModelLockReason(model);
               const effort = selectedEntry
                 ? selectedEntry.effort
-                : getInitialEffort(model, { lockPremiumEfforts });
+                : getInitialEffort(model);
               return (
                 <ModelPickerModelRow
                   key={getModelKey(model.providerId, model.modelId)}
@@ -80,7 +76,7 @@ export function ModelPickerMakersView({
                   lockReason={lockReason}
                   isDegraded={degradedModelIds.has(model.modelId)}
                   effort={effort}
-                  effortStops={getEffortStops(model, { lockPremiumEfforts })}
+                  effortStops={getEffortStops(model)}
                   onSelectModel={onSelectModel}
                   onChangeEffort={
                     onChangeEffort && ((next) => onChangeEffort(model, next))

--- a/front/components/model_picker/ModelPickerModelRow.test.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.test.tsx
@@ -1,5 +1,4 @@
 import { ModelPickerModelRow } from "@app/components/model_picker/ModelPickerModelRow";
-import { getEffortStops } from "@app/components/model_picker/modelPickerUtils";
 import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import {
@@ -37,7 +36,7 @@ function TestMenu({ onSelectModel, onOpenChange }: TestMenuProps) {
           lockReason={null}
           isDegraded={false}
           effort={MODEL.defaultReasoningEffort}
-          effortStops={getEffortStops(MODEL, { lockPremiumEfforts: false })}
+          effortStops={[]}
           onSelectModel={onSelectModel}
           onChangeEffort={vi.fn()}
         />

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -5,7 +5,7 @@ import {
   getInitialEffort,
   getModelLockReason,
   getTierLockReason,
-  WORKSPACE_PLAN_LOCKED_TOOLTIP,
+  PREMIUM_ENTITLEMENT_LOCKED_TOOLTIP,
 } from "@app/components/model_picker/modelPickerUtils";
 import type {
   EnabledModelConfigurationType,
@@ -28,7 +28,7 @@ const SONNET_AVAILABILITY: ModelSelectionAvailabilityType = {
   reasoningEfforts: [
     { effort: "light", unavailabilityReason: null },
     { effort: "medium", unavailabilityReason: null },
-    { effort: "high", unavailabilityReason: "workspace_plan" },
+    { effort: "high", unavailabilityReason: "premium_entitlement" },
   ],
   lockReason: null,
 };
@@ -43,7 +43,7 @@ function withAvailability(
 function streamModel(
   modelId: ModelStreamIdType,
   lockReason: ModelSelectionLockReason | null,
-  isSelectable = lockReason !== "model_access"
+  isSelectable = lockReason !== "tier_limit"
 ): EnabledModelConfigurationType {
   return {
     ...withAvailability(
@@ -95,13 +95,13 @@ describe("modelPickerUtils", () => {
     expect(
       getEffortStopTooltip({
         effort: "high",
-        unavailabilityReason: "workspace_plan",
+        unavailabilityReason: "premium_entitlement",
       })
-    ).toBe(WORKSPACE_PLAN_LOCKED_TOOLTIP);
+    ).toBe(PREMIUM_ENTITLEMENT_LOCKED_TOOLTIP);
     expect(
       getEffortStopTooltip({
         effort: "medium",
-        unavailabilityReason: "model_access",
+        unavailabilityReason: "tier_limit",
       })
     ).toBe(
       "Your current model access doesn't include this option. " +
@@ -113,14 +113,14 @@ describe("modelPickerUtils", () => {
     it("uses the stream model's backend-owned lock reason", () => {
       expect(
         getTierLockReason("complex", [
-          streamModel(AUTO_COMPLEX_MODEL_ID, "model_access"),
+          streamModel(AUTO_COMPLEX_MODEL_ID, "tier_limit"),
         ])
-      ).toBe("model_access");
+      ).toBe("tier_limit");
       expect(
         getTierLockReason("complex", [
-          streamModel(AUTO_COMPLEX_MODEL_ID, "workspace_plan"),
+          streamModel(AUTO_COMPLEX_MODEL_ID, "premium_entitlement"),
         ])
-      ).toBe("workspace_plan");
+      ).toBe("premium_entitlement");
       expect(
         getTierLockReason("fast", [streamModel(AUTO_FAST_MODEL_ID, null)])
       ).toBeNull();
@@ -132,7 +132,7 @@ describe("modelPickerUtils", () => {
 
     it("defaults to Basic when Standard is above the member's tier cap", () => {
       expect(
-        getDefaultTierId([streamModel(AUTO_MODEL_ID, "model_access", false)])
+        getDefaultTierId([streamModel(AUTO_MODEL_ID, "tier_limit", false)])
       ).toBe("fast");
     });
 

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -5,12 +5,12 @@ import {
   getInitialEffort,
   getModelLockReason,
   getTierLockReason,
-  PREMIUM_MODEL_LOCKED_TOOLTIP,
+  WORKSPACE_PLAN_LOCKED_TOOLTIP,
 } from "@app/components/model_picker/modelPickerUtils";
 import type {
   EnabledModelConfigurationType,
   ModelSelectionAvailabilityType,
-  ModelSelectionUnavailabilityReason,
+  ModelSelectionLockReason,
 } from "@app/types/api/assistant/models";
 import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
@@ -28,9 +28,9 @@ const SONNET_AVAILABILITY: ModelSelectionAvailabilityType = {
   reasoningEfforts: [
     { effort: "light", unavailabilityReason: null },
     { effort: "medium", unavailabilityReason: null },
-    { effort: "high", unavailabilityReason: "premium" },
+    { effort: "high", unavailabilityReason: "workspace_plan" },
   ],
-  unavailabilityReason: null,
+  lockReason: null,
 };
 
 function withAvailability(
@@ -42,8 +42,8 @@ function withAvailability(
 
 function streamModel(
   modelId: ModelStreamIdType,
-  unavailabilityReason: ModelSelectionUnavailabilityReason | null,
-  isSelectable = unavailabilityReason !== "model_tier"
+  lockReason: ModelSelectionLockReason | null,
+  isSelectable = lockReason !== "model_access"
 ): EnabledModelConfigurationType {
   return {
     ...withAvailability(
@@ -55,7 +55,7 @@ function streamModel(
       {
         defaultReasoningEffort: "none",
         reasoningEfforts: [],
-        unavailabilityReason,
+        lockReason,
       }
     ),
     isSelectable,
@@ -93,12 +93,15 @@ describe("modelPickerUtils", () => {
       })
     ).toBe("This model doesn't support High reasoning.");
     expect(
-      getEffortStopTooltip({ effort: "high", unavailabilityReason: "premium" })
-    ).toBe(PREMIUM_MODEL_LOCKED_TOOLTIP);
+      getEffortStopTooltip({
+        effort: "high",
+        unavailabilityReason: "workspace_plan",
+      })
+    ).toBe(WORKSPACE_PLAN_LOCKED_TOOLTIP);
     expect(
       getEffortStopTooltip({
         effort: "medium",
-        unavailabilityReason: "model_tier",
+        unavailabilityReason: "model_access",
       })
     ).toBe(
       "Your current model access doesn't include this option. " +
@@ -110,14 +113,14 @@ describe("modelPickerUtils", () => {
     it("uses the stream model's backend-owned lock reason", () => {
       expect(
         getTierLockReason("complex", [
-          streamModel(AUTO_COMPLEX_MODEL_ID, "model_tier"),
+          streamModel(AUTO_COMPLEX_MODEL_ID, "model_access"),
         ])
-      ).toBe("model_tier");
+      ).toBe("model_access");
       expect(
         getTierLockReason("complex", [
-          streamModel(AUTO_COMPLEX_MODEL_ID, "premium"),
+          streamModel(AUTO_COMPLEX_MODEL_ID, "workspace_plan"),
         ])
-      ).toBe("premium");
+      ).toBe("workspace_plan");
       expect(
         getTierLockReason("fast", [streamModel(AUTO_FAST_MODEL_ID, null)])
       ).toBeNull();
@@ -129,7 +132,7 @@ describe("modelPickerUtils", () => {
 
     it("defaults to Basic when Standard is above the member's tier cap", () => {
       expect(
-        getDefaultTierId([streamModel(AUTO_MODEL_ID, "model_tier", false)])
+        getDefaultTierId([streamModel(AUTO_MODEL_ID, "model_access", false)])
       ).toBe("fast");
     });
 

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -3,17 +3,16 @@ import {
   getEffortStops,
   getEffortStopTooltip,
   getInitialEffort,
+  getModelLockReason,
   getTierLockReason,
-  isPremiumModel,
   PREMIUM_MODEL_LOCKED_TOOLTIP,
 } from "@app/components/model_picker/modelPickerUtils";
-import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
-import {
-  CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
-  CLAUDE_OPUS_4_8_MODEL_ID,
-  CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_5_MODEL_ID,
-} from "@app/types/assistant/models/anthropic";
+import type {
+  EnabledModelConfigurationType,
+  ModelSelectionAvailabilityType,
+  ModelSelectionUnavailabilityReason,
+} from "@app/types/api/assistant/models";
+import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
 import {
   AUTO_COMPLEX_MODEL_CONFIG,
@@ -21,214 +20,124 @@ import {
   AUTO_FAST_MODEL_ID,
   AUTO_MODEL_ID,
 } from "@app/types/assistant/models/auto";
-import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
-import { getTierForModel } from "@app/types/assistant/models/model_tiers";
-import { O1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
-import type { ModelIdType } from "@app/types/assistant/models/types";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { describe, expect, it } from "vitest";
 
-const GATED = { lockPremiumEfforts: true };
-const UNGATED = { lockPremiumEfforts: false };
+const SONNET_AVAILABILITY: ModelSelectionAvailabilityType = {
+  defaultReasoningEffort: "medium",
+  reasoningEfforts: [
+    { effort: "light", unavailabilityReason: null },
+    { effort: "medium", unavailabilityReason: null },
+    { effort: "high", unavailabilityReason: "premium" },
+  ],
+  unavailabilityReason: null,
+};
 
-const unavailabilityReasonByEffort = (
-  stops: ReturnType<typeof getEffortStops>
-): Record<string, string | null> =>
-  Object.fromEntries(
-    stops.map((stop) => [stop.effort, stop.unavailabilityReason])
-  );
+function withAvailability(
+  model: ModelConfigurationType,
+  selectionAvailability: ModelSelectionAvailabilityType
+): EnabledModelConfigurationType {
+  return { ...model, isSelectable: true, selectionAvailability };
+}
 
-describe("modelPickerUtils premium gating", () => {
-  describe("getTierForModel", () => {
-    it("mirrors the static tier table", () => {
-      expect(getTierForModel(CLAUDE_OPUS_4_8_MODEL_ID, "light")).toBe(
-        "premium"
-      );
-      expect(getTierForModel(CLAUDE_SONNET_5_MODEL_ID, "light")).toBe(
-        "cost_efficient"
-      );
-      expect(getTierForModel(CLAUDE_SONNET_5_MODEL_ID, "medium")).toBe(
-        "balanced"
-      );
-      expect(getTierForModel(CLAUDE_SONNET_5_MODEL_ID, "high")).toBe("premium");
-    });
+function streamModel(
+  modelId: ModelStreamIdType,
+  unavailabilityReason: ModelSelectionUnavailabilityReason | null,
+  isSelectable = unavailabilityReason !== "model_tier"
+): EnabledModelConfigurationType {
+  return {
+    ...withAvailability(
+      {
+        ...AUTO_COMPLEX_MODEL_CONFIG,
+        modelId,
+        providerId: modelId,
+      },
+      {
+        defaultReasoningEffort: "none",
+        reasoningEfforts: [],
+        unavailabilityReason,
+      }
+    ),
+    isSelectable,
+  };
+}
 
-    it("treats models absent from the static table as premium", () => {
-      const customModelId = "my-custom-model-from-eap" as ModelIdType;
-      expect(getTierForModel(customModelId, "high")).toBe("premium");
-    });
+describe("modelPickerUtils", () => {
+  it("reads effort and model availability reported by the backend", () => {
+    const model = withAvailability(
+      CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+      SONNET_AVAILABILITY
+    );
+
+    expect(getEffortStops(model)).toEqual(SONNET_AVAILABILITY.reasoningEfforts);
+    expect(getInitialEffort(model)).toBe("medium");
+    expect(getModelLockReason(model)).toBeNull();
   });
 
-  describe("getEffortStops", () => {
-    it("locks premium efforts with reason 'premium' when gated (mixed model)", () => {
-      // Sonnet 5: light=cost_efficient, medium=balanced, high=premium.
-      const stops = getEffortStops(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED);
-      expect(unavailabilityReasonByEffort(stops)).toEqual({
-        light: null,
-        medium: null,
-        high: "premium",
-      });
-    });
-
-    it("locks every premium effort of a mid-tier reasoning model", () => {
-      // Gemini 2.5 Pro: light=balanced, medium=premium, high=premium.
-      const stops = getEffortStops(GEMINI_2_5_PRO_MODEL_CONFIG, GATED);
-      expect(unavailabilityReasonByEffort(stops)).toEqual({
-        light: null,
-        medium: "premium",
-        high: "premium",
-      });
-    });
-
-    it("does not lock anything when ungated", () => {
-      const stops = getEffortStops(
-        CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
-        UNGATED
-      );
-      expect(stops.every((stop) => stop.unavailabilityReason === null)).toBe(
-        true
-      );
-    });
+  it("falls back to the model default while an older response is in flight", () => {
+    expect(getEffortStops(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)).toEqual([]);
+    expect(getInitialEffort(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)).toBe(
+      CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
+    );
+    expect(getModelLockReason(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)).toBeNull();
   });
 
-  describe("getEffortStopTooltip", () => {
-    it("explains why an effort is unselectable", () => {
-      expect(
-        getEffortStopTooltip({
-          effort: "light",
-          unavailabilityReason: null,
-        })
-      ).toBeNull();
-      expect(
-        getEffortStopTooltip({
-          effort: "high",
-          unavailabilityReason: "unsupported",
-        })
-      ).toBe("This model doesn't support High reasoning.");
-      expect(
-        getEffortStopTooltip({
-          effort: "high",
-          unavailabilityReason: "premium",
-        })
-      ).toBe(PREMIUM_MODEL_LOCKED_TOOLTIP);
-      expect(
-        getEffortStopTooltip({
-          effort: "medium",
-          unavailabilityReason: "model_tier",
-        })
-      ).toBe(
-        "Your current model access doesn't include this option. " +
-          "Contact your administrator to get access."
-      );
-    });
+  it("explains why an effort is unselectable", () => {
+    expect(
+      getEffortStopTooltip({ effort: "light", unavailabilityReason: null })
+    ).toBeNull();
+    expect(
+      getEffortStopTooltip({
+        effort: "high",
+        unavailabilityReason: "unsupported",
+      })
+    ).toBe("This model doesn't support High reasoning.");
+    expect(
+      getEffortStopTooltip({ effort: "high", unavailabilityReason: "premium" })
+    ).toBe(PREMIUM_MODEL_LOCKED_TOOLTIP);
+    expect(
+      getEffortStopTooltip({
+        effort: "medium",
+        unavailabilityReason: "model_tier",
+      })
+    ).toBe(
+      "Your current model access doesn't include this option. " +
+        "Contact your administrator to get access."
+    );
   });
 
-  describe("isPremiumModel", () => {
-    it("locks a whole-premium reasoning model when gated", () => {
-      expect(isPremiumModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, GATED)).toBe(
-        true
-      );
-    });
-
-    it("locks a whole-premium non-reasoning model (only 'none') when gated", () => {
-      expect(isPremiumModel(O1_MODEL_CONFIG, GATED)).toBe(true);
-    });
-
-    it("keeps mixed models selectable when gated", () => {
-      expect(isPremiumModel(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED)).toBe(
-        false
-      );
-      expect(isPremiumModel(GEMINI_2_5_PRO_MODEL_CONFIG, GATED)).toBe(false);
-    });
-
-    it("never locks a model when ungated", () => {
+  describe("tier availability", () => {
+    it("uses the stream model's backend-owned lock reason", () => {
       expect(
-        isPremiumModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, UNGATED)
-      ).toBe(false);
-      expect(isPremiumModel(O1_MODEL_CONFIG, UNGATED)).toBe(false);
-    });
-  });
-
-  describe("getTierLockReason", () => {
-    const streamModel = (
-      modelId: ModelStreamIdType,
-      isSelectable: boolean
-    ): EnabledModelConfigurationType => ({
-      ...AUTO_COMPLEX_MODEL_CONFIG,
-      modelId,
-      providerId: modelId,
-      isSelectable,
-    });
-
-    it("locks a tier whose stream is above the member's cap", () => {
-      expect(
-        getTierLockReason("complex", {
-          ...UNGATED,
-          streamModels: [streamModel(AUTO_COMPLEX_MODEL_ID, false)],
-        })
+        getTierLockReason("complex", [
+          streamModel(AUTO_COMPLEX_MODEL_ID, "model_tier"),
+        ])
       ).toBe("model_tier");
       expect(
-        getTierLockReason("fast", {
-          ...UNGATED,
-          streamModels: [streamModel(AUTO_FAST_MODEL_ID, true)],
-        })
-      ).toBeNull();
-    });
-
-    it("locks the Premium tier on a legacy plan whatever the cap", () => {
-      expect(
-        getTierLockReason("complex", {
-          ...GATED,
-          streamModels: [streamModel(AUTO_COMPLEX_MODEL_ID, true)],
-        })
+        getTierLockReason("complex", [
+          streamModel(AUTO_COMPLEX_MODEL_ID, "premium"),
+        ])
       ).toBe("premium");
-    });
-
-    it("does not lock a tier whose stream is absent from the payload", () => {
       expect(
-        getTierLockReason("standard", { ...UNGATED, streamModels: [] })
+        getTierLockReason("fast", [streamModel(AUTO_FAST_MODEL_ID, null)])
       ).toBeNull();
     });
-  });
 
-  describe("getDefaultTierId", () => {
-    const streamModel = (
-      modelId: ModelStreamIdType,
-      isSelectable: boolean
-    ): EnabledModelConfigurationType => ({
-      ...AUTO_COMPLEX_MODEL_CONFIG,
-      modelId,
-      providerId: modelId,
-      isSelectable,
+    it("leaves a tier unlocked until its stream model is loaded", () => {
+      expect(getTierLockReason("standard", [])).toBeNull();
     });
 
-    it("falls back to Basic when Standard is above the member's cap", () => {
-      expect(getDefaultTierId([streamModel(AUTO_MODEL_ID, false)])).toBe(
-        "fast"
-      );
+    it("defaults to Basic when Standard is above the member's tier cap", () => {
+      expect(
+        getDefaultTierId([streamModel(AUTO_MODEL_ID, "model_tier", false)])
+      ).toBe("fast");
     });
 
-    it("keeps Standard when the member can run it, or while the payload is in flight", () => {
-      expect(getDefaultTierId([streamModel(AUTO_MODEL_ID, true)])).toBe(
+    it("defaults to Standard when selectable or still loading", () => {
+      expect(getDefaultTierId([streamModel(AUTO_MODEL_ID, null)])).toBe(
         "standard"
       );
       expect(getDefaultTierId([])).toBe("standard");
-    });
-  });
-
-  describe("getInitialEffort", () => {
-    it("never returns a premium effort when gated (mixed models)", () => {
-      expect(
-        getTierForModel(
-          CLAUDE_SONNET_5_MODEL_ID,
-          getInitialEffort(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED)
-        )
-      ).not.toBe("premium");
-      expect(
-        getTierForModel(
-          GEMINI_2_5_PRO_MODEL_CONFIG.modelId,
-          getInitialEffort(GEMINI_2_5_PRO_MODEL_CONFIG, GATED)
-        )
-      ).not.toBe("premium");
     });
   });
 });

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -2,7 +2,7 @@ import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type {
   EnabledModelConfigurationType,
   ModelSelectionAvailabilityType,
-  ModelSelectionUnavailabilityReason,
+  ModelSelectionLockReason,
   ModelStreamResolutionsType,
   ReasoningEffortSelectionAvailabilityType,
 } from "@app/types/api/assistant/models";
@@ -23,16 +23,14 @@ import type {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import capitalize from "lodash/capitalize";
 
-// Shown when a whole-premium model row or a premium reasoning-effort stop is
-// locked because the workspace is on a legacy (non usage-based) plan.
-export const PREMIUM_MODEL_LOCKED_TOOLTIP =
+// Shown when a model or reasoning effort is locked by the workspace plan.
+export const WORKSPACE_PLAN_LOCKED_TOOLTIP =
   "This option isn't available on your workspace's current plan. " +
   "Contact your administrator to upgrade.";
 
-// Shown when a model row is locked because the model's tier is not enabled for
-// the workspace's current model-tier ceiling (independent of the plan: this
-// applies even on usage-based plans whose tier grants stop below the model).
-const MODEL_TIER_LOCKED_TOOLTIP =
+// Shown when a model or reasoning effort is outside the model access granted
+// through the workspace, a group, or the member directly.
+const MODEL_ACCESS_LOCKED_TOOLTIP =
   "Your current model access doesn't include this option. " +
   "Contact your administrator to get access.";
 
@@ -101,7 +99,7 @@ export function getTierLockReason(
   // payload lands (`useModels` returns an empty list while it is in flight), so
   // locking on absence would flash every row locked on each open. Default to
   // unlocked — the server refuses an out-of-tier stream at send time anyway.
-  return streamModel?.selectionAvailability?.unavailabilityReason ?? null;
+  return streamModel?.selectionAvailability?.lockReason ?? null;
 }
 
 export function getTierIdForMetaModelId(modelId: string): ModelTierId | null {
@@ -188,11 +186,11 @@ export interface ModelPickerSelectionModel {
   onRevert?: () => void;
 }
 
-export type ModelLockReason = ModelSelectionUnavailabilityReason;
+export type ModelLockReason = ModelSelectionLockReason;
 
 // One stop of the reasoning-effort slider. A null reason means it is available.
-// Unsupported efforts are unavailable; premium and model-tier efforts are
-// locked behind access controls.
+// Unsupported efforts are unavailable; workspace-plan and model-access
+// restrictions are locks.
 export type EffortStop = ReasoningEffortSelectionAvailabilityType;
 
 export function buildTierSelection(tierId: ModelTierId): ModelSelectionType {
@@ -321,15 +319,15 @@ export function getInitialEffort(
 export function getModelLockReason(
   model: ModelConfigurationType
 ): ModelLockReason | null {
-  return getSelectionAvailability(model)?.unavailabilityReason ?? null;
+  return getSelectionAvailability(model)?.lockReason ?? null;
 }
 
 export function getModelLockTooltip(reason: ModelLockReason): string {
   switch (reason) {
-    case "premium":
-      return PREMIUM_MODEL_LOCKED_TOOLTIP;
-    case "model_tier":
-      return MODEL_TIER_LOCKED_TOOLTIP;
+    case "workspace_plan":
+      return WORKSPACE_PLAN_LOCKED_TOOLTIP;
+    case "model_access":
+      return MODEL_ACCESS_LOCKED_TOOLTIP;
     default:
       assertNeverAndIgnore(reason);
       return "";
@@ -338,10 +336,10 @@ export function getModelLockTooltip(reason: ModelLockReason): string {
 
 export function getEffortStopTooltip(stop: EffortStop): string | null {
   switch (stop.unavailabilityReason) {
-    case "premium":
-      return PREMIUM_MODEL_LOCKED_TOOLTIP;
-    case "model_tier":
-      return MODEL_TIER_LOCKED_TOOLTIP;
+    case "workspace_plan":
+      return WORKSPACE_PLAN_LOCKED_TOOLTIP;
+    case "model_access":
+      return MODEL_ACCESS_LOCKED_TOOLTIP;
     case "unsupported":
       return `This model doesn't support ${capitalize(stop.effort)} reasoning.`;
     case null:

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -23,14 +23,15 @@ import type {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import capitalize from "lodash/capitalize";
 
-// Shown when a model or reasoning effort is locked by the workspace plan.
-export const WORKSPACE_PLAN_LOCKED_TOOLTIP =
+// Shown when the workspace is not entitled to a premium model or reasoning
+// effort.
+export const PREMIUM_ENTITLEMENT_LOCKED_TOOLTIP =
   "This option isn't available on your workspace's current plan. " +
   "Contact your administrator to upgrade.";
 
-// Shown when a model or reasoning effort is outside the model access granted
+// Shown when a model or reasoning effort exceeds the tier limit granted
 // through the workspace, a group, or the member directly.
-const MODEL_ACCESS_LOCKED_TOOLTIP =
+const TIER_LIMIT_LOCKED_TOOLTIP =
   "Your current model access doesn't include this option. " +
   "Contact your administrator to get access.";
 
@@ -189,8 +190,8 @@ export interface ModelPickerSelectionModel {
 export type ModelLockReason = ModelSelectionLockReason;
 
 // One stop of the reasoning-effort slider. A null reason means it is available.
-// Unsupported efforts are unavailable; workspace-plan and model-access
-// restrictions are locks.
+// Unsupported efforts are unavailable; missing premium entitlement and tier
+// limits are locks.
 export type EffortStop = ReasoningEffortSelectionAvailabilityType;
 
 export function buildTierSelection(tierId: ModelTierId): ModelSelectionType {
@@ -324,10 +325,10 @@ export function getModelLockReason(
 
 export function getModelLockTooltip(reason: ModelLockReason): string {
   switch (reason) {
-    case "workspace_plan":
-      return WORKSPACE_PLAN_LOCKED_TOOLTIP;
-    case "model_access":
-      return MODEL_ACCESS_LOCKED_TOOLTIP;
+    case "premium_entitlement":
+      return PREMIUM_ENTITLEMENT_LOCKED_TOOLTIP;
+    case "tier_limit":
+      return TIER_LIMIT_LOCKED_TOOLTIP;
     default:
       assertNeverAndIgnore(reason);
       return "";
@@ -336,10 +337,10 @@ export function getModelLockTooltip(reason: ModelLockReason): string {
 
 export function getEffortStopTooltip(stop: EffortStop): string | null {
   switch (stop.unavailabilityReason) {
-    case "workspace_plan":
-      return WORKSPACE_PLAN_LOCKED_TOOLTIP;
-    case "model_access":
-      return MODEL_ACCESS_LOCKED_TOOLTIP;
+    case "premium_entitlement":
+      return PREMIUM_ENTITLEMENT_LOCKED_TOOLTIP;
+    case "tier_limit":
+      return TIER_LIMIT_LOCKED_TOOLTIP;
     case "unsupported":
       return `This model doesn't support ${capitalize(stop.effort)} reasoning.`;
     case null:

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -1,7 +1,10 @@
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type {
   EnabledModelConfigurationType,
+  ModelSelectionAvailabilityType,
+  ModelSelectionUnavailabilityReason,
   ModelStreamResolutionsType,
+  ReasoningEffortSelectionAvailabilityType,
 } from "@app/types/api/assistant/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
@@ -11,19 +14,12 @@ import {
   AUTO_MODEL_ID,
   isModelStreamId,
 } from "@app/types/assistant/models/auto";
-import {
-  getTierForModel,
-  STATIC_MODEL_SUPPORTED_REASONING_EFFORTS,
-} from "@app/types/assistant/models/model_tiers";
-import { isStaticModelId } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
-  ModelIdType,
   ModelMakerIdType,
   ModelSelectionType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
-import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import capitalize from "lodash/capitalize";
 
@@ -93,25 +89,10 @@ export function getModelTier(tierId: ModelTierId): ModelTierDefinition {
   );
 }
 
-const PREMIUM_MODEL_TIER_IDS: ModelTierId[] = ["complex"];
-
-// A tier row is locked either because the workspace is on a legacy plan without
-// premium access, or because the stream's own model tier is above the member's
-// cap — the server refuses such a selection, so the picker must not offer it.
 export function getTierLockReason(
   tierId: ModelTierId,
-  {
-    lockPremiumEfforts,
-    streamModels,
-  }: {
-    lockPremiumEfforts: boolean;
-    streamModels: EnabledModelConfigurationType[];
-  }
+  streamModels: EnabledModelConfigurationType[]
 ): ModelLockReason | null {
-  if (lockPremiumEfforts && PREMIUM_MODEL_TIER_IDS.includes(tierId)) {
-    return "premium";
-  }
-
   const { metaModelId } = getModelTier(tierId);
   const streamModel = streamModels.find(
     (model) => model.modelId === metaModelId
@@ -120,11 +101,7 @@ export function getTierLockReason(
   // payload lands (`useModels` returns an empty list while it is in flight), so
   // locking on absence would flash every row locked on each open. Default to
   // unlocked — the server refuses an out-of-tier stream at send time anyway.
-  if (streamModel && !streamModel.isSelectable) {
-    return "model_tier";
-  }
-
-  return null;
+  return streamModel?.selectionAvailability?.unavailabilityReason ?? null;
 }
 
 export function getTierIdForMetaModelId(modelId: string): ModelTierId | null {
@@ -211,21 +188,12 @@ export interface ModelPickerSelectionModel {
   onRevert?: () => void;
 }
 
-export type ModelLockReason = "premium" | "model_tier";
-export type EffortUnavailabilityReason = "unsupported" | ModelLockReason;
+export type ModelLockReason = ModelSelectionUnavailabilityReason;
 
 // One stop of the reasoning-effort slider. A null reason means it is available.
 // Unsupported efforts are unavailable; premium and model-tier efforts are
 // locked behind access controls.
-export interface EffortStop {
-  effort: ReasoningEffort;
-  unavailabilityReason: EffortUnavailabilityReason | null;
-}
-
-// The reasoning-effort slider always presents these three canonical levels so
-// its shape stays consistent across models. "none" is not a level here: it
-// means "no reasoning" and is never a selectable slider position.
-const SLIDER_EFFORTS: ReasoningEffort[] = ["light", "medium", "high"];
+export type EffortStop = ReasoningEffortSelectionAvailabilityType;
 
 export function buildTierSelection(tierId: ModelTierId): ModelSelectionType {
   const { metaModelId } = getModelTier(tierId);
@@ -323,115 +291,37 @@ export function isSameSelection(
   return isSameDisplay(a, b);
 }
 
-interface LockPremiumOptions {
-  lockPremiumEfforts?: boolean;
+function hasSelectionAvailability(
+  model: ModelConfigurationType
+): model is ModelConfigurationType & {
+  selectionAvailability: ModelSelectionAvailabilityType;
+} {
+  return "selectionAvailability" in model;
 }
 
-function modelSupportsEffortStatically(
-  modelId: ModelIdType,
-  effort: ReasoningEffort
-): boolean {
-  if (!isStaticModelId(modelId)) {
-    return false;
-  }
-  return STATIC_MODEL_SUPPORTED_REASONING_EFFORTS[modelId][effort];
+export function getSelectionAvailability(
+  model: ModelConfigurationType
+): ModelSelectionAvailabilityType | null {
+  return hasSelectionAvailability(model) ? model.selectionAvailability : null;
 }
 
-// The single authority for whether a reasoning-effort level is selectable.
-export function getEffortStops(
-  enabledModel: ModelConfigurationType,
-  { lockPremiumEfforts = false }: LockPremiumOptions = {}
-): EffortStop[] {
-  const allowed = new Set(
-    getAvailableReasoningEfforts(enabledModel.supportedReasoningEfforts)
-  );
-
-  return SLIDER_EFFORTS.map((effort) => {
-    if (!allowed.has(effort)) {
-      return {
-        effort,
-        unavailabilityReason: modelSupportsEffortStatically(
-          enabledModel.modelId,
-          effort
-        )
-          ? "model_tier"
-          : "unsupported",
-      };
-    }
-    if (
-      lockPremiumEfforts &&
-      getTierForModel(enabledModel.modelId, effort) === "premium"
-    ) {
-      return { effort, unavailabilityReason: "premium" };
-    }
-    return { effort, unavailabilityReason: null };
-  });
+export function getEffortStops(model: ModelConfigurationType): EffortStop[] {
+  return getSelectionAvailability(model)?.reasoningEfforts ?? [];
 }
 
-// The reasoning effort to use when a model is freshly selected: its default when
-// that is allowed, otherwise the first available stop.
 export function getInitialEffort(
-  enabledModel: ModelConfigurationType,
-  options: LockPremiumOptions = {}
+  model: ModelConfigurationType
 ): ReasoningEffort {
-  const stops = getEffortStops(enabledModel, options);
-  const preferred = stops.find(
-    (stop) =>
-      stop.effort === enabledModel.defaultReasoningEffort &&
-      stop.unavailabilityReason === null
-  );
-  if (preferred) {
-    return preferred.effort;
-  }
   return (
-    stops.find((stop) => stop.unavailabilityReason === null)?.effort ?? "none"
+    getSelectionAvailability(model)?.defaultReasoningEffort ??
+    model.defaultReasoningEffort
   );
-}
-
-function isReasoningModel(modelId: ModelIdType): boolean {
-  if (!isStaticModelId(modelId)) {
-    return false;
-  }
-  const support = STATIC_MODEL_SUPPORTED_REASONING_EFFORTS[modelId];
-  return SLIDER_EFFORTS.some((effort) => support[effort]);
-}
-
-// Whether a whole model row must be locked
-export function isPremiumModel(
-  enabledModel: ModelConfigurationType,
-  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
-): boolean {
-  const stops = getEffortStops(enabledModel, { lockPremiumEfforts });
-  const hasUsableSliderEffort = stops.some(
-    (stop) => stop.unavailabilityReason === null
-  );
-
-  if (isReasoningModel(enabledModel.modelId) && !hasUsableSliderEffort) {
-    return true;
-  }
-
-  if (!lockPremiumEfforts) {
-    return false;
-  }
-  const supportedSlider = stops.filter(
-    (stop) => stop.unavailabilityReason !== "unsupported"
-  );
-  if (supportedSlider.length > 0) {
-    return supportedSlider.every(
-      (stop) => stop.unavailabilityReason === "premium"
-    );
-  }
-  return getTierForModel(enabledModel.modelId, "none") === "premium";
 }
 
 export function getModelLockReason(
-  enabledModel: ModelConfigurationType,
-  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
+  model: ModelConfigurationType
 ): ModelLockReason | null {
-  if (!isPremiumModel(enabledModel, { lockPremiumEfforts })) {
-    return null;
-  }
-  return lockPremiumEfforts ? "premium" : "model_tier";
+  return getSelectionAvailability(model)?.unavailabilityReason ?? null;
 }
 
 export function getModelLockTooltip(reason: ModelLockReason): string {

--- a/front/components/model_picker/useModelPickerModels.ts
+++ b/front/components/model_picker/useModelPickerModels.ts
@@ -1,6 +1,5 @@
 import type { MakerGroup } from "@app/components/model_picker/modelPickerUtils";
 import { MODEL_TIERS } from "@app/components/model_picker/modelPickerUtils";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { useModels } from "@app/lib/swr/models";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -9,7 +8,6 @@ import type {
   ModelConfigurationType,
   ModelMakerIdType,
 } from "@app/types/assistant/models/types";
-import { isCreditPricedPlan } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";
 
@@ -33,14 +31,7 @@ export function useModelPickerModels({
   // catalog.
   modelIds?: string[];
 }) {
-  const { hasFeature } = useFeatureFlags();
-  const { subscription } = useAuth();
-  const canSelectPremiumModels =
-    isCreditPricedPlan(subscription.plan) ||
-    subscription.plan.hasAdvancedModelAccess ||
-    hasFeature("claude_4_5_opus_feature");
   const isFilterMode = mode === "filter";
-  const lockPremiumEfforts = !canSelectPremiumModels;
 
   const { models, streams, degradedModelIds, isModelsLoading } = useModels({
     owner,
@@ -110,7 +101,6 @@ export function useModelPickerModels({
 
   return {
     modelProps: {
-      lockPremiumEfforts,
       ignoreTierRestrictions: isFilterMode,
       tiers,
       degradedModelIds,
@@ -124,6 +114,5 @@ export function useModelPickerModels({
     streamModels,
     degradedModelIds,
     isModelsLoading,
-    lockPremiumEfforts,
   };
 }

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -17,6 +17,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export interface AvailableTool {
   sId: string;
@@ -41,9 +42,10 @@ export interface AvailableSkill {
  * plan, and workspace provider whitelisting.
  */
 export async function getAvailableModelsForWorkspace(
-  auth: Authenticator
+  auth: Authenticator,
+  preloadedFeatureFlags: WhitelistableFeature[] | null = null
 ): Promise<ModelConfigurationType[]> {
-  const featureFlags = await getFeatureFlags(auth);
+  const featureFlags = preloadedFeatureFlags ?? (await getFeatureFlags(auth));
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.plan();
   const region = regionConfig.getCurrentRegion();

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -123,7 +123,7 @@ describe("withModelSelectability", () => {
     expect(sonnet?.selectionAvailability?.reasoningEfforts).toEqual([
       { effort: "light", unavailabilityReason: null },
       { effort: "medium", unavailabilityReason: null },
-      { effort: "high", unavailabilityReason: "model_tier" },
+      { effort: "high", unavailabilityReason: "model_access" },
     ]);
   });
 
@@ -220,17 +220,17 @@ describe("getModelsForAuth", () => {
       reasoningEfforts: [
         { effort: "light", unavailabilityReason: null },
         { effort: "medium", unavailabilityReason: null },
-        { effort: "high", unavailabilityReason: "premium" },
+        { effort: "high", unavailabilityReason: "workspace_plan" },
       ],
-      unavailabilityReason: null,
+      lockReason: null,
     });
     expect(singleEffortModel?.selectionAvailability?.reasoningEfforts).toEqual([
       { effort: "light", unavailabilityReason: "unsupported" },
       { effort: "medium", unavailabilityReason: "unsupported" },
       { effort: "high", unavailabilityReason: null },
     ]);
-    expect(premiumStream?.selectionAvailability?.unavailabilityReason).toBe(
-      "premium"
+    expect(premiumStream?.selectionAvailability?.lockReason).toBe(
+      "workspace_plan"
     );
     expect(defaultModel.selectionAvailability).toBeDefined();
   });
@@ -251,9 +251,7 @@ describe("getModelsForAuth", () => {
       effort: "high",
       unavailabilityReason: null,
     });
-    expect(
-      premiumStream?.selectionAvailability?.unavailabilityReason
-    ).toBeNull();
+    expect(premiumStream?.selectionAvailability?.lockReason).toBeNull();
   });
 });
 

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -3,6 +3,7 @@ import { setUserMaxAllowedTier } from "@app/lib/model_tiers/allowed_tiers";
 import {
   getDefaultModelFromEnabledModels,
   getEnabledModelsForAuth,
+  getModelsForAuth,
   resolveStreamModel,
   withModelSelectability,
 } from "@app/lib/model_tiers/enabled_models";
@@ -22,6 +23,7 @@ import {
   AUTO_MODEL_CONFIG,
   MODEL_STREAMS,
 } from "@app/types/assistant/models/auto";
+import { FIREWORKS_GLM_5P2_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
 import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -109,6 +111,22 @@ describe("withModelSelectability", () => {
     expect(model.defaultReasoningEffort).toBe("medium");
   });
 
+  it("reports tier-capped efforts as unavailable in the models response", async () => {
+    const auth = await userAuthForTierCap("balanced");
+
+    const { models } = await getModelsForAuth(auth);
+    const sonnet = models.find(
+      (model) =>
+        model.modelId === CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+
+    expect(sonnet?.selectionAvailability?.reasoningEfforts).toEqual([
+      { effort: "light", unavailabilityReason: null },
+      { effort: "medium", unavailabilityReason: null },
+      { effort: "high", unavailabilityReason: "model_tier" },
+    ]);
+  });
+
   it("marks frontier-only models as not selectable when capped at balanced", async () => {
     const auth = await userAuthForTierCap("balanced");
 
@@ -172,6 +190,70 @@ describe("withModelSelectability", () => {
     expect(model.supportedReasoningEfforts).toEqual(
       CUSTOM_MODEL_CONFIG.supportedReasoningEfforts
     );
+  });
+});
+
+describe("getModelsForAuth", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let adminAuth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  it("reports complete selection availability for legacy plans", async () => {
+    const { models, defaultModel } = await getModelsForAuth(adminAuth);
+    const sonnet = models.find(
+      (model) =>
+        model.modelId === CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+    const singleEffortModel = models.find(
+      (model) => model.modelId === FIREWORKS_GLM_5P2_MODEL_CONFIG.modelId
+    );
+    const premiumStream = models.find(
+      (model) => model.modelId === AUTO_COMPLEX_MODEL_CONFIG.modelId
+    );
+
+    expect(sonnet?.selectionAvailability).toEqual({
+      defaultReasoningEffort: "medium",
+      reasoningEfforts: [
+        { effort: "light", unavailabilityReason: null },
+        { effort: "medium", unavailabilityReason: null },
+        { effort: "high", unavailabilityReason: "premium" },
+      ],
+      unavailabilityReason: null,
+    });
+    expect(singleEffortModel?.selectionAvailability?.reasoningEfforts).toEqual([
+      { effort: "light", unavailabilityReason: "unsupported" },
+      { effort: "medium", unavailabilityReason: "unsupported" },
+      { effort: "high", unavailabilityReason: null },
+    ]);
+    expect(premiumStream?.selectionAvailability?.unavailabilityReason).toBe(
+      "premium"
+    );
+    expect(defaultModel.selectionAvailability).toBeDefined();
+  });
+
+  it("uses the workspace feature flag to unlock premium options", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "claude_4_5_opus_feature");
+
+    const { models } = await getModelsForAuth(adminAuth);
+    const sonnet = models.find(
+      (model) =>
+        model.modelId === CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+    const premiumStream = models.find(
+      (model) => model.modelId === AUTO_COMPLEX_MODEL_CONFIG.modelId
+    );
+
+    expect(sonnet?.selectionAvailability?.reasoningEfforts).toContainEqual({
+      effort: "high",
+      unavailabilityReason: null,
+    });
+    expect(
+      premiumStream?.selectionAvailability?.unavailabilityReason
+    ).toBeNull();
   });
 });
 

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -123,7 +123,7 @@ describe("withModelSelectability", () => {
     expect(sonnet?.selectionAvailability?.reasoningEfforts).toEqual([
       { effort: "light", unavailabilityReason: null },
       { effort: "medium", unavailabilityReason: null },
-      { effort: "high", unavailabilityReason: "model_access" },
+      { effort: "high", unavailabilityReason: "tier_limit" },
     ]);
   });
 
@@ -220,7 +220,7 @@ describe("getModelsForAuth", () => {
       reasoningEfforts: [
         { effort: "light", unavailabilityReason: null },
         { effort: "medium", unavailabilityReason: null },
-        { effort: "high", unavailabilityReason: "workspace_plan" },
+        { effort: "high", unavailabilityReason: "premium_entitlement" },
       ],
       lockReason: null,
     });
@@ -230,7 +230,7 @@ describe("getModelsForAuth", () => {
       { effort: "high", unavailabilityReason: null },
     ]);
     expect(premiumStream?.selectionAvailability?.lockReason).toBe(
-      "workspace_plan"
+      "premium_entitlement"
     );
     expect(defaultModel.selectionAvailability).toBeDefined();
   });

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -2,12 +2,16 @@ import { getDegradedModelIds } from "@app/lib/api/assistant/degraded_models";
 import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
 import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { resolveAllowedTierNames } from "@app/lib/model_tiers/allowed_tiers";
 import type {
   EnabledModelConfigurationType,
   GetEnabledModelsResponseType,
+  ModelSelectionAvailabilityType,
+  ModelSelectionUnavailabilityReason,
   ModelStreamResolutionsType,
   ModelStreamResolutionType,
+  ReasoningEffortSelectionUnavailabilityReason,
 } from "@app/types/api/assistant/models";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
 import {
@@ -30,11 +34,120 @@ import type {
   ReasoningEffortSupport,
 } from "@app/types/assistant/models/types";
 import { getMaximumReasoningEffort } from "@app/types/assistant/models/types";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+const PICKER_REASONING_EFFORTS: ReasoningEffort[] = ["light", "medium", "high"];
 
 function isStaticModel(
   modelId: string
 ): modelId is keyof typeof STATIC_MODEL_TIERS {
   return modelId in STATIC_MODEL_TIERS;
+}
+
+function canSelectPremiumOptions(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[]
+): boolean {
+  const plan = auth.plan();
+
+  return (
+    (plan !== null &&
+      (isCreditPricedPlan(plan) || plan.hasAdvancedModelAccess)) ||
+    featureFlags.includes("claude_4_5_opus_feature")
+  );
+}
+
+function getEffortUnavailabilityReason(
+  model: ModelConfigurationType,
+  enabledModel: EnabledModelConfigurationType,
+  effort: ReasoningEffort,
+  premiumOptionsAreSelectable: boolean
+): ReasoningEffortSelectionUnavailabilityReason | null {
+  if (!model.supportedReasoningEfforts[effort]) {
+    return "unsupported";
+  }
+
+  if (!enabledModel.supportedReasoningEfforts[effort]) {
+    return "model_tier";
+  }
+
+  if (
+    !premiumOptionsAreSelectable &&
+    getTierForModel(model.modelId, effort) === "premium"
+  ) {
+    return "premium";
+  }
+
+  return null;
+}
+
+function getSelectionAvailability(
+  model: ModelConfigurationType,
+  enabledModel: EnabledModelConfigurationType,
+  premiumOptionsAreSelectable: boolean
+): ModelSelectionAvailabilityType {
+  const usesReasoningEffort = PICKER_REASONING_EFFORTS.some(
+    (effort) => model.supportedReasoningEfforts[effort]
+  );
+  const efforts: ReasoningEffort[] = usesReasoningEffort
+    ? PICKER_REASONING_EFFORTS
+    : ["none"];
+  const options = efforts.map((effort) => ({
+    effort,
+    unavailabilityReason: getEffortUnavailabilityReason(
+      model,
+      enabledModel,
+      effort,
+      premiumOptionsAreSelectable
+    ),
+  }));
+  const selectableOptions = options.filter(
+    ({ unavailabilityReason }) => unavailabilityReason === null
+  );
+
+  let unavailabilityReason: ModelSelectionUnavailabilityReason | null = null;
+  if (selectableOptions.length === 0) {
+    if (
+      options.some((option) => option.unavailabilityReason === "model_tier")
+    ) {
+      unavailabilityReason = "model_tier";
+    } else if (
+      options.some((option) => option.unavailabilityReason === "premium")
+    ) {
+      unavailabilityReason = "premium";
+    }
+  }
+
+  const defaultOption = selectableOptions.find(
+    ({ effort }) => effort === enabledModel.defaultReasoningEffort
+  );
+
+  return {
+    defaultReasoningEffort:
+      defaultOption?.effort ?? selectableOptions[0]?.effort ?? "none",
+    reasoningEfforts: usesReasoningEffort ? options : [],
+    unavailabilityReason,
+  };
+}
+
+function withSelectionAvailability(
+  models: ModelConfigurationType[],
+  enabledModels: EnabledModelConfigurationType[],
+  premiumOptionsAreSelectable: boolean
+): EnabledModelConfigurationType[] {
+  return enabledModels.map((enabledModel, index) => {
+    // withModelSelectability preserves the input order and cardinality.
+    const model = models[index] ?? enabledModel;
+    return {
+      ...enabledModel,
+      selectionAvailability: getSelectionAvailability(
+        model,
+        enabledModel,
+        premiumOptionsAreSelectable
+      ),
+    };
+  });
 }
 
 function restrictModelConfigToAllowedTiers(
@@ -241,7 +354,19 @@ export function getStreamResolutions(
 export async function getModelsForAuth(
   auth: Authenticator
 ): Promise<GetEnabledModelsResponseType> {
-  const models = await getEnabledModelsForAuth(auth);
+  const featureFlags = await getFeatureFlags(auth);
+  const availableModels = await getAvailableModelsForWorkspace(
+    auth,
+    featureFlags
+  );
+  const enabledModels = await withModelSelectability(auth, {
+    models: availableModels,
+  });
+  const models = withSelectionAvailability(
+    availableModels,
+    enabledModels,
+    canSelectPremiumOptions(auth, featureFlags)
+  );
   const degradedModelIds = getDegradedModelIds();
 
   return {

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -69,14 +69,14 @@ function getEffortUnavailabilityReason(
   }
 
   if (!enabledModel.supportedReasoningEfforts[effort]) {
-    return "model_access";
+    return "tier_limit";
   }
 
   if (
     !premiumOptionsAreSelectable &&
     getTierForModel(model.modelId, effort) === "premium"
   ) {
-    return "workspace_plan";
+    return "premium_entitlement";
   }
 
   return null;
@@ -109,13 +109,15 @@ function getSelectionAvailability(
   let lockReason: ModelSelectionLockReason | null = null;
   if (selectableOptions.length === 0) {
     if (
-      options.some((option) => option.unavailabilityReason === "model_access")
+      options.some((option) => option.unavailabilityReason === "tier_limit")
     ) {
-      lockReason = "model_access";
+      lockReason = "tier_limit";
     } else if (
-      options.some((option) => option.unavailabilityReason === "workspace_plan")
+      options.some(
+        (option) => option.unavailabilityReason === "premium_entitlement"
+      )
     ) {
-      lockReason = "workspace_plan";
+      lockReason = "premium_entitlement";
     }
   }
 

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -8,7 +8,7 @@ import type {
   EnabledModelConfigurationType,
   GetEnabledModelsResponseType,
   ModelSelectionAvailabilityType,
-  ModelSelectionUnavailabilityReason,
+  ModelSelectionLockReason,
   ModelStreamResolutionsType,
   ModelStreamResolutionType,
   ReasoningEffortSelectionUnavailabilityReason,
@@ -69,14 +69,14 @@ function getEffortUnavailabilityReason(
   }
 
   if (!enabledModel.supportedReasoningEfforts[effort]) {
-    return "model_tier";
+    return "model_access";
   }
 
   if (
     !premiumOptionsAreSelectable &&
     getTierForModel(model.modelId, effort) === "premium"
   ) {
-    return "premium";
+    return "workspace_plan";
   }
 
   return null;
@@ -106,16 +106,16 @@ function getSelectionAvailability(
     ({ unavailabilityReason }) => unavailabilityReason === null
   );
 
-  let unavailabilityReason: ModelSelectionUnavailabilityReason | null = null;
+  let lockReason: ModelSelectionLockReason | null = null;
   if (selectableOptions.length === 0) {
     if (
-      options.some((option) => option.unavailabilityReason === "model_tier")
+      options.some((option) => option.unavailabilityReason === "model_access")
     ) {
-      unavailabilityReason = "model_tier";
+      lockReason = "model_access";
     } else if (
-      options.some((option) => option.unavailabilityReason === "premium")
+      options.some((option) => option.unavailabilityReason === "workspace_plan")
     ) {
-      unavailabilityReason = "premium";
+      lockReason = "workspace_plan";
     }
   }
 
@@ -127,7 +127,7 @@ function getSelectionAvailability(
     defaultReasoningEffort:
       defaultOption?.effort ?? selectableOptions[0]?.effort ?? "none",
     reasoningEfforts: usesReasoningEffort ? options : [],
-    unavailabilityReason,
+    lockReason,
   };
 }
 

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -7,7 +7,30 @@ import type {
 
 export type EnabledModelConfigurationType = ModelConfigurationType & {
   isSelectable: boolean;
+  // Added by the models endpoint. Optional for compatibility with responses
+  // produced by an older server during a rolling deployment.
+  selectionAvailability?: ModelSelectionAvailabilityType;
 };
+
+export type ModelSelectionUnavailabilityReason = "premium" | "model_tier";
+
+export type ReasoningEffortSelectionUnavailabilityReason =
+  | "unsupported"
+  | ModelSelectionUnavailabilityReason;
+
+export interface ReasoningEffortSelectionAvailabilityType {
+  effort: ReasoningEffort;
+  // null means this exact model + reasoning effort can be selected.
+  unavailabilityReason: ReasoningEffortSelectionUnavailabilityReason | null;
+}
+
+export interface ModelSelectionAvailabilityType {
+  defaultReasoningEffort: ReasoningEffort;
+  // Reasoning models always report Light, Medium, and High so the slider keeps
+  // a stable shape. Non-reasoning models report no effort stops.
+  reasoningEfforts: ReasoningEffortSelectionAvailabilityType[];
+  unavailabilityReason: ModelSelectionUnavailabilityReason | null;
+}
 
 export type ModelStreamResolutionType = {
   providerId: ModelProviderIdType;

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -12,11 +12,11 @@ export type EnabledModelConfigurationType = ModelConfigurationType & {
   selectionAvailability?: ModelSelectionAvailabilityType;
 };
 
-export type ModelSelectionUnavailabilityReason = "premium" | "model_tier";
+export type ModelSelectionLockReason = "workspace_plan" | "model_access";
 
 export type ReasoningEffortSelectionUnavailabilityReason =
   | "unsupported"
-  | ModelSelectionUnavailabilityReason;
+  | ModelSelectionLockReason;
 
 export interface ReasoningEffortSelectionAvailabilityType {
   effort: ReasoningEffort;
@@ -29,7 +29,7 @@ export interface ModelSelectionAvailabilityType {
   // Reasoning models always report Light, Medium, and High so the slider keeps
   // a stable shape. Non-reasoning models report no effort stops.
   reasoningEfforts: ReasoningEffortSelectionAvailabilityType[];
-  unavailabilityReason: ModelSelectionUnavailabilityReason | null;
+  lockReason: ModelSelectionLockReason | null;
 }
 
 export type ModelStreamResolutionType = {

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -12,7 +12,10 @@ export type EnabledModelConfigurationType = ModelConfigurationType & {
   selectionAvailability?: ModelSelectionAvailabilityType;
 };
 
-export type ModelSelectionLockReason = "workspace_plan" | "model_access";
+// `premium_entitlement` means the workspace is not entitled to premium
+// options. `tier_limit` means the option exceeds the effective tier ceiling
+// granted through the workspace, a group, or the member directly.
+export type ModelSelectionLockReason = "premium_entitlement" | "tier_limit";
 
 export type ReasoningEffortSelectionUnavailabilityReason =
   | "unsupported"


### PR DESCRIPTION
## Description

The model picker currently recomputes premium model and reasoning-effort access in the browser, and the button picker and slash picker do not use the same checks.

This follow-up to #31365 makes `/api/w/:wId/models` report the availability of each model and reasoning effort, including `premium`, `model_tier`, and `unsupported` reasons. Both picker entry points now consume that response and no longer read plan or feature-flag state themselves. Model selection and enforcement remain unchanged.

## Tests

- Added coverage for backend availability across legacy plans, feature-flag access, tier caps, unsupported efforts, and the models endpoint.
- Updated model picker and slash picker tests.

## Risk

- Medium, affects the model and reasoning-effort options shown in the picker.

## Deploy Plan

- Deploy front.