### PR TITLE
feat: move agent_configurationt endpoint to new es index

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -1,11 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import {
-  fetchAgentCostStats,
-  fetchAgentOverview,
-  getAgentCostStats,
-} from "@app/lib/api/assistant/observability/overview";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -13,7 +7,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 const ParamsSchema = z.object({
   aId: z.string(),
@@ -50,59 +43,21 @@ app.get(
       });
     }
 
-    const { days, version } = ctx.req.valid("query");
-    const owner = auth.getNonNullableWorkspace();
+    const { days } = ctx.req.valid("query");
 
-    const baseQuery = buildAgentAnalyticsBaseQuery({
-      workspaceId: owner.sId,
-      agentId: assistant.sId,
-      days,
-      version,
-    });
-
-    const [feedbackCounts, overview, costStatsResult] = await Promise.all([
-      AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+    const feedbackCounts =
+      await await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
         auth,
         assistant.sId,
         days
-      ),
-      fetchAgentOverview(baseQuery),
-      fetchAgentCostStats(auth, {
-        agentIds: [assistant.sId],
-        days,
-        version,
-      }),
-    ]);
-    const costs = getAgentCostStats(
-      costStatsResult.isOk() ? costStatsResult.value : new Map(),
-      assistant.sId
-    );
-
-    if (overview.isErr()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve agent overview: ${fromError(overview.error).toString()}`,
-        },
-      });
-    }
-
-    const { activeUsers, conversationCount, messageCount } = overview.value;
+      );
 
     return ctx.json({
-      activeUsers,
-      mentions: {
-        messageCount,
-        conversationCount,
-        timePeriodSec: days * 24 * 60 * 60,
-      },
       feedbacks: {
         positiveFeedbacks: feedbackCounts.positive,
         negativeFeedbacks: feedbackCounts.negative,
         timePeriodSec: days * 24 * 60 * 60,
       },
-      costs,
     });
   }
 );

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -46,7 +46,7 @@ app.get(
     const { days } = ctx.req.valid("query");
 
     const feedbackCounts =
-      await await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
+      await AgentMessageFeedbackResource.getFeedbackCountForAssistant(
         auth,
         assistant.sId,
         days

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -32,7 +32,6 @@ import {
   formatMcpDescription,
 } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import {
   describeMcpServer,
   getAvailableModelsForWorkspace,
@@ -837,8 +836,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    const owner = auth.getNonNullableWorkspace();
-
     // Verify agent configuration exists and is accessible.
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId: agentConfigurationId,
@@ -854,11 +851,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     const numberOfDays = days ?? 30;
-    const baseQuery = buildAgentAnalyticsBaseQuery({
-      workspaceId: owner.sId,
-      agentId: agentConfigurationId,
-      days: numberOfDays,
-    });
 
     const [feedbackCounts, overviewResult] = await Promise.all([
       AgentMessageFeedbackResource.getFeedbackCountForAssistant(
@@ -866,7 +858,10 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         agentConfigurationId,
         numberOfDays
       ),
-      fetchAgentOverview(baseQuery),
+      fetchAgentOverview(auth, {
+        agentId: agentConfigurationId,
+        days: numberOfDays,
+      }),
     ]);
 
     if (overviewResult.isErr()) {

--- a/front/lib/api/assistant/builder/sidekick_prompts.ts
+++ b/front/lib/api/assistant/builder/sidekick_prompts.ts
@@ -3,7 +3,6 @@ import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/con
 import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
 import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
@@ -192,20 +191,16 @@ async function fetchInsightsMarkdown(
   auth: Authenticator,
   agentConfigurationId: string
 ): Promise<string | null> {
-  const owner = auth.getNonNullableWorkspace();
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: agentConfigurationId,
-    days: INSIGHTS_DAYS,
-  });
-
   const [feedbackCounts, overviewResult] = await Promise.all([
     AgentMessageFeedbackResource.getFeedbackCountForAssistant(
       auth,
       agentConfigurationId,
       INSIGHTS_DAYS
     ),
-    fetchAgentOverview(baseQuery),
+    fetchAgentOverview(auth, {
+      agentId: agentConfigurationId,
+      days: INSIGHTS_DAYS,
+    }),
   ]);
 
   if (overviewResult.isErr()) {

--- a/front/lib/api/assistant/observability/overview.test.ts
+++ b/front/lib/api/assistant/observability/overview.test.ts
@@ -1,0 +1,127 @@
+import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
+});
+
+const SHARDS = { total: 1, successful: 1, skipped: 0, failed: 0 };
+
+function mockOverviewAggs(aggs: {
+  active_users?: number;
+  conversations?: number;
+  total_messages?: number;
+}) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      took: 1,
+      timed_out: false,
+      _shards: SHARDS,
+      hits: { total: { value: 0, relation: "eq" as const }, hits: [] },
+      aggregations: {
+        active_users: { value: aggs.active_users ?? 0 },
+        conversations: { value: aggs.conversations ?? 0 },
+        total_messages: { value: aggs.total_messages ?? 0 },
+      },
+    })
+  );
+}
+
+describe("fetchAgentOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns overview metrics from aggregation values", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    mockOverviewAggs({
+      active_users: 42,
+      conversations: 120,
+      total_messages: 350,
+    });
+
+    const result = await fetchAgentOverview(authenticator, {
+      agentId: "agent-abc",
+      days: 30,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toEqual({
+      activeUsers: 42,
+      conversationCount: 120,
+      messageCount: 350,
+    });
+  });
+
+  it("defaults to 0 when aggregation values are missing", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: SHARDS,
+        hits: { total: { value: 0, relation: "eq" as const }, hits: [] },
+        aggregations: {},
+      })
+    );
+
+    const result = await fetchAgentOverview(authenticator, {
+      agentId: "agent-abc",
+      days: 7,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toEqual({
+      activeUsers: 0,
+      conversationCount: 0,
+      messageCount: 0,
+    });
+  });
+
+  it("passes agent filter and version to the ES query", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    mockOverviewAggs({});
+
+    await fetchAgentOverview(authenticator, {
+      agentId: "agent-xyz",
+      days: 14,
+      version: "3",
+    });
+
+    expect(searchConsumptionAnalytics).toHaveBeenCalledOnce();
+
+    const [query, options] = vi.mocked(searchConsumptionAnalytics).mock
+      .calls[0];
+
+    const filters = (query as { bool: { filter: unknown[] } }).bool.filter;
+    const hasAgentFilter = filters.some(
+      (f: any) =>
+        f?.term?.["agent.attributed_id"] === "agent-xyz" ||
+        f?.terms?.["agent.attributed_id"]?.includes("agent-xyz")
+    );
+    expect(hasAgentFilter).toBe(true);
+
+    const hasVersionFilter = filters.some(
+      (f: any) => f?.term?.["agent.version"] === "3"
+    );
+    expect(hasVersionFilter).toBe(true);
+
+    expect(options?.size).toBe(0);
+  });
+});

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -1,8 +1,13 @@
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CONVERSATION_ID_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentCostStats } from "@app/types/api/assistant/observability/overview";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -20,16 +25,55 @@ type OverviewAggs = {
 };
 
 export async function fetchAgentOverview(
-  baseQuery: estypes.QueryDslQueryContainer
+  auth: Authenticator,
+  {
+    agentId,
+    days,
+    version,
+  }: {
+    agentId: string;
+    days: number;
+    version?: string;
+  }
 ): Promise<Result<AgentOverview, Error>> {
+  const period = await resolveConsumptionPeriod(auth, { kind: "days", days });
+
+  const extraFilters: estypes.QueryDslQueryContainer[] = [];
+  if (version) {
+    extraFilters.push({ term: { "agent.version": version } });
+  }
+
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter: { agents: [agentId] },
+    extraFilters,
+  });
+
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
     {
-      active_users: { cardinality: { field: "user_id" } },
-      conversations: { cardinality: { field: "conversation_id" } },
-      total_messages: { value_count: { field: "message_id" } },
+      active_users: {
+        cardinality: {
+          field: CONSUMPTION_DIMENSION_FIELDS.user,
+          precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+        },
+      },
+      conversations: {
+        cardinality: {
+          field: CONVERSATION_ID_FIELD,
+          precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+        },
+      },
+      total_messages: {
+        cardinality: {
+          field: AGENT_MESSAGE_ID_FIELD,
+          precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+        },
+      },
     };
 
-  const result = await searchAnalytics<never, OverviewAggs>(baseQuery, {
+  const result = await searchConsumptionAnalytics<never, OverviewAggs>(query, {
     aggregations,
     size: 0,
   });
@@ -45,115 +89,4 @@ export async function fetchAgentOverview(
     conversationCount: Math.round(aggs?.conversations?.value ?? 0),
     messageCount: Math.round(aggs?.total_messages?.value ?? 0),
   });
-}
-
-const EMPTY_COST_STATS: AgentCostStats = {
-  totalCostCredits: null,
-  avgCostCredits: null,
-  medianCostCredits: null,
-};
-
-type KeyedTDigestPercentiles = Omit<
-  estypes.AggregationsTDigestPercentilesAggregate,
-  "values"
-> & {
-  values: Record<string, number | null>;
-};
-
-type CostAgentBucket = {
-  key: string;
-  total_cost?: estypes.AggregationsSumAggregate;
-  avg_cost?: estypes.AggregationsAvgAggregate;
-  median_cost?: KeyedTDigestPercentiles;
-};
-
-type AgentCostStatsAggs = {
-  by_agent?: estypes.AggregationsMultiBucketAggregateBase<CostAgentBucket>;
-};
-
-export async function fetchAgentCostStats(
-  auth: Authenticator,
-  {
-    agentIds,
-    days,
-    startDate,
-    endDate,
-    version,
-  }: {
-    agentIds: string[];
-    days?: number;
-    startDate?: string;
-    endDate?: string;
-    version?: string;
-  }
-): Promise<Result<Map<string, AgentCostStats>, ElasticsearchError>> {
-  if (agentIds.length === 0) {
-    return new Ok(new Map());
-  }
-
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    agentIds,
-    days,
-    startDate,
-    endDate,
-    version,
-  });
-
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter: [
-        baseQuery,
-        // Billed cost per execution: `cost.billable_awu` is already 0 for the
-        // non-billable (errored terminal) part, so no status filter is needed and
-        // failed multi-execution messages still contribute their non-error work.
-        // `> 0` keeps this to messages that actually incurred billed cost.
-        { range: { "cost.billable_awu": { gt: 0 } } },
-      ],
-    },
-  };
-
-  const result = await searchAnalytics<never, AgentCostStatsAggs>(query, {
-    aggregations: {
-      by_agent: {
-        terms: { field: "agent_id", size: agentIds.length },
-        aggs: {
-          total_cost: { sum: { field: "cost.billable_awu" } },
-          avg_cost: { avg: { field: "cost.billable_awu" } },
-          median_cost: {
-            percentiles: { field: "cost.billable_awu", percents: [50] },
-          },
-        },
-      },
-    },
-    size: 0,
-  });
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const buckets = bucketsToArray<CostAgentBucket>(
-    result.value.aggregations?.by_agent?.buckets
-  );
-
-  return new Ok(
-    new Map(
-      buckets.map((bucket) => [
-        String(bucket.key),
-        {
-          totalCostCredits: bucket.total_cost?.value ?? null,
-          avgCostCredits: bucket.avg_cost?.value ?? null,
-          medianCostCredits: bucket.median_cost?.values?.["50.0"] ?? null,
-        },
-      ])
-    )
-  );
-}
-
-export function getAgentCostStats(
-  map: Map<string, AgentCostStats>,
-  agentId: string
-): AgentCostStats {
-  return map.get(agentId) ?? EMPTY_COST_STATS;
 }

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -1,8 +1,4 @@
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
-import {
-  fetchAgentCostStats,
-  getAgentCostStats,
-} from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
@@ -96,20 +92,7 @@ export async function fetchTopAgents(
     return new Ok([]);
   }
 
-  const [agents, costStatsResult] = await Promise.all([
-    resolveAnalyticsAgentLabels(auth, bucketAgentIds),
-    fetchAgentCostStats(auth, {
-      agentIds: bucketAgentIds,
-      days,
-      startDate,
-      endDate,
-    }),
-  ]);
-
-  if (costStatsResult.isErr()) {
-    return costStatsResult;
-  }
-  const costStatsMap = costStatsResult.value;
+  const agents = await resolveAnalyticsAgentLabels(auth, bucketAgentIds);
 
   const rows = buckets.flatMap((bucket) => {
     const agentId = String(bucket.key);
@@ -124,8 +107,6 @@ export async function fetchTopAgents(
         pictureUrl: label.pictureUrl,
         messageCount: bucket.doc_count ?? 0,
         userCount: Math.round(bucket.unique_users?.value ?? 0),
-        totalCostCredits: getAgentCostStats(costStatsMap, agentId)
-          .totalCostCredits,
       },
     ];
   });

--- a/front/lib/api/workspace/analytics.ts
+++ b/front/lib/api/workspace/analytics.ts
@@ -9,7 +9,6 @@ export type WorkspaceTopAgentRow = {
   pictureUrl: string | null;
   messageCount: number;
   userCount: number;
-  totalCostCredits: number | null;
 };
 
 export type GetWorkspaceTopAgentsResponse = {

--- a/front/types/api/assistant/observability/overview.ts
+++ b/front/types/api/assistant/observability/overview.ts
@@ -1,20 +1,7 @@
-export type AgentCostStats = {
-  totalCostCredits: number | null;
-  avgCostCredits: number | null;
-  medianCostCredits: number | null;
-};
-
 export type GetAgentOverviewResponseBody = {
-  activeUsers: number;
-  mentions: {
-    messageCount: number;
-    conversationCount: number;
-    timePeriodSec: number;
-  };
   feedbacks: {
     positiveFeedbacks: number;
     negativeFeedbacks: number;
     timePeriodSec: number;
   };
-  costs: AgentCostStats;
 };


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/10185

- `/api/w/:wId/assistant/agent_configurations/:aId/observability/overview` used to call `fetchAgentOverview` and `fetchAgentCostStats` which call `searchAnalytics`.
- Turns out this endpoint is only used to display feedback count, so removed those calls from this endpoint
- Turns out `fetchAgentCostStats` result is never used, so removed this function entirely
- Migrated `fetchAgentOverview` which is use elsewhere to `searchConsumtptionAnalytics`


## Tests

- added tests for `fetchAgentOverview`
- lint + browse agent config locally to check nothing is broken

## Risk

Low. Safe to rollback while the es index `front.agent_message_analytics` exists

## Deploy Plan

Front only

