### PR TITLE
Harden legacy Frame mutations after conversion

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.test.ts
@@ -1,6 +1,7 @@
 // Legacy Frame publishing runs esbuild, whose TextEncoder invariant requires Node rather than jsdom.
 // @vitest-environment node
 
+import { revertClientExecutableFileChanges } from "@app/lib/api/files/client_executable";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -537,6 +538,30 @@ describe("POST /api/v1/w/[wId]/sandbox/frames", () => {
     expect(
       await FileResource.fetchById(context.auth, context.frame.sId)
     ).toBeNull();
+  });
+
+  it("rejects legacy revert after the stable Frame identity converts", async () => {
+    const context = await setupLegacyFrameConversion();
+    const response = await requestFrameConvert(
+      context.workspace.sId,
+      context.token,
+      context.sourcePath,
+      context.manifestPath
+    );
+    expect(response.status, await response.text()).toBe(200);
+
+    const revertResult = await revertClientExecutableFileChanges(context.auth, {
+      fileId: context.frame.sId,
+      revertedByAgentConfigurationId: "agent",
+    });
+
+    expect(revertResult.isErr() && revertResult.error).toMatchObject({
+      message: expect.stringContaining("edit its Frames v2 source instead"),
+      tracked: false,
+    });
+    const frame = await FileResource.fetchById(context.auth, context.frame.sId);
+    expect(frame?.fileName).toBe(FRAME_MANIFEST_FILE);
+    expect(frame?.mountFilePath).toBe(context.manifestMountFilePath);
   });
 
   it("rejects deletion while conversion recovery is pending", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
@@ -1,6 +1,9 @@
+import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -102,6 +105,30 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
 
     expect(response.status).toBe(200);
     expect((await response.json()).file.fileName).toBe("new-name.pdf");
+  });
+
+  it("rejects renaming a stable Frame identity after conversion", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "manager",
+    });
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 1024,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conv" },
+      mountFilePath: `w/${workspace.sId}/conversations/conv/files/Frame/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const response = await patchRename(workspace, file.sId, {
+      fileName: "Legacy.tsx",
+    });
+
+    expect(response.status).toBe(409);
+    const reloaded = await FileResource.fetchById(auth, file.sId);
+    expect(reloaded?.fileName).toBe(FRAME_MANIFEST_FILE);
   });
 
   it("should deny non-manager from renaming non-project files", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -1,3 +1,4 @@
+import { renameClientExecutableFile } from "@app/lib/api/files/client_executable";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { FileType } from "@app/types/files";
@@ -65,6 +66,23 @@ app.patch(
     }
 
     const { fileName } = ctx.req.valid("json");
+    if (file.isShareableFrame) {
+      const result = await renameClientExecutableFile(auth, {
+        fileId,
+        newFileName: fileName,
+      });
+      if (result.isErr()) {
+        return apiError(ctx, {
+          status_code: 409,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
+      return ctx.json({ file: result.value.toJSON(auth) });
+    }
+
     await file.rename(fileName);
 
     return ctx.json({ file: file.toJSON(auth) });

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -7,7 +7,10 @@ import {
   getFileContent,
   getUpdatedContentAndOccurrences,
 } from "@app/lib/api/files/utils";
-import { withLegacyFrameMutationLock } from "@app/lib/api/frames/operation_lock";
+import {
+  withLegacyFrameMutationLock,
+  withLegacyFrameMutationResultLock,
+} from "@app/lib/api/frames/operation_lock";
 import {
   diffAuthorizedFileRefs,
   fetchShareableFileAllowlistState,
@@ -15,6 +18,7 @@ import {
 } from "@app/lib/api/viz/authorized_file_access";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
+import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -58,6 +62,45 @@ function validateFileTitle({
     });
   }
   return new Ok(undefined);
+}
+
+type ClientExecutableMutationError = {
+  message: string;
+  tracked: boolean;
+};
+
+async function withLockedLegacyFrameMutation<T>(
+  auth: Authenticator,
+  fileId: string,
+  mutation: (
+    file: FileResource,
+    contentType: InteractiveContentFileContentType
+  ) => Promise<Result<T, ClientExecutableMutationError>>
+): Promise<Result<T, ClientExecutableMutationError>> {
+  const result = await withLegacyFrameMutationResultLock(fileId, async () => {
+    const fresh = await FileResource.fetchById(auth, fileId);
+    if (!fresh) {
+      return new Err({ message: `File not found: ${fileId}`, tracked: false });
+    }
+    if (!isInteractiveContentType(fresh.contentType)) {
+      return new Err({
+        message:
+          `File '${fileId}' is no longer a legacy interactive content file; ` +
+          "edit its Frames v2 source instead.",
+        tracked: false,
+      });
+    }
+    return mutation(fresh, fresh.contentType);
+  });
+  if (result.isErr()) {
+    return isLockAcquisitionTimeoutError(result.error)
+      ? new Err({
+          message: "Another Frame operation is in progress; retry shortly.",
+          tracked: false,
+        })
+      : new Err(result.error);
+  }
+  return result;
 }
 
 export async function createClientExecutableFile(
@@ -311,40 +354,34 @@ export async function renameClientExecutableFile(
     renamedByAgentConfigurationId?: string;
   }
 ): Promise<Result<FileResource, { tracked: boolean; message: string }>> {
-  const fileResource = await FileResource.fetchById(auth, fileId);
-  if (!fileResource) {
-    return new Err({ message: `File not found: ${fileId}`, tracked: false });
-  }
+  return withLockedLegacyFrameMutation(
+    auth,
+    fileId,
+    async (fileResource, contentType) => {
+      const fileNameValidationResult = validateFileTitle({
+        fileName: newFileName,
+        mimeType: contentType,
+      });
+      if (fileNameValidationResult.isErr()) {
+        return fileNameValidationResult;
+      }
 
-  if (!isInteractiveContentType(fileResource.contentType)) {
-    return new Err({
-      message: `File '${fileId}' is not an interactive content file (content type: ${fileResource.contentType})`,
-      tracked: false,
-    });
-  }
+      await fileResource.rename(newFileName);
 
-  const fileNameValidationResult = validateFileTitle({
-    fileName: newFileName,
-    mimeType: fileResource.contentType,
-  });
-  if (fileNameValidationResult.isErr()) {
-    return fileNameValidationResult;
-  }
+      if (
+        renamedByAgentConfigurationId &&
+        fileResource.useCaseMetadata?.lastEditedByAgentConfigurationId !==
+          renamedByAgentConfigurationId
+      ) {
+        await fileResource.setUseCaseMetadata(auth, {
+          ...fileResource.useCaseMetadata,
+          lastEditedByAgentConfigurationId: renamedByAgentConfigurationId,
+        });
+      }
 
-  await fileResource.rename(newFileName);
-
-  if (
-    renamedByAgentConfigurationId &&
-    fileResource.useCaseMetadata?.lastEditedByAgentConfigurationId !==
-      renamedByAgentConfigurationId
-  ) {
-    await fileResource.setUseCaseMetadata(auth, {
-      ...fileResource.useCaseMetadata,
-      lastEditedByAgentConfigurationId: renamedByAgentConfigurationId,
-    });
-  }
-
-  return new Ok(fileResource);
+      return new Ok(fileResource);
+    }
+  );
 }
 
 export async function getClientExecutableFileContent(
@@ -421,23 +458,20 @@ export async function revertClientExecutableFileChanges(
 ): Promise<
   Result<{ fileResource: FileResource }, { tracked: boolean; message: string }>
 > {
-  const fileResource = await FileResource.fetchById(auth, fileId);
-  if (!fileResource) {
-    return new Err({ tracked: true, message: "File not found" });
-  }
-
-  const revertResult = await fileResource.revert(auth, {
-    revertedByAgentConfigurationId,
-  });
-
-  if (revertResult.isErr()) {
-    return new Err({
-      tracked: false,
-      message: revertResult.error,
+  return withLockedLegacyFrameMutation(auth, fileId, async (fileResource) => {
+    const revertResult = await fileResource.revert(auth, {
+      revertedByAgentConfigurationId,
     });
-  }
 
-  return new Ok({ fileResource });
+    if (revertResult.isErr()) {
+      return new Err({
+        tracked: false,
+        message: revertResult.error,
+      });
+    }
+
+    return new Ok({ fileResource });
+  });
 }
 
 export async function getClientExecutableFileShareUrl(

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -1,6 +1,7 @@
 import {
   removeContentNodesFromProject,
   removeFileFromProject,
+  renameProjectFile,
 } from "@app/lib/api/projects/context";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -10,12 +11,62 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { getPodFilesBasePath } from "@app/types/mount_path";
 import { Err } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("renameProjectFile", () => {
+  afterEach(() => {
+    fileStorageMock.reset();
+  });
+
+  it("rejects renaming a folder that contains a Frame", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const mountBasePath = getPodFilesBasePath({
+      workspaceId: workspace.sId,
+      podId: project.sId,
+    });
+    const framePath = `${mountBasePath}folder/Legacy.tsx`;
+    await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "Legacy.tsx",
+      fileSize: 123,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: project.sId },
+      mountFilePath: framePath,
+    });
+    fileStorageMock.setFileExists((path) => path === `${mountBasePath}folder/`);
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix === `${mountBasePath}folder/`
+        ? [{ name: framePath, metadata: {} }]
+        : []
+    );
+    fileStorageMock.setObject(framePath, "legacy source");
+
+    const result = await renameProjectFile(auth, {
+      space: project,
+      relativeFilePath: "folder",
+      newFileName: "renamed",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "Folders containing Frames cannot be renamed"
+    );
+    expect(fileStorageMock.getObject(framePath)).toBe("legacy source");
+  });
+});
 
 describe("removeFileFromProject", () => {
   beforeEach(() => {

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -5,11 +5,11 @@ import {
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { DustFileSystem } from "@app/lib/api/file_system";
+import { renameCanonicalFile } from "@app/lib/api/files/file_system_ops";
 import {
   deleteGCSMountFile,
   moveFile,
   renameGCSMountDirectory,
-  renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
 import { cleanupProjectFileFragments } from "@app/lib/api/projects/file_cleanup";
@@ -694,6 +694,14 @@ export async function renameProjectFile(
       auth,
       mountPaths
     );
+    if (fileResources.some((file) => file.isShareableFrame)) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          "Folders containing Frames cannot be renamed; move each Frame source explicitly."
+        )
+      );
+    }
 
     const renameResult = await renameGCSMountDirectory(
       auth,
@@ -723,33 +731,18 @@ export async function renameProjectFile(
     return new Ok(undefined);
   }
 
-  const podsPrefix = getPodFilesBasePath({
-    workspaceId: owner.sId,
-    podId: space.sId,
-  });
-  const podsGcsPath = `${podsPrefix}${normalized}`;
-
-  const fileResources = await FileResource.fetchByMountFilePaths(auth, [
-    podsGcsPath,
-  ]);
-
-  const renameResult = await renameGCSMountFile(
+  const fsResult = await DustFileSystem.forPod(auth, space);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+  const renameResult = await renameCanonicalFile(
     auth,
-    { useCase: "pod", podId: space.sId },
-    { relativeFilePath: normalized, newFileName }
+    fsResult.value,
+    podScopedPath(space.sId, normalized),
+    newFileName
   );
-  if (renameResult.isErr()) {
-    return renameResult;
-  }
 
-  if (fileResources.length > 0) {
-    await fileResources[0].renameMountFile(
-      newFileName,
-      renameResult.value.newGcsPath
-    );
-  }
-
-  return new Ok(undefined);
+  return renameResult.isErr() ? new Err(renameResult.error) : new Ok(undefined);
 }
 
 /**


### PR DESCRIPTION
## Description

Serialize legacy Frame rename and revert with conversion, refetch the stable identity under the shared mutation lock, and reject legacy-ID mutations after conversion. Project single-file rename reuses the locked canonical path, while folder rename rejects directories containing Frames before any storage mutation.

Stack: #31691 -> this PR -> #31544.

## Tests

- stable-ID rename and revert regressions pass
- direct project-folder rename coverage proves storage remains untouched
- included in the final 134-test changed-front and 86-test changed-front-api suites
- Biome and diff checks pass

## Deploy Plan

Merge after #31691 and before #31544. Keep conversion unused and flag-disabled until #31544 has landed and the WorkOS `frame.converted` schema is registered.