### PR TITLE
fix(pricing): add long-context billing tiers for GPT 5.6 and Gemini Pro

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -27,6 +27,13 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 20.0,
     cache_creation_input_tokens: 5.0,
     cache_read_input_tokens: 0.4,
+    long_context: {
+      prompt_token_threshold: 272_001,
+      input: 8.0,
+      output: 30.0,
+      cache_creation_input_tokens: 10.0,
+      cache_read_input_tokens: 0.8,
+    },
   },
   // https://openai.com/api/pricing
   "gpt-5.6-terra": {
@@ -34,6 +41,13 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 12.0,
     cache_creation_input_tokens: 2.5,
     cache_read_input_tokens: 0.2,
+    long_context: {
+      prompt_token_threshold: 272_001,
+      input: 4.0,
+      output: 18.0,
+      cache_creation_input_tokens: 5.0,
+      cache_read_input_tokens: 0.4,
+    },
   },
   // Verified 2026-08-19: https://developers.openai.com/api/docs/models/gpt-5.6-terra
   // Prompts above 272K input tokens cost 2x input and 1.5x output for the full request.
@@ -57,6 +71,13 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 1.2,
     cache_creation_input_tokens: 0.25,
     cache_read_input_tokens: 0.02,
+    long_context: {
+      prompt_token_threshold: 272_001,
+      input: 0.4,
+      output: 1.8,
+      cache_creation_input_tokens: 0.5,
+      cache_read_input_tokens: 0.04,
+    },
   },
   // Verified 2026-08-21: https://developers.openai.com/api/docs/models/gpt-5.5
   "gpt-5.5": {
@@ -320,17 +341,26 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     input: 0.9,
     output: 2.8,
   },
-  // Conservative: pricing is 2/12 for first 200k tokens
-  // then 4/18 beyond that.
+  // https://ai.google.dev/gemini-api/docs/pricing: 2/12 up to 200k input tokens,
+  // 4/18 beyond that.
   "gemini-3-pro-preview": {
-    input: 4,
-    output: 18,
+    input: 2,
+    output: 12,
+    long_context: {
+      prompt_token_threshold: 200_001,
+      input: 4,
+      output: 18,
+    },
   },
