### PR TITLE
style(analytics): clarify unit used on graphs and cards

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -153,7 +153,7 @@ export function ConsumptionBurnUpChart({
 
   return (
     <ChartContainer
-      title="Cumulative consumption"
+      title="Credits over time"
       additionalControls={additionalControls}
       isLoading={isTimeseriesLoading}
       errorMessage={

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -262,7 +262,7 @@ export function ConsumptionDailyChart({
   );
   return (
     <ChartContainer
-      title="Daily consumption"
+      title="Credits over time"
       additionalControls={additionalControls}
       isLoading={isTimeseriesLoading}
       errorMessage={

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -167,7 +167,7 @@ export function ConsumptionSummaryView({
       >
         <SummaryCard
           label="Used this period"
-          value={formatCredits(totalCredits)}
+          value={`${formatCredits(totalCredits)} credits`}
           hint={
             creditUsage
               ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`


### PR DESCRIPTION
## Description

**Units on the analytics**
Feedback from users that they were confused about the analytics because the unit is unclear (they were trying to guess if the numbers were credits, tokens, messages, conversations).

Added "credits" units in the first card and update graph title.

<img width="1099" height="690" alt="image" src="https://github.com/user-attachments/assets/ffccd979-c776-4a60-9189-033354a5a71a" />

## Tests

Previewed locally. 

## Risk

None. Wording only.

## Deploy Plan

Normal deploy.
