### PR TITLE
[front] Handle 422 duplicate uniqueness_key on seat edit as idempotent success

### DIFF
--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -39,9 +39,13 @@ const {
   mockContractsEdit,
   mockSetCustomFieldValues,
   MockConflictError,
+  MockUnprocessableEntityError,
 } = vi.hoisted(() => {
   class MockConflictError extends Error {
     status = 409;
+  }
+  class MockUnprocessableEntityError extends Error {
+    status = 422;
   }
   return {
     mockCreate: vi.fn(),
@@ -51,6 +55,7 @@ const {
     mockContractsEdit: vi.fn(),
     mockSetCustomFieldValues: vi.fn(),
     MockConflictError,
+    MockUnprocessableEntityError,
   };
 });
 
@@ -73,7 +78,11 @@ vi.mock("@metronome/sdk", () => {
       },
     };
   }
-  return { default: MockMetronome, ConflictError: MockConflictError };
+  return {
+    default: MockMetronome,
+    ConflictError: MockConflictError,
+    UnprocessableEntityError: MockUnprocessableEntityError,
+  };
 });
 
 vi.mock("@app/lib/api/config", () => ({
@@ -511,8 +520,14 @@ describe("updateSubscriptionSeats", () => {
     expect(typeof call.uniqueness_key).toBe("string");
   });
 
-  it("treats a duplicate-key 409 as success (edit already applied on a 504 retry)", async () => {
-    mockContractsEdit.mockRejectedValueOnce(new MockConflictError("duplicate"));
+  it("treats a duplicate uniqueness_key 422 as success (edit already applied on a 504 retry)", async () => {
+    // Metronome surfaces a reused uniqueness_key as a 422, not the 409 the docs
+    // imply. The message guard is what tells it apart from a real 422.
+    mockContractsEdit.mockRejectedValueOnce(
+      new MockUnprocessableEntityError(
+        "422 Uniqueness key already exists: c3b61abb-e577-46f9-aaa5-0c488769db8c"
+      )
+    );
 
     const result = await updateSubscriptionSeats({
       metronomeCustomerId: "cust-1",
@@ -523,6 +538,38 @@ describe("updateSubscriptionSeats", () => {
     });
 
     unwrapOk(result);
+  });
+
+  it("also treats a duplicate uniqueness_key 409 as success (defensive)", async () => {
+    mockContractsEdit.mockRejectedValueOnce(
+      new MockConflictError("Uniqueness key already exists: some-key")
+    );
+
+    const result = await updateSubscriptionSeats({
+      metronomeCustomerId: "cust-1",
+      contractId: "contract-1",
+      fromSubscriptionId: "sub-1",
+      addUnassignedSeats: 137,
+      startingAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    unwrapOk(result);
+  });
+
+  it("surfaces a non-duplicate 422 as an error (does not swallow real validation failures)", async () => {
+    mockContractsEdit.mockRejectedValueOnce(
+      new MockUnprocessableEntityError("422 Invalid seat_updates payload")
+    );
+
+    const result = await updateSubscriptionSeats({
+      metronomeCustomerId: "cust-1",
+      contractId: "contract-1",
+      fromSubscriptionId: "sub-1",
+      addUnassignedSeats: 137,
+      startingAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    expect(result.isErr()).toBe(true);
   });
 
   it("chunks adds and removes into separate edits above the cap", async () => {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -24,7 +24,11 @@ import { Err, Ok } from "@app/types/shared/result";
 import { ONE_DAY_MS, ONE_HOUR_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import Metronome, { BadRequestError, ConflictError } from "@metronome/sdk";
+import Metronome, {
+  BadRequestError,
+  ConflictError,
+  UnprocessableEntityError,
+} from "@metronome/sdk";
 import type { Commit, ContractV2, Credit, V1 } from "@metronome/sdk/resources";
 import type { ContractRetrieveRateScheduleResponse } from "@metronome/sdk/resources/v1/contracts/contracts";
 import type { ProductListResponse } from "@metronome/sdk/resources/v1/contracts/products";
@@ -1551,6 +1555,19 @@ export async function getMetronomeSeatActiveSince({
 // Metronome rejects any single contracts.edit carrying more than 1000 seat IDs.
 const MAX_SEAT_IDS_PER_EDIT = 1000;
 
+// A retried contracts.edit that reuses an already-consumed `uniqueness_key` is
+// rejected with a 422 `UnprocessableEntityError` whose message is "Uniqueness
+// key already exists: <key>" (despite the docs implying a 409). We also accept
+// the 409 `ConflictError` defensively in case the API's status ever changes.
+// The message guard keeps this from swallowing an unrelated 422 validation
+// error (e.g. a genuinely malformed edit body).
+function isDuplicateUniquenessKeyError(err: unknown): boolean {
+  return (
+    (err instanceof UnprocessableEntityError || err instanceof ConflictError) &&
+    /uniqueness key already exists/i.test(err.message)
+  );
+}
+
 export async function updateSubscriptionSeats({
   metronomeCustomerId,
   contractId,
@@ -1657,9 +1674,11 @@ export async function updateSubscriptionSeats({
     // still apply server-side — so the SDK's retry-on-5xx (client maxRetries: 5)
     // would blindly re-send the delta and stack it (an add of 137 unassigned
     // landing 4× → 548). A fresh per-edit `uniqueness_key` makes the retry safe:
-    // Metronome rejects a duplicate key with a 409, so a retry of an
-    // already-applied edit is a no-op we treat as success — the edit becomes
-    // idempotent against retries instead of stacking.
+    // Metronome rejects a duplicate key, so a retry of an already-applied edit
+    // is a no-op we treat as success — the edit becomes idempotent against
+    // retries instead of stacking. The rejection surfaces as a 422
+    // `UnprocessableEntityError` ("Uniqueness key already exists"), NOT the 409
+    // the docs suggest — see `isDuplicateUniquenessKeyError`.
     const uniquenessKey = randomUUID();
     try {
       await getMetronomeClient().v2.contracts.edit({
@@ -1669,7 +1688,7 @@ export async function updateSubscriptionSeats({
         uniqueness_key: uniquenessKey,
       });
     } catch (err) {
-      if (err instanceof ConflictError) {
+      if (isDuplicateUniquenessKeyError(err)) {
         // Duplicate uniqueness_key → this exact edit already landed (a retry
         // after a 504 that applied server-side). Idempotent success.
         logger.info(


### PR DESCRIPTION
## Description

Follow-up hotfix to #31578. That PR added a fresh per-edit `uniqueness_key` on
the seat-count `v2.contracts.edit` so that an SDK auto-retry (after a lost/slow
response) can't blindly re-apply the cumulative seat delta and stack it (the
548-phantom-unassigned-seat incident). The retry-after-apply is rejected by
Metronome as a duplicate key, and the catch treated that rejection as an
idempotent success.

The catch only handled `ConflictError` (409) — the status the docs imply. In
production the Metronome SDK actually maps a duplicate `uniqueness_key` to a
**422 `UnprocessableEntityError`** ("Uniqueness key already exists: <key>"), so
the rejection fell through to `Err` and surfaced as a hard sync failure on the
`metronome-seat-count-sync` workflow (workspace `HzXDVQGUQF`).

The Metronome audit log for that run confirms the mechanism: the edit
**succeeded** server-side at 20:07:03, the SDK retried the same key ~29s later,
and Metronome correctly rejected the duplicate (422) at 20:07:32 — the
idempotency guard doing its job. Only our 409-vs-422 mismatch turned that
successful edit into a reported failure.

This change accepts the 422 (and 409 defensively) as an idempotent success via a
small `isDuplicateUniquenessKeyError` guard, gated on the
`"uniqueness key already exists"` message so genuine 422 validation errors still
surface as errors. Stacking remains impossible regardless: Metronome rejects the
duplicate key at the server level, independent of how we classify the error.

## Tests

- `front/lib/metronome/client.test.ts`: the duplicate-key test now throws a 422
  `UnprocessableEntityError` with the real message; added a defensive 409 case
  and a "non-duplicate 422 surfaces as an error" case. 25/25 pass.
- `npx tsgo --noEmit` clean.

## Risk

Low. Narrows a false-failure path to success; the message guard prevents
swallowing real 422 validation errors. No change to the happy path. The
anti-stacking guarantee is unaffected (server-side duplicate-key rejection).

## Deploy Plan

Standard `front` deploy. Resolves an active production error on the
`metronome-seat-count-sync` workflow introduced by the already-merged #31578.