### PR TITLE
Add free-seat lifetime rate-limiter

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -155,6 +155,7 @@ function memberFromUpgradeRequest(
     freeCreditEmptyAlert: null,
     creditState: "capped",
     nearLimit: false,
+    rateLimiterState: null,
     seatUsageTarget: null,
     overallUsageTarget: null,
   };

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -156,6 +156,8 @@ function memberFromUpgradeRequest(
     creditState: "capped",
     nearLimit: false,
     rateLimiterState: null,
+    // Synthesized from a capped user's upgrade request.
+    isSpendCapped: true,
     seatUsageTarget: null,
     overallUsageTarget: null,
   };

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -5,7 +5,10 @@ import { MemberConsumptionExportButton } from "@app/components/poke/credits/Memb
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { ResetFairUseButton } from "@app/components/poke/credits/ResetFairUseButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import type {
+  MemberUsageType,
+  RateLimiterState,
+} from "@app/lib/api/credits/members_usage";
 import { formatCredits, formatCreditsPrecise } from "@app/lib/client/credits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
@@ -132,6 +135,17 @@ const USER_CREDIT_STATE_CHIP_COLOR: Record<
   on_pool: "success",
   on_pool_low_balance: "warning",
   capped: "warning",
+};
+
+// The rate-limiter's verdict, rendered as a chip. Labels distinguish capped vs
+// near-limit (both warning-toned).
+const RATE_LIMITER_STATE_CHIP: Record<
+  RateLimiterState,
+  { color: "success" | "warning"; label: string }
+> = {
+  capped: { color: "warning", label: "capped" },
+  near_limit: { color: "warning", label: "near limit" },
+  ok: { color: "success", label: "ok" },
 };
 
 // Free seats hold a per-user credit with two balance alerts: "low" (≤20%) and
