### PR TITLE
[front] fix: polish member invite modal UI

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -351,7 +351,7 @@ export function InviteEmailButtonWithModal({
           disabled={disabled}
         />
       </DialogTrigger>
-      <DialogContent size="md">
+      <DialogContent size="lg">
         <DialogHeader>
           <div className="flex flex-col gap-1">
             <DialogTitle>Invite new users</DialogTitle>

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -6,6 +6,7 @@ import {
   formatPriceCents,
   getAvailableFrequencies,
   groupSeatTypesByFrequency,
+  includedSeatsOpen,
   SeatCard,
   sortSeatTypes,
 } from "@app/components/workspace/SeatCard";
@@ -87,6 +88,11 @@ function seatBadge(
   seatType: MembershipSeatType,
   info: SeatTypeInfo
 ): ReactNode {
+  const openCount = includedSeatsOpen(info);
+  if (openCount > 0) {
+    return <Chip size="xs" color="primary" label={`${openCount} Available`} />;
+  }
+
   if (seatType === "free") {
     return <Chip size="xs" color="primary" label="If eligible" />;
   }

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -6,7 +6,6 @@ import {
   formatPriceCents,
   getAvailableFrequencies,
   groupSeatTypesByFrequency,
-  includedSeatsOpen,
   SeatCard,
   sortSeatTypes,
 } from "@app/components/workspace/SeatCard";
@@ -26,13 +25,13 @@ import {
 import { useSeatPlan } from "@app/lib/swr/credits";
 import { isEmailValid } from "@app/lib/utils";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { isMembershipSeatType, toBaseSeatType } from "@app/types/memberships";
+import { isMembershipSeatType } from "@app/types/memberships";
 import type { SubscriptionPerSeatPricing } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
 import {
   Button,
+  Chip,
   ContentMessage,
   Dialog,
   DialogContainer,
@@ -89,27 +88,12 @@ function seatBadge(
   info: SeatTypeInfo
 ): ReactNode {
   if (seatType === "free") {
-    return <span className="text-xs text-foreground">Free if eligible</span>;
+    return <Chip size="xs" color="primary" label="If eligible" />;
   }
-  const price = formatPriceCents(
-    info.priceCents,
-    info.currency,
-    info.billingFrequency
-  );
-  if (toBaseSeatType(seatType) === "workspace") {
-    return (
-      <span className="text-xs text-foreground">
-        {price} · User can spend credits from the workspace pool.
-      </span>
-    );
-  }
-  const openCount = includedSeatsOpen(info);
+
   return (
-    <span className="text-xs text-foreground">
-      {price} ·{" "}
-      {openCount > 0
-        ? `${openCount} included seat${pluralize(openCount)} open`
-        : "Plan included seats used. You can still invite new users."}
+    <span className="text-xs text-foreground tabular-nums">
+      {formatPriceCents(info.priceCents, info.currency, info.billingFrequency)}
     </span>
   );
 }

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -419,7 +419,7 @@ export function InviteEmailButtonWithModal({
                     />
                   </div>
                 )}
-                <div className="flex max-h-64 flex-col gap-2 overflow-y-auto pr-1">
+                <div className="flex flex-col gap-2">
                   {seatTypesByFrequency[activeFrequency].map((seatType) => {
                     const info = seatPlans[seatType];
                     if (!info) {

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -407,7 +407,7 @@ export function SeatCard({
             />
           </div>
           <span className="truncate text-base font-semibold text-foreground">
-            {stripYearlySuffix(info.name)}
+            {stripYearlySuffix(info.name).replace(/\s+Seat$/, "")}
           </span>
         </div>
         <div className="shrink-0 tabular-nums">{badge}</div>

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -17,6 +17,7 @@ import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   AlertCircle,
   Card,
+  CoinsStacked01,
   cn,
   Icon,
   LayerSingle,
@@ -389,33 +390,38 @@ export function SeatCard({
       size="sm"
       selected={isSelected}
       onClick={onClick}
-      className="grid w-full grid-cols-2 items-start gap-4 ring-0"
+      className="w-full flex-col items-stretch gap-2 ring-0"
     >
-      <div className="flex min-w-0 items-start gap-2">
-        <div
-          className={cn(
-            "flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
-            iconBackgroundClass
-          )}
-        >
-          <Icon
-            visual={seatIcon}
-            size="sm"
-            className={getSeatIconColorClass(seatType)}
-          />
-        </div>
-        <div className="flex min-w-0 flex-col gap-1">
-          <span className="text-base font-semibold text-foreground">
+      <div className="flex w-full items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <div
+            className={cn(
+              "flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
+              iconBackgroundClass
+            )}
+          >
+            <Icon
+              visual={seatIcon}
+              size="sm"
+              className={getSeatIconColorClass(seatType)}
+            />
+          </div>
+          <span className="truncate text-base font-semibold text-foreground">
             {stripYearlySuffix(info.name)}
           </span>
-          {info.awuCredits > 0 && (
-            <span className="text-xs text-muted-foreground">
-              {formatAwuCredits(info)}
-            </span>
-          )}
         </div>
+        <div className="shrink-0 tabular-nums">{badge}</div>
       </div>
-      <div className="min-w-0 pt-0.5 text-left tabular-nums">{badge}</div>
+      {info.awuCredits > 0 && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Icon
+            visual={CoinsStacked01}
+            size="xs"
+            className="text-muted-foreground"
+          />
+          <span className="text-xs">{formatAwuCredits(info)}</span>
+        </div>
+      )}
     </Card>
   );
 }

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -389,33 +389,33 @@ export function SeatCard({
       size="sm"
       selected={isSelected}
       onClick={onClick}
-      className="w-full flex-col items-stretch gap-2"
+      className="grid w-full grid-cols-2 items-start gap-4 ring-0"
     >
-      <div className="flex w-full items-center justify-between">
-        <div className="flex min-w-0 basis-1/2 items-center gap-2">
-          <div
-            className={cn(
-              "flex h-7 w-7 items-center justify-center rounded-lg",
-              iconBackgroundClass
-            )}
-          >
-            <Icon
-              visual={seatIcon}
-              size="sm"
-              className={getSeatIconColorClass(seatType)}
-            />
-          </div>
+      <div className="flex min-w-0 items-start gap-2">
+        <div
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
+            iconBackgroundClass
+          )}
+        >
+          <Icon
+            visual={seatIcon}
+            size="sm"
+            className={getSeatIconColorClass(seatType)}
+          />
+        </div>
+        <div className="flex min-w-0 flex-col gap-1">
           <span className="text-base font-semibold text-foreground">
             {stripYearlySuffix(info.name)}
           </span>
+          {info.awuCredits > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {formatAwuCredits(info)}
+            </span>
+          )}
         </div>
-        <div className="flex min-w-0 basis-1/2 justify-end">{badge}</div>
       </div>
-      {info.awuCredits > 0 && (
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <span className="text-xs">{formatAwuCredits(info)}</span>
-        </div>
-      )}
+      <div className="min-w-0 pt-0.5 text-left tabular-nums">{badge}</div>
     </Card>
   );
 }


### PR DESCRIPTION
## Description

Implements the Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=9514-22920&m=dev#1910302163).

This PR polishes the invite modal, the seat options were vertically misaligned, tall enough that the third option was clipped behind an inner scroll area, and the copy was unclear to end users.
Also makes the dialog a tiny bit wider so that the description of the role fits on one line.

Current live version

<img width="449" height="688" alt="image" src="https://github.com/user-attachments/assets/a6615cbb-4c91-44b4-ae54-35afc4217a45" />

Proposal

<img width="577" height="643" alt="image" src="https://github.com/user-attachments/assets/1f80ce94-4d01-43a3-b003-5dfe8252e73f" />

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
