### PR TITLE
[front] members: model tiers column for workspaces without usage page

### DIFF
--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -2,7 +2,9 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { GroupDialog } from "@app/components/groups/GroupDialog";
 import { getGroupKindChip } from "@app/components/groups/GroupKinds";
 import { ProvisionedGroupDialog } from "@app/components/groups/ProvisionedGroupDialog";
+import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
+import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
 import { useAppRouter } from "@app/lib/platform";
@@ -48,9 +50,10 @@ type GroupRowData = {
 
 interface WorkspaceGroupsListProps {
   owner: WorkspaceType;
+  showModelTiers: boolean;
 }
 
-const columns: ColumnDef<GroupRowData>[] = [
+const baseColumns: ColumnDef<GroupRowData>[] = [
   {
     id: "name",
     accessorKey: "name",
@@ -81,47 +84,75 @@ const columns: ColumnDef<GroupRowData>[] = [
       );
     },
   },
-  {
-    id: "actions",
-    header: "",
-    meta: { className: "w-12" },
-    cell: ({ row }) => {
-      const { onDelete } = row.original;
-      if (!onDelete) {
-        return null;
-      }
-      return (
-        <DataTable.CellContent>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                icon={DotsHorizontal}
-                size="mini"
-                variant="ghost-secondary"
-                onClick={(e) => e.stopPropagation()}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuContent
-                align="end"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <DropdownMenuItem
-                  label="Delete"
-                  icon={Trash01}
-                  variant="warning"
-                  onClick={onDelete}
-                />
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
-          </DropdownMenu>
-        </DataTable.CellContent>
-      );
-    },
-  },
 ];
 
-export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
+function buildModelTiersColumn(owner: WorkspaceType): ColumnDef<GroupRowData> {
+  return {
+    id: "modelTiers",
+    header: () => (
+      <span className="flex items-center gap-1">
+        Models tier
+        <ModelTiersInfoButton />
+      </span>
+    ),
+    meta: { className: "w-64" },
+    cell: ({ row }) => (
+      <div
+        onClick={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <GroupModelTierPickerDropdown
+          owner={owner}
+          groupId={row.original.groupId}
+        />
+      </div>
+    ),
+  };
+}
+
+const actionsColumn: ColumnDef<GroupRowData> = {
+  id: "actions",
+  header: "",
+  meta: { className: "w-12" },
+  cell: ({ row }) => {
+    const { onDelete } = row.original;
+    if (!onDelete) {
+      return null;
+    }
+    return (
+      <DataTable.CellContent>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              icon={DotsHorizontal}
+              size="mini"
+              variant="ghost-secondary"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuContent
+              align="end"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <DropdownMenuItem
+                label="Delete"
+                icon={Trash01}
+                variant="warning"
+                onClick={onDelete}
+              />
+            </DropdownMenuContent>
+          </DropdownMenuPortal>
+        </DropdownMenu>
+      </DataTable.CellContent>
+    );
+  },
+};
+
+export function WorkspaceGroupsList({
+  owner,
+  showModelTiers,
+}: WorkspaceGroupsListProps) {
   const { groups, isGroupsLoading } = useGroups({
     owner,
     kinds: MANAGEABLE_GROUP_KINDS,
@@ -195,6 +226,15 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
       };
     });
   }, [groups, handleDeleteGroup]);
