### PR TITLE
Add Frames v2 source validation

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.55"
+version = "0.1.56"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.55"
+version = "0.1.56"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -11,7 +11,8 @@ use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, FrameCallByIdRequest, FrameCallFromSourceRequest,
     FrameCallResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
-    FrameRegisterResponse, FrameShareLinkResponse, MCPServerView, SandboxServerViewsResponse,
+    FrameRegisterResponse, FrameShareLinkResponse, FrameValidateRequest, FrameValidateResponse,
+    MCPServerView, SandboxServerViewsResponse,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -187,6 +188,18 @@ impl DustApiClient {
         self.post(
             "sandbox/frames/register",
             &FrameRegisterRequest { manifest_path },
+        )
+        .await
+    }
+
+    pub async fn validate_frame(
+        &self,
+        manifest_path: &str,
+    ) -> anyhow::Result<FrameValidateResponse> {
+        self.post_with_timeout(
+            "sandbox/frames/validate",
+            &FrameValidateRequest { manifest_path },
+            POLL_MAX_DURATION,
         )
         .await
     }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -40,6 +40,12 @@ pub struct FrameRegisterRequest<'a> {
     pub manifest_path: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameValidateRequest<'a> {
+    pub manifest_path: &'a str,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FramePublishResponse {
@@ -57,6 +63,15 @@ pub struct FrameRegisterResponse {
     pub frame_id: String,
     pub manifest_path: String,
     pub created: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameValidateResponse {
+    pub frame_id: String,
+    pub manifest_path: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -3,6 +3,7 @@ mod create;
 mod publish;
 mod register;
 mod share_link;
+mod validate;
 
 use std::path::{Component, Path, PathBuf};
 
@@ -14,6 +15,7 @@ pub use create::run as cmd_frame_create;
 pub use publish::run as cmd_frame_publish;
 pub use register::run as cmd_frame_register;
 pub use share_link::run as cmd_frame_share_link;
+pub use validate::run as cmd_frame_validate;
 
 const FRAME_MANIFEST_FILE: &str = "manifest.json";
 const FILES_ROOT: &str = "/files";
@@ -50,6 +52,11 @@ pub enum FrameCommand {
     ShareLink {
         /// Existing Frame folder under /files
         directory: PathBuf,
+    },
+    /// Validate a Frames v2 source without publishing it
+    Validate {
+        /// Absolute path to a v2 manifest under /files
+        manifest: PathBuf,
     },
     /// Build and publish a Frame from its current source
     Publish {

--- a/cli/dust-sandbox/src/commands/frame/validate.rs
+++ b/cli/dust-sandbox/src/commands/frame/validate.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use crate::api::DustApiClient;
+
+use super::{print_response, scoped_manifest_path};
+
+pub async fn run(manifest: &Path) -> anyhow::Result<()> {
+    let manifest_path = scoped_manifest_path(manifest)?;
+    let client = DustApiClient::from_env()?;
+    let response = client.validate_frame(&manifest_path).await?;
+    print_response(&response)
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub use filesystem::{run as run_filesystem, FilesystemCommand};
 pub use forward::cmd_forward;
 pub use frame::{
     cmd_frame_call, cmd_frame_create, cmd_frame_publish, cmd_frame_register, cmd_frame_share_link,
+    cmd_frame_validate,
 };
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -147,6 +147,9 @@ async fn run() -> anyhow::Result<()> {
             commands::frame::FrameCommand::ShareLink { directory } => {
                 commands::cmd_frame_share_link(&directory).await?
             }
+            commands::frame::FrameCommand::Validate { manifest } => {
+                commands::cmd_frame_validate(&manifest).await?
+            }
             commands::frame::FrameCommand::Publish { source } => {
                 commands::cmd_frame_publish(&source).await?
             }
@@ -533,6 +536,29 @@ mod tests {
                 );
             }
             Commands::Frame { .. } => panic!("expected publish"),
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn frame_validate_parses() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "frame",
+            "validate",
+            "/files/pod-vlt_123/Status/manifest.json",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Frame {
+                command: commands::frame::FrameCommand::Validate { manifest },
+            } => {
+                assert_eq!(
+                    manifest,
+                    std::path::PathBuf::from("/files/pod-vlt_123/Status/manifest.json")
+                );
+            }
+            Commands::Frame { .. } => panic!("expected validate"),
             _ => panic!("expected frame"),
         }
     }

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/errors.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/errors.ts
@@ -1,0 +1,42 @@
+import { isFramePublicationError } from "@app/lib/api/frames/publication_storage";
+import type { PublishFrameFromSourceError } from "@app/lib/api/frames/publish_from_source";
+import { isPublishFrameError } from "@app/lib/api/viz/publish_frame";
+import { isDustFileSystemError } from "@app/types/file_system";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export function frameSourceErrorStatus(
+  error: PublishFrameFromSourceError
+): 400 | 403 | 500 {
+  if (isDustFileSystemError(error)) {
+    if (error.code === "unauthorized") {
+      return 403;
+    }
+    return error.code === "internal" ? 500 : 400;
+  }
+
+  if (isFramePublicationError(error)) {
+    return error.code === "unauthorized" ? 403 : 400;
+  }
+
+  if (isPublishFrameError(error)) {
+    return error.code === "internal" ? 500 : 400;
+  }
+
+  const code = error.code;
+  switch (code) {
+    case "sandbox_unavailable":
+    case "reconcile_failed":
+    case "internal":
+      return 500;
+    case "build_failed":
+    case "invalid_contract":
+    case "invalid_path":
+    case "not_found":
+    case "publish_conflict":
+    case "reconcile_blocked":
+    case "schema_extraction_failed":
+      return 400;
+    default:
+      return assertNever(code);
+  }
+}

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -64,6 +64,21 @@ function requestFrameRegister(
   });
 }
 
+function requestFrameValidate(
+  workspaceId: string,
+  token: string,
+  manifestPath: string
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/frames/validate`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ manifestPath }),
+  });
+}
+
 function requestFrameShare(
   workspaceId: string,
   token: string,
@@ -206,6 +221,48 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(frame?.useCaseMetadata?.activePublicationId).toBe(
       published.publicationId
     );
+  });
+
+  it("validates a registered Frame without activating a publication", async () => {
+    const context = await setup();
+    assert(context.frame);
+
+    const response = await requestFrameValidate(
+      context.workspace.sId,
+      context.token,
+      context.manifestPath
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      frameId: context.frame.sId,
+      manifestPath: context.manifestPath,
+      warnings: [],
+    });
+    expect(
+      (await FileResource.fetchById(context.auth, context.frame.sId))
+        ?.useCaseMetadata?.activePublicationId
+    ).toBeUndefined();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("does not validate a legacy Frame through the v2-only command", async () => {
+    const context = await setupLegacyFrame();
+
+    const response = await requestFrameValidate(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message:
+          "Pre-publish validation is only available for Frames v2 manifests.",
+      },
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("returns the existing Frame share link without changing use rights", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/validate.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/validate.ts
@@ -1,52 +1,36 @@
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
-import { publishFrameFromSource } from "@app/lib/api/frames/publish_from_source";
+import { validateFrameFromSource } from "@app/lib/api/frames/publish_from_source";
 import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { sandboxApp } from "@front-api/middlewares/ctx";
-import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-import call from "./call";
-import callById from "./call_by_id";
 import { frameSourceErrorStatus } from "./errors";
-import register from "./register";
-import share from "./share";
-import validateFrame from "./validate";
 
-const FramePublishRequestSchema = z.object({
+const FrameValidateRequestSchema = z.object({
   manifestPath: z.string().min(1),
 });
 
-type FramePublishResponse = {
+type FrameValidateResponse = {
   frameId: string;
   manifestPath: string;
-  publicationId?: string;
-  warnings?: ValidationWarning[];
+  warnings: ValidationWarning[];
 };
 
-// Mounted at /api/v1/w/:wId/sandbox/frames.
 const app = sandboxApp();
-
-app.use("*", sandboxAuth({ allowedTokenKinds: ["action"] }));
-app.route("/call", call);
-app.route("/:frameId/call", callById);
-app.route("/register", register);
-app.route("/share", share);
-app.route("/validate", validateFrame);
 
 /**
  * @ignoreswagger
  * internal endpoint
  */
 app.post(
-  "/publish",
-  validate("json", FramePublishRequestSchema),
-  async (ctx): HandlerResult<FramePublishResponse> => {
+  "/",
+  validate("json", FrameValidateRequestSchema),
+  async (ctx): HandlerResult<FrameValidateResponse> => {
     const auth = ctx.get("auth");
     const claims = ctx.get("sandboxClaims");
     if (!isSandboxExecTokenPayload(claims)) {
@@ -54,7 +38,7 @@ app.post(
         status_code: 403,
         api_error: {
           type: "invalid_request_error",
-          message: "This sandbox token cannot publish Frames.",
+          message: "This sandbox token cannot validate Frames.",
         },
       });
     }
@@ -79,47 +63,31 @@ app.post(
       });
     }
 
-    // Keep the request field name for compatibility. Legacy Frames pass their entry source path.
     const { manifestPath } = ctx.req.valid("json");
-    const publication = await publishFrameFromSource(auth, {
+    const validation = await validateFrameFromSource(auth, {
       conversation: conversation.toJSON(),
-      publishedByAgentConfigurationId: claims.aId,
       sourcePath: manifestPath,
     });
-    if (publication.isErr()) {
-      const status = frameSourceErrorStatus(publication.error);
+    if (validation.isErr()) {
+      const status = frameSourceErrorStatus(validation.error);
       return apiError(ctx, {
         status_code: status,
         api_error: {
           type:
             status === 500 ? "internal_server_error" : "invalid_request_error",
-          message: publication.error.message,
+          message: validation.error.message,
         },
       });
     }
 
-    switch (publication.value.kind) {
-      case "legacy":
-        return ctx.json(
-          {
-            frameId: publication.value.frameId,
-            manifestPath: publication.value.sourcePath,
-            warnings: publication.value.warnings,
-          },
-          200
-        );
-      case "v2":
-        return ctx.json(
-          {
-            frameId: publication.value.frameId,
-            manifestPath: publication.value.sourcePath,
-            publicationId: publication.value.publicationId,
-          },
-          200
-        );
-      default:
-        return assertNever(publication.value);
-    }
+    return ctx.json(
+      {
+        frameId: validation.value.frameId,
+        manifestPath: validation.value.sourcePath,
+        warnings: validation.value.warnings,
+      },
+      200
+    );
   }
 );
 

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -73,6 +73,13 @@ const uiOnlyManifest = FrameManifestSchema.parse({
   description: "Track tasks.",
 });
 
+const databaseManifest = FrameManifestSchema.parse({
+  version: 1,
+  name: "Task List",
+  description: "Track tasks.",
+  databases: [{ name: "tasks", schema: "databases/tasks.db.ts" }],
+});
+
 const sourceFiles = [
   {
     relativePath: "index.tsx",
@@ -187,6 +194,22 @@ describe("buildAndPublishFramePublication", () => {
       (await FileResource.fetchById(auth, frame.sId))?.useCaseMetadata
         ?.activePublicationId
     ).toBe(activePublicationId);
+  });
+
+  it("validates database schema contracts without publishing", async () => {
+    const { auth, conversation } = await setup();
+
+    const result = await validateFramePublication(auth, {
+      conversation,
+      manifest: databaseManifest,
+      sourceFiles: sourceFiles.slice(0, 1),
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_source",
+      message: "Frame database schema not found: tasks (databases/tasks.db.ts)",
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("builds and publishes the UI without starting a sandbox", async () => {

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
 
-import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import {
+  buildAndPublishFramePublication,
+  validateFramePublication,
+} from "@app/lib/api/frames/build_and_publish";
 import {
   computeFrameSourcePathSetSha256,
   FRAME_SOURCE_STAGING_ROOT,
@@ -154,6 +157,38 @@ beforeEach(() => {
 });
 
 describe("buildAndPublishFramePublication", () => {
+  it("validates UI and Tailwind without writing a publication", async () => {
+    const { auth, conversation, frame } = await setup();
+    const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    await frame.setActiveFramePublication(activePublicationId);
+
+    const result = await validateFramePublication(auth, {
+      conversation,
+      manifest: uiOnlyManifest,
+      sourceFiles: [
+        {
+          ...sourceFiles[0],
+          content: Buffer.from(
+            'export default function App() { return <main className="h-[600px]">Tasks</main>; }'
+          ),
+        },
+      ],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value.warnings).toMatchObject([
+      {
+        type: "tailwind",
+        message: expect.stringContaining("index.tsx: Forbidden Tailwind"),
+      },
+    ]);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+    expect(
+      (await FileResource.fetchById(auth, frame.sId))?.useCaseMetadata
+        ?.activePublicationId
+    ).toBe(activePublicationId);
+  });
+
   it("builds and publishes the UI without starting a sandbox", async () => {
     const { auth, conversation, frame } = await setup();
 

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -6,6 +6,7 @@ import type {
   FramePublicationSourceFile,
 } from "@app/lib/api/frames/publication_storage";
 import {
+  buildFramePublicationContracts,
   FramePublicationError,
   publishFramePublication,
 } from "@app/lib/api/frames/publication_storage";
@@ -203,6 +204,15 @@ export async function validateFramePublication(
   });
   if (buildResult.isErr()) {
     return buildResult;
+  }
+
+  const contracts = buildFramePublicationContracts({
+    functionArtifacts: buildResult.value.functionArtifacts,
+    manifest,
+    sourceFiles,
+  });
+  if (contracts.isErr()) {
+    return contracts;
   }
 
   return new Ok({ warnings: collectFrameTailwindWarnings(sourceFiles) });

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import type { ValidationWarning } from "@app/lib/api/files/content_validation";
+import { validateTailwindCode } from "@app/lib/api/files/content_validation";
 import type {
   FramePublicationFunctionArtifact,
   FramePublicationSourceFile,
@@ -19,6 +21,11 @@ import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+type FramePublicationBuild = {
+  functionArtifacts: FramePublicationFunctionArtifact[];
+  uiBundleCode: string;
+};
 
 async function buildFrameUiBundle({
   manifest,
@@ -54,29 +61,19 @@ async function buildFrameUiBundle({
   return new Ok(buildResult.value.code);
 }
 
-/**
- * Build the UI and every declared function from one captured source snapshot, then atomically
- * publish its artifacts. Function builds stage the snapshot in the invoking conversation's DSBX;
- * source stays in its authoring scope. No publication storage is touched until every build succeeds.
- */
-export async function buildAndPublishFramePublication(
+async function buildFramePublication(
   auth: Authenticator,
   {
     conversation,
-    frame,
     manifest,
     sourceFiles,
   }: {
     conversation: ConversationWithoutContentType;
-    frame: FileResource;
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
   }
 ): Promise<
-  Result<
-    { publicationId: string },
-    FramePublicationError | SandboxFunctionError
-  >
+  Result<FramePublicationBuild, FramePublicationError | SandboxFunctionError>
 > {
   const seenSourcePaths = new Set<string>();
   for (const sourceFile of sourceFiles) {
@@ -100,11 +97,8 @@ export async function buildAndPublishFramePublication(
   }
 
   if (manifest.functions.length === 0) {
-    return publishFramePublication(auth, {
-      frame,
+    return new Ok({
       functionArtifacts: [],
-      manifest,
-      sourceFiles,
       uiBundleCode: uiBundle.value,
     });
   }
@@ -151,11 +145,107 @@ export async function buildAndPublishFramePublication(
     return functionArtifactResult;
   }
 
-  return publishFramePublication(auth, {
-    frame,
+  return new Ok({
     functionArtifacts: functionArtifactResult.value,
+    uiBundleCode: uiBundle.value,
+  });
+}
+
+function collectFrameTailwindWarnings(
+  sourceFiles: FramePublicationSourceFile[]
+): ValidationWarning[] {
+  const warnings: ValidationWarning[] = [];
+  for (const sourceFile of sourceFiles) {
+    if (!/\.(?:jsx|tsx)$/.test(sourceFile.relativePath)) {
+      continue;
+    }
+
+    const validation = validateTailwindCode(
+      sourceFile.content.toString("utf8")
+    );
+    if (validation.isErr()) {
+      warnings.push(
+        ...validation.error.map((warning) => ({
+          ...warning,
+          message: `${sourceFile.relativePath}: ${warning.message}`,
+        }))
+      );
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Run the publication build without storing, reconciling, or activating anything.
+ */
+export async function validateFramePublication(
+  auth: Authenticator,
+  {
+    conversation,
     manifest,
     sourceFiles,
-    uiBundleCode: uiBundle.value,
+  }: {
+    conversation: ConversationWithoutContentType;
+    manifest: FrameManifest;
+    sourceFiles: FramePublicationSourceFile[];
+  }
+): Promise<
+  Result<
+    { warnings: ValidationWarning[] },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  const buildResult = await buildFramePublication(auth, {
+    conversation,
+    manifest,
+    sourceFiles,
+  });
+  if (buildResult.isErr()) {
+    return buildResult;
+  }
+
+  return new Ok({ warnings: collectFrameTailwindWarnings(sourceFiles) });
+}
+
+/**
+ * Build the UI and every declared function from one captured source snapshot, then atomically
+ * publish its artifacts. Function builds stage the snapshot in the invoking conversation's DSBX;
+ * source stays in its authoring scope. No publication storage is touched until every build succeeds.
+ */
+export async function buildAndPublishFramePublication(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifest,
+    sourceFiles,
+  }: {
+    conversation: ConversationWithoutContentType;
+    frame: FileResource;
+    manifest: FrameManifest;
+    sourceFiles: FramePublicationSourceFile[];
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  const buildResult = await buildFramePublication(auth, {
+    conversation,
+    manifest,
+    sourceFiles,
+  });
+  if (buildResult.isErr()) {
+    return buildResult;
+  }
+
+  return publishFramePublication(auth, {
+    frame,
+    functionArtifacts: buildResult.value.functionArtifacts,
+    manifest,
+    sourceFiles,
+    uiBundleCode: buildResult.value.uiBundleCode,
   });
 }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -107,27 +107,20 @@ function getFrameIdentity(
   return new Ok({ workspaceId: owner.sId, frameId: frame.sId });
 }
 
-export async function storeFramePublication(
-  auth: Authenticator,
-  {
-    frame,
-    functionArtifacts,
-    manifest,
-    sourceFiles,
-    uiBundleCode,
-  }: {
-    frame: FileResource;
-    functionArtifacts: FramePublicationFunctionArtifact[];
-    manifest: FrameManifest;
-    sourceFiles: FramePublicationSourceFile[];
-    uiBundleCode: string;
-  }
-): Promise<Result<{ publicationId: string }, FramePublicationError>> {
-  const frameIdentity = getFrameIdentity(auth, frame);
-  if (frameIdentity.isErr()) {
-    return frameIdentity;
-  }
+type FramePublicationContracts = Pick<
+  FramePublicationDescriptor,
+  "databases" | "functions"
+>;
 
+export function buildFramePublicationContracts({
+  functionArtifacts,
+  manifest,
+  sourceFiles,
+}: {
+  functionArtifacts: FramePublicationFunctionArtifact[];
+  manifest: FrameManifest;
+  sourceFiles: FramePublicationSourceFile[];
+}): Result<FramePublicationContracts, FramePublicationError> {
   const sourceFilesByPath = new Map<string, FramePublicationSourceFile>();
   for (const sourceFile of sourceFiles) {
     if (!isSafeFrameRelativePath(sourceFile.relativePath)) {
@@ -166,7 +159,8 @@ export async function storeFramePublication(
       );
     }
   }
-  const databaseContracts: FramePublicationDescriptor["databases"] = [];
+
+  const databases: FramePublicationDescriptor["databases"] = [];
   for (const database of manifest.databases) {
     const schemaFile = sourceFilesByPath.get(database.schema);
     if (!schemaFile) {
@@ -186,7 +180,7 @@ export async function storeFramePublication(
         )
       );
     }
-    databaseContracts.push({
+    databases.push({
       name: database.name,
       schemaSource,
       schemaSha256: sha256(schemaSource),
@@ -219,7 +213,8 @@ export async function storeFramePublication(
     }
     functionArtifactsByName.set(artifact.name, artifact);
   }
-  const functionContracts: FramePublicationDescriptor["functions"] = [];
+
+  const functions: FramePublicationDescriptor["functions"] = [];
   for (const fn of manifest.functions) {
     const artifact = functionArtifactsByName.get(fn.name);
     if (!artifact) {
@@ -230,13 +225,46 @@ export async function storeFramePublication(
         )
       );
     }
-    functionContracts.push({
+    functions.push({
       name: fn.name,
       bundleSha256: sha256(artifact.bundleCode),
       userIdentity: artifact.userIdentity,
       inputSchema: artifact.inputSchema,
       outputSchema: artifact.outputSchema,
     });
+  }
+
+  return new Ok({ databases, functions });
+}
+
+export async function storeFramePublication(
+  auth: Authenticator,
+  {
+    frame,
+    functionArtifacts,
+    manifest,
+    sourceFiles,
+    uiBundleCode,
+  }: {
+    frame: FileResource;
+    functionArtifacts: FramePublicationFunctionArtifact[];
+    manifest: FrameManifest;
+    sourceFiles: FramePublicationSourceFile[];
+    uiBundleCode: string;
+  }
+): Promise<Result<{ publicationId: string }, FramePublicationError>> {
+  const frameIdentity = getFrameIdentity(auth, frame);
+  if (frameIdentity.isErr()) {
+    return frameIdentity;
+  }
+
+  const contracts = buildFramePublicationContracts({
+    functionArtifacts,
+    manifest,
+    sourceFiles,
+  });
+  if (contracts.isErr()) {
+    return contracts;
   }
 
   const identity = {
@@ -257,8 +285,8 @@ export async function storeFramePublication(
       }))
       .sort((left, right) => left.path.localeCompare(right.path)),
     ui: { bundleSha256: sha256(uiBundleCode) },
-    functions: functionContracts,
-    databases: databaseContracts,
+    functions: contracts.value.functions,
+    databases: contracts.value.databases,
   } satisfies FramePublicationDescriptor);
   if (!descriptorResult.success) {
     return new Err(

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -2,7 +2,10 @@ import path from "node:path";
 
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
-import { buildAndPublishFramePublication } from "@app/lib/api/frames/build_and_publish";
+import {
+  buildAndPublishFramePublication,
+  validateFramePublication,
+} from "@app/lib/api/frames/build_and_publish";
 import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
@@ -14,6 +17,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { FrameManifest } from "@app/types/api/frame_manifest";
 import {
   FRAME_MANIFEST_FILE,
   isSafeFrameRelativePath,
@@ -58,18 +62,27 @@ export type PublishFrameFromSourceResult =
       publicationId: string;
     };
 
-export async function publishFrameFromSource(
+export type ValidateFrameFromSourceResult = {
+  frameId: string;
+  sourcePath: string;
+  warnings: ValidationWarning[];
+};
+
+async function resolveFrameFromSource(
   auth: Authenticator,
   {
     conversation,
-    publishedByAgentConfigurationId,
     sourcePath,
   }: {
     conversation: ConversationWithoutContentType;
-    publishedByAgentConfigurationId: string;
     sourcePath: string;
   }
-): Promise<Result<PublishFrameFromSourceResult, PublishFrameFromSourceError>> {
+): Promise<
+  Result<
+    { dustFs: DustFileSystem; frame: FileResource; normalizedPath: string },
+    DustFileSystemError | FramePublicationError
+  >
+> {
   const normalizedPath = DustFileSystem.normalizeScopedPath(sourcePath);
   if (!normalizedPath) {
     return frameError(
@@ -103,6 +116,30 @@ export async function publishFrameFromSource(
   if (!frame || (!frame.isFrameV2 && !frame.isInteractiveContent)) {
     return frameError("invalid_source", `No Frame found at ${normalizedPath}.`);
   }
+
+  return new Ok({ dustFs, frame, normalizedPath });
+}
+
+export async function publishFrameFromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    publishedByAgentConfigurationId,
+    sourcePath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    publishedByAgentConfigurationId: string;
+    sourcePath: string;
+  }
+): Promise<Result<PublishFrameFromSourceResult, PublishFrameFromSourceError>> {
+  const resolved = await resolveFrameFromSource(auth, {
+    conversation,
+    sourcePath,
+  });
+  if (resolved.isErr()) {
+    return resolved;
+  }
+  const { dustFs, frame, normalizedPath } = resolved.value;
 
   if (frame.isFrameV2) {
     const publication = await publishFrameV2FromSource(auth, {
@@ -147,25 +184,64 @@ export async function publishFrameFromSource(
   });
 }
 
-/**
- * Publish a Frames v2 FileResource from its current source folder. The FileResource path is the
- * authority: callers cannot point a Frame identity at a different manifest or source tree.
- */
-async function publishFrameV2FromSourceWithSourceLockHeld(
+export async function validateFrameFromSource(
   auth: Authenticator,
   {
     conversation,
+    sourcePath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    sourcePath: string;
+  }
+): Promise<Result<ValidateFrameFromSourceResult, PublishFrameFromSourceError>> {
+  const resolved = await resolveFrameFromSource(auth, {
+    conversation,
+    sourcePath,
+  });
+  if (resolved.isErr()) {
+    return resolved;
+  }
+  const { frame, normalizedPath } = resolved.value;
+  if (!frame.isFrameV2) {
+    return frameError(
+      "invalid_frame",
+      "Pre-publish validation is only available for Frames v2 manifests."
+    );
+  }
+
+  const validation = await validateFrameV2FromSource(auth, {
+    conversation,
+    frame,
+    manifestPath: normalizedPath,
+  });
+  if (validation.isErr()) {
+    return validation;
+  }
+
+  return new Ok({
+    frameId: frame.sId,
+    sourcePath: normalizedPath,
+    warnings: validation.value.warnings,
+  });
+}
+
+/**
+ * Capture the manifest and source tree addressed by a Frames v2 FileResource. The FileResource
+ * path is authoritative: callers cannot point a Frame identity at a different source tree.
+ */
+async function readFrameV2SourceWithSourceLockHeld(
+  auth: Authenticator,
+  {
     frame,
     manifestPath,
   }: {
-    conversation: ConversationWithoutContentType;
     frame: FileResource;
     manifestPath: string;
   }
 ): Promise<
   Result<
-    { publicationId: string },
-    FramePublicationError | SandboxFunctionError
+    { manifest: FrameManifest; sourceFiles: FramePublicationSourceFile[] },
+    FramePublicationError
   >
 > {
   const canonicalManifestPath = frame.toScopedPath(auth);
@@ -317,11 +393,38 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
     sourceFiles.push({ content: content.value, contentType, relativePath });
   }
 
+  return new Ok({ manifest: manifestResult.value, sourceFiles });
+}
+
+async function publishFrameV2FromSourceWithSourceLockHeld(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { publicationId: string },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  const source = await readFrameV2SourceWithSourceLockHeld(auth, {
+    frame,
+    manifestPath,
+  });
+  if (source.isErr()) {
+    return source;
+  }
+
   return buildAndPublishFramePublication(auth, {
     conversation,
     frame,
-    manifest: manifestResult.value,
-    sourceFiles,
+    ...source.value,
   });
 }
 
@@ -377,4 +480,65 @@ export async function publishFrameV2FromSource(
   }
 
   return publication;
+}
+
+export async function validateFrameV2FromSource(
+  auth: Authenticator,
+  {
+    conversation,
+    frame,
+    manifestPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    frame: FileResource;
+    manifestPath: string;
+  }
+): Promise<
+  Result<
+    { warnings: ValidationWarning[] },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  if (!frame.isFrameV2) {
+    return frameError(
+      "invalid_frame",
+      `File '${frame.sId}' is not a Frames v2 manifest.`
+    );
+  }
+
+  const validation = await withFrameSourceLock(frame.sId, async () => {
+    const freshFrame = await frame.fetchFreshFrameV2(auth);
+    if (!freshFrame) {
+      return frameError(
+        "invalid_frame",
+        `Frame '${frame.sId}' no longer exists.`
+      );
+    }
+
+    const source = await readFrameV2SourceWithSourceLockHeld(auth, {
+      frame: freshFrame,
+      manifestPath,
+    });
+    if (source.isErr()) {
+      return source;
+    }
+
+    return validateFramePublication(auth, {
+      conversation,
+      ...source.value,
+    });
+  });
+  if (validation.isErr()) {
+    if (isLockAcquisitionTimeoutError(validation.error)) {
+      return new Err(
+        new SandboxFunctionError(
+          "publish_conflict",
+          "Another source operation is in progress for this Frame; retry shortly."
+        )
+      );
+    }
+    return new Err(validation.error);
+  }
+
+  return validation;
 }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.104",
+      tag: "0.8.105",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.55/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.56/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.104";
-const DSBX_CLI_VERSION = "0.1.55";
+const DUST_BASE_IMAGE_VERSION = "0.8.105";
+const DSBX_CLI_VERSION = "0.1.56";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -68,6 +68,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("stable Frame ID");
     expect(instructions).toContain("additionally requires read access");
     expect(instructions).toContain("does not test the Frame");
+    expect(instructions).toContain("dsbx frame validate");
     expect(instructions).toContain(
       "Frame sharing and use rights are configured by the user in the Dust UI"
     );
@@ -104,6 +105,14 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(
       "Never run concurrent file mutations against the same path"
     );
+    expect(instructions).toContain(
+      "Do not replace an entire UI or function for a localized"
+    );
+    expect(instructions).toContain(
+      "mark required fields in a newly created table as `.notNull()`"
+    );
+    expect(instructions).toContain("shared Zod domain");
+    expect(instructions).toContain("instead of `bun build`");
     expect(instructions).toContain(
       "Other interactive-content tools remain available"
     );

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -333,10 +333,10 @@ Before publishing a Frames v2 manifest, validate the current source snapshot:
 dsbx frame validate /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
 
-This runs the manifest, UI, function-build, and Tailwind checks without storing or activating a
-publication or changing database state. Fix every error and Tailwind warning before publishing. Use
-this command instead of \`bun build\` or an ad hoc regex scan: those do not use the Frame build context
-and report unrelated or noisy failures.
+This runs the manifest, UI, function-build, database-contract, and Tailwind checks without storing or
+activating a publication or reconciling Frame-owned databases. Fix every error and Tailwind warning
+before publishing. Use this command instead of \`bun build\` or an ad hoc regex scan: those do not use
+the Frame build context and report unrelated or noisy failures.
 
 There is no separate v2 function publish. Once validation is clean, publish the manifest once; the
 UI source, all declared functions, and all declared database schemas are built or reconciled,

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -173,9 +173,10 @@ export default {
 \`\`\`
 
 Keep each function focused on one endpoint. Put validation, formatting, clients, and other logic
-used by several functions in \`functions/lib/\` rather than duplicating it. Publishing bundles each
-entry point and its relative imports from one source snapshot. Editing any source or helper changes
-nothing for viewers until the whole Frame is published again.
+used by several functions in \`functions/lib/\` rather than duplicating it. Define shared Zod domain
+schemas once in that folder and import them into each function that uses them. Publishing bundles
+each entry point and its relative imports from one source snapshot. Editing any source or helper
+changes nothing for viewers until the whole Frame is published again.
 
 \`zod\`, \`drizzle-orm\`, and \`@dust/pod\` are available to function source. Other npm packages are
 not guaranteed at build time.
@@ -198,10 +199,10 @@ export const comments = sqliteTable(
   "comments",
   {
     id: integer("id").primaryKey({ autoIncrement: true }),
-    threadId: text("thread_id"),
-    authorId: text("author_id"),
-    body: text("body"),
-    createdAt: integer("created_at", { mode: "timestamp" }),
+    threadId: text("thread_id").notNull(),
+    authorId: text("author_id").notNull(),
+    body: text("body").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
   },
   (table) => [index("comments_thread_idx").on(table.threadId)]
 );
@@ -221,10 +222,12 @@ Do not redefine tables inside function files, hand-write SQL schema changes, or 
 in module globals. The schema file is the source of truth for row serialization too, so keep column
 modes identical by always importing its table objects.
 
-Schema evolution is additive-only: add tables, nullable columns, and indexes. Do not drop, rename,
-or retype existing objects. In particular:
+Schema evolution is additive-only: add tables, columns, and indexes. Do not drop, rename, or retype
+existing objects. In particular:
 
-- make new columns nullable unless they have a default;
+- mark required fields in a newly created table as \`.notNull()\`;
+- when adding a column to an existing table, make it nullable or give it a default so existing rows
+  remain valid;
 - give each table an \`id\` and \`createdAt\`;
 - avoid foreign keys, CHECK constraints, and UNIQUE constraints; enforce integrity in code and use
   \`uniqueIndex()\` only when existing rows are known to satisfy it;
@@ -324,9 +327,20 @@ loading, empty, and error states for every call. Function failures are
 
 ## Publish a Frame
 
-There is no separate v2 function publish. After every source change that should become visible,
-publish the manifest once; the UI source, all declared functions, and all declared database schemas
-are validated, built or reconciled, stored, and activated atomically:
+Before publishing a Frames v2 manifest, validate the current source snapshot:
+
+\`\`\`bash
+dsbx frame validate /files/<scope>/<frame-folder>/manifest.json
+\`\`\`
+
+This runs the manifest, UI, function-build, and Tailwind checks without storing or activating a
+publication or changing database state. Fix every error and Tailwind warning before publishing. Use
+this command instead of \`bun build\` or an ad hoc regex scan: those do not use the Frame build context
+and report unrelated or noisy failures.
+
+There is no separate v2 function publish. Once validation is clean, publish the manifest once; the
+UI source, all declared functions, and all declared database schemas are built or reconciled,
+stored, and activated atomically:
 
 \`\`\`bash
 dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
@@ -363,5 +377,8 @@ initial scope.
 
 Use the Computer to edit Frame source. Never run concurrent file mutations against the same path:
 read the current file, apply one edit, then start the next edit to that file.
+
+When fixing a validation or runtime problem, preserve working structure and make the smallest
+targeted edit. Do not replace an entire UI or function for a localized state, schema, or styling bug.
 
 ${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}`;


### PR DESCRIPTION
## Description

Adds `dsbx frame validate`, backed by the same source capture and build pipeline as publication but stopping before publication storage, database reconciliation, or activation. It reuses publication contract validation and returns targeted Tailwind warnings alongside manifest, UI, function-build, and database-contract failures. The private adapter is `@ignoreswagger`.

Updates the Frames v2 skill to validate before publishing, avoid out-of-context `bun build` and regex checks, make localized fixes, use correct SQLite nullability, and share Zod domain schemas. Bumps dsbx to 0.1.56 and dust-base to 0.8.105.

Stacked on #31658.

## Tests

- Focused front tests for build/validation, publication storage, source publishing, skill instructions, and sandbox image registry
- 15 sandbox Frames endpoint tests
- `cargo test frame_`
- front and front-api `tsgo --noEmit`
- Biome and Swagger annotation checks

## Risk

Low. Validation can start a function build sandbox, but it is author-initiated and does not store or activate a publication or reconcile a Frame-owned database. The feature remains behind `frames_v2`.

## Deploy Plan

1. Merge #31658 first.
2. Deploy Front with the internal validation endpoint.
3. Release dsbx 0.1.56.
4. Build and release dust-base 0.8.105.
5. Use `/poke/kill` to replace sandboxes running older dust-base versions.