### PR TITLE
Type-check Frame UI in the sandbox against Viz runtime types

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -19,6 +19,18 @@ import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Frame UI type checking needs a sandbox and the Viz runtime types artifact; neither exists here.
+vi.mock("@app/lib/api/viz/frame_runtime_types", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/viz/frame_runtime_types")
+    >();
+  return {
+    ...actual,
+    getFrameRuntimeTypesArtifact: vi.fn().mockResolvedValue(null),
+  };
+});
+
 vi.mock("@app/lib/lock", async (importActual) => {
   const actual = await importActual<typeof import("@app/lib/lock")>();
   return {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -114,6 +114,7 @@ app.post(
             frameId: publication.value.frameId,
             manifestPath: publication.value.sourcePath,
             publicationId: publication.value.publicationId,
+            warnings: publication.value.warnings,
           },
           200
         );

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text-v2.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text-v2.test.ts
@@ -17,7 +17,19 @@ import { getConversationFilesBasePath } from "@app/types/mount_path";
 import type { LightWorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Frame UI type checking needs a sandbox and the Viz runtime types artifact; neither exists here.
+vi.mock("@app/lib/api/viz/frame_runtime_types", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/viz/frame_runtime_types")
+    >();
+  return {
+    ...actual,
+    getFrameRuntimeTypesArtifact: vi.fn().mockResolvedValue(null),
+  };
+});
 
 const manifest = JSON.stringify({
   version: 1,

--- a/front/lib/api/bundler/bundle_module.ts
+++ b/front/lib/api/bundler/bundle_module.ts
@@ -52,9 +52,9 @@ interface BundleModuleParams {
    */
   transform?: (relPath: string, content: string) => string;
   /**
-   * Gate for non-relative specifiers, the engine's other consumer-specific seam. Returns an error
-   * message for an import the runtime cannot provide, or null to leave it external. Frames use it
-   * to reject packages missing from the renderer's import map at build time.
+   * Called for every bare import (`react`, `lodash`, ...). Return an error message to fail the
+   * build, or null to keep the import external. Frames use it to reject packages the renderer
+   * does not provide.
    */
   unsupportedExternalMessage?: (specifier: string) => string | null;
 }

--- a/front/lib/api/bundler/bundle_module.ts
+++ b/front/lib/api/bundler/bundle_module.ts
@@ -51,6 +51,12 @@ interface BundleModuleParams {
    * root-relative path and raw contents, returns the (possibly rewritten) contents.
    */
   transform?: (relPath: string, content: string) => string;
+  /**
+   * Gate for non-relative specifiers, the engine's other consumer-specific seam. Returns an error
+   * message for an import the runtime cannot provide, or null to leave it external. Frames use it
+   * to reject packages missing from the renderer's import map at build time.
+   */
+  unsupportedExternalMessage?: (specifier: string) => string | null;
 }
 
 // Extensions probed, in order, when a relative import omits one (e.g. `./Chart` -> `./Chart.tsx`).
@@ -129,6 +135,7 @@ export async function bundleModule({
   reader,
   esbuild: esbuildOptions,
   transform,
+  unsupportedExternalMessage,
 }: BundleModuleParams): Promise<Result<{ code: string }, BundleError>> {
   const index = new Set(await reader.list());
   if (!index.has(entryRelPath)) {
@@ -201,6 +208,11 @@ export async function bundleModule({
         }
 
         // Non-relative specifiers stay external (resolved by the runtime import scope).
+        const unsupportedMessage = unsupportedExternalMessage?.(args.path);
+        if (unsupportedMessage) {
+          return { errors: [{ text: unsupportedMessage }] };
+        }
+
         return { path: args.path, external: true };
       });
 

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -4,14 +4,20 @@ import {
   buildAndPublishFramePublication,
   validateFramePublication,
 } from "@app/lib/api/frames/build_and_publish";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import {
   computeFrameSourcePathSetSha256,
   FRAME_SOURCE_STAGING_ROOT,
 } from "@app/lib/api/frames/source_staging";
+import {
+  ensureFrameRuntimeTypesInstalled,
+  typeCheckFrameUiOnSandbox,
+} from "@app/lib/api/frames/ui_type_check";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { getFrameRuntimeTypesArtifact } from "@app/lib/api/viz/frame_runtime_types";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -48,6 +54,30 @@ vi.mock(
     return { ...actual, buildSandboxFunctionOnReadySandbox: vi.fn() };
   }
 );
+
+vi.mock("@app/lib/api/frames/ui_type_check", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/frames/ui_type_check")>();
+  return {
+    ...actual,
+    ensureFrameRuntimeTypesInstalled: vi.fn(),
+    typeCheckFrameUiOnSandbox: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/viz/frame_runtime_types", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/viz/frame_runtime_types")
+    >();
+  return { ...actual, getFrameRuntimeTypesArtifact: vi.fn() };
+});
+
+const runtimeTypesArtifact = {
+  id: "a".repeat(64),
+  tarball: Buffer.from("tarball"),
+  tarballSha256: "b".repeat(64),
+};
 
 const manifest = FrameManifestSchema.parse({
   version: 1,
@@ -161,6 +191,13 @@ async function setup(): Promise<{
 beforeEach(() => {
   vi.clearAllMocks();
   fileStorageMock.reset();
+  vi.mocked(getFrameRuntimeTypesArtifact).mockResolvedValue(null);
+  vi.mocked(ensureFrameRuntimeTypesInstalled).mockResolvedValue(
+    new Ok(`/var/lib/dust/frame-runtime/${runtimeTypesArtifact.id}`)
+  );
+  vi.mocked(typeCheckFrameUiOnSandbox).mockResolvedValue(
+    new Ok({ warnings: [] })
+  );
 });
 
 describe("buildAndPublishFramePublication", () => {
@@ -216,7 +253,7 @@ describe("buildAndPublishFramePublication", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
-  it("builds and publishes the UI without starting a sandbox", async () => {
+  it("builds and publishes the UI without a sandbox when runtime types are unavailable", async () => {
     const { auth, conversation, frame } = await setup();
 
     const result = await buildAndPublishFramePublication(auth, {
@@ -239,6 +276,142 @@ describe("buildAndPublishFramePublication", () => {
     expect(fileStorageMock.getObject(uiBundlePath)).toContain(
       'data-source="index.tsx:'
     );
+  });
+
+  it("type-checks the UI in the sandbox against the runtime types before publishing", async () => {
+    const { auth, conversation, frame, sandbox } = await setup();
+    vi.mocked(getFrameRuntimeTypesArtifact).mockResolvedValue(
+      runtimeTypesArtifact
+    );
+    vi.mocked(typeCheckFrameUiOnSandbox).mockResolvedValue(
+      new Ok({
+        warnings: [
+          {
+            type: "typescript",
+            message:
+              "index.tsx:1:7: error TS2322: Type 'string' is not assignable to type 'number'.",
+          },
+        ],
+      })
+    );
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest: uiOnlyManifest,
+      sourceFiles,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(ensureFrameRuntimeTypesInstalled).toHaveBeenCalledWith(auth, {
+      sandbox,
+      artifact: runtimeTypesArtifact,
+    });
+    expect(typeCheckFrameUiOnSandbox).toHaveBeenCalledWith(auth, {
+      sandbox,
+      runtimeDirectory: `/var/lib/dust/frame-runtime/${runtimeTypesArtifact.id}`,
+      stagingDirectory: expect.stringMatching(
+        new RegExp(`^${FRAME_SOURCE_STAGING_ROOT}/[^/]+$`)
+      ),
+      entryRelPath: "index.tsx",
+    });
+    expect(sandbox.writeFile).toHaveBeenCalledTimes(sourceFiles.length);
+    expect(result.value.warnings).toEqual([
+      {
+        type: "typescript",
+        message:
+          "index.tsx:1:7: error TS2322: Type 'string' is not assignable to type 'number'.",
+      },
+    ]);
+    expect(fileStorageMock.saveFileCalls.length).toBeGreaterThan(0);
+  });
+
+  it("keeps the active publication when the UI fails type checking", async () => {
+    const { auth, conversation, frame } = await setup();
+    const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
+    await frame.setActiveFramePublication({
+      publicationId: activePublicationId,
+      name: "Task List",
+      description: "Track tasks.",
+    });
+    vi.mocked(getFrameRuntimeTypesArtifact).mockResolvedValue(
+      runtimeTypesArtifact
+    );
+    vi.mocked(typeCheckFrameUiOnSandbox).mockResolvedValue(
+      new Err(
+        new FramePublicationError(
+          "ui_build_failed",
+          "Frame UI imports do not resolve against the Frame runtime:\nindex.tsx:1:10: error TS2305: Module '\"shadcn\"' has no exported member 'Nope'."
+        )
+      )
+    );
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest: uiOnlyManifest,
+      sourceFiles,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "ui_build_failed",
+      message: expect.stringContaining("has no exported member 'Nope'"),
+    });
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+    expect(
+      (await FileResource.fetchById(auth, frame.sId))?.useCaseMetadata
+        ?.activePublicationId
+    ).toBe(activePublicationId);
+  });
+
+  it("publishes the UI without type checking when the sandbox is unavailable", async () => {
+    const { auth, conversation, frame } = await setup();
+    vi.mocked(getFrameRuntimeTypesArtifact).mockResolvedValue(
+      runtimeTypesArtifact
+    );
+    vi.mocked(ensureConversationSandboxReadyWithScope).mockResolvedValue(
+      new Err(new Error("provider down"))
+    );
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest: uiOnlyManifest,
+      sourceFiles: sourceFiles.slice(0, 1),
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(typeCheckFrameUiOnSandbox).not.toHaveBeenCalled();
+  });
+
+  it("rejects imports the Frame runtime cannot provide at bundle time", async () => {
+    const { auth, conversation, frame } = await setup();
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest: uiOnlyManifest,
+      sourceFiles: [
+        {
+          ...sourceFiles[0],
+          content: Buffer.from(
+            'import { Avatar } from "@/components/ui/avatar";\nexport default function App() { return <Avatar />; }'
+          ),
+        },
+      ],
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "ui_build_failed",
+      message: expect.stringContaining(
+        'Unsupported import "@/components/ui/avatar"'
+      ),
+    });
+    expect(ensureConversationSandboxReadyWithScope).not.toHaveBeenCalled();
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
   it("builds every declared function before publishing", async () => {

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -11,12 +11,18 @@ import {
   publishFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import { withStagedFrameSource } from "@app/lib/api/frames/source_staging";
+import {
+  ensureFrameRuntimeTypesInstalled,
+  typeCheckFrameUiOnSandbox,
+} from "@app/lib/api/frames/ui_type_check";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { buildFrameBundle } from "@app/lib/api/viz/build_frame_bundle";
+import { getFrameRuntimeTypesArtifact } from "@app/lib/api/viz/frame_runtime_types";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import { isSafeFrameRelativePath } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -26,6 +32,7 @@ import { Err, Ok } from "@app/types/shared/result";
 type FramePublicationBuild = {
   functionArtifacts: FramePublicationFunctionArtifact[];
   uiBundleCode: string;
+  warnings: ValidationWarning[];
 };
 
 async function buildFrameUiBundle({
@@ -97,10 +104,19 @@ async function buildFramePublication(
     return uiBundle;
   }
 
-  if (manifest.functions.length === 0) {
+  // Type checking is best-effort: without an artifact the UI still bundles and its imports were
+  // gated by the bundler, so publication proceeds and the gap is only logged.
+  const runtimeTypes = await getFrameRuntimeTypesArtifact();
+  const hasFunctions = manifest.functions.length > 0;
+  if (!hasFunctions && !runtimeTypes) {
+    logger.warn(
+      { conversationId: conversation.sId },
+      "Publishing Frame UI without type checking: Frame runtime types artifact unavailable"
+    );
     return new Ok({
       functionArtifacts: [],
       uiBundleCode: uiBundle.value,
+      warnings: [],
     });
   }
 
@@ -109,18 +125,56 @@ async function buildFramePublication(
     conversation
   );
   if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
+    if (hasFunctions) {
+      return new Err(
+        new SandboxFunctionError(
+          "sandbox_unavailable",
+          ensureResult.error.message
+        )
+      );
+    }
+    logger.warn(
+      { conversationId: conversation.sId, err: ensureResult.error },
+      "Publishing Frame UI without type checking: sandbox unavailable"
     );
+    return new Ok({
+      functionArtifacts: [],
+      uiBundleCode: uiBundle.value,
+      warnings: [],
+    });
   }
   const sandbox = ensureResult.value.sandbox;
-  const functionArtifactResult = await withStagedFrameSource(
+
+  let runtimeDirectory: string | null = null;
+  if (runtimeTypes) {
+    const installResult = await ensureFrameRuntimeTypesInstalled(auth, {
+      sandbox,
+      artifact: runtimeTypes,
+    });
+    if (installResult.isErr()) {
+      return installResult;
+    }
+    runtimeDirectory = installResult.value;
+  }
+
+  const stagedResult = await withStagedFrameSource(
     auth,
     { sandbox, sourceFiles },
     async (stagingDirectory) => {
+      let warnings: ValidationWarning[] = [];
+      if (runtimeDirectory) {
+        const typeCheck = await typeCheckFrameUiOnSandbox(auth, {
+          sandbox,
+          runtimeDirectory,
+          stagingDirectory,
+          entryRelPath: manifest.uiEntryPoint,
+        });
+        if (typeCheck.isErr()) {
+          return typeCheck;
+        }
+        warnings = typeCheck.value.warnings;
+      }
+
       const functionArtifacts: FramePublicationFunctionArtifact[] = [];
       for (const fn of manifest.functions) {
         const buildResult = await buildSandboxFunctionOnReadySandbox(auth, {
@@ -139,16 +193,17 @@ async function buildFramePublication(
         functionArtifacts.push({ name: fn.name, ...buildResult.value });
       }
 
-      return new Ok(functionArtifacts);
+      return new Ok({ functionArtifacts, warnings });
     }
   );
-  if (functionArtifactResult.isErr()) {
-    return functionArtifactResult;
+  if (stagedResult.isErr()) {
+    return stagedResult;
   }
 
   return new Ok({
-    functionArtifacts: functionArtifactResult.value,
+    functionArtifacts: stagedResult.value.functionArtifacts,
     uiBundleCode: uiBundle.value,
+    warnings: stagedResult.value.warnings,
   });
 }
 
@@ -215,13 +270,19 @@ export async function validateFramePublication(
     return contracts;
   }
 
-  return new Ok({ warnings: collectFrameTailwindWarnings(sourceFiles) });
+  return new Ok({
+    warnings: [
+      ...collectFrameTailwindWarnings(sourceFiles),
+      ...buildResult.value.warnings,
+    ],
+  });
 }
 
 /**
  * Build the UI and every declared function from one captured source snapshot, then atomically
- * publish its artifacts. Function builds stage the snapshot in the invoking conversation's DSBX;
- * source stays in its authoring scope. No publication storage is touched until every build succeeds.
+ * publish its artifacts. The snapshot is staged in the invoking conversation's DSBX, where the UI
+ * is type-checked against the Frame runtime types and functions are built; source stays in its
+ * authoring scope. No publication storage is touched until every build succeeds.
  */
 export async function buildAndPublishFramePublication(
   auth: Authenticator,
@@ -238,7 +299,7 @@ export async function buildAndPublishFramePublication(
   }
 ): Promise<
   Result<
-    { publicationId: string },
+    { publicationId: string; warnings: ValidationWarning[] },
     FramePublicationError | SandboxFunctionError
   >
 > {
@@ -251,11 +312,19 @@ export async function buildAndPublishFramePublication(
     return buildResult;
   }
 
-  return publishFramePublication(auth, {
+  const publication = await publishFramePublication(auth, {
     frame,
     functionArtifacts: buildResult.value.functionArtifacts,
     manifest,
     sourceFiles,
     uiBundleCode: buildResult.value.uiBundleCode,
+  });
+  if (publication.isErr()) {
+    return publication;
+  }
+
+  return new Ok({
+    publicationId: publication.value.publicationId,
+    warnings: buildResult.value.warnings,
   });
 }

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -71,6 +71,7 @@ export type PublishFrameFromSourceResult =
       frameId: string;
       sourcePath: string;
       publicationId: string;
+      warnings: ValidationWarning[];
     };
 
 export type ValidateFrameFromSourceResult = {
@@ -167,6 +168,7 @@ export async function publishFrameFromSource(
       frameId: frame.sId,
       sourcePath: normalizedPath,
       publicationId: publication.value.publicationId,
+      warnings: publication.value.warnings,
     });
   }
 
@@ -438,7 +440,7 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
   }
 ): Promise<
   Result<
-    { publicationId: string },
+    { publicationId: string; warnings: ValidationWarning[] },
     FramePublicationError | SandboxFunctionError
   >
 > {
@@ -470,7 +472,7 @@ export async function publishFrameV2FromSource(
   }
 ): Promise<
   Result<
-    { publicationId: string },
+    { publicationId: string; warnings: ValidationWarning[] },
     FramePublicationError | SandboxFunctionError
   >
 > {

--- a/front/lib/api/frames/ui_type_check.test.ts
+++ b/front/lib/api/frames/ui_type_check.test.ts
@@ -1,0 +1,331 @@
+// @vitest-environment node
+
+import {
+  ensureFrameRuntimeTypesInstalled,
+  FRAME_RUNTIME_TYPES_ROOT,
+  parseTscOutput,
+  typeCheckFrameUiOnSandbox,
+} from "@app/lib/api/frames/ui_type_check";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const artifact = {
+  id: "a".repeat(64),
+  tarball: Buffer.from("not-really-a-tarball"),
+  tarballSha256: "b".repeat(64),
+};
+
+const stagingDirectory = "/var/lib/dust/frame-sources/staged";
+
+async function setup() {
+  const { workspace, user } = await createResourceTest({ role: "admin" });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  assert(auth);
+  const sandbox = await SandboxResource.makeNew(auth, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  const writeFile = vi
+    .spyOn(sandbox, "writeFile")
+    .mockResolvedValue(new Ok(undefined));
+  const execRoot = vi
+    .spyOn(sandbox, "execRoot")
+    .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+  const exec = vi
+    .spyOn(sandbox, "exec")
+    .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+
+  return { auth, sandbox, writeFile, execRoot, exec };
+}
+
+function renderedRootCommands(
+  execRoot: Awaited<ReturnType<typeof setup>>["execRoot"]
+) {
+  return execRoot.mock.calls.map((call) => renderRootCommand(call[1]));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parseTscOutput", () => {
+  it("parses located and global diagnostics with continuation lines", () => {
+    expect(
+      parseTscOutput(
+        [
+          "/src/index.tsx(3,5): error TS2322: Type 'string' is not assignable to type 'number'.",
+          "/check/entry-check.tsx(2,28): error TS2786: 'FrameComponent' cannot be used as a JSX component.",
+          "  Its type 'number' is not a valid JSX element type.",
+          "error TS5083: Cannot read file 'tsconfig.json'.",
+          "",
+        ].join("\n")
+      )
+    ).toEqual([
+      {
+        file: "/src/index.tsx",
+        line: 3,
+        column: 5,
+        code: "TS2322",
+        message: "Type 'string' is not assignable to type 'number'.",
+      },
+      {
+        file: "/check/entry-check.tsx",
+        line: 2,
+        column: 28,
+        code: "TS2786",
+        message:
+          "'FrameComponent' cannot be used as a JSX component.\nIts type 'number' is not a valid JSX element type.",
+      },
+      {
+        file: null,
+        line: null,
+        column: null,
+        code: "TS5083",
+        message: "Cannot read file 'tsconfig.json'.",
+      },
+    ]);
+  });
+});
+
+describe("ensureFrameRuntimeTypesInstalled", () => {
+  it("skips the upload when the artifact is already installed", async () => {
+    const { auth, sandbox, writeFile, execRoot } = await setup();
+
+    const result = await ensureFrameRuntimeTypesInstalled(auth, {
+      sandbox,
+      artifact,
+    });
+
+    expect(result.isOk() && result.value).toBe(
+      `${FRAME_RUNTIME_TYPES_ROOT}/${artifact.id}`
+    );
+    expect(renderedRootCommands(execRoot)).toEqual([
+      `/usr/bin/test -f ${FRAME_RUNTIME_TYPES_ROOT}/${artifact.id}/tsconfig.json`,
+    ]);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("uploads, verifies and atomically installs a missing artifact", async () => {
+    const { auth, sandbox, writeFile, execRoot } = await setup();
+    execRoot.mockResolvedValueOnce(
+      new Ok({ exitCode: 1, stdout: "", stderr: "" })
+    );
+
+    const result = await ensureFrameRuntimeTypesInstalled(auth, {
+      sandbox,
+      artifact,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const [, tarballPath] = writeFile.mock.calls[0];
+    expect(tarballPath).toMatch(
+      new RegExp(
+        `^${FRAME_RUNTIME_TYPES_ROOT}/\\.${artifact.id}\\.[^/]+\\.tgz$`
+      )
+    );
+    const commands = renderedRootCommands(execRoot);
+    expect(commands).toHaveLength(4);
+    expect(commands[1]).toContain(
+      `/usr/bin/install -d -m 0755 -o root -g root ${FRAME_RUNTIME_TYPES_ROOT}`
+    );
+    expect(commands[2]).toContain(`${artifact.tarballSha256}`);
+    expect(commands[2]).toContain("/usr/bin/sha256sum -c --status");
+    expect(commands[2]).toContain("/usr/bin/tar -xzf");
+    expect(commands[2]).toContain(
+      `/usr/bin/mv -T -- '${FRAME_RUNTIME_TYPES_ROOT}/.${artifact.id}.`
+    );
+    expect(commands[3]).toMatch(/^\/usr\/bin\/rm -rf -- /);
+  });
+
+  it("reports a failed installation", async () => {
+    const { auth, sandbox, execRoot } = await setup();
+    execRoot
+      .mockResolvedValueOnce(new Ok({ exitCode: 1, stdout: "", stderr: "" }))
+      .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 1, stdout: "", stderr: "sha256sum: WARNING" })
+      );
+
+    const result = await ensureFrameRuntimeTypesInstalled(auth, {
+      sandbox,
+      artifact,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "internal",
+      message:
+        "Frame runtime types installation failed with exit code 1: sha256sum: WARNING",
+    });
+    expect(renderedRootCommands(execRoot).at(-1)).toMatch(
+      /^\/usr\/bin\/rm -rf -- /
+    );
+  });
+});
+
+describe("typeCheckFrameUiOnSandbox", () => {
+  const params = {
+    runtimeDirectory: `${FRAME_RUNTIME_TYPES_ROOT}/${artifact.id}`,
+    stagingDirectory,
+    entryRelPath: "index.tsx",
+  };
+
+  it("runs tsc as the workload user over a scratch entry check", async () => {
+    const { auth, sandbox, writeFile, execRoot, exec } = await setup();
+
+    const result = await typeCheckFrameUiOnSandbox(auth, {
+      sandbox,
+      ...params,
+    });
+
+    expect(result.isOk() && result.value).toEqual({ warnings: [] });
+    expect(writeFile).toHaveBeenCalledTimes(2);
+    const [
+      [, entryCheckPath, entryCheckBytes],
+      [, tsconfigPath, tsconfigBytes],
+    ] = writeFile.mock.calls;
+    expect(entryCheckPath).toMatch(
+      /^\/tmp\/dust-frame-ui-checks\/[^/]+\/entry-check\.tsx$/
+    );
+    expect(Buffer.from(entryCheckBytes).toString("utf8")).toBe(
+      `import FrameComponent from "${stagingDirectory}/index";\n` +
+        "export const entryCheck = <FrameComponent />;\n"
+    );
+    expect(JSON.parse(Buffer.from(tsconfigBytes).toString("utf8"))).toEqual({
+      extends: `${params.runtimeDirectory}/tsconfig.json`,
+      compilerOptions: { noEmit: true },
+      files: [entryCheckPath],
+    });
+    expect(tsconfigPath).toBe(
+      entryCheckPath.replace("entry-check.tsx", "tsconfig.json")
+    );
+    expect(exec).toHaveBeenCalledWith(
+      auth,
+      expect.stringMatching(
+        /^cd '\/tmp\/dust-frame-ui-checks\/[^/]+' && \/opt\/npm-global\/bin\/tsc -p tsconfig\.json --pretty false$/
+      ),
+      { timeoutMs: 120_000, user: "agent-proxied" }
+    );
+    expect(renderedRootCommands(execRoot).at(-1)).toMatch(
+      /^\/usr\/bin\/rm -rf -- \/tmp\/dust-frame-ui-checks\/[^/]+$/
+    );
+  });
+
+  it("fails publication on unresolved imports and keeps other diagnostics as warnings", async () => {
+    const { auth, sandbox, exec } = await setup();
+    exec.mockResolvedValue(
+      new Ok({
+        exitCode: 2,
+        stdout: [
+          `${stagingDirectory}/index.tsx(1,10): error TS2305: Module '"shadcn"' has no exported member 'Nope'.`,
+          `${stagingDirectory}/index.tsx(4,7): error TS2322: Type 'string' is not assignable to type 'number'.`,
+        ].join("\n"),
+        stderr: "",
+      })
+    );
+
+    const result = await typeCheckFrameUiOnSandbox(auth, {
+      sandbox,
+      ...params,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "ui_build_failed",
+      message:
+        "Frame UI imports do not resolve against the Frame runtime:\n" +
+        `index.tsx:1:10: error TS2305: Module '"shadcn"' has no exported member 'Nope'.`,
+    });
+  });
+
+  it("fails publication when the entry point is not a prop-less component", async () => {
+    const { auth, sandbox, exec, writeFile } = await setup();
+    exec.mockImplementation(async () => {
+      const [, entryCheckPath] = writeFile.mock.calls[0];
+      return new Ok({
+        exitCode: 2,
+        stdout: `${entryCheckPath}(2,28): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.`,
+        stderr: "",
+      });
+    });
+
+    const result = await typeCheckFrameUiOnSandbox(auth, {
+      sandbox,
+      ...params,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "ui_build_failed",
+      message:
+        "Frame UI entry point must default-export a component that renders without props:\n" +
+        "error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.",
+    });
+  });
+
+  it("returns type errors as warnings", async () => {
+    const { auth, sandbox, exec } = await setup();
+    exec.mockResolvedValue(
+      new Ok({
+        exitCode: 2,
+        stdout: `${stagingDirectory}/lib/util.ts(4,7): error TS2322: Type 'string' is not assignable to type 'number'.`,
+        stderr: "",
+      })
+    );
+
+    const result = await typeCheckFrameUiOnSandbox(auth, {
+      sandbox,
+      ...params,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      warnings: [
+        {
+          type: "typescript",
+          message:
+            "lib/util.ts:4:7: error TS2322: Type 'string' is not assignable to type 'number'.",
+        },
+      ],
+    });
+  });
+
+  it("reports a compiler failure as internal", async () => {
+    const { auth, sandbox, exec } = await setup();
+    exec.mockResolvedValue(
+      new Ok({ exitCode: 127, stdout: "", stderr: "tsc: not found" })
+    );
+
+    const result = await typeCheckFrameUiOnSandbox(auth, {
+      sandbox,
+      ...params,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "internal",
+      message: "Frame UI type check failed with exit code 127: tsc: not found",
+    });
+  });
+
+  it("propagates sandbox failures", async () => {
+    const { auth, sandbox, exec } = await setup();
+    exec.mockResolvedValue(new Err(new Error("sandbox gone")));
+
+    const result = await typeCheckFrameUiOnSandbox(auth, {
+      sandbox,
+      ...params,
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "internal",
+      message: "sandbox gone",
+    });
+  });
+});

--- a/front/lib/api/frames/ui_type_check.test.ts
+++ b/front/lib/api/frames/ui_type_check.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 
+import path from "node:path";
+
 import {
   ensureFrameRuntimeTypesInstalled,
   FRAME_RUNTIME_TYPES_ROOT,
@@ -248,15 +250,15 @@ describe("typeCheckFrameUiOnSandbox", () => {
   });
 
   it("fails publication when the entry point is not a prop-less component", async () => {
-    const { auth, sandbox, exec, writeFile } = await setup();
-    exec.mockImplementation(async () => {
-      const [, entryCheckPath] = writeFile.mock.calls[0];
-      return new Ok({
+    const { auth, sandbox, exec } = await setup();
+    exec.mockResolvedValue(
+      new Ok({
         exitCode: 2,
-        stdout: `${entryCheckPath}(2,28): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.`,
+        stdout:
+          "entry-check.tsx(2,28): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.",
         stderr: "",
-      });
-    });
+      })
+    );
 
     const result = await typeCheckFrameUiOnSandbox(auth, {
       sandbox,
@@ -272,14 +274,19 @@ describe("typeCheckFrameUiOnSandbox", () => {
   });
 
   it("returns type errors as warnings", async () => {
-    const { auth, sandbox, exec } = await setup();
-    exec.mockResolvedValue(
-      new Ok({
+    const { auth, sandbox, exec, writeFile } = await setup();
+    exec.mockImplementation(async () => {
+      const [, entryCheckPath] = writeFile.mock.calls[0];
+      const diagnosticPath = path.posix.relative(
+        path.posix.dirname(entryCheckPath),
+        `${stagingDirectory}/lib/util.ts`
+      );
+      return new Ok({
         exitCode: 2,
-        stdout: `${stagingDirectory}/lib/util.ts(4,7): error TS2322: Type 'string' is not assignable to type 'number'.`,
+        stdout: `${diagnosticPath}(4,7): error TS2322: Type 'string' is not assignable to type 'number'.`,
         stderr: "",
-      })
-    );
+      });
+    });
 
     const result = await typeCheckFrameUiOnSandbox(auth, {
       sandbox,

--- a/front/lib/api/frames/ui_type_check.ts
+++ b/front/lib/api/frames/ui_type_check.ts
@@ -1,0 +1,429 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import type { ValidationWarning } from "@app/lib/api/files/content_validation";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { FrameRuntimeTypesArtifact } from "@app/lib/api/viz/frame_runtime_types";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Type-checks a staged Frame UI source tree inside the publishing sandbox, against the Frame
+ * runtime types artifact Viz generates from its real runtime modules. `tsc` never evaluates the
+ * source, and it runs as the egress-controlled sandbox user, so untrusted Frame code stays on the
+ * workload side.
+ *
+ * Diagnostics that mean the bundle cannot import at render time (unresolved modules, missing
+ * exports, an entry point that is not a prop-less component) fail publication; every other
+ * diagnostic is returned as a warning for the author.
+ */
+
+export const FRAME_RUNTIME_TYPES_ROOT = "/var/lib/dust/frame-runtime";
+// Non-mounted scratch root, so a check never writes into the files mount.
+const CHECK_SCRATCH_ROOT = "/tmp/dust-frame-ui-checks";
+// `typescript` is installed globally in the sandbox image (see image/registry.ts).
+const TSC_BIN_PATH = "/opt/npm-global/bin/tsc";
+const TYPE_CHECK_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
+const MAX_REPORTED_DIAGNOSTICS = 10;
+const MAX_ERROR_MESSAGE_CHARS = 8 * 1024;
+// tsc exits with 2 when it reports diagnostics for a valid project.
+const TSC_DIAGNOSTICS_EXIT_CODE = 2;
+
+// Diagnostics whose presence means the bundle would fail to import in the renderer.
+const RESOLUTION_ERROR_CODES = new Set([
+  "TS1192", // Module has no default export.
+  "TS2305", // Module has no exported member.
+  "TS2307", // Cannot find module.
+  "TS2613", // Module has no default export; did you mean a named import?
+  "TS2614", // Module has no exported member; did you mean the default import?
+  "TS2724", // Module has no exported member named X; did you mean Y?
+]);
+
+// Groups: file, line, column (all optional together), code, message.
+const TSC_DIAGNOSTIC_LINE = /^(?:(.+?)\((\d+),(\d+)\): )?error (TS\d+): (.*)$/;
+
+export interface TscDiagnostic {
+  file: string | null;
+  line: number | null;
+  column: number | null;
+  code: string;
+  message: string;
+}
+
+type RootExecResult = Awaited<ReturnType<SandboxResource["execRoot"]>>;
+
+function rootCommandFailure(
+  result: RootExecResult,
+  operation: string
+): SandboxFunctionError | undefined {
+  if (result.isErr()) {
+    return new SandboxFunctionError("internal", result.error.message);
+  }
+  if (result.value.exitCode !== 0) {
+    const detail = result.value.stderr.trim() || result.value.stdout.trim();
+    return new SandboxFunctionError(
+      "internal",
+      `${operation} failed with exit code ${result.value.exitCode}${detail ? `: ${detail}` : "."}`
+    );
+  }
+  return undefined;
+}
+
+/** Parses `tsc --pretty false` output; continuation lines belong to the preceding diagnostic. */
+export function parseTscOutput(stdout: string): TscDiagnostic[] {
+  const diagnostics: TscDiagnostic[] = [];
+  for (const line of stdout.split("\n")) {
+    const match = TSC_DIAGNOSTIC_LINE.exec(line);
+    if (match) {
+      const [, file, lineNumber, column, code, message] = match;
+      diagnostics.push({
+        file: file ?? null,
+        line: lineNumber ? Number(lineNumber) : null,
+        column: column ? Number(column) : null,
+        code,
+        message,
+      });
+      continue;
+    }
+
+    const previous = diagnostics.at(-1);
+    if (previous && /^\s+\S/.test(line)) {
+      previous.message = `${previous.message}\n${line.trim()}`;
+    }
+  }
+
+  return diagnostics;
+}
+
+function boundMessage(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_CHARS
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_CHARS)}\n...`
+    : message;
+}
+
+function formatDiagnostic(
+  diagnostic: TscDiagnostic,
+  stagingDirectory: string
+): string {
+  const location =
+    diagnostic.file === null
+      ? ""
+      : `${path.posix.relative(stagingDirectory, diagnostic.file)}:${diagnostic.line ?? 0}:${diagnostic.column ?? 0}: `;
+
+  return `${location}error ${diagnostic.code}: ${diagnostic.message}`;
+}
+
+/**
+ * Installs the runtime types artifact under a root-owned, content-addressed directory once per
+ * sandbox. Returns the directory holding the artifact's `tsconfig.json`.
+ */
+export async function ensureFrameRuntimeTypesInstalled(
+  auth: Authenticator,
+  {
+    sandbox,
+    artifact,
+  }: {
+    sandbox: SandboxResource;
+    artifact: FrameRuntimeTypesArtifact;
+  }
+): Promise<Result<string, SandboxFunctionError>> {
+  const runtimeDirectory = path.posix.join(
+    FRAME_RUNTIME_TYPES_ROOT,
+    artifact.id
+  );
+  const runtimeTsconfigPath = path.posix.join(
+    runtimeDirectory,
+    "tsconfig.json"
+  );
+
+  const probeResult = await sandbox.execRoot(
+    auth,
+    rootCommand.exec("/usr/bin/test", ["-f", runtimeTsconfigPath])
+  );
+  if (probeResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", probeResult.error.message)
+    );
+  }
+  if (probeResult.value.exitCode === 0) {
+    return new Ok(runtimeDirectory);
+  }
+
+  const uploadId = `.${artifact.id}.${randomUUID()}`;
+  const tarballPath = path.posix.join(
+    FRAME_RUNTIME_TYPES_ROOT,
+    `${uploadId}.tgz`
+  );
+  const extractDirectory = path.posix.join(FRAME_RUNTIME_TYPES_ROOT, uploadId);
+  let result: Result<string, SandboxFunctionError>;
+  try {
+    const createResult = await sandbox.execRoot(
+      auth,
+      rootCommand.exec("/usr/bin/install", [
+        "-d",
+        "-m",
+        "0755",
+        "-o",
+        "root",
+        "-g",
+        "root",
+        FRAME_RUNTIME_TYPES_ROOT,
+      ])
+    );
+    const createFailure = rootCommandFailure(
+      createResult,
+      "Frame runtime types root creation"
+    );
+    if (createFailure) {
+      return new Err(createFailure);
+    }
+
+    const uploadResult = await sandbox.writeFile(
+      auth,
+      tarballPath,
+      Uint8Array.from(artifact.tarball).buffer
+    );
+    if (uploadResult.isErr()) {
+      return new Err(
+        new SandboxFunctionError("internal", uploadResult.error.message)
+      );
+    }
+
+    // Verify the upload before root extracts it, extract into a private directory, strip
+    // anything that is not a plain file or directory, then publish it atomically. A concurrent
+    // install of the same artifact may win the rename; that is fine as long as the result exists.
+    const installResult = await sandbox.execRoot(
+      auth,
+      rootCommand.unsafeShell(
+        [
+          `/usr/bin/printf '%s  %s\\n' ${shellEscape(artifact.tarballSha256)} ${shellEscape(tarballPath)} | /usr/bin/sha256sum -c --status`,
+          `/usr/bin/install -d -m 0755 -o root -g root -- ${shellEscape(extractDirectory)}`,
+          `/usr/bin/tar -xzf ${shellEscape(tarballPath)} -C ${shellEscape(extractDirectory)}`,
+          `/usr/bin/chown -R root:root -- ${shellEscape(extractDirectory)}`,
+          `/usr/bin/find ${shellEscape(extractDirectory)} -type d -exec /usr/bin/chmod 0755 -- {} +`,
+          `/usr/bin/find ${shellEscape(extractDirectory)} -type f -exec /usr/bin/chmod 0644 -- {} +`,
+          `test -z "$(/usr/bin/find ${shellEscape(extractDirectory)} ! -type d ! -type f -print -quit)"`,
+          `test -f ${shellEscape(path.posix.join(extractDirectory, "tsconfig.json"))}`,
+          `{ /usr/bin/mv -T -- ${shellEscape(extractDirectory)} ${shellEscape(runtimeDirectory)} 2>/dev/null || test -f ${shellEscape(runtimeTsconfigPath)}; }`,
+        ].join(" && "),
+        "Verify, extract, harden and atomically publish the Frame runtime types artifact."
+      )
+    );
+    const installFailure = rootCommandFailure(
+      installResult,
+      "Frame runtime types installation"
+    );
+    result = installFailure
+      ? new Err(installFailure)
+      : new Ok(runtimeDirectory);
+  } finally {
+    await sandbox.execRoot(
+      auth,
+      rootCommand.exec("/usr/bin/rm", [
+        "-rf",
+        "--",
+        tarballPath,
+        extractDirectory,
+      ])
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Runs `tsc` over the staged Frame UI entry point and everything it imports. Resolution failures
+ * and an invalid entry component fail with `ui_build_failed`; other diagnostics become warnings.
+ */
+export async function typeCheckFrameUiOnSandbox(
+  auth: Authenticator,
+  {
+    sandbox,
+    runtimeDirectory,
+    stagingDirectory,
+    entryRelPath,
+  }: {
+    sandbox: SandboxResource;
+    runtimeDirectory: string;
+    stagingDirectory: string;
+    entryRelPath: string;
+  }
+): Promise<
+  Result<
+    { warnings: ValidationWarning[] },
+    FramePublicationError | SandboxFunctionError
+  >
+> {
+  const scratchDirectory = path.posix.join(CHECK_SCRATCH_ROOT, randomUUID());
+  const entryCheckPath = path.posix.join(scratchDirectory, "entry-check.tsx");
+  const tsconfigPath = path.posix.join(scratchDirectory, "tsconfig.json");
+  // TypeScript rejects `.ts`/`.tsx` extensions in import specifiers.
+  const entryImportPath = path.posix.join(
+    stagingDirectory,
+    entryRelPath.replace(/\.(?:tsx|ts|jsx|js)$/, "")
+  );
+  const entryCheckSource =
+    `import FrameComponent from ${JSON.stringify(entryImportPath)};\n` +
+    "export const entryCheck = <FrameComponent />;\n";
+  const tsconfig = {
+    extends: path.posix.join(runtimeDirectory, "tsconfig.json"),
+    compilerOptions: { noEmit: true },
+    files: [entryCheckPath],
+  };
+
+  let result: Result<
+    { warnings: ValidationWarning[] },
+    FramePublicationError | SandboxFunctionError
+  >;
+  try {
+    const createResult = await sandbox.execRoot(
+      auth,
+      rootCommand.and([
+        rootCommand.exec("/usr/bin/install", [
+          "-d",
+          "-m",
+          "0755",
+          "-o",
+          "root",
+          "-g",
+          "root",
+          CHECK_SCRATCH_ROOT,
+        ]),
+        rootCommand.exec("/usr/bin/install", [
+          "-d",
+          "-m",
+          "0755",
+          "-o",
+          "root",
+          "-g",
+          "root",
+          scratchDirectory,
+        ]),
+      ])
+    );
+    const createFailure = rootCommandFailure(
+      createResult,
+      "Frame UI type check scratch creation"
+    );
+    if (createFailure) {
+      return new Err(createFailure);
+    }
+
+    for (const [filePath, content] of [
+      [entryCheckPath, entryCheckSource],
+      [tsconfigPath, JSON.stringify(tsconfig)],
+    ] as const) {
+      const writeResult = await sandbox.writeFile(
+        auth,
+        filePath,
+        Uint8Array.from(Buffer.from(content, "utf8")).buffer
+      );
+      if (writeResult.isErr()) {
+        return new Err(
+          new SandboxFunctionError("internal", writeResult.error.message)
+        );
+      }
+    }
+    const hardenResult = await sandbox.execRoot(
+      auth,
+      rootCommand.exec("/usr/bin/chmod", [
+        "-R",
+        "u=rwX,go=rX",
+        "--",
+        scratchDirectory,
+      ])
+    );
+    const hardenFailure = rootCommandFailure(
+      hardenResult,
+      "Frame UI type check scratch hardening"
+    );
+    if (hardenFailure) {
+      return new Err(hardenFailure);
+    }
+
+    const execResult = await sandbox.exec(
+      auth,
+      `cd ${shellEscape(scratchDirectory)} && ${TSC_BIN_PATH} -p tsconfig.json --pretty false`,
+      { timeoutMs: TYPE_CHECK_EXEC_TIMEOUT_MS, user: "agent-proxied" }
+    );
+    if (execResult.isErr()) {
+      return new Err(
+        new SandboxFunctionError("internal", execResult.error.message)
+      );
+    }
+    const { exitCode, stdout, stderr } = execResult.value;
+    if (exitCode === 0) {
+      return new Ok({ warnings: [] });
+    }
+    const diagnostics = parseTscOutput(stdout);
+    if (exitCode !== TSC_DIAGNOSTICS_EXIT_CODE || diagnostics.length === 0) {
+      const detail = stderr.trim() || stdout.trim();
+      return new Err(
+        new SandboxFunctionError(
+          "internal",
+          `Frame UI type check failed with exit code ${exitCode}${detail ? `: ${boundMessage(detail)}` : "."}`
+        )
+      );
+    }
+
+    const entryDiagnostics = diagnostics.filter(
+      (diagnostic) => diagnostic.file === entryCheckPath
+    );
+    if (entryDiagnostics.length > 0) {
+      return new Err(
+        new FramePublicationError(
+          "ui_build_failed",
+          boundMessage(
+            `Frame UI entry point must default-export a component that renders without props:\n${entryDiagnostics
+              .slice(0, MAX_REPORTED_DIAGNOSTICS)
+              .map(
+                (diagnostic) =>
+                  `error ${diagnostic.code}: ${diagnostic.message}`
+              )
+              .join("\n")}`
+          )
+        )
+      );
+    }
+
+    const resolutionDiagnostics = diagnostics.filter((diagnostic) =>
+      RESOLUTION_ERROR_CODES.has(diagnostic.code)
+    );
+    if (resolutionDiagnostics.length > 0) {
+      return new Err(
+        new FramePublicationError(
+          "ui_build_failed",
+          boundMessage(
+            `Frame UI imports do not resolve against the Frame runtime:\n${resolutionDiagnostics
+              .slice(0, MAX_REPORTED_DIAGNOSTICS)
+              .map((diagnostic) =>
+                formatDiagnostic(diagnostic, stagingDirectory)
+              )
+              .join("\n")}`
+          )
+        )
+      );
+    }
+
+    result = new Ok({
+      warnings: diagnostics
+        .slice(0, MAX_REPORTED_DIAGNOSTICS)
+        .map((diagnostic) => ({
+          type: "typescript",
+          message: boundMessage(formatDiagnostic(diagnostic, stagingDirectory)),
+        })),
+    });
+  } finally {
+    await sandbox.execRoot(
+      auth,
+      rootCommand.exec("/usr/bin/rm", ["-rf", "--", scratchDirectory])
+    );
+  }
+
+  return result;
+}

--- a/front/lib/api/frames/ui_type_check.ts
+++ b/front/lib/api/frames/ui_type_check.ts
@@ -207,9 +207,9 @@ export async function ensureFrameRuntimeTypesInstalled(
           `/usr/bin/chown -R root:root -- ${shellEscape(extractDirectory)}`,
           `/usr/bin/find ${shellEscape(extractDirectory)} -type d -exec /usr/bin/chmod 0755 -- {} +`,
           `/usr/bin/find ${shellEscape(extractDirectory)} -type f -exec /usr/bin/chmod 0644 -- {} +`,
-          `test -z "$(/usr/bin/find ${shellEscape(extractDirectory)} ! -type d ! -type f -print -quit)"`,
-          `test -f ${shellEscape(path.posix.join(extractDirectory, "tsconfig.json"))}`,
-          `{ /usr/bin/mv -T -- ${shellEscape(extractDirectory)} ${shellEscape(runtimeDirectory)} 2>/dev/null || test -f ${shellEscape(runtimeTsconfigPath)}; }`,
+          `/usr/bin/test -z "$(/usr/bin/find ${shellEscape(extractDirectory)} ! -type d ! -type f -print -quit)"`,
+          `/usr/bin/test -f ${shellEscape(path.posix.join(extractDirectory, "tsconfig.json"))}`,
+          `{ /usr/bin/mv -T -- ${shellEscape(extractDirectory)} ${shellEscape(runtimeDirectory)} 2>/dev/null || /usr/bin/test -f ${shellEscape(runtimeTsconfigPath)}; }`,
         ].join(" && "),
         "Verify, extract, harden and atomically publish the Frame runtime types artifact."
       )
@@ -360,7 +360,13 @@ export async function typeCheckFrameUiOnSandbox(
     if (exitCode === 0) {
       return new Ok({ warnings: [] });
     }
-    const diagnostics = parseTscOutput(stdout);
+    const diagnostics = parseTscOutput(stdout).map((diagnostic) => ({
+      ...diagnostic,
+      file:
+        diagnostic.file === null
+          ? null
+          : path.posix.resolve(scratchDirectory, diagnostic.file),
+    }));
     if (exitCode !== TSC_DIAGNOSTICS_EXIT_CODE || diagnostics.length === 0) {
       const detail = stderr.trim() || stdout.trim();
       return new Err(

--- a/front/lib/api/viz/build_frame_bundle.ts
+++ b/front/lib/api/viz/build_frame_bundle.ts
@@ -5,6 +5,8 @@ import type {
 } from "@app/lib/api/bundler/bundle_module";
 import { bundleModule } from "@app/lib/api/bundler/bundle_module";
 import type { DustFileSystem } from "@app/lib/api/file_system";
+import { isFrameFileReference } from "@app/lib/api/viz/extract_file_refs";
+import { FRAME_RUNTIME_IMPORT_NAMES } from "@app/lib/api/viz/frame_runtime_imports";
 import { injectSourceLocationTags } from "@app/lib/api/viz/source_location_tags";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -22,11 +24,32 @@ const FRAME_ESBUILD_OPTIONS: BundleEsbuildOptions = {
   minify: false,
 };
 
+const FRAME_RUNTIME_IMPORT_NAME_SET = new Set<string>(
+  FRAME_RUNTIME_IMPORT_NAMES
+);
+
+// The renderer resolves bare specifiers from a fixed import map plus Dust file references; anything
+// else throws when the bundle is imported, so it is rejected at build time with a fixable message.
+function unsupportedFrameImportMessage(specifier: string): string | null {
+  if (
+    FRAME_RUNTIME_IMPORT_NAME_SET.has(specifier) ||
+    isFrameFileReference(specifier)
+  ) {
+    return null;
+  }
+
+  return (
+    `Unsupported import "${specifier}". Frames can only import ` +
+    `${FRAME_RUNTIME_IMPORT_NAMES.map((name) => `"${name}"`).join(", ")}, ` +
+    "relative source files, or Dust file references."
+  );
+}
+
 /**
  * Bundle a multi-file frame into a single self-contained module. Thin wrapper over
- * {@link bundleModule} supplying the viz esbuild options and the JSX source-location transform, so
- * live edits on the rendered bundle route back to the correct source file. All graph-walking lives
- * in the generic engine.
+ * {@link bundleModule} supplying the viz esbuild options, the JSX source-location transform (so
+ * live edits on the rendered bundle route back to the correct source file) and the runtime import
+ * gate. All graph-walking lives in the generic engine.
  */
 export async function buildFrameBundle({
   entryRelPath,
@@ -42,6 +65,7 @@ export async function buildFrameBundle({
     // Stamp each source file with `data-source` tags before inlining so the rendered bundle keeps
     // the origin of every JSX element for live edits.
     transform: injectSourceLocationTags,
+    unsupportedExternalMessage: unsupportedFrameImportMessage,
   });
 }
 

--- a/front/lib/api/viz/extract_file_refs.ts
+++ b/front/lib/api/viz/extract_file_refs.ts
@@ -9,6 +9,15 @@ export type FileRef =
   | { type: "fileId"; fileId: string }
   | { type: "path"; scopedPath: string };
 
+function isFileIdReference(value: string): boolean {
+  return /^fil_[a-zA-Z0-9]{10,}$/.test(value);
+}
+
+/** Whether a string is a Dust file reference a Frame may import or pass to `useFile`. */
+export function isFrameFileReference(value: string): boolean {
+  return isFileIdReference(value) || isAgentScopedPath(value);
+}
+
 export function extractFileRefs(code: string): FileRef[] {
   const refs = new Map<string, FileRef>();
 
@@ -17,7 +26,7 @@ export function extractFileRefs(code: string): FileRef[] {
       return;
     }
 
-    if (/^fil_[a-zA-Z0-9]{10,}$/.test(value)) {
+    if (isFileIdReference(value)) {
       refs.set(value, { type: "fileId", fileId: value });
     } else if (isAgentScopedPath(value)) {
       refs.set(value, { type: "path", scopedPath: value });

--- a/front/lib/api/viz/frame_runtime_imports.test.ts
+++ b/front/lib/api/viz/frame_runtime_imports.test.ts
@@ -1,19 +1,9 @@
 import { FRAME_RUNTIME_IMPORT_NAMES as VALIDATOR_IMPORT_NAMES } from "@app/lib/api/viz/frame_runtime_imports";
 import { describe, expect, it } from "vitest";
 import { FRAME_RUNTIME_IMPORT_NAMES as RENDERER_IMPORT_NAMES } from "../../../../viz/app/lib/frame-runtime-imports";
-import vizPackage from "../../../../viz/package.json";
-import frontPackage from "../../../package.json";
 
 describe("Frame runtime imports", () => {
-  it("keeps publication validation aligned with the renderer import map", () => {
+  it("keeps the bundler import gate aligned with the renderer import map", () => {
     expect(VALIDATOR_IMPORT_NAMES).toEqual(RENDERER_IMPORT_NAMES);
-  });
-
-  it("keeps aliased declarations aligned with renderer package versions", () => {
-    expect(frontPackage.devDependencies).toMatchObject({
-      "@dust-frame-runtime/lucide-react": `npm:lucide-react@${vizPackage.dependencies["lucide-react"].replace("^", "")}`,
-      "@dust-frame-runtime/motion": `npm:motion@${vizPackage.dependencies.motion.replace("^", "")}`,
-      "@dust-frame-runtime/recharts": `npm:recharts@${vizPackage.dependencies.recharts}`,
-    });
   });
 });

--- a/front/lib/api/viz/frame_runtime_types.test.ts
+++ b/front/lib/api/viz/frame_runtime_types.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+
+import { createHash } from "node:crypto";
+
+import config from "@app/lib/api/config";
+import {
+  getFrameRuntimeTypesArtifact,
+  resetFrameRuntimeTypesArtifactCacheForTests,
+} from "@app/lib/api/viz/frame_runtime_types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+const tarball = Buffer.from("tarball-bytes");
+const manifest = {
+  version: 1,
+  id: "a".repeat(64),
+  path: `/frame-runtime/${"a".repeat(64)}.tgz`,
+  tarballSha256: createHash("sha256").update(tarball).digest("hex"),
+  sizeBytes: tarball.byteLength,
+};
+
+function respondWith(manifestBody: unknown, tarballBody: Buffer = tarball) {
+  fetchMock.mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/frame-runtime/manifest.json")) {
+      return new Response(JSON.stringify(manifestBody), { status: 200 });
+    }
+    if (url.endsWith(manifest.path)) {
+      return new Response(new Uint8Array(tarballBody), { status: 200 });
+    }
+    return new Response(null, { status: 404 });
+  });
+}
+
+beforeEach(() => {
+  resetFrameRuntimeTypesArtifactCacheForTests();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.spyOn(config, "getVizPublicUrl").mockReturnValue("https://viz.test/");
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+describe("getFrameRuntimeTypesArtifact", () => {
+  it("fetches the manifest and verified tarball, then reuses them", async () => {
+    respondWith(manifest);
+
+    const first = await getFrameRuntimeTypesArtifact();
+    const second = await getFrameRuntimeTypesArtifact();
+
+    expect(first).toEqual({
+      id: manifest.id,
+      tarball,
+      tarballSha256: manifest.tarballSha256,
+    });
+    expect(second).toBe(first);
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      "https://viz.test/frame-runtime/manifest.json",
+      `https://viz.test${manifest.path}`,
+    ]);
+  });
+
+  it("re-checks the manifest after the interval without re-downloading an unchanged tarball", async () => {
+    respondWith(manifest);
+    const first = await getFrameRuntimeTypesArtifact();
+    vi.advanceTimersByTime(61_000);
+
+    const second = await getFrameRuntimeTypesArtifact();
+
+    expect(second).toBe(first);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns null when Viz has no artifact and nothing is cached", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+    expect(await getFrameRuntimeTypesArtifact()).toBeNull();
+  });
+
+  it("keeps the cached artifact when a refresh fails", async () => {
+    respondWith(manifest);
+    const first = await getFrameRuntimeTypesArtifact();
+    vi.advanceTimersByTime(61_000);
+    fetchMock.mockRejectedValue(new Error("connection refused"));
+
+    expect(await getFrameRuntimeTypesArtifact()).toBe(first);
+  });
+
+  it("rejects a tarball that does not match its manifest", async () => {
+    respondWith(manifest, Buffer.from("tampered"));
+
+    expect(await getFrameRuntimeTypesArtifact()).toBeNull();
+  });
+
+  it("rejects an invalid manifest", async () => {
+    respondWith({ ...manifest, path: "/etc/passwd" });
+
+    expect(await getFrameRuntimeTypesArtifact()).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/lib/api/viz/frame_runtime_types.test.ts
+++ b/front/lib/api/viz/frame_runtime_types.test.ts
@@ -77,19 +77,30 @@ describe("getFrameRuntimeTypesArtifact", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("returns null when Viz has no artifact and nothing is cached", async () => {
+  it("returns null when Viz has no artifact and does not retry before the interval", async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
 
     expect(await getFrameRuntimeTypesArtifact()).toBeNull();
+    expect(await getFrameRuntimeTypesArtifact()).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(61_000);
+    respondWith(manifest);
+
+    expect(await getFrameRuntimeTypesArtifact()).toMatchObject({
+      id: manifest.id,
+    });
   });
 
-  it("keeps the cached artifact when a refresh fails", async () => {
+  it("keeps the cached artifact when a refresh fails and does not retry before the interval", async () => {
     respondWith(manifest);
     const first = await getFrameRuntimeTypesArtifact();
     vi.advanceTimersByTime(61_000);
     fetchMock.mockRejectedValue(new Error("connection refused"));
 
     expect(await getFrameRuntimeTypesArtifact()).toBe(first);
+    expect(await getFrameRuntimeTypesArtifact()).toBe(first);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("rejects a tarball that does not match its manifest", async () => {

--- a/front/lib/api/viz/frame_runtime_types.ts
+++ b/front/lib/api/viz/frame_runtime_types.ts
@@ -1,0 +1,175 @@
+import { createHash } from "node:crypto";
+
+import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+/**
+ * Fetches the Frame runtime types artifact Viz generates at build time (see
+ * viz/app/lib/frame-runtime-types/build.ts) so Frame UI source can be type-checked in the
+ * publishing sandbox against the exact modules and package versions the renderer exposes.
+ *
+ * The manifest is re-checked at most once per minute and the tarball is only downloaded when
+ * its id changes. Fetch failures fall back to the last artifact this process fetched, or to
+ * `null` when there is none, so a Viz outage degrades type checking instead of blocking
+ * publication.
+ */
+
+const MANIFEST_CHECK_INTERVAL_MS = 60_000;
+const FETCH_TIMEOUT_MS = 15_000;
+const MAX_TARBALL_BYTES = 64 * 1024 * 1024;
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+// Mirrors FrameRuntimeTypesManifest in viz/app/lib/frame-runtime-types/build.ts.
+const FrameRuntimeTypesManifestSchema = z.object({
+  version: z.literal(1),
+  id: z.string().regex(SHA256_HEX),
+  path: z.string().regex(/^\/frame-runtime\/[0-9a-f]{64}\.tgz$/),
+  tarballSha256: z.string().regex(SHA256_HEX),
+  sizeBytes: z.number().int().positive().max(MAX_TARBALL_BYTES),
+});
+
+export interface FrameRuntimeTypesArtifact {
+  id: string;
+  tarball: Buffer;
+  tarballSha256: string;
+}
+
+interface ArtifactCache {
+  artifact: FrameRuntimeTypesArtifact | null;
+  manifestCheckedAtMs: number;
+  inflight: Promise<FrameRuntimeTypesArtifact | null> | null;
+}
+
+let cache: ArtifactCache = {
+  artifact: null,
+  manifestCheckedAtMs: 0,
+  inflight: null,
+};
+
+async function fetchFromViz(urlPath: string): Promise<Result<Response, Error>> {
+  const baseUrl = config.getVizPublicUrl().replace(/\/$/, "");
+  try {
+    const response = await fetch(`${baseUrl}${urlPath}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return new Err(
+        new Error(`GET ${urlPath} failed with status ${response.status}.`)
+      );
+    }
+    return new Ok(response);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+async function fetchLatestArtifact(
+  current: FrameRuntimeTypesArtifact | null
+): Promise<Result<FrameRuntimeTypesArtifact, Error>> {
+  const manifestResponse = await fetchFromViz("/frame-runtime/manifest.json");
+  if (manifestResponse.isErr()) {
+    return manifestResponse;
+  }
+
+  let manifestBody: unknown;
+  try {
+    manifestBody = await manifestResponse.value.json();
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+  const manifest = FrameRuntimeTypesManifestSchema.safeParse(manifestBody);
+  if (!manifest.success) {
+    return new Err(
+      new Error(
+        `Invalid Frame runtime types manifest: ${manifest.error.message}`
+      )
+    );
+  }
+  if (current?.id === manifest.data.id) {
+    return new Ok(current);
+  }
+
+  const tarballResponse = await fetchFromViz(manifest.data.path);
+  if (tarballResponse.isErr()) {
+    return tarballResponse;
+  }
+  let tarball: Buffer;
+  try {
+    tarball = Buffer.from(await tarballResponse.value.arrayBuffer());
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+  if (tarball.byteLength > MAX_TARBALL_BYTES) {
+    return new Err(
+      new Error(
+        `Frame runtime types tarball exceeds ${MAX_TARBALL_BYTES} bytes.`
+      )
+    );
+  }
+  const tarballSha256 = createHash("sha256").update(tarball).digest("hex");
+  if (tarballSha256 !== manifest.data.tarballSha256) {
+    return new Err(
+      new Error("Frame runtime types tarball does not match its manifest.")
+    );
+  }
+
+  return new Ok({ id: manifest.data.id, tarball, tarballSha256 });
+}
+
+async function refreshArtifact(): Promise<FrameRuntimeTypesArtifact | null> {
+  const previous = cache.artifact;
+  const latest = await fetchLatestArtifact(previous);
+  if (latest.isErr()) {
+    logger.warn(
+      { err: latest.error, cachedArtifactId: previous?.id ?? null },
+      "Frame runtime types artifact unavailable; Frame UI type checking uses the cached artifact if any"
+    );
+    return previous;
+  }
+
+  if (latest.value !== previous) {
+    logger.info(
+      {
+        artifactId: latest.value.id,
+        sizeBytes: latest.value.tarball.byteLength,
+      },
+      "Fetched Frame runtime types artifact"
+    );
+  }
+  cache = {
+    ...cache,
+    artifact: latest.value,
+    manifestCheckedAtMs: Date.now(),
+  };
+
+  return latest.value;
+}
+
+/** The current Frame runtime types artifact, or null when none could be fetched. */
+export async function getFrameRuntimeTypesArtifact(): Promise<FrameRuntimeTypesArtifact | null> {
+  if (
+    cache.artifact &&
+    Date.now() - cache.manifestCheckedAtMs < MANIFEST_CHECK_INTERVAL_MS
+  ) {
+    return cache.artifact;
+  }
+  if (cache.inflight) {
+    return cache.inflight;
+  }
+
+  const inflight = refreshArtifact().finally(() => {
+    cache = { ...cache, inflight: null };
+  });
+  cache = { ...cache, inflight };
+
+  return inflight;
+}
+
+export function resetFrameRuntimeTypesArtifactCacheForTests(): void {
+  cache = { artifact: null, manifestCheckedAtMs: 0, inflight: null };
+}

--- a/front/lib/api/viz/frame_runtime_types.ts
+++ b/front/lib/api/viz/frame_runtime_types.ts
@@ -12,10 +12,10 @@ import { z } from "zod";
  * viz/app/lib/frame-runtime-types/build.ts) so Frame UI source can be type-checked in the
  * publishing sandbox against the exact modules and package versions the renderer exposes.
  *
- * The manifest is re-checked at most once per minute and the tarball is only downloaded when
- * its id changes. Fetch failures fall back to the last artifact this process fetched, or to
- * `null` when there is none, so a Viz outage degrades type checking instead of blocking
- * publication.
+ * Viz is contacted at most once per minute, whether the last attempt succeeded or failed, and
+ * the tarball is only downloaded when its id changes. Fetch failures fall back to the last
+ * artifact this process fetched, or to `null` when there is none, so a Viz outage degrades type
+ * checking instead of blocking publication or stalling every publish on a fetch timeout.
  */
 
 const MANIFEST_CHECK_INTERVAL_MS = 60_000;
@@ -129,6 +129,7 @@ async function refreshArtifact(): Promise<FrameRuntimeTypesArtifact | null> {
       { err: latest.error, cachedArtifactId: previous?.id ?? null },
       "Frame runtime types artifact unavailable; Frame UI type checking uses the cached artifact if any"
     );
+    cache = { ...cache, manifestCheckedAtMs: Date.now() };
     return previous;
   }
 
@@ -152,10 +153,7 @@ async function refreshArtifact(): Promise<FrameRuntimeTypesArtifact | null> {
 
 /** The current Frame runtime types artifact, or null when none could be fetched. */
 export async function getFrameRuntimeTypesArtifact(): Promise<FrameRuntimeTypesArtifact | null> {
-  if (
-    cache.artifact &&
-    Date.now() - cache.manifestCheckedAtMs < MANIFEST_CHECK_INTERVAL_MS
-  ) {
+  if (Date.now() - cache.manifestCheckedAtMs < MANIFEST_CHECK_INTERVAL_MS) {
     return cache.artifact;
   }
   if (cache.inflight) {

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -100,6 +100,15 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(
       "Use the Computer to create and edit their source"
     );
+    expect(instructions).toContain(
+      'import { Avatar, Button, Input, Textarea } from "shadcn";'
+    );
+    expect(instructions).toContain(
+      "Never use `@/components/ui/*` or another project-local package alias"
+    );
+    expect(instructions).toContain(
+      "replace only that import with a supported runtime import"
+    );
     expect(instructions).toContain("Do not pass the convenience aliases");
     expect(instructions).toContain("`/files/conversation` or `/files/pod`");
     expect(instructions).toContain(

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -38,6 +38,16 @@ In a Pod, create it under \`/files/pod-<podId>/...\` instead. The command scaffo
 \`manifest.json\` and \`index.tsx\`, then assigns the Frame's stable identity. Edit the generated
 source before publishing it.
 
+Frames use a fixed runtime import map. Import shadcn components directly from \`shadcn\`:
+
+\`\`\`tsx
+import { Avatar, Button, Input, Textarea } from "shadcn";
+\`\`\`
+
+Never use \`@/components/ui/*\` or another project-local package alias. If validation reports an
+unsupported alias, replace only that import with a supported runtime import; do not rewrite or
+remove working UI components.
+
 Always pass canonical \`/files/conversation-<conversationId>/...\` or
 \`/files/pod-<podId>/...\` paths to \`dsbx frame\`. Do not pass the convenience aliases
 \`/files/conversation\` or \`/files/pod\`.

--- a/front/package.json
+++ b/front/package.json
@@ -230,9 +230,6 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
-    "@dust-frame-runtime/lucide-react": "npm:lucide-react@0.483.0",
-    "@dust-frame-runtime/motion": "npm:motion@12.40.0",
-    "@dust-frame-runtime/recharts": "npm:recharts@2.15.4",
     "@faker-js/faker": "^9.3.0",
     "@google-cloud/storage": "^7.11.2",
     "@tailwindcss/postcss": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -490,9 +490,6 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
-        "@dust-frame-runtime/lucide-react": "npm:lucide-react@0.483.0",
-        "@dust-frame-runtime/motion": "npm:motion@12.40.0",
-        "@dust-frame-runtime/recharts": "npm:recharts@2.15.4",
         "@faker-js/faker": "^9.3.0",
         "@google-cloud/storage": "^7.11.2",
         "@tailwindcss/postcss": "^4.3.0",
@@ -4349,101 +4346,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@dust-frame-runtime/lucide-react": {
-      "name": "lucide-react",
-      "version": "0.483.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.483.0.tgz",
-      "integrity": "sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@dust-frame-runtime/motion": {
-      "name": "motion",
-      "version": "12.40.0",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
-      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "framer-motion": "^12.40.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@dust-frame-runtime/recharts": {
-      "name": "recharts",
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
-      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^18.3.1",
-        "react-smooth": "^4.0.4",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@dust-frame-runtime/recharts/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@dust-frame-runtime/recharts/node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
-      "dev": true,
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/@dust-tt/client": {
@@ -57055,6 +56957,7 @@
         "@types/react-dom": "^18.3.5",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.21.0",
         "vitest": "^4.0.16"
       },
       "engines": {

--- a/viz/.gitignore
+++ b/viz/.gitignore
@@ -16,6 +16,9 @@
 # production
 /build
 
+# generated frame runtime types artifact (see scripts/build-frame-runtime-types.ts)
+/public/frame-runtime/
+
 # misc
 .DS_Store
 *.pem

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -4,6 +4,7 @@ import { EditableFrame } from "@viz/app/components/EditableFrame";
 import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
 import { VizContext } from "@viz/app/components/VizContext";
 import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import type * as FrameReactHooks from "@viz/app/lib/frame-runtime/react-hooks";
 import type { FrameRuntimeImportName } from "@viz/app/lib/frame-runtime-imports";
 import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
 import {
@@ -495,7 +496,7 @@ export function VisualizationWrapper({
             usePodFunction,
             usePodFunctionMutation,
             useUserIdentity,
-          },
+          } satisfies typeof FrameReactHooks,
         } satisfies Record<FrameRuntimeImportName, unknown>;
 
         const refs = extractFileRefs(codeToUse);

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -6,6 +6,7 @@ import { VizContext } from "@viz/app/components/VizContext";
 import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import type * as FrameReactHooks from "@viz/app/lib/frame-runtime/react-hooks";
 import type { FrameRuntimeImportName } from "@viz/app/lib/frame-runtime-imports";
+import { FRAME_RUNTIME_STATIC_MODULES } from "@viz/app/lib/frame-runtime-modules";
 import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
 import {
   PodFunctionHooksProvider,
@@ -31,19 +32,10 @@ import {
   type SupportedMessage,
   validateMessage,
 } from "@viz/app/types/messages";
-import * as dustSlideshowV1 from "@viz/components/dust/slideshow/v1";
-import * as dustSlideshowV2 from "@viz/components/dust/slideshow/v2";
-import * as shadcnAll from "@viz/components/ui";
-import * as utilsAll from "@viz/lib/utils";
 import { toBlob, toSvg } from "html-to-image";
-import * as lucideAll from "lucide-react";
-import * as motionAll from "motion/react";
-import * as papaparseAll from "papaparse";
-import * as reactAll from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { importCode, Runner } from "react-runner";
-import * as rechartsAll from "recharts";
 
 // Delay before marking the viz as ready in PDF mode, to let Recharts animations complete.
 const PDF_MODE_READY_DELAY_MS = 5000;
@@ -471,18 +463,7 @@ export function VisualizationWrapper({
           : fetchedCode;
 
         const baseImports = {
-          papaparse: papaparseAll,
-          react: reactAll,
-          recharts: rechartsAll,
-          shadcn: shadcnAll,
-          // Legacy support for utils from previous versions.
-          utils: utilsAll,
-          // New location for utils.
-          "@viz/lib/utils": utilsAll,
-          "lucide-react": lucideAll,
-          "motion/react": motionAll,
-          "@dust/slideshow/v1": dustSlideshowV1,
-          "@dust/slideshow/v2": dustSlideshowV2,
+          ...FRAME_RUNTIME_STATIC_MODULES,
           "@dust/react-hooks": {
             SandboxFunctionCallError,
             callFunction: (functionId: string, input?: unknown) =>
@@ -532,13 +513,7 @@ export function VisualizationWrapper({
           code: "() => {import Comp from '@dust/generated-code'; return (<Comp />);}",
           scope: {
             import: {
-              react: reactAll,
-              recharts: rechartsAll,
-              shadcn: shadcnAll,
-              utils: utilsAll,
-              "lucide-react": lucideAll,
-              "@dust/slideshow/v1": dustSlideshowV1,
-              "@dust/slideshow/v2": dustSlideshowV2,
+              ...FRAME_RUNTIME_STATIC_MODULES,
               "@dust/generated-code": generatedModule,
             },
           },

--- a/viz/app/lib/frame-runtime-modules.test.ts
+++ b/viz/app/lib/frame-runtime-modules.test.ts
@@ -1,0 +1,29 @@
+import type { FrameRuntimeImportName } from "@viz/app/lib/frame-runtime-imports";
+import { FRAME_RUNTIME_IMPORT_NAMES } from "@viz/app/lib/frame-runtime-imports";
+import type { FrameRuntimeStaticImportName } from "@viz/app/lib/frame-runtime-modules";
+import { FRAME_RUNTIME_STATIC_MODULES } from "@viz/app/lib/frame-runtime-modules";
+import { FRAME_RUNTIME_MODULE_SOURCES } from "@viz/app/lib/frame-runtime-types/build";
+import { describe, expect, it } from "vitest";
+
+function isStaticImportName(
+  importName: FrameRuntimeImportName
+): importName is FrameRuntimeStaticImportName {
+  return importName !== "@dust/react-hooks";
+}
+
+describe("Frame runtime modules", () => {
+  it("generates runtime types from the modules the renderer exposes", async () => {
+    for (const importName of FRAME_RUNTIME_IMPORT_NAMES) {
+      if (!isStaticImportName(importName)) {
+        continue;
+      }
+      const source: Record<string, unknown> = await import(
+        FRAME_RUNTIME_MODULE_SOURCES[importName]
+      );
+
+      expect(Object.keys(source).sort(), importName).toEqual(
+        Object.keys(FRAME_RUNTIME_STATIC_MODULES[importName]).sort()
+      );
+    }
+  });
+});

--- a/viz/app/lib/frame-runtime-modules.ts
+++ b/viz/app/lib/frame-runtime-modules.ts
@@ -1,0 +1,35 @@
+import type { FrameRuntimeImportName } from "@viz/app/lib/frame-runtime-imports";
+import * as dustSlideshowV1 from "@viz/components/dust/slideshow/v1";
+import * as dustSlideshowV2 from "@viz/components/dust/slideshow/v2";
+import * as shadcnAll from "@viz/components/ui";
+import * as utilsAll from "@viz/lib/utils";
+import * as lucideAll from "lucide-react";
+import * as motionAll from "motion/react";
+import * as papaparseAll from "papaparse";
+import * as reactAll from "react";
+import * as rechartsAll from "recharts";
+
+export type FrameRuntimeStaticImportName = Exclude<
+  FrameRuntimeImportName,
+  "@dust/react-hooks"
+>;
+
+/**
+ * The modules a Frame can import that do not depend on the rendering context. The Frame runtime
+ * types artifact is generated from the same modules; `frame-runtime-modules.test.ts` keeps the
+ * two aligned.
+ */
+export const FRAME_RUNTIME_STATIC_MODULES = {
+  papaparse: papaparseAll,
+  react: reactAll,
+  recharts: rechartsAll,
+  shadcn: shadcnAll,
+  // Legacy support for utils from previous versions.
+  utils: utilsAll,
+  // New location for utils.
+  "@viz/lib/utils": utilsAll,
+  "lucide-react": lucideAll,
+  "motion/react": motionAll,
+  "@dust/slideshow/v1": dustSlideshowV1,
+  "@dust/slideshow/v2": dustSlideshowV2,
+} satisfies Record<FrameRuntimeStaticImportName, unknown>;

--- a/viz/app/lib/frame-runtime-types/build.test.ts
+++ b/viz/app/lib/frame-runtime-types/build.test.ts
@@ -1,0 +1,183 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { FRAME_RUNTIME_IMPORT_NAMES } from "@viz/app/lib/frame-runtime-imports";
+import { buildFrameRuntimeTypes } from "@viz/app/lib/frame-runtime-types/build";
+import ts from "typescript";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const VIZ_ROOT = path.resolve(__dirname, "../../..");
+
+let workDir: string;
+let runtimeDir: string;
+let stagingDir: string;
+
+/**
+ * Type-checks a Frame the way Front does in the sandbox: the artifact's tsconfig is extended by a
+ * scratch tsconfig whose only root is an entry-check file importing the Frame's entry point.
+ */
+function checkFrame(
+  files: Record<string, string>,
+  entryRelPath = "index.tsx"
+): string[] {
+  fs.rmSync(stagingDir, { recursive: true, force: true });
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(stagingDir, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+  const entryCheckPath = path.join(workDir, "entry-check.tsx");
+  const entryImportPath = path.join(
+    stagingDir,
+    entryRelPath.replace(/\.(?:tsx|ts|jsx|js)$/, "")
+  );
+  fs.writeFileSync(
+    entryCheckPath,
+    `import FrameComponent from ${JSON.stringify(entryImportPath)};\n` +
+      "export const entryCheck = <FrameComponent />;\n"
+  );
+  const parsed = ts.parseJsonConfigFileContent(
+    {
+      extends: path.join(runtimeDir, "tsconfig.json"),
+      compilerOptions: { noEmit: true },
+      files: [entryCheckPath],
+    },
+    ts.sys,
+    workDir
+  );
+  const program = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: parsed.options,
+  });
+
+  return ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")
+    );
+}
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), "frame-runtime-types-test-"));
+  runtimeDir = path.join(workDir, "runtime");
+  stagingDir = path.join(workDir, "frame");
+  const outDir = path.join(workDir, "out");
+  const manifest = buildFrameRuntimeTypes({ vizRoot: VIZ_ROOT, outDir });
+
+  expect(manifest.path).toBe(`/frame-runtime/${manifest.id}.tgz`);
+  expect(fs.readdirSync(outDir).sort()).toEqual([
+    `${manifest.id}.tgz`,
+    "manifest.json",
+  ]);
+  expect(
+    JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8"))
+  ).toEqual(manifest);
+
+  fs.mkdirSync(runtimeDir);
+  execFileSync("tar", [
+    "-xzf",
+    path.join(outDir, `${manifest.id}.tgz`),
+    "-C",
+    runtimeDir,
+  ]);
+}, 120_000);
+
+afterAll(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("buildFrameRuntimeTypes", () => {
+  it("maps every runtime import name to a declaration inside the artifact", () => {
+    const tsconfig = JSON.parse(
+      fs.readFileSync(path.join(runtimeDir, "tsconfig.json"), "utf8")
+    );
+    for (const importName of FRAME_RUNTIME_IMPORT_NAMES) {
+      const [target] = tsconfig.compilerOptions.paths[importName];
+      expect(target, importName).toMatch(/^\.\//);
+      expect(fs.existsSync(path.join(runtimeDir, target)), importName).toBe(
+        true
+      );
+    }
+  });
+
+  it("accepts a typed multi-file Frame using every runtime module", () => {
+    const diagnostics = checkFrame({
+      "index.tsx": `import { useState } from "react";
+import { LineChart } from "recharts";
+import { Circle } from "lucide-react";
+import { motion } from "motion/react";
+import Papa from "papaparse";
+import { Button, Card } from "shadcn";
+import { cn } from "@viz/lib/utils";
+import { usePodFunction, useFile, triggerUserFileDownload } from "@dust/react-hooks";
+import data from "./data.json";
+import type { Props } from "./types";
+import attachment from "conversation-conv_123/data.csv";
+export default function App(_props: Props) {
+  const [count] = useState<number>(1);
+  const result = usePodFunction("list-items", {});
+  const file = useFile("fil_abcdefghij");
+  const parsed = Papa.parse<string[]>("a,b");
+  return (
+    <Card className={cn("p-2")}>
+      <Circle />
+      <motion.div />
+      <LineChart width={1} height={1} data={[]} />
+      <Button onClick={() => triggerUserFileDownload({ content: "x" })}>
+        {data.label}{count}{String(result.data)}{file?.name}{parsed.data.length}{String(attachment)}
+      </Button>
+    </Card>
+  );
+}`,
+      "data.json": JSON.stringify({ label: "Hello" }),
+      "types.ts": "export interface Props { title?: string }",
+    });
+
+    expect(diagnostics).toEqual([]);
+  }, 60_000);
+
+  it("rejects imports the runtime does not provide", () => {
+    expect(
+      checkFrame({
+        "index.tsx": `import { Avatar } from "@/components/ui/avatar";
+export default function App() { return <Avatar />; }`,
+      })
+    ).toEqual([
+      "Cannot find module '@/components/ui/avatar' or its corresponding type declarations.",
+    ]);
+    expect(
+      checkFrame({
+        "index.tsx": `import { DefinitelyMissing } from "shadcn";
+export default function App() { return <DefinitelyMissing />; }`,
+      })
+    ).toEqual([
+      "Module '\"shadcn\"' has no exported member 'DefinitelyMissing'.",
+    ]);
+    expect(
+      checkFrame({
+        "index.tsx": `import { definitelyMissing } from "@dust/react-hooks";
+export default function App() { return <main>{String(definitelyMissing)}</main>; }`,
+      })
+    ).toEqual([
+      "Module '\"@dust/react-hooks\"' has no exported member 'definitelyMissing'.",
+    ]);
+  }, 60_000);
+
+  it("reports type errors and invalid entry components", () => {
+    expect(
+      checkFrame({
+        "index.tsx": `const count: number = "one";
+export default function App() { return <main>{count}</main>; }`,
+      })
+    ).toEqual(["Type 'string' is not assignable to type 'number'."]);
+    expect(
+      checkFrame({
+        "index.tsx": `export default function App({ title }: { title: string }) { return <main>{title}</main>; }`,
+      })
+    ).toEqual([
+      "Property 'title' is missing in type '{}' but required in type '{ title: string; }'.",
+    ]);
+  }, 60_000);
+});

--- a/viz/app/lib/frame-runtime-types/build.test.ts
+++ b/viz/app/lib/frame-runtime-types/build.test.ts
@@ -66,9 +66,9 @@ beforeAll(() => {
   const outDir = path.join(workDir, "out");
   const manifest = buildFrameRuntimeTypes({ vizRoot: VIZ_ROOT, outDir });
 
-  expect(manifest.path).toBe(`/frame-runtime/${manifest.id}.tgz`);
+  expect(manifest.path).toBe(`/frame-runtime/${manifest.tarballSha256}.tgz`);
   expect(fs.readdirSync(outDir).sort()).toEqual([
-    `${manifest.id}.tgz`,
+    `${manifest.tarballSha256}.tgz`,
     "manifest.json",
   ]);
   expect(
@@ -78,7 +78,7 @@ beforeAll(() => {
   fs.mkdirSync(runtimeDir);
   execFileSync("tar", [
     "-xzf",
-    path.join(outDir, `${manifest.id}.tgz`),
+    path.join(outDir, `${manifest.tarballSha256}.tgz`),
     "-C",
     runtimeDir,
   ]);

--- a/viz/app/lib/frame-runtime-types/build.ts
+++ b/viz/app/lib/frame-runtime-types/build.ts
@@ -1,0 +1,395 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { FrameRuntimeImportName } from "@viz/app/lib/frame-runtime-imports";
+import { FRAME_RUNTIME_IMPORT_NAMES } from "@viz/app/lib/frame-runtime-imports";
+import ts from "typescript";
+
+/**
+ * Builds the Frame runtime types artifact: a tarball holding every type declaration needed to
+ * type-check Frame UI source against the modules VisualizationWrapper exposes at runtime. Viz
+ * generates it at build time and serves it from `public/frame-runtime/`; Front installs it in the
+ * publishing sandbox and runs `tsc` against it. Because it is generated from the real runtime
+ * modules and the real installed packages, it cannot drift from what Frames get at render time.
+ *
+ * Layout of the extracted artifact:
+ * - `tsconfig.json`: compiler options and `paths` mapping each runtime import name to its
+ *   declaration file. Consumers extend it and add the files to check.
+ * - `viz/**`: declarations emitted from Viz's own runtime sources (shadcn, utils, slideshow,
+ *   the `@dust/react-hooks` contract).
+ * - `node_modules/**`: the declaration files and package manifests of every package the above
+ *   reaches, copied from the versions Viz has installed.
+ * - `node_modules/@types/dust-frame-refs`: ambient modules for Dust file references.
+ */
+
+// Source module behind each runtime import name, as VisualizationWrapper wires it.
+const FRAME_RUNTIME_MODULE_SOURCES = {
+  papaparse: "papaparse",
+  react: "react",
+  recharts: "recharts",
+  shadcn: "@viz/components/ui",
+  utils: "@viz/lib/utils",
+  "@viz/lib/utils": "@viz/lib/utils",
+  "lucide-react": "lucide-react",
+  "motion/react": "motion/react",
+  "@dust/slideshow/v1": "@viz/components/dust/slideshow/v1",
+  "@dust/slideshow/v2": "@viz/components/dust/slideshow/v2",
+  "@dust/react-hooks": "@viz/app/lib/frame-runtime/react-hooks",
+} as const satisfies Record<FrameRuntimeImportName, string>;
+
+// Mirrors the file reference forms `parseFileRefs.ts` accepts, so `import data from
+// "conversation-<id>/data.json"` type-checks as `any` instead of an unresolved module.
+const FRAME_FILE_REFERENCE_MODULE_PATTERNS = [
+  "fil_*",
+  "conversation-*",
+  "pod-*",
+  "conversation/*",
+  "pod/*",
+  "project/*",
+];
+
+const FRAME_REFS_TYPES_PACKAGE = "dust-frame-refs";
+
+export const FRAME_RUNTIME_TYPES_MANIFEST_VERSION = 1;
+
+export interface FrameRuntimeTypesManifest {
+  version: typeof FRAME_RUNTIME_TYPES_MANIFEST_VERSION;
+  // Content hash of the extracted tree; consumers key their install directory on it.
+  id: string;
+  // URL path of the tarball, relative to the Viz origin.
+  path: string;
+  tarballSha256: string;
+  sizeBytes: number;
+}
+
+function sha256(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]): string {
+  return ts.formatDiagnostics(diagnostics, {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  });
+}
+
+function readVizCompilerOptions(vizRoot: string): ts.CompilerOptions {
+  const configPath = path.join(vizRoot, "tsconfig.json");
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (configFile.error) {
+    throw new Error(formatDiagnostics([configFile.error]));
+  }
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    vizRoot
+  );
+  if (parsed.errors.length > 0) {
+    throw new Error(formatDiagnostics(parsed.errors));
+  }
+
+  return parsed.options;
+}
+
+function resolveRuntimeModule(
+  specifier: string,
+  vizRoot: string,
+  options: ts.CompilerOptions
+): string {
+  const resolved = ts.resolveModuleName(
+    specifier,
+    path.join(vizRoot, "__frame_runtime_anchor__.ts"),
+    options,
+    ts.sys
+  ).resolvedModule;
+  if (!resolved) {
+    throw new Error(`Cannot resolve Frame runtime module "${specifier}".`);
+  }
+
+  return resolved.resolvedFileName;
+}
+
+function isDeclarationFile(fileName: string): boolean {
+  return /\.d\.[cm]?ts$/.test(fileName);
+}
+
+function toDeclarationFileName(fileName: string): string {
+  if (isDeclarationFile(fileName)) {
+    return fileName;
+  }
+
+  return fileName.replace(/\.(?:tsx|ts|jsx|js|mts|cts)$/, ".d.ts");
+}
+
+function walkFiles(root: string): string[] {
+  const files: string[] = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    if (!directory) {
+      continue;
+    }
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.isFile()) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  return files.sort();
+}
+
+export function buildFrameRuntimeTypes({
+  vizRoot,
+  outDir,
+}: {
+  vizRoot: string;
+  outDir: string;
+}): FrameRuntimeTypesManifest {
+  const vizOptions = readVizCompilerOptions(vizRoot);
+  const nodeModulesMarker = `${path.sep}node_modules${path.sep}`;
+
+  const runtimeSourceFiles = new Map<FrameRuntimeImportName, string>();
+  for (const importName of FRAME_RUNTIME_IMPORT_NAMES) {
+    runtimeSourceFiles.set(
+      importName,
+      resolveRuntimeModule(
+        FRAME_RUNTIME_MODULE_SOURCES[importName],
+        vizRoot,
+        vizOptions
+      )
+    );
+  }
+
+  const stageRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "dust-frame-runtime-types-")
+  );
+  try {
+    const stagedVizDir = path.join(stageRoot, "viz");
+    const stagedNodeModulesDir = path.join(stageRoot, "node_modules");
+
+    // Only the runtime modules are roots; TypeScript pulls in everything they reach.
+    const emitOptions: ts.CompilerOptions = {
+      ...vizOptions,
+      declaration: true,
+      declarationMap: false,
+      emitDeclarationOnly: true,
+      incremental: false,
+      composite: false,
+      noEmit: false,
+      outDir: stagedVizDir,
+      plugins: undefined,
+      rootDir: vizRoot,
+      sourceMap: false,
+      tsBuildInfoFile: undefined,
+      types: [],
+    };
+    const program = ts.createProgram({
+      rootNames: Array.from(runtimeSourceFiles.values()),
+      options: emitOptions,
+    });
+
+    const isVizSource = (fileName: string) =>
+      fileName.startsWith(`${vizRoot}${path.sep}`) &&
+      !fileName.includes(nodeModulesMarker);
+    const preEmitDiagnostics = ts
+      .getPreEmitDiagnostics(program)
+      .filter(
+        (diagnostic) =>
+          diagnostic.category === ts.DiagnosticCategory.Error &&
+          (!diagnostic.file || isVizSource(diagnostic.file.fileName))
+      );
+    if (preEmitDiagnostics.length > 0) {
+      throw new Error(
+        `Frame runtime sources do not type-check:\n${formatDiagnostics(preEmitDiagnostics)}`
+      );
+    }
+
+    const emitResult = program.emit(undefined, undefined, undefined, true);
+    const emitErrors = emitResult.diagnostics.filter(
+      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error
+    );
+    if (emitErrors.length > 0) {
+      throw new Error(
+        `Frame runtime declaration emit failed:\n${formatDiagnostics(emitErrors)}`
+      );
+    }
+
+    const copiedPackageManifests = new Set<string>();
+    const copyPackageManifests = (packageFilePath: string) => {
+      // Copy every package.json between the file and its enclosing node_modules directory so
+      // package entry points and subpath exports resolve inside the artifact.
+      let directory = path.dirname(packageFilePath);
+      while (path.basename(directory) !== "node_modules") {
+        const manifestPath = path.join(directory, "package.json");
+        if (
+          !copiedPackageManifests.has(manifestPath) &&
+          fs.existsSync(manifestPath)
+        ) {
+          copiedPackageManifests.add(manifestPath);
+          const relative = manifestPath.slice(
+            manifestPath.indexOf(nodeModulesMarker) + nodeModulesMarker.length
+          );
+          const target = path.join(stagedNodeModulesDir, relative);
+          fs.mkdirSync(path.dirname(target), { recursive: true });
+          fs.copyFileSync(manifestPath, target);
+        }
+        const parent = path.dirname(directory);
+        if (parent === directory) {
+          break;
+        }
+        directory = parent;
+      }
+    };
+
+    for (const sourceFile of program.getSourceFiles()) {
+      const { fileName } = sourceFile;
+      const markerIndex = fileName.indexOf(nodeModulesMarker);
+      if (markerIndex !== -1) {
+        // The sandbox compiler ships its own default libraries.
+        if (
+          fileName.includes(
+            `${nodeModulesMarker}typescript${path.sep}lib${path.sep}`
+          )
+        ) {
+          continue;
+        }
+        const relative = fileName.slice(markerIndex + nodeModulesMarker.length);
+        const target = path.join(stagedNodeModulesDir, relative);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.copyFileSync(fileName, target);
+        copyPackageManifests(fileName);
+      } else if (isVizSource(fileName) && isDeclarationFile(fileName)) {
+        // Declaration emit skips inputs that are already declarations.
+        const target = path.join(
+          stagedVizDir,
+          path.relative(vizRoot, fileName)
+        );
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.copyFileSync(fileName, target);
+      }
+    }
+
+    const frameRefsDir = path.join(
+      stagedNodeModulesDir,
+      "@types",
+      FRAME_REFS_TYPES_PACKAGE
+    );
+    fs.mkdirSync(frameRefsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(frameRefsDir, "index.d.ts"),
+      `${FRAME_FILE_REFERENCE_MODULE_PATTERNS.map(
+        (pattern) => `declare module ${JSON.stringify(pattern)};`
+      ).join("\n")}\n`
+    );
+    fs.writeFileSync(
+      path.join(frameRefsDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: `@types/${FRAME_REFS_TYPES_PACKAGE}`,
+          version: "1.0.0",
+          types: "index.d.ts",
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const toStagedPath = (fileName: string): string => {
+      const markerIndex = fileName.indexOf(nodeModulesMarker);
+      const staged =
+        markerIndex !== -1
+          ? path.join(
+              stagedNodeModulesDir,
+              fileName.slice(markerIndex + nodeModulesMarker.length)
+            )
+          : path.join(
+              stagedVizDir,
+              toDeclarationFileName(path.relative(vizRoot, fileName))
+            );
+      if (!fs.existsSync(staged)) {
+        throw new Error(`Staged declaration missing for ${fileName}.`);
+      }
+
+      return `./${path.relative(stageRoot, staged).split(path.sep).join("/")}`;
+    };
+    const paths: Record<string, string[]> = {
+      "@viz/*": ["./viz/*"],
+    };
+    runtimeSourceFiles.forEach((fileName, importName) => {
+      paths[importName] = [toStagedPath(fileName)];
+    });
+    // Mirrors Viz's own compiler options where they affect Frame source; `paths` and
+    // `typeRoots` are relative to this file, so consumers extend it from anywhere.
+    const artifactTsconfig = {
+      compilerOptions: {
+        allowJs: true,
+        allowSyntheticDefaultImports: true,
+        baseUrl: ".",
+        checkJs: false,
+        esModuleInterop: true,
+        isolatedModules: false,
+        jsx: "preserve",
+        lib: ["dom", "dom.iterable", "esnext"],
+        module: "esnext",
+        moduleResolution: "bundler",
+        noEmit: true,
+        paths,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+        strict: true,
+        target: "es2020",
+        typeRoots: ["./node_modules/@types"],
+        types: ["react", FRAME_REFS_TYPES_PACKAGE],
+      },
+    };
+    fs.writeFileSync(
+      path.join(stageRoot, "tsconfig.json"),
+      `${JSON.stringify(artifactTsconfig, null, 2)}\n`
+    );
+
+    const treeHash = createHash("sha256");
+    for (const filePath of walkFiles(stageRoot)) {
+      treeHash.update(path.relative(stageRoot, filePath));
+      treeHash.update("\0");
+      treeHash.update(fs.readFileSync(filePath));
+      treeHash.update("\0");
+    }
+    const id = treeHash.digest("hex");
+
+    fs.mkdirSync(outDir, { recursive: true });
+    for (const entry of fs.readdirSync(outDir)) {
+      if (entry.endsWith(".tgz")) {
+        fs.rmSync(path.join(outDir, entry));
+      }
+    }
+    const tarballName = `${id}.tgz`;
+    const tarballPath = path.join(outDir, tarballName);
+    execFileSync("tar", ["-czf", tarballPath, "-C", stageRoot, "."], {
+      stdio: "pipe",
+    });
+    const tarball = fs.readFileSync(tarballPath);
+    const manifest: FrameRuntimeTypesManifest = {
+      version: FRAME_RUNTIME_TYPES_MANIFEST_VERSION,
+      id,
+      path: `/frame-runtime/${tarballName}`,
+      tarballSha256: sha256(tarball),
+      sizeBytes: tarball.byteLength,
+    };
+    fs.writeFileSync(
+      path.join(outDir, "manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`
+    );
+
+    return manifest;
+  } finally {
+    fs.rmSync(stageRoot, { recursive: true, force: true });
+  }
+}

--- a/viz/app/lib/frame-runtime-types/build.ts
+++ b/viz/app/lib/frame-runtime-types/build.ts
@@ -25,8 +25,9 @@ import ts from "typescript";
  * - `node_modules/@types/dust-frame-refs`: ambient modules for Dust file references.
  */
 
-// Source module behind each runtime import name, as VisualizationWrapper wires it.
-const FRAME_RUNTIME_MODULE_SOURCES = {
+// Source module behind each runtime import name. `frame-runtime-modules.test.ts` checks these
+// resolve to the very modules the renderer exposes under the same names.
+export const FRAME_RUNTIME_MODULE_SOURCES = {
   papaparse: "papaparse",
   react: "react",
   recharts: "recharts",

--- a/viz/app/lib/frame-runtime-types/build.ts
+++ b/viz/app/lib/frame-runtime-types/build.ts
@@ -57,9 +57,10 @@ export const FRAME_RUNTIME_TYPES_MANIFEST_VERSION = 1;
 
 export interface FrameRuntimeTypesManifest {
   version: typeof FRAME_RUNTIME_TYPES_MANIFEST_VERSION;
-  // Content hash of the extracted tree; consumers key their install directory on it.
+  // Content hash of the extracted tree; consumers key their install directory on it, so a
+  // rebuild of identical sources never re-installs.
   id: string;
-  // URL path of the tarball, relative to the Viz origin.
+  // URL path of the tarball, relative to the Viz origin. Named after `tarballSha256`.
   path: string;
   tarballSha256: string;
   sizeBytes: number;
@@ -370,17 +371,21 @@ export function buildFrameRuntimeTypes({
         fs.rmSync(path.join(outDir, entry));
       }
     }
-    const tarballName = `${id}.tgz`;
-    const tarballPath = path.join(outDir, tarballName);
-    execFileSync("tar", ["-czf", tarballPath, "-C", stageRoot, "."], {
+    // tar and gzip embed timestamps, so two builds of the same tree produce different bytes. The
+    // file is named after the bytes it holds so a URL can never serve two different tarballs.
+    const stagedTarballPath = path.join(outDir, ".frame-runtime.tgz");
+    execFileSync("tar", ["-czf", stagedTarballPath, "-C", stageRoot, "."], {
       stdio: "pipe",
     });
-    const tarball = fs.readFileSync(tarballPath);
+    const tarball = fs.readFileSync(stagedTarballPath);
+    const tarballSha256 = sha256(tarball);
+    const tarballName = `${tarballSha256}.tgz`;
+    fs.renameSync(stagedTarballPath, path.join(outDir, tarballName));
     const manifest: FrameRuntimeTypesManifest = {
       version: FRAME_RUNTIME_TYPES_MANIFEST_VERSION,
       id,
       path: `/frame-runtime/${tarballName}`,
-      tarballSha256: sha256(tarball),
+      tarballSha256,
       sizeBytes: tarball.byteLength,
     };
     fs.writeFileSync(

--- a/viz/app/lib/frame-runtime/react-hooks.d.ts
+++ b/viz/app/lib/frame-runtime/react-hooks.d.ts
@@ -1,0 +1,23 @@
+// Type contract of the `@dust/react-hooks` module Frames import at runtime. VisualizationWrapper
+// checks the runtime object it builds against this file, and the Frame runtime types artifact
+// ships it to publication type checking, so the two cannot drift.
+export { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+export {
+  usePodFunction,
+  usePodFunctionMutation,
+  useUserIdentity,
+} from "@viz/app/lib/pod-function-hooks";
+
+export declare function callFunction(
+  functionId: string,
+  input?: unknown
+): Promise<unknown>;
+
+export declare function captureScreenshot(name?: string): Promise<void>;
+
+export declare function triggerUserFileDownload(input: {
+  content: string | Blob;
+  filename?: string;
+}): Promise<void>;
+
+export declare function useFile(fileId: string): File | null;

--- a/viz/package.json
+++ b/viz/package.json
@@ -7,7 +7,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3007",
-    "build": "next build",
+    "build": "npm run build:frame-runtime-types && next build",
+    "build:frame-runtime-types": "tsx scripts/build-frame-runtime-types.ts",
     "start": "next start",
     "test": "vitest --run",
     "format": "biome format --write .",
@@ -81,6 +82,7 @@
     "@types/react-dom": "^18.3.5",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.21.0",
     "vitest": "^4.0.16"
   }
 }

--- a/viz/scripts/build-frame-runtime-types.ts
+++ b/viz/scripts/build-frame-runtime-types.ts
@@ -1,0 +1,13 @@
+// Generates the Frame runtime types artifact into `public/frame-runtime/` before `next build`.
+// Run from the viz package root: `npm run build:frame-runtime-types`.
+import path from "node:path";
+
+import { buildFrameRuntimeTypes } from "@viz/app/lib/frame-runtime-types/build";
+import logger from "@viz/app/lib/logger";
+
+const vizRoot = process.cwd();
+const manifest = buildFrameRuntimeTypes({
+  vizRoot,
+  outDir: path.join(vizRoot, "public", "frame-runtime"),
+});
+logger.info({ manifest }, "Built Frame runtime types artifact");


### PR DESCRIPTION
## Description

Type-check Frames v2 UI source before publishing, against the modules Viz actually exposes at render time, without a synchronous Front → Viz call and without running a TypeScript compiler inside the renderer.

- Viz generates a **Frame runtime types artifact** at build time (`scripts/build-frame-runtime-types.ts`): declarations emitted from its real runtime modules (`shadcn`, `utils`, slideshow, the `@dust/react-hooks` contract) plus the declaration files of every package they reach, at the versions Viz has installed. It is served from `public/frame-runtime/` as a content-addressed tarball (~1.3 MB gzipped) with a manifest. The `@dust/react-hooks` contract is a checked-in `.d.ts` that `VisualizationWrapper` now `satisfies`, so the runtime object and the typings cannot drift.
- Front fetches the artifact through a per-process cache (manifest re-checked once a minute, tarball downloaded only when its id changes, last good artifact kept on failure) and installs it once per sandbox under a root-owned, content-addressed directory after verifying its hash.
- Publishing stages the source snapshot in the conversation's DSBX as before, then runs `tsc` there as `agent-proxied` over an entry-check file that imports the Frame's entry point. Unresolved modules, missing exports and an entry point that is not a prop-less component fail publication with `ui_build_failed`; every other diagnostic is returned as a `typescript` warning alongside the existing Tailwind warnings. Publish responses for v2 Frames now carry `warnings`.
- The bundler gains an import gate: bare specifiers outside the renderer's import map (or Dust file references) fail the UI build immediately, before any sandbox work, with a message listing the supported imports. The Front mirror of the import-name list is kept in sync with Viz by the existing test.
- When the artifact or the sandbox is unavailable and the Frame has no functions, publication proceeds without the type check and the gap is logged, so a Viz or sandbox outage degrades validation instead of blocking authors.
- Removes the `@dust-frame-runtime/*` mirror packages from Front and teaches the Frames skill to import shadcn components from `shadcn` rather than project-local aliases.

## Tests

- Viz: the generator test builds the artifact and type-checks sample Frames against it the way the sandbox does (typed multi-file Frame using every runtime module, unsupported alias, missing `shadcn`/`@dust/react-hooks` export, type error, entry component with required props). Full viz suite green; `tsc` and a production `next build` run the generator.
- Front: unit coverage for `tsc` output parsing, the artifact install and check commands, the artifact fetch cache, the bundler gate, and the publication flow with the artifact present, rejected, or unavailable. Front, front-api and viz typecheck clean; the touched front and front-api suites pass.
- Not verified here: an end-to-end run against a real sandbox (the image already ships `typescript` globally under `/opt/npm-global`).

## Risk

The publish path for UI-only Frames now uses the conversation sandbox when the artifact is available, so it pays sandbox readiness. `tsc` over a shadcn-importing Frame takes ~2–3 s in the sandbox. Publication only hard-fails on resolution diagnostics; other type errors are warnings, so strict-mode noise on agent-written code cannot block publishing.

## Deploy Plan

1. Deploy Viz (the artifact appears at `/frame-runtime/manifest.json`).
2. Deploy Front. Until Viz is deployed, Front logs the missing artifact and publishes without the type check.
