### PR TITLE
Add direct Frames v2 function calls

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.54"
+version = "0.1.55"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,9 +9,9 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FrameCallRequest, FrameCallResponse, FramePublishRequest,
-    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, FrameShareLinkResponse,
-    MCPServerView, SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FrameCallByIdRequest, FrameCallFromSourceRequest,
+    FrameCallResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
+    FrameRegisterResponse, FrameShareLinkResponse, MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -145,7 +145,24 @@ impl DustApiClient {
         .await
     }
 
-    pub async fn call_frame(
+    pub async fn call_frame_by_id(
+        &self,
+        frame_id: &str,
+        function_name: &str,
+        input: Option<&serde_json::Value>,
+    ) -> anyhow::Result<FrameCallResponse> {
+        self.post_with_timeout(
+            &format!("sandbox/frames/{frame_id}/call"),
+            &FrameCallByIdRequest {
+                function_name,
+                input,
+            },
+            POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn call_frame_from_source(
         &self,
         source_path: &str,
         function_name: &str,
@@ -153,7 +170,7 @@ impl DustApiClient {
     ) -> anyhow::Result<FrameCallResponse> {
         self.post_with_timeout(
             "sandbox/frames/call",
-            &FrameCallRequest {
+            &FrameCallFromSourceRequest {
                 source_path,
                 function_name,
                 input,

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -9,9 +9,9 @@ use tokio::time::sleep;
 use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
-    CallToolResponse, CallToolResult, FramePublishRequest, FramePublishResponse,
-    FrameRegisterRequest, FrameRegisterResponse, FrameShareLinkResponse, MCPServerView,
-    SandboxServerViewsResponse,
+    CallToolResponse, CallToolResult, FrameCallRequest, FrameCallResponse, FramePublishRequest,
+    FramePublishResponse, FrameRegisterRequest, FrameRegisterResponse, FrameShareLinkResponse,
+    MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -139,6 +139,24 @@ impl DustApiClient {
             "sandbox/frames/publish",
             &FramePublishRequest {
                 manifest_path: source_path,
+            },
+            POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn call_frame(
+        &self,
+        source_path: &str,
+        function_name: &str,
+        input: Option<&serde_json::Value>,
+    ) -> anyhow::Result<FrameCallResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/call",
+            &FrameCallRequest {
+                source_path,
+                function_name,
+                input,
             },
             POLL_MAX_DURATION,
         )

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -5,7 +5,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FrameCallRequest<'a> {
+pub struct FrameCallByIdRequest<'a> {
+    pub function_name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<&'a serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameCallFromSourceRequest<'a> {
     pub source_path: &'a str,
     pub function_name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -5,6 +5,23 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct FrameCallRequest<'a> {
+    pub source_path: &'a str,
+    pub function_name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<&'a serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameCallResponse {
+    pub frame_id: String,
+    pub function_name: String,
+    pub result: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FramePublishRequest<'a> {
     pub manifest_path: &'a str,
 }

--- a/cli/dust-sandbox/src/commands/frame/call.rs
+++ b/cli/dust-sandbox/src/commands/frame/call.rs
@@ -1,0 +1,39 @@
+use std::path::Path;
+
+use anyhow::Context;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_path};
+
+pub async fn run(source: &Path, function_name: &str, input: Option<&str>) -> anyhow::Result<()> {
+    let source_path = scoped_path(source)?;
+    let input = parse_input(input)?;
+    let client = DustApiClient::from_env()?;
+    let response = client
+        .call_frame(&source_path, function_name, input.as_ref())
+        .await?;
+    print_response(&response)
+}
+
+fn parse_input(input: Option<&str>) -> anyhow::Result<Option<serde_json::Value>> {
+    input
+        .map(serde_json::from_str)
+        .transpose()
+        .context("input must be valid JSON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_optional_json_input() {
+        let input = parse_input(Some(r#"{"message":"hello"}"#))
+            .expect("valid JSON input")
+            .expect("present input");
+        assert_eq!(input["message"], "hello");
+        assert_eq!(parse_input(None).expect("absent input"), None);
+        assert!(parse_input(Some("{")).is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/frame/call.rs
+++ b/cli/dust-sandbox/src/commands/frame/call.rs
@@ -1,19 +1,40 @@
 use std::path::Path;
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 
 use crate::api::DustApiClient;
 
 use super::{print_response, scoped_path};
 
-pub async fn run(source: &Path, function_name: &str, input: Option<&str>) -> anyhow::Result<()> {
-    let source_path = scoped_path(source)?;
+pub async fn run(target: &str, function_name: &str, input: Option<&str>) -> anyhow::Result<()> {
     let input = parse_input(input)?;
     let client = DustApiClient::from_env()?;
-    let response = client
-        .call_frame(&source_path, function_name, input.as_ref())
-        .await?;
+    let response = if target.starts_with("fil_") {
+        validate_frame_id(target)?;
+        client
+            .call_frame_by_id(target, function_name, input.as_ref())
+            .await?
+    } else {
+        let source_path = scoped_path(Path::new(target))?;
+        client
+            .call_frame_from_source(&source_path, function_name, input.as_ref())
+            .await?
+    };
     print_response(&response)
+}
+
+fn validate_frame_id(frame_id: &str) -> anyhow::Result<()> {
+    let Some(encoded) = frame_id.strip_prefix("fil_") else {
+        bail!("invalid Frame ID: {frame_id}");
+    };
+    if encoded.is_empty()
+        || !encoded
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        bail!("invalid Frame ID: {frame_id}");
+    }
+    Ok(())
 }
 
 fn parse_input(input: Option<&str>) -> anyhow::Result<Option<serde_json::Value>> {
@@ -35,5 +56,12 @@ mod tests {
         assert_eq!(input["message"], "hello");
         assert_eq!(parse_input(None).expect("absent input"), None);
         assert!(parse_input(Some("{")).is_err());
+    }
+
+    #[test]
+    fn validates_frame_ids() {
+        assert!(validate_frame_id("fil_abc123XYZ").is_ok());
+        assert!(validate_frame_id("fil_bad/path").is_err());
+        assert!(validate_frame_id("fil_").is_err());
     }
 }

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -22,8 +22,8 @@ const FILES_ROOT: &str = "/files";
 pub enum FrameCommand {
     /// Invoke a named function from a Frame's active publication
     Call {
-        /// Absolute path to the Frame folder or manifest under /files
-        source: PathBuf,
+        /// Frame ID, or absolute path to its folder or manifest under /files
+        target: String,
         /// Bare function name declared in the manifest
         function_name: String,
         /// JSON input passed to the function

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -1,3 +1,4 @@
+mod call;
 mod create;
 mod publish;
 mod register;
@@ -8,6 +9,7 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{bail, Context};
 use clap::Subcommand;
 
+pub use call::run as cmd_frame_call;
 pub use create::run as cmd_frame_create;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
@@ -18,6 +20,16 @@ const FILES_ROOT: &str = "/files";
 
 #[derive(Subcommand)]
 pub enum FrameCommand {
+    /// Invoke a named function from a Frame's active publication
+    Call {
+        /// Absolute path to the Frame folder or manifest under /files
+        source: PathBuf,
+        /// Bare function name declared in the manifest
+        function_name: String,
+        /// JSON input passed to the function
+        #[arg(long, value_name = "JSON")]
+        input: Option<String>,
+    },
     /// Create and register a new Frame folder
     Create {
         /// Frame folder under /files/conversation-... or /files/pod-...

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -13,7 +13,9 @@ pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
-pub use frame::{cmd_frame_create, cmd_frame_publish, cmd_frame_register, cmd_frame_share_link};
+pub use frame::{
+    cmd_frame_call, cmd_frame_create, cmd_frame_publish, cmd_frame_register, cmd_frame_share_link,
+};
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -132,10 +132,10 @@ async fn run() -> anyhow::Result<()> {
         },
         Commands::Frame { command } => match command {
             commands::frame::FrameCommand::Call {
-                source,
+                target,
                 function_name,
                 input,
-            } => commands::cmd_frame_call(&source, &function_name, input.as_deref()).await?,
+            } => commands::cmd_frame_call(&target, &function_name, input.as_deref()).await?,
             commands::frame::FrameCommand::Create {
                 directory,
                 name,
@@ -214,34 +214,36 @@ mod tests {
 
     #[test]
     fn parses_frame_call() {
-        let cli = Cli::try_parse_from([
-            "dsbx",
-            "frame",
-            "call",
+        for target in [
+            "fil_abc123XYZ",
             "/files/conversation-conv_123/Status/manifest.json",
-            "get-status",
-            "--input",
-            r#"{"scope":"current"}"#,
-        ])
-        .expect("should parse");
+        ] {
+            let cli = Cli::try_parse_from([
+                "dsbx",
+                "frame",
+                "call",
+                target,
+                "get-status",
+                "--input",
+                r#"{"scope":"current"}"#,
+            ])
+            .expect("should parse");
 
-        match cli.command {
-            Commands::Frame {
-                command:
-                    commands::frame::FrameCommand::Call {
-                        source,
-                        function_name,
-                        input,
-                    },
-            } => {
-                assert_eq!(
-                    source,
-                    std::path::PathBuf::from("/files/conversation-conv_123/Status/manifest.json")
-                );
-                assert_eq!(function_name, "get-status");
-                assert_eq!(input.as_deref(), Some(r#"{"scope":"current"}"#));
+            match cli.command {
+                Commands::Frame {
+                    command:
+                        commands::frame::FrameCommand::Call {
+                            target: parsed_target,
+                            function_name,
+                            input,
+                        },
+                } => {
+                    assert_eq!(parsed_target, target);
+                    assert_eq!(function_name, "get-status");
+                    assert_eq!(input.as_deref(), Some(r#"{"scope":"current"}"#));
+                }
+                _ => panic!("expected Frame call subcommand"),
             }
-            _ => panic!("expected Frame call subcommand"),
         }
     }
 

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -212,6 +212,39 @@ mod tests {
         assert_eq!(exit_code_for(&anyhow::anyhow!("boom")), 1);
     }
 
+    #[test]
+    fn parses_frame_call() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "call",
+            "/files/conversation-conv_123/Status/manifest.json",
+            "get-status",
+            "--input",
+            r#"{"scope":"current"}"#,
+        ])
+        .expect("should parse");
+
+        match cli.command {
+            Commands::Frame {
+                command:
+                    commands::frame::FrameCommand::Call {
+                        source,
+                        function_name,
+                        input,
+                    },
+            } => {
+                assert_eq!(
+                    source,
+                    std::path::PathBuf::from("/files/conversation-conv_123/Status/manifest.json")
+                );
+                assert_eq!(function_name, "get-status");
+                assert_eq!(input.as_deref(), Some(r#"{"scope":"current"}"#));
+            }
+            _ => panic!("expected Frame call subcommand"),
+        }
+    }
+
     struct ToolsFields {
         json: bool,
         args_json: Option<String>,

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -131,6 +131,11 @@ async fn run() -> anyhow::Result<()> {
             commands::db::DbCommand::Query { name } => commands::cmd_db_query(&name).await?,
         },
         Commands::Frame { command } => match command {
+            commands::frame::FrameCommand::Call {
+                source,
+                function_name,
+                input,
+            } => commands::cmd_frame_call(&source, &function_name, input.as_deref()).await?,
             commands::frame::FrameCommand::Create {
                 directory,
                 name,

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/call.test.ts
@@ -116,6 +116,32 @@ function requestFrameCall({
   });
 }
 
+function requestFrameCallById({
+  workspaceId,
+  token,
+  frameId,
+  functionName = "get-status",
+  input = { scope: "current" },
+}: {
+  workspaceId: string;
+  token: string;
+  frameId: string;
+  functionName?: string;
+  input?: unknown;
+}) {
+  return honoApp.request(
+    `/api/v1/w/${workspaceId}/sandbox/frames/${frameId}/call`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ functionName, input }),
+    }
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
@@ -129,7 +155,24 @@ beforeEach(() => {
   );
 });
 
-describe("POST /api/v1/w/:wId/sandbox/frames/call", () => {
+describe("sandbox Frame calls", () => {
+  it("calls an active Frame function by its stable ID", async () => {
+    const context = await setup();
+
+    const response = await requestFrameCallById({
+      workspaceId: context.workspace.sId,
+      token: context.token,
+      frameId: context.frame.sId,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      frameId: context.frame.sId,
+      functionName: "get-status",
+      result: { status: "ready" },
+    });
+  });
+
   it("calls an active Frame function resolved from its source folder", async () => {
     const context = await setup();
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/call.test.ts
@@ -1,0 +1,194 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_functions";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return { ...actual, getSandboxFunctionInvocationEvents: vi.fn() };
+});
+
+vi.mock("@app/temporal/sandbox_functions/client", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/temporal/sandbox_functions/client")
+    >();
+  return {
+    ...actual,
+    launchSandboxFunctionInvocationWorkflow: vi.fn(
+      async () => new Ok(undefined)
+    ),
+  };
+});
+
+const schema: JSONSchema = { type: "object" };
+
+function eventStream(
+  ...events: SandboxFunctionInvocationEvent[]
+): ReturnType<typeof getSandboxFunctionInvocationEvents> {
+  return (async function* () {
+    for (const [index, data] of events.entries()) {
+      yield { eventId: String(index), data };
+    }
+  })();
+}
+
+async function setup() {
+  const context = await createSandboxTokenTestContext();
+  await FeatureFlagFactory.basic(context.auth, "frames_v2");
+  const sourceDirectoryPath = `conversation-${context.conversation.sId}/Status`;
+  const publicationId = "publication-1";
+  const frame = await FileFactory.create(context.auth, null, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 100,
+    status: "ready",
+    useCase: "conversation",
+    useCaseMetadata: {
+      conversationId: context.conversation.sId,
+      activePublicationId: publicationId,
+    },
+    mountFilePath: `${getConversationFilesBasePath({
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    })}Status/manifest.json`,
+  });
+  await frame.setShareScope(context.auth, "workspace_and_emails");
+  await withTransaction((transaction) =>
+    SandboxFunctionResource.createForFramePublication(
+      context.auth,
+      {
+        frame,
+        publicationId,
+        functions: [
+          {
+            name: "get-status",
+            description: "Get the status.",
+            userIdentity: "optional",
+            executionMode: "durable",
+            defaultStake: "never_ask",
+            bundleCode:
+              "export default { fetch: async () => Response.json({}) };",
+            inputSchema: schema,
+            outputSchema: schema,
+          },
+        ],
+      },
+      transaction
+    )
+  );
+
+  return { ...context, frame, sourceDirectoryPath };
+}
+
+function requestFrameCall({
+  workspaceId,
+  token,
+  sourcePath,
+  functionName = "get-status",
+  input = { scope: "current" },
+}: {
+  workspaceId: string;
+  token: string;
+  sourcePath: string;
+  functionName?: string;
+  input?: unknown;
+}) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/call`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ sourcePath, functionName, input }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+    eventStream({
+      type: "sandbox_function_invocation_result",
+      created: 0,
+      invocationId: "sfi_test",
+      functionId: "sfn_test",
+      result: { status: "ready" },
+    })
+  );
+});
+
+describe("POST /api/v1/w/:wId/sandbox/frames/call", () => {
+  it("calls an active Frame function resolved from its source folder", async () => {
+    const context = await setup();
+
+    const response = await requestFrameCall({
+      workspaceId: context.workspace.sId,
+      token: context.token,
+      sourcePath: context.sourceDirectoryPath,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      frameId: context.frame.sId,
+      functionName: "get-status",
+      result: { status: "ready" },
+    });
+  });
+
+  it("rejects functions outside the active Frame publication", async () => {
+    const context = await setup();
+
+    const response = await requestFrameCall({
+      workspaceId: context.workspace.sId,
+      token: context.token,
+      sourcePath: `${context.sourceDirectoryPath}/manifest.json`,
+      functionName: "missing",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: expect.stringContaining('No active function named "missing"'),
+      },
+    });
+  });
+
+  it("returns the function error code and message", async () => {
+    const context = await setup();
+    vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+      eventStream({
+        type: "sandbox_function_invocation_error",
+        created: 0,
+        invocationId: "sfi_test",
+        functionId: "sfn_test",
+        error: { code: "threw", message: "boom" },
+      })
+    );
+
+    const response = await requestFrameCall({
+      workspaceId: context.workspace.sId,
+      token: context.token,
+      sourcePath: context.sourceDirectoryPath,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        type: "invalid_request_error",
+        message: expect.stringContaining("(threw): boom"),
+      },
+    });
+  });
+});

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/call.ts
@@ -2,7 +2,7 @@ import {
   type CallFrameFunctionFromSourceResult,
   callFrameFunctionFromSource,
   type FrameFunctionCallFromSourceError,
-  FrameFunctionExecutionError,
+  isFrameFunctionExecutionError,
 } from "@app/lib/api/frames/call_from_source";
 import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { hasFeatureFlag } from "@app/lib/auth";
@@ -43,10 +43,20 @@ function frameCallErrorStatus(
 }
 
 function fileSystemErrorStatus(error: DustFileSystemError): 400 | 403 | 500 {
-  if (error.code === "unauthorized") {
-    return 403;
+  switch (error.code) {
+    case "unauthorized":
+      return 403;
+    case "internal":
+      return 500;
+    case "already_exists":
+    case "invalid_path":
+    case "legacy_path":
+    case "not_found":
+    case "too_many_mounts":
+      return 400;
+    default:
+      return assertNever(error.code);
   }
-  return error.code === "internal" ? 500 : 400;
 }
 
 const app = sandboxApp();
@@ -96,7 +106,7 @@ app.post(
       ...ctx.req.valid("json"),
     });
     if (result.isErr()) {
-      if (result.error instanceof FrameFunctionExecutionError) {
+      if (isFrameFunctionExecutionError(result.error)) {
         const { callError } = result.error;
         if (
           callError.code === "user_authentication_required" ||

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/call.ts
@@ -1,0 +1,159 @@
+import {
+  type CallFrameFunctionFromSourceResult,
+  callFrameFunctionFromSource,
+  type FrameFunctionCallFromSourceError,
+  FrameFunctionExecutionError,
+} from "@app/lib/api/frames/call_from_source";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
+import {
+  type DustFileSystemError,
+  isDustFileSystemError,
+} from "@app/types/file_system";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { getSandboxFunctionInvocationErrorStatusCode } from "@front-api/lib/api/sandbox_function_invocation_errors";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameCallRequestSchema = z.object({
+  sourcePath: z.string().min(1),
+  functionName: z.string().refine(isValidSandboxFunctionSlug),
+  input: z.unknown().optional(),
+});
+
+function frameCallErrorStatus(
+  error: FrameFunctionCallFromSourceError
+): 400 | 403 | 404 | 500 {
+  switch (error.code) {
+    case "invalid_source":
+      return 400;
+    case "unauthorized":
+      return 403;
+    case "frame_not_found":
+    case "function_not_found":
+      return 404;
+    default:
+      return assertNever(error.code);
+  }
+}
+
+function fileSystemErrorStatus(error: DustFileSystemError): 400 | 403 | 500 {
+  if (error.code === "unauthorized") {
+    return 403;
+  }
+  return error.code === "internal" ? 500 : 400;
+}
+
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameCallRequestSchema),
+  async (ctx): HandlerResult<CallFrameFunctionFromSourceResult> => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot call Frame functions.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, claims.cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: `Conversation ${claims.cId} not found.`,
+        },
+      });
+    }
+
+    const result = await callFrameFunctionFromSource(auth, {
+      conversation: conversation.toJSON(),
+      ...ctx.req.valid("json"),
+    });
+    if (result.isErr()) {
+      if (result.error instanceof FrameFunctionExecutionError) {
+        const { callError } = result.error;
+        if (
+          callError.code === "user_authentication_required" ||
+          callError.code === "frame_runtime_unavailable"
+        ) {
+          return apiError(ctx, {
+            status_code: getSandboxFunctionInvocationErrorStatusCode(
+              callError.code
+            ),
+            api_error: {
+              type: callError.code,
+              message: callError.message,
+            },
+          });
+        }
+        const status =
+          callError.code === "invocation_failed" ||
+          callError.code === "transport_error"
+            ? 500
+            : 400;
+        return apiError(
+          ctx,
+          {
+            status_code: status,
+            api_error: {
+              type:
+                status === 500
+                  ? "internal_server_error"
+                  : "invalid_request_error",
+              message: `Frame function "${result.error.functionName}" returned an error (${callError.code}): ${callError.message}`,
+            },
+          },
+          result.error
+        );
+      }
+
+      const status = isDustFileSystemError(result.error)
+        ? fileSystemErrorStatus(result.error)
+        : frameCallErrorStatus(result.error);
+      return apiError(
+        ctx,
+        {
+          status_code: status,
+          api_error: {
+            type:
+              status === 500
+                ? "internal_server_error"
+                : "invalid_request_error",
+            message: result.error.message,
+          },
+        },
+        result.error
+      );
+    }
+
+    return ctx.json(result.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/call_by_id.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/call_by_id.ts
@@ -1,19 +1,24 @@
 import {
   type CallFrameFunctionResult,
-  callFrameFunctionFromSource,
+  callFrameFunction,
 } from "@app/lib/api/frames/call_frame_function";
 import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { hasFeatureFlag } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import {
-  FrameFunctionCallFromSourceRequestSchema,
+  FrameFunctionCallRequestSchema,
   frameFunctionCallApiError,
 } from "./call_utils";
+
+const FrameCallParamsSchema = z.object({
+  frameId: z.string().refine((value) => isResourceSId("file", value)),
+});
 
 const app = sandboxApp();
 
@@ -23,7 +28,8 @@ const app = sandboxApp();
  */
 app.post(
   "/",
-  validate("json", FrameFunctionCallFromSourceRequestSchema),
+  validate("param", FrameCallParamsSchema),
+  validate("json", FrameFunctionCallRequestSchema),
   async (ctx): HandlerResult<CallFrameFunctionResult> => {
     const auth = ctx.get("auth");
     const claims = ctx.get("sandboxClaims");
@@ -46,19 +52,8 @@ app.post(
       });
     }
 
-    const conversation = await ConversationResource.fetchById(auth, claims.cId);
-    if (!conversation) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "conversation_not_found",
-          message: `Conversation ${claims.cId} not found.`,
-        },
-      });
-    }
-
-    const result = await callFrameFunctionFromSource(auth, {
-      conversation: conversation.toJSON(),
+    const result = await callFrameFunction(auth, {
+      frameId: ctx.req.valid("param").frameId,
       ...ctx.req.valid("json"),
     });
     if (result.isErr()) {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/call_utils.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/call_utils.ts
@@ -1,0 +1,103 @@
+import {
+  type CallFrameFunctionFromSourceError,
+  type FrameFunctionCallError,
+  isFrameFunctionExecutionError,
+} from "@app/lib/api/frames/call_frame_function";
+import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
+import {
+  type DustFileSystemError,
+  isDustFileSystemError,
+} from "@app/types/file_system";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { getSandboxFunctionInvocationErrorStatusCode } from "@front-api/lib/api/sandbox_function_invocation_errors";
+import { z } from "zod";
+
+export const FrameFunctionCallRequestSchema = z.object({
+  functionName: z.string().refine(isValidSandboxFunctionSlug),
+  input: z.unknown().optional(),
+});
+
+export const FrameFunctionCallFromSourceRequestSchema =
+  FrameFunctionCallRequestSchema.extend({
+    sourcePath: z.string().min(1),
+  });
+
+function frameCallErrorStatus(
+  error: FrameFunctionCallError
+): 400 | 403 | 404 | 500 {
+  switch (error.code) {
+    case "invalid_source":
+      return 400;
+    case "unauthorized":
+      return 403;
+    case "frame_not_found":
+    case "function_not_found":
+      return 404;
+    default:
+      return assertNever(error.code);
+  }
+}
+
+function fileSystemErrorStatus(error: DustFileSystemError): 400 | 403 | 500 {
+  switch (error.code) {
+    case "unauthorized":
+      return 403;
+    case "internal":
+      return 500;
+    case "already_exists":
+    case "invalid_path":
+    case "legacy_path":
+    case "not_found":
+    case "too_many_mounts":
+      return 400;
+    default:
+      return assertNever(error.code);
+  }
+}
+
+export function frameFunctionCallApiError(
+  error: CallFrameFunctionFromSourceError
+): {
+  statusCode: 400 | 401 | 403 | 404 | 409 | 500;
+  type:
+    | "frame_runtime_unavailable"
+    | "internal_server_error"
+    | "invalid_request_error"
+    | "user_authentication_required";
+  message: string;
+} {
+  if (isFrameFunctionExecutionError(error)) {
+    const { callError } = error;
+    if (
+      callError.code === "user_authentication_required" ||
+      callError.code === "frame_runtime_unavailable"
+    ) {
+      return {
+        statusCode: getSandboxFunctionInvocationErrorStatusCode(callError.code),
+        type: callError.code,
+        message: callError.message,
+      };
+    }
+    const statusCode =
+      callError.code === "invocation_failed" ||
+      callError.code === "transport_error"
+        ? 500
+        : 400;
+    return {
+      statusCode,
+      type:
+        statusCode === 500 ? "internal_server_error" : "invalid_request_error",
+      message: `Frame function "${error.functionName}" returned an error (${callError.code}): ${callError.message}`,
+    };
+  }
+
+  const statusCode = isDustFileSystemError(error)
+    ? fileSystemErrorStatus(error)
+    : frameCallErrorStatus(error);
+  return {
+    statusCode,
+    type:
+      statusCode === 500 ? "internal_server_error" : "invalid_request_error",
+    message: error.message,
+  };
+}

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -18,6 +18,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import call from "./call";
+import callById from "./call_by_id";
 import register from "./register";
 import share from "./share";
 
@@ -72,6 +73,7 @@ const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
 app.route("/call", call);
+app.route("/:frameId/call", callById);
 app.route("/register", register);
 app.route("/share", share);
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -17,6 +17,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import call from "./call";
 import register from "./register";
 import share from "./share";
 
@@ -70,6 +71,7 @@ function frameErrorStatus(error: PublishFrameFromSourceError): 400 | 403 | 500 {
 const app = sandboxApp();
 
 app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
+app.route("/call", call);
 app.route("/register", register);
 app.route("/share", share);
 

--- a/front/lib/api/frames/call_frame_function.ts
+++ b/front/lib/api/frames/call_frame_function.ts
@@ -12,7 +12,7 @@ import type { DustFileSystemError } from "@app/types/file_system";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-export class FrameFunctionCallFromSourceError extends Error {
+export class FrameFunctionCallError extends Error {
   constructor(
     readonly code:
       | "invalid_source"
@@ -22,7 +22,7 @@ export class FrameFunctionCallFromSourceError extends Error {
     message: string
   ) {
     super(message);
-    this.name = "FrameFunctionCallFromSourceError";
+    this.name = "FrameFunctionCallError";
   }
 }
 
@@ -44,16 +44,59 @@ export function isFrameFunctionExecutionError(
   return error instanceof FrameFunctionExecutionError;
 }
 
-export type CallFrameFunctionFromSourceError =
-  | DustFileSystemError
-  | FrameFunctionCallFromSourceError
+export type CallFrameFunctionError =
+  | FrameFunctionCallError
   | FrameFunctionExecutionError;
 
-export type CallFrameFunctionFromSourceResult = {
+export type CallFrameFunctionFromSourceError =
+  | DustFileSystemError
+  | CallFrameFunctionError;
+
+export type CallFrameFunctionResult = {
   frameId: string;
   functionName: string;
   result: unknown;
 };
+
+/** Invoke one function from a Frame's active publication after checking use rights. */
+export async function callFrameFunction(
+  auth: Authenticator,
+  {
+    frameId,
+    functionName,
+    input,
+  }: {
+    frameId: string;
+    functionName: string;
+    input?: unknown;
+  }
+): Promise<Result<CallFrameFunctionResult, CallFrameFunctionError>> {
+  const sandboxFunction = await resolveActiveFrameFunctionForUse(auth, {
+    frameId,
+    functionName,
+  });
+  if (!sandboxFunction) {
+    return new Err(
+      new FrameFunctionCallError(
+        "function_not_found",
+        `No active function named "${functionName}" found for this Frame.`
+      )
+    );
+  }
+
+  const callResult = await callSandboxFunction(auth, sandboxFunction, input);
+  if (callResult.isErr()) {
+    return new Err(
+      new FrameFunctionExecutionError(functionName, callResult.error)
+    );
+  }
+
+  return new Ok({
+    frameId,
+    functionName,
+    result: callResult.value,
+  });
+}
 
 /** Resolve a registered Frame from its mounted source and invoke its active function. */
 export async function callFrameFunctionFromSource(
@@ -69,13 +112,11 @@ export async function callFrameFunctionFromSource(
     functionName: string;
     input?: unknown;
   }
-): Promise<
-  Result<CallFrameFunctionFromSourceResult, CallFrameFunctionFromSourceError>
-> {
+): Promise<Result<CallFrameFunctionResult, CallFrameFunctionFromSourceError>> {
   const normalizedSourcePath = DustFileSystem.normalizeScopedPath(sourcePath);
   if (!normalizedSourcePath || !normalizedSourcePath.includes("/")) {
     return new Err(
-      new FrameFunctionCallFromSourceError(
+      new FrameFunctionCallError(
         "invalid_source",
         "Frame source must point to its folder or manifest.json."
       )
@@ -93,7 +134,7 @@ export async function callFrameFunctionFromSource(
   const dustFs = fsResult.value;
   if (!dustFs.isGCSBacked()) {
     return new Err(
-      new FrameFunctionCallFromSourceError(
+      new FrameFunctionCallError(
         "invalid_source",
         "Frames v2 calls do not support the database-backed filesystem."
       )
@@ -109,7 +150,7 @@ export async function callFrameFunctionFromSource(
     );
   if (!readableMount) {
     return new Err(
-      new FrameFunctionCallFromSourceError(
+      new FrameFunctionCallError(
         "unauthorized",
         "Read access to the Frame source folder is required."
       )
@@ -119,10 +160,7 @@ export async function callFrameFunctionFromSource(
   const mountFilePath = dustFs.toMountFilePath(manifestPath);
   if (!mountFilePath) {
     return new Err(
-      new FrameFunctionCallFromSourceError(
-        "invalid_source",
-        "Invalid Frame source path."
-      )
+      new FrameFunctionCallError("invalid_source", "Invalid Frame source path.")
     );
   }
   const [frame] = await FileResource.fetchByMountFilePaths(auth, [
@@ -130,36 +168,16 @@ export async function callFrameFunctionFromSource(
   ]);
   if (!frame?.isFrameV2) {
     return new Err(
-      new FrameFunctionCallFromSourceError(
+      new FrameFunctionCallError(
         "frame_not_found",
         `No registered Frames v2 package found at ${normalizedSourcePath}.`
       )
     );
   }
 
-  const sandboxFunction = await resolveActiveFrameFunctionForUse(auth, {
+  return callFrameFunction(auth, {
     frameId: frame.sId,
     functionName,
-  });
-  if (!sandboxFunction) {
-    return new Err(
-      new FrameFunctionCallFromSourceError(
-        "function_not_found",
-        `No active function named "${functionName}" found for this Frame.`
-      )
-    );
-  }
-
-  const callResult = await callSandboxFunction(auth, sandboxFunction, input);
-  if (callResult.isErr()) {
-    return new Err(
-      new FrameFunctionExecutionError(functionName, callResult.error)
-    );
-  }
-
-  return new Ok({
-    frameId: frame.sId,
-    functionName,
-    result: callResult.value,
+    input,
   });
 }

--- a/front/lib/api/frames/call_from_source.ts
+++ b/front/lib/api/frames/call_from_source.ts
@@ -1,0 +1,159 @@
+import path from "node:path";
+
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
+import { resolveActiveFrameFunctionForUse } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { DustFileSystemError } from "@app/types/file_system";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export class FrameFunctionCallFromSourceError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_source"
+      | "unauthorized"
+      | "frame_not_found"
+      | "function_not_found",
+    message: string
+  ) {
+    super(message);
+    this.name = "FrameFunctionCallFromSourceError";
+  }
+}
+
+export class FrameFunctionExecutionError extends Error {
+  readonly code = "call_failed" as const;
+
+  constructor(
+    readonly functionName: string,
+    readonly callError: SandboxFunctionCallError
+  ) {
+    super(callError.message);
+    this.name = "FrameFunctionExecutionError";
+  }
+}
+
+export type CallFrameFunctionFromSourceError =
+  | DustFileSystemError
+  | FrameFunctionCallFromSourceError
+  | FrameFunctionExecutionError;
+
+export type CallFrameFunctionFromSourceResult = {
+  frameId: string;
+  functionName: string;
+  result: unknown;
+};
+
+/** Resolve a registered Frame from its mounted source and invoke its active function. */
+export async function callFrameFunctionFromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    sourcePath,
+    functionName,
+    input,
+  }: {
+    conversation: ConversationWithoutContentType;
+    sourcePath: string;
+    functionName: string;
+    input?: unknown;
+  }
+): Promise<
+  Result<CallFrameFunctionFromSourceResult, CallFrameFunctionFromSourceError>
+> {
+  const normalizedSourcePath = DustFileSystem.normalizeScopedPath(sourcePath);
+  if (!normalizedSourcePath || !normalizedSourcePath.includes("/")) {
+    return new Err(
+      new FrameFunctionCallFromSourceError(
+        "invalid_source",
+        "Frame source must point to its folder or manifest.json."
+      )
+    );
+  }
+  const manifestPath =
+    path.posix.basename(normalizedSourcePath) === FRAME_MANIFEST_FILE
+      ? normalizedSourcePath
+      : path.posix.join(normalizedSourcePath, FRAME_MANIFEST_FILE);
+
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+  const dustFs = fsResult.value;
+  if (!dustFs.isGCSBacked()) {
+    return new Err(
+      new FrameFunctionCallFromSourceError(
+        "invalid_source",
+        "Frames v2 calls do not support the database-backed filesystem."
+      )
+    );
+  }
+
+  const readableMount = dustFs
+    .getMounts()
+    .find(
+      (mount) =>
+        manifestPath.startsWith(`${mount.scopedPrefix}/`) &&
+        mount.permissions.canRead
+    );
+  if (!readableMount) {
+    return new Err(
+      new FrameFunctionCallFromSourceError(
+        "unauthorized",
+        "Read access to the Frame source folder is required."
+      )
+    );
+  }
+
+  const mountFilePath = dustFs.toMountFilePath(manifestPath);
+  if (!mountFilePath) {
+    return new Err(
+      new FrameFunctionCallFromSourceError(
+        "invalid_source",
+        "Invalid Frame source path."
+      )
+    );
+  }
+  const [frame] = await FileResource.fetchByMountFilePaths(auth, [
+    mountFilePath,
+  ]);
+  if (!frame?.isFrameV2) {
+    return new Err(
+      new FrameFunctionCallFromSourceError(
+        "frame_not_found",
+        `No registered Frames v2 package found at ${normalizedSourcePath}.`
+      )
+    );
+  }
+
+  const sandboxFunction = await resolveActiveFrameFunctionForUse(auth, {
+    frameId: frame.sId,
+    functionName,
+  });
+  if (!sandboxFunction) {
+    return new Err(
+      new FrameFunctionCallFromSourceError(
+        "function_not_found",
+        `No active function named "${functionName}" found for this Frame.`
+      )
+    );
+  }
+
+  const callResult = await callSandboxFunction(auth, sandboxFunction, input);
+  if (callResult.isErr()) {
+    return new Err(
+      new FrameFunctionExecutionError(functionName, callResult.error)
+    );
+  }
+
+  return new Ok({
+    frameId: frame.sId,
+    functionName,
+    result: callResult.value,
+  });
+}

--- a/front/lib/api/frames/call_from_source.ts
+++ b/front/lib/api/frames/call_from_source.ts
@@ -38,6 +38,12 @@ export class FrameFunctionExecutionError extends Error {
   }
 }
 
+export function isFrameFunctionExecutionError(
+  error: unknown
+): error is FrameFunctionExecutionError {
+  return error instanceof FrameFunctionExecutionError;
+}
+
 export type CallFrameFunctionFromSourceError =
   | DustFileSystemError
   | FrameFunctionCallFromSourceError

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.103",
+      tag: "0.8.104",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.54/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.55/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.103";
-const DSBX_CLI_VERSION = "0.1.54";
+const DUST_BASE_IMAGE_VERSION = "0.8.104";
+const DSBX_CLI_VERSION = "0.1.55";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -65,7 +65,9 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("dsbx frame share-link");
     expect(instructions).toContain("dsbx frame call");
-    expect(instructions).toContain("it does not test the Frame UI");
+    expect(instructions).toContain("stable Frame ID");
+    expect(instructions).toContain("additionally requires read access");
+    expect(instructions).toContain("does not test the Frame");
     expect(instructions).toContain(
       "Frame sharing and use rights are configured by the user in the Dust UI"
     );

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -64,6 +64,8 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("dsbx frame create");
     expect(instructions).toContain("dsbx frame register");
     expect(instructions).toContain("dsbx frame share-link");
+    expect(instructions).toContain("dsbx frame call");
+    expect(instructions).toContain("it does not test the Frame UI");
     expect(instructions).toContain(
       "Frame sharing and use rights are configured by the user in the Dust UI"
     );

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -335,6 +335,15 @@ dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
 If validation, a function build, or database reconciliation fails, no partial publication becomes
 active. Fix the reported error and rerun the command.
 
+Call a function from the active publication by its bare manifest name:
+
+\`\`\`bash
+dsbx frame call /files/<scope>/<frame-folder>/manifest.json <function-name> --input '<json>'
+\`\`\`
+
+The Frame folder is also accepted in place of the manifest path. Use this to exercise published
+server behavior directly; it does not test the Frame UI.
+
 For a legacy Frame, pass its entry source file instead:
 
 \`\`\`bash

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -335,14 +335,16 @@ dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
 If validation, a function build, or database reconciliation fails, no partial publication becomes
 active. Fix the reported error and rerun the command.
 
-Call a function from the active publication by its bare manifest name:
+Call a function from the active publication by its stable Frame ID and bare manifest name:
 
 \`\`\`bash
-dsbx frame call /files/<scope>/<frame-folder>/manifest.json <function-name> --input '<json>'
+dsbx frame call <frame-id> <function-name> --input '<json>'
 \`\`\`
 
-The Frame folder is also accepted in place of the manifest path. Use this to exercise published
-server behavior directly; it does not test the Frame UI.
+During authoring, the mounted Frame folder or manifest path is also accepted in place of the ID.
+The ID form requires Frame use rights; the path form additionally requires read access to the
+mounted source. Use this to exercise published server behavior directly; it does not test the Frame
+UI.
 
 For a legacy Frame, pass its entry source file instead:
 


### PR DESCRIPTION
## Description

Add `dsbx frame call` so agents can invoke a named function from a registered Frame's active publication.

The preferred form takes the stable Frame ID and checks Frame use rights directly. For authoring convenience, the existing source-folder or manifest-path form remains supported and additionally requires read access to that mounted source.

Both forms reuse the existing active-publication resolver and sandbox function invocation path. The private action-token endpoints are behind `frames_v2` and ignored by Swagger.

Bump dsbx to 0.1.55 and dust-base to 0.8.104 so the command ships in the sandbox image.

## Tests

Added functional coverage for calls by Frame ID and source path, active-publication scoping, runtime errors, JSON input, Frame-ID validation, and the full CLI argument contract for both target forms.

## Risk

Low. This adds private action-token endpoints and a CLI command behind `frames_v2`; existing Frame and Pod Function invocation paths are unchanged.

## Deploy Plan

1. Deploy Front with both private invocation endpoints.
2. Release dsbx 0.1.55.
3. Build and release dust-base 0.8.104.
4. Use `/poke/kill` to replace sandboxes running older dust-base versions.
