### PR TITLE
[Admin Governance] Use Authenticator.can for spaces

### DIFF
--- a/front-api/middlewares/with_space.ts
+++ b/front-api/middlewares/with_space.ts
@@ -25,19 +25,20 @@ function hasPermission(
   space: SpaceResource,
   options: WithSpaceOptions
 ): boolean {
-  if (options.requireCanAdministrate && !space.canAdministrate(auth)) {
+  if (options.requireCanAdministrate && !auth.can("admin", space)) {
     return false;
   }
   if (
     options.requireCanReadOrAdministrate &&
-    !space.canReadOrAdministrate(auth)
+    !auth.can("read", space) &&
+    !auth.can("admin", space)
   ) {
     return false;
   }
-  if (options.requireCanRead && !space.canRead(auth)) {
+  if (options.requireCanRead && !auth.can("read", space)) {
     return false;
   }
-  if (options.requireCanWrite && !space.canWrite(auth)) {
+  if (options.requireCanWrite && !auth.can("write", space)) {
     return false;
   }
   return true;

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -199,7 +199,8 @@ app.get(
     const spaceId = file.useCaseMetadata?.spaceId;
     const space =
       spaceId && auth ? await SpaceResource.fetchById(auth, spaceId) : null;
-    const canRead = space && space.isProject() && auth && space.canRead(auth);
+    const canRead =
+      space && space.isProject() && auth && auth.can("read", space);
     // Standing of the viewer in the Pod hosting the Frame, mirroring what pod hosts thread into
     // the frame identity (podInfo.isMember / podInfo.isEditor). Display-only: invocations
     // re-authorize server-side.
@@ -213,7 +214,7 @@ app.get(
       space &&
       space.isProject() &&
       auth &&
-      space.canAdministrate(auth)
+      auth.can("admin", space)
     );
     // The share token this viewer used is a workspace member's capability to invoke the frame's
     // app's functions. For invite-only frames, a member only reaches this point with an active

--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -289,7 +289,7 @@ async function checkFileAccess(
       auth,
       file.useCaseMetadata.spaceId
     );
-    if (!space || !space.canRead(auth)) {
+    if (!space || !auth.can("read", space)) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/v1/w/[wId]/files/fileId.test.ts
+++ b/front-api/routes/v1/w/[wId]/files/fileId.test.ts
@@ -1,3 +1,4 @@
+import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { honoApp } from "@front-api/app";
@@ -28,7 +29,15 @@ vi.mock("@app/lib/resources/space_resource", () => ({
   SpaceResource: {
     fetchById: vi.fn().mockResolvedValue({
       id: "test-space-id",
-      canRead: vi.fn().mockReturnValue(true),
+      getAccessControlLists: vi
+        .fn()
+        .mockImplementation((auth: Authenticator) => [
+          {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            roles: [],
+            grantedVerbs: ["read"],
+          },
+        ]),
     }),
   },
 }));

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -71,7 +71,7 @@ app.get(
     if (
       !space ||
       space.isConversations() ||
-      !space.canReadOrAdministrate(auth)
+      (!auth.can("read", space) && !auth.can("admin", space))
     ) {
       return apiError(ctx, {
         status_code: 404,

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -319,7 +319,7 @@ app.post(
     let spaceModelId: number | null = null;
     if (spaceId) {
       const space = await SpaceResource.fetchById(auth, spaceId);
-      if (!space || !space.canReadOrAdministrate(auth)) {
+      if (!space || (!auth.can("read", space) && !auth.can("admin", space))) {
         return apiError(ctx, {
           status_code: 404,
           api_error: {

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -61,7 +61,7 @@ app.get(
 
     // Fetch and verify space access.
     const space = await SpaceResource.fetchById(auth, spaceId);
-    if (!space || !space.canReadOrAdministrate(auth)) {
+    if (!space || (!auth.can("read", space) && !auth.can("admin", space))) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
@@ -23,7 +23,7 @@ app.get(
     const { spaceId } = ctx.req.valid("param");
 
     const space = await SpaceResource.fetchById(auth, spaceId);
-    if (!space || !space.canReadOrAdministrate(auth)) {
+    if (!space || (!auth.can("read", space) && !auth.can("admin", space))) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
@@ -112,7 +112,7 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
         // We excluded archived projects and we only list projects where the user is a member.
         archivedAt: null,
         isMember: true,
-        isEditor: space.canAdministrate(auth),
+        isEditor: auth.can("admin", space),
         isStarred: starredSpaceModelIds.has(space.id),
       },
       unreadConversations:

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.ts
@@ -73,7 +73,7 @@ app.post(
         auth,
         file.useCaseMetadata.spaceId
       );
-      if (!space || !space.canWrite(auth)) {
+      if (!space || !auth.can("write", space)) {
         return apiError(ctx, {
           status_code: 404,
           api_error: { type: "file_not_found", message: "File not found." },

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -282,7 +282,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const isFileAuthor = file.userId === auth.user()?.id;
   const isUploadUseCase =
     file.useCase === "upsert_table" || file.useCase === "folders_document";
-  const canWriteInSpace = space ? space.canWrite(auth) : false;
+  const canWriteInSpace = space ? auth.can("write", space) : false;
 
   if (
     isUploadUseCase &&
@@ -362,7 +362,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const isFileAuthor = file.userId === auth.user()?.id;
   const isUploadUseCase =
     file.useCase === "upsert_table" || file.useCase === "folders_document";
-  const canWriteInSpace = space ? space.canWrite(auth) : false;
+  const canWriteInSpace = space ? auth.can("write", space) : false;
 
   if (
     isUploadUseCase &&
@@ -533,7 +533,7 @@ async function checkFileAccess(
     file.useCase === "folders_document" ||
     file.useCase === "project_context"
   ) {
-    if (!space || !space.canRead(auth)) {
+    if (!space || !auth.can("read", space)) {
       return apiError(ctx, {
         status_code: 404,
         api_error: { type: "file_not_found", message: "File not found." },

--- a/front-api/routes/w/[wId]/files/[fileId]/metadata.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/metadata.ts
@@ -32,7 +32,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
     ? await SpaceResource.fetchById(auth, useCaseMetadata.spaceId)
     : null;
 
-  if (useCase === "folders_document" && (!space || !space.canRead(auth))) {
+  if (useCase === "folders_document" && (!space || !auth.can("read", space))) {
     return apiError(ctx, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -44,7 +44,7 @@ app.patch(
       : null;
 
     if (file.useCase === "project_context") {
-      if (!space || !space.canWrite(auth)) {
+      if (!space || !auth.can("write", space)) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {

--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
@@ -100,7 +100,7 @@ app.post(
       });
     }
 
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -43,7 +43,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const [space] = await SpaceResource.fetchByModelIds(auth, [taskRow.spaceId]);
-  if (!space || !space.canRead(auth) || !space.isProject()) {
+  if (!space || !auth.can("read", space) || !space.isProject()) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -60,7 +60,7 @@ app.post(
     const owner = auth.getNonNullableWorkspace();
 
     if (
-      !space.canWrite(auth) ||
+      !auth.can("write", space) ||
       !(await auth.hasWorkspacePermission("admin", "dust_app"))
     ) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -233,7 +233,7 @@ app.post(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    if (!space.canAdministrate(auth)) {
+    if (!auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -36,7 +36,7 @@ app.patch(
     const space = ctx.get("space");
     const dataSource = ctx.get("dataSource");
 
-    if (space.isSystem() && !space.canAdministrate(auth)) {
+    if (space.isSystem() && !auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -46,7 +46,7 @@ app.patch(
         },
       });
     }
-    if (space.isGlobal() && !space.canWrite(auth)) {
+    if (space.isGlobal() && !auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -98,7 +98,7 @@ app.delete(
     const space = ctx.get("space");
     const dataSource = ctx.get("dataSource");
 
-    if (space.isSystem() && !space.canAdministrate(auth)) {
+    if (space.isSystem() && !auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -108,7 +108,7 @@ app.delete(
         },
       });
     }
-    if (space.isGlobal() && !space.canWrite(auth)) {
+    if (space.isGlobal() && !auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -120,10 +120,10 @@ app.delete(
     }
 
     const isAuthorized =
-      space.canWrite(auth) ||
+      auth.can("write", space) ||
       // Remote database connectors can also be deleted by system-space admins.
       (space.isSystem() &&
-        space.canAdministrate(auth) &&
+        auth.can("admin", space) &&
         isRemoteDatabase(dataSource));
     if (!isAuthorized) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -82,7 +82,7 @@ app.post(
     const plan = auth.getNonNullablePlan();
 
     if (space.isSystem()) {
-      if (!space.canAdministrate(auth)) {
+      if (!auth.can("admin", space)) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {
@@ -104,7 +104,7 @@ app.post(
         });
       }
 
-      if (!space.canWrite(auth)) {
+      if (!auth.can("write", space)) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -154,7 +154,7 @@ app.patch(
     }
     const { auth, space, normalizedRelative } = built;
 
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -213,7 +213,7 @@ app.delete(
     }
     const { auth, space, normalizedRelative } = built;
 
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -261,7 +261,7 @@ app.post(
       });
     }
 
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(c, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -93,7 +93,7 @@ app.post(
       });
     }
 
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(c, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -1,6 +1,6 @@
 import * as projectsContext from "@app/lib/api/projects/context";
+import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
@@ -177,8 +177,10 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
     });
 
     it("returns 403 when the user lacks write permission", async () => {
-      vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
       const { workspace, project } = await setupProject();
+      vi.spyOn(Authenticator.prototype, "can").mockImplementation(
+        (verb) => verb !== "write"
+      );
       const response = await fileRequest(
         workspace,
         project.sId,
@@ -248,8 +250,10 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
     });
 
     it("returns 403 when the user lacks write permission", async () => {
-      vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
       const { workspace, project } = await setupProject();
+      vi.spyOn(Authenticator.prototype, "can").mockImplementation(
+        (verb) => verb !== "write"
+      );
       const response = await fileRequest(
         workspace,
         project.sId,
@@ -315,8 +319,10 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
     });
 
     it("returns 404 when the user lacks write permission (requireCanWrite)", async () => {
-      vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
       const { workspace, project } = await setupProject();
+      vi.spyOn(Authenticator.prototype, "can").mockImplementation(
+        (verb) => verb !== "write"
+      );
       const response = await fileRequest(
         workspace,
         project.sId,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -322,10 +322,10 @@ app.get(
       space: {
         ...enrichedSpace,
         categories,
-        canWrite: space.canWrite(auth),
-        canRead: space.canRead(auth),
+        canWrite: auth.can("write", space),
+        canRead: auth.can("read", space),
         isMember: space.isMember(auth),
-        isEditor: space.canAdministrate(auth),
+        isEditor: auth.can("admin", space),
         members: currentMembers,
         description: meta?.description ?? null,
         archivedAt: meta?.archivedAt?.getTime() ?? null,
@@ -352,7 +352,7 @@ app.patch(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    if (!space.canAdministrate(auth)) {
+    if (!auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -443,7 +443,7 @@ app.delete(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    if (!space.canAdministrate(auth)) {
+    if (!auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -37,7 +37,7 @@ app.patch(
       });
     }
 
-    if (!space.canAdministrate(auth)) {
+    if (!auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -159,7 +159,7 @@ app.patch(
     }
 
     // Audit log when an admin who is not a member of the space updates its permissions.
-    if (!space.canRead(auth)) {
+    if (!auth.can("read", space)) {
       const user = auth.user();
       auditLog(
         {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
@@ -43,7 +43,7 @@ app.delete(
         },
       });
     }
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/[fileId].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/[fileId].ts
@@ -38,7 +38,7 @@ app.delete(
         },
       });
     }
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -78,7 +78,7 @@ app.post(
       });
     }
 
-    if (!space.canWrite(auth)) {
+    if (!auth.can("write", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -63,7 +63,7 @@ app.patch(
       });
     }
 
-    if (!space.canAdministrate(auth)) {
+    if (!auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_restriction_impact.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_restriction_impact.ts
@@ -28,7 +28,7 @@ app.get(
 
     // Only editors can flip the visibility toggle this warning belongs to, and the counts
     // aggregate other members' usage.
-    if (!space.canAdministrate(auth)) {
+    if (!auth.can("admin", space)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/projects-lookup.ts
+++ b/front-api/routes/w/[wId]/spaces/projects-lookup.ts
@@ -26,7 +26,7 @@ app.get("/", async (ctx): HandlerResult<SpacesLookupResponseBody> => {
   const uniqueIds = Array.from(new Set(ids));
   const spaces = await SpaceResource.fetchByIds(auth, uniqueIds);
   const openProjects = spaces.filter(
-    (space) => space.isProject() && space.canRead(auth)
+    (space) => space.isProject() && auth.can("read", space)
   );
 
   const projectsWithDescriptions = await enrichProjectsWithMetadata(

--- a/front-api/routes/w/[wId]/webhook_sources/views/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/index.ts
@@ -25,7 +25,9 @@ app.get(
     const spaceIds = rawSpaceIds.length > 0 ? rawSpaceIds.split(",") : [];
 
     const spaces = await SpaceResource.fetchByIds(auth, spaceIds);
-    const allowedSpaces = spaces.filter((s) => s.canReadOrAdministrate(auth));
+    const allowedSpaces = spaces.filter(
+      (space) => auth.can("read", space) || auth.can("admin", space)
+    );
     const views = await WebhookSourcesViewResource.listBySpaces(
       auth,
       allowedSpaces

--- a/front/lib/agent_builder/server_side_props_helpers.ts
+++ b/front/lib/agent_builder/server_side_props_helpers.ts
@@ -43,7 +43,7 @@ export const getAccessibleSourcesAndAppsForActions = async (
       await SpaceResource.listWorkspaceSpaces(auth, {
         includeProjectSpaces: true,
       })
-    ).filter((space) => !space.isSystem() && space.canRead(auth));
+    ).filter((space) => !space.isSystem() && auth.can("read", space));
 
     const [dsViews, allMCPServerViews] = await Promise.all([
       DataSourceViewResource.listBySpaces(auth, accessibleSpaces, {

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -291,7 +291,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
           )
         );
       }
-      if (!pod.canAdministrate(auth)) {
+      if (!auth.can("admin", pod)) {
         return new Err(
           new MCPError("Not authorized to manage work areas for this pod.")
         );
@@ -342,7 +342,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
           )
         );
       }
-      if (!pod.canAdministrate(auth)) {
+      if (!auth.can("admin", pod)) {
         return new Err(
           new MCPError("Not authorized to manage work areas for this pod.")
         );
@@ -385,7 +385,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       const [space] = activationPod
         ? await SpaceResource.fetchByModelIds(auth, [activationPod.spaceId])
         : [];
-      if (!row || !space || !space.canAdministrate(auth)) {
+      if (!row || !space || !auth.can("admin", space)) {
         return new Err(new MCPError("Work area not found."));
       }
 

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -79,7 +79,7 @@ export async function resolveFile(
       );
     }
     const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-    if (!space || !space.canRead(auth)) {
+    if (!space || !auth.can("read", space)) {
       return new Err(
         new MCPError("You do not have read permissions for this pod.", {
           tracked: false,

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -143,7 +143,7 @@ export async function getPod(
     // membership, so a caller passing an arbitrary pod id could otherwise read its members,
     // conversations, documents and tasks. Report unreadable pods as not-found so this cannot
     // probe which pod sIds exist.
-    if (!pod.canRead(auth)) {
+    if (!auth.can("read", pod)) {
       return new Err(
         new MCPError(`Pod not found: ${podId}`, { tracked: false })
       );
@@ -192,7 +192,7 @@ function checkWritePermission(
   auth: Authenticator,
   space: SpaceResource
 ): Result<void, MCPError> {
-  if (!space.canWrite(auth)) {
+  if (!auth.can("write", space)) {
     return new Err(
       new MCPError("You do not have write permissions for this Pod", {
         tracked: false,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -255,7 +255,7 @@ export function createProjectManagerTools(
 
         const { pod } = contextRes.value;
 
-        if (!pod.canAdministrate(auth)) {
+        if (!auth.can("admin", pod)) {
           return new Err(
             new MCPError(
               "You do not have permission to edit this Pod's information",
@@ -367,7 +367,7 @@ export function createProjectManagerTools(
 
         const { pod } = contextRes.value;
 
-        if (!pod.canAdministrate(auth)) {
+        if (!auth.can("admin", pod)) {
           return new Err(
             new MCPError(
               "You do not have permission to edit this Pod's information",
@@ -423,7 +423,7 @@ export function createProjectManagerTools(
 
         const { pod } = contextRes.value;
 
-        if (!pod.canAdministrate(auth)) {
+        if (!auth.can("admin", pod)) {
           return new Err(
             new MCPError(
               "You do not have permission to edit this Pod's default agent",
@@ -498,7 +498,7 @@ export function createProjectManagerTools(
 
         const { pod } = contextRes.value;
 
-        if (!pod.canAdministrate(auth)) {
+        if (!auth.can("admin", pod)) {
           return new Err(
             new MCPError("You do not have permission to update Pod members", {
               tracked: false,

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -140,7 +140,7 @@ export async function updateActivationRecommendationForUser(
     ? await SpaceResource.fetchByModelIds(auth, [activationPod.spaceId])
     : [];
   const canUpdate = rec.activationPodId
-    ? Boolean(space?.canAdministrate(auth))
+    ? Boolean(space && auth.can("admin", space))
     : rec.userId === auth.getNonNullableUser().id;
   if (!canUpdate) {
     return "not_found";

--- a/front/lib/api/activation/work_areas.ts
+++ b/front/lib/api/activation/work_areas.ts
@@ -37,7 +37,7 @@ export async function listActivationWorkAreasForUser(
 
   if (podId !== undefined) {
     const space = await SpaceResource.fetchById(auth, podId);
-    if (!space || !space.canAdministrate(auth)) {
+    if (!space || !auth.can("admin", space)) {
       return [];
     }
 
@@ -84,7 +84,7 @@ export async function updateActivationWorkAreaForUser(
   const [space] = activationPod
     ? await SpaceResource.fetchByModelIds(auth, [activationPod.spaceId])
     : [];
-  if (!row || !space || !space.canAdministrate(auth)) {
+  if (!row || !space || !auth.can("admin", space)) {
     return new Err(
       new DustError("activation_work_area_not_found", "Work area not found.")
     );

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -134,7 +134,7 @@ export async function createOrUpgradeAgentConfiguration({
     // Validate that all requested spaces were found and user can read them
     if (!dangerouslySkipPermissionFiltering) {
       const readableSpaceIds = new Set(
-        additionalSpaces.filter((s) => s.canRead(auth)).map((s) => s.sId)
+        additionalSpaces.filter((space) => auth.can("read", space)).map((s) => s.sId)
       );
       const inaccessibleSpaces = assistant.additionalRequestedSpaceIds.filter(
         (sId) => !readableSpaceIds.has(sId)

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -134,7 +134,9 @@ export async function createOrUpgradeAgentConfiguration({
     // Validate that all requested spaces were found and user can read them
     if (!dangerouslySkipPermissionFiltering) {
       const readableSpaceIds = new Set(
-        additionalSpaces.filter((space) => auth.can("read", space)).map((s) => s.sId)
+        additionalSpaces
+          .filter((space) => auth.can("read", space))
+          .map((s) => s.sId)
       );
       const inaccessibleSpaces = assistant.additionalRequestedSpaceIds.filter(
         (sId) => !readableSpaceIds.has(sId)

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -140,7 +140,7 @@ export async function validateSelectableSpaces(
     );
   }
 
-  if (spaces.some((space) => !space.canRead(auth))) {
+  if (spaces.some((space) => !auth.can("read", space))) {
     return new Err(
       new SelectedConversationSpacesError(
         "space_not_found",
@@ -427,7 +427,7 @@ async function getValidSelectedSpaceIdsForAgentRun(
     );
 
   return selectedSpaces
-    .filter((space) => space.canRead(auth) && space.isRegular())
+    .filter((space) => auth.can("read", space) && space.isRegular())
     .map((space) => space.sId);
 }
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -216,9 +216,9 @@ export async function softDeleteDataSourceAndLaunchScrubWorkflow(
 > {
   const owner = auth.getNonNullableWorkspace();
   const isAuthorized =
-    dataSource.space.canWrite(auth) ||
+    auth.can("write", dataSource.space) ||
     // Only allow to remote database connectors if the user is an admin.
-    (dataSource.space.canAdministrate(auth) && isRemoteDatabase(dataSource));
+    (auth.can("admin", dataSource.space) && isRemoteDatabase(dataSource));
 
   if (!isAuthorized) {
     return new Err({

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -143,8 +143,8 @@ function createPodMount(
     legacyPrefix: includeLegacy ? LEGACY_PREFIX_PROJECT : null,
     legacySandboxMountPoint: includeLegacy ? `/files/pod` : null,
     permissions: {
-      canRead: space.canRead(auth),
-      canWrite: space.canWrite(auth),
+      canRead: auth.can("read", space),
+      canWrite: auth.can("write", space),
     },
   };
 }
@@ -353,7 +353,7 @@ export class DustFileSystem {
     // Decided by the caller that owns that concern (the file system only passes them to setup).
     { sandboxOnlyMounts = [] }: { sandboxOnlyMounts?: SandboxOnlyMount[] } = {}
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
-    if (!space.canRead(auth)) {
+    if (!auth.can("read", space)) {
       return new Err(
         new DustFileSystemError(
           "unauthorized",

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -151,8 +151,8 @@ describe("publishFrameFromSource", () => {
       workspace.sId
     );
     assert(viewerAuth);
-    expect(space.canRead(viewerAuth)).toBe(true);
-    expect(space.canWrite(viewerAuth)).toBe(false);
+    expect(viewerAuth.can("read", space)).toBe(true);
+    expect(viewerAuth.can("write", space)).toBe(false);
 
     const conversation = await ConversationFactory.create(viewerAuth, {
       agentConfigurationId: "test-agent",
@@ -335,8 +335,8 @@ describe("publishFrameV2FromSource", () => {
       workspace.sId
     );
     assert(viewerAuth);
-    expect(space.canRead(viewerAuth)).toBe(true);
-    expect(space.canWrite(viewerAuth)).toBe(false);
+    expect(viewerAuth.can("read", space)).toBe(true);
+    expect(viewerAuth.can("write", space)).toBe(false);
 
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: "test-agent",

--- a/front/lib/api/mcp_server/tools/conversations/list.ts
+++ b/front/lib/api/mcp_server/tools/conversations/list.ts
@@ -44,7 +44,11 @@ export function registerConversationsListTool(server: McpServer) {
 
       if (podId) {
         const pod = await SpaceResource.fetchById(auth, podId);
-        if (!pod || !pod.isProject() || !pod.canReadOrAdministrate(auth)) {
+        if (
+          !pod ||
+          !pod.isProject() ||
+          (!auth.can("read", pod) && !auth.can("admin", pod))
+        ) {
           return mcpError("Pod not found or you do not have access.");
         }
 

--- a/front/lib/api/mcp_server/tools/files/context.ts
+++ b/front/lib/api/mcp_server/tools/files/context.ts
@@ -54,7 +54,7 @@ export async function getDustFileSystemForScope(
   }
 
   const pod = await SpaceResource.fetchById(auth, scope.pod_id);
-  if (!pod || !pod.isProject() || !pod.canRead(auth)) {
+  if (!pod || !pod.isProject() || !auth.can("read", pod)) {
     return new Err(`Pod not found or you do not have access: ${scope.pod_id}`);
   }
 

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -183,7 +183,7 @@ export async function moveConversationToProject(
               )
             );
           }
-          if (!previousProject.canAdministrate(auth)) {
+          if (!auth.can("admin", previousProject)) {
             return new Err(
               new DustError(
                 "unauthorized",
@@ -323,7 +323,7 @@ export async function moveConversationOutOfProject(
             )
           );
         }
-        if (!project.canAdministrate(auth)) {
+        if (!auth.can("admin", project)) {
           return new Err(
             new DustError(
               "unauthorized",

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -221,7 +221,7 @@ export async function enrichProjectsWithMetadata(
     ...enrichedSpaces[i],
     description: metadataMap.get(space.id)?.description ?? null,
     isMember: space.isMember(auth),
-    isEditor: space.canAdministrate(auth),
+    isEditor: auth.can("admin", space),
     archivedAt: metadataMap.get(space.id)?.archivedAt?.getTime() ?? null,
   }));
 }

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -45,7 +45,7 @@ export async function searchProjectConversations(
   }
 
   const spaces = (await SpaceResource.fetchByIds(auth, spaceIds)).filter(
-    (space) => space.canRead(auth)
+    (space) => auth.can("read", space)
   );
 
   if (spaces.length === 0) {

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -110,7 +110,7 @@ export async function handleSearch(
       includeProjectSpaces: allowPods,
     });
     spaces = allWorkspaceSpaces.filter(
-      (s) => s.canAdministrate(auth) || s.canRead(auth)
+      (space) => auth.can("admin", space) || auth.can("read", space)
     );
   } else {
     spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -22,7 +22,7 @@ export async function resolveAdditionalRequestedSpaceModelIds(
   const spaces = await SpaceResource.fetchByIds(auth, requestedSpaceIds);
   const readableSpacesById = new Map(
     spaces
-      .filter((space) => space.canRead(auth))
+      .filter((space) => auth.can("read", space))
       .map((space) => [space.sId, space])
   );
 

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -311,14 +311,14 @@ describe("createSpaceAndGroup", () => {
         ).toBe(true);
 
         const staleAuth = await Authenticator.fromJSON(staleAuthJson);
-        expect(pod.canAdministrate(staleAuth)).toBe(false);
+        expect(staleAuth.can("admin", pod)).toBe(false);
         expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(false);
 
         await staleAuth.refresh();
         expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
 
         const refreshedPod = await SpaceResource.fetchById(staleAuth, pod.sId);
-        expect(refreshedPod?.canAdministrate(staleAuth)).toBe(true);
+        expect(staleAuth.can("admin", refreshedPod!)).toBe(true);
       }
 
       createConnectorSpy.mockRestore();
@@ -361,7 +361,7 @@ describe("createSpaceAndGroup", () => {
         // above, which has to call refresh() itself).
         expect(userAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
         expect(userAuth.getGrantedVerbs("space", pod.id)).toContain("admin");
-        expect(pod.canAdministrate(userAuth)).toBe(true);
+        expect(userAuth.can("admin", pod)).toBe(true);
       }
 
       createConnectorSpy.mockRestore();
@@ -465,11 +465,11 @@ describe("createSpaceAndGroup", () => {
       expect(await asMember!.isRestricted(memberAuth)).toBe(false);
 
       // The member group confers write; the global group's `reader` grant only confers read.
-      expect(asMember!.canRead(memberAuth)).toBe(true);
-      expect(asMember!.canWrite(memberAuth)).toBe(true);
+      expect(memberAuth.can("read", asMember!)).toBe(true);
+      expect(memberAuth.can("write", asMember!)).toBe(true);
 
-      expect(asNonMember!.canRead(nonMemberAuth)).toBe(true);
-      expect(asNonMember!.canWrite(nonMemberAuth)).toBe(false);
+      expect(nonMemberAuth.can("read", asNonMember!)).toBe(true);
+      expect(nonMemberAuth.can("write", asNonMember!)).toBe(false);
     });
 
     it("should create a restricted space without global group", async () => {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -177,7 +177,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     "Cannot delete spaces that are not regular or project."
   );
   assert(
-    space.canAdministrate(auth),
+    auth.can("admin", space),
     "Only project editors or workspace admins can delete project spaces."
   );
 
@@ -771,7 +771,7 @@ export async function createSpaceAndGroup(
         // Seeding a regular space's members requires administering it. The member
         // group is a regular_auto group whose permissions are not checked directly,
         // so gate on the space instead.
-        if (!space.canAdministrate(auth)) {
+        if (!auth.can("admin", space)) {
           return new Err(
             new DustError(
               "unauthorized",
@@ -806,7 +806,7 @@ export async function createSpaceAndGroup(
         // For group-based spaces, we need to associate the selected groups with the space
         if (params.groupIds.length > 0) {
           // Associating groups requires administering the space.
-          if (!space.canAdministrate(auth)) {
+          if (!auth.can("admin", space)) {
             return new Err(
               new DustError(
                 "unauthorized",

--- a/front/lib/api/spaces/access.ts
+++ b/front/lib/api/spaces/access.ts
@@ -88,9 +88,7 @@ export async function listUsersWithoutAccessToSpaces(
   }
 
   const unauthorizedSpaceIds = spaces
-    .filter(
-      (space) => !auth.can("read", space) && !auth.can("admin", space)
-    )
+    .filter((space) => !auth.can("read", space) && !auth.can("admin", space))
     .map((space) => space.sId);
   if (unauthorizedSpaceIds.length > 0) {
     return new Err(

--- a/front/lib/api/spaces/access.ts
+++ b/front/lib/api/spaces/access.ts
@@ -88,7 +88,9 @@ export async function listUsersWithoutAccessToSpaces(
   }
 
   const unauthorizedSpaceIds = spaces
-    .filter((space) => !space.canReadOrAdministrate(auth))
+    .filter(
+      (space) => !auth.can("read", space) && !auth.can("admin", space)
+    )
     .map((space) => space.sId);
   if (unauthorizedSpaceIds.length > 0) {
     return new Err(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1620,6 +1620,10 @@ export class Authenticator {
     return this.hasPermissionForAcls(verb, target.getAccessControlLists(this));
   }
 
+  can(verb: GrantVerb, target: WithAccessControl): boolean {
+    return this.hasPermission(verb, target);
+  }
+
   /**
    * Whether the caller holds `verb` on EVERY one of the given targets (conjunction).
    */

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -578,8 +578,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const workspace = auth.getNonNullableWorkspace();
 
     // Check if the user has access to the space.
-    // Note, using canRead because spaces members do not have write access to the space as write is tied with datasources.
-    if (space && !space.canRead(auth)) {
+    // Use read because space members do not have write access to the space; write is tied to data
+    // sources.
+    if (space && !auth.can("read", space)) {
       throw new Error(
         "Cannot create conversation in a space you do not have access to."
       );
@@ -1127,9 +1128,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     // concern, not a conjunctive ACL. Missing/deleted project spaces deny access.
     const accessiblePodConversations: ConversationResource[] = podConversations
       .filter(
-        (c) =>
-          spaceIdToSpaceMap.has(c.spaceId) &&
-          spaceIdToSpaceMap.get(c.spaceId)!.canRead(auth)
+        (c) => {
+          const space = spaceIdToSpaceMap.get(c.spaceId);
+          return space ? auth.can("read", space) : false;
+        }
       )
       .map((c) => this.fromModel(c, spaceIdToSpaceMap.get(c.spaceId) ?? null));
 
@@ -1279,7 +1281,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       const spaces = await SpaceResource.fetchByModelIds(auth, [
         conversation.spaceId,
       ]);
-      return spaces.length > 0 && spaces[0].canRead(auth)
+      return spaces.length > 0 && auth.can("read", spaces[0])
         ? "allowed"
         : "conversation_access_restricted";
     }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1127,12 +1127,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     // further restrict who can open the conversation — they remain a runtime/scope
     // concern, not a conjunctive ACL. Missing/deleted project spaces deny access.
     const accessiblePodConversations: ConversationResource[] = podConversations
-      .filter(
-        (c) => {
-          const space = spaceIdToSpaceMap.get(c.spaceId);
-          return space ? auth.can("read", space) : false;
-        }
-      )
+      .filter((c) => {
+        const space = spaceIdToSpaceMap.get(c.spaceId);
+        return space ? auth.can("read", space) : false;
+      })
       .map((c) => this.fromModel(c, spaceIdToSpaceMap.get(c.spaceId) ?? null));
 
     // If there are no regular conversations, return the accessible pod conversations immediately.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -2150,7 +2150,7 @@ export class FileResource extends BaseResource<FileModel> {
         auth,
         file.useCaseMetadata.spaceId
       );
-      if (!space || !space.canRead(auth)) {
+      if (!space || !auth.can("read", space)) {
         return { verified: false };
       }
     }

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -136,7 +136,7 @@ export class InternalMCPServerInMemoryResource {
   ) {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
-    if (!systemSpace.canAdministrate(auth)) {
+    if (!auth.can("admin", systemSpace)) {
       throw new DustError(
         "unauthorized",
         "The user is not authorized to create an internal MCP server"

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -841,8 +841,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     }
   ): Promise<MCPServerViewResource[]> {
     // Filter out spaces that the user does not have read or administrate access to
-    const accessibleSpaces = spaces.filter((s) =>
-      s.canReadOrAdministrate(auth)
+    const accessibleSpaces = spaces.filter(
+      (space) => auth.can("read", space) || auth.can("admin", space)
     );
     if (accessibleSpaces.length === 0) {
       return [];
@@ -1144,7 +1144,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     const matches = views.filter((view) => {
       if (
         view.space.kind === "system" ||
-        !view.space.canReadOrAdministrate(auth)
+        (!auth.can("read", view.space) && !auth.can("admin", view.space))
       ) {
         return false;
       }

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -7,16 +7,17 @@ import type { ModelId } from "@app/types/shared/model_id";
  * pre-fetched `spaceId -> SpaceResource` map so callers resolve the spaces once and reuse them
  * across many items.
  *
- * Space access is served from `group_permissions` via `SpaceResource.canRead` (which also honors
- * the `use_legacy_acls` kill switch). A requested space missing from the map — deleted, or belonging
- * to another workspace — is treated as not readable.
+ * Space access is served from `group_permissions` via `auth.can` (which also honors the
+ * `use_legacy_acls` kill switch). A requested space missing from the map — deleted, or belonging to
+ * another workspace — is treated as not readable.
  */
 export function canReadRequestedSpaces(
   auth: Authenticator,
   spaceById: Map<ModelId, SpaceResource>,
   requestedSpaceIds: ModelId[]
 ): boolean {
-  return requestedSpaceIds.every(
-    (spaceId) => spaceById.get(spaceId)?.canRead(auth) ?? false
-  );
+  return requestedSpaceIds.every((spaceId) => {
+    const space = spaceById.get(spaceId);
+    return space ? auth.can("read", space) : false;
+  });
 }

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -188,19 +188,19 @@ export abstract class ResourceWithSpace<
   }
 
   canAdministrate(auth: Authenticator) {
-    return this.space.canAdministrate(auth);
+    return auth.can("admin", this);
   }
 
   canReadOrAdministrate(auth: Authenticator) {
-    return this.space.canReadOrAdministrate(auth);
+    return auth.can("read", this) || auth.can("admin", this);
   }
 
   canRead(auth: Authenticator) {
-    return this.space.canRead(auth);
+    return auth.can("read", this);
   }
 
   canWrite(auth: Authenticator) {
-    return this.space.canWrite(auth);
+    return auth.can("write", this);
   }
 
   // This method determines if the authenticated user can fetch data, based on workspace ownership.

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -261,7 +261,7 @@ function getSandboxFunctionUserIdentity(
     workspaceId: workspace.sId,
     // Same predicate as the `isEditor` the pod UI serializes: pod editor group members plus
     // workspace admins via role.
-    isPodEditor: pod?.canAdministrate(auth) ?? false,
+    isPodEditor: pod ? auth.can("admin", pod) : false,
     // Same predicate as the pod UI's `isMember` and the `pod_member_required` policy: users in
     // any of the pod's groups. Workspace admins outside them are not members.
     isPodMember: pod?.isMember(auth) ?? false,
@@ -1320,7 +1320,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         }
         viewerModelId = sandboxFunction.frame
           ? viewer.id
-          : sandboxFunction.space.canAdministrate(auth)
+          : auth.can("admin", sandboxFunction.space)
             ? undefined
             : viewer.id;
         break;

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1008,10 +1008,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
-      if (
-        !auth.can("read", this.space) &&
-        !auth.can("admin", this.space)
-      ) {
+      if (!auth.can("read", this.space) && !auth.can("admin", this.space)) {
         return new Err(new Error("Sandbox function space is not accessible."));
       }
 

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -431,7 +431,9 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     const accessibleSpacesById = new Map(
       spaces
         .filter(
-          (space) => space.isProject() && space.canReadOrAdministrate(auth)
+          (space) =>
+            space.isProject() &&
+            (auth.can("read", space) || auth.can("admin", space))
         )
         .map((space) => [space.id, space])
     );
@@ -1006,7 +1008,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
-      if (!this.space.canReadOrAdministrate(auth)) {
+      if (
+        !auth.can("read", this.space) &&
+        !auth.can("admin", this.space)
+      ) {
         return new Err(new Error("Sandbox function space is not accessible."));
       }
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1333,7 +1333,7 @@ describe("SpaceResource", () => {
           );
 
           expect(await reloadedSpace!.fetchIsAdminControlled()).toBe(true);
-          expect(reloadedSpace!.canAdministrate(adminAuth)).toBe(true);
+          expect(adminAuth.can("admin", reloadedSpace!)).toBe(true);
         });
 
         it("does not let managers administrate", async () => {
@@ -1357,7 +1357,7 @@ describe("SpaceResource", () => {
             projectSpace.sId
           );
 
-          expect(reloadedSpace!.canAdministrate(managerAuth)).toBe(false);
+          expect(managerAuth.can("admin", reloadedSpace!)).toBe(false);
         });
 
         it("blocks addEditors while admin-controlled", async () => {
@@ -2609,8 +2609,8 @@ describe("SpaceResource group_permissions enforcement", () => {
     );
 
     // Member group confers read+write; served from the group_permissions table.
-    expect(space.canRead(memberAuth)).toBe(true);
-    expect(space.canWrite(memberAuth)).toBe(true);
+    expect(memberAuth.can("read", space)).toBe(true);
+    expect(memberAuth.can("write", space)).toBe(true);
   });
 
   // An open regular space attaches the workspace global group as a `reader` viewer, so everyone can
@@ -2648,11 +2648,11 @@ describe("SpaceResource group_permissions enforcement", () => {
     expect(await openSpace!.isRestricted(adminAuth)).toBe(false);
 
     // The member group confers write; the global group's `reader` grant only confers read.
-    expect(openSpace!.canRead(memberAuth)).toBe(true);
-    expect(openSpace!.canWrite(memberAuth)).toBe(true);
+    expect(memberAuth.can("read", openSpace!)).toBe(true);
+    expect(memberAuth.can("write", openSpace!)).toBe(true);
 
-    expect(openSpace!.canRead(nonMemberAuth)).toBe(true);
-    expect(openSpace!.canWrite(nonMemberAuth)).toBe(false);
+    expect(nonMemberAuth.can("read", openSpace!)).toBe(true);
+    expect(nonMemberAuth.can("write", openSpace!)).toBe(false);
   });
 
   it("enforces the table: group mode accepts a manual group, and deselecting it revokes access", async () => {
@@ -2675,8 +2675,8 @@ describe("SpaceResource group_permissions enforcement", () => {
       workspace.sId
     );
     const withGroup = await SpaceResource.fetchById(adminAuth, space.sId);
-    expect(withGroup!.canRead(memberAuth)).toBe(true);
-    expect(withGroup!.canWrite(memberAuth)).toBe(true);
+    expect(memberAuth.can("read", withGroup!)).toBe(true);
+    expect(memberAuth.can("write", withGroup!)).toBe(true);
 
     // Deselecting the manual group must drop its association, not just the provisioned ones.
     const unsetRes = await space.updatePermissions(adminAuth, {
@@ -2693,8 +2693,8 @@ describe("SpaceResource group_permissions enforcement", () => {
       workspace.sId
     );
     const withoutGroup = await SpaceResource.fetchById(adminAuth, space.sId);
-    expect(withoutGroup!.canRead(refreshedMemberAuth)).toBe(false);
-    expect(withoutGroup!.canWrite(refreshedMemberAuth)).toBe(false);
+    expect(refreshedMemberAuth.can("read", withoutGroup!)).toBe(false);
+    expect(refreshedMemberAuth.can("write", withoutGroup!)).toBe(false);
   });
 
   it("stops a group-mode group from granting once the space switches to manual", async () => {
@@ -2716,7 +2716,7 @@ describe("SpaceResource group_permissions enforcement", () => {
       memberUser.sId,
       workspace.sId
     );
-    expect(inGroupMode!.canRead(memberAuth)).toBe(true);
+    expect(memberAuth.can("read", inGroupMode!)).toBe(true);
 
     // Switching back to manual leaves the group_vaults row in place, so only the kind filter in
     // `spaceGroupRoles` stops it granting in a mode that never selected it.
@@ -2734,8 +2734,8 @@ describe("SpaceResource group_permissions enforcement", () => {
       workspace.sId
     );
     const inManualMode = await SpaceResource.fetchById(adminAuth, space.sId);
-    expect(inManualMode!.canRead(refreshedMemberAuth)).toBe(false);
-    expect(inManualMode!.canWrite(refreshedMemberAuth)).toBe(false);
+    expect(refreshedMemberAuth.can("read", inManualMode!)).toBe(false);
+    expect(refreshedMemberAuth.can("write", inManualMode!)).toBe(false);
   });
 
   it("rejects internal groups in group management mode", async () => {
@@ -2804,11 +2804,11 @@ describe("SpaceResource group_permissions enforcement", () => {
 
     // In group management mode the provisioned group is the space's member group, so it is what
     // carries write.
-    expect(openSpace!.canRead(memberAuth)).toBe(true);
-    expect(openSpace!.canWrite(memberAuth)).toBe(true);
+    expect(memberAuth.can("read", openSpace!)).toBe(true);
+    expect(memberAuth.can("write", openSpace!)).toBe(true);
 
-    expect(openSpace!.canRead(nonMemberAuth)).toBe(true);
-    expect(openSpace!.canWrite(nonMemberAuth)).toBe(false);
+    expect(nonMemberAuth.can("read", openSpace!)).toBe(true);
+    expect(nonMemberAuth.can("write", openSpace!)).toBe(false);
   });
 
   it("enforces the table: member is denied when the space has no grants", async () => {
@@ -2825,7 +2825,7 @@ describe("SpaceResource group_permissions enforcement", () => {
       workspace.sId
     );
 
-    expect(space.canRead(memberAuth)).toBe(false);
+    expect(memberAuth.can("read", space)).toBe(false);
   });
 
   it("refreshes the caller's grant snapshot after opening a space", async () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -560,7 +560,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const lastValue = lastSpace?.name ?? null;
 
     return {
-      spaces: resultSpaces.filter((space) => space.canRead(auth)),
+      spaces: resultSpaces.filter((space) => auth.can("read", space)),
       hasMore,
       lastValue,
     };
@@ -628,12 +628,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       });
     }
 
-    return spaces.filter((s) => s.canRead(auth));
+    return spaces.filter((space) => auth.can("read", space));
   }
 
   static async canAdministrateSystemSpace(auth: Authenticator) {
     const systemSpace = await this.fetchWorkspaceSystemSpace(auth);
-    return systemSpace.canAdministrate(auth);
+    return auth.can("admin", systemSpace);
   }
 
   static async fetchWorkspaceSystemSpace(
@@ -932,7 +932,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     newName: string
   ): Promise<Result<undefined, Error>> {
-    if (!this.canAdministrate(auth)) {
+    if (!auth.can("admin", this)) {
       return new Err(new Error("Only admins can update space names."));
     }
 
@@ -1012,7 +1012,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       >
     >
   > {
-    if (!this.canAdministrate(auth)) {
+    if (!auth.can("admin", this)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1243,7 +1243,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // caller's own membership), so the group set and grants `auth` resolved at construction are now
     // stale. Refresh the caller's snapshot now that the write has committed — no transaction, so the
     // re-read sees the committed rows and the `afterCommit`-invalidated cache — so any later
-    // permission check in the same request (e.g. the post-update `canRead` in the members handler)
+    // permission check in the same request (e.g. the post-update read check in the members handler)
     // sees the new state instead of a pre-mutation view.
     await auth.refresh();
 
@@ -1414,7 +1414,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       >
     >
   > {
-    if (!this.canAdministrate(auth)) {
+    if (!auth.can("admin", this)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1455,8 +1455,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }
     }
 
-    // Authorization is the space-level `canAdministrate` gate above; the member group is resolved
-    // from group_permissions and mutated directly.
+    // Authorization is the space-level admin gate above; the member group is resolved from
+    // group_permissions and mutated directly.
     const memberGroup = await this.fetchManualMemberGroup(auth);
 
     const addMemberRes = await memberGroup.dangerouslyAddMembers(auth, {
@@ -1491,7 +1491,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       >
     >
   > {
-    if (!this.canAdministrate(auth)) {
+    if (!auth.can("admin", this)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1585,7 +1585,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       >
     >
   > {
-    if (!this.canAdministrate(auth)) {
+    if (!auth.can("admin", this)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1663,7 +1663,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       >
     >
   > {
-    if (!this.canAdministrate(auth)) {
+    if (!auth.can("admin", this)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -2179,7 +2179,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Users can add themselves to open projects; otherwise managing a space's members requires
     // administration rights (held by workspace admins and a project's editors) — a project's plain
-    // members hold `write` but must not be able to add others, so this gates on `canAdministrate`.
+    // members hold `write` but must not be able to add others, so this gates on `admin`.
     if (this.isProject() && !(await this.isRestricted(auth))) {
       const currentUser = auth.getNonNullableUser();
       if (userId === currentUser.sId) {
@@ -2187,28 +2187,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }
     }
 
-    return this.canAdministrate(auth);
-  }
-
-  canAdministrate(auth: Authenticator) {
-    return this.hasSpacePermission(auth, "admin");
-  }
-
-  canWrite(auth: Authenticator) {
-    return this.hasSpacePermission(auth, "write");
-  }
-
-  canRead(auth: Authenticator) {
-    return this.hasSpacePermission(auth, "read");
-  }
-
-  // Serves the space permission decision from `group_permissions` (see `getAccessControlLists`).
-  private hasSpacePermission(auth: Authenticator, verb: GrantVerb): boolean {
-    return auth.hasPermission(verb, this);
-  }
-
-  canReadOrAdministrate(auth: Authenticator) {
-    return this.canRead(auth) || this.canAdministrate(auth);
+    return auth.can("admin", this);
   }
 
   isGlobal() {

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -66,7 +66,7 @@ export async function resolveTriggerSpaceId(
   }
 
   const pod = await SpaceResource.fetchById(auth, spaceId);
-  if (!pod || !pod.isProject() || !pod.canRead(auth)) {
+  if (!pod || !pod.isProject() || !auth.can("read", pod)) {
     return new Err("Pod not found or not accessible.");
   }
 

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -261,8 +261,8 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     spaces: SpaceResource[],
     options?: ResourceFindOptions<WebhookSourcesViewModel>
   ): Promise<WebhookSourcesViewResource[]> {
-    const allowedSpaces = spaces.filter((space) =>
-      space.canReadOrAdministrate(auth)
+    const allowedSpaces = spaces.filter(
+      (space) => auth.can("read", space) || auth.can("admin", space)
     );
     if (allowedSpaces.length === 0) {
       return [];
@@ -282,7 +282,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     space: SpaceResource,
     options?: ResourceFindOptions<WebhookSourcesViewModel>
   ): Promise<WebhookSourcesViewResource[]> {
-    if (!space.canReadOrAdministrate(auth)) {
+    if (!auth.can("read", space) && !auth.can("admin", space)) {
       return [];
     }
     return this.listBySpaces(auth, [space], options);

--- a/front/scripts/ensure_pod_sandbox.ts
+++ b/front/scripts/ensure_pod_sandbox.ts
@@ -101,7 +101,7 @@ makeScript(
       }
     }
 
-    if (!pod.canRead(auth)) {
+    if (!auth.can("read", pod)) {
       logger.error(
         { podId: pod.sId, userEmail },
         "User has no read access to this pod — pass a pod they are an editor of, or a fresh --name to create one"

--- a/front/scripts/seed/factories/seedSpace.ts
+++ b/front/scripts/seed/factories/seedSpace.ts
@@ -57,7 +57,7 @@ export async function seedSpace(
 
     // The member group is a regular_auto group whose permissions are not
     // checked directly; gate on administration of the space instead.
-    if (!restrictedSpace.canAdministrate(auth)) {
+    if (!auth.can("admin", restrictedSpace)) {
       throw new Error("Only admins or group editors can change group members");
     }
     // Add the users to the group so they can access the space

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -53,7 +53,7 @@ async function createConversationForAgentConfiguration({
   let spaceModelId: ModelId | null = null;
   if (trigger.spaceId) {
     const pod = await SpaceResource.fetchById(auth, trigger.spaceId);
-    if (pod && pod.isProject() && pod.canRead(auth)) {
+    if (pod && pod.isProject() && auth.can("read", pod)) {
       spaceModelId = pod.id;
     } else {
       logger.warn(


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31648.

Adds Authenticator.can as a concise alias for hasPermission.

Uses the new helper for space permission checks and removes SpaceResource.canRead, canWrite, canAdministrate, and canReadOrAdministrate. Former read-or-admin checks keep both branches explicitly because system-space admins do not receive the read verb.

## Risks

Blast radius: space authorization call sites; behavior is unchanged.

Risk: permission checks are security-sensitive, but this is a direct delegation refactor covered by the existing space permission tests.

## Deploy Plan

- deploy front and front-sse