### PR TITLE
[Email Agents] Retry transient regional relay failures

### DIFF
--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -140,6 +140,84 @@ describe("POST /api/email/webhook", () => {
     }
   });
 
+  it("retries a relay after a transient server error", async () => {
+    const { user } = await createResourceTest({ role: "admin" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 502 }))
+      .mockResolvedValueOnce(
+        Response.json({ received: false }, { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const response = await postWebhook(user.email, {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+      const firstHeaders = fetchMock.mock.calls[0][1].headers;
+      const secondHeaders = fetchMock.mock.calls[2][1].headers;
+      expect(firstHeaders[EMAIL_WEBHOOK_RELAY_ID_HEADER]).toBe(
+        secondHeaders[EMAIL_WEBHOOK_RELAY_ID_HEADER]
+      );
+      expect(sendEmailToRecipients).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not retry a relay received before its response failed", async () => {
+    const { user } = await createResourceTest({ role: "admin" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 502 }))
+      .mockResolvedValueOnce(
+        Response.json({ received: true }, { status: 200 })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const response = await postWebhook(user.email, {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      expect(fetchMock.mock.calls[1][0]).toBe(
+        "http://other-region.test/api/email/webhook/relay-status"
+      );
+      expect(sendEmailToRecipients).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not retry against a target without receipt support", async () => {
+    const { user } = await createResourceTest({ role: "admin" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 502 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const response = await postWebhook(user.email, {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() =>
+        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("records a relay receipt and ignores a duplicate", async () => {
     const relayId = randomUUID();
     const headers = {

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -23,6 +23,7 @@ import {
 import apiConfig from "@app/lib/api/config";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
@@ -32,6 +33,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { IncomingForm } from "formidable";
 import { readFile } from "fs/promises";
+import { z } from "zod";
 
 /**
  * Node-style headers shape: matches the record built from
@@ -60,6 +62,10 @@ export const EMAIL_WEBHOOK_RELAY_HEADER_VALUE = "1";
 
 const EMAIL_RELAY_KEY_PREFIX = "email-webhook-relay";
 const EMAIL_RELAY_RECEIPT_TTL_SECONDS = 60 * 60;
+const EMAIL_RELAY_RETRY_DELAY_MS = 200;
+const HTTP_SERVER_ERROR_STATUS_MIN = 500;
+
+const RemoteRelayReceiptSchema = z.object({ received: z.boolean() });
 
 function isRelayedWebhookRequest(headers: EmailWebhookHeaders): boolean {
   return (
@@ -213,12 +219,135 @@ export async function hasEmailRelayReceipt(relayId: string): Promise<boolean> {
   return Boolean(await redis.get(makeEmailRelayKey(relayId)));
 }
 
+async function getRemoteRelayReceipt({
+  url,
+  relayId,
+}: {
+  url: string;
+  relayId: string;
+}): Promise<Result<boolean, Error>> {
+  try {
+    const response = await fetch(`${url}/api/email/webhook/relay-status`, {
+      headers: {
+        Authorization: `Bearer ${regionsConfig.getLookupApiSecret()}`,
+        [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
+        [EMAIL_WEBHOOK_RELAY_ID_HEADER]: relayId,
+      },
+    });
+    if (!response.ok) {
+      return new Err(
+        new Error(`Relay receipt lookup failed with status ${response.status}`)
+      );
+    }
+
+    const bodyRes = RemoteRelayReceiptSchema.safeParse(await response.json());
+    if (!bodyRes.success) {
+      return new Err(
+        new Error("Relay receipt lookup returned an invalid body")
+      );
+    }
+
+    return new Ok(bodyRes.data.received);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+async function postEmailRelay({
+  url,
+  name,
+  headers,
+  formData,
+}: {
+  url: string;
+  name: string;
+  headers: Record<string, string>;
+  formData: FormData;
+}): Promise<Result<Response, Error>> {
+  try {
+    const response = await fetch(`${url}/api/email/webhook`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+    if (response.status >= HTTP_SERVER_ERROR_STATUS_MIN) {
+      return new Err(
+        new Error(
+          `Relay to ${name} failed with status ${response.status}: ${response.statusText}`
+        )
+      );
+    }
+    return new Ok(response);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+async function sendEmailRelay({
+  url,
+  name,
+  relayId,
+  senderEmail,
+  headers,
+  formData,
+}: {
+  url: string;
+  name: string;
+  relayId: string;
+  senderEmail: string;
+  headers: Record<string, string>;
+  formData: FormData;
+}): Promise<Result<void, Error>> {
+  let responseRes = await postEmailRelay({ url, name, headers, formData });
+  if (responseRes.isErr()) {
+    const receiptRes = await getRemoteRelayReceipt({ url, relayId });
+    if (receiptRes.isOk() && receiptRes.value) {
+      return new Ok(undefined);
+    }
+    if (receiptRes.isErr()) {
+      return new Err(responseRes.error);
+    }
+
+    logger.warn(
+      {
+        error: responseRes.error,
+        senderEmail,
+        sourceRegion: regionsConfig.getCurrentRegion(),
+        targetRegion: name,
+      },
+      "[email] Retrying inbound email relay"
+    );
+    await setTimeoutAsync(EMAIL_RELAY_RETRY_DELAY_MS);
+    responseRes = await postEmailRelay({ url, name, headers, formData });
+
+    if (responseRes.isErr()) {
+      const retryReceiptRes = await getRemoteRelayReceipt({ url, relayId });
+      if (retryReceiptRes.isOk() && retryReceiptRes.value) {
+        return new Ok(undefined);
+      }
+    }
+  }
+
+  if (responseRes.isErr()) {
+    return new Err(responseRes.error);
+  }
+  if (!responseRes.value.ok) {
+    return new Err(
+      new Error(
+        `Relay to ${name} failed with status ${responseRes.value.status}: ${responseRes.value.statusText}`
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
 export async function relayEmailToOtherRegion(
   email: InboundEmail,
   { sourceError }: { sourceError: EmailTriggerError }
 ): Promise<Result<void, Error>> {
   try {
     const { url, name } = regionsConfig.getOtherRegionInfo();
+    const relayId = randomUUID();
     const formData = new FormData();
 
     formData.set("subject", email.subject);
@@ -241,25 +370,25 @@ export async function relayEmailToOtherRegion(
       );
     }
 
-    const response = await fetch(`${url}/api/email/webhook`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${regionsConfig.getLookupApiSecret()}`,
-        [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
-        [EMAIL_WEBHOOK_RELAY_SOURCE_REGION_HEADER]:
-          regionsConfig.getCurrentRegion(),
-        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: sourceError.type,
-        [EMAIL_WEBHOOK_RELAY_ID_HEADER]: randomUUID(),
-      },
-      body: formData,
-    });
+    const relayHeaders = {
+      Authorization: `Bearer ${regionsConfig.getLookupApiSecret()}`,
+      [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
+      [EMAIL_WEBHOOK_RELAY_SOURCE_REGION_HEADER]:
+        regionsConfig.getCurrentRegion(),
+      [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: sourceError.type,
+      [EMAIL_WEBHOOK_RELAY_ID_HEADER]: relayId,
+    };
 
-    if (!response.ok) {
-      return new Err(
-        new Error(
-          `Relay to ${name} failed with status ${response.status}: ${response.statusText}`
-        )
-      );
+    const relayRes = await sendEmailRelay({
+      url,
+      name,
+      relayId,
+      senderEmail: email.sender.email,
+      headers: relayHeaders,
+      formData,
+    });
+    if (relayRes.isErr()) {
+      return relayRes;
     }
 
     logger.info(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10266.

Stacked on https://github.com/dust-tt/dust/pull/31657.

Production logs for the reported email show that the US lookup did attempt the EU relay. That relay returned a transient 502 and had no matching target-region receipt; a relay for the same sender had succeeded nine minutes earlier.

Retry a cross-region email relay once after a network or server failure, but only when the target explicitly confirms that it did not receive the first request. Once receipt is confirmed, the source treats the target as the owner and never replays the email because Email Agents processing is not idempotent.

## Risks

Blast radius: inbound Email Agents requests that require a cross-region relay.
Risk: low after the dependency is fully deployed; retries require an explicit negative receipt from the target.

## Deploy Plan

- do not merge or deploy this PR until #31657 is deployed to every `front-api` pod in both regions
- after that rollout is confirmed, deploy normally to both regions

## Test

- [ ] `NODE_ENV=test npm -w front-api test -- routes/email/webhook.test.ts` (local shared test containers unavailable; covered by CI)
- [x] `npx tsgo --noEmit -p front/tsconfig.json`
- [x] `npx tsgo --noEmit -p front-api/tsconfig.json`
- [x] `npm -w front-api run lint:swagger-annotations`
