### PR TITLE
[front] members search: batch group names, accept several group kinds

### DIFF
--- a/front-api/routes/w/[wId]/members/search.test.ts
+++ b/front-api/routes/w/[wId]/members/search.test.ts
@@ -1,5 +1,7 @@
+import { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -231,6 +233,47 @@ describe("GET /api/w/:wId/members/search", () => {
     const data = await response.json();
     expect(data.total).toBe(0);
     expect(data.members).toHaveLength(0);
+  });
+
+  it("returns 400 on an unknown group kind", async () => {
+    const { workspace } = await setup();
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { groupKinds: "provisioned,nope" })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns the members' groups of the requested kinds", async () => {
+    const { workspace, user } = await setup();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const sales = await GroupFactory.regularManual(workspace, "Sales");
+    const idpTeam = await GroupFactory.provisioned(workspace, "IdP Team");
+    await GroupFactory.withMembers(adminAuth, sales, [user]);
+    await GroupFactory.withMembers(adminAuth, idpTeam, [user]);
+
+    const withoutKinds = await honoApp.request(searchUrl(workspace.sId));
+    expect((await withoutKinds.json()).members[0].workspace.groups).toBe(
+      undefined
+    );
+
+    const oneKind = await honoApp.request(
+      searchUrl(workspace.sId, { groupKind: "provisioned" })
+    );
+    expect((await oneKind.json()).members[0].workspace.groups).toEqual([
+      "IdP Team",
+    ]);
+
+    const twoKinds = await honoApp.request(
+      searchUrl(workspace.sId, { groupKinds: "provisioned,regular_manual" })
+    );
+    expect((await twoKinds.json()).members[0].workspace.groups).toEqual([
+      "IdP Team",
+      "Sales",
+    ]);
   });
 
   it("returns 400 on an unknown role filter", async () => {

--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -14,12 +14,21 @@ import { z } from "zod";
 
 const DEFAULT_PAGE_LIMIT = 25;
 
+const GroupKindSchema = z.enum(GROUP_KINDS).exclude(["system"]);
+
 const SearchMembersQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).catch(0),
   limit: z.coerce.number().int().min(0).max(150).catch(DEFAULT_PAGE_LIMIT),
   searchTerm: z.string().optional(),
   searchEmails: z.string().optional(),
-  groupKind: z.enum(GROUP_KINDS).exclude(["system"]).optional(),
+  // Members carry the names of their groups of these kinds. `groupKinds` is a
+  // comma-separated list; `groupKind` is the legacy single-kind form.
+  groupKind: GroupKindSchema.optional(),
+  groupKinds: z
+    .string()
+    .transform((value) => value.split(","))
+    .pipe(z.array(GroupKindSchema))
+    .optional(),
   // Restricts the results to the members holding that role.
   role: ActiveRoleSchema.optional(),
   // Deprecated: the builder-role filter was removed; accepted but ignored to
@@ -44,6 +53,8 @@ app.get(
   > => {
     const auth = ctx.get("auth");
     const query = ctx.req.valid("query");
+    const groupKinds =
+      query.groupKinds ?? (query.groupKind ? [query.groupKind] : undefined);
 
     const emails = query.searchEmails?.split(",");
     if (emails?.length && emails.length > MAX_SEARCH_EMAILS) {
@@ -61,7 +72,7 @@ app.get(
       {
         searchTerm: query.searchTerm,
         searchEmails: emails,
-        groupKind: query.groupKind,
+        groupKinds,
         role: query.role,
       },
       query

--- a/front/components/members/WorkspaceMembersSection.tsx
+++ b/front/components/members/WorkspaceMembersSection.tsx
@@ -38,6 +38,8 @@ import { useCallback, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
 
+const PROVISIONED_GROUP_KINDS = ["provisioned"] as const;
+
 interface WorkspaceMembersSectionProps {
   currentUser: UserType | null;
   isProvisioningEnabled: boolean;
@@ -197,7 +199,7 @@ function WorkspaceMembersList({
     searchTerm,
     pageIndex: pagination.pageIndex,
     pageSize: DEFAULT_PAGE_SIZE,
-    groupKind: isProvisioningEnabled ? "provisioned" : undefined,
+    groupKinds: isProvisioningEnabled ? PROVISIONED_GROUP_KINDS : undefined,
     role: roleFilter === "all" ? undefined : roleFilter,
   });
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -18,7 +18,6 @@ import type { SearchMembersPaginationParams } from "@app/lib/resources/user_reso
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceConversationKillSwitchValue } from "@app/lib/resources/workspace_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -321,7 +320,9 @@ export async function searchMembers(
   options: {
     searchTerm?: string;
     searchEmails?: string[];
-    groupKind?: Exclude<GroupKind, "system">;
+    // When set, each member carries the names of the groups of these kinds
+    // they belong to.
+    groupKinds?: Exclude<GroupKind, "system">[];
     role?: ActiveRoleType;
   },
   paginationParams: SearchMembersPaginationParams
@@ -377,47 +378,45 @@ export async function searchMembers(
     total = results.value.total;
   }
 
-  const usersWithWorkspace = await concurrentExecutor(
-    users,
-    async (u) => {
-      const [m] = u.memberships ?? [];
-      let role: RoleType = "none";
-      let groups: string[] | undefined;
-      let origin: MembershipOriginType | undefined = undefined;
+  // One row-bounded query for the whole page instead of one per member.
+  const groupNamesByUserModelId = options.groupKinds?.length
+    ? await GroupResource.listGroupNamesByUserModelIdInWorkspace({
+        workspace: owner,
+        userModelIds: users.map((u) => u.id),
+        groupKinds: options.groupKinds,
+      })
+    : null;
 
-      if (m) {
-        const membership = new MembershipResource(
-          MembershipResource.model,
-          m.get()
-        );
+  const usersWithWorkspace = users.map((u) => {
+    const [m] = u.memberships ?? [];
+    let role: RoleType = "none";
+    let origin: MembershipOriginType | undefined = undefined;
 
-        role = !membership.isRevoked()
-          ? ACTIVE_ROLES.includes(membership.role)
-            ? membership.role
-            : "none"
-          : "none";
+    if (m) {
+      const membership = new MembershipResource(
+        MembershipResource.model,
+        m.get()
+      );
 
-        origin = membership.origin;
-      }
+      role = !membership.isRevoked()
+        ? ACTIVE_ROLES.includes(membership.role)
+          ? membership.role
+          : "none"
+        : "none";
 
-      if (options.groupKind) {
-        const groupsResult = await GroupResource.listUserGroupsInWorkspace({
-          user: u,
-          workspace: owner,
-          groupKinds: [options.groupKind],
-        });
+      origin = membership.origin;
+    }
 
-        groups = groupsResult.map((g) => g.toJSON()).map((g) => g.name);
-      }
+    const groups = groupNamesByUserModelId
+      ? (groupNamesByUserModelId.get(u.id) ?? [])
+      : undefined;
 
-      return {
-        ...u.toJSON(),
-        workspace: { ...owner, role, groups, flags: null },
-        origin,
-      };
-    },
-    { concurrency: 5 }
-  );
+    return {
+      ...u.toJSON(),
+      workspace: { ...owner, role, groups, flags: null },
+      origin,
+    };
+  });
 
   return {
     members: usersWithWorkspace,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -15,7 +15,6 @@ import type {
 } from "@app/types/api/users/spend_limit";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { GroupKind } from "@app/types/groups";
-import { isGroupKind } from "@app/types/groups";
 import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
 import { MEMBERSHIP_SEAT_TYPES, PAID_SEAT_TYPES } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -128,7 +127,7 @@ export function useSearchMembers<
   searchTerm,
   pageIndex,
   pageSize,
-  groupKind,
+  groupKinds,
   role,
   disabled,
 }: {
@@ -136,7 +135,7 @@ export function useSearchMembers<
   searchTerm: string;
   pageIndex: number;
   pageSize: number;
-  groupKind?: Exclude<GroupKind, "system">;
+  groupKinds?: readonly Exclude<GroupKind, "system">[];
   role?: ActiveRoleType;
   disabled?: boolean;
 }) {
@@ -162,8 +161,8 @@ export function useSearchMembers<
     limit: pageSize.toString(),
   });
 
-  if (groupKind && isGroupKind(groupKind)) {
-    searchParams.set("groupKind", groupKind);
+  if (groupKinds && groupKinds.length > 0) {
+    searchParams.set("groupKinds", groupKinds.join(","));
   }
 
   if (role) {


### PR DESCRIPTION
`searchMembers` ran one group lookup per member. It now fetches the page's group names in a single row-bounded query.

The `members/search` route accepts a comma-separated `groupKinds` parameter; the legacy single `groupKind` still works. Unknown kinds return 400.

No client behavior change: the People page keeps requesting provisioned groups only. Prepares model tiers on the People page (follow-up PR).
