### PR TITLE
[front] model tiers: shared members hook, table prop, usage page predicate

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,4 +1,5 @@
 import { computeIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
+import { isUsagePageEnabled } from "@app/lib/plans/usage_page";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
 import type {
@@ -319,8 +320,7 @@ export const subNavigationAdmin = ({
             },
           ]
         : []),
-      ...(isCreditPricedPlan(subscription.plan) ||
-      featureFlags.includes("usage_page_read_only")
+      ...(isUsagePageEnabled(subscription.plan, featureFlags)
         ? [
             {
               id: "usage" as const,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -15,6 +15,7 @@ import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitMod
 import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
+import type { MembersUsageTableModelTiers } from "@app/components/workspace/MembersUsageTable";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import { TopUpsHistoryTable } from "@app/components/workspace/TopUpsHistoryTable";
@@ -25,6 +26,7 @@ import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNot
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
+import { useMembersModelTiers } from "@app/hooks/useMembersModelTiers";
 import { useTableRowsSelection } from "@app/hooks/useTableRowsSelection";
 import {
   cycleElapsedPercent,
@@ -38,19 +40,13 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
-import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
-import { INHERIT_MODEL_TIER } from "@app/lib/client/model_tier_options";
-import {
-  buildModelTierDefinitionByName,
-  expandMaxTierName,
-} from "@app/lib/client/model_tiers";
-import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   isCreditPricedFreePlan,
   isEnterprisePlanPrefix,
   isFreePlan,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
+import { isUsagePageEnabled } from "@app/lib/plans/usage_page";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
@@ -69,13 +65,6 @@ import {
   useUpdateMemberSeatType,
 } from "@app/lib/swr/memberships";
 import {
-  useGroupAllowedModelTiers,
-  useModelTiers,
-  useUserAllowedModelTierMutations,
-  useUserAllowedModelTiers,
-  useWorkspaceAllowedModelTiers,
-} from "@app/lib/swr/model_tiers";
-import {
   useResolveUpgradeRequest,
   useUpgradeRequests,
 } from "@app/lib/swr/upgrade_requests";
@@ -85,7 +74,6 @@ import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
-import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,
@@ -216,13 +204,13 @@ export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const router = useAppRouter();
-  const { hasFeature } = useFeatureFlags();
+  const { featureFlags } = useFeatureFlags();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
+  const canViewUsage = isUsagePageEnabled(subscription.plan, featureFlags);
   // Legacy-contract workspaces can view this page in read-only mode behind a
   // flag: analytics and member spend render as usual, but every action (top up,
   // invite, seat changes, spend limits, settings) is disabled.
-  const isReadOnly = !isCreditPriced && hasFeature("usage_page_read_only");
-  const canViewUsage = isCreditPriced || isReadOnly;
+  const isReadOnly = canViewUsage && !isCreditPriced;
   // A cancelled subscription already has its end date scheduled with
   // Metronome; scheduling a seat change on top of it can land past that end
   // date and get rejected. Block seat changes until the subscription is
@@ -373,22 +361,6 @@ export function UsagePage() {
       setEditSpendLimitMember(member);
     },
     []
-  );
-  const { setUserAllowedModelTier, clearUserAllowedModelTier } =
-    useUserAllowedModelTierMutations({ owner });
-  const handleSetUserModelTier = useCallback(
-    (member: MemberUsageType, selection: UserModelTierSelection) => {
-      if (selection === INHERIT_MODEL_TIER) {
-        void clearUserAllowedModelTier({ userId: member.sId });
-        return;
-      }
-
-      void setUserAllowedModelTier({
-        userId: member.sId,
-        tierName: selection,
-      });
-    },
-    [clearUserAllowedModelTier, setUserAllowedModelTier]
   );
   const handleUpgradePlanRequest = useCallback(
     (request: MembershipUpgradeRequestType) => {
@@ -563,58 +535,22 @@ export function UsagePage() {
   const selectedGroupName =
     groups.find((g) => g.sId === groupFilter)?.name ?? null;
 
-  const { tiers: modelTiersCatalog } = useModelTiers({
+  const { getResolvedModelTiers, getModelTierMenuItem } = useMembersModelTiers({
     owner,
     disabled: !isWorkspaceAdmin,
   });
-  const { users: userAllowedModelTiers } = useUserAllowedModelTiers({
-    owner,
-    disabled: !isWorkspaceAdmin,
-  });
-  const { groups: groupAllowedModelTiers } = useGroupAllowedModelTiers({
-    owner,
-    disabled: !isWorkspaceAdmin,
-  });
-  const { maxTierName: workspaceMaxTierName } = useWorkspaceAllowedModelTiers({
-    owner,
-    disabled: !isWorkspaceAdmin,
-  });
-  const modelTierDefinitionByName = useMemo(
-    () => buildModelTierDefinitionByName(modelTiersCatalog),
-    [modelTiersCatalog]
+  const membersModelTiers = useMemo<MembersUsageTableModelTiers | undefined>(
+    () =>
+      isWorkspaceAdmin
+        ? {
+            getResolved: (member) =>
+              getResolvedModelTiers(member.sId, member.groups),
+            getMenuItem: (member) =>
+              getModelTierMenuItem(member.sId, member.groups),
+          }
+        : undefined,
+    [isWorkspaceAdmin, getResolvedModelTiers, getModelTierMenuItem]
   );
-  const workspaceAllowedModelTiers = useMemo(
-    () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
-    [workspaceMaxTierName]
-  );
-  const userModelTierSelectionByUserId = useMemo(() => {
-    const map: Record<string, UserModelTierSelection> = {};
-    for (const entry of userAllowedModelTiers) {
-      map[entry.userId] = entry.maxTierName;
-    }
-    return map;
-  }, [userAllowedModelTiers]);
-  const userAllowedModelTiersByUserId = useMemo(() => {
-    const map: Record<string, ModelsTierName[]> = {};
-    for (const entry of userAllowedModelTiers) {
-      map[entry.userId] = expandMaxTierName(entry.maxTierName);
-    }
-    return map;
-  }, [userAllowedModelTiers]);
-  const groupModelTiersByGroupId = useMemo(() => {
-    const map: Record<string, ModelsTierName[]> = {};
-    for (const entry of groupAllowedModelTiers) {
-      map[entry.groupId] = expandMaxTierName(entry.maxTierName);
-    }
-    return map;
-  }, [groupAllowedModelTiers]);
-  const groupNameToId = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const group of groups) {
-      map.set(group.name, group.sId);
-    }
-    return map;
-  }, [groups]);
 
   // Cross-page selection for batch actions on the members table. Resets when the
   // filter identity changes (the "all matching" set is no longer the same).
@@ -1041,20 +977,13 @@ export function UsagePage() {
       readOnly={isReadOnly}
       seatActionsDisabled={isSubscriptionCancelled}
       showSpendLimit={!isFreePlanWorkspace}
-      showModelTiersColumn={isWorkspaceAdmin}
-      userModelTierSelectionByUserId={userModelTierSelectionByUserId}
-      userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
-      groupModelTiersByGroupId={groupModelTiersByGroupId}
-      workspaceAllowedModelTiers={workspaceAllowedModelTiers}
-      groupNameToId={groupNameToId}
-      modelTierDefinitionByName={modelTierDefinitionByName}
+      modelTiers={membersModelTiers}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
       seatChangePendingMemberIds={seatChangePendingMemberIds}
       isSeatBased={isSeatBased}
       onChangeSeat={handleChangeSeatFromTable}
       onRemoveSeat={onRemoveSeat}
       onEditSpendLimit={handleEditSpendLimitFromTable}
-      onSetUserModelTier={handleSetUserModelTier}
       pagination={pagination}
       setPagination={setPagination}
       totalRowCount={totalMembersUsage}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -3,6 +3,7 @@ import {
   SEAT_TYPE_ICONS,
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
+import type { MembersUsageTableModelTiers } from "@app/components/workspace/MembersUsageTable";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import {
@@ -11,7 +12,10 @@ import {
 } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import { expandMaxTierName } from "@app/lib/client/model_tiers";
+import {
+  expandMaxTierName,
+  resolveModelTiersForUser,
+} from "@app/lib/client/model_tiers";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   usePokeAwuPoolCurrentCycle,
@@ -243,6 +247,26 @@ export function PoolUsagePage() {
     return map;
   }, [allGroups]);
 
+  const membersModelTiers = useMemo<MembersUsageTableModelTiers>(
+    () => ({
+      getResolved: (member) =>
+        resolveModelTiersForUser({
+          userId: member.sId,
+          groupNames: member.groups,
+          groupNameToId,
+          userAllowedTierNamesByUserId: userAllowedModelTiersByUserId,
+          groupTierNamesByGroupId: groupModelTiersByGroupId,
+          workspaceAllowedTierNames: workspaceAllowedModelTiers,
+        }),
+    }),
+    [
+      groupNameToId,
+      userAllowedModelTiersByUserId,
+      groupModelTiersByGroupId,
+      workspaceAllowedModelTiers,
+    ]
+  );
+
   const seatFilterDropdown = (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -388,11 +412,7 @@ export function PoolUsagePage() {
                   setSorting={handleSetSorting}
                   variant="compact"
                   showGroupsColumn={false}
-                  showModelTiersColumn
-                  userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
-                  groupModelTiersByGroupId={groupModelTiersByGroupId}
-                  workspaceAllowedModelTiers={workspaceAllowedModelTiers}
-                  groupNameToId={groupNameToId}
+                  modelTiers={membersModelTiers}
                 />
               )}
             </Page.Vertical>

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -12,22 +12,11 @@ import {
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
-import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
-import {
-  getUserModelTierMenuItemsWithSelection,
-  INHERIT_MODEL_TIER,
-  toUserModelTierSelection,
-} from "@app/lib/client/model_tier_options";
-import {
-  formatModelTiersSummary,
-  formatUserModelTierInheritLabel,
-  resolveModelTiersForUser,
-} from "@app/lib/client/model_tiers";
-import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
+import { formatModelTiersSummary } from "@app/lib/client/model_tiers";
+import type { ResolvedAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
 import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
-import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
@@ -57,23 +46,6 @@ import type {
   SortingState,
 } from "@tanstack/react-table";
 import { useMemo } from "react";
-
-const EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID: Record<
-  string,
-  UserModelTierSelection
-> = {};
-const EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID: Record<
-  string,
-  ModelsTierName[]
-> = {};
-const EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID: Record<string, ModelsTierName[]> =
-  {};
-const EMPTY_WORKSPACE_ALLOWED_MODEL_TIERS: ModelsTierName[] = [];
-const EMPTY_GROUP_NAME_TO_ID = new Map<string, string>();
-const EMPTY_MODEL_TIER_DEFINITION_BY_NAME = new Map<
-  ModelsTierName,
-  ModelsTierDefinition
->();
 
 type RowData = {
   sId: string;
@@ -798,6 +770,11 @@ function buildColumns({
 // keeps the customer-facing usage page unchanged.
 export type MembersUsageTableVariant = "legacy" | "compact";
 
+export interface MembersUsageTableModelTiers {
+  getResolved: (member: MemberUsageType) => ResolvedAllowedModelTiers;
+  getMenuItem?: (member: MemberUsageType) => MenuItem;
+}
+
 interface MembersUsageTableProps {
   members: MemberUsageType[];
   // End of the current billing period (workspace-level, from the members-usage
@@ -816,18 +793,10 @@ interface MembersUsageTableProps {
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
-  onSetUserModelTier?: (
-    member: MemberUsageType,
-    selection: UserModelTierSelection
-  ) => void;
-  showModelTiersColumn?: boolean;
+  // Shows the "Models tier" column; the row menu item is added only when
+  // `getMenuItem` is provided.
+  modelTiers?: MembersUsageTableModelTiers;
   variant?: MembersUsageTableVariant;
-  userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
-  userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
-  groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
-  workspaceAllowedModelTiers?: ModelsTierName[];
-  groupNameToId?: Map<string, string>;
-  modelTierDefinitionByName?: Map<ModelsTierName, ModelsTierDefinition>;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
   totalRowCount: number;
@@ -853,15 +822,8 @@ export function MembersUsageTable({
   onChangeSeat,
   onRemoveSeat,
   onEditSpendLimit,
-  onSetUserModelTier,
-  showModelTiersColumn = false,
+  modelTiers,
   variant = "legacy",
-  userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
-  userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
-  groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
-  workspaceAllowedModelTiers = EMPTY_WORKSPACE_ALLOWED_MODEL_TIERS,
-  groupNameToId = EMPTY_GROUP_NAME_TO_ID,
-  modelTierDefinitionByName = EMPTY_MODEL_TIER_DEFINITION_BY_NAME,
   pagination,
   setPagination,
   totalRowCount,
@@ -875,15 +837,8 @@ export function MembersUsageTable({
   const rows: RowData[] = useMemo(
     () =>
       members.map((m) => {
-        const resolvedModelTiers = showModelTiersColumn
-          ? resolveModelTiersForUser({
-              userId: m.sId,
-              groupNames: m.groups,
-              groupNameToId,
-              userAllowedTierNamesByUserId: userAllowedModelTiersByUserId,
-              groupTierNamesByGroupId: groupModelTiersByGroupId,
-              workspaceAllowedTierNames: workspaceAllowedModelTiers,
-            })
+        const resolvedModelTiers = modelTiers
+          ? modelTiers.getResolved(m)
           : null;
 
         return {
@@ -956,33 +911,8 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showModelTiersColumn && onSetUserModelTier
-              ? [
-                  {
-                    kind: "submenu" as const,
-                    label: "Models tier",
-                    disabled: readOnly,
-                    selectionMode: "checkbox" as const,
-                    items: getUserModelTierMenuItemsWithSelection({
-                      selectedValue:
-                        userModelTierSelectionByUserId[m.sId] ??
-                        INHERIT_MODEL_TIER,
-                      inheritLabel: formatUserModelTierInheritLabel({
-                        groupNames: m.groups,
-                        groupNameToId,
-                        groupTierNamesByGroupId: groupModelTiersByGroupId,
-                        workspaceAllowedTierNames: workspaceAllowedModelTiers,
-                      }),
-                    }).map((tierItem) => ({
-                      id: tierItem.id,
-                      name: tierItem.name,
-                      description: tierItem.description,
-                      checked: tierItem.checked,
-                    })),
-                    onSelect: (itemId: string) =>
-                      onSetUserModelTier(m, toUserModelTierSelection(itemId)),
-                  },
-                ]
+            ...(modelTiers?.getMenuItem
+              ? [{ ...modelTiers.getMenuItem(m), disabled: readOnly }]
               : []),
             ...(isSeatBased && m.seatType && m.seatType !== "none"
               ? [
@@ -1004,19 +934,13 @@ export function MembersUsageTable({
       seatChangePendingMemberIds,
       isSeatBased,
       showSpendLimit,
-      showModelTiersColumn,
+      modelTiers,
       variant,
-      userModelTierSelectionByUserId,
-      userAllowedModelTiersByUserId,
-      groupModelTiersByGroupId,
-      workspaceAllowedModelTiers,
-      groupNameToId,
       readOnly,
       seatActionsDisabled,
       onChangeSeat,
       onRemoveSeat,
       onEditSpendLimit,
-      onSetUserModelTier,
     ]
   );
 
@@ -1025,17 +949,11 @@ export function MembersUsageTable({
       buildColumns({
         enableSelection,
         showGroupsColumn,
-        showModelTiersColumn,
+        showModelTiersColumn: modelTiers !== undefined,
         creditsResetAt,
         variant,
       }),
-    [
-      enableSelection,
-      showGroupsColumn,
-      showModelTiersColumn,
-      creditsResetAt,
-      variant,
-    ]
+    [enableSelection, showGroupsColumn, modelTiers, creditsResetAt, variant]
   );
 
   if (isLoading) {

--- a/front/hooks/useMembersModelTiers.test.ts
+++ b/front/hooks/useMembersModelTiers.test.ts
@@ -1,0 +1,127 @@
+import { useMembersModelTiers } from "@app/hooks/useMembersModelTiers";
+import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
+import assert from "@app/lib/utils/assert";
+import type { LightWorkspaceType } from "@app/types/user";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { setUserAllowedModelTier, clearUserAllowedModelTier } = vi.hoisted(
+  () => ({
+    setUserAllowedModelTier: vi.fn(),
+    clearUserAllowedModelTier: vi.fn(),
+  })
+);
+
+vi.mock("@app/lib/swr/groups", () => ({
+  useGroups: () => ({
+    groups: [
+      { sId: "grp_sales", name: "Sales" },
+      { sId: "grp_eng", name: "Engineering" },
+    ],
+  }),
+}));
+
+vi.mock("@app/lib/swr/model_tiers", () => ({
+  useUserAllowedModelTiers: () => ({
+    users: [{ userId: "usr_override", maxTierName: "cost_efficient" }],
+  }),
+  useGroupAllowedModelTiers: () => ({
+    groups: [{ groupId: "grp_sales", maxTierName: "balanced" }],
+  }),
+  useWorkspaceAllowedModelTiers: () => ({ maxTierName: "premium" }),
+  useUserAllowedModelTierMutations: () => ({
+    setUserAllowedModelTier,
+    clearUserAllowedModelTier,
+  }),
+}));
+
+const owner: LightWorkspaceType = {
+  id: 1,
+  sId: "w_test",
+  name: "Test Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  regionalModelsOnly: false,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+function renderMembersModelTiers() {
+  return renderHook(() => useMembersModelTiers({ owner, disabled: false }))
+    .result.current;
+}
+
+function getSubmenu(userId: string, groupNames: string[]) {
+  const item = renderMembersModelTiers().getModelTierMenuItem(
+    userId,
+    groupNames
+  );
+  assert(item.kind === "submenu", "Expected a submenu item");
+  return item;
+}
+
+describe("useMembersModelTiers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("gives precedence to the user override", () => {
+    const resolved = renderMembersModelTiers().getResolvedModelTiers(
+      "usr_override",
+      ["Sales"]
+    );
+    expect(resolved.source).toBe("user");
+    expect(getMaxTierName(resolved.tiers)).toBe("cost_efficient");
+  });
+
+  it("falls back to the highest tier among the member's groups", () => {
+    const resolved = renderMembersModelTiers().getResolvedModelTiers(
+      "usr_member",
+      ["Engineering", "Sales"]
+    );
+    expect(resolved.source).toBe("groups");
+    expect(getMaxTierName(resolved.tiers)).toBe("balanced");
+  });
+
+  it("falls back to the workspace tier without group overrides", () => {
+    const resolved = renderMembersModelTiers().getResolvedModelTiers(
+      "usr_member",
+      ["Engineering"]
+    );
+    expect(resolved.source).toBe("workspace");
+    expect(getMaxTierName(resolved.tiers)).toBe("premium");
+  });
+
+  it("labels the inherit entry after where the tier comes from", () => {
+    expect(getSubmenu("usr_member", ["Sales"]).items[0].name).toBe(
+      "Inherited from groups"
+    );
+    expect(getSubmenu("usr_member", []).items[0].name).toBe(
+      "Inherited from workspace"
+    );
+  });
+
+  it("checks the current selection", () => {
+    const checked = getSubmenu("usr_override", [])
+      .items.filter((item) => item.checked)
+      .map((item) => item.id);
+    expect(checked).toEqual(["cost_efficient"]);
+  });
+
+  it("sets or clears the user override on select", () => {
+    const submenu = getSubmenu("usr_member", []);
+
+    submenu.onSelect("balanced");
+    expect(setUserAllowedModelTier).toHaveBeenCalledWith({
+      userId: "usr_member",
+      tierName: "balanced",
+    });
+
+    submenu.onSelect("inherit");
+    expect(clearUserAllowedModelTier).toHaveBeenCalledWith({
+      userId: "usr_member",
+    });
+  });
+});

--- a/front/hooks/useMembersModelTiers.ts
+++ b/front/hooks/useMembersModelTiers.ts
@@ -1,0 +1,143 @@
+import {
+  getUserModelTierMenuItemsWithSelection,
+  INHERIT_MODEL_TIER,
+  toUserModelTierSelection,
+} from "@app/lib/client/model_tier_options";
+import {
+  expandMaxTierName,
+  formatUserModelTierInheritLabel,
+  resolveModelTiersForUser,
+} from "@app/lib/client/model_tiers";
+import type { ResolvedAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
+import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
+import { useGroups } from "@app/lib/swr/groups";
+import {
+  useGroupAllowedModelTiers,
+  useUserAllowedModelTierMutations,
+  useUserAllowedModelTiers,
+  useWorkspaceAllowedModelTiers,
+} from "@app/lib/swr/model_tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { MenuItem } from "@dust-tt/sparkle";
+import { useCallback, useMemo } from "react";
+
+// Resolves the effective model tier of workspace members (user override, then
+// groups, then workspace) and builds the "Models tier" row menu. Callers pass
+// each member's cap-eligible group names, as returned by the members endpoints.
+export function useMembersModelTiers({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled: boolean;
+}) {
+  const { groups } = useGroups({
+    owner,
+    kinds: CAP_ELIGIBLE_GROUP_KINDS,
+    disabled,
+  });
+  const { users: userAllowedModelTiers } = useUserAllowedModelTiers({
+    owner,
+    disabled,
+  });
+  const { groups: groupAllowedModelTiers } = useGroupAllowedModelTiers({
+    owner,
+    disabled,
+  });
+  const { maxTierName: workspaceMaxTierName } = useWorkspaceAllowedModelTiers({
+    owner,
+    disabled,
+  });
+  const { setUserAllowedModelTier, clearUserAllowedModelTier } =
+    useUserAllowedModelTierMutations({ owner });
+
+  const workspaceAllowedTierNames = useMemo(
+    () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
+    [workspaceMaxTierName]
+  );
+  const userMaxTierNameByUserId = useMemo(() => {
+    const map: Record<string, ModelsTierName> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = entry.maxTierName;
+    }
+    return map;
+  }, [userAllowedModelTiers]);
+  const userAllowedTierNamesByUserId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [userAllowedModelTiers]);
+  const groupTierNamesByGroupId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of groupAllowedModelTiers) {
+      map[entry.groupId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [groupAllowedModelTiers]);
+  const groupNameToId = useMemo(
+    () => new Map(groups.map((group) => [group.name, group.sId])),
+    [groups]
+  );
+
+  const getResolvedModelTiers = useCallback(
+    (userId: string, groupNames: string[]): ResolvedAllowedModelTiers =>
+      resolveModelTiersForUser({
+        userId,
+        groupNames,
+        groupNameToId,
+        userAllowedTierNamesByUserId,
+        groupTierNamesByGroupId,
+        workspaceAllowedTierNames,
+      }),
+    [
+      groupNameToId,
+      userAllowedTierNamesByUserId,
+      groupTierNamesByGroupId,
+      workspaceAllowedTierNames,
+    ]
+  );
+
+  const getModelTierMenuItem = useCallback(
+    (userId: string, groupNames: string[]): MenuItem => ({
+      kind: "submenu",
+      label: "Models tier",
+      selectionMode: "checkbox",
+      items: getUserModelTierMenuItemsWithSelection({
+        selectedValue: userMaxTierNameByUserId[userId] ?? INHERIT_MODEL_TIER,
+        inheritLabel: formatUserModelTierInheritLabel({
+          groupNames,
+          groupNameToId,
+          groupTierNamesByGroupId,
+          workspaceAllowedTierNames,
+        }),
+      }).map((tierItem) => ({
+        id: tierItem.id,
+        name: tierItem.name,
+        description: tierItem.description,
+        checked: tierItem.checked,
+      })),
+      onSelect: (itemId: string) => {
+        const selection = toUserModelTierSelection(itemId);
+        if (selection === INHERIT_MODEL_TIER) {
+          void clearUserAllowedModelTier({ userId });
+          return;
+        }
+        void setUserAllowedModelTier({ userId, tierName: selection });
+      },
+    }),
+    [
+      userMaxTierNameByUserId,
+      groupNameToId,
+      groupTierNamesByGroupId,
+      workspaceAllowedTierNames,
+      clearUserAllowedModelTier,
+      setUserAllowedModelTier,
+    ]
+  );
+
+  return { getResolvedModelTiers, getModelTierMenuItem };
+}

--- a/front/lib/client/model_tiers.ts
+++ b/front/lib/client/model_tiers.ts
@@ -1,4 +1,3 @@
-import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { resolveAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
 import { expandTiersUpTo } from "@app/lib/model_tiers/tier_order";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
@@ -77,10 +76,4 @@ export function formatUserModelTierInheritLabel({
   return resolved.source === "groups"
     ? "Inherited from groups"
     : "Inherited from workspace";
-}
-
-export function buildModelTierDefinitionByName(
-  tiers: readonly ModelsTierDefinition[]
-): Map<ModelsTierName, ModelsTierDefinition> {
-  return new Map(tiers.map((tier) => [tier.name, tier]));
 }

--- a/front/lib/plans/usage_page.ts
+++ b/front/lib/plans/usage_page.ts
@@ -1,0 +1,14 @@
+import type { PlanType } from "@app/types/plan";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+// The Usage page is available to credit-priced workspaces, and to legacy-contract
+// workspaces in read-only mode behind a flag.
+export function isUsagePageEnabled(
+  plan: PlanType,
+  featureFlags: WhitelistableFeature[]
+): boolean {
+  return (
+    isCreditPricedPlan(plan) || featureFlags.includes("usage_page_read_only")
+  );
+}


### PR DESCRIPTION
Refactor, no user-facing change.

- `useMembersModelTiers` resolves a member's effective model tier (user override, groups, workspace) and builds the "Models tier" row menu. Previously inlined in `UsagePage` and `MembersUsageTable`.
- `MembersUsageTable` takes a single optional `modelTiers` prop (resolver + optional menu builder) instead of six coupled optional props. Poke's pool usage page adapted.
- `isUsagePageEnabled` centralizes the Usage page access rule, used by the sidebar and the Usage page.
- Hook tests cover precedence, inherit labels, and set/clear.

Stacked on #31679. Prepares model tiers on the People page (follow-up PR).
