### PR TITLE
feat: add weeky and monthly granuarity to analytics chart

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
@@ -20,7 +20,7 @@ const TIMESERIES: GetConsumptionTimeseriesResponse = {
     endDate: "2026-08-01T00:00:00.000Z",
   },
   granularity: "day",
-  mode: "daily",
+  mode: "period",
   metric: "credit_micro",
   breakdownBy: null,
   groups: [{ groupKey: "total", name: "Total" }],

--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -2,7 +2,10 @@ import { PersonalUsageCard } from "@app/components/credits/PersonalUsageCard";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionChart } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
-import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import {
+  ConsumptionGranularitySelector,
+  ConsumptionPeriodSelector,
+} from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { DEFAULT_CONSUMPTION_DIMENSION } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
@@ -15,8 +18,14 @@ import {
   setUsageFilterFromAttributionRow,
   toConsumptionScopeFilter,
 } from "@app/components/workspace/analytics/usageFilter";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
+import {
+  DEFAULT_CONSUMPTION_GRANULARITY,
+  DEFAULT_CONSUMPTION_PERIOD,
+} from "@app/lib/analytics/consumption_period";
 import { PERSONAL_CONSUMPTION_ANALYTICS_SCOPE } from "@app/lib/analytics/consumption_scope";
 import {
   TRACKING_ACTIONS,
@@ -49,6 +58,9 @@ export function UserAnalyticsPopover({
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
+  const [granularity, setGranularity] = useState<ConsumptionGranularity>(
+    DEFAULT_CONSUMPTION_GRANULARITY
+  );
   const [dimension, setDimension] = useState<ConsumptionDimension>(
     DEFAULT_CONSUMPTION_DIMENSION
   );
@@ -80,10 +92,14 @@ export function UserAnalyticsPopover({
               disabled={!open}
             />
           </div>
-          <div className="col-span-2 row-start-2 sm:col-span-1 sm:col-start-2 sm:row-start-1">
+          <div className="col-span-2 row-start-2 flex items-center gap-2 sm:col-span-1 sm:col-start-2 sm:row-start-1">
             <ConsumptionPeriodSelector
               period={period}
               onPeriodChange={setPeriod}
+            />
+            <ConsumptionGranularitySelector
+              granularity={granularity}
+              onGranularityChange={setGranularity}
             />
           </div>
           <DialogClose asChild>
@@ -139,6 +155,7 @@ export function UserAnalyticsPopover({
                 <ConsumptionChart
                   workspaceId={owner.sId}
                   period={period}
+                  granularity={granularity}
                   dimension={dimension}
                   filter={scopeFilter}
                   analyticsScope={PERSONAL_CONSUMPTION_ANALYTICS_SCOPE}

--- a/front/components/assistant/details/tabs/AgentInsightsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.tsx
@@ -7,7 +7,10 @@ import {
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionChart } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
-import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import {
+  ConsumptionGranularitySelector,
+  ConsumptionPeriodSelector,
+} from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
@@ -19,8 +22,14 @@ import {
   setUsageFilterFromAttributionRow,
   toConsumptionScopeFilter,
 } from "@app/components/workspace/analytics/usageFilter";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
+import {
+  DEFAULT_CONSUMPTION_GRANULARITY,
+  DEFAULT_CONSUMPTION_PERIOD,
+} from "@app/lib/analytics/consumption_period";
 import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WorkspaceType } from "@app/types/user";
@@ -49,6 +58,9 @@ export function AgentInsightsTab({
     useState<InsightsSubTab>("analytics");
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
+  );
+  const [granularity, setGranularity] = useState<ConsumptionGranularity>(
+    DEFAULT_CONSUMPTION_GRANULARITY
   );
   const [dimension, setDimension] = useState<ConsumptionDimension>("user");
   const [filter, setFilter] = useState<UsageFilter>({});
@@ -88,10 +100,16 @@ export function AgentInsightsTab({
               <TabsTrigger value="feedback" label="Feedback" />
             </TabsList>
             {selectedSubTab === "analytics" ? (
-              <ConsumptionPeriodSelector
-                period={period}
-                onPeriodChange={setPeriod}
-              />
+              <div className="flex items-center gap-2">
+                <ConsumptionPeriodSelector
+                  period={period}
+                  onPeriodChange={setPeriod}
+                />
+                <ConsumptionGranularitySelector
+                  granularity={granularity}
+                  onGranularityChange={setGranularity}
+                />
+              </div>
             ) : (
               <ObservabilityPeriodSelector
                 workspaceId={owner.sId}
@@ -151,6 +169,7 @@ export function AgentInsightsTab({
                       <ConsumptionChart
                         workspaceId={owner.sId}
                         period={period}
+                        granularity={granularity}
                         dimension={dimension}
                         filter={scopeFilter}
                         analyticsScope={analyticsScope}

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -7,7 +7,10 @@ import { ConsumptionAttributionTable } from "@app/components/workspace/analytics
 import type { ConsumptionChartProps } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
 import type { ConsumptionOverviewProps } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
-import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import {
+  ConsumptionGranularitySelector,
+  ConsumptionPeriodSelector,
+} from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionSummaryProps } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
@@ -25,9 +28,13 @@ import {
 import { useAnalyticsViewState } from "@app/hooks/useAnalyticsViewState";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useResolvedUsageFilter } from "@app/hooks/useResolvedUsageFilter";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
 import {
   consumptionPeriodKey,
+  DEFAULT_CONSUMPTION_GRANULARITY,
   DEFAULT_CONSUMPTION_PERIOD,
 } from "@app/lib/analytics/consumption_period";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -223,9 +230,11 @@ export function AnalyticsConsumptionContent({
     filter,
     handleDimensionChange,
     period,
+    granularity,
     scopeFilter,
     setFilter,
     setPeriod,
+    setGranularity,
     shouldReduceMotion,
   } = state;
   const {
@@ -244,12 +253,32 @@ export function AnalyticsConsumptionContent({
     setPeriod(nextPeriod);
   };
 
+  const handleGranularityChange = (nextGranularity: ConsumptionGranularity) => {
+    trackAnalyticsClick(trackingWorkspaceId, "granularity_selector", {
+      granularity: nextGranularity,
+    });
+    setGranularity(nextGranularity);
+  };
+
   const handleFilterChange = (nextFilter: UsageFilter) => {
     trackAnalyticsClick(trackingWorkspaceId, "filter", {
       filter_action: "apply",
     });
     setFilter(nextFilter);
   };
+
+  const selectors = (
+    <div className="flex items-center gap-2">
+      <ConsumptionPeriodSelector
+        period={period}
+        onPeriodChange={handlePeriodChange}
+      />
+      <ConsumptionGranularitySelector
+        granularity={granularity}
+        onGranularityChange={handleGranularityChange}
+      />
+    </div>
+  );
 
   const header = embedded ? (
     <div className="flex w-full flex-col gap-4 sm:flex-row sm:justify-between">
@@ -260,10 +289,7 @@ export function AnalyticsConsumptionContent({
           showError={showOverviewError}
         />
       </div>
-      <ConsumptionPeriodSelector
-        period={period}
-        onPeriodChange={handlePeriodChange}
-      />
+      {selectors}
     </div>
   ) : (
     <div className="flex w-full flex-row justify-between">
@@ -271,10 +297,7 @@ export function AnalyticsConsumptionContent({
         <Page.H variant="h3">{title}</Page.H>
         <OverviewComponent workspaceId={owner.sId} period={period} />
       </div>
-      <ConsumptionPeriodSelector
-        period={period}
-        onPeriodChange={handlePeriodChange}
-      />
+      {selectors}
     </div>
   );
 
@@ -332,6 +355,7 @@ export function AnalyticsConsumptionContent({
               <ChartComponent
                 workspaceId={owner.sId}
                 period={period}
+                granularity={granularity}
                 dimension={dimension}
                 filter={scopeFilter}
                 onModeChange={(mode) => {
@@ -399,10 +423,14 @@ export function useAnalyticsConsumptionState(
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
+  const [granularity, setGranularity] = useState<ConsumptionGranularity>(
+    DEFAULT_CONSUMPTION_GRANULARITY
+  );
   const { dimension: dimensionParam } = useQueryParams(["dimension"]);
   const dimension = consumptionDimensionFromQueryParam(dimensionParam.value);
   const [filter, setFilter] = useState<UsageFilter>({});
   const activePeriod = urlState?.period ?? period;
+  const activeGranularity = urlState?.granularity ?? granularity;
   const activeDimension = urlState?.dimension ?? dimension;
   const activeFilter = urlState?.filter ?? filter;
   const scopeFilter = toConsumptionScopeFilter(activeFilter);
@@ -415,10 +443,12 @@ export function useAnalyticsConsumptionState(
   return {
     dimension: activeDimension,
     filter: activeFilter,
+    granularity: activeGranularity,
     handleDimensionChange: urlState?.setDimension ?? handleDimensionChange,
     period: activePeriod,
     scopeFilter,
     setFilter: urlState?.setFilter ?? setFilter,
+    setGranularity: urlState?.setGranularity ?? setGranularity,
     setPeriod: urlState?.setPeriod ?? setPeriod,
     shouldReduceMotion,
   };

--- a/front/components/poke/analytics/PokeConsumptionChart.tsx
+++ b/front/components/poke/analytics/PokeConsumptionChart.tsx
@@ -28,7 +28,7 @@ function PokeConsumptionDailyChart({
     usePokeConsumptionTimeseries({
       workspaceId,
       period,
-      mode: "daily",
+      mode: "period",
       breakdownBy: dimension,
       breakdownCount: CONSUMPTION_CHART_BREAKDOWN_COUNT,
       filter,
@@ -110,13 +110,13 @@ export function PokeConsumptionChart({
   dimension,
   filter,
 }: ConsumptionChartProps) {
-  const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
+  const [mode, setMode] = useState<ConsumptionTimeseriesMode>("period");
   const modeSelector = (
     <ButtonsSwitchList value={mode} size="xs">
       <ButtonsSwitch
-        value="daily"
-        label="Daily"
-        onClick={() => setMode("daily")}
+        value="period"
+        label="Per period"
+        onClick={() => setMode("period")}
       />
       <ButtonsSwitch
         value="cumulative"

--- a/front/components/poke/analytics/PokeConsumptionChart.tsx
+++ b/front/components/poke/analytics/PokeConsumptionChart.tsx
@@ -4,6 +4,7 @@ import {
   CONSUMPTION_CHART_BREAKDOWN_COUNT,
   ConsumptionDailyChart,
 } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import { consumptionGranularityLabel } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionTimeseriesMode } from "@app/lib/api/analytics/consumption/timeseries";
 import {
   usePokeConsumptionOverview,
@@ -115,7 +116,7 @@ export function PokeConsumptionChart({
     <ButtonsSwitchList value={mode} size="xs">
       <ButtonsSwitch
         value="period"
-        label="Per period"
+        label={consumptionGranularityLabel("day")}
         onClick={() => setMode("period")}
       />
       <ButtonsSwitch

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -9,6 +9,7 @@ import type {
   ConsumptionPeriodSelection,
 } from "@app/lib/analytics/consumption_period";
 import {
+  consumptionGranularityLabel,
   DEFAULT_CONSUMPTION_GRANULARITY,
   findPartialTimestamp,
   formatConsumptionDate,
@@ -466,7 +467,7 @@ export function ConsumptionChart({
         <ButtonsSwitchList value={mode} size="xs">
           <ButtonsSwitch
             value="period"
-            label="Per period"
+            label={consumptionGranularityLabel(granularity)}
             onClick={() => handleModeChange("period")}
           />
           <ButtonsSwitch

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -4,8 +4,12 @@ import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
 import {
+  DEFAULT_CONSUMPTION_GRANULARITY,
   findPartialTimestamp,
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
@@ -350,6 +354,7 @@ export function ConsumptionDailyChart({
 export interface ConsumptionChartProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  granularity?: ConsumptionGranularity;
   dimension: ConsumptionDimension;
   filter?: ConsumptionScopeFilter;
   analyticsScope?: ConsumptionAnalyticsScope;
@@ -360,6 +365,7 @@ export interface ConsumptionChartProps {
 function WorkspaceConsumptionDailyChart({
   workspaceId,
   period,
+  granularity = DEFAULT_CONSUMPTION_GRANULARITY,
   dimension,
   filter,
   analyticsScope,
@@ -369,7 +375,8 @@ function WorkspaceConsumptionDailyChart({
     useConsumptionTimeseries({
       workspaceId,
       period,
-      mode: "daily",
+      granularity,
+      mode: "period",
       breakdownBy: dimension,
       breakdownCount: CONSUMPTION_CHART_BREAKDOWN_COUNT,
       filter,
@@ -393,6 +400,7 @@ interface WorkspaceConsumptionBurnUpChartProps
 function WorkspaceConsumptionBurnUpChart({
   workspaceId,
   period,
+  granularity = DEFAULT_CONSUMPTION_GRANULARITY,
   filter,
   analyticsScope,
   disabled,
@@ -407,10 +415,6 @@ function WorkspaceConsumptionBurnUpChart({
   const isFiltered = Object.values(filter ?? {}).some(
     (values) => values.length > 0
   );
-  // A cap only exists on a billing cycle, when there's no filter. Gating on the
-  // selection rather than on the response alone keeps a previous cycle's cap —
-  // kept around by `keepPreviousData` while the new request lands — from drawing
-  // a target over a period that has none.
   const capCredits =
     period.kind === "cycle" && !isFiltered
       ? (overview?.creditUsage?.capCredits ?? null)
@@ -420,6 +424,7 @@ function WorkspaceConsumptionBurnUpChart({
     useConsumptionTimeseries({
       workspaceId,
       period,
+      granularity,
       mode: "cumulative",
       filter,
       analyticsScope,
@@ -440,13 +445,14 @@ function WorkspaceConsumptionBurnUpChart({
 export function ConsumptionChart({
   workspaceId,
   period,
+  granularity = DEFAULT_CONSUMPTION_GRANULARITY,
   dimension,
   filter,
   analyticsScope,
   disabled,
   onModeChange,
 }: ConsumptionChartProps) {
-  const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
+  const [mode, setMode] = useState<ConsumptionTimeseriesMode>("period");
 
   const handleModeChange = (nextMode: ConsumptionTimeseriesMode) => {
     onModeChange?.(nextMode);
@@ -459,9 +465,9 @@ export function ConsumptionChart({
         <h2 className="text-base font-semibold text-foreground">Consumption</h2>
         <ButtonsSwitchList value={mode} size="xs">
           <ButtonsSwitch
-            value="daily"
-            label="Daily"
-            onClick={() => handleModeChange("daily")}
+            value="period"
+            label="Per period"
+            onClick={() => handleModeChange("period")}
           />
           <ButtonsSwitch
             value="cumulative"
@@ -474,6 +480,7 @@ export function ConsumptionChart({
         <WorkspaceConsumptionBurnUpChart
           workspaceId={workspaceId}
           period={period}
+          granularity={granularity}
           filter={filter}
           analyticsScope={analyticsScope}
           disabled={disabled}
@@ -482,6 +489,7 @@ export function ConsumptionChart({
         <WorkspaceConsumptionDailyChart
           workspaceId={workspaceId}
           period={period}
+          granularity={granularity}
           dimension={dimension}
           filter={filter}
           analyticsScope={analyticsScope}

--- a/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
@@ -1,6 +1,11 @@
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
 import {
+  CONSUMPTION_GRANULARITY_OPTIONS,
   CONSUMPTION_PERIOD_OPTIONS,
+  consumptionGranularityLabel,
   consumptionPeriodFromKey,
   consumptionPeriodKey,
   consumptionPeriodLabel,
@@ -48,6 +53,51 @@ export function ConsumptionPeriodSelector({
               key={consumptionPeriodKey(option)}
               value={consumptionPeriodKey(option)}
               label={consumptionPeriodLabel(option)}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface ConsumptionGranularitySelectorProps {
+  granularity: ConsumptionGranularity;
+  onGranularityChange: (granularity: ConsumptionGranularity) => void;
+}
+
+export function ConsumptionGranularitySelector({
+  granularity,
+  onGranularityChange,
+}: ConsumptionGranularitySelectorProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label={consumptionGranularityLabel(granularity)}
+          size="sm"
+          variant="outline"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={granularity}
+          onValueChange={(value) => {
+            if (
+              CONSUMPTION_GRANULARITY_OPTIONS.includes(
+                value as ConsumptionGranularity
+              )
+            ) {
+              onGranularityChange(value as ConsumptionGranularity);
+            }
+          }}
+        >
+          {CONSUMPTION_GRANULARITY_OPTIONS.map((option) => (
+            <DropdownMenuRadioItem
+              key={option}
+              value={option}
+              label={consumptionGranularityLabel(option)}
             />
           ))}
         </DropdownMenuRadioGroup>

--- a/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
@@ -5,6 +5,7 @@ import type {
 import {
   CONSUMPTION_GRANULARITY_OPTIONS,
   CONSUMPTION_PERIOD_OPTIONS,
+  consumptionGranularityFromKey,
   consumptionGranularityLabel,
   consumptionPeriodFromKey,
   consumptionPeriodKey,
@@ -84,11 +85,9 @@ export function ConsumptionGranularitySelector({
         <DropdownMenuRadioGroup
           value={granularity}
           onValueChange={(value) => {
-            const match = CONSUMPTION_GRANULARITY_OPTIONS.find(
-              (o) => o === value
-            );
-            if (match) {
-              onGranularityChange(match);
+            const selection = consumptionGranularityFromKey(value);
+            if (selection) {
+              onGranularityChange(selection);
             }
           }}
         >

--- a/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
@@ -84,12 +84,11 @@ export function ConsumptionGranularitySelector({
         <DropdownMenuRadioGroup
           value={granularity}
           onValueChange={(value) => {
-            if (
-              CONSUMPTION_GRANULARITY_OPTIONS.includes(
-                value as ConsumptionGranularity
-              )
-            ) {
-              onGranularityChange(value as ConsumptionGranularity);
+            const match = CONSUMPTION_GRANULARITY_OPTIONS.find(
+              (o) => o === value
+            );
+            if (match) {
+              onGranularityChange(match);
             }
           }}
         >

--- a/front/hooks/useAnalyticsViewState.ts
+++ b/front/hooks/useAnalyticsViewState.ts
@@ -4,7 +4,10 @@ import {
   usageFilterFromIds,
   usageFilterToIds,
 } from "@app/components/workspace/analytics/usageFilter";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
 import type { AnalyticsViewState } from "@app/lib/analytics/view_params";
 import {
   analyticsViewQueryString,
@@ -67,6 +70,10 @@ export function useAnalyticsViewState() {
     setView((current) => ({ ...current, period }));
   }, []);
 
+  const setGranularity = useCallback((granularity: ConsumptionGranularity) => {
+    setView((current) => ({ ...current, granularity }));
+  }, []);
+
   const setDimension = useCallback((dimension: ConsumptionDimension) => {
     setView((current) => ({ ...current, dimension }));
   }, []);
@@ -80,9 +87,11 @@ export function useAnalyticsViewState() {
 
   return {
     period: view.period,
+    granularity: view.granularity,
     dimension: view.dimension,
     filter: view.filter,
     setPeriod,
+    setGranularity,
     setDimension,
     setFilter,
   };

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -2,7 +2,10 @@ import {
   getConsumptionAnalyticsUrl,
   useConsumptionQuery,
 } from "@app/hooks/useConsumptionQuery";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
 import {
   DEFAULT_CONSUMPTION_PERIOD_DAYS,
   normalizedConsumptionFilter,
@@ -18,6 +21,7 @@ import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumptio
 
 type ConsumptionTimeseriesBody = ConsumptionBody & {
   mode: ConsumptionTimeseriesMode;
+  granularity?: ConsumptionGranularity;
   breakdownBy?: ConsumptionBreakdownDimension;
   breakdownCount?: number;
 };
@@ -25,8 +29,8 @@ type ConsumptionTimeseriesBody = ConsumptionBody & {
 export interface UseConsumptionTimeseriesParams {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  granularity?: ConsumptionGranularity;
   mode: ConsumptionTimeseriesMode;
-  // Omit for a single total series.
   breakdownBy?: ConsumptionBreakdownDimension;
   breakdownCount?: number;
   filter?: ConsumptionScopeFilter;
@@ -37,6 +41,7 @@ export interface UseConsumptionTimeseriesParams {
 export function useConsumptionTimeseries({
   workspaceId,
   period,
+  granularity,
   mode,
   breakdownBy,
   breakdownCount,
@@ -55,6 +60,7 @@ export function useConsumptionTimeseries({
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
     filter: normalizedConsumptionFilter(filter),
     mode,
+    granularity,
     breakdownBy,
     breakdownCount,
   };

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -42,6 +42,12 @@ const CONSUMPTION_GRANULARITY_LABELS: Record<ConsumptionGranularity, string> = {
   month: "Monthly",
 };
 
+export function consumptionGranularityFromKey(
+  key: string
+): ConsumptionGranularity | null {
+  return CONSUMPTION_GRANULARITY_OPTIONS.find((o) => o === key) ?? null;
+}
+
 export function consumptionGranularityLabel(
   granularity: ConsumptionGranularity
 ): string {

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -2,7 +2,7 @@ import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/perio
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
 import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/types/api/analytics/consumption";
 
-export const CONSUMPTION_PERIOD_DAY_OPTIONS = [7, 30, 90] as const;
+export const CONSUMPTION_PERIOD_DAY_OPTIONS = [7, 30, 90, 180] as const;
 
 export const DEFAULT_CONSUMPTION_PERIOD_DAYS = 30;
 
@@ -24,6 +24,29 @@ export const CONSUMPTION_PERIOD_OPTIONS: ConsumptionPeriodSelection[] = [
     days,
   })),
 ];
+
+export const CONSUMPTION_GRANULARITY_OPTIONS = [
+  "day",
+  "week",
+  "month",
+] as const;
+
+export type ConsumptionGranularity =
+  (typeof CONSUMPTION_GRANULARITY_OPTIONS)[number];
+
+export const DEFAULT_CONSUMPTION_GRANULARITY: ConsumptionGranularity = "day";
+
+const CONSUMPTION_GRANULARITY_LABELS: Record<ConsumptionGranularity, string> = {
+  day: "Daily",
+  week: "Weekly",
+  month: "Monthly",
+};
+
+export function consumptionGranularityLabel(
+  granularity: ConsumptionGranularity
+): string {
+  return CONSUMPTION_GRANULARITY_LABELS[granularity];
+}
 
 export function formatConsumptionDate(date: string | number): string {
   return new Date(date).toLocaleDateString("en-US", {

--- a/front/lib/analytics/view_params.test.ts
+++ b/front/lib/analytics/view_params.test.ts
@@ -1,5 +1,9 @@
 import { CONSUMPTION_DIMENSIONS } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
-import { CONSUMPTION_PERIOD_OPTIONS } from "@app/lib/analytics/consumption_period";
+import {
+  CONSUMPTION_GRANULARITY_OPTIONS,
+  CONSUMPTION_PERIOD_OPTIONS,
+  DEFAULT_CONSUMPTION_GRANULARITY,
+} from "@app/lib/analytics/consumption_period";
 import type { AnalyticsViewState } from "@app/lib/analytics/view_params";
 import {
   analyticsConsumptionHref,
@@ -34,6 +38,7 @@ const VIEW_CASES: [query: string, state: AnalyticsViewState][] = [
     "a=8oGtWFRlPa",
     {
       period: { kind: "cycle" },
+      granularity: DEFAULT_CONSUMPTION_GRANULARITY,
       dimension: "agent",
       filter: { agent: ["8oGtWFRlPa"] },
     },
@@ -42,6 +47,7 @@ const VIEW_CASES: [query: string, state: AnalyticsViewState][] = [
     "p=30&d=model&a=8oGtWFRlPa&s=slack",
     {
       period: { kind: "days", days: 30 },
+      granularity: DEFAULT_CONSUMPTION_GRANULARITY,
       dimension: "model",
       filter: { agent: ["8oGtWFRlPa"], source: ["slack"] },
     },
@@ -50,6 +56,7 @@ const VIEW_CASES: [query: string, state: AnalyticsViewState][] = [
     "k=Zapier+prod+*main*",
     {
       period: { kind: "cycle" },
+      granularity: DEFAULT_CONSUMPTION_GRANULARITY,
       dimension: "agent",
       filter: { api_key: ["Zapier prod *main*"] },
     },
@@ -84,6 +91,7 @@ describe("analytics view params", () => {
       })
     ).toEqual({
       p: undefined,
+      gr: undefined,
       d: undefined,
       a: undefined,
       u: undefined,
@@ -100,6 +108,12 @@ describe("analytics view params", () => {
 describe("every axis of the view survives the round trip", () => {
   it.each(CONSUMPTION_PERIOD_OPTIONS)("period %o", (period) => {
     const view = { ...DEFAULT_ANALYTICS_VIEW_STATE, period };
+
+    expect(roundTripped(view)).toEqual(view);
+  });
+
+  it.each(CONSUMPTION_GRANULARITY_OPTIONS)("granularity %s", (granularity) => {
+    const view = { ...DEFAULT_ANALYTICS_VIEW_STATE, granularity };
 
     expect(roundTripped(view)).toEqual(view);
   });
@@ -162,6 +176,7 @@ describe("analyticsViewUrlQuery", () => {
     ).toEqual({
       tab: "explore",
       p: undefined,
+      gr: undefined,
       d: "model",
       a: undefined,
       u: undefined,

--- a/front/lib/analytics/view_params.ts
+++ b/front/lib/analytics/view_params.ts
@@ -3,9 +3,14 @@ import {
   consumptionDimensionFromQueryParam,
   DEFAULT_CONSUMPTION_DIMENSION,
 } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type {
+  ConsumptionGranularity,
+  ConsumptionPeriodSelection,
+} from "@app/lib/analytics/consumption_period";
 import {
+  CONSUMPTION_GRANULARITY_OPTIONS,
   CONSUMPTION_PERIOD_DAY_OPTIONS,
+  DEFAULT_CONSUMPTION_GRANULARITY,
   DEFAULT_CONSUMPTION_PERIOD,
 } from "@app/lib/analytics/consumption_period";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
@@ -20,12 +25,14 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type AnalyticsViewState = {
   period: ConsumptionPeriodSelection;
+  granularity: ConsumptionGranularity;
   dimension: ConsumptionDimension;
   filter: Partial<Record<ConsumptionScopeDimension, string[]>>;
 };
 
 export const DEFAULT_ANALYTICS_VIEW_STATE: AnalyticsViewState = {
   period: DEFAULT_CONSUMPTION_PERIOD,
+  granularity: DEFAULT_CONSUMPTION_GRANULARITY,
   dimension: DEFAULT_CONSUMPTION_DIMENSION,
   filter: {},
 };
@@ -33,6 +40,8 @@ export const DEFAULT_ANALYTICS_VIEW_STATE: AnalyticsViewState = {
 export const MAX_ANALYTICS_URL_LENGTH = 2_048;
 
 const PERIOD_PARAM = "p";
+
+const GRANULARITY_PARAM = "gr";
 
 const DIMENSION_PARAM = "d";
 
@@ -49,6 +58,7 @@ const CATEGORY_PARAM = {
 
 export const ANALYTICS_VIEW_PARAMS: readonly string[] = [
   PERIOD_PARAM,
+  GRANULARITY_PARAM,
   DIMENSION_PARAM,
   ...Object.values(CATEGORY_PARAM),
 ];
@@ -85,6 +95,24 @@ function readPeriod(
   return days ? { kind: "days", days } : DEFAULT_CONSUMPTION_PERIOD;
 }
 
+function granularityParam(
+  granularity: ConsumptionGranularity
+): string | undefined {
+  return granularity === DEFAULT_CONSUMPTION_GRANULARITY
+    ? undefined
+    : granularity;
+}
+
+function readGranularity(
+  value: string | string[] | undefined
+): ConsumptionGranularity {
+  const [first] = readValues(value);
+  const match = CONSUMPTION_GRANULARITY_OPTIONS.find(
+    (option) => option === first
+  );
+  return match ?? DEFAULT_CONSUMPTION_GRANULARITY;
+}
+
 /**
  * Best effort: a value this build does not know falls back to the default for
  * its field, and a filter longer than the API accepts is cut to fit, so a
@@ -106,6 +134,7 @@ export function readAnalyticsView(query: AnalyticsQuery): AnalyticsViewState {
   // view state has to be read here before this compiles.
   return {
     period: readPeriod(query[PERIOD_PARAM]),
+    granularity: readGranularity(query[GRANULARITY_PARAM]),
     dimension: consumptionDimensionFromQueryParam(
       readValues(query[DIMENSION_PARAM])[0]
     ),
@@ -132,6 +161,7 @@ export function analyticsViewQuery(view: AnalyticsViewState): AnalyticsQuery {
   // until someone gives it one.
   const fields = {
     period: { [PERIOD_PARAM]: periodParam(view.period) },
+    granularity: { [GRANULARITY_PARAM]: granularityParam(view.granularity) },
     dimension: {
       [DIMENSION_PARAM]:
         view.dimension === DEFAULT_CONSUMPTION_DIMENSION
@@ -190,6 +220,7 @@ export function analyticsConsumptionHref(
 ): string {
   const view: AnalyticsViewState = {
     period: input.period ?? DEFAULT_ANALYTICS_VIEW_STATE.period,
+    granularity: input.granularity ?? DEFAULT_ANALYTICS_VIEW_STATE.granularity,
     dimension: input.dimension ?? DEFAULT_ANALYTICS_VIEW_STATE.dimension,
     filter: input.filter ?? {},
   };

--- a/front/lib/analytics/view_params.ts
+++ b/front/lib/analytics/view_params.ts
@@ -8,8 +8,8 @@ import type {
   ConsumptionPeriodSelection,
 } from "@app/lib/analytics/consumption_period";
 import {
-  CONSUMPTION_GRANULARITY_OPTIONS,
   CONSUMPTION_PERIOD_DAY_OPTIONS,
+  consumptionGranularityFromKey,
   DEFAULT_CONSUMPTION_GRANULARITY,
   DEFAULT_CONSUMPTION_PERIOD,
 } from "@app/lib/analytics/consumption_period";
@@ -107,10 +107,10 @@ function readGranularity(
   value: string | string[] | undefined
 ): ConsumptionGranularity {
   const [first] = readValues(value);
-  const match = CONSUMPTION_GRANULARITY_OPTIONS.find(
-    (option) => option === first
+  return (
+    consumptionGranularityFromKey(first ?? "") ??
+    DEFAULT_CONSUMPTION_GRANULARITY
   );
-  return match ?? DEFAULT_CONSUMPTION_GRANULARITY;
 }
 
 /**

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -50,7 +50,7 @@ export const DEFAULT_CONSUMPTION_BREAKDOWN_COUNT = 10;
 
 export const ConsumptionTimeseriesBodySchema = ConsumptionBodySchema.extend({
   granularity: z.enum(["day", "week", "month"]).optional().default("day"),
-  mode: z.enum(["daily", "cumulative"]).optional().default("daily"),
+  mode: z.enum(["period", "cumulative"]).optional().default("period"),
   metric: z
     .enum(CONSUMPTION_METRICS)
     .optional()

--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -108,7 +108,7 @@ describe("fetchConsumptionTimeseries", () => {
     const result = await fetchConsumptionTimeseries(auth, {
       period,
       granularity: "day",
-      mode: "daily",
+      mode: "period",
     });
 
     const [, options] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
@@ -136,7 +136,7 @@ describe("fetchConsumptionTimeseries", () => {
     await fetchConsumptionTimeseries(auth, {
       period,
       granularity: "day",
-      mode: "daily",
+      mode: "period",
     });
 
     const [, options] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
@@ -164,7 +164,7 @@ describe("fetchConsumptionTimeseries", () => {
     const result = await fetchConsumptionTimeseries(auth, {
       period,
       granularity: "day",
-      mode: "daily",
+      mode: "period",
     });
 
     expect(result.isOk()).toBe(true);
@@ -183,7 +183,7 @@ describe("fetchConsumptionTimeseries", () => {
     await fetchConsumptionTimeseries(auth, {
       period,
       granularity: "day",
-      mode: "daily",
+      mode: "period",
       filter: { agents: ["a1"], sources: ["web", "slack"], skills: ["s1"] },
     });
 
@@ -257,7 +257,7 @@ describe("fetchConsumptionTimeseries", () => {
       await fetchConsumptionTimeseries(auth, {
         period,
         granularity: "day",
-        mode: "daily",
+        mode: "period",
         breakdownBy: dimension,
         breakdownCount: 10,
       });
@@ -302,7 +302,7 @@ describe("fetchConsumptionTimeseries", () => {
       const result = await fetchConsumptionTimeseries(auth, {
         period,
         granularity: "day",
-        mode: "daily",
+        mode: "period",
         breakdownBy: "agent",
       });
 
@@ -331,7 +331,7 @@ describe("fetchConsumptionTimeseries", () => {
       const result = await fetchConsumptionTimeseries(auth, {
         period,
         granularity: "day",
-        mode: "daily",
+        mode: "period",
         breakdownBy: "user",
         breakdownCount: 1,
       });
@@ -368,7 +368,7 @@ describe("fetchConsumptionTimeseries", () => {
       const result = await fetchConsumptionTimeseries(auth, {
         period,
         granularity: "day",
-        mode: "daily",
+        mode: "period",
         breakdownBy: "skill",
       });
 
@@ -390,7 +390,7 @@ describe("fetchConsumptionTimeseries", () => {
       const result = await fetchConsumptionTimeseries(auth, {
         period,
         granularity: "day",
-        mode: "daily",
+        mode: "period",
         breakdownBy: "model",
       });
 

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -29,7 +29,7 @@ import { resolveDimensionDisplayNames } from "./labels";
 export { DEFAULT_CONSUMPTION_BREAKDOWN_COUNT } from "@app/lib/api/analytics/consumption/schema";
 
 export type ConsumptionGranularity = "day" | "week" | "month";
-export type ConsumptionTimeseriesMode = "daily" | "cumulative";
+export type ConsumptionTimeseriesMode = "period" | "cumulative";
 
 export const TOTAL_GROUP_KEY = "total";
 


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10272

- Add a granularity dropdown in the analytics page: `daily`, `weekly, `monthly` (done in the 3 place we display analytics: admin, user analytics, agent analytics)
- Add a "last 180 days" option to the period selector
- Rename graph mode from "daily" to "per period"
- The API already supports granularity, only the mode is renamed from "daily" to "period"

## Tests

Eyeballed the 3 place we display analytics

<img width="275" height="202" alt="Screenshot 2026-09-02 at 12 58 46" src="https://github.com/user-attachments/assets/d0c20029-9cb4-47d7-9504-d97958c070e7" />
<img width="1139" height="726" alt="Screenshot 2026-09-02 at 12 55 07" src="https://github.com/user-attachments/assets/cb6eb0cc-9add-4b47-98e4-cf7881d82aed" />
<img width="1113" height="280" alt="Screenshot 2026-09-02 at 12 54 47" src="https://github.com/user-attachments/assets/53df51bf-3046-4179-ad87-04c850d776a0" />

## Risk

Low

## Deploy Plan

Front only