### PR TITLE
Harden Frame moves during legacy conversion

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].test.ts
@@ -1,4 +1,5 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
+import { LegacyFrameMutationConflictError } from "@app/lib/api/frames/operation_lock";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Err, Ok } from "@app/types/shared/result";
@@ -179,5 +180,27 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/files/:rel (move)", () =
         destRelativeFilePath: "archive/chart.png",
       }
     );
+  });
+
+  it("returns 409 when the Frame changed during the move", async () => {
+    const mountFileOps = await import("@app/lib/api/files/mount_file_ops");
+    vi.spyOn(mountFileOps, "moveMountFileWithinScope").mockResolvedValue(
+      new Err(
+        new LegacyFrameMutationConflictError(
+          "The Frame changed while it was being moved."
+        )
+      )
+    );
+    const { workspace, conversation } = await setup();
+
+    const response = await postMove(
+      workspace,
+      conversation.sId,
+      ["Legacy.tsx"],
+      { destRelativeFilePath: "archive/Legacy.tsx" }
+    );
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -1,5 +1,6 @@
 import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
+import { isFrameMutationConflictError } from "@app/lib/api/frames/operation_lock";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -157,6 +158,15 @@ app.post(
                 ? "workspace_auth_error"
                 : "invalid_request_error",
             message,
+          },
+        });
+      }
+      if (isFrameMutationConflictError(moveResult.error)) {
+        return apiError(ctx, {
+          status_code: 409,
+          api_error: {
+            type: "invalid_request_error",
+            message: moveResult.error.message,
           },
         });
       }

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -4,9 +4,11 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import {
   DUST_FILE_CONTENT_TYPE_HEADER,
   DUST_FILE_ID_HEADER,
+  frameContentType,
   frameV2ContentType,
 } from "@app/types/files";
 import { honoApp } from "@front-api/app";
@@ -15,6 +17,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
+  executeWithLockResult: vi.fn(async (_lockName: string, fn: () => unknown) =>
+    fn()
+  ),
 }));
 
 function makeReadStream() {
@@ -378,6 +383,53 @@ describe("PATCH /api/w/:wId/files/path/:canonicalPath", () => {
 
     expect(response.status).toBe(200);
     expect(bucket.copyFile).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a pending-conversion Frame rename before moving source bytes", async () => {
+    const { workspace, auth, conversation } = await setup();
+    const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+    const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const manifestMountFilePath = `w/${workspace.sId}/conversations/${conversation.sId}/files/Status/${FRAME_MANIFEST_FILE}`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 42,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: conversation.sId,
+        pendingFrameV2Conversion: {
+          legacyContentType: frameContentType,
+          legacyFileName: "Legacy.tsx",
+          legacyFileSize: 42,
+          legacyMountFilePath: `w/${workspace.sId}/conversations/${conversation.sId}/files/Legacy.tsx`,
+          legacyRenderableVersion: "original",
+          legacyUseCase: "conversation",
+          legacyUseCaseMetadata: { conversationId: conversation.sId },
+          manifestMountFilePath,
+          manifestPath,
+          sourcePath: `conversation-${conversation.sId}/Legacy.tsx`,
+        },
+      },
+      mountFilePath: manifestMountFilePath,
+    });
+    setExistingFiles([`/files/Status/${FRAME_MANIFEST_FILE}`], {
+      contentType: frameV2ContentType,
+      size: "42",
+    });
+    const bucket = getInspectablePrivateUploadBucket();
+
+    const response = await request(workspace, manifestPath, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "rename", fileName: "renamed.json" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(bucket.copyFile).not.toHaveBeenCalled();
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.fileName).toBe(FRAME_MANIFEST_FILE);
+    expect(reloaded?.mountFilePath).toBe(manifestMountFilePath);
   });
 
   it("returns 200 immediately when source and dest are identical", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -1,4 +1,5 @@
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
+import { isFrameMutationConflictError } from "@app/lib/api/frames/operation_lock";
 import {
   deleteProjectFile,
   moveProjectFile,
@@ -9,6 +10,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { APIErrorResponse } from "@app/types/error";
+import { isDustFileSystemError } from "@app/types/file_system";
 import {
   getPodFilesBasePath,
   isResolveMountFilePathError,
@@ -188,6 +190,15 @@ app.patch(
       newFileName: fileName.trim(),
     });
     if (renameResult.isErr()) {
+      if (isDustFileSystemError(renameResult.error, "invalid_path")) {
+        return apiError(ctx, {
+          status_code: 409,
+          api_error: {
+            type: "invalid_request_error",
+            message: renameResult.error.message,
+          },
+        });
+      }
       return apiError(ctx, {
         status_code: 500,
         api_error: {
@@ -289,6 +300,15 @@ app.post(
                 ? "workspace_auth_error"
                 : "invalid_request_error",
             message,
+          },
+        });
+      }
+      if (isFrameMutationConflictError(moveResult.error)) {
+        return apiError(c, {
+          status_code: 409,
+          api_error: {
+            type: "invalid_request_error",
+            message: moveResult.error.message,
           },
         });
       }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -1,8 +1,10 @@
+import { LegacyFrameMutationConflictError } from "@app/lib/api/frames/operation_lock";
 import * as projectsContext from "@app/lib/api/projects/context";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { DustFileSystemError } from "@app/types/file_system";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { PassThrough } from "stream";
@@ -203,6 +205,27 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       );
       expect(response.status).toBe(500);
     });
