### PR TITLE
fix: display company data in api keys table

### DIFF
--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -4,6 +4,7 @@ import { formatCredits } from "@app/lib/client/credits";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
+import { GLOBAL_SPACE_NAME } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -507,7 +508,12 @@ export function APIKeysTable({
   const rows = useMemo<APIKeyRowData[]>(
     () =>
       keys.map((key) => {
-        const spaces = key.spaces.map((space) => space.name);
+        // Every key reaches the global space, but `key.spaces` only echoes the spaces it was
+        // scoped to. The label is added here, as `NewAPIKeyDialog` does with its fixed chip.
+        const spaces = [
+          GLOBAL_SPACE_NAME,
+          ...key.spaces.map((space) => space.name),
+        ];
         const scope = formatKeyScope(key.role);
         const status = getKeyStatus(key);
         const creator = key.creator ?? "Unknown creator";


### PR DESCRIPTION
## Description

This PR fixes the API keys table to display the global company space alongside each key’s explicitly scoped spaces.

<img width="529" height="96" alt="Capture d’écran 2026-09-02 à 14 15 17" src="https://github.com/user-attachments/assets/9b0b3f89-5af2-41bb-accb-3e68ed93e1ad" />



## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.