### PR TITLE
[front] rename input bar to composer in UI and use curly quote

### DIFF
--- a/front/components/skill_builder/SkillBuilderAvailabilityMessage.tsx
+++ b/front/components/skill_builder/SkillBuilderAvailabilityMessage.tsx
@@ -18,18 +18,18 @@ function getAvailabilityItems(
   switch (availability) {
     case "editors":
       return [
-        "Only editors can find it via the input bar and agent builder",
+        "Only editors can find it via the composer and agent builder",
         "The skill remains available through agents and skills that use it",
       ];
     case "workspace_users":
       // When restricted, "All members" contradicts the space gate above, so we
       // refer back to the gated members with "They can all".
       return [
-        `${restricted ? "They can all" : "All members can"} find it via the input bar and agent builder`,
+        `${restricted ? "They can all" : "All members can"} find it via the composer and agent builder`,
       ];
     case "users_and_agents":
       return [
-        "All members can find it via the input bar and agent builder",
+        "All members can find it via the composer and agent builder",
         "Agents with Discover Skills can use it automatically",
       ];
     default:

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -203,7 +203,7 @@ export function SkillBuilderSettingsSection({
           >
             <ul className="list-disc space-y-1 pl-5">
               <li>
-                All members can find it via the input bar and agent builder
+                All members can find it via the composer and agent builder
               </li>
               <li>
                 Any agent with Discover Skills, including Dust, can use it

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -35,7 +35,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
     dialogDescription: (count) => {
       const pronoun = count === 1 ? "it" : "them";
       const subject = count === 1 ? "The skill remains" : "The skills remain";
-      return `Only editors can find ${pronoun} via the input bar and agent builder. ${subject} available through agents and skills that use ${pronoun}.`;
+      return `Only editors can find ${pronoun} via the composer and agent builder. ${subject} available through agents and skills that use ${pronoun}.`;
     },
   },
   {
@@ -45,7 +45,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
       `Make ${count} skill${pluralize(count)} available to all members`,
     dialogDescription: (count) => {
       const pronoun = count === 1 ? "it" : "them";
-      return `All members can find ${pronoun} via the input bar and agent builder.`;
+      return `All members can find ${pronoun} via the composer and agent builder.`;
     },
   },
   {
@@ -55,7 +55,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
     getDialogTitle: () => `This affects your entire workspace`,
     dialogDescription: (count) => {
       const pronoun = count === 1 ? "it" : "them";
-      return `All members can find ${pronoun} via the input bar and agent builder. Agents with Discover Skills, including Dust, can use ${pronoun} automatically.`;
+      return `All members can find ${pronoun} via the composer and agent builder. Agents with Discover Skills, including Dust, can use ${pronoun} automatically.`;
     },
   },
 ];

--- a/front/lib/client/greetings.ts
+++ b/front/lib/client/greetings.ts
@@ -1,13 +1,13 @@
 const GREETINGS = [
-  "What's next, [Name]?",
+  "What’s next, [Name]?",
   "What are we working on, [Name]?",
-  "What's on your mind, [Name]?",
+  "What’s on your mind, [Name]?",
   "What are we building, [Name]?",
   "Where do we start, [Name]?",
-  "What's the plan, [Name]?",
+  "What‘s the plan, [Name]?",
   "What can I help with, [Name]?",
   "What should we start with, [Name]?",
-  "What's cooking, [Name]?",
+  "What’s cooking, [Name]?",
   "Ready when you are, [Name].",
 ];
 

--- a/front/lib/skills/labels.ts
+++ b/front/lib/skills/labels.ts
@@ -13,12 +13,12 @@ export const SKILL_AVAILABILITY_DISPLAY: Record<
   editors: {
     label: "Editors only",
     color: "primary",
-    tooltip: "Only editors can find it via the input bar and agent builder",
+    tooltip: "Only editors can find it via the composer and agent builder",
   },
   workspace_users: {
     label: "Members",
     color: "success",
-    tooltip: "All members can find it via the input bar and agent builder",
+    tooltip: "All members can find it via the composer and agent builder",
   },
   users_and_agents: {
     label: "Members and agents",


### PR DESCRIPTION
## Description
We want to say composer instead of input bar for user facing communication so I'm renaming it 🫡 (will do the same for the doc)

Also I use curly quote for greeting messages 🫡

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
