### PR TITLE
[front] usage: open the page to all workspaces, hide credit plan sections for the others

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -302,10 +302,13 @@ function getLimitPromptForCode(
     }
 
     case "user_credits_exhausted": {
+      // Off credit plans the per-member cap is set by Dust, not on the Usage
+      // page, so there is nothing for an admin to change there.
+      const canManageCap = isAdmin && isCreditPricedPlan(subscription.plan);
       return {
         title: "Usage cap reached",
-        validateLabel: isAdmin ? "Go to Usage" : "Ok",
-        onValidate: isAdmin
+        validateLabel: canManageCap ? "Go to Usage" : "Ok",
+        onValidate: canManageCap
           ? () => {
               void router.push(`/w/${owner.sId}/usage?openChangeMySeat`);
             }
@@ -313,9 +316,11 @@ function getLimitPromptForCode(
         children: (
           <>
             <Page.P>
-              {isAdmin
+              {canManageCap
                 ? "You have reached your personal usage cap. On the usage page you can change your seat or adjust user caps."
-                : "You have reached your personal usage cap. Please contact your administrator to increase it."}
+                : isAdmin
+                  ? "You have reached your personal usage cap. Please contact your Dust representative to adjust it."
+                  : "You have reached your personal usage cap. Please contact your administrator to increase it."}
             </Page.P>
           </>
         ),

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -319,19 +319,14 @@ export const subNavigationAdmin = ({
             },
           ]
         : []),
-      ...(isCreditPricedPlan(subscription.plan) ||
-      featureFlags.includes("usage_page_read_only")
-        ? [
-            {
-              id: "usage" as const,
-              label: "Usage",
-              icon: PieChart01,
-              href: `/w/${owner.sId}/usage`,
-              current: isCurrent("usage"),
-              disabled: !hasManagerRole,
-            },
-          ]
-        : []),
+      {
+        id: "usage" as const,
+        label: "Usage",
+        icon: PieChart01,
+        href: `/w/${owner.sId}/usage`,
+        current: isCurrent("usage"),
+        disabled: !hasManagerRole,
+      },
       {
         id: "model_providers",
         label: "Model Providers",

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -32,11 +32,7 @@ import {
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import { INHERIT_MODEL_TIER } from "@app/lib/client/model_tier_options";
@@ -51,11 +47,10 @@ import {
   isFreePlan,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
-import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import { useSearchParam } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
   useAwuPurchaseInfo,
-  useCreditPurchaseInfo,
   useMyUsage,
   useSeatPlan,
 } from "@app/lib/swr/credits";
@@ -81,7 +76,6 @@ import {
 } from "@app/lib/swr/upgrade_requests";
 import { useUsageSettings } from "@app/lib/swr/usage_settings";
 import {
-  useAwuUsageFromAnalytics,
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
@@ -215,14 +209,11 @@ const DEFAULT_PAGE_SIZE = 25;
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
-  const router = useAppRouter();
-  const { hasFeature } = useFeatureFlags();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
-  // Legacy-contract workspaces can view this page in read-only mode behind a
-  // flag: analytics and member spend render as usual, but every action (top up,
-  // invite, seat changes, spend limits, settings) is disabled.
-  const isReadOnly = !isCreditPriced && hasFeature("usage_page_read_only");
-  const canViewUsage = isCreditPriced || isReadOnly;
+  // Legacy-contract workspaces see this page without the credit pool, seat and
+  // credits columns. Credit actions (top up, invite, seat changes, spend limits,
+  // usage settings) are disabled for them; model tiers stay editable.
+  const isReadOnly = !isCreditPriced;
   // A cancelled subscription already has its end date scheduled with
   // Metronome; scheduling a seat change on top of it can land past that end
   // date and get rejected. Block seat changes until the subscription is
@@ -449,12 +440,6 @@ export function UsagePage() {
 
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
-  useEffect(() => {
-    if (!canViewUsage) {
-      void router.push(`/w/${owner.sId}/members`);
-    }
-  }, [canViewUsage, router, owner.sId]);
-
   // Auto-open the "change my seat" modal when arriving from a blocked-state
   useEffect(() => {
     if (openChangeMySeatParam !== null && myUsage !== null) {
@@ -471,6 +456,7 @@ export function UsagePage() {
     mutateAwuPoolSummary,
   } = useAwuPoolSummary({
     workspaceId: owner.sId,
+    disabled: !isCreditPriced,
   });
 
   // TODO(2026-08-24): add back logic to show consumption here.
@@ -483,7 +469,7 @@ export function UsagePage() {
   } = useConsumptionOverview({
     workspaceId: owner.sId,
     period: DEFAULT_CONSUMPTION_PERIOD,
-    disabled: !canViewUsage || !showConsumptionAnalytics,
+    disabled: !showConsumptionAnalytics,
   });
 
   const { awuPurchaseInfo, isAwuPurchaseInfoLoading, isAwuPurchaseInfoError } =
@@ -491,47 +477,6 @@ export function UsagePage() {
       workspaceId: owner.sId,
       disabled: !showBuyCreditDialog,
     });
-
-  const { billingCycleStartDay } = useCreditPurchaseInfo({
-    workspaceId: owner.sId,
-    disabled: !isReadOnly,
-  });
-
-  // Legacy contracts have no pool credits or commits, so the pool summary's
-  // overage figure is meaningless. In read-only mode we instead show the
-  // period's raw consumption from the AWU usage analytics endpoint (the same
-  // ES-backed data the usage charts use), summing its ungrouped "total" series
-  // over the current billing cycle.
-  const daysSinceCycleStart = useMemo(() => {
-    const now = new Date();
-    // Clamp the cycle day to 28 to avoid short-month edge cases — this only
-    // feeds a read-only estimate of the period's consumption.
-    const startDay = Math.min(billingCycleStartDay ?? 1, 28);
-    const start = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), startDay)
-    );
-    if (start.getTime() > now.getTime()) {
-      start.setUTCMonth(start.getUTCMonth() - 1);
-    }
-    return Math.max(
-      1,
-      Math.ceil((now.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
-    );
-  }, [billingCycleStartDay]);
-  const { awuUsageData } = useAwuUsageFromAnalytics({
-    workspaceId: owner.sId,
-    granularity: "day",
-    days: daysSinceCycleStart,
-    disabled: !isReadOnly,
-  });
-  const periodSpendCredits = useMemo(
-    () =>
-      (awuUsageData?.points ?? []).reduce(
-        (sum, point) => sum + (point.values.total ?? 0),
-        0
-      ),
-    [awuUsageData]
-  );
 
   const {
     membersUsage,
@@ -831,6 +776,7 @@ export function UsagePage() {
 
   const { seatPlans } = useSeatPlan({
     workspaceId: owner.sId,
+    disabled: !isCreditPriced,
   });
 
   const { perSeatPricing } = usePerSeatPricing({
@@ -890,8 +836,7 @@ export function UsagePage() {
     (creditUsage.status.target === "on_target" ? "on_target" : "off_target");
 
   const totalConsumedCredits = showConsumptionAnalytics
-    ? (consumptionOverview?.totalCredits ??
-      (isReadOnly ? periodSpendCredits : poolConsumedCredits))
+    ? (consumptionOverview?.totalCredits ?? poolConsumedCredits)
     : poolConsumedCredits;
 
   const initialTotalCredits = creditUsage?.capCredits ?? totalActiveCredits;
@@ -918,10 +863,6 @@ export function UsagePage() {
     creditsResetAt ??
     consumptionOverview?.period.endDate ??
     null;
-
-  if (!canViewUsage) {
-    return null;
-  }
 
   const topUpButton = isWorkspaceAdmin ? (
     <Button
@@ -1039,6 +980,7 @@ export function UsagePage() {
       isLoading={isMembersUsageLoading}
       isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}
+      showCreditPlanColumns={isCreditPriced}
       seatActionsDisabled={isSubscriptionCancelled}
       showSpendLimit={!isFreePlanWorkspace}
       showModelTiersColumn={isWorkspaceAdmin}
@@ -1150,7 +1092,7 @@ export function UsagePage() {
           />
         )}
 
-        {showConsumptionAnalytics ? (
+        {isCreditPriced && showConsumptionAnalytics ? (
           <Page.Vertical gap="none" align="stretch">
             <h2 className="heading-sm text-foreground">Credit Pool</h2>
             <div className="flex flex-col gap-2 pt-4">
@@ -1259,9 +1201,10 @@ export function UsagePage() {
           </Page.Vertical>
         ) : null}
 
-        {!showConsumptionAnalytics &&
+        {isCreditPriced &&
+        !showConsumptionAnalytics &&
         !isAwuPoolSummaryLoading &&
-        (isAwuPoolSummaryError || hasPool || isReadOnly) ? (
+        (isAwuPoolSummaryError || hasPool) ? (
           <Page.Vertical gap="xs" align="stretch">
             <Page.H variant="h4">Workspace credit pool</Page.H>
 
@@ -1300,24 +1243,15 @@ export function UsagePage() {
                   </div>
                 )}
                 <div className="flex items-center gap-2">
-                  {isReadOnly ? (
+                  {overageCredits !== null && overageCredits > 0 && (
                     <span className="copy-sm text-muted-foreground">
-                      {formatCredits(periodSpendCredits)} credits spent this
-                      period
+                      {formatCredits(overageCredits)} overage credits
                     </span>
-                  ) : (
-                    <>
-                      {overageCredits !== null && overageCredits > 0 && (
-                        <span className="copy-sm text-muted-foreground">
-                          {formatCredits(overageCredits)} overage credits
-                        </span>
-                      )}
-                      {isEnterprise && (
-                        <span className="copy-sm text-muted-foreground">
-                          Contact your Dust sales representative to buy credits
-                        </span>
-                      )}
-                    </>
+                  )}
+                  {isEnterprise && (
+                    <span className="copy-sm text-muted-foreground">
+                      Contact your Dust sales representative to buy credits
+                    </span>
                   )}
                 </div>
               </>
@@ -1377,10 +1311,9 @@ export function UsagePage() {
                         <GroupModelTierPickerDropdown
                           owner={owner}
                           groupId={groupFilter}
-                          readOnly={isReadOnly}
                         />
                       )}
-                      {seatFilterDropdown}
+                      {isCreditPriced && seatFilterDropdown}
                     </div>
                   )}
                 </div>
@@ -1422,27 +1355,29 @@ export function UsagePage() {
           {isWorkspaceAdmin && (
             <TabsContent value="settings">
               <div className="flex flex-col gap-10">
-                <UsageSettingsCard
-                  workspaceId={owner.sId}
-                  readOnly={isReadOnly}
-                  hasPool={hasPool}
-                />
-                {isWorkspaceAdmin && (
-                  <ModelTiersSettingsCard owner={owner} readOnly={isReadOnly} />
+                {isCreditPriced && (
+                  <UsageSettingsCard
+                    workspaceId={owner.sId}
+                    readOnly={isReadOnly}
+                    hasPool={hasPool}
+                  />
                 )}
-                <LockedSection
-                  locked={!isAwuPoolSummaryLoading && !hasPool}
-                  className="flex flex-col gap-10"
-                >
-                  <UsageProgrammaticLimitCard
-                    workspaceId={owner.sId}
-                    readOnly={isReadOnly}
-                  />
-                  <UsageNotificationsCard
-                    workspaceId={owner.sId}
-                    readOnly={isReadOnly}
-                  />
-                </LockedSection>
+                <ModelTiersSettingsCard owner={owner} />
+                {isCreditPriced && (
+                  <LockedSection
+                    locked={!isAwuPoolSummaryLoading && !hasPool}
+                    className="flex flex-col gap-10"
+                  >
+                    <UsageProgrammaticLimitCard
+                      workspaceId={owner.sId}
+                      readOnly={isReadOnly}
+                    />
+                    <UsageNotificationsCard
+                      workspaceId={owner.sId}
+                      readOnly={isReadOnly}
+                    />
+                  </LockedSection>
+                )}
               </div>
             </TabsContent>
           )}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -987,10 +987,9 @@ export function UsagePage() {
       creditsResetAt={creditsResetAt}
       isLoading={isMembersUsageLoading}
       isRefreshing={isMembersUsageRefreshing}
-      readOnly={!isCreditPriced}
       showSeatAndCredits={isCreditPriced}
       seatActionsDisabled={isSubscriptionCancelled}
-      showSpendLimit={!isFreePlanWorkspace}
+      showSpendLimit={isCreditPriced && !isFreePlanWorkspace}
       showModelTiersColumn={isWorkspaceAdmin}
       userModelTierSelectionByUserId={userModelTierSelectionByUserId}
       userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -268,7 +268,10 @@ export function UsagePage() {
       : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 
-  const { myUsage } = useMyUsage({ workspaceId: owner.sId });
+  const { myUsage } = useMyUsage({
+    workspaceId: owner.sId,
+    disabled: !isCreditPriced,
+  });
   const openChangeMySeatParam = useSearchParam("openChangeMySeat");
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
@@ -442,10 +445,10 @@ export function UsagePage() {
     useState<WorkspaceLimit | null>(null);
   // Auto-open the "change my seat" modal when arriving from a blocked-state
   useEffect(() => {
-    if (openChangeMySeatParam !== null && myUsage !== null) {
+    if (isCreditPriced && openChangeMySeatParam !== null && myUsage !== null) {
       setChangeSeatMember(myUsage);
     }
-  }, [openChangeMySeatParam, myUsage]);
+  }, [isCreditPriced, openChangeMySeatParam, myUsage]);
 
   const {
     totalRemainingCredits,
@@ -772,6 +775,7 @@ export function UsagePage() {
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
+    disabled: !isCreditPriced,
   });
 
   const { seatPlans } = useSeatPlan({
@@ -781,6 +785,7 @@ export function UsagePage() {
 
   const { perSeatPricing } = usePerSeatPricing({
     workspaceId: owner.sId,
+    disabled: !isCreditPriced,
   });
 
   const isSeatBased = Object.keys(seatPlans).length > 1;
@@ -800,7 +805,10 @@ export function UsagePage() {
     );
   }, [seatPlans]);
 
-  const { usageSettings } = useUsageSettings({ workspaceId: owner.sId });
+  const { usageSettings } = useUsageSettings({
+    workspaceId: owner.sId,
+    disabled: !isCreditPriced,
+  });
 
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -210,10 +210,9 @@ export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
-  // Legacy-contract workspaces see this page without the credit pool, seat and
-  // credits columns. Credit actions (top up, invite, seat changes, spend limits,
-  // usage settings) are disabled for them; model tiers stay editable.
-  const isReadOnly = !isCreditPriced;
+  // Workspaces off a credit plan see this page without the credit pool, seat
+  // and credits columns, spend limits and upgrade requests. Credit actions (top
+  // up, invite, seat changes) are disabled for them; model tiers stay editable.
   // A cancelled subscription already has its end date scheduled with
   // Metronome; scheduling a seat change on top of it can land past that end
   // date and get rejected. Block seat changes until the subscription is
@@ -315,6 +314,7 @@ export function UsagePage() {
   >("members");
   const { upgradeRequests, isUpgradeRequestsLoading } = useUpgradeRequests({
     workspaceId: owner.sId,
+    disabled: !isCreditPriced,
   });
 
   const filteredUpgradeRequests = useMemo(() => {
@@ -870,7 +870,7 @@ export function UsagePage() {
       icon={ArrowUp}
       size="sm"
       variant="outline"
-      disabled={isReadOnly || !usageSettings.topUpEnabled}
+      disabled={!isCreditPriced || !usageSettings.topUpEnabled}
       onClick={() => setShowBuyCreditDialog(true)}
     />
   ) : null;
@@ -890,7 +890,7 @@ export function UsagePage() {
           prefillText=""
           perSeatPricing={perSeatPricing}
           onInviteClick={onInviteClick}
-          disabled={isReadOnly}
+          disabled={!isCreditPriced}
           isFreePlan={isFreePlanWorkspace}
         />
       )}
@@ -979,8 +979,8 @@ export function UsagePage() {
       creditsResetAt={creditsResetAt}
       isLoading={isMembersUsageLoading}
       isRefreshing={isMembersUsageRefreshing}
-      readOnly={isReadOnly}
-      showCreditPlanColumns={isCreditPriced}
+      readOnly={!isCreditPriced}
+      showSeatAndCredits={isCreditPriced}
       seatActionsDisabled={isSubscriptionCancelled}
       showSpendLimit={!isFreePlanWorkspace}
       showModelTiersColumn={isWorkspaceAdmin}
@@ -1003,7 +1003,7 @@ export function UsagePage() {
       sorting={sorting}
       setSorting={handleSetSorting}
       showGroupsColumn={groups.length > 0}
-      enableSelection={!isReadOnly}
+      enableSelection={isCreditPriced}
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}
     />
@@ -1022,7 +1022,7 @@ export function UsagePage() {
           ? handleBatchChangeSeat
           : undefined
       }
-      disabled={isReadOnly}
+      disabled={!isCreditPriced}
     />
   );
 
@@ -1067,19 +1067,21 @@ export function UsagePage() {
         ) : (
           <div className="flex items-center justify-between">
             <Page.Header title="Usage" />
-            {!isReadOnly && usageSettings.topUpEnabled && isWorkspaceAdmin && (
-              <Button
-                label="Top up"
-                icon={ArrowUp}
-                size="sm"
-                variant="outline"
-                onClick={() => setShowBuyCreditDialog(true)}
-              />
-            )}
+            {isCreditPriced &&
+              usageSettings.topUpEnabled &&
+              isWorkspaceAdmin && (
+                <Button
+                  label="Top up"
+                  icon={ArrowUp}
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowBuyCreditDialog(true)}
+                />
+              )}
           </div>
         )}
 
-        {!isReadOnly && isCreditPricedFreePlan(subscription.plan.code) && (
+        {isCreditPricedFreePlan(subscription.plan.code) && (
           <FreePlanUpgradeSection
             action={
               <Button
@@ -1285,25 +1287,27 @@ export function UsagePage() {
               {searchAndInviteRow}
               <div className="flex flex-col gap-2">
                 <div className="flex flex-row items-center justify-between gap-2">
-                  <ButtonsSwitchList
-                    size="xs"
-                    defaultValue="members"
-                    onValueChange={(v: string) =>
-                      setMembersTab(v === "requests" ? "requests" : "members")
-                    }
-                  >
-                    <ButtonsSwitch value="members" label="Members" />
-                    <ButtonsSwitch
-                      value="requests"
-                      label="Requests"
-                      isCounter
-                      counterValue={
-                        filteredUpgradeRequests.length > 0
-                          ? String(filteredUpgradeRequests.length)
-                          : undefined
+                  {isCreditPriced && (
+                    <ButtonsSwitchList
+                      size="xs"
+                      defaultValue="members"
+                      onValueChange={(v: string) =>
+                        setMembersTab(v === "requests" ? "requests" : "members")
                       }
-                    />
-                  </ButtonsSwitchList>
+                    >
+                      <ButtonsSwitch value="members" label="Members" />
+                      <ButtonsSwitch
+                        value="requests"
+                        label="Requests"
+                        isCounter
+                        counterValue={
+                          filteredUpgradeRequests.length > 0
+                            ? String(filteredUpgradeRequests.length)
+                            : undefined
+                        }
+                      />
+                    </ButtonsSwitchList>
+                  )}
                   {membersTab === "members" && (
                     <div className="flex flex-row items-center gap-2">
                       {groupsFilterDropdown}
@@ -1341,7 +1345,7 @@ export function UsagePage() {
           <TabsContent value="groups">
             <GroupsUsageTable
               owner={owner}
-              readOnly={isReadOnly}
+              showSpendLimitColumn={isCreditPriced}
               showModelTiersColumn={isWorkspaceAdmin}
             />
           </TabsContent>
@@ -1358,7 +1362,6 @@ export function UsagePage() {
                 {isCreditPriced && (
                   <UsageSettingsCard
                     workspaceId={owner.sId}
-                    readOnly={isReadOnly}
                     hasPool={hasPool}
                   />
                 )}
@@ -1368,14 +1371,8 @@ export function UsagePage() {
                     locked={!isAwuPoolSummaryLoading && !hasPool}
                     className="flex flex-col gap-10"
                   >
-                    <UsageProgrammaticLimitCard
-                      workspaceId={owner.sId}
-                      readOnly={isReadOnly}
-                    />
-                    <UsageNotificationsCard
-                      workspaceId={owner.sId}
-                      readOnly={isReadOnly}
-                    />
+                    <UsageProgrammaticLimitCard workspaceId={owner.sId} />
+                    <UsageNotificationsCard workspaceId={owner.sId} />
                   </LockedSection>
                 )}
               </div>

--- a/front/components/workspace/GroupModelTierPickerDropdown.tsx
+++ b/front/components/workspace/GroupModelTierPickerDropdown.tsx
@@ -13,13 +13,11 @@ import type { LightWorkspaceType } from "@app/types/user";
 interface GroupModelTierPickerDropdownProps {
   owner: LightWorkspaceType;
   groupId: string;
-  readOnly?: boolean;
 }
 
 export function GroupModelTierPickerDropdown({
   owner,
   groupId,
-  readOnly = false,
 }: GroupModelTierPickerDropdownProps) {
   const { groups: groupAllowedModelTiers, isGroupAllowedModelTiersLoading } =
     useGroupAllowedModelTiers({ owner });
@@ -48,7 +46,6 @@ export function GroupModelTierPickerDropdown({
           tierName: value as ModelsTierName,
         });
       }}
-      readOnly={readOnly}
       isLoading={isGroupAllowedModelTiersLoading}
       isMutating={isGroupAllowedModelTierMutating}
     />

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from "react";
 
 interface GroupsUsageTableProps {
   owner: LightWorkspaceType;
-  readOnly: boolean;
+  showSpendLimitColumn?: boolean;
   showModelTiersColumn?: boolean;
 }
 
@@ -26,14 +26,13 @@ type GroupInfo = CellContext<GroupRowData, string>;
 
 interface GroupCapCellProps {
   group: GroupRowData;
-  readOnly: boolean;
   onSave: (group: GroupRowData, limit: GroupSpendLimit) => Promise<void>;
 }
 
 // Per-row editable cap cell. Empty input clears the cap (unlimited); 0 blocks
 // the group's pool access; a positive integer sets a custom limit. Reverts to
 // the current value when nothing is persisted.
-function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
+function GroupCapCell({ group, onSave }: GroupCapCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const current = group.poolCapAwuCredits;
 
@@ -68,7 +67,6 @@ function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
         onSave={handleSave}
         onFocus={() => setIsEditing(true)}
         onBlur={() => setIsEditing(false)}
-        disabled={readOnly}
       />
     </div>
   );
@@ -76,7 +74,7 @@ function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
 
 export function GroupsUsageTable({
   owner,
-  readOnly,
+  showSpendLimitColumn = true,
   showModelTiersColumn = false,
 }: GroupsUsageTableProps) {
   const { groups, isGroupsLoading } = useGroups({
@@ -123,25 +121,28 @@ export function GroupsUsageTable({
         ),
         enableSorting: false,
       },
-      {
-        id: "cap",
-        header: "Spend limit",
-        meta: { className: "w-64" },
-        cell: (info: GroupInfo) => (
-          <GroupCapCell
-            group={info.row.original}
-            readOnly={readOnly}
-            onSave={async (group, limit) => {
-              await doUpdateGroupSpendLimit({
-                groupId: group.groupId,
-                groupName: group.name,
-                limit,
-              });
-            }}
-          />
-        ),
-        enableSorting: false,
-      },
+      ...(showSpendLimitColumn
+        ? [
+            {
+              id: "cap",
+              header: "Spend limit",
+              meta: { className: "w-64" },
+              cell: (info: GroupInfo) => (
+                <GroupCapCell
+                  group={info.row.original}
+                  onSave={async (group, limit) => {
+                    await doUpdateGroupSpendLimit({
+                      groupId: group.groupId,
+                      groupName: group.name,
+                      limit,
+                    });
+                  }}
+                />
+              ),
+              enableSorting: false,
+            } satisfies ColumnDef<GroupRowData, string>,
+          ]
+        : []),
       ...(showModelTiersColumn
         ? [
             {
@@ -164,7 +165,7 @@ export function GroupsUsageTable({
           ]
         : []),
     ],
-    [owner, readOnly, showModelTiersColumn, doUpdateGroupSpendLimit]
+    [owner, showSpendLimitColumn, showModelTiersColumn, doUpdateGroupSpendLimit]
   );
 
   if (isGroupsLoading) {

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -178,10 +178,12 @@ export function GroupsUsageTable({
 
   return (
     <div className="flex flex-col gap-3">
-      <span className="copy-sm text-muted-foreground">
-        A group's monthly spend limit applies to each of its members. When a
-        member belongs to several groups, the highest limit is used.
-      </span>
+      {showSpendLimitColumn && (
+        <span className="copy-sm text-muted-foreground">
+          A group's monthly spend limit applies to each of its members. When a
+          member belongs to several groups, the highest limit is used.
+        </span>
+      )}
       <DataTable
         filterColumn="name"
         data={rows}

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -157,7 +157,6 @@ export function GroupsUsageTable({
                 <GroupModelTierPickerDropdown
                   owner={owner}
                   groupId={info.row.original.groupId}
-                  readOnly={readOnly}
                 />
               ),
               enableSorting: false,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -805,7 +805,8 @@ function buildColumns({
     ...(showSeatAndCredits
       ? buildCreditPlanColumns({ creditsResetAt, variant })
       : []),
-    actionsColumn,
+    // Every row action belongs to one of these two groups.
+    ...(showSeatAndCredits || showModelTiersColumn ? [actionsColumn] : []),
   ];
 }
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -826,9 +826,10 @@ interface MembersUsageTableProps {
   seatChangePendingMemberIds: ReadonlySet<string>;
   isSeatBased: boolean;
   showSpendLimit: boolean;
-  readOnly: boolean;
-  // Seat and credits usage columns plus the seat and spend limit row actions.
-  // Off for workspaces that are not on a credit plan.
+  // Disables every row action (Poke's read-only view).
+  readOnly?: boolean;
+  // Seat and credits usage columns plus the seat row actions. Off for
+  // workspaces that are not on a credit plan.
   showSeatAndCredits?: boolean;
   // Disables only the seat-assign/change/remove actions (e.g. while the
   // subscription has a cancellation scheduled), independent of `readOnly`.
@@ -868,7 +869,7 @@ export function MembersUsageTable({
   seatChangePendingMemberIds,
   isSeatBased,
   showSpendLimit,
-  readOnly,
+  readOnly = false,
   showSeatAndCredits = true,
   seatActionsDisabled = false,
   onChangeSeat,
@@ -966,10 +967,7 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showSeatAndCredits &&
-            showSpendLimit &&
-            hasSeat &&
-            m.seatType !== "free"
+            ...(showSpendLimit && hasSeat && m.seatType !== "free"
               ? [
                   {
                     kind: "item" as const,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -895,6 +895,8 @@ export function MembersUsageTable({
   const rows: RowData[] = useMemo(
     () =>
       members.map((m) => {
+        const hasSeat = m.seatType !== null && m.seatType !== "none";
+        const canEditSeat = showSeatAndCredits && isSeatBased && hasSeat;
         const resolvedModelTiers = showModelTiersColumn
           ? resolveModelTiersForUser({
               userId: m.sId,
@@ -943,7 +945,7 @@ export function MembersUsageTable({
           })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
-            ...(showSeatAndCredits && (!m.seatType || m.seatType === "none")
+            ...(showSeatAndCredits && !hasSeat
               ? [
                   {
                     kind: "item" as const,
@@ -953,10 +955,7 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showSeatAndCredits &&
-            isSeatBased &&
-            m.seatType &&
-            m.seatType !== "none"
+            ...(canEditSeat
               ? [
                   {
                     kind: "item" as const,
@@ -968,9 +967,8 @@ export function MembersUsageTable({
               : []),
             ...(showSeatAndCredits &&
             showSpendLimit &&
-            m.seatType &&
-            m.seatType !== "free" &&
-            m.seatType !== "none"
+            hasSeat &&
+            m.seatType !== "free"
               ? [
                   {
                     kind: "item" as const,
@@ -1007,10 +1005,7 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showSeatAndCredits &&
-            isSeatBased &&
-            m.seatType &&
-            m.seatType !== "none"
+            ...(canEditSeat
               ? [
                   {
                     kind: "item" as const,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -786,14 +786,14 @@ function buildColumns({
   enableSelection,
   showGroupsColumn,
   showModelTiersColumn,
-  showCreditPlanColumns,
+  showSeatAndCredits,
   creditsResetAt,
   variant,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
   showModelTiersColumn: boolean;
-  showCreditPlanColumns: boolean;
+  showSeatAndCredits: boolean;
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
 }): ColumnDef<RowData, string>[] {
@@ -802,7 +802,7 @@ function buildColumns({
     nameColumn,
     ...(showGroupsColumn ? [groupsColumn] : []),
     ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
-    ...(showCreditPlanColumns
+    ...(showSeatAndCredits
       ? buildCreditPlanColumns({ creditsResetAt, variant })
       : []),
     actionsColumn,
@@ -826,9 +826,9 @@ interface MembersUsageTableProps {
   isSeatBased: boolean;
   showSpendLimit: boolean;
   readOnly: boolean;
-  // Seat and credits usage columns, plus the seat and spend limit actions.
-  // Hidden for workspaces that are not on a credit plan.
-  showCreditPlanColumns?: boolean;
+  // Seat and credits usage columns plus the seat and spend limit row actions.
+  // Off for workspaces that are not on a credit plan.
+  showSeatAndCredits?: boolean;
   // Disables only the seat-assign/change/remove actions (e.g. while the
   // subscription has a cancellation scheduled), independent of `readOnly`.
   seatActionsDisabled?: boolean;
@@ -868,7 +868,7 @@ export function MembersUsageTable({
   isSeatBased,
   showSpendLimit,
   readOnly,
-  showCreditPlanColumns = true,
+  showSeatAndCredits = true,
   seatActionsDisabled = false,
   onChangeSeat,
   onRemoveSeat,
@@ -943,7 +943,7 @@ export function MembersUsageTable({
           })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
-            ...(showCreditPlanColumns && (!m.seatType || m.seatType === "none")
+            ...(showSeatAndCredits && (!m.seatType || m.seatType === "none")
               ? [
                   {
                     kind: "item" as const,
@@ -953,7 +953,7 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showCreditPlanColumns &&
+            ...(showSeatAndCredits &&
             isSeatBased &&
             m.seatType &&
             m.seatType !== "none"
@@ -966,7 +966,7 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showCreditPlanColumns &&
+            ...(showSeatAndCredits &&
             showSpendLimit &&
             m.seatType &&
             m.seatType !== "free" &&
@@ -1007,7 +1007,7 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showCreditPlanColumns &&
+            ...(showSeatAndCredits &&
             isSeatBased &&
             m.seatType &&
             m.seatType !== "none"
@@ -1038,7 +1038,7 @@ export function MembersUsageTable({
       workspaceAllowedModelTiers,
       groupNameToId,
       readOnly,
-      showCreditPlanColumns,
+      showSeatAndCredits,
       seatActionsDisabled,
       onChangeSeat,
       onRemoveSeat,
@@ -1053,7 +1053,7 @@ export function MembersUsageTable({
         enableSelection,
         showGroupsColumn,
         showModelTiersColumn,
-        showCreditPlanColumns,
+        showSeatAndCredits,
         creditsResetAt,
         variant,
       }),
@@ -1061,7 +1061,7 @@ export function MembersUsageTable({
       enableSelection,
       showGroupsColumn,
       showModelTiersColumn,
-      showCreditPlanColumns,
+      showSeatAndCredits,
       creditsResetAt,
       variant,
     ]

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -756,24 +756,14 @@ const actionsColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function buildColumns({
-  enableSelection,
-  showGroupsColumn,
-  showModelTiersColumn,
+function buildCreditPlanColumns({
   creditsResetAt,
   variant,
 }: {
-  enableSelection: boolean;
-  showGroupsColumn: boolean;
-  showModelTiersColumn: boolean;
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
 }): ColumnDef<RowData, string>[] {
   return [
-    ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
-    nameColumn,
-    ...(showGroupsColumn ? [groupsColumn] : []),
-    ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
     ...(() => {
       switch (variant) {
         case "compact":
@@ -789,6 +779,32 @@ function buildColumns({
       ...buildConsumedAwuCreditsColumn(creditsResetAt),
       meta: { className: "w-64" },
     },
+  ];
+}
+
+function buildColumns({
+  enableSelection,
+  showGroupsColumn,
+  showModelTiersColumn,
+  showCreditPlanColumns,
+  creditsResetAt,
+  variant,
+}: {
+  enableSelection: boolean;
+  showGroupsColumn: boolean;
+  showModelTiersColumn: boolean;
+  showCreditPlanColumns: boolean;
+  creditsResetAt: string | null;
+  variant: MembersUsageTableVariant;
+}): ColumnDef<RowData, string>[] {
+  return [
+    ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
+    nameColumn,
+    ...(showGroupsColumn ? [groupsColumn] : []),
+    ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
+    ...(showCreditPlanColumns
+      ? buildCreditPlanColumns({ creditsResetAt, variant })
+      : []),
     actionsColumn,
   ];
 }
@@ -810,6 +826,9 @@ interface MembersUsageTableProps {
   isSeatBased: boolean;
   showSpendLimit: boolean;
   readOnly: boolean;
+  // Seat and credits usage columns, plus the seat and spend limit actions.
+  // Hidden for workspaces that are not on a credit plan.
+  showCreditPlanColumns?: boolean;
   // Disables only the seat-assign/change/remove actions (e.g. while the
   // subscription has a cancellation scheduled), independent of `readOnly`.
   seatActionsDisabled?: boolean;
@@ -849,6 +868,7 @@ export function MembersUsageTable({
   isSeatBased,
   showSpendLimit,
   readOnly,
+  showCreditPlanColumns = true,
   seatActionsDisabled = false,
   onChangeSeat,
   onRemoveSeat,
@@ -923,7 +943,7 @@ export function MembersUsageTable({
           })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
-            ...(!m.seatType || m.seatType === "none"
+            ...(showCreditPlanColumns && (!m.seatType || m.seatType === "none")
               ? [
                   {
                     kind: "item" as const,
@@ -933,7 +953,10 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(isSeatBased && m.seatType && m.seatType !== "none"
+            ...(showCreditPlanColumns &&
+            isSeatBased &&
+            m.seatType &&
+            m.seatType !== "none"
               ? [
                   {
                     kind: "item" as const,
@@ -943,7 +966,8 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(showSpendLimit &&
+            ...(showCreditPlanColumns &&
+            showSpendLimit &&
             m.seatType &&
             m.seatType !== "free" &&
             m.seatType !== "none"
@@ -961,7 +985,6 @@ export function MembersUsageTable({
                   {
                     kind: "submenu" as const,
                     label: "Models tier",
-                    disabled: readOnly,
                     selectionMode: "checkbox" as const,
                     items: getUserModelTierMenuItemsWithSelection({
                       selectedValue:
@@ -984,7 +1007,10 @@ export function MembersUsageTable({
                   },
                 ]
               : []),
-            ...(isSeatBased && m.seatType && m.seatType !== "none"
+            ...(showCreditPlanColumns &&
+            isSeatBased &&
+            m.seatType &&
+            m.seatType !== "none"
               ? [
                   {
                     kind: "item" as const,
@@ -1012,6 +1038,7 @@ export function MembersUsageTable({
       workspaceAllowedModelTiers,
       groupNameToId,
       readOnly,
+      showCreditPlanColumns,
       seatActionsDisabled,
       onChangeSeat,
       onRemoveSeat,
@@ -1026,6 +1053,7 @@ export function MembersUsageTable({
         enableSelection,
         showGroupsColumn,
         showModelTiersColumn,
+        showCreditPlanColumns,
         creditsResetAt,
         variant,
       }),
@@ -1033,6 +1061,7 @@ export function MembersUsageTable({
       enableSelection,
       showGroupsColumn,
       showModelTiersColumn,
+      showCreditPlanColumns,
       creditsResetAt,
       variant,
     ]

--- a/front/components/workspace/usage/ModelTiersSettingsCard.tsx
+++ b/front/components/workspace/usage/ModelTiersSettingsCard.tsx
@@ -13,13 +13,9 @@ import { Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
 
 interface ModelTiersSettingsCardProps {
   owner: LightWorkspaceType;
-  readOnly: boolean;
 }
 
-export function ModelTiersSettingsCard({
-  owner,
-  readOnly,
-}: ModelTiersSettingsCardProps) {
+export function ModelTiersSettingsCard({ owner }: ModelTiersSettingsCardProps) {
   const {
     maxTierName: workspaceMaxTierName,
     isWorkspaceAllowedModelTiersLoading,
@@ -53,7 +49,6 @@ export function ModelTiersSettingsCard({
                   tierName: value as ModelsTierName,
                 });
               }}
-              readOnly={readOnly}
               isLoading={isWorkspaceAllowedModelTiersLoading}
               isMutating={isWorkspaceAllowedModelTierMutating}
             />
@@ -65,9 +60,7 @@ export function ModelTiersSettingsCard({
           action={
             <SliderToggle
               selected={isRestrictedModelsForPublishedAgentsEnabled}
-              disabled={
-                readOnly || isRestrictedModelsForPublishedAgentsChanging
-              }
+              disabled={isRestrictedModelsForPublishedAgentsChanging}
               onClick={() => void doTogglePublishedAgentsRestrictedModels()}
             />
           }

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -12,12 +12,10 @@ import { useState } from "react";
 
 interface UsageNotificationsCardProps {
   workspaceId: string;
-  readOnly: boolean;
 }
 
 export function UsageNotificationsCard({
   workspaceId,
-  readOnly,
 }: UsageNotificationsCardProps) {
   const { usageNotifications, isUsageNotificationsLoading } =
     useUsageNotifications({ workspaceId });
@@ -101,7 +99,7 @@ export function UsageNotificationsCard({
                 onSave={handleSaveBalanceThreshold}
                 onFocus={() => setIsEditingThreshold(true)}
                 onBlur={() => setIsEditingThreshold(false)}
-                disabled={readOnly || isUsageNotificationsLoading}
+                disabled={isUsageNotificationsLoading}
               />
             </div>
           }
@@ -113,9 +111,7 @@ export function UsageNotificationsCard({
             <SliderToggle
               selected={usageNotifications.upgradeRequestEmail}
               disabled={
-                readOnly ||
-                isSavingUpgradeRequestEmail ||
-                isUsageNotificationsLoading
+                isSavingUpgradeRequestEmail || isUsageNotificationsLoading
               }
               onClick={() => void handleToggleUpgradeRequestEmail()}
             />

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -7,12 +7,10 @@ import { useState } from "react";
 
 interface UsageProgrammaticLimitCardProps {
   workspaceId: string;
-  readOnly: boolean;
 }
 
 export function UsageProgrammaticLimitCard({
   workspaceId,
-  readOnly,
 }: UsageProgrammaticLimitCardProps) {
   const { programmaticUsageLimit, isProgrammaticUsageLimitLoading } =
     useProgrammaticUsageLimit({ workspaceId });
@@ -74,7 +72,7 @@ export function UsageProgrammaticLimitCard({
                 onSave={handleSaveLimit}
                 onFocus={() => setIsEditing(true)}
                 onBlur={() => setIsEditing(false)}
-                disabled={readOnly || isProgrammaticUsageLimitLoading}
+                disabled={isProgrammaticUsageLimitLoading}
               />
             </div>
           }

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -19,13 +19,11 @@ import { useState } from "react";
 
 interface UsageSettingsCardProps {
   workspaceId: string;
-  readOnly: boolean;
   hasPool: boolean;
 }
 
 export function UsageSettingsCard({
   workspaceId,
-  readOnly,
   hasPool,
 }: UsageSettingsCardProps) {
   const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
@@ -114,7 +112,7 @@ export function UsageSettingsCard({
                   onSave={handleSaveDefaultLimit}
                   onFocus={() => setIsEditingDefaultLimit(true)}
                   onBlur={() => setIsEditingDefaultLimit(false)}
-                  disabled={readOnly || isDefaultUserSpendLimitLoading}
+                  disabled={isDefaultUserSpendLimitLoading}
                 />
               </div>
             }
@@ -126,9 +124,7 @@ export function UsageSettingsCard({
           action={
             <SliderToggle
               selected={usageSettings.allowUpgradeRequest}
-              disabled={
-                readOnly || isUpdatingUsageSettings || isUsageSettingsLoading
-              }
+              disabled={isUpdatingUsageSettings || isUsageSettingsLoading}
               onClick={() => void handleToggleAllowUpgradeRequest()}
             />
           }
@@ -147,7 +143,6 @@ export function UsageSettingsCard({
                   usageSettings.requireUpgradeRequestReason
                 }
                 disabled={
-                  readOnly ||
                   isUpdatingUsageSettings ||
                   isUsageSettingsLoading ||
                   !usageSettings.allowUpgradeRequest
@@ -181,7 +176,6 @@ export function UsageSettingsCard({
                 usageSettings.autoSeatUpgradeEnabled
               }
               disabled={
-                readOnly ||
                 isUpdatingUsageSettings ||
                 isUsageSettingsLoading ||
                 !usageSettings.autoSeatUpgradeAvailable

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -86,14 +86,21 @@ async function patchCreditUsageConfiguration(
   }
 }
 
-export function useUsageSettings({ workspaceId }: { workspaceId: string }) {
+export function useUsageSettings({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
   const { fetcher } = useFetcher();
   const configurationFetcher: Fetcher<GetCreditUsageConfigurationResponseBody> =
     fetcher;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     getCreditUsageConfigurationEndpoint(workspaceId),
-    configurationFetcher
+    configurationFetcher,
+    { disabled }
   );
 
   const usageSettings: UsageSettings = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -183,12 +183,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "flvndvd",
   },
-  usage_page_read_only: {
-    description:
-      "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",
-    stage: "self_serve",
-    owner: "tdraier",
-  },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "self_serve",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -803,7 +803,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "stateful_conversation_window"
   | "run_tools_from_prompt"
   | "usage_data_api"
-  | "usage_page_read_only"
   | "pricing_groups"
   | "workspace_analytics"
   | "xai_feature"


### PR DESCRIPTION
The Usage page is now available to every workspace. The sidebar entry no longer depends on the plan or the `usage_page_read_only` flag, which is removed. We needed it to allow user change the Model Tiers.

Workspaces that are not on a credit plan get the page without:
- the Workspace credit pool block (title, counter, progress bar),
- the Seat and Credits usage columns, the seat filter, and the seat / spend limit row actions,
- the credit-only settings cards (default spend limit, programmatic limit, notifications) and the top-ups tab.

Model tiers are editable for them: per member, per group, and the workspace default in Settings. Credit actions (top up, invite, seat changes, spend limits) stay disabled as before.

The credit pool summary and seat plan endpoints are no longer called for those workspaces.


To test: check on Dust then on your perso workspace on free-friends family
