### PR TITLE
Fix EU elevenlabs URL.

### DIFF
--- a/front-api/routes/w/[wId]/services/transcribe/get-token.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/get-token.ts
@@ -1,9 +1,11 @@
 import { config as regionsConfig } from "@app/lib/api/regions/config";
+import {
+  getElevenLabs,
+  REGION_TO_ELEVENLABS_ENVIRONMENT,
+} from "@app/lib/utils/transcribe_service";
 import { dustManagedServiceCredentials } from "@app/types/api/credentials";
 import type { GetTranscribeTokenResponseBody } from "@app/types/api/transcribe";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
-import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -38,22 +40,13 @@ app.get("/", async (ctx): HandlerResult<GetTranscribeTokenResponseBody> => {
     });
   }
 
-  const isEu = regionsConfig.getCurrentRegion() === "europe-west1";
-
-  const elevenlabs = new ElevenLabsClient({
-    apiKey,
-    environment: isEu
-      ? ElevenLabsEnvironment.ProductionEu
-      : ElevenLabsEnvironment.ProductionUs,
-  });
-
   try {
+    const elevenlabs = getElevenLabs();
     const { token } =
       await elevenlabs.tokens.singleUse.create("realtime_scribe");
+    const region = regionsConfig.getCurrentRegion();
 
-    const baseUri = isEu
-      ? "wss://api.eu.elevenlabs.io"
-      : "wss://api.elevenlabs.io";
+    const baseUri = REGION_TO_ELEVENLABS_ENVIRONMENT[region].websocketUrl;
 
     return ctx.json({ token, baseUri });
   } catch (err) {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -48,10 +48,9 @@ import {
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
-import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
@@ -77,10 +76,7 @@ import {
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
-import {
-  assertNever,
-  assertNeverAndIgnore,
-} from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -316,7 +312,6 @@ const InputBarContainer = ({
   animatePlaceholder,
   onShake,
   isCompact = false,
-  onExpandInputBar,
   onEditorFocusChange,
   onOverlayOpenChange,
   onVoiceActiveChange,
@@ -335,7 +330,6 @@ const InputBarContainer = ({
     null
   );
   const { subscription } = useAuth();
-  const { hasFeature } = useFeatureFlags();
   const isMobile = useIsMobile();
   const clientType = useClientType();
   const {
@@ -1011,42 +1005,7 @@ const InputBarContainer = ({
     });
   }, [attachedNodes]);
 
-  const isLiveStt = hasFeature("live_speech_to_text");
-
-  const voiceTranscriberService = useVoiceTranscriberService({
-    owner,
-    fileUploaderService,
-    onTranscribeComplete: (transcript) => {
-      for (const message of transcript) {
-        switch (message.type) {
-          case "text":
-            editorService.insertText(message.text);
-            break;
-          case "mention": {
-            const agent = agentsById.get(message.id);
-            if (agent) {
-              handleSingleAgentSelect(toRichAgentMentionType(agent));
-            }
-            break;
-          }
-          default:
-            assertNever(message);
-        }
-      }
-      if (isCompactRef.current) {
-        void submitCompactVoiceMessageRef.current?.();
-      }
-    },
-    onError: (error) => {
-      sendNotification({
-        type: "error",
-        title: "Failed to transcribe voice",
-        description: normalizeError(error).message,
-      });
-    },
-  });
-
-  const voiceLiveTranscriberService = useVoiceLiveTranscriberService({
+  const activeVoiceService = useVoiceLiveTranscriberService({
     owner,
     onPartialTranscript: (text) => {
       editorService.setVoicePartialText(text);
@@ -1068,10 +1027,6 @@ const InputBarContainer = ({
       });
     },
   });
-
-  const activeVoiceService = isLiveStt
-    ? voiceLiveTranscriberService
-    : voiceTranscriberService;
 
   // Keep the editor non-editable while the input is fully disabled (e.g. a
   // non-owner viewing a conversation with an active wake-up). The placeholder

--- a/front/lib/api/actions/servers/elevenlabs/utils.ts
+++ b/front/lib/api/actions/servers/elevenlabs/utils.ts
@@ -4,12 +4,9 @@ import type {
   VoiceUseCase,
 } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { VOICE_LANGUAGES } from "@app/lib/api/actions/servers/speech_generator/metadata";
-import { config as regionsConfig } from "@app/lib/api/regions/config";
+import { getElevenLabs } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
-import { dustManagedServiceCredentials } from "@app/types/api/credentials";
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { Voice } from "@elevenlabs/elevenlabs-js/api/types";
-import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
 
 interface VoiceDefinition {
   voiceId: string;
@@ -168,7 +165,7 @@ async function fetchVoices(): Promise<VoiceDefinition[]> {
   }
 
   try {
-    const client = getElevenLabsClient();
+    const client = getElevenLabs();
     const resp = await client.voices.getAll();
     const definitions = resp.voices
       .map(toVoiceDefinition)
@@ -255,19 +252,6 @@ export async function resolveDefaultVoiceId({
 
   // 5) Final safety fallback.
   return DEFAULT_GENDER_FALLBACK[gender];
-}
-
-export function getElevenLabsClient() {
-  const credentials = dustManagedServiceCredentials();
-  const environment =
-    regionsConfig.getCurrentRegion() === "europe-west1"
-      ? ElevenLabsEnvironment.ProductionEu
-      : ElevenLabsEnvironment.ProductionUs;
-
-  return new ElevenLabsClient({
-    apiKey: credentials.ELEVENLABS_API_KEY,
-    environment,
-  });
 }
 
 export async function streamToBase64(

--- a/front/lib/api/actions/servers/sound_studio/tools/index.ts
+++ b/front/lib/api/actions/servers/sound_studio/tools/index.ts
@@ -1,11 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  getElevenLabsClient,
-  streamToBase64,
-} from "@app/lib/api/actions/servers/elevenlabs/utils";
+import { streamToBase64 } from "@app/lib/api/actions/servers/elevenlabs/utils";
 import { SOUND_STUDIO_TOOLS_METADATA } from "@app/lib/api/actions/servers/sound_studio/metadata";
+import { getElevenLabs } from "@app/lib/utils/transcribe_service";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -17,7 +15,7 @@ const handlers: ToolHandlers<typeof SOUND_STUDIO_TOOLS_METADATA> = {
     name = "sfx",
   }) => {
     try {
-      const client = getElevenLabsClient();
+      const client = getElevenLabs();
 
       const stream = await client.textToSoundEffects.convert({
         text: prompt,

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -2,7 +2,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
-  getElevenLabsClient,
   resolveDefaultVoiceId,
   streamToBase64,
 } from "@app/lib/api/actions/servers/elevenlabs/utils";
@@ -10,6 +9,7 @@ import {
   isAllowedAudioUrl,
   SPEECH_GENERATOR_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/speech_generator/metadata";
+import { getElevenLabs } from "@app/lib/utils/transcribe_service";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -30,7 +30,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
     }
 
     try {
-      const client = getElevenLabsClient();
+      const client = getElevenLabs();
 
       const result = await client.speechToText.convert({
         ...(audio_url
@@ -61,7 +61,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
     name = "speech",
   }) => {
     try {
-      const client = getElevenLabsClient();
+      const client = getElevenLabs();
 
       const voiceId = await resolveDefaultVoiceId({
         language,
@@ -106,7 +106,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
 
   text_to_dialogue: async ({ dialogues, name = "dialogue" }) => {
     try {
-      const client = getElevenLabsClient();
+      const client = getElevenLabs();
 
       // resolveDefaultVoiceId is called once (cached after first call), so
       // sequential resolution here avoids redundant API fetches on cold start.

--- a/front/lib/utils/transcribe_service.ts
+++ b/front/lib/utils/transcribe_service.ts
@@ -13,14 +13,28 @@ import fs from "fs";
 
 const TRANSCRIPTION_TIMEOUT_SECONDS = 5 * 60; // 5 minutes.
 
-async function getElevenLabs() {
+export const REGION_TO_ELEVENLABS_ENVIRONMENT = {
+  "europe-west1": {
+    environment: ElevenLabsEnvironment.ProductionEu,
+    apiUrl: "https://api.eu.residency.elevenlabs.io",
+    websocketUrl: "wss://api.eu.residency.elevenlabs.io",
+  },
+  "us-central1": {
+    environment: ElevenLabsEnvironment.ProductionUs,
+    apiUrl: "https://api.elevenlabs.io",
+    websocketUrl: "wss://api.elevenlabs.io",
+  },
+};
+
+export function getElevenLabs() {
   const credentials = dustManagedServiceCredentials();
+  const apiKey = credentials.ELEVENLABS_API_KEY;
+  const region = regionsConfig.getCurrentRegion();
+
   const elevenLabsEnvironment =
-    regionsConfig.getCurrentRegion() === "europe-west1"
-      ? ElevenLabsEnvironment.ProductionEu
-      : ElevenLabsEnvironment.ProductionUs;
+    REGION_TO_ELEVENLABS_ENVIRONMENT[region].environment;
   return new ElevenLabsClient({
-    apiKey: credentials.ELEVENLABS_API_KEY,
+    apiKey: apiKey,
     environment: elevenLabsEnvironment,
     timeoutInSeconds: TRANSCRIPTION_TIMEOUT_SECONDS,
   });
@@ -41,7 +55,7 @@ export async function transcribeFile(
   input: FormidableFileLike
 ): Promise<Result<string, Error>> {
   try {
-    const el = await getElevenLabs();
+    const el = getElevenLabs();
     const file = await toReadable(input);
     const response = (await el.speechToText.convert({
       modelId: _ELEVENLABS_TRANSCRIBE_MODEL,

--- a/front/scripts/dev/voices_elevenlabs.ts
+++ b/front/scripts/dev/voices_elevenlabs.ts
@@ -1,8 +1,8 @@
-import { getElevenLabsClient } from "@app/lib/api/actions/servers/elevenlabs/utils";
 import type {
   VoiceGender,
   VoiceUseCase,
 } from "@app/lib/api/actions/servers/speech_generator/metadata";
+import { getElevenLabs } from "@app/lib/utils/transcribe_service";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { Voice } from "@elevenlabs/elevenlabs-js/api/types";
@@ -213,7 +213,7 @@ function tsArray(selected: CandidateVoice[]) {
 }
 
 async function getElevenLabsVoices(logger: Logger) {
-  const client = getElevenLabsClient();
+  const client = getElevenLabs();
 
   const resp = await client.voices.getAll();
   const voices = resp.voices;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -16,12 +16,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "fontanierh",
   },
-  live_speech_to_text: {
-    description:
-      "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",
-    stage: "dust_only",
-    owner: "adrsimon",
-  },
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -813,7 +813,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_dust_keys"
   | "sensitivity_labels"
   | "use_vertex_for_supported_models"
-  | "live_speech_to_text"
   | "workspace_default_agent"
   | "whitelabel_frames"
   | "user_memory"


### PR DESCRIPTION
## Description

Route EU ElevenLabs transcription, speech generation, sound effects, and realtime token connections through `api.eu.residency.elevenlabs.io` using a shared region mapping in `transcribe_service`. Remove the `live_speech_to_text` feature flag and legacy transcriber path so `InputBarContainer` uses live transcription directly, with matching JS SDK types.

## Tests

I did not run automated or manual tests for this change.

## Risk

Low to medium risk. Regional ElevenLabs URL selection affects EU speech and transcription flows, while the shared mapping keeps REST and WebSocket endpoints aligned. The change is rollback-safe through a git revert.

## Deploy Plan

Deploy `front-api` and `front`. No SQL migrations or infrastructure changes. Publish `@dust-tt/client` separately if SDK changes are released independently.