-  // Gemini 3.1 Pro: same pricing structure as 3 Pro (2/12 for <=200k, 4/18 for >200k)
-  // Using conservative pricing for the higher tier
+  // Gemini 3.1 Pro: same pricing structure as 3 Pro (2/12 for <=200k, 4/18 for >200k).
   "gemini-3.1-pro-preview": {
-    input: 4,
-    output: 18,
+    input: 2,
+    output: 12,
+    long_context: {
+      prompt_token_threshold: 200_001,
+      input: 4,
+      output: 18,
+    },
   },
   "gemini-3-flash-preview": {
     input: 0.5,

--- a/front/lib/api/assistant/token_pricing/index.test.ts
+++ b/front/lib/api/assistant/token_pricing/index.test.ts
@@ -4,9 +4,16 @@ import {
 } from "@app/lib/api/assistant/token_pricing";
 import { EU_UPLIFT_MODEL_IDS } from "@app/lib/api/assistant/token_pricing/eu";
 import {
+  GEMINI_3_1_PRO_MODEL_ID,
+  GEMINI_3_PRO_MODEL_ID,
+} from "@app/types/assistant/models/google_ai_studio";
+import {
   GPT_5_4_MODEL_ID,
   GPT_5_5_MODEL_ID,
+  GPT_5_6_LUNA_MODEL_ID,
+  GPT_5_6_SOL_MODEL_ID,
   GPT_5_6_TERRA_LONG_CONTEXT_MODEL_ID,
+  GPT_5_6_TERRA_MODEL_ID,
   GPT_5_MODEL_ID,
 } from "@app/types/assistant/models/openai";
 import {
@@ -229,6 +236,116 @@ describe("computeTokensCostForUsageInMicroUsd", () => {
 
     expect(globalCostMicroUsd).toBe(846_004);
     expect(euCostMicroUsd).toBeCloseTo(globalCostMicroUsd * 1.1, 6);
+  });
+
+  it("uses standard Sol pricing through 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_6_SOL_MODEL_ID,
+        promptTokens: 272_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(1_108_000);
+  });
+
+  it("uses Sol long-context pricing above 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_6_SOL_MODEL_ID,
+        promptTokens: 272_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(2_206_008);
+  });
+
+  it("uses standard base Terra pricing through 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_6_TERRA_MODEL_ID,
+        promptTokens: 272_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(556_000);
+  });
+
+  it("uses base Terra long-context pricing above 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_6_TERRA_MODEL_ID,
+        promptTokens: 272_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(1_106_004);
+  });
+
+  it("uses standard Luna pricing through 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        promptTokens: 272_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBeCloseTo(55_600, 6);
+  });
+
+  it("uses Luna long-context pricing above 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        promptTokens: 272_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBeCloseTo(110_600.4, 6);
+  });
+
+  it("uses standard Gemini 3 Pro pricing through 200k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GEMINI_3_PRO_MODEL_ID,
+        promptTokens: 200_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(412_000);
+  });
+
+  it("uses Gemini 3 Pro long-context pricing above 200k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GEMINI_3_PRO_MODEL_ID,
+        promptTokens: 200_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(818_004);
+  });
+
+  it("uses standard Gemini 3.1 Pro pricing through 200k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GEMINI_3_1_PRO_MODEL_ID,
+        promptTokens: 200_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(412_000);
+  });
+
+  it("uses Gemini 3.1 Pro long-context pricing above 200k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GEMINI_3_1_PRO_MODEL_ID,
+        promptTokens: 200_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(818_004);
   });
 
   it("uses long-context Grok 4.5 pricing at 200k prompt tokens", () => {

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
@@ -59,6 +59,13 @@ describe("GPT 5.6 model configurations", () => {
       output: 20.0,
       cache_creation_input_tokens: 5.0,
       cache_read_input_tokens: 0.4,
+      long_context: {
+        prompt_token_threshold: 272_001,
+        input: 8.0,
+        output: 30.0,
+        cache_creation_input_tokens: 10.0,
+        cache_read_input_tokens: 0.8,
+      },
     });
     expect(
       OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream.tokenPricing


### PR DESCRIPTION
## Description

Several models were billed at a single flat rate even though their providers price prompts above a
context threshold at a higher tier for the whole request.

OpenAI GPT 5.6 (Sol, Terra, Luna) had no `long_context` entry, so prompts above 272K input tokens
were billed at the short-context rate. Added the published long-context tiers (2x input / cached
input / cache writes, 1.5x output), matching the tables at
https://developers.openai.com/api/docs/pricing:

| model | short (in/cached/write/out) | long (in/cached/write/out) |
| --- | --- | --- |
| gpt-5.6-sol | 4 / 0.4 / 5 / 20 | 8 / 0.8 / 10 / 30 |
| gpt-5.6-terra | 2 / 0.2 / 2.5 / 12 | 4 / 0.4 / 5 / 18 |
| gpt-5.6-luna | 0.2 / 0.02 / 0.25 / 1.2 | 0.4 / 0.04 / 0.5 / 1.8 |

Sol, Terra and Luna are all configured with a 272K context window today, so the new tier is not
reachable through those model IDs — it makes the table correct if the window is ever raised, and
keeps the family consistent with `gpt-5.6-terra-long-context`, `gpt-5.5` and `gpt-5.4`, which
already carry the tier.

Gemini 3 Pro and 3.1 Pro were priced flat at the *high* tier (4/18) with a comment noting the real
structure is 2/12 up to 200K input tokens and 4/18 above. Both are configured with a 1M context
window, so this over-billed every prompt below 200K tokens. They now use the tiered entry, so
short-context prompts are billed at 2/12 and long-context ones stay at 4/18.

EU pricing picks up all of the new tiers automatically through `applyRegionalUplift`.

Not changed: `gpt-5.4-mini`, `gpt-5.4-nano` and the Flash/Flash-Lite families have no long-context
SKU, and `gpt-5.5-pro` / `gpt-5.4-pro` are not in our model list.

## Tests

Added threshold-boundary cases in `token_pricing/index.test.ts` for Sol, Terra, Luna, Gemini 3 Pro
and Gemini 3.1 Pro (one at the threshold, one just above), and updated the Sol pricing-sync
assertion in `gpt_five_dot_six.test.ts`.

## Risk

Gemini 3 Pro / 3.1 Pro prompts under 200K input tokens are now billed at half the input rate and
2/3 of the output rate they were before — that is the correction, but it does lower recorded cost
for those models going forward. Rollback is a revert of this commit; no data migration involved.

## Deploy Plan

Nothing specific — pricing is read from code at usage-computation time.
