### PR TITLE
Add skill availability to skill details in side panel

### DIFF
--- a/front/components/pages/builder/skills/utils.ts
+++ b/front/components/pages/builder/skills/utils.ts
@@ -1,4 +1,4 @@
-import { SKILL_AVAILABILITY_DISPLAY } from "@app/components/skills/SkillsTable";
+import { SKILL_AVAILABILITY_DISPLAY } from "@app/lib/skills/labels";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type {
   SkillAvailability,

--- a/front/components/skills/SkillDetailsBody.tsx
+++ b/front/components/skills/SkillDetailsBody.tsx
@@ -7,6 +7,7 @@ import {
   hasRelations,
   isDustProvidedSkill,
 } from "@app/lib/skill";
+import { SKILL_AVAILABILITY_DISPLAY } from "@app/lib/skills/labels";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type {
   SkillRelations,
@@ -15,6 +16,7 @@ import type {
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
   Button,
+  Chip,
   ContentMessage,
   ContentMessageAction,
   InfoCircle,
@@ -141,12 +143,23 @@ export function SkillDetailsHeader({
     });
 
   const SkillAvatar = getSkillAvatarIcon(skill);
+  const availabilityDisplay = SKILL_AVAILABILITY_DISPLAY[skill.availability];
 
   return (
     <div className="flex flex-col items-center gap-4 pt-4">
       <div className="relative flex items-center justify-center">
-        {/* eslint-disable-next-line react-hooks/static-components */}
-        <SkillAvatar name="Skill avatar" size="xl" />
+        <div className="relative flex flex-col items-center gap-2">
+          {/* eslint-disable-next-line react-hooks/static-components */}
+          <SkillAvatar name="Skill avatar" size="xl" />
+          {skill.status === "active" && (
+            <Chip
+              size="mini"
+              color={availabilityDisplay.color}
+              label={availabilityDisplay.label}
+              className="absolute -bottom-3 shadow-sm"
+            />
+          )}
+        </div>
       </div>
 
       {/* Title and edit info */}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -6,6 +6,7 @@ import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import config from "@app/lib/api/config";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
+import { SKILL_AVAILABILITY_DISPLAY } from "@app/lib/skills/labels";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 import {
   getManageSkillsRoute,
@@ -192,27 +193,6 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
       return null;
   }
 }
-
-export const SKILL_AVAILABILITY_DISPLAY: Record<
-  SkillAvailability,
-  { label: string; color: "primary" | "success" | "highlight"; tooltip: string }
-> = {
-  editors: {
-    label: "Editors only",
-    color: "primary",
-    tooltip: "Only editors can find it via the input bar and agent builder",
-  },
-  workspace_users: {
-    label: "Members",
-    color: "success",
-    tooltip: "All members can find it via the input bar and agent builder",
-  },
-  users_and_agents: {
-    label: "Members and agents",
-    color: "highlight",
-    tooltip: "Available to all members and agents with Discover Skills",
-  },
-};
 
 const nameColumn = {
   header: "Name",

--- a/front/lib/skills/labels.ts
+++ b/front/lib/skills/labels.ts
@@ -1,5 +1,28 @@
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration_constants";
+
 // Maximum length (in characters) of a skill's agent-facing description.
 export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 1_000;
 
 export const SKILL_INVOCATION_LABEL = "When to use this skill";
 export const SKILL_INSTRUCTIONS_LABEL = "Instructions";
+
+export const SKILL_AVAILABILITY_DISPLAY: Record<
+  SkillAvailability,
+  { label: string; color: "primary" | "success" | "highlight"; tooltip: string }
+> = {
+  editors: {
+    label: "Editors only",
+    color: "primary",
+    tooltip: "Only editors can find it via the input bar and agent builder",
+  },
+  workspace_users: {
+    label: "Members",
+    color: "success",
+    tooltip: "All members can find it via the input bar and agent builder",
+  },
+  users_and_agents: {
+    label: "Members and agents",
+    color: "highlight",
+    tooltip: "Available to all members and agents with Discover Skills",
+  },
+};


### PR DESCRIPTION
## Description

Similar to the "published" chip for agents, we display the availability for the skills in the side panel (in conversation, in maange skill page, in analytics...)


<img width="371" height="240" alt="Screenshot 2026-09-02 at 14 34 47" src="https://github.com/user-attachments/assets/317ddd95-ea52-48be-90e9-d03b2c77f063" />

<img width="259" height="207" alt="Screenshot 2026-09-02 at 14 34 55" src="https://github.com/user-attachments/assets/0d0d5609-fed0-4ec3-ac03-d83e09891e95" />

<img width="218" height="208" alt="Screenshot 2026-09-02 at 14 35 05" src="https://github.com/user-attachments/assets/760c737e-5bf9-439c-b688-ececebf8291f" />

## Tests

tested locally

## Risk

low, purely UI and easy to revert

## Deploy Plan

deploy front