@@ -394,6 +408,19 @@ function makeColumns({
             />
           </span>
         );
+      },
+    },
+    {
+      accessorKey: "rateLimiterState",
+      header: "Rate limiter state",
+      enableSorting: false,
+      cell: ({ row }) => {
+        const { rateLimiterState } = row.original;
+        if (rateLimiterState === null) {
+          return <span>—</span>;
+        }
+        const { color, label } = RATE_LIMITER_STATE_CHIP[rateLimiterState];
+        return <Chip size="xs" color={color} label={label} />;
       },
     },
     {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -33,10 +33,7 @@ import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective"
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
-import type {
-  MembershipSeatType,
-  UserCreditState,
-} from "@app/types/memberships";
+import type { MembershipSeatType } from "@app/types/memberships";
 import {
   isPaidSeatType,
   SEAT_TYPE_ORDER,
@@ -113,7 +110,7 @@ type RowData = {
   isTotalAllowedUsagePending: boolean;
   isSeatChangePending: boolean;
   overallUsageTarget: CreditUsageTarget | null;
-  creditState: UserCreditState;
+  isSpendCapped: boolean;
   canUpgradeSeat: boolean;
   onOpenChangeSeatRecap: () => void;
   onOpenSpendLimitRecap: () => void;
@@ -851,13 +848,13 @@ const offPaceColumn: ColumnDef<RowData, string> = {
   cell: (info: Info) => {
     const {
       overallUsageTarget,
-      creditState,
+      isSpendCapped,
       canUpgradeSeat,
       onOpenChangeSeatRecap,
       onOpenSpendLimitRecap,
     } = info.row.original;
 
-    if (creditState === "capped") {
+    if (isSpendCapped) {
       if (!canUpgradeSeat) {
         return (
           <DataTable.CellContent className="justify-center">
@@ -1227,7 +1224,7 @@ export function MembersUsageTable({
           ),
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
           overallUsageTarget: m.overallUsageTarget,
-          creditState: m.creditState,
+          isSpendCapped: m.isSpendCapped,
           canUpgradeSeat: canUpgradeSeat(m),
           onOpenChangeSeatRecap: () => onOpenChangeSeatRecap(m),
           onOpenSpendLimitRecap: () => onOpenSpendLimitRecap(m),

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -208,17 +208,13 @@ export async function computeAndStoreAgentMessageCredits(
   // contract billing cycle).
   if (recordedCostDelta > 0) {
     if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
-      // Per-user cap.
+      // Per-user cap. Free and paid consumption are kept in separate counters:
+      // free seats accrue only against their lifetime counter, everyone else
+      // only against the per-cycle counter. Recording a free seat's usage into
+      // the per-cycle counter would leak it into their paid cap after a
+      // free→pro switch within the same cycle (mirrors the Metronome
+      // `free-<sId>` user-key split).
       if (user) {
-        await recordUserSpendLimitUsage(auth, {
-          user,
-          incrementBy: recordedCostDelta,
-          cycle: spendLimitCycleOverrideForAuth(auth),
-        });
-
-        // Free seats accrue against a lifetime counter (their enforced limiter)
-        // instead of the per-cycle cap. Their per-cycle counter above is
-        // recorded but never read.
         const membership =
           await MembershipResource.getActiveMembershipOfUserInWorkspace({
             user,
@@ -228,6 +224,12 @@ export async function computeAndStoreAgentMessageCredits(
           await recordFreeSeatLifetimeUsage(auth, {
             user,
             incrementBy: recordedCostDelta,
+          });
+        } else {
+          await recordUserSpendLimitUsage(auth, {
+            user,
+            incrementBy: recordedCostDelta,
+            cycle: spendLimitCycleOverrideForAuth(auth),
           });
         }
       }

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -5,7 +5,10 @@ import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant
 import { recordProgrammaticSpendLimitUsage } from "@app/lib/api/credits/programmatic_usage_limit";
 import { recordApiKeySpendLimitUsage } from "@app/lib/api/keys/spend_limit";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
-import { recordUserSpendLimitUsage } from "@app/lib/api/users/spend_limit";
+import {
+  recordFreeSeatLifetimeUsage,
+  recordUserSpendLimitUsage,
+} from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import {
@@ -15,6 +18,7 @@ import {
 import { getUsageType } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
@@ -211,6 +215,21 @@ export async function computeAndStoreAgentMessageCredits(
           incrementBy: recordedCostDelta,
           cycle: spendLimitCycleOverrideForAuth(auth),
         });
+
+        // Free seats accrue against a lifetime counter (their enforced limiter)
+        // instead of the per-cycle cap. Their per-cycle counter above is
+        // recorded but never read.
+        const membership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: auth.getNonNullableWorkspace(),
+          });
+        if (membership?.seatType === "free") {
+          await recordFreeSeatLifetimeUsage(auth, {
+            user,
+            incrementBy: recordedCostDelta,
+          });
+        }
       }
 
       // Per-API-key cap, for calls authenticated with an API key.

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -278,6 +278,31 @@ export const makeSpendLimitCycleWindowBounds = (
   };
 };
 
+// Fixed-window counter backing the free-seat *lifetime* spend allowance.
+// Distinct base key from the per-cycle spend-cap key above: free seats carry a
+// lifetime credit balance (not a per-cycle cap), so their counter never rolls
+// over. Paired with `makeSpendLimitLifetimeWindowBounds` (a stable, non-cycle
+// label), it is a single per-user key that accumulates for the seat's lifetime.
+export const makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser = (
+  owner: LightWorkspaceType,
+  user: UserType
+) => {
+  return `workspace:${owner.id}:user:${user.id}:free_seat_lifetime_awu_microcredit_count`;
+};
+
+// Never-rolling fixed-window bounds for the free-seat lifetime counter. The
+// label is stable (not cycle-derived) so the counter is a single lasting key,
+// and `windowEndMs` is far in the future so it never expires under the
+// PEXPIREAT grace. Mirror of `makeSpendLimitCycleWindowBounds` for the lifetime
+// dimension.
+const FREE_SEAT_LIFETIME_WINDOW_END_MS = Date.UTC(2100, 0, 1);
+export const makeSpendLimitLifetimeWindowBounds = (): FixedWindowBounds => {
+  return {
+    label: "lifetime",
+    windowEndMs: FREE_SEAT_LIFETIME_WINDOW_END_MS,
+  };
+};
+
 // Fixed-window counter backing the admin-configured per-API-key spend cap.
 // Keyed by the key model id (the calling key is active, and key names are
 // unique among active keys, so id and name are 1:1 here). Bucketed on the

--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -100,22 +100,18 @@ export async function isApiKeyBlocked(
 
 /**
  * Whether the user has consumed ≥ 80% of their per-user cap (soft warning). With
- * the rate-cap flag on, from the Redis fixed-window counter; with it off, from
- * the Metronome-driven near-limit flag. Free/none seats have no cycle cap for
- * the counter to model, so they always fall back to the Metronome near-limit
- * flag (driven by their lifetime credit-balance alert).
+ * the rate-cap flag on, entirely from the Redis fixed-window counters (per-cycle
+ * cap for pool seats, lifetime allowance for free seats) — no Metronome
+ * fallback. With the flag off, from the Metronome-driven near-limit flag.
  */
 export async function isUserAwuWarned(
   auth: Authenticator,
   { user }: { user: UserResource }
 ): Promise<boolean> {
-  const workspace = auth.getNonNullableWorkspace();
   if (await spendLimitRateCapEnabled(auth)) {
-    const rateWarned = await isUserSpendLimitRateWarningReached(auth, { user });
-    if (rateWarned !== null) {
-      return rateWarned;
-    }
+    return isUserSpendLimitRateWarningReached(auth, { user });
   }
+  const workspace = auth.getNonNullableWorkspace();
   return isUserAwuWarnedByMetronome(workspace.sId, user.sId);
 }
 

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -3,9 +3,11 @@ import {
   getPremiumModelMessageUsage,
   getPremiumModelMessageUsedCountsByUser,
   makeApiKeySpendLimitAwuCreditsRateLimitKey,
+  makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser,
   makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace,
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
   makeSpendLimitCycleWindowBounds,
+  makeSpendLimitLifetimeWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import {
@@ -2273,28 +2275,29 @@ export async function getMembersUsage({
     "enforce_user_spend_limit_rate_cap"
   );
 
-  // Bulk-fetch Metronome near-limit flags from Redis (poke-only). Still needed
-  // when the rate-cap flag is on: free/none seats have no cycle cap for the
-  // rate-limiter counter to model, so they fall back to this flag (driven by
-  // their lifetime credit-balance alert).
-  const nearLimitByUserId = includeAlertLinks
-    ? new Map(
-        await concurrentExecutor(
-          users,
-          async (u) =>
-            [
-              u.sId,
-              await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
-            ] as const,
-          { concurrency: 8 }
+  // Bulk-fetch Metronome near-limit flags from Redis (poke-only, and only when
+  // the rate-cap flag is off). With the flag on, near-limit is derived entirely
+  // from the rate-limiter counters below — no Metronome fallback.
+  const nearLimitByUserId =
+    includeAlertLinks && !spendCapEnabled
+      ? new Map(
+          await concurrentExecutor(
+            users,
+            async (u) =>
+              [
+                u.sId,
+                await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
+              ] as const,
+            { concurrency: 8 }
+          )
         )
-      )
-    : new Map<string, boolean>();
+      : new Map<string, boolean>();
 
   // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
-  // display beside the Elasticsearch-derived usage. The counter is bucketed on
-  // the current contract billing cycle — resolve the window once, then read each
-  // user's key. The same cycle also backs the per-member seat-usage pace below.
+  // display beside the Elasticsearch-derived usage. Free seats are enforced on a
+  // never-rolling *lifetime* counter (their lifetime credit allowance); everyone
+  // else on the per-contract-cycle counter. The cycle also backs the per-member
+  // seat-usage pace below, so resolve it regardless.
   const rateLimiterSpendByUserId = new Map<string, number>();
   let billingCycle: BillingCycle | null = null;
   if (includeAlertLinks) {
@@ -2303,32 +2306,41 @@ export async function getMembersUsage({
     );
     if (periodResult.isOk() && periodResult.value) {
       billingCycle = periodResult.value;
-      const bounds = makeSpendLimitCycleWindowBounds(
-        periodResult.value.cycleStart,
-        periodResult.value.cycleEnd
-      );
-      const entries = await concurrentExecutor(
-        users,
-        async (u) => {
-          const result = await getFixedWindowCount({
-            key: makeSpendLimitAwuCreditsRateLimitKeyForUser(
+    }
+    const cycleBounds = billingCycle
+      ? makeSpendLimitCycleWindowBounds(
+          billingCycle.cycleStart,
+          billingCycle.cycleEnd
+        )
+      : null;
+    const lifetimeBounds = makeSpendLimitLifetimeWindowBounds();
+    const entries = await concurrentExecutor(
+      users,
+      async (u) => {
+        const isFreeSeat = membershipByUserId.get(u.id)?.seatType === "free";
+        const key = isFreeSeat
+          ? makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
               workspace,
               u.toJSON()
-            ),
-            bounds,
-          });
-          // The counter stores microCredits; convert back to credits so it
-          // lines up with the ES/MT figures (all in credits).
-          return [
-            u.sId,
-            result.isOk() ? microCreditsToCredits(result.value) : 0,
-          ] as const;
-        },
-        { concurrency: 8 }
-      );
-      for (const [sId, value] of entries) {
-        rateLimiterSpendByUserId.set(sId, value);
-      }
+            )
+          : makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, u.toJSON());
+        const bounds = isFreeSeat ? lifetimeBounds : cycleBounds;
+        if (!bounds) {
+          // Non-free seat with no resolvable contract cycle: nothing to read.
+          return [u.sId, 0] as const;
+        }
+        const result = await getFixedWindowCount({ key, bounds });
+        // The counter stores microCredits; convert back to credits so it
+        // lines up with the ES/MT figures (all in credits).
+        return [
+          u.sId,
+          result.isOk() ? microCreditsToCredits(result.value) : 0,
+        ] as const;
+      },
+      { concurrency: 8 }
+    );
+    for (const [sId, value] of entries) {
+      rateLimiterSpendByUserId.set(sId, value);
     }
   }
 
@@ -2504,10 +2516,15 @@ export async function getMembersUsage({
         : spendLimitSource === "default" && normalizedSeatType
           ? (defaultCapAlertsBySeatType[normalizedSeatType] ?? null)
           : null;
-    const spendLimitAlertId = includeAlertLinks
+    // With the rate-cap flag on, the per-user cap / 80%-warning and free-seat
+    // balance Metronome alerts no longer drive enforcement (the Redis rate
+    // limiter does), so their poke badges/deep-links are dropped to avoid
+    // showing signals that are no longer authoritative.
+    const showMetronomeAlerts = includeAlertLinks && !spendCapEnabled;
+    const spendLimitAlertId = showMetronomeAlerts
       ? (effectiveCapAlert?.alertId ?? null)
       : null;
-    const spendLimitWarningAlertId = includeAlertLinks
+    const spendLimitWarningAlertId = showMetronomeAlerts
       ? (effectiveCapAlert?.warningAlertId ?? null)
       : null;
 
@@ -2515,26 +2532,31 @@ export async function getMembersUsage({
     // these per-user credit-balance alerts. Alerts are keyed by the
     // free-prefixed Metronome user id.
     const freeCreditAlerts =
-      membership.seatType === "free"
+      showMetronomeAlerts && membership.seatType === "free"
         ? (freeCreditAlertIds?.get(metronomeUserId) ?? null)
         : null;
 
     const rateLimiterSpendAwuCredits = includeAlertLinks
       ? (rateLimiterSpendByUserId.get(userId) ?? 0)
       : null;
-    // Poke-only near-limit. With the rate-cap flag on, use the rate-limiter
-    // counter ≥ 80% of the effective cap — but only for seats that actually
-    // have a cycle cap. Free/none seats (no effective cap) have no counter to
-    // model their lifetime balance, so they fall back to the Metronome
-    // near-limit flag, same as when the flag is off.
-    const hasCycleCap =
-      effectiveSpendLimitAwuCredits !== null &&
-      effectiveSpendLimitAwuCredits > 0;
+    // Poke-only near-limit. With the rate-cap flag on, mirror enforcement: the
+    // rate-limiter counter ≥ 80% of the threshold the seat is capped against —
+    // the free-seat *lifetime* allowance for free seats, the effective per-cycle
+    // cap otherwise. `rateLimiterSpendAwuCredits` already holds the matching
+    // counter (lifetime for free seats, per-cycle otherwise). When no rate-cap
+    // threshold applies (no cap) it reads `false`; with the flag off it uses the
+    // Metronome near-limit flag. No Metronome fallback under the flag.
+    const rateCapThresholdAwuCredits =
+      membership.seatType === "free"
+        ? freeStartingBalanceAwu
+        : effectiveSpendLimitAwuCredits;
     const nearLimit =
       includeAlertLinks &&
-      (spendCapEnabled && hasCycleCap
+      (spendCapEnabled &&
+      rateCapThresholdAwuCredits !== null &&
+      rateCapThresholdAwuCredits > 0
         ? (rateLimiterSpendAwuCredits ?? 0) >=
-          USER_AWU_WARNING_PERCENTAGE * effectiveSpendLimitAwuCredits
+          USER_AWU_WARNING_PERCENTAGE * rateCapThresholdAwuCredits
         : (nearLimitByUserId.get(userId) ?? false));
 
     // Seat-allowance consumption used for pace classification below: free

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1190,19 +1190,10 @@ export async function fetchRemainingCapCreditsPercentageForUser({
  */
 export async function getEffectiveSpendCapAwuCreditsForUser(
   auth: Authenticator,
-  { user }: { user: UserResource }
+  { user, membership }: { user: UserResource; membership: MembershipResource }
 ): Promise<number | null> {
   const workspace = auth.getNonNullableWorkspace();
   const { metronomeCustomerId } = workspace;
-
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace,
-    });
-  if (!membership) {
-    return null;
-  }
 
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
@@ -1442,6 +1433,59 @@ export async function resyncProgrammaticSpendLimitCounterFromEsUsage(
   return new Ok({ programmaticCounterSeeded: setResult.isOk() });
 }
 
+/**
+ * Reads a single user's Redis fixed-window spend-cap counter and returns whether
+ * it has reached the given threshold. Free seats read the never-rolling lifetime
+ * counter; everyone else the per-contract-cycle counter. Returns `false` (not
+ * capped) when no threshold applies, the billing cycle can't be resolved, or on
+ * a Redis read error — matching the fail-open enforcement in
+ * `lib/api/users/spend_limit.ts` (no Metronome fallback under the flag).
+ */
+async function isUserRateLimiterSpendCapped(
+  auth: Authenticator,
+  {
+    user,
+    isFreeSeat,
+    thresholdAwuCredits,
+    billingCycle,
+  }: {
+    user: UserResource;
+    isFreeSeat: boolean;
+    thresholdAwuCredits: number | null;
+    billingCycle: BillingCycle | null;
+  }
+): Promise<boolean> {
+  if (thresholdAwuCredits === null || thresholdAwuCredits <= 0) {
+    return false;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const bounds = isFreeSeat
+    ? makeSpendLimitLifetimeWindowBounds()
+    : billingCycle
+      ? makeSpendLimitCycleWindowBounds(
+          billingCycle.cycleStart,
+          billingCycle.cycleEnd
+        )
+      : null;
+  if (!bounds) {
+    return false;
+  }
+
+  const key = isFreeSeat
+    ? makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
+        workspace,
+        user.toJSON()
+      )
+    : makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON());
+  const result = await getFixedWindowCount({ key, bounds });
+  if (result.isErr()) {
+    return false;
+  }
+
+  return microCreditsToCredits(result.value) >= thresholdAwuCredits;
+}
+
 export type GetMemberUsageResponseBody = {
   member: MemberUsageType | null;
   // Optional for backward compatibility with clients deployed before target
@@ -1633,6 +1677,26 @@ export async function getMemberUsage({
     defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
+  // Flag-aware per-user cap verdict, consistent with the members table and with
+  // enforcement in lib/api/credits/access_control.ts: under the flag, read the
+  // Redis rate-limiter counter (lifetime allowance for free seats, per-cycle cap
+  // otherwise) with no Metronome fallback; with it off, the persisted Metronome
+  // credit state.
+  const spendCapEnabled = (await getFeatureFlags(auth)).includes(
+    "enforce_user_spend_limit_rate_cap"
+  );
+  const isSpendCapped = spendCapEnabled
+    ? await isUserRateLimiterSpendCapped(auth, {
+        user: userResource,
+        isFreeSeat: membership.seatType === "free",
+        thresholdAwuCredits:
+          membership.seatType === "free"
+            ? freeSeatAllowanceAwu
+            : spendLimitAwuCredits,
+        billingCycle,
+      })
+    : membership.creditState === "capped";
+
   const member: MemberUsageType = {
     sId: userId,
     name: userResource.fullName() || userResource.name,
@@ -1667,9 +1731,7 @@ export async function getMemberUsage({
     creditState: membership.creditState,
     nearLimit: false,
     rateLimiterState: null,
-    // Single-member path (my-usage): no rate-limiter read here, so fall back to
-    // the persisted credit state. Not consumed by the poke Unblock action.
-    isSpendCapped: membership.creditState === "capped",
+    isSpendCapped,
     seatUsageTarget: null,
     overallUsageTarget: null,
   };

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -99,6 +99,10 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import { z } from "zod";
 
+// The rate-limiter's spend-cap verdict for a member (poke debugging): the
+// synchronous counter vs the seat's cap threshold.
+export type RateLimiterState = "capped" | "near_limit" | "ok";
+
 export type MemberUsageType = {
   sId: string;
   name: string;
@@ -170,10 +174,16 @@ export type MemberUsageType = {
   // Per-user credit state machine state (personal-credits → pool → capped
   // progression) persisted on the membership. Surfaced for debugging.
   creditState: UserCreditState;
-  // Whether the user has consumed ≥ 80% of their effective limit. With the
-  // rate-cap flag on, derived from the Redis rate-limiter counter; with it off,
-  // from the Metronome nearLimit flag (see user_block.ts). Poke-only.
+  // Whether the user has consumed ≥ 80% of their effective limit, per the
+  // Metronome near-limit flag (see user_block.ts). Shown in the "Credit state"
+  // column. Poke-only. See `rateLimiterState` for the rate-limiter view.
   nearLimit: boolean;
+  // The rate-limiter's view of the user's spend cap (independent of the flag):
+  // "capped" (counter ≥ cap), "near_limit" (≥ 80%), or "ok". The counter is the
+  // lifetime one for free seats and the per-cycle one otherwise, compared to the
+  // free-seat allowance / effective cycle cap. Null when no cap applies or not
+  // requested. Poke-only.
+  rateLimiterState: RateLimiterState | null;
   // Classifies seat-allowance consumption against how far the billing cycle
   // has elapsed: "elevated"/"critical" mean the member is burning through
   // their seat allowance faster than a linear pace would predict. Poke-only
@@ -1648,6 +1658,7 @@ export async function getMemberUsage({
     freeCreditEmptyAlert: null,
     creditState: membership.creditState,
     nearLimit: false,
+    rateLimiterState: null,
     seatUsageTarget: null,
     overallUsageTarget: null,
   };
@@ -2275,23 +2286,22 @@ export async function getMembersUsage({
     "enforce_user_spend_limit_rate_cap"
   );
 
-  // Bulk-fetch Metronome near-limit flags from Redis (poke-only, and only when
-  // the rate-cap flag is off). With the flag on, near-limit is derived entirely
-  // from the rate-limiter counters below — no Metronome fallback.
-  const nearLimitByUserId =
-    includeAlertLinks && !spendCapEnabled
-      ? new Map(
-          await concurrentExecutor(
-            users,
-            async (u) =>
-              [
-                u.sId,
-                await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
-              ] as const,
-            { concurrency: 8 }
-          )
+  // Bulk-fetch Metronome near-limit flags from Redis (poke-only). This backs the
+  // "near limit" chip in the Metronome "Credit state" column; the rate-limiter's
+  // own verdict is surfaced separately as `rateLimiterState`.
+  const nearLimitByUserId = includeAlertLinks
+    ? new Map(
+        await concurrentExecutor(
+          users,
+          async (u) =>
+            [
+              u.sId,
+              await isUserAwuWarnedByMetronome(workspace.sId, u.sId),
+            ] as const,
+          { concurrency: 8 }
         )
-      : new Map<string, boolean>();
+      )
+    : new Map<string, boolean>();
 
   // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
   // display beside the Elasticsearch-derived usage. Free seats are enforced on a
@@ -2539,25 +2549,34 @@ export async function getMembersUsage({
     const rateLimiterSpendAwuCredits = includeAlertLinks
       ? (rateLimiterSpendByUserId.get(userId) ?? 0)
       : null;
-    // Poke-only near-limit. With the rate-cap flag on, mirror enforcement: the
-    // rate-limiter counter ≥ 80% of the threshold the seat is capped against —
-    // the free-seat *lifetime* allowance for free seats, the effective per-cycle
-    // cap otherwise. `rateLimiterSpendAwuCredits` already holds the matching
-    // counter (lifetime for free seats, per-cycle otherwise). When no rate-cap
-    // threshold applies (no cap) it reads `false`; with the flag off it uses the
-    // Metronome near-limit flag. No Metronome fallback under the flag.
+    // Poke-only near-limit for the Metronome "Credit state" column, from the
+    // Metronome near-limit flag.
+    const nearLimit =
+      includeAlertLinks && (nearLimitByUserId.get(userId) ?? false);
+
+    // Poke-only rate-limiter verdict (independent of the flag): the counter vs
+    // the threshold the seat is capped against — the free-seat lifetime
+    // allowance for free seats, the effective per-cycle cap otherwise.
+    // `rateLimiterSpendAwuCredits` already holds the matching counter (lifetime
+    // for free seats, per-cycle otherwise). Null when no cap applies.
     const rateCapThresholdAwuCredits =
       membership.seatType === "free"
         ? freeStartingBalanceAwu
         : effectiveSpendLimitAwuCredits;
-    const nearLimit =
+    let rateLimiterState: RateLimiterState | null = null;
+    if (
       includeAlertLinks &&
-      (spendCapEnabled &&
       rateCapThresholdAwuCredits !== null &&
       rateCapThresholdAwuCredits > 0
-        ? (rateLimiterSpendAwuCredits ?? 0) >=
-          USER_AWU_WARNING_PERCENTAGE * rateCapThresholdAwuCredits
-        : (nearLimitByUserId.get(userId) ?? false));
+    ) {
+      const spend = rateLimiterSpendAwuCredits ?? 0;
+      rateLimiterState =
+        spend >= rateCapThresholdAwuCredits
+          ? "capped"
+          : spend >= USER_AWU_WARNING_PERCENTAGE * rateCapThresholdAwuCredits
+            ? "near_limit"
+            : "ok";
+    }
 
     // Seat-allowance consumption used for pace classification below: free
     // seats track their live Metronome balance instead of the period spend
@@ -2642,6 +2661,7 @@ export async function getMembersUsage({
         freeCreditEmptyAlert: freeCreditAlerts?.empty ?? null,
         creditState: membership.creditState,
         nearLimit,
+        rateLimiterState,
         fairUse: fairUseByUserId.get(userId) ?? null,
         premiumMessageUsage: premiumMessageUsageByUserId.get(userId) ?? null,
         seatUsageTarget,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -59,7 +59,10 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
+import {
+  lifetimeSpendCycleUtc,
+  spendLimitCycleOverrideForAuth,
+} from "@app/lib/spend_limits/cycle";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
 import {
   resolveEffectiveSpendLimitAwuCredits,
@@ -1253,7 +1256,11 @@ export async function getEffectiveSpendCapAwuCreditsForUser(
  *
  * Resyncs whichever cycle the workspace is bucketed on — the Metronome contract
  * billing period, or the UTC calendar month for workspaces without a contract —
- * so it writes the same Redis keys enforcement reads.
+ * so it writes the same Redis keys enforcement reads. Free seats are enforced on
+ * a never-rolling lifetime counter instead: for them it seeds the free-seat
+ * lifetime key from all-time `is_free_seat` consumption and zeroes the per-cycle
+ * key (and vice-versa for paid seats), so a seat that changed type is never left
+ * capped on a stale counter.
  */
 export async function resyncSpendLimitCountersFromEsUsage(
   auth: Authenticator
@@ -1268,10 +1275,11 @@ export async function resyncSpendLimitCountersFromEsUsage(
       new Error("No active Metronome billing period to resync against.")
     );
   }
-  const bounds = makeSpendLimitCycleWindowBounds(
+  const cycleBounds = makeSpendLimitCycleWindowBounds(
     cycle.cycleStart,
     cycle.cycleEnd
   );
+  const lifetimeBounds = makeSpendLimitLifetimeWindowBounds();
 
   const { memberships } = await MembershipResource.getActiveMemberships({
     workspace,
@@ -1285,19 +1293,34 @@ export async function resyncSpendLimitCountersFromEsUsage(
   );
   const userByModelId = new Map(users.map((u) => [u.id, u]));
 
-  // Read the same Elasticsearch-derived consumption the members table shows as
-  // "Consumed (ES)": keyed by user sId, with the free/paid split applied per
-  // seat. This is the source of truth we overwrite the counter with.
-  const freeSeatUserIds = memberships.flatMap((m) => {
+  // Free and paid seats are enforced on different Redis counters over different
+  // windows: free seats on a never-rolling *lifetime* counter (their all-time
+  // `is_free_seat` consumption against a lifetime credit allowance), everyone
+  // else on the per-cycle counter. Read each side over its own window so we seed
+  // the exact key/value enforcement reads (mirroring `isUserRateLimiterSpendCapped`
+  // and the members-table read).
+  const freeUserIds = memberships.flatMap((m) => {
     const u = userByModelId.get(m.userId);
     return u && m.seatType === "free" ? [u.sId] : [];
   });
-  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
-    workspace,
-    userIds: users.map((u) => u.sId),
-    freeSeatUserIds,
-    cycle,
+  const paidUserIds = memberships.flatMap((m) => {
+    const u = userByModelId.get(m.userId);
+    return u && m.seatType !== "free" ? [u.sId] : [];
   });
+  const [cycleConsumedByUserId, lifetimeConsumedByUserId] = await Promise.all([
+    fetchConsumedAwuCreditsByUserId({
+      workspace,
+      userIds: paidUserIds,
+      freeSeatUserIds: [],
+      cycle,
+    }),
+    fetchConsumedAwuCreditsByUserId({
+      workspace,
+      userIds: freeUserIds,
+      freeSeatUserIds: freeUserIds,
+      cycle: lifetimeSpendCycleUtc(),
+    }),
+  ]);
 
   const results = await concurrentExecutor(
     memberships,
@@ -1306,17 +1329,36 @@ export async function resyncSpendLimitCountersFromEsUsage(
       if (!user) {
         return false;
       }
-      const consumed = consumedByUserId.get(user.sId) ?? 0;
-      const setResult = await setFixedWindowCount({
-        key: makeSpendLimitAwuCreditsRateLimitKeyForUser(
-          workspace,
-          user.toJSON()
-        ),
-        bounds,
+      const isFreeSeat = membership.seatType === "free";
+      const consumed = isFreeSeat
+        ? (lifetimeConsumedByUserId.get(user.sId) ?? 0)
+        : (cycleConsumedByUserId.get(user.sId) ?? 0);
+
+      const cycleKey = makeSpendLimitAwuCreditsRateLimitKeyForUser(
+        workspace,
+        user.toJSON()
+      );
+      const lifetimeKey = makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
+        workspace,
+        user.toJSON()
+      );
+
+      // Seed the counter enforcement reads for this seat, and zero the other one
+      // so a seat that changed type since the last resync can't stay capped on a
+      // stale counter enforcement no longer reads for it.
+      const seedResult = await setFixedWindowCount({
+        key: isFreeSeat ? lifetimeKey : cycleKey,
+        bounds: isFreeSeat ? lifetimeBounds : cycleBounds,
         value: Math.max(0, roundCreditsToMicroCredits(consumed)),
         logger,
       });
-      return setResult.isOk();
+      const clearResult = await setFixedWindowCount({
+        key: isFreeSeat ? cycleKey : lifetimeKey,
+        bounds: isFreeSeat ? cycleBounds : lifetimeBounds,
+        value: 0,
+        logger,
+      });
+      return seedResult.isOk() && clearResult.isOk();
     },
     { concurrency: 8 }
   );

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -184,6 +184,14 @@ export type MemberUsageType = {
   // free-seat allowance / effective cycle cap. Null when no cap applies or not
   // requested. Poke-only.
   rateLimiterState: RateLimiterState | null;
+  // Flag-aware "blocked by the per-user spend cap" verdict — the signal the poke
+  // Unblock action keys off. With the rate-cap flag on, from the rate-limiter
+  // counter (`rateLimiterState`); with it off, from the persisted Metronome
+  // credit state. Mirrors the enforcement switch in
+  // lib/api/credits/access_control.ts, so it never disagrees with what actually
+  // blocks. The single-member / synthetic construction paths (which don't read
+  // the rate-limiter) fall back to the persisted credit state.
+  isSpendCapped: boolean;
   // Classifies seat-allowance consumption against how far the billing cycle
   // has elapsed: "elevated"/"critical" mean the member is burning through
   // their seat allowance faster than a linear pace would predict. Poke-only
@@ -1659,6 +1667,9 @@ export async function getMemberUsage({
     creditState: membership.creditState,
     nearLimit: false,
     rateLimiterState: null,
+    // Single-member path (my-usage): no rate-limiter read here, so fall back to
+    // the persisted credit state. Not consumed by the poke Unblock action.
+    isSpendCapped: membership.creditState === "capped",
     seatUsageTarget: null,
     overallUsageTarget: null,
   };
@@ -2578,6 +2589,13 @@ export async function getMembersUsage({
             : "ok";
     }
 
+    // Flag-aware per-user cap verdict for the poke Unblock action: the
+    // rate-limiter counter under the flag, the Metronome credit state otherwise
+    // (mirrors the enforcement switch in lib/api/credits/access_control.ts).
+    const isSpendCapped = spendCapEnabled
+      ? rateLimiterState === "capped"
+      : membership.creditState === "capped";
+
     // Seat-allowance consumption used for pace classification below: free
     // seats track their live Metronome balance instead of the period spend
     // (same distinction the seat-usage ring draws client-side). A missing
@@ -2662,6 +2680,7 @@ export async function getMembersUsage({
         creditState: membership.creditState,
         nearLimit,
         rateLimiterState,
+        isSpendCapped,
         fairUse: fairUseByUserId.get(userId) ?? null,
         premiumMessageUsage: premiumMessageUsageByUserId.get(userId) ?? null,
         seatUsageTarget,

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -1,6 +1,8 @@
 import {
+  makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser,
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
   makeSpendLimitCycleWindowBounds,
+  makeSpendLimitLifetimeWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
 import {
   buildAuditLogTarget,
@@ -25,12 +27,15 @@ import {
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
+import { getCachedCustomerPerUserCreditBalances } from "@app/lib/metronome/client";
+import { CONTRACT_CREDIT_TYPE_FREE_SEAT } from "@app/lib/metronome/constants";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   currentCalendarMonthCycleUtc,
+  lifetimeSpendCycleUtc,
   resolveSpendLimitCycleBounds,
 } from "@app/lib/spend_limits/cycle";
 import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
@@ -561,18 +566,24 @@ async function isSpendCapCounterReached(
     thresholdAwuCredits,
     bounds,
     cycle,
+    key,
   }: {
     user: UserResource;
     thresholdAwuCredits: number;
     bounds: FixedWindowBounds;
     cycle?: BillingCycle;
+    // The Redis counter key. Defaults to the per-cycle spend-cap key; the
+    // free-seat lifetime path passes its own key.
+    key?: string;
   }
 ): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
 
   const count = await readSpendLimitCountWithLazySeed(auth, {
     user,
-    key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
+    key:
+      key ??
+      makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
     bounds,
     cycle,
   });
@@ -598,11 +609,12 @@ async function isSpendCapCounterReached(
  * uses. Runs alongside the Metronome per-user cap (`isUserBlocked`) as a faster,
  * independent backup.
  *
- * Returns `null` when the user has no cycle spend cap at all (e.g. free/none
- * seats, whose lifetime credit balance is not modeled by this cycle counter) —
- * the caller must fall back to the Metronome credit state for those. Returns
- * `false` (does not block) when the billing period can't be resolved or on a
- * Redis read error (fail-open).
+ * Free/none seats have no cycle cap; free seats instead enforce their lifetime
+ * credit allowance via `isFreeSeatLifetimeCapReached`. Returns `null` only when
+ * no rate-limiter cap applies at all (none seats, or free seats with no
+ * resolvable allowance) — the caller must fall back to the Metronome credit
+ * state for those. Returns `false` (does not block) when the billing period
+ * can't be resolved or on a Redis read error (fail-open).
  */
 export async function isUserSpendLimitRateCapReached(
   auth: Authenticator,
@@ -612,7 +624,7 @@ export async function isUserSpendLimitRateCapReached(
 
   const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
   if (threshold === null) {
-    return null;
+    return isFreeSeatLifetimeCapReached(auth, { user });
   }
 
   const bounds = await resolveSpendLimitCycleBounds(workspace);
@@ -635,10 +647,11 @@ export async function isUserSpendLimitRateCapReached(
  * is the rate-limiter counterpart of the Metronome-driven `isUserAwuWarned`
  * flag.
  *
- * Returns `null` when the user has no cycle spend cap at all (e.g. free/none
- * seats — the caller must fall back to the Metronome near-limit flag). Returns
- * `false` when the billing period can't be resolved or on a Redis read error
- * (fail-open).
+ * Free/none seats have no cycle cap; free seats instead warn on their lifetime
+ * credit allowance via `isFreeSeatLifetimeWarningReached`. Returns `null` only
+ * when no rate-limiter cap applies at all — the caller falls back to the
+ * Metronome near-limit flag. Returns `false` when the billing period can't be
+ * resolved or on a Redis read error (fail-open).
  */
 export async function isUserSpendLimitRateWarningReached(
   auth: Authenticator,
@@ -648,7 +661,7 @@ export async function isUserSpendLimitRateWarningReached(
 
   const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
   if (threshold === null) {
-    return null;
+    return isFreeSeatLifetimeWarningReached(auth, { user });
   }
 
   const bounds = await resolveSpendLimitCycleBounds(workspace);
@@ -660,6 +673,99 @@ export async function isUserSpendLimitRateWarningReached(
     user,
     thresholdAwuCredits: threshold * USER_AWU_WARNING_PERCENTAGE,
     bounds,
+  });
+}
+
+/**
+ * Resolves a free seat's lifetime credit allowance (AWU credits) from the
+ * cached Metronome per-user free-seat credit — the admin-editable, per-user,
+ * contract-surviving grant (`startingBalanceAwu`). This is the enforced
+ * threshold for the free-seat lifetime counter.
+ *
+ * Returns `null` when the workspace isn't Metronome-billed, the cached read
+ * fails, or the user has no positive free-seat grant (e.g. "none" seats, or a
+ * misconfigured 0 grant) — callers treat `null` as "not free-seat-governed" and
+ * fall back to the Metronome credit state.
+ */
+async function getFreeSeatLifetimeAllowanceAwuCredits(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<number | null> {
+  const { metronomeCustomerId } = auth.getNonNullableWorkspace();
+  if (!metronomeCustomerId) {
+    return null;
+  }
+
+  const balances = await getCachedCustomerPerUserCreditBalances({
+    metronomeCustomerId,
+    contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  });
+  if (balances.isErr()) {
+    return null;
+  }
+
+  const allowance = balances.value.get(user.sId)?.startingBalanceAwu ?? 0;
+  return allowance > 0 ? allowance : null;
+}
+
+/**
+ * Synchronous enforcement of a free seat's *lifetime* credit allowance from the
+ * Redis fixed-window counter. Unlike the per-cycle cap, the window never rolls:
+ * the counter accumulates the seat's lifetime AWU (seeded from all-time
+ * `is_free_seat` consumption) and the threshold is the per-user Metronome grant.
+ * Returns `null` when the user has no free-seat allowance (caller falls back to
+ * the Metronome credit state); `false` on a Redis read error (fail-open).
+ */
+export async function isFreeSeatLifetimeCapReached(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<boolean | null> {
+  const allowance = await getFreeSeatLifetimeAllowanceAwuCredits(auth, {
+    user,
+  });
+  if (allowance === null) {
+    return null;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  return isSpendCapCounterReached(auth, {
+    user,
+    thresholdAwuCredits: allowance,
+    bounds: makeSpendLimitLifetimeWindowBounds(),
+    cycle: lifetimeSpendCycleUtc(),
+    key: makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
+      workspace,
+      user.toJSON()
+    ),
+  });
+}
+
+/**
+ * "Near limit" (warning) counterpart of `isFreeSeatLifetimeCapReached`: the
+ * lifetime counter against `USER_AWU_WARNING_PERCENTAGE` (80%) of the free-seat
+ * allowance. Returns `null` when the user has no free-seat allowance.
+ */
+export async function isFreeSeatLifetimeWarningReached(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<boolean | null> {
+  const allowance = await getFreeSeatLifetimeAllowanceAwuCredits(auth, {
+    user,
+  });
+  if (allowance === null) {
+    return null;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  return isSpendCapCounterReached(auth, {
+    user,
+    thresholdAwuCredits: allowance * USER_AWU_WARNING_PERCENTAGE,
+    bounds: makeSpendLimitLifetimeWindowBounds(),
+    cycle: lifetimeSpendCycleUtc(),
+    key: makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
+      workspace,
+      user.toJSON()
+    ),
   });
 }
 
@@ -746,6 +852,41 @@ export async function recordUserSpendLimitUsage(
     key,
     bounds,
     incrementBy: incrementByMicroCredits,
+    logger,
+  });
+}
+
+/**
+ * Adds `incrementBy` AWU credits to a free seat's *lifetime* fixed-window
+ * counter — the one enforced by `isFreeSeatLifetimeCapReached`. Same
+ * seed-then-increment pattern as `recordUserSpendLimitUsage`, but bucketed on
+ * the never-rolling lifetime window (seeded from all-time `is_free_seat`
+ * consumption). Only call this for free-seat users; the caller resolves the seat
+ * type.
+ */
+export async function recordFreeSeatLifetimeUsage(
+  auth: Authenticator,
+  { user, incrementBy }: { user: UserResource; incrementBy: number }
+): Promise<void> {
+  if (!Number.isFinite(incrementBy) || incrementBy <= 0) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const bounds = makeSpendLimitLifetimeWindowBounds();
+  const cycle = lifetimeSpendCycleUtc();
+  const key = makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
+    workspace,
+    user.toJSON()
+  );
+
+  // Seed from all-time free-seat ES consumption on the counter's first touch.
+  await readSpendLimitCountWithLazySeed(auth, { user, key, bounds, cycle });
+
+  await addFixedWindowCount({
+    key,
+    bounds,
+    incrementBy: roundCreditsToMicroCredits(incrementBy),
     logger,
   });
 }

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -621,9 +621,27 @@ export async function isUserSpendLimitRateCapReached(
 ): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
-  if (threshold === null) {
+  // Free seats have no per-cycle cap; they enforce their lifetime credit
+  // allowance instead. Branch on the actual seat type rather than inferring it
+  // from a null effective cap.
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return false;
+  }
+  if (membership.seatType === "free") {
     return isFreeSeatLifetimeCapReached(auth, { user });
+  }
+
+  const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, {
+    user,
+    membership,
+  });
+  if (threshold === null) {
+    return false;
   }
 
   const bounds = await resolveSpendLimitCycleBounds(workspace);
@@ -657,9 +675,26 @@ export async function isUserSpendLimitRateWarningReached(
 ): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
-  if (threshold === null) {
+  // Free seats warn on their lifetime credit allowance, not a per-cycle cap.
+  // Branch on the actual seat type rather than inferring it from a null cap.
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return false;
+  }
+  if (membership.seatType === "free") {
     return isFreeSeatLifetimeWarningReached(auth, { user });
+  }
+
+  const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, {
+    user,
+    membership,
+  });
+  if (threshold === null) {
+    return false;
   }
 
   const bounds = await resolveSpendLimitCycleBounds(workspace);

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -609,17 +609,16 @@ async function isSpendCapCounterReached(
  * uses. Runs alongside the Metronome per-user cap (`isUserBlocked`) as a faster,
  * independent backup.
  *
- * Free/none seats have no cycle cap; free seats instead enforce their lifetime
- * credit allowance via `isFreeSeatLifetimeCapReached`. Returns `null` only when
- * no rate-limiter cap applies at all (none seats, or free seats with no
- * resolvable allowance) — the caller must fall back to the Metronome credit
- * state for those. Returns `false` (does not block) when the billing period
- * can't be resolved or on a Redis read error (fail-open).
+ * Free seats have no cycle cap; they enforce their lifetime credit allowance via
+ * `isFreeSeatLifetimeCapReached` instead. Under the flag there is no Metronome
+ * credit-state fallback: this always returns a boolean. `false` when no cap
+ * applies (no cycle cap and no free-seat allowance), the billing period can't be
+ * resolved, or on a Redis read error (fail-open).
  */
 export async function isUserSpendLimitRateCapReached(
   auth: Authenticator,
   { user }: { user: UserResource }
-): Promise<boolean | null> {
+): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
 
   const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
@@ -647,16 +646,15 @@ export async function isUserSpendLimitRateCapReached(
  * is the rate-limiter counterpart of the Metronome-driven `isUserAwuWarned`
  * flag.
  *
- * Free/none seats have no cycle cap; free seats instead warn on their lifetime
- * credit allowance via `isFreeSeatLifetimeWarningReached`. Returns `null` only
- * when no rate-limiter cap applies at all — the caller falls back to the
- * Metronome near-limit flag. Returns `false` when the billing period can't be
- * resolved or on a Redis read error (fail-open).
+ * Free seats warn on their lifetime credit allowance via
+ * `isFreeSeatLifetimeWarningReached` instead. Under the flag there is no
+ * Metronome near-limit fallback: this always returns a boolean (`false` when no
+ * cap applies, the billing period can't be resolved, or on a Redis read error).
  */
 export async function isUserSpendLimitRateWarningReached(
   auth: Authenticator,
   { user }: { user: UserResource }
-): Promise<boolean | null> {
+): Promise<boolean> {
   const workspace = auth.getNonNullableWorkspace();
 
   const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
@@ -684,8 +682,9 @@ export async function isUserSpendLimitRateWarningReached(
  *
  * Returns `null` when the workspace isn't Metronome-billed, the cached read
  * fails, or the user has no positive free-seat grant (e.g. "none" seats, or a
- * misconfigured 0 grant) — callers treat `null` as "not free-seat-governed" and
- * fall back to the Metronome credit state.
+ * misconfigured 0 grant). For an actual free seat the grant should always
+ * resolve; a `null` there is a transient read failure and callers fail open (no
+ * Metronome fallback under the flag).
  */
 async function getFreeSeatLifetimeAllowanceAwuCredits(
   auth: Authenticator,
@@ -713,21 +712,26 @@ async function getFreeSeatLifetimeAllowanceAwuCredits(
  * Redis fixed-window counter. Unlike the per-cycle cap, the window never rolls:
  * the counter accumulates the seat's lifetime AWU (seeded from all-time
  * `is_free_seat` consumption) and the threshold is the per-user Metronome grant.
- * Returns `null` when the user has no free-seat allowance (caller falls back to
- * the Metronome credit state); `false` on a Redis read error (fail-open).
+ * Returns `false` (does not block, fail-open) when the user has no free-seat
+ * allowance (a non-free seat, or a transient allowance-read failure) or on a
+ * Redis read error — there is no Metronome credit-state fallback under the flag.
  */
 export async function isFreeSeatLifetimeCapReached(
   auth: Authenticator,
   { user }: { user: UserResource }
-): Promise<boolean | null> {
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
   const allowance = await getFreeSeatLifetimeAllowanceAwuCredits(auth, {
     user,
   });
   if (allowance === null) {
-    return null;
+    logger.error(
+      { workspaceId: workspace.sId, userId: user.sId },
+      "[FreeSeatLifetime] cap: no free-seat allowance resolved; failing open"
+    );
+    return false;
   }
 
-  const workspace = auth.getNonNullableWorkspace();
   return isSpendCapCounterReached(auth, {
     user,
     thresholdAwuCredits: allowance,
@@ -743,20 +747,25 @@ export async function isFreeSeatLifetimeCapReached(
 /**
  * "Near limit" (warning) counterpart of `isFreeSeatLifetimeCapReached`: the
  * lifetime counter against `USER_AWU_WARNING_PERCENTAGE` (80%) of the free-seat
- * allowance. Returns `null` when the user has no free-seat allowance.
+ * allowance. Fails open (`false`) with no resolvable allowance; no Metronome
+ * fallback under the flag.
  */
 export async function isFreeSeatLifetimeWarningReached(
   auth: Authenticator,
   { user }: { user: UserResource }
-): Promise<boolean | null> {
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
   const allowance = await getFreeSeatLifetimeAllowanceAwuCredits(auth, {
     user,
   });
   if (allowance === null) {
-    return null;
+    logger.error(
+      { workspaceId: workspace.sId, userId: user.sId },
+      "[FreeSeatLifetime] warning: no free-seat allowance resolved; failing open"
+    );
+    return false;
   }
 
-  const workspace = auth.getNonNullableWorkspace();
   return isSpendCapCounterReached(auth, {
     user,
     thresholdAwuCredits: allowance * USER_AWU_WARNING_PERCENTAGE,

--- a/front/lib/spend_limits/cycle.ts
+++ b/front/lib/spend_limits/cycle.ts
@@ -28,6 +28,20 @@ export function currentCalendarMonthCycleUtc(
 }
 
 /**
+ * The "cycle" the free-seat lifetime spend limiter sums over: from well before
+ * any Dust usage existed to the far future. It anchors the ES seed window for
+ * the lifetime counter — combined with the `is_free_seat` filter it yields a
+ * seat's all-time consumption. Not a real billing cycle; a fixed, never-rolling
+ * window that pairs with `makeSpendLimitLifetimeWindowBounds`.
+ */
+export function lifetimeSpendCycleUtc(): BillingCycle {
+  return {
+    cycleStart: new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 0)),
+    cycleEnd: new Date(Date.UTC(2100, 0, 1, 0, 0, 0, 0)),
+  };
+}
+
+/**
  * The cycle to force on the per-user spend-cap helpers for this workspace, or
  * `undefined` to let them resolve the Metronome contract billing period as usual.
  *

--- a/front/tests/utils/MemberUsageFactory.ts
+++ b/front/tests/utils/MemberUsageFactory.ts
@@ -21,6 +21,7 @@ export function makeMemberUsage(
     name: "Member One",
     nearLimit: false,
     rateLimiterState: null,
+    isSpendCapped: false,
     nextCreditResetAt: null,
     sId: "member1",
     scheduledSeatChangeAt: null,

--- a/front/tests/utils/MemberUsageFactory.ts
+++ b/front/tests/utils/MemberUsageFactory.ts
@@ -20,6 +20,7 @@ export function makeMemberUsage(
     memberUsageLimit: null,
     name: "Member One",
     nearLimit: false,
+    rateLimiterState: null,
     nextCreditResetAt: null,
     sId: "member1",
     scheduledSeatChangeAt: null,


### PR DESCRIPTION
## Description

Follow-up to #31625. Free seats have a **lifetime** credit balance — an admin-editable, contract-surviving per-user Metronome credit (`startingBalanceAwu`, toppable via the `grant-user-free-credits` poke plugin) — not a per-cycle cap, so #31625 left them on the Metronome balance-threshold alert. This adds a synchronous **lifetime rate-limiter** for free seats behind `enforce_user_spend_limit_rate_cap`: under the flag, free-seat blocking and near-limit are driven **entirely by the rate limiter** (no Metronome credit-state fallback), matching how pool seats moved off Metronome.

### Enforcement
- New per-user **lifetime** fixed-window counter (`makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser` + never-rolling `makeSpendLimitLifetimeWindowBounds`), seeded from all-time `is_free_seat` ES consumption, recorded per message in `credit_cost.ts` for free-seat users.
- Threshold = the per-user free-seat allowance from the cached Metronome credit (`startingBalanceAwu`); admin top-ups just raise it (no new store, poke top-up flow unchanged).
- `isUserSpendLimitRate{Cap,Warning}Reached` delegate free seats to `isFreeSeatLifetime{Cap,Warning}Reached`. Under the flag these always return a boolean — **no Metronome credit-state fallback**; if the allowance can't be resolved they fail open (`false`) and log an error.
- The Metronome free-seat balance alerts keep running as the **flag-off** enforcement source, and still drive the free→pro auto-upgrade (`dispatchSeatBalanceExhausted`, not flag-gated).

### Poke usage tab (under the flag)
- **RL** column shows the lifetime counter for free seats (per-cycle counter otherwise).
- **near-limit** mirrors enforcement: lifetime counter vs the free-seat allowance for free seats, per-cycle cap otherwise.
- The Metronome **alert badges** (per-user cap / 80% warning / free-seat low+empty) are dropped, since they no longer drive enforcement.

## Tests

- tsgo clean on the changed backend files (two pre-existing sparkle `ProgressRing`/icon-size errors in unrelated component files are environmental).
- Passing: credit_check, members_usage, metronome/user_block, programmatic_usage_limit, keys/spend_limit, groups/spend_limit, spend_limits/effective, default_user_spend_limit, alerts/spend_limits.

## Risk

Low–moderate, flag-gated. With the flag off, free seats are unchanged (Metronome). With it on, free-seat blocking/near-limit is the lifetime counter; the Metronome alerts remain the flag-off source and still drive auto-upgrade. Extra cost: one cached Metronome read + a post-finalize membership fetch per free-seat message. No schema or API-contract changes.

## Deploy Plan

Standard deploy, no migrations. Roll out behind the existing `enforce_user_spend_limit_rate_cap` feature flag.