+
+  const columns = useMemo(
+    () => [
+      ...baseColumns,
+      ...(showModelTiers ? [buildModelTiersColumn(owner)] : []),
+      actionsColumn,
+    ],
+    [owner, showModelTiers]
+  );
 
   return (
     <div className="flex flex-col gap-4">

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -5,10 +5,15 @@ import {
   normalizeDisplayRole,
   ROLES_DATA,
 } from "@app/components/members/Roles";
+import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
+import { formatModelTiersSummary } from "@app/lib/client/model_tiers";
+import type { ResolvedAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
+import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import assert from "@app/lib/utils/assert";
 import type { MembershipOriginType } from "@app/types/memberships";
 import type { RoleType, UserType } from "@app/types/user";
+import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Chip,
   DataTable,
@@ -35,6 +40,8 @@ type RowData = {
   onClick: () => void;
   onRemoveMemberClick?: () => void;
   origin?: MembershipOriginType;
+  modelTiers?: ResolvedAllowedModelTiers;
+  menuItems?: MenuItem[];
 };
 
 type Info = CellContext<RowData, string>;
@@ -61,12 +68,18 @@ function getTableRows({
   allUsers,
   onClick,
   onRemoveMemberClick,
+  getResolvedModelTiers,
+  getMenuItems,
   currentUserId,
   allowRemoveSelfAndProvisionedUsers,
 }: {
   allUsers: SearchMemberWithWorkspaceType[];
   onClick: (user: SearchMemberWithWorkspaceType) => void;
   onRemoveMemberClick?: (user: SearchMemberWithWorkspaceType) => void;
+  getResolvedModelTiers?: (
+    user: SearchMemberWithWorkspaceType
+  ) => ResolvedAllowedModelTiers;
+  getMenuItems?: (user: SearchMemberWithWorkspaceType) => MenuItem[];
   currentUserId: string;
   allowRemoveSelfAndProvisionedUsers: boolean;
 }): RowData[] {
@@ -89,6 +102,8 @@ function getTableRows({
       onClick: () => onClick(user),
       onRemoveMemberClick: () => onRemoveMemberClick?.(user),
       origin,
+      modelTiers: getResolvedModelTiers?.(user),
+      menuItems: getMenuItems?.(user),
     };
   });
 }
@@ -173,7 +188,64 @@ const memberColumns = [
       </DataTable.CellContent>
     ),
   },
+  {
+    id: "modelTiers" as const,
+    header: () => (
+      <span className="flex items-center gap-1">
+        Models tier
+        <ModelTiersInfoButton />
+      </span>
+    ),
+    cell: (info: Info) => {
+      const modelTiers = info.row.original.modelTiers;
+      if (!modelTiers) {
+        return null;
+      }
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground">
+            {formatModelTiersSummary(getMaxTierName(modelTiers.tiers))}
+            {modelTiers.source === "user" ? " (custom)" : ""}
+          </span>
+        </DataTable.CellContent>
+      );
+    },
+    meta: {
+      className: "w-48",
+    },
+  },
+  {
+    id: "actions" as const,
+    header: "",
+    cell: (info: Info) => {
+      const menuItems = info.row.original.menuItems;
+      if (!menuItems) {
+        return null;
+      }
+      return (
+        <div
+          onClick={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <DataTable.MoreButton menuItems={menuItems} />
+        </div>
+      );
+    },
+    meta: {
+      className: "w-14",
+    },
+  },
 ];
