### PR TITLE
[front] chore: read user analytics from consumption analytics

### DIFF
--- a/front/lib/api/actions/servers/user_analytics/index.test.ts
+++ b/front/lib/api/actions/servers/user_analytics/index.test.ts
@@ -1,0 +1,185 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { TOOLS } from "@app/lib/api/actions/servers/user_analytics";
+import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
+import {
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    searchAnalytics: vi.fn(),
+    searchConsumptionAnalytics: vi.fn(),
+  };
+});
+
+const SHARDS = { total: 1, successful: 1, skipped: 0, failed: 0 };
+
+function getToolByName(name: "get_personal_usage" | "get_workspace_activity") {
+  const tool = TOOLS.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Tool ${name} not found`);
+  }
+  return tool;
+}
+
+function createTestExtra(auth: Authenticator): ToolHandlerExtra {
+  return {
+    auth,
+    requestId: "user-analytics-test",
+    // @ts-expect-error These query tests do not require an agent run context.
+    runContext: undefined,
+    sendNotification: async () => {},
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request");
+    },
+    signal: new AbortController().signal,
+  };
+}
+
+function mockConsumptionRankings({
+  activeUserCount = 0,
+}: {
+  activeUserCount?: number;
+} = {}) {
+  vi.mocked(searchConsumptionAnalytics).mockImplementation(
+    async (_query, options) => {
+      const field = options?.aggregations?.by_group?.terms?.field;
+      const buckets =
+        field === "user.id"
+          ? Array.from({ length: activeUserCount }, (_, index) => ({
+              key: `user-${index}`,
+              doc_count: 1,
+              credit_micro: { value: 1 },
+              messages: { value: 1 },
+            }))
+          : [];
+
+      return new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: SHARDS,
+        hits: { total: { value: 0, relation: "eq" as const }, hits: [] },
+        aggregations: {
+          by_group: { buckets },
+          total_credit_micro: { value: 0 },
+        },
+      });
+    }
+  );
+}
+
+describe("user_analytics tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads personal usage rankings from consumption analytics", async () => {
+    const { authenticator, user, workspace } = await createResourceTest({});
+    mockConsumptionRankings();
+
+    const result = await getToolByName("get_personal_usage").handler(
+      {
+        startDate: "2026-08-01",
+        endDate: "2026-08-02",
+        timezone: "UTC",
+      },
+      createTestExtra(authenticator)
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(searchAnalytics).not.toHaveBeenCalled();
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(3);
+
+    const calls = vi.mocked(searchConsumptionAnalytics).mock.calls;
+    expect(
+      calls.map(([, options]) => options?.aggregations?.by_group?.terms?.field)
+    ).toEqual(
+      expect.arrayContaining([
+        "agent.attributed_id",
+        "tool.attributed_skill_ids",
+        "tool.server_name",
+      ])
+    );
+
+    for (const [query] of calls) {
+      expect(query.bool?.filter).toEqual(
+        expect.arrayContaining([
+          { term: { workspace_id: workspace.sId } },
+          { term: { "user.id": user.sId } },
+          {
+            range: {
+              completed_at: {
+                gte: "2026-08-01T00:00:00.000Z",
+                lt: "2026-08-03T00:00:00.000Z",
+              },
+            },
+          },
+        ])
+      );
+    }
+
+    const agentCall = calls.find(
+      ([, options]) =>
+        options?.aggregations?.by_group?.terms?.field === "agent.attributed_id"
+    );
+    expect(agentCall?.[1]?.aggregations?.by_group).toMatchObject({
+      terms: { order: { messages: "desc" } },
+      aggs: {
+        messages: {
+          cardinality: { field: "agent_message_id" },
+        },
+      },
+    });
+
+    for (const field of ["tool.attributed_skill_ids", "tool.server_name"]) {
+      const invocationCall = calls.find(
+        ([, options]) => options?.aggregations?.by_group?.terms?.field === field
+      );
+      expect(invocationCall?.[1]?.aggregations?.by_group).toMatchObject({
+        terms: { order: { _count: "desc" } },
+      });
+      expect(
+        invocationCall?.[1]?.aggregations?.by_group?.aggs?.messages
+      ).toBeUndefined();
+    }
+  });
+
+  it("reads workspace activity and its anonymity floor from consumption analytics", async () => {
+    const { authenticator, workspace } = await createResourceTest({});
+    mockConsumptionRankings({
+      activeUserCount: MIN_USERS_FOR_ANONYMITY,
+    });
+
+    const result = await getToolByName("get_workspace_activity").handler(
+      {},
+      createTestExtra(authenticator)
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(searchAnalytics).not.toHaveBeenCalled();
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(3);
+
+    const calls = vi.mocked(searchConsumptionAnalytics).mock.calls;
+    expect(
+      calls.map(([, options]) => options?.aggregations?.by_group?.terms?.field)
+    ).toEqual(["user.id", "agent.attributed_id", "tool.attributed_skill_ids"]);
+
+    for (const [query] of calls) {
+      expect(query.bool?.filter).toEqual(
+        expect.arrayContaining([
+          { term: { workspace_id: workspace.sId } },
+          expect.objectContaining({
+            range: expect.objectContaining({ completed_at: expect.anything() }),
+          }),
+        ])
+      );
+    }
+  });
+});

--- a/front/lib/api/actions/servers/user_analytics/index.ts
+++ b/front/lib/api/actions/servers/user_analytics/index.ts
@@ -9,21 +9,19 @@ import {
   USER_ANALYTICS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/user_analytics/metadata";
 import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
-import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import {
+  resolveTimeWindow,
+  toConsumptionPeriod,
+} from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
+} from "@app/lib/api/analytics/consumption/top";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
 import { fetchJobTypeCohort } from "@app/lib/api/assistant/observability/job_type_cohorts";
-import { fetchAvailableSkillsBySkillId } from "@app/lib/api/assistant/observability/skill_usage";
-import {
-  fetchAvailableTools,
-  resolveToolDisplayNames,
-} from "@app/lib/api/assistant/observability/tool_usage";
-import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
-import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
-import {
-  buildAgentAnalyticsBaseQuery,
-  daysToInstantRange,
-} from "@app/lib/api/assistant/observability/utils";
+import { resolveToolDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { JOB_TYPE_LABELS } from "@app/types/job_type";
@@ -63,56 +61,70 @@ async function buildDetailedUsageSections(
   auth: Authenticator,
   { userIds, window }: { userIds: string[]; window: ResolvedTimeWindow }
 ): Promise<string[]> {
-  const ws = auth.getNonNullableWorkspace();
-  const { startDate, endDate } = window;
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: ws.sId,
-    startDate,
-    endDate,
-    userIds,
-  });
+  const period = toConsumptionPeriod(window);
+  const filter = { users: userIds };
 
   const [skillsResult, toolsResult, agentsResult] = await Promise.all([
-    fetchAvailableSkillsBySkillId(baseQuery),
-    fetchAvailableTools(baseQuery),
-    fetchTopAgents(auth, {
-      startDate,
-      endDate,
+    fetchConsumptionTopGroups(auth, {
+      dimension: "skill",
+      period,
       limit: TOP_ITEMS_LIMIT,
-      userIds,
+      filter,
+      rankBy: "count",
+      includePreviousCredits: false,
+      includeTotalCount: false,
+    }),
+    fetchConsumptionTopGroups(auth, {
+      dimension: "tool",
+      period,
+      limit: TOP_ITEMS_LIMIT,
+      filter,
+      rankBy: "count",
+      includePreviousCredits: false,
+      includeTotalCount: false,
+    }),
+    fetchConsumptionTopGroups(auth, {
+      dimension: "agent",
+      period,
+      limit: TOP_ITEMS_LIMIT,
+      filter,
+      rankBy: "count",
+      includePreviousCredits: false,
+      includeTotalCount: false,
     }),
   ]);
 
   const sections: string[] = [];
 
-  // Filter to agents the caller can actually access — fetchTopAgents is
-  // workspace-scoped and its internal label resolver has a fallback that leaks
-  // names from private spaces.
-  const candidateAgents = (agentsResult.isOk() ? agentsResult.value : []).slice(
-    0,
-    TOP_ITEMS_LIMIT
+  // Filter to agents the caller can actually access — consumption label
+  // resolution has a workspace-scoped fallback that includes private agents.
+  const candidateAgents = await resolveConsumptionGroupLabels(
+    auth,
+    "agent",
+    agentsResult.isOk() ? agentsResult.value.groups : []
   );
   let topAgents = candidateAgents;
   if (candidateAgents.length > 0) {
     const accessible = await getAgentConfigurations(auth, {
-      agentIds: candidateAgents.map((a) => a.agentId),
+      agentIds: candidateAgents.map((a) => a.key),
       variant: "extra_light",
     });
     const accessibleIds = new Set(accessible.map((a) => a.sId));
-    topAgents = candidateAgents.filter((a) => accessibleIds.has(a.agentId));
+    topAgents = candidateAgents.filter((a) => accessibleIds.has(a.key));
   }
   if (topAgents.length > 0) {
     const lines = topAgents.map(
-      (a, i) =>
-        `${i + 1}. ${a.name} [${a.agentId}] — ${a.messageCount} messages`
+      (a, i) => `${i + 1}. ${a.name} [${a.key}] — ${a.count} messages`
     );
     sections.push(`Top agents (most used first):\n${lines.join("\n")}`);
   }
 
-  const topSkillRows = (skillsResult.isOk() ? skillsResult.value : []).slice(
-    0,
-    TOP_ITEMS_LIMIT
-  );
+  const topSkillRows = (
+    skillsResult.isOk() ? skillsResult.value.groups : []
+  ).map((skill) => ({
+    skillId: skill.key,
+    totalExecutions: skill.count,
+  }));
   const skills = await resolveAccessibleSkills(auth, topSkillRows);
   if (skills.length > 0) {
     const lines = skills.map(
@@ -121,9 +133,12 @@ async function buildDetailedUsageSections(
     sections.push(`Top skills (most used first):\n${lines.join("\n")}`);
   }
 
-  const topTools = (toolsResult.isOk() ? toolsResult.value : []).slice(
-    0,
-    TOP_ITEMS_LIMIT
+  const topTools = (toolsResult.isOk() ? toolsResult.value.groups : []).map(
+    (tool) => ({
+      serverName: tool.key,
+      displayName: tool.key,
+      totalExecutions: tool.count,
+    })
   );
   if (topTools.length > 0) {
     const resolved = await resolveToolDisplayNames(auth, topTools).catch(
@@ -227,12 +242,9 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_workspace_activity: async (_params, { auth }) => {
-    const ws = auth.getNonNullableWorkspace();
-    const { startDate, endDate } = daysToInstantRange(DAYS);
-    const baseQuery = buildAgentAnalyticsBaseQuery({
-      workspaceId: ws.sId,
-      startDate,
-      endDate,
+    const period = await resolveConsumptionPeriod(auth, {
+      kind: "days",
+      days: DAYS,
     });
 
     // Anonymity floor: a workspace-wide aggregate can de-anonymize individuals
@@ -240,13 +252,16 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
     // distinct active users before surfacing anything. Fetching the top users
     // capped at the floor is enough to decide — the count saturates at the
     // threshold.
-    const activeUsersResult = await fetchTopUsers(auth, {
-      startDate,
-      endDate,
+    const activeUsersResult = await fetchConsumptionTopGroups(auth, {
+      dimension: "user",
+      period,
       limit: MIN_USERS_FOR_ANONYMITY,
+      rankBy: "count",
+      includePreviousCredits: false,
+      includeTotalCount: false,
     });
     const activeUserCount = activeUsersResult.isOk()
-      ? activeUsersResult.value.length
+      ? activeUsersResult.value.groups.length
       : 0;
     if (activeUserCount < MIN_USERS_FOR_ANONYMITY) {
       return new Ok([
@@ -263,40 +278,57 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
     }
 
     const [agentsResult, skillsResult] = await Promise.all([
-      fetchTopAgents(auth, { days: DAYS, limit: TOP_ITEMS_LIMIT }),
-      fetchAvailableSkillsBySkillId(baseQuery),
+      fetchConsumptionTopGroups(auth, {
+        dimension: "agent",
+        period,
+        limit: TOP_ITEMS_LIMIT,
+        rankBy: "count",
+        includePreviousCredits: false,
+        includeTotalCount: false,
+      }),
+      fetchConsumptionTopGroups(auth, {
+        dimension: "skill",
+        period,
+        limit: TOP_ITEMS_LIMIT,
+        rankBy: "count",
+        includePreviousCredits: false,
+        includeTotalCount: false,
+      }),
     ]);
 
     const sections: string[] = [];
 
-    const candidateAgents = (
-      agentsResult.isOk() ? agentsResult.value : []
-    ).slice(0, TOP_ITEMS_LIMIT);
+    const candidateAgents = await resolveConsumptionGroupLabels(
+      auth,
+      "agent",
+      agentsResult.isOk() ? agentsResult.value.groups : []
+    );
     let topAgents = candidateAgents;
     if (candidateAgents.length > 0) {
-      // Filter to agents the user can actually access — fetchTopAgents is workspace-scoped
-      // and its internal label resolver has a fallback that leaks names from private spaces.
+      // Filter to agents the user can actually access — consumption label
+      // resolution has a workspace-scoped fallback that includes private agents.
       const accessible = await getAgentConfigurations(auth, {
-        agentIds: candidateAgents.map((a) => a.agentId),
+        agentIds: candidateAgents.map((a) => a.key),
         variant: "extra_light",
       });
       const accessibleIds = new Set(accessible.map((a) => a.sId));
-      topAgents = candidateAgents.filter((a) => accessibleIds.has(a.agentId));
+      topAgents = candidateAgents.filter((a) => accessibleIds.has(a.key));
     }
     if (topAgents.length > 0) {
       const lines = topAgents.map(
-        (a, i) =>
-          `${i + 1}. ${a.name} [${a.agentId}] — ${a.messageCount} messages`
+        (a, i) => `${i + 1}. ${a.name} [${a.key}] — ${a.count} messages`
       );
       sections.push(
         `Most popular agents (most used first):\n${lines.join("\n")}`
       );
     }
 
-    const topSkillRows = (skillsResult.isOk() ? skillsResult.value : []).slice(
-      0,
-      TOP_ITEMS_LIMIT
-    );
+    const topSkillRows = (
+      skillsResult.isOk() ? skillsResult.value.groups : []
+    ).map((skill) => ({
+      skillId: skill.key,
+      totalExecutions: skill.count,
+    }));
     const skills = await resolveAccessibleSkills(auth, topSkillRows);
     if (skills.length > 0) {
       const lines = skills.map(


### PR DESCRIPTION
## Description

The `user_analytics` MCP server currently queries the legacy analytics index. This PR switches its agent, member, skill, and tool tools to the consumption analytics without changing the target behavior.

A few changes in shape since the existing queries rely on the fact that 1 message is 1 doc in the legacy index.

No script to check for potential diff, this is only used by the activation skill (the server is in `auto_hidden_builder`) so we don't really have to be at perfect parity with the existing behavior as long as the new logic is sound.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
