### PR TITLE
feat: add spaceIds to the Slack bot whitelist

### DIFF
--- a/connectors/migrations/pre-deploy/20260901145827_add_space_ids_to_slack_bot_whitelist.sql
+++ b/connectors/migrations/pre-deploy/20260901145827_add_space_ids_to_slack_bot_whitelist.sql
@@ -1,0 +1,3 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."slack_bot_whitelist" ADD COLUMN "spaceIds" character varying(255)[];

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -300,6 +300,7 @@ export class SlackBotWhitelistModel extends ConnectorBaseModel<SlackBotWhitelist
   declare updatedAt: CreationOptional<Date>;
   declare botName: string;
   declare groupIds: string[];
+  declare spaceIds: string[] | null;
   declare whitelistType: SlackbotWhitelistType;
   declare slackConfigurationId: ForeignKey<SlackConfigurationModel["id"]>;
 }
@@ -326,6 +327,10 @@ SlackBotWhitelistModel.init(
       defaultValue: "summon_agent",
     },
     groupIds: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    spaceIds: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },


### PR DESCRIPTION
## Description

First of three PRs moving the Slack workflow summoning whitelist off group ids and onto space ids. This one is schema only: a nullable `spaceIds` column on `slack_bot_whitelist` plus its pre-deploy migration, so the reads and writes in #31667 land on a deployed schema.

Nothing reads or writes the column yet.

## Tests

None, the column is unused at this point.

## Risk

None. Adding a nullable column to a small table.

## Deploy Plan

1. Run `connectors/migrations/pre-deploy/20260901145827_add_space_ids_to_slack_bot_whitelist.sql`.
2. Deploy connectors.