### PR TITLE
Define the Frame UI runtime import contract

### DIFF
--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -7,6 +7,8 @@ on:
       - sdks/js/**
       - front/**
       - sparkle/**
+      - viz/app/lib/frame-runtime-imports.ts
+      - viz/package.json
       - .github/workflows/build-and-test-front.yml
 
 permissions:

--- a/front/lib/api/viz/frame_runtime_imports.test.ts
+++ b/front/lib/api/viz/frame_runtime_imports.test.ts
@@ -1,0 +1,19 @@
+import { FRAME_RUNTIME_IMPORT_NAMES as VALIDATOR_IMPORT_NAMES } from "@app/lib/api/viz/frame_runtime_imports";
+import { describe, expect, it } from "vitest";
+import { FRAME_RUNTIME_IMPORT_NAMES as RENDERER_IMPORT_NAMES } from "../../../../viz/app/lib/frame-runtime-imports";
+import vizPackage from "../../../../viz/package.json";
+import frontPackage from "../../../package.json";
+
+describe("Frame runtime imports", () => {
+  it("keeps publication validation aligned with the renderer import map", () => {
+    expect(VALIDATOR_IMPORT_NAMES).toEqual(RENDERER_IMPORT_NAMES);
+  });
+
+  it("keeps aliased declarations aligned with renderer package versions", () => {
+    expect(frontPackage.devDependencies).toMatchObject({
+      "@dust-frame-runtime/lucide-react": `npm:lucide-react@${vizPackage.dependencies["lucide-react"].replace("^", "")}`,
+      "@dust-frame-runtime/motion": `npm:motion@${vizPackage.dependencies.motion.replace("^", "")}`,
+      "@dust-frame-runtime/recharts": `npm:recharts@${vizPackage.dependencies.recharts}`,
+    });
+  });
+});

--- a/front/lib/api/viz/frame_runtime_imports.ts
+++ b/front/lib/api/viz/frame_runtime_imports.ts
@@ -13,16 +13,3 @@ export const FRAME_RUNTIME_IMPORT_NAMES = [
   "@dust/slideshow/v2",
   "@dust/react-hooks",
 ] as const;
-
-export type FrameRuntimeImportName =
-  (typeof FRAME_RUNTIME_IMPORT_NAMES)[number];
-
-const FRAME_RUNTIME_IMPORT_NAME_SET = new Set<string>(
-  FRAME_RUNTIME_IMPORT_NAMES
-);
-
-export function isFrameRuntimeImportName(
-  value: string
-): value is FrameRuntimeImportName {
-  return FRAME_RUNTIME_IMPORT_NAME_SET.has(value);
-}

--- a/front/lib/api/viz/frame_runtime_imports.ts
+++ b/front/lib/api/viz/frame_runtime_imports.ts
@@ -1,0 +1,28 @@
+// Mirrors the import map owned by viz/app/lib/frame-runtime-imports.ts. The sync test fails if the
+// renderer changes without updating publication validation.
+export const FRAME_RUNTIME_IMPORT_NAMES = [
+  "papaparse",
+  "react",
+  "recharts",
+  "shadcn",
+  "utils",
+  "@viz/lib/utils",
+  "lucide-react",
+  "motion/react",
+  "@dust/slideshow/v1",
+  "@dust/slideshow/v2",
+  "@dust/react-hooks",
+] as const;
+
+export type FrameRuntimeImportName =
+  (typeof FRAME_RUNTIME_IMPORT_NAMES)[number];
+
+const FRAME_RUNTIME_IMPORT_NAME_SET = new Set<string>(
+  FRAME_RUNTIME_IMPORT_NAMES
+);
+
+export function isFrameRuntimeImportName(
+  value: string
+): value is FrameRuntimeImportName {
+  return FRAME_RUNTIME_IMPORT_NAME_SET.has(value);
+}

--- a/front/package.json
+++ b/front/package.json
@@ -230,6 +230,9 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@dust-frame-runtime/lucide-react": "npm:lucide-react@0.483.0",
+    "@dust-frame-runtime/motion": "npm:motion@12.40.0",
+    "@dust-frame-runtime/recharts": "npm:recharts@2.15.4",
     "@faker-js/faker": "^9.3.0",
     "@google-cloud/storage": "^7.11.2",
     "@tailwindcss/postcss": "^4.3.0",
@@ -250,6 +253,7 @@
     "@types/luxon": "^3.4.2",
     "@types/minimist": "^1.2.2",
     "@types/node": "^24.12.2",
+    "@types/papaparse": "5.5.2",
     "@types/pegjs": "^0.10.3",
     "@types/pg": "^8.11.11",
     "@types/react": "^18.3.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -490,6 +490,9 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
+        "@dust-frame-runtime/lucide-react": "npm:lucide-react@0.483.0",
+        "@dust-frame-runtime/motion": "npm:motion@12.40.0",
+        "@dust-frame-runtime/recharts": "npm:recharts@2.15.4",
         "@faker-js/faker": "^9.3.0",
         "@google-cloud/storage": "^7.11.2",
         "@tailwindcss/postcss": "^4.3.0",
@@ -510,6 +513,7 @@
         "@types/luxon": "^3.4.2",
         "@types/minimist": "^1.2.2",
         "@types/node": "^24.12.2",
+        "@types/papaparse": "5.5.2",
         "@types/pegjs": "^0.10.3",
         "@types/pg": "^8.11.11",
         "@types/react": "^18.3.18",
@@ -4345,6 +4349,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dust-frame-runtime/lucide-react": {
+      "name": "lucide-react",
+      "version": "0.483.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.483.0.tgz",
+      "integrity": "sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dust-frame-runtime/motion": {
+      "name": "motion",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.40.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dust-frame-runtime/recharts": {
+      "name": "recharts",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dust-frame-runtime/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@dust-frame-runtime/recharts/node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dev": true,
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/@dust-tt/client": {
@@ -28510,6 +28609,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -32092,13 +32197,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/http-proxy/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
@@ -45619,6 +45717,21 @@
         "react-dom": "^16.0.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -56970,12 +57083,6 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "viz/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "viz/node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -57062,21 +57169,6 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "viz/node_modules/recharts/node_modules/react-smooth": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "viz/node_modules/sonner": {

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -4,6 +4,7 @@ import { EditableFrame } from "@viz/app/components/EditableFrame";
 import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
 import { VizContext } from "@viz/app/components/VizContext";
 import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import type { FrameRuntimeImportName } from "@viz/app/lib/frame-runtime-imports";
 import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
 import {
   PodFunctionHooksProvider,
@@ -468,7 +469,7 @@ export function VisualizationWrapper({
           ? transformEditableText(fetchedCode)
           : fetchedCode;
 
-        const baseImports: Record<string, unknown> = {
+        const baseImports = {
           papaparse: papaparseAll,
           react: reactAll,
           recharts: rechartsAll,
@@ -495,7 +496,7 @@ export function VisualizationWrapper({
             usePodFunctionMutation,
             useUserIdentity,
           },
-        };
+        } satisfies Record<FrameRuntimeImportName, unknown>;
 
         const refs = extractFileRefs(codeToUse);
         const cache = new Map<string, Promise<unknown>>();

--- a/viz/app/lib/frame-runtime-imports.ts
+++ b/viz/app/lib/frame-runtime-imports.ts
@@ -1,0 +1,16 @@
+export const FRAME_RUNTIME_IMPORT_NAMES = [
+  "papaparse",
+  "react",
+  "recharts",
+  "shadcn",
+  "utils",
+  "@viz/lib/utils",
+  "lucide-react",
+  "motion/react",
+  "@dust/slideshow/v1",
+  "@dust/slideshow/v2",
+  "@dust/react-hooks",
+] as const;
+
+export type FrameRuntimeImportName =
+  (typeof FRAME_RUNTIME_IMPORT_NAMES)[number];


### PR DESCRIPTION
## Description

Define the import names available to Frame UI code and make the renderer prove that its import map implements that contract.

Mirror the contract in Front for publication validation. Renderer-version aliases provide matching Recharts, Lucide, and Motion declarations; parity tests catch import-name or package-version drift.

## Tests

Added contract parity tests for renderer imports and aliased package versions.

## Risk

Low. This does not change the renderer's runtime imports; it makes the existing map explicit and adds validation dependencies used by the stacked PR.

## Deploy Plan

Standard deploy.