### PR TITLE
[front] enh: add observability for fair-use limit hits

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -83,7 +83,10 @@ import {
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
+import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
@@ -3123,6 +3126,23 @@ async function isMessagesLimitReached(
       result.isOk() &&
       result.value >= roundCreditsToMicroCredits(maxAwuCredits)
     ) {
+      logger.info(
+        {
+          workspaceId: owner.sId,
+          userId: user.sId,
+          messageOrigin: context.origin,
+          fairUseAwuCreditsUsed: microCreditsToCredits(result.value),
+          fairUseAwuCreditsLimit: maxAwuCredits,
+          fairUseAwuCreditsTimeframe: maxAwuCreditsTimeframe,
+        },
+        "Fair-use AWU credit limit triggered."
+      );
+      statsDMetrics.increment(
+        "assistant.rate_limiter.fair_use_awu.limit_triggered",
+        1,
+        [`workspace_id:${owner.sId}`, `message_origin:${context.origin}`]
+      );
+
       return {
         isLimitReached: true,
         limitType: "plan_message_limit_exceeded",

--- a/front/lib/api/assistant/conversation_rate_limits.test.ts
+++ b/front/lib/api/assistant/conversation_rate_limits.test.ts
@@ -1,0 +1,59 @@
+import { checkMessagesLimit } from "@app/lib/api/assistant/conversation";
+import { getRedisStreamClient } from "@app/lib/api/redis";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
+import { statsDMetrics } from "@app/lib/utils/statsd";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  statsDMetrics: {
+    decrement: vi.fn(),
+    distribution: vi.fn(),
+    gauge: vi.fn(),
+    histogram: vi.fn(),
+    increment: vi.fn(),
+    timing: vi.fn(),
+  },
+}));
+
+describe("checkMessagesLimit", () => {
+  it("records fair-use limit hits with the trigger message origin", async () => {
+    const { authenticator, user, workspace } = await createResourceTest({});
+    const { maxAwuCredits } =
+      authenticator.getNonNullablePlan().limits.assistant;
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    vi.mocked(redis.eval).mockImplementation(async (...args) => {
+      const script = [args[0], args[1]].find(
+        (arg): arg is string => typeof arg === "string"
+      );
+      if (!script) {
+        throw new Error("Expected Redis eval script.");
+      }
+      return script.includes("oldest_timestamp_ms")
+        ? [roundCreditsToMicroCredits(maxAwuCredits), -1]
+        : 1;
+    });
+
+    const result = await checkMessagesLimit(authenticator, {
+      mentions: [],
+      context: {
+        username: user.username,
+        fullName: user.fullName(),
+        email: user.email,
+        profilePictureUrl: null,
+        timezone: "UTC",
+        origin: "triggered",
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.api_error.type).toBe("plan_message_limit_exceeded");
+    }
+    expect(statsDMetrics.increment).toHaveBeenCalledWith(
+      "assistant.rate_limiter.fair_use_awu.limit_triggered",
+      1,
+      [`workspace_id:${workspace.sId}`, "message_origin:triggered"]
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fair-use AWU rejections use the generic `plan_message_limit_exceeded` error, which makes failed trigger runs difficult to isolate.

Emit a dedicated `assistant.rate_limiter.fair_use_awu.limit_triggered` metric at the exact fair-use decision, tagged by workspace and message origin, plus a structured log with the user, usage, limit, and timeframe. Trigger failures can now be filtered with `message_origin:triggered` while the existing API error contract remains unchanged.

## Tests

- Added focused coverage for a trigger-originated message rejected at the fair-use limit and its emitted metric tags.

## Risk

- Low. This only adds telemetry to the existing rejection branch.

## Deploy Plan

- Deploy front.