### PR TITLE
[front] model picker: reword degradation tooltip, badge degraded makers, input-bar only

### DIFF
--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -186,6 +186,7 @@ export function AdvancedSettings() {
         showLabel={true}
         side="top"
         disabled={false}
+        showDegradations={false}
         onSelectionChange={(newModelSelection) => {
           generationSettingsField.onChange({
             ...generationSettings,

--- a/front/components/model_picker/DegradedModelIcon.tsx
+++ b/front/components/model_picker/DegradedModelIcon.tsx
@@ -17,9 +17,6 @@ export function DegradedModelIcon({ icon }: DegradedModelIconProps) {
   );
 }
 
-// Standalone version of the badge above: the same filled `info` disc with the
-// glyph knocked out in white (InfoCircle draws its ring just inside the icon
-// box, so the disc is inset by a hair — mirrors DoubleIcon's filled badge).
 export function DegradedInfoIcon() {
   return (
     <span className="relative flex h-5 w-5">

--- a/front/components/model_picker/DegradedModelIcon.tsx
+++ b/front/components/model_picker/DegradedModelIcon.tsx
@@ -1,4 +1,4 @@
-import { DoubleIcon, InfoCircle } from "@dust-tt/sparkle";
+import { DoubleIcon, Icon, InfoCircle } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
 interface DegradedModelIconProps {
@@ -14,5 +14,17 @@ export function DegradedModelIcon({ icon }: DegradedModelIconProps) {
       position="top-right"
       secondaryColor="info"
     />
+  );
+}
+
+// Standalone version of the badge above: the same filled `info` disc with the
+// glyph knocked out in white (InfoCircle draws its ring just inside the icon
+// box, so the disc is inset by a hair — mirrors DoubleIcon's filled badge).
+export function DegradedInfoIcon() {
+  return (
+    <span className="relative flex h-5 w-5">
+      <span className="absolute inset-px rounded-full bg-info-500" />
+      <Icon visual={InfoCircle} size="sm" className="relative text-white" />
+    </span>
   );
 }

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -17,7 +17,7 @@ import type {
 import {
   buildModelSelection,
   buildTierSelection,
-  DEGRADED_MODEL_TOOLTIP,
+  getDegradedModelTooltip,
   getInitialEffort,
   getModelTier,
   getModelWithReasoningEffortLabel,
@@ -83,6 +83,9 @@ export interface ModelPickerProps {
   // surface. Consumers that don't pass it (e.g. the agent builder) are not
   // tracked.
   trackingSurface?: ModelPickerSurface;
+  // Degradation badges warn about picking a model to chat with right now; the
+  // agent builder configures a durable default, so it turns them off.
+  showDegradations?: boolean;
 }
 
 export function ModelPicker({
@@ -103,6 +106,7 @@ export function ModelPicker({
   commitApiRef,
   openApiRef,
   trackingSurface,
+  showDegradations = true,
 }: ModelPickerProps) {
   const clientType = useClientType();
 
@@ -118,7 +122,7 @@ export function ModelPicker({
     streamModels,
     lockPremiumEfforts,
     degradedModelIds,
-  } = useModelPickerModels({ owner });
+  } = useModelPickerModels({ owner, showDegradations });
   const { menuStateProps, resetMenu } = useModelPickerMenuState();
 
   const { shown: baseSelection, agentDefault } = useMemo(
@@ -277,9 +281,11 @@ export function ModelPicker({
       ? MODEL_TIER_ICON[shown.display.tierId]
       : getModelMakerLogo(getModelMaker(shown.display.model), isDark);
 
-  const isShownModelDegraded =
+  const degradedModelTooltip =
     shown.display.kind === "model" &&
-    degradedModelIds.has(shown.display.model.modelId);
+    degradedModelIds.has(shown.display.model.modelId)
+      ? getDegradedModelTooltip(shown.display.model.displayName)
+      : null;
 
   // Model name and reasoning effort read as one string for the tooltip and the
   // accessible name, but the visible trigger splits the effort into its own
@@ -313,7 +319,7 @@ export function ModelPicker({
           variant={buttonVariant}
           size={buttonSize}
           icon={
-            isShownModelDegraded ? (
+            degradedModelTooltip !== null ? (
               <DegradedModelIcon icon={buttonIcon} />
             ) : (
               buttonIcon
@@ -331,11 +337,8 @@ export function ModelPicker({
           }
           isSelect={showLabel && showDropdownArrow}
           tooltip={
-            isShownModelDegraded
-              ? DEGRADED_MODEL_TOOLTIP
-              : showLabel
-                ? undefined
-                : `Model picker: ${label}`
+            degradedModelTooltip ??
+            (showLabel ? undefined : `Model picker: ${label}`)
           }
           aria-label={`Model picker: ${label}`}
           disabled={disabled}

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -55,8 +55,6 @@ export function ModelPickerMakersView({
     <>
       {makerGroups.map((maker) => {
         const makerLogo = getModelMakerLogo(maker.makerId, isDark);
-        // Surface the degradation on the collapsed maker row so the member
-        // doesn't have to open every submenu to spot an affected model.
         const hasDegradedModel = maker.models.some((model) =>
           degradedModelIds.has(model.modelId)
         );

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -1,3 +1,4 @@
+import { DegradedModelIcon } from "@app/components/model_picker/DegradedModelIcon";
 import { ModelPickerModelRow } from "@app/components/model_picker/ModelPickerModelRow";
 import type {
   MakerGroup,
@@ -52,46 +53,60 @@ export function ModelPickerMakersView({
 
   return (
     <>
-      {makerGroups.map((maker) => (
-        <DropdownMenuSub key={maker.makerId}>
-          <DropdownMenuSubTrigger
-            label={getModelMakerDisplayName(maker.makerId)}
-            icon={getModelMakerLogo(maker.makerId, isDark)}
-          />
-          <DropdownMenuSubContent className="w-64">
-            {maker.models.map((model) => {
-              const selectedEntry = findSelectedModelEntry(model, selection);
-              const isSelected = selectedEntry !== undefined;
-              const isDefault =
-                selection.agentDefault !== null &&
-                isModelSelection(model, selection.agentDefault);
-              const lockReason = ignoreTierRestrictions
-                ? null
-                : getModelLockReason(model, { lockPremiumEfforts });
-              const effort = selectedEntry
-                ? selectedEntry.effort
-                : getInitialEffort(model, { lockPremiumEfforts });
-              return (
-                <ModelPickerModelRow
-                  key={getModelKey(model.providerId, model.modelId)}
-                  model={model}
-                  isSelected={isSelected}
-                  isDefault={isDefault}
-                  lockReason={lockReason}
-                  isDegraded={degradedModelIds.has(model.modelId)}
-                  effort={effort}
-                  effortStops={getEffortStops(model, { lockPremiumEfforts })}
-                  onSelectModel={onSelectModel}
-                  onChangeEffort={
-                    onChangeEffort && ((next) => onChangeEffort(model, next))
-                  }
-                  onRevert={isSelected ? selection.onRevert : undefined}
-                />
-              );
-            })}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      ))}
+      {makerGroups.map((maker) => {
+        const makerLogo = getModelMakerLogo(maker.makerId, isDark);
+        // Surface the degradation on the collapsed maker row so the member
+        // doesn't have to open every submenu to spot an affected model.
+        const hasDegradedModel = maker.models.some((model) =>
+          degradedModelIds.has(model.modelId)
+        );
+        return (
+          <DropdownMenuSub key={maker.makerId}>
+            <DropdownMenuSubTrigger
+              label={getModelMakerDisplayName(maker.makerId)}
+              icon={
+                hasDegradedModel ? (
+                  <DegradedModelIcon icon={makerLogo} />
+                ) : (
+                  makerLogo
+                )
+              }
+            />
+            <DropdownMenuSubContent className="w-64">
+              {maker.models.map((model) => {
+                const selectedEntry = findSelectedModelEntry(model, selection);
+                const isSelected = selectedEntry !== undefined;
+                const isDefault =
+                  selection.agentDefault !== null &&
+                  isModelSelection(model, selection.agentDefault);
+                const lockReason = ignoreTierRestrictions
+                  ? null
+                  : getModelLockReason(model, { lockPremiumEfforts });
+                const effort = selectedEntry
+                  ? selectedEntry.effort
+                  : getInitialEffort(model, { lockPremiumEfforts });
+                return (
+                  <ModelPickerModelRow
+                    key={getModelKey(model.providerId, model.modelId)}
+                    model={model}
+                    isSelected={isSelected}
+                    isDefault={isDefault}
+                    lockReason={lockReason}
+                    isDegraded={degradedModelIds.has(model.modelId)}
+                    effort={effort}
+                    effortStops={getEffortStops(model, { lockPremiumEfforts })}
+                    onSelectModel={onSelectModel}
+                    onChangeEffort={
+                      onChangeEffort && ((next) => onChangeEffort(model, next))
+                    }
+                    onRevert={isSelected ? selection.onRevert : undefined}
+                  />
+                );
+              })}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        );
+      })}
     </>
   );
 }

--- a/front/components/model_picker/ModelPickerModelRow.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.tsx
@@ -1,3 +1,4 @@
+import { DegradedInfoIcon } from "@app/components/model_picker/DegradedModelIcon";
 import { ModelPickerSelectionIndicator } from "@app/components/model_picker/ModelPickerSelectionIndicator";
 import { ModelTierChip } from "@app/components/model_picker/ModelTierChip";
 import type {
@@ -5,7 +6,7 @@ import type {
   ModelLockReason,
 } from "@app/components/model_picker/modelPickerUtils";
 import {
-  DEGRADED_MODEL_TOOLTIP,
+  getDegradedModelTooltip,
   getModelLockTooltip,
 } from "@app/components/model_picker/modelPickerUtils";
 import { ReasoningEffortSlider } from "@app/components/model_picker/ReasoningEffortSlider";
@@ -13,7 +14,7 @@ import type {
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
-import { DropdownMenuItem, Icon, InfoCircle, Lock01 } from "@dust-tt/sparkle";
+import { DropdownMenuItem, Icon, Lock01 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 
@@ -67,9 +68,7 @@ export function ModelPickerModelRow({
   const endComponent =
     isSelected || isDegraded ? (
       <div className="flex items-center gap-2">
-        {isDegraded && (
-          <Icon visual={InfoCircle} size="sm" className="text-info-500" />
-        )}
+        {isDegraded && <DegradedInfoIcon />}
         {isSelected && (
           <>
             <ModelTierChip
@@ -89,7 +88,9 @@ export function ModelPickerModelRow({
         label={`${model.displayName}${isDefault ? " (Default)" : ""}`}
         icon={icon}
         truncateText
-        tooltip={isDegraded ? DEGRADED_MODEL_TOOLTIP : undefined}
+        tooltip={
+          isDegraded ? getDegradedModelTooltip(model.displayName) : undefined
+        }
         endComponent={endComponent}
         onClick={() => {
           onSelectModel(model);

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -41,7 +41,7 @@ const MODEL_TIER_LOCKED_TOOLTIP =
   "Contact your administrator to get access.";
 
 export function getDegradedModelTooltip(displayName: string): string {
-  return `${displayName} is sometimes failing right now. You may want to select another one.`;
+  return `${displayName} is unreliable right now. You may want to select another model.`;
 }
 
 // The three primary picks of the model picker. Each tier is backed by a

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -40,9 +40,9 @@ const MODEL_TIER_LOCKED_TOOLTIP =
   "Your current model access doesn't include this option. " +
   "Contact your administrator to get access.";
 
-export const DEGRADED_MODEL_TOOLTIP =
-  "This model is currently degraded following an incident on the provider side. " +
-  "Answers may be slower or fail — consider picking another model.";
+export function getDegradedModelTooltip(displayName: string): string {
+  return `${displayName} is sometimes failing right now. You may want to select another one.`;
+}
 
 // The three primary picks of the model picker. Each tier is backed by a
 // meta-model that is resolved to a concrete model at message-send time. Tier ids

--- a/front/components/model_picker/useModelPickerModels.ts
+++ b/front/components/model_picker/useModelPickerModels.ts
@@ -18,6 +18,8 @@ import { useMemo } from "react";
 // plan restrictions instead of padlocking the rows they exclude.
 type ModelPickerMenuMode = "select" | "filter";
 
+const EMPTY_DEGRADED_MODEL_IDS: ReadonlySet<string> = new Set();
+
 // The model lists every surface rendering `ModelPickerContent` offers, and what
 // the member is allowed to pick from them.
 export function useModelPickerModels({
@@ -25,6 +27,7 @@ export function useModelPickerModels({
   disabled,
   mode = "select",
   modelIds,
+  showDegradations = true,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
@@ -32,6 +35,9 @@ export function useModelPickerModels({
   // When set, the menu offers exactly these models instead of the workspace
   // catalog.
   modelIds?: string[];
+  // Degradation badges warn about picking a model to chat with right now;
+  // surfaces configuring a durable default (the agent builder) turn them off.
+  showDegradations?: boolean;
 }) {
   const { hasFeature } = useFeatureFlags();
   const { subscription } = useAuth();
@@ -42,10 +48,18 @@ export function useModelPickerModels({
   const isFilterMode = mode === "filter";
   const lockPremiumEfforts = !canSelectPremiumModels;
 
-  const { models, streams, degradedModelIds, isModelsLoading } = useModels({
+  const {
+    models,
+    streams,
+    degradedModelIds: allDegradedModelIds,
+    isModelsLoading,
+  } = useModels({
     owner,
     disabled,
   });
+  const degradedModelIds = showDegradations
+    ? allDegradedModelIds
+    : EMPTY_DEGRADED_MODEL_IDS;
 
   // Concrete models (meta-models are surfaced as tiers instead).
   const allModels = useMemo<ModelConfigurationType[]>(() => {


### PR DESCRIPTION
## Description

<img width="1071" height="753" alt="Screenshot 2026-09-03 at 11 25 09" src="https://github.com/user-attachments/assets/933d9438-96d5-4609-8a99-cad956ec9273" />


Reworks how model degradation is surfaced in the model picker:

- **Tooltip wording**
- **Provider-level badge**
- **Filled model-row icon**
- **Input bar only**

## Tests

- `npm -w front run test -- components/model_picker` — 22 tests pass.
- `npm -w front run tsgo` and biome pass (lefthook pre-commit).

## Risk

Low — UI-only changes scoped to the model picker components. No API or data changes. Safe to rollback.

## Deploy Plan

Standard front deploy, no special ordering.
