### PR TITLE
feat: avoid fetching regular_auto groups with fetchById

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/group_permissions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/group_permissions.ts
@@ -3,7 +3,7 @@ import {
   getPokeGroupPermissionsForGroup,
   getPokeGroupPermissionsForResource,
 } from "@app/lib/api/poke/group_permissions";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import { fetchPokeGroupById } from "@app/lib/api/poke/groups";
 import { GROUP_PERMISSION_RESOURCE_TYPES } from "@app/types/group_permissions";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -33,8 +33,8 @@ app.get(
     const query = ctx.req.valid("query");
 
     if ("groupId" in query) {
-      const groupRes = await GroupResource.fetchById(auth, query.groupId);
-      if (groupRes.isErr()) {
+      const group = await fetchPokeGroupById(auth, query.groupId);
+      if (!group) {
         return apiError(ctx, {
           status_code: 404,
           api_error: {
@@ -45,10 +45,7 @@ app.get(
       }
 
       return ctx.json({
-        groupPermissions: await getPokeGroupPermissionsForGroup(
-          auth,
-          groupRes.value
-        ),
+        groupPermissions: await getPokeGroupPermissionsForGroup(auth, group),
       });
     }
 

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,6 +1,6 @@
 import type { PokeGetGroupDetails } from "@app/lib/api/poke/groups";
+import { fetchPokeGroupById } from "@app/lib/api/poke/groups";
 import { getGroupMembersWithWorkspaces } from "@app/lib/api/workspace";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -21,8 +21,8 @@ app.get(
     const auth = ctx.get("auth");
     const { groupId } = ctx.req.valid("param");
 
-    const groupRes = await GroupResource.fetchById(auth, groupId);
-    if (groupRes.isErr()) {
+    const group = await fetchPokeGroupById(auth, groupId);
+    if (!group) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {
@@ -32,7 +32,6 @@ app.get(
       });
     }
 
-    const group = groupRes.value;
     const members = await getGroupMembersWithWorkspaces(auth, group);
 
     return ctx.json({

--- a/front/lib/api/poke/groups.ts
+++ b/front/lib/api/poke/groups.ts
@@ -1,3 +1,6 @@
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { GroupType } from "@app/types/groups";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 
@@ -9,3 +12,26 @@ export type PokeGetGroupDetails = {
   members: UserTypeWithWorkspaces[];
   group: GroupType;
 };
+
+// Resolve a group by sId for Poke, regardless of kind.
+//
+// `GroupResource.fetchById` deliberately does not surface the internal kinds (`regular_auto`
+// groups backing a space's members/editors, `system`, `agent_editors`) — outside Poke those are
+// reached from the resource they back. Poke is the exception: its group permissions tables list
+// grants of every kind and link each group name to its group page, so that page (and the
+// grants-by-group endpoint behind it) must resolve any group id an operator arrives with.
+export async function fetchPokeGroupById(
+  auth: Authenticator,
+  id: string
+): Promise<GroupResource | null> {
+  const modelId = getResourceIdFromSId(id);
+  if (modelId === null) {
+    return null;
+  }
+
+  const [group] = await GroupResource.dangerouslyFetchByModelIds(auth, [
+    modelId,
+  ]);
+
+  return group ?? null;
+}

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { fetchPokeGroupById } from "@app/lib/api/poke/groups";
 import {
   findWorkspaceByWorkOSOrganizationId,
   getWorkspaceInfos,
@@ -13,7 +14,6 @@ import {
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -339,11 +339,10 @@ async function searchPokeResourcesBySId(
     }
 
     case "group": {
-      const groupRes = await GroupResource.fetchById(workspaceAuth, sId);
-      if (groupRes.isErr()) {
+      const group = await fetchPokeGroupById(workspaceAuth, sId);
+      if (!group) {
         return [];
       }
-      const group = groupRes.value;
 
       return [
         {

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -845,7 +845,7 @@ describe("GroupResource", () => {
       const regularGroup = await GroupResource.makeNew({
         name: "Pool Cap Group",
         workspaceId: workspace.id,
-        kind: "regular_auto",
+        kind: "regular_manual",
       });
       expect(regularGroup.poolCapAwuCredits).toBeNull();
 


### PR DESCRIPTION
## Description

This PR makes sure that the `fetchById` method in groupResource is not being used to fetch regular_auto groups. This is needed as permissions will be removed from regular_auto groups. Regular_auto groups should be fetched only from their resources with `fetchRegularAutoGroupForResource` or dangerously fetched from poke.

## Tests

Manually.

## Risks

Limited to Poke group lookup and display paths.

## Deploy Plan

Standard deployment.