+
+    it("returns 409 when a Frame source blocks the rename", async () => {
+      vi.spyOn(projectsContext, "renameProjectFile").mockResolvedValue(
+        new Err(
+          new DustFileSystemError(
+            "invalid_path",
+            "Folders containing Frames cannot be renamed."
+          )
+        )
+      );
+      const { workspace, project } = await setupProject();
+      const response = await fileRequest(
+        workspace,
+        project.sId,
+        ["pod", "Frame"],
+        { method: "PATCH", body: { fileName: "Renamed" } }
+      );
+
+      expect(response.status).toBe(409);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
   });
 
   describe("DELETE", () => {
@@ -347,6 +370,29 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
         body: { destRelativeFilePath: "file.txt" },
       });
       expect(response.status).toBe(500);
+    });
+
+    it("returns 409 when the Frame changed during the move", async () => {
+      vi.mocked(projectsContext.moveProjectFile).mockResolvedValue(
+        new Err(
+          new LegacyFrameMutationConflictError(
+            "The Frame changed while it was being moved."
+          )
+        )
+      );
+      const { workspace, project } = await setupProject();
+      const response = await fileRequest(
+        workspace,
+        project.sId,
+        ["Legacy.tsx"],
+        {
+          method: "POST",
+          body: { destRelativeFilePath: "archive/Legacy.tsx" },
+        }
+      );
+
+      expect(response.status).toBe(409);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
     });
   });
 });

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -6,12 +6,17 @@
 
 import type { DustFileSystem } from "@app/lib/api/file_system";
 import { decodeBuffer } from "@app/lib/api/files/utils";