+
+export type MembersListColumn =
+  | "name"
+  | "email"
+  | "role"
+  | "remove"
+  | "status"
+  | "groups"
+  | "modelTiers"
+  | "actions";
 
 interface MembersListProps {
   allowRemoveSelfAndProvisionedUsers?: boolean;
@@ -181,7 +253,11 @@ interface MembersListProps {
   membersData: MembersData;
   onRowClick: (user: SearchMemberWithWorkspaceType) => void;
   onRemoveMemberClick?: (user: SearchMemberWithWorkspaceType) => void;
-  showColumns: ("name" | "email" | "role" | "remove" | "status" | "groups")[];
+  getResolvedModelTiers?: (
+    user: SearchMemberWithWorkspaceType
+  ) => ResolvedAllowedModelTiers;
+  getMenuItems?: (user: SearchMemberWithWorkspaceType) => MenuItem[];
+  showColumns: MembersListColumn[];
   pagination?: PaginationState;
   setPagination?: (pagination: PaginationState) => void;
 }
@@ -192,6 +268,8 @@ export function MembersList({
   membersData,
   onRowClick,
   onRemoveMemberClick,
+  getResolvedModelTiers,
+  getMenuItems,
   showColumns,
   pagination,
   setPagination,
@@ -199,6 +277,14 @@ export function MembersList({
   assert(
     !showColumns.includes("remove") || onRemoveMemberClick,
     "onRemoveMemberClick is required if remove column is shown"
+  );
+  assert(
+    !showColumns.includes("modelTiers") || getResolvedModelTiers,
+    "getResolvedModelTiers is required if modelTiers column is shown"
+  );
+  assert(
+    !showColumns.includes("actions") || getMenuItems,
+    "getMenuItems is required if actions column is shown"
   );
 
   const { members, totalMembersCount, isLoading } = membersData;
@@ -211,6 +297,8 @@ export function MembersList({
       allUsers: filteredMembers,
       onClick: onRowClick,
       onRemoveMemberClick,
+      getResolvedModelTiers,
+      getMenuItems,
       currentUserId: currentUser?.sId ?? "current-user-not-loaded",
       allowRemoveSelfAndProvisionedUsers,
     });
@@ -218,6 +306,8 @@ export function MembersList({
     members,
     onRowClick,
     onRemoveMemberClick,
+    getResolvedModelTiers,
+    getMenuItems,
     currentUser?.sId,
     allowRemoveSelfAndProvisionedUsers,
   ]);

--- a/front/components/members/WorkspaceMembersSection.tsx
+++ b/front/components/members/WorkspaceMembersSection.tsx
@@ -4,6 +4,7 @@ import { InvitationsList } from "@app/components/members/InvitationsList";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
 import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
 import { isFullUserType } from "@app/components/members/MemberSelectionTable";
+import type { MembersListColumn } from "@app/components/members/MembersList";
 import { MembersList } from "@app/components/members/MembersList";
 import type { RoleFilter } from "@app/components/members/Roles";
 import {
@@ -11,8 +12,10 @@ import {
   ROLE_FILTER_OPTIONS,
 } from "@app/components/members/Roles";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
+import { useMembersModelTiers } from "@app/hooks/useMembersModelTiers";
 import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSearchMembers } from "@app/lib/swr/memberships";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   SubscriptionPerSeatPricing,
   SubscriptionType,
@@ -34,7 +37,7 @@ import {
   SearchInput,
 } from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -48,6 +51,7 @@ interface WorkspaceMembersSectionProps {
   subscription: SubscriptionType;
   perSeatPricing: SubscriptionPerSeatPricing | null;
   hasAvailableSeats: boolean;
+  showModelTiers: boolean;
 }
 
 export function WorkspaceMembersSection({
@@ -58,6 +62,7 @@ export function WorkspaceMembersSection({
   subscription,
   perSeatPricing,
   hasAvailableSeats,
+  showModelTiers,
 }: WorkspaceMembersSectionProps) {
   const [view, setView] = useState("members");
   const [searchTerm, setSearchTerm] = useState("");
@@ -149,6 +154,7 @@ export function WorkspaceMembersSection({
           searchTerm={searchTerm}
           roleFilter={roleFilter}
           isProvisioningEnabled={isProvisioningEnabled}
+          showModelTiers={showModelTiers}
         />
       )}
       {view === "invitations" && isManualInvitationsEnabled && (
@@ -175,6 +181,7 @@ interface WorkspaceMembersListProps {
   searchTerm: string;
   roleFilter: RoleFilter;
   isProvisioningEnabled: boolean;
+  showModelTiers: boolean;
 }
 
 function WorkspaceMembersList({
@@ -183,6 +190,7 @@ function WorkspaceMembersList({
   searchTerm,
   roleFilter,
   isProvisioningEnabled,
+  showModelTiers,
 }: WorkspaceMembersListProps) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -194,12 +202,20 @@ function WorkspaceMembersList({
   const [selectedMember, setSelectedMember] =
     useState<UserTypeWithWorkspace | null>(null);
 
+  // Model tiers resolve through every cap-eligible group; the provisioning view
+  // only needs the provisioned ones for its Groups column.
+  const membersGroupKinds = showModelTiers
+    ? CAP_ELIGIBLE_GROUP_KINDS
+    : isProvisioningEnabled
+      ? PROVISIONED_GROUP_KINDS
+      : undefined;
+
   const membersData = useSearchMembers<UserTypeWithWorkspace>({
     workspaceId: owner.sId,
     searchTerm,
     pageIndex: pagination.pageIndex,
     pageSize: DEFAULT_PAGE_SIZE,
-    groupKinds: isProvisioningEnabled ? PROVISIONED_GROUP_KINDS : undefined,
+    groupKinds: membersGroupKinds,
     role: roleFilter === "all" ? undefined : roleFilter,
   });
 
@@ -221,17 +237,43 @@ function WorkspaceMembersList({
     }
   }, []);
 
+  const { getResolvedModelTiers, getModelTierMenuItem } = useMembersModelTiers({
+    owner,
+    disabled: !showModelTiers,
+  });
+  const getRowResolvedModelTiers = useCallback(
+    (user: SearchMemberWithWorkspaceType) =>
+      getResolvedModelTiers(user.sId, user.workspace.groups ?? []),
+    [getResolvedModelTiers]
+  );
+  const getRowMenuItems = useCallback(
+    (user: SearchMemberWithWorkspaceType) => [
+      getModelTierMenuItem(user.sId, user.workspace.groups ?? []),
+    ],
+    [getModelTierMenuItem]
+  );
+  const showColumns = useMemo<MembersListColumn[]>(
+    () => [
+      "name",
+      "email",
+      "role",
+      ...(isProvisioningEnabled ? (["status", "groups"] as const) : []),
+      ...(showModelTiers ? (["modelTiers", "actions"] as const) : []),
+    ],
+    [isProvisioningEnabled, showModelTiers]
+  );
+
   return (
     <>
       <MembersList
         currentUser={currentUser}
         membersData={membersData}
         onRowClick={handleRowClick}
-        showColumns={
-          isProvisioningEnabled
-            ? ["name", "email", "role", "status", "groups"]
-            : ["name", "email", "role"]
+        showColumns={showColumns}
+        getResolvedModelTiers={
+          showModelTiers ? getRowResolvedModelTiers : undefined
         }
+        getMenuItems={showModelTiers ? getRowMenuItems : undefined}
         pagination={pagination}
         setPagination={setPagination}
       />

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -1,13 +1,19 @@
 import { WorkspaceGroupsList } from "@app/components/groups/WorkspaceGroupsList";
 import { WorkspaceMembersSection } from "@app/components/members/WorkspaceMembersSection";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
+import { isUsagePageEnabled } from "@app/lib/plans/usage_page";
 import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
   useWorkspaceVerifiedDomains,
 } from "@app/lib/swr/workspaces";
+import { isAdmin } from "@app/types/user";
 import {
   Page,
   Spinner,
@@ -18,6 +24,7 @@ import {
 } from "@dust-tt/sparkle";
 
 export function MembersPage() {
+  const { featureFlags } = useFeatureFlags();
   const owner = useWorkspace();
   const { subscription, user } = useAuth();
   const plan = subscription.plan;
@@ -37,6 +44,9 @@ export function MembersPage() {
   const isProvisioningEnabled = isSCIMEnabled(plan) && hasVerifiedDomains;
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
+  // Workspaces with a Usage page manage model tiers there.
+  const showModelTiers =
+    isAdmin(owner) && !isUsagePageEnabled(plan, featureFlags);
 
   const isLoading =
     isVerifiedDomainsLoading ||
@@ -60,6 +70,7 @@ export function MembersPage() {
       subscription={subscription}
       perSeatPricing={perSeatPricing}
       hasAvailableSeats={hasAvailableSeats}
+      showModelTiers={showModelTiers}
     />
   );
 
@@ -79,7 +90,10 @@ export function MembersPage() {
             {membersContent}
           </TabsContent>
           <TabsContent value="groups" className="flex flex-col gap-4">
-            <WorkspaceGroupsList owner={owner} />
+            <WorkspaceGroupsList
+              owner={owner}
+              showModelTiers={showModelTiers}
+            />
           </TabsContent>
         </Tabs>
       </div>


### PR DESCRIPTION
Workspaces without access to the Usage page (not credit-priced, no `usage_page_read_only` flag) had no way to manage model tiers.

On the People page, for admins of those workspaces only:
- Members tab: "Models tier" column with the effective tier, plus a row menu to set a user override.
- Groups tab: "Models tier" column with the existing group tier picker.

The Usage page is unchanged.

Stacked on #31680 (shared hook) and #31679 (members search returns group names). Deploy front-api before front-spa: on an old backend the page still loads but shows the workspace tier for everyone until the API ships.
