### PR TITLE
Harden Frame deletion during legacy conversion

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -506,6 +506,63 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     );
   });
 
+  it("refetches a stale legacy delete after conversion commits", async () => {
+    const context = await setupLegacyFrameConversion();
+    const staleLegacyFrame = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    assert(staleLegacyFrame);
+
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+    expect(response.status, await response.text()).toBe(200);
+    const convertedFrame = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    assert(convertedFrame);
+    await convertedFrame.markAsReady(context.auth);
+
+    const deleteResult = await staleLegacyFrame.delete(context.auth);
+
+    expect(
+      deleteResult.isOk(),
+      deleteResult.isErr() ? deleteResult.error.message : undefined
+    ).toBe(true);
+    expect(
+      await FileResource.fetchById(context.auth, context.frame.sId)
+    ).toBeNull();
+  });
+
+  it("rejects deletion while conversion recovery is pending", async () => {
+    const context = await setupLegacyFrameConversion();
+    await markLegacyFrameConversionPending(context);
+    const pendingFrame = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    assert(pendingFrame);
+
+    const deleteResult = await pendingFrame.delete(context.auth);
+
+    expect(deleteResult.isErr() && deleteResult.error).toMatchObject({
+      name: "LegacyFrameMutationConflictError",
+      message: expect.stringContaining("recover it before deleting"),
+    });
+    const preservedFrame = await FileResource.fetchById(
+      context.auth,
+      context.frame.sId
+    );
+    expect(
+      preservedFrame?.useCaseMetadata?.pendingFrameV2Conversion
+    ).toBeDefined();
+  });
+
   it("registers one stable Frame identity", async () => {
     const context = await setup({ registered: false });
 

--- a/front/lib/api/frames/operation_lock.test.ts
+++ b/front/lib/api/frames/operation_lock.test.ts
@@ -2,8 +2,10 @@ import {
   getFramePublishLockName,
   getFrameSourceLockName,
   getLegacyFrameMutationLockName,
+  withFrameSourceAndPublishLocks,
   withFrameSourceLock,
   withLegacyFrameMutationLock,
+  withLegacyFrameMutationResultLock,
 } from "@app/lib/api/frames/operation_lock";
 import type { RedisClientType } from "@app/lib/api/redis";
 import { Ok } from "@app/types/shared/result";
@@ -108,5 +110,47 @@ describe("Frame operation locks", () => {
     await expect(first).resolves.toBe("first");
     await vi.advanceTimersByTimeAsync(100);
     await expect(second).resolves.toBe("second");
+  });
+
+  it("takes source before publish for destructive Frame operations", async () => {
+    const redis = makeRedisClient();
+    getRedisStreamClientMock.mockResolvedValue(redis);
+
+    const result = await withFrameSourceAndPublishLocks(
+      "frame-123",
+      async () => new Ok("deleted")
+    );
+
+    expect(result.isOk() && result.value).toBe("deleted");
+    expect(redis.set).toHaveBeenNthCalledWith(
+      1,
+      "lock:frame:source:frame-123",
+      expect.any(String),
+      expect.objectContaining({ PX: 10 * 60_000 })
+    );
+    expect(redis.set).toHaveBeenNthCalledWith(
+      2,
+      "lock:frame:publish:frame-123",
+      expect.any(String),
+      expect.objectContaining({ PX: 10 * 60_000 })
+    );
+  });
+
+  it("returns a typed timeout when a legacy Frame mutation cannot acquire the lock", async () => {
+    const redis = makeRedisClient();
+    vi.mocked(redis.set).mockResolvedValue(null);
+    getRedisStreamClientMock.mockResolvedValue(redis);
+
+    const resultPromise = withLegacyFrameMutationResultLock(
+      "frame-123",
+      async () => new Ok("deleted")
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const result = await resultPromise;
+    expect(result.isErr() && result.error).toMatchObject({
+      lockName: "file:edit:frame-123",
+      name: "LockAcquisitionTimeoutError",
+    });
   });
 });

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -5,6 +5,13 @@ import type { Result } from "@app/types/shared/result";
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
 const FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS = 30_000;
 
+export class LegacyFrameMutationConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LegacyFrameMutationConflictError";
+  }
+}
+
 export function getFramePublishLockName(frameId: string): string {
   return `frame:publish:${frameId}`;
 }