+import {
+  withFrameSourceLock,
+  withLegacyFrameMutationResultLock,
+} from "@app/lib/api/frames/operation_lock";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import {
   DustFileSystemError,
+  isDustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/types/file_system";
@@ -276,6 +281,53 @@ function inferDestMountInfo(
   return null;
 }
 
+async function withLockedFrameMountMutation<T>(
+  auth: Authenticator,
+  file: FileResource,
+  expectedMountFilePath: string,
+  mutation: (fresh: FileResource) => Promise<Result<T, DustFileSystemError>>
+): Promise<Result<T, DustFileSystemError>> {
+  const mutateFreshFrame = async () => {
+    const fresh = await FileResource.fetchById(auth, file.sId);
+    if (
+      !fresh?.isShareableFrame ||
+      fresh.contentType !== file.contentType ||
+      fresh.mountFilePath !== expectedMountFilePath
+    ) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          "The Frame changed while it was being moved; retry from its current state."
+        )
+      );
+    }
+    if (fresh.useCaseMetadata?.pendingFrameV2Conversion) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          "The Frame has an interrupted conversion; recover it before moving."
+        )
+      );
+    }
+    return mutation(fresh);
+  };
+
+  const result = file.isFrameV2
+    ? await withFrameSourceLock(file.sId, mutateFreshFrame)
+    : await withLegacyFrameMutationResultLock(file.sId, mutateFreshFrame);
+  if (result.isErr()) {
+    return new Err(
+      isDustFileSystemError(result.error)
+        ? result.error
+        : new DustFileSystemError(
+            "invalid_path",
+            "Another Frame operation is in progress; retry the move."
+          )
+    );
+  }
+  return result;
+}
+
 /**
  * Rename a file at `scopedPath` to `newFileName` (same directory) and sync the
  * linked FileResource record if one exists.
@@ -296,27 +348,46 @@ export async function renameCanonicalFile(
     scopedPath
   );
 
-  const renameResult = await dustFs.rename(scopedPath, newFileName);
-  if (renameResult.isErr()) {
-    return renameResult;
-  }
-
-  if (linkedFileResource) {
-    const { dest } = renameResult.value;
-    const destGcsPath = dustFs.toMountFilePath(dest);
-    const destInfo = inferDestMountInfo(dest);
-
-    if (destGcsPath && destInfo) {
-      await linkedFileResource.updateMount({
-        destFileName: newFileName,
-        destMountFilePath: destGcsPath,
-        destUseCase: destInfo.useCase,
-        destUseCaseMetadata: destInfo.useCaseMetadata,
-      });
+  const renameCurrentFile = async (currentFile?: FileResource) => {
+    const renameResult = await dustFs.rename(scopedPath, newFileName);
+    if (renameResult.isErr()) {
+      return renameResult;
     }
+
+    if (currentFile) {
+      const { dest } = renameResult.value;
+      const destGcsPath = dustFs.toMountFilePath(dest);
+      const destInfo = inferDestMountInfo(dest);
+
+      if (destGcsPath && destInfo) {
+        await currentFile.updateMount({
+          destFileName: newFileName,
+          destMountFilePath: destGcsPath,
+          destUseCase: destInfo.useCase,
+          destUseCaseMetadata: destInfo.useCaseMetadata,
+        });
+      }
+    }
+
+    return renameResult;
+  };
+
+  if (linkedFileResource?.isShareableFrame) {
+    const expectedMountFilePath = linkedFileResource.mountFilePath;
+    if (!expectedMountFilePath) {
+      return new Err(
+        new DustFileSystemError("internal", "Frame source path not found.")
+      );
+    }
+    return withLockedFrameMountMutation(
+      auth,
+      linkedFileResource,
+      expectedMountFilePath,
+      renameCurrentFile
+    );
   }
 
-  return renameResult;
+  return renameCurrentFile(linkedFileResource);
 }
 
 /**
@@ -334,28 +405,47 @@ export async function moveCanonicalFile(
   // Look up the linked FileResource before the bytes move.
   const linkedFileResource = await fetchLinkedFileResource(auth, dustFs, src);
 
-  const moveResult = await dustFs.move({ src, dest });
-  if (moveResult.isErr()) {
-    return moveResult;
-  }
-
-  // Update the FileResource to point to the new location.
-  if (linkedFileResource) {
-    const destGcsPath = dustFs.toMountFilePath(dest);
-    const destInfo = inferDestMountInfo(dest);
-
-    if (destGcsPath && destInfo) {
-      const destFileName = dest.split("/").pop() ?? dest;
-      await linkedFileResource.updateMount({
-        destFileName,
-        destMountFilePath: destGcsPath,
-        destUseCase: destInfo.useCase,
-        destUseCaseMetadata: destInfo.useCaseMetadata,
-      });
+  const moveCurrentFile = async (currentFile?: FileResource) => {
+    const moveResult = await dustFs.move({ src, dest });
+    if (moveResult.isErr()) {
+      return moveResult;
     }
+
+    // Update the FileResource to point to the new location.
+    if (currentFile) {
+      const destGcsPath = dustFs.toMountFilePath(dest);
+      const destInfo = inferDestMountInfo(dest);
+
+      if (destGcsPath && destInfo) {
+        const destFileName = dest.split("/").pop() ?? dest;
+        await currentFile.updateMount({
+          destFileName,
+          destMountFilePath: destGcsPath,
+          destUseCase: destInfo.useCase,
+          destUseCaseMetadata: destInfo.useCaseMetadata,
+        });
+      }
+    }
+
+    return moveResult;
+  };
+
+  if (linkedFileResource?.isShareableFrame) {
+    const expectedMountFilePath = linkedFileResource.mountFilePath;
+    if (!expectedMountFilePath) {
+      return new Err(
+        new DustFileSystemError("internal", "Frame source path not found.")
+      );
+    }
+    return withLockedFrameMountMutation(
+      auth,
+      linkedFileResource,
+      expectedMountFilePath,
+      moveCurrentFile
+    );
   }
 
-  return moveResult;
+  return moveCurrentFile(linkedFileResource);
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -5,16 +5,22 @@ import {
   getConversationFileMountSignedUrl,
   getGCSPathFromScopedPath,
   getScopedPathFromGCSPath,
+  moveFile,
   renameGCSMountDirectory,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
+import { LegacyFrameMutationConflictError } from "@app/lib/api/frames/operation_lock";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS } from "@app/lib/file_storage/signed_url_cache";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import assert from "assert";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -461,6 +467,140 @@ describe("copyMountFile", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("GCS copy unavailable");
     }
+  });
+});
+
+describe("moveFile", () => {
+  it("keeps the supplied legacy Frame resource in sync after a move", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const sourceGcsPath = `w/${workspace.sId}/conversations/conv/files/Legacy.tsx`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Legacy.tsx",
+      fileSize: 1,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conv" },
+      mountFilePath: sourceGcsPath,
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const result = await moveFile(auth, {
+      file: frame,
+      sourceGcsPath,
+      destScope: { useCase: "pod", podId: "pod" },
+      destRelativeFilePath: "Legacy.tsx",
+      destFileName: "Legacy.tsx",
+      destUseCase: "project_context",
+      destUseCaseMetadata: { spaceId: "pod" },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(frame.useCase).toBe("project_context");
+    expect(frame.useCaseMetadata).toEqual({ spaceId: "pod" });
+  });
+
+  it("aborts a stale legacy Frame move after conversion without touching GCS", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const sourceGcsPath = `w/${workspace.sId}/conversations/conv/files/Legacy.tsx`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Legacy.tsx",
+      fileSize: 1,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conv" },
+      mountFilePath: sourceGcsPath,
+    });
+    const staleFrame = await FileResource.fetchById(auth, frame.sId);
+    assert(staleFrame);
+    await frame.updateFrameSourceBinding({
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 1,
+      mountFilePath: `w/${workspace.sId}/pods/pod/files/Frame/${FRAME_MANIFEST_FILE}`,
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: "pod" },
+    });
+
+    const copyFileMock = vi.fn().mockResolvedValue(undefined);
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+      delete: deleteMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const result = await moveFile(auth, {
+      file: staleFrame,
+      sourceGcsPath,
+      destScope: { useCase: "pod", podId: "pod" },
+      destRelativeFilePath: "Legacy.tsx",
+      destFileName: "Legacy.tsx",
+      destUseCase: "project_context",
+      destUseCaseMetadata: { spaceId: "pod" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(LegacyFrameMutationConflictError);
+    }
+    expect(copyFileMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Frames v2 move while conversion recovery is pending", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const sourceGcsPath = `w/${workspace.sId}/conversations/conv/files/Frame/${FRAME_MANIFEST_FILE}`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 1,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: "conv",
+        pendingFrameV2Conversion: {
+          legacyContentType: frameContentType,
+          legacyFileName: "Legacy.tsx",
+          legacyFileSize: 1,
+          legacyMountFilePath: `w/${workspace.sId}/conversations/conv/files/Legacy.tsx`,
+          legacyRenderableVersion: "original",
+          legacyUseCase: "conversation",
+          legacyUseCaseMetadata: { conversationId: "conv" },
+          manifestMountFilePath: sourceGcsPath,
+          manifestPath: `conversation-conv/Frame/${FRAME_MANIFEST_FILE}`,
+          sourcePath: "conversation-conv/Legacy.tsx",
+        },
+      },
+      mountFilePath: sourceGcsPath,
+    });
+
+    const copyFileMock = vi.fn().mockResolvedValue(undefined);
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+      delete: deleteMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const result = await moveFile(auth, {
+      file: frame,
+      sourceGcsPath,
+      destScope: { useCase: "pod", podId: "pod" },
+      destRelativeFilePath: `Frame/${FRAME_MANIFEST_FILE}`,
+      destFileName: FRAME_MANIFEST_FILE,
+      destUseCase: "project_context",
+      destUseCaseMetadata: { spaceId: "pod" },
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      name: "LegacyFrameMutationConflictError",
+      message: expect.stringContaining("recover it before moving"),
+    });
+    expect(copyFileMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -4,6 +4,11 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
+import {
+  LegacyFrameMutationConflictError,
+  withFrameSourceLock,
+  withLegacyFrameMutationResultLock,
+} from "@app/lib/api/frames/operation_lock";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import {
@@ -11,7 +16,7 @@ import {
   MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
 } from "@app/lib/file_storage/signed_url_cache";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -514,35 +519,70 @@ export async function moveFile(
 ): Promise<Result<void, Error>> {
   const destGcsPath = `${resolvePrefix(auth.getNonNullableWorkspace(), destScope)}${destRelativeFilePath}`;
 
-  const moveRes = await moveGCSMountFile({
-    sourceGcsPath,
-    destGcsPath,
-  });
-  if (moveRes.isErr()) {
-    return moveRes;
-  }
-
-  if (file) {
-    await file.updateMount({
-      destFileName,
-      destMountFilePath: destGcsPath,
-      destUseCase,
-      destUseCaseMetadata,
+  const moveCurrentFile = async (
+    currentFile: FileResource | undefined
+  ): Promise<Result<void, Error>> => {
+    const moveRes = await moveGCSMountFile({
+      sourceGcsPath,
+      destGcsPath,
     });
+    if (moveRes.isErr()) {
+      return moveRes;
+    }
+
+    if (currentFile) {
+      await currentFile.updateMount({
+        destFileName,
+        destMountFilePath: destGcsPath,
+        destUseCase,
+        destUseCaseMetadata,
+      });
+    }
+
+    const prefix = resolvePrefix(auth.getNonNullableWorkspace(), destScope);
+    const relativeFilePath = sourceGcsPath.startsWith(prefix)
+      ? sourceGcsPath.slice(prefix.length)
+      : destRelativeFilePath;
+    const lastSlash = destRelativeFilePath.lastIndexOf("/");
+    const parentRelativePath =
+      lastSlash >= 0 ? destRelativeFilePath.slice(0, lastSlash) : "";
+
+    void emitGCSMountFileMovedAuditLog(auth, destScope, {
+      relativeFilePath,
+      parentRelativePath,
+    });
+
+    return new Ok(undefined);
+  };
+
+  if (file?.isShareableFrame) {
+    const moveFreshFrame = async (): Promise<Result<void, Error>> => {
+      const fresh = await FileResource.fetchById(auth, file.sId);
+      if (
+        !fresh?.isShareableFrame ||
+        fresh.contentType !== file.contentType ||
+        fresh.mountFilePath !== sourceGcsPath
+      ) {
+        return new Err(
+          new LegacyFrameMutationConflictError(
+            "The Frame changed while it was being moved; retry from its current state."
+          )
+        );
+      }
+      if (fresh.useCaseMetadata?.pendingFrameV2Conversion) {
+        return new Err(
+          new LegacyFrameMutationConflictError(
+            "The Frame has an interrupted conversion; recover it before moving."
+          )
+        );
+      }
+      return moveCurrentFile(file);
+    };
+
+    return file.isFrameV2
+      ? withFrameSourceLock(file.sId, moveFreshFrame)
+      : withLegacyFrameMutationResultLock(file.sId, moveFreshFrame);
   }
 
-  const prefix = resolvePrefix(auth.getNonNullableWorkspace(), destScope);
-  const relativeFilePath = sourceGcsPath.startsWith(prefix)
-    ? sourceGcsPath.slice(prefix.length)
-    : destRelativeFilePath;
-  const lastSlash = destRelativeFilePath.lastIndexOf("/");
-  const parentRelativePath =
-    lastSlash >= 0 ? destRelativeFilePath.slice(0, lastSlash) : "";
-
-  void emitGCSMountFileMovedAuditLog(auth, destScope, {
-    relativeFilePath,
-    parentRelativePath,
-  });
-
-  return new Ok(undefined);
+  return moveCurrentFile(file);
 }

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -35,6 +35,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameContentType } from "@app/types/files";
 import assert from "assert";
 
 beforeEach(() => {
@@ -95,5 +96,46 @@ describe("moveFrameV2Source", () => {
       `release:${getFramePublishLockName(c.frame.sId)}`,
       `release:${getFrameSourceLockName(c.frame.sId)}`,
     ]);
+  });
+
+  it("rejects a source move while conversion recovery is pending", async () => {
+    const c = await setupFrameSourceStorageTest();
+    await c.frame.setUseCaseMetadata(c.auth, {
+      ...c.frame.useCaseMetadata,
+      pendingFrameV2Conversion: {
+        legacyContentType: frameContentType,
+        legacyFileName: "Legacy.tsx",
+        legacyFileSize: 1,
+        legacyMountFilePath: `${c.sourceMountDirectory}/Legacy.tsx`,
+        legacyRenderableVersion: "original",
+        legacyUseCase: "conversation",
+        legacyUseCaseMetadata: { conversationId: c.conversation.sId },
+        manifestMountFilePath: `${c.sourceMountDirectory}/${FRAME_MANIFEST_FILE}`,
+        manifestPath: `${c.sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+        sourcePath: `conversation-${c.conversation.sId}/Legacy.tsx`,
+      },
+    });
+    const destinationDirectoryPath = `conversation-${c.conversation.sId}/Archive/Renamed`;
+
+    const moved = await moveFrameV2Source(c.auth, {
+      conversation: c.conversation,
+      destinationDirectoryPath,
+      sourceDirectoryPath: c.sourceDirectoryPath,
+    });
+
+    expect(moved.isErr() && moved.error).toMatchObject({
+      code: "conflict",
+      message: expect.stringContaining("recover it before moving"),
+    });
+    const reloaded = await FileResource.fetchById(c.auth, c.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${c.sourceMountDirectory}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(
+      fileStorageMock.getObject(
+        `${c.sourceMountDirectory.replace("/Status", "/Archive/Renamed")}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBeUndefined();
+    expect(emitMovedAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -119,6 +119,12 @@ export async function moveFrameV2Source(
         "The Frame source changed while it was being moved; retry from its current path."
       );
     }
+    if (freshFrame.useCaseMetadata?.pendingFrameV2Conversion) {
+      return moveError(
+        "conflict",
+        "The Frame has an interrupted conversion; recover it before moving."
+      );
+    }
 
     const [registeredDestination] = await FileResource.fetchByMountFilePaths(
       auth,

--- a/front/lib/api/frames/operation_lock.ts
+++ b/front/lib/api/frames/operation_lock.ts
@@ -1,5 +1,9 @@
 import type { LockAcquisitionTimeoutError } from "@app/lib/lock";
-import { executeWithLock, executeWithLockResult } from "@app/lib/lock";
+import {
+  executeWithLock,
+  executeWithLockResult,
+  isLockAcquisitionTimeoutError,
+} from "@app/lib/lock";
 import type { Result } from "@app/types/shared/result";
 
 const FRAME_OPERATION_LOCK_TTL_MS = 10 * 60_000;
@@ -10,6 +14,15 @@ export class LegacyFrameMutationConflictError extends Error {
     super(message);
     this.name = "LegacyFrameMutationConflictError";
   }
+}
+
+export function isFrameMutationConflictError(
+  error: unknown
+): error is LegacyFrameMutationConflictError | LockAcquisitionTimeoutError {
+  return (
+    error instanceof LegacyFrameMutationConflictError ||
+    isLockAcquisitionTimeoutError(error)
+  );
 }
 
 export function getFramePublishLockName(frameId: string): string {


### PR DESCRIPTION
## Description

Serialize Frame moves and canonical renames with conversion without changing generic `FileResource.updateMount` semantics. Legacy Frames share the fixed 10-minute `file:edit` lease; Frames v2 use the source lock. Each path refetches and verifies the binding before touching storage, rejects pending recovery, and maps typed contention to a retryable client response.

Stack: #31690 -> this PR -> #31694.

## Tests

- GCS mount, canonical path, source move, conversation move, and Pod move/rename coverage passes
- included in the final 134-test changed-front and 86-test changed-front-api suites
- Biome and diff checks pass

## Deploy Plan

Merge after #31690. This lifecycle hardening is mandatory: keep conversion unused and flag-disabled until #31694 and #31544 have landed and the WorkOS `frame.converted` schema is registered.