### PR TITLE
[front] fix: allow role switching with debug tools

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/index.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.test.ts
@@ -1,4 +1,5 @@
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -242,6 +243,29 @@ describe("POST /api/w/:wId/members/:uId", () => {
       expect(response.status).toBe(403);
       const data = await response.json();
       expect(data.error.type).toBe("workspace_auth_error");
+    });
+  });
+
+  describe("forced role changes", () => {
+    it("should allow a regular user to force their role when debug tools are enabled", async () => {
+      const { auth, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
+      await FeatureFlagFactory.basic(auth, "show_debug_tools");
+
+      const response = await honoApp.request(
+        memberUrl(workspace.sId, user.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: "admin", force: "true" }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.member.workspaces[0].role).toBe("admin");
     });
   });
 

--- a/front-api/routes/w/[wId]/members/[uId]/index.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.test.ts
@@ -1,8 +1,11 @@
+import { DUST_COMPANY_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
 
@@ -247,10 +250,13 @@ describe("POST /api/w/:wId/members/:uId", () => {
   });
 
   describe("forced role changes", () => {
-    it("should allow a regular user to force their role when debug tools are enabled", async () => {
-      const { auth, workspace, user } = await createPrivateApiMockRequest({
+    it("should allow a regular user in Dust's company workspace to force their role", async () => {
+      const plan = await PlanFactory.enterprise(DUST_COMPANY_PLAN_CODE);
+      const workspace = await WorkspaceFactory.fromPlan(plan);
+      const { auth, user } = await createPrivateApiMockRequest({
         method: "POST",
         role: "user",
+        workspace,
       });
       await FeatureFlagFactory.basic(auth, "show_debug_tools");
 
@@ -266,6 +272,27 @@ describe("POST /api/w/:wId/members/:uId", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.member.workspaces[0].role).toBe("admin");
+    });
+
+    it("should reject a regular user outside Dust's company workspace", async () => {
+      const { auth, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
+      await FeatureFlagFactory.basic(auth, "show_debug_tools");
+
+      const response = await honoApp.request(
+        memberUrl(workspace.sId, user.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: "admin", force: "true" }),
+        }
+      );
+
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.type).toBe("workspace_auth_error");
     });
   });
 

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -108,7 +108,6 @@ app.post(
     const featureFlags = await getFeatureFlags(auth);
     const body = ctx.req.valid("json");
 
-    // Allow users in Dust's company workspace to force role for testing.
     const allowForDustWorkspaceTesting =
       isDustCompanyPlan(auth.getNonNullablePlan().code) &&
       showDebugTools(featureFlags) &&

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -107,13 +107,11 @@ app.post(
     const featureFlags = await getFeatureFlags(auth);
     const body = ctx.req.valid("json");
 
-    // Allow Dust Super User to force role for testing
-    const allowForSuperUserTesting =
-      showDebugTools(featureFlags) &&
-      auth.isDustSuperUser() &&
-      body.force === "true";
+    // Allow users with debug tools enabled to force role for testing.
+    const allowForDebugToolsTesting =
+      showDebugTools(featureFlags) && body.force === "true";
 
-    if (!auth.isManager() && !allowForSuperUserTesting) {
+    if (!auth.isManager() && !allowForDebugToolsTesting) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -148,7 +146,7 @@ app.post(
     if (
       (targetIsAdmin || assigningAdmin) &&
       !auth.isAdmin() &&
-      !allowForSuperUserTesting
+      !allowForDebugToolsTesting
     ) {
       return apiError(ctx, {
         status_code: 403,

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -10,6 +10,7 @@ import {
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { getFeatureFlags } from "@app/lib/auth";
 import { showDebugTools } from "@app/lib/development";
+import { isDustCompanyPlan } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type {
@@ -107,11 +108,13 @@ app.post(
     const featureFlags = await getFeatureFlags(auth);
     const body = ctx.req.valid("json");
 
-    // Allow users with debug tools enabled to force role for testing.
-    const allowForDebugToolsTesting =
-      showDebugTools(featureFlags) && body.force === "true";
+    // Allow users in Dust's company workspace to force role for testing.
+    const allowForDustWorkspaceTesting =
+      isDustCompanyPlan(auth.getNonNullablePlan().code) &&
+      showDebugTools(featureFlags) &&
+      body.force === "true";
 
-    if (!auth.isManager() && !allowForDebugToolsTesting) {
+    if (!auth.isManager() && !allowForDustWorkspaceTesting) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -146,7 +149,7 @@ app.post(
     if (
       (targetIsAdmin || assigningAdmin) &&
       !auth.isAdmin() &&
-      !allowForDebugToolsTesting
+      !allowForDustWorkspaceTesting
     ) {
       return apiError(ctx, {
         status_code: 403,


### PR DESCRIPTION
## Description

The role-switching actions in Dev Tools are visible whenever debug tools are enabled, but their API call will always fail since we can't have a Dust super-user session in the app anymore.

This PR replaces the backend check to check `isDustCompanyPlan` instead.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