@@ -41,12 +48,33 @@ export function withFrameSourceLock<T, E>(
   );
 }
 
+export function withFrameSourceAndPublishLocks<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
+  return withFrameSourceLock(frameId, () =>
+    withFramePublishLock(frameId, callback)
+  );
+}
+
 /** Serialize conversion with every mutation of the same legacy Frame. */
 export function withLegacyFrameMutationLock<T>(
   frameId: string,
   callback: () => Promise<T>
 ): Promise<T> {
   return executeWithLock(
+    getLegacyFrameMutationLockName(frameId),
+    callback,
+    FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS,
+    { lockTtlMs: FRAME_OPERATION_LOCK_TTL_MS }
+  );
+}
+
+export function withLegacyFrameMutationResultLock<T, E>(
+  frameId: string,
+  callback: () => Promise<Result<T, E>>
+): Promise<Result<T, E | LockAcquisitionTimeoutError>> {
+  return executeWithLockResult(
     getLegacyFrameMutationLockName(frameId),
     callback,
     FRAME_OPERATION_LOCK_ACQUISITION_TIMEOUT_MS,

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -3,6 +3,7 @@ import {
   removeFileFromProject,
 } from "@app/lib/api/projects/context";
 import { MessageModel } from "@app/lib/models/agent/conversation";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -12,12 +13,17 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { frameV2ContentType } from "@app/types/files";
-import { beforeEach, describe, expect, it } from "vitest";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { Err } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("removeFileFromProject", () => {
   beforeEach(() => {
     // keep tests isolated; factories already run in their own DB context
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("deletes the file and deletes orphaned project content fragments", async () => {
@@ -84,6 +90,39 @@ describe("removeFileFromProject", () => {
         where: { id: file.id, workspaceId: workspace.id },
       })
     ).not.toBeNull();
+    expect(
+      await ContentFragmentModel.findOne({
+        where: {
+          fileId: file.id,
+          spaceId: project.id,
+          workspaceId: workspace.id,
+        },
+      })
+    ).not.toBeNull();
+  });
+
+  it("keeps project fragments when a legacy Frame deletion is blocked", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: frameContentType,
+      fileName: "Legacy.tsx",
+      fileSize: 123,
+      status: "ready",
+    });
+    vi.spyOn(FileResource.prototype, "delete").mockResolvedValue(
+      new Err(new Error("Frame mutation lock timed out"))
+    );
+
+    const result = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
     expect(
       await ContentFragmentModel.findOne({
         where: {

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -529,10 +529,18 @@ export async function removeFileFromProject(
     return new Err(new Error("File not found."));
   }
 
-  // Frames v2 own their source package and project-fragment cleanup. Let the canonical Frame
-  // deletion path run before this function mutates any fragments so source failures are retryable.
-  if (file.isFrameV2) {
-    return file.delete(auth);
+  // Frame deletion owns project-fragment cleanup inside its mutation lock. Calling it first keeps
+  // a lock timeout from partially removing project state, while preserving a live row for retry
+  // if cleanup fails.
+  if (file.isShareableFrame) {
+    const deleteRes = await file.delete(auth);
+    if (deleteRes.isErr()) {
+      return new Err(deleteRes.error);
+    }
+    if (file.isInteractiveContent) {
+      requestDustProjectIncrementalSync(auth, space);
+    }
+    return new Ok(undefined);
   }
 
   const workspaceId = auth.getNonNullableWorkspace().id;

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -14,7 +14,11 @@ import {
   getProcessedContentType,
   hasProcessedVersion,
 } from "@app/lib/api/files/processing";
-import { withFramePublishLock } from "@app/lib/api/frames/operation_lock";
+import {
+  LegacyFrameMutationConflictError,
+  withFrameSourceAndPublishLocks,
+  withLegacyFrameMutationResultLock,
+} from "@app/lib/api/frames/operation_lock";
 import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import { cleanupProjectFileFragments } from "@app/lib/api/projects/file_cleanup";
 import { requestDustProjectIncrementalSync } from "@app/lib/api/projects/request_incremental_sync";
@@ -856,12 +860,19 @@ export class FileResource extends BaseResource<FileModel> {
       return new Err(writeAccess.error);
     }
 
-    return withFramePublishLock(this.sId, async () => {
+    return withFrameSourceAndPublishLocks(this.sId, async () => {
       const frame = await this.fetchFreshFrameV2(auth);
       if (!frame || frame.toScopedPath(auth) !== manifestPath) {
         return new Err(
           new Error(
             "The Frame source changed while it was being deleted; retry from its current path."
+          )
+        );
+      }
+      if (frame.useCaseMetadata?.pendingFrameV2Conversion) {
+        return new Err(
+          new LegacyFrameMutationConflictError(
+            "The Frame has an interrupted conversion; recover it before deleting."
           )
         );
       }
@@ -942,6 +953,52 @@ export class FileResource extends BaseResource<FileModel> {
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     if (this.isFrameV2) {
       return this.deleteFrameV2(auth);
+    }
+
+    if (this.isInteractiveContent) {
+      const expectedMountFilePath = this.mountFilePath;
+      return withLegacyFrameMutationResultLock(this.sId, async () => {
+        const fresh = await FileResource.fetchById(auth, this.sId);
+        if (!fresh) {
+          return new Err(
+            new LegacyFrameMutationConflictError(
+              "The legacy Frame was deleted by another operation."
+            )
+          );
+        }
+        if (fresh.isFrameV2) {
+          return fresh.deleteFrameV2(auth);
+        }
+        if (
+          !fresh.isInteractiveContent ||
+          fresh.mountFilePath !== expectedMountFilePath
+        ) {
+          return new Err(
+            new LegacyFrameMutationConflictError(
+              "The legacy Frame changed while it was being deleted; retry from its current state."
+            )
+          );
+        }
+        if (fresh.useCase === "project_context") {
+          const spaceId = fresh.useCaseMetadata?.spaceId;
+          const projectSpace = spaceId
+            ? await SpaceResource.fetchById(auth, spaceId)
+            : null;
+          if (!projectSpace?.isProject()) {
+            return new Err(new Error("Frame source Pod not found."));
+          }
+          try {
+            await cleanupProjectFileFragments({
+              fileModelId: fresh.id,
+              spaceModelId: projectSpace.id,
+              workspaceModelId: auth.getNonNullableWorkspace().id,
+            });
+          } catch (error) {
+            return new Err(normalizeError(error));
+          }
+        }
+        return fresh.deleteAfterSandboxCleanup(auth);
+      });
     }
 
     return this.deleteAfterSandboxCleanup(auth);


### PR DESCRIPTION
## Description

Protect Frame deletion across the conversion lifecycle without changing generic file deletion semantics. Legacy deletion shares the fixed 10-minute `file:edit` lease and refetches under the lock; if conversion wins, a stale legacy delete follows the fresh Frames v2 path. Frames v2 deletion takes source then publish locks and rejects pending recovery before touching source state. Project fragment cleanup stays inside the successful Frame deletion path.

Stack: #31548 -> this PR -> #31691.

## Tests

- four operation-lock tests cover the long legacy lease, typed timeout, and source-before-publish ordering
- stale legacy deletion, pending recovery deletion, Frame resource deletion, and project fragment preservation are covered
- included in the final 134-test changed-front and 86-test changed-front-api suites
- Biome and diff checks pass

## Deploy Plan

Merge after #31548. This lifecycle hardening is mandatory: keep conversion unused and flag-disabled until #31691, #31694, and #31544 have landed and the WorkOS `frame.converted` schema is registered.