### PR TITLE
Move the provider kill-switch overlay from workspace materialization to the Authenticator

### DIFF
--- a/front-api/routes/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,5 +1,6 @@
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
 import {
+  getEffectiveWhiteListedProviders,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
 } from "@app/lib/api/assistant/models";
@@ -19,9 +20,10 @@ app.post(
     const auth = ctx.get("auth");
     const { instructions } = ctx.req.valid("json");
 
+    const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
     const model = !auth.isUpgraded()
-      ? await getSmallWhitelistedModel(auth)
-      : await getLargeWhitelistedModel(auth);
+      ? getSmallWhitelistedModel(auth, undefined, { whiteListedProviders })
+      : getLargeWhitelistedModel(auth, undefined, { whiteListedProviders });
     if (!model) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,5 +1,8 @@
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
-import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  isProviderWhitelistedForAuth,
+} from "@app/lib/api/assistant/models";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isSupportedModel } from "@app/types/assistant/assistant";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
@@ -120,7 +123,14 @@ app.post(
       });
     }
 
-    if (!isProviderWhitelistedForAuth(auth, model.providerId)) {
+    const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+    if (
+      !isProviderWhitelistedForAuth(
+        auth,
+        model.providerId,
+        whiteListedProviders
+      )
+    ) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
@@ -1,4 +1,5 @@
 import { getModelConfigForWebSummarization } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
+import { getEffectiveWhiteListedProviders } from "@app/lib/api/assistant/models";
 import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -13,7 +14,11 @@ describe("getModelConfigForWebSummarization", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const featureFlags = await getFeatureFlags(auth);
 
-    expect(getModelConfigForWebSummarization(auth, featureFlags)).toMatchObject(
+    expect(getModelConfigForWebSummarization(
+        auth,
+        featureFlags,
+        await getEffectiveWhiteListedProviders(auth)
+      )).toMatchObject(
       {
         modelConfiguration: {
           providerId: "openai",
@@ -30,12 +35,18 @@ describe("getModelConfigForWebSummarization", () => {
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const featureFlags = await getFeatureFlags(auth);
+    const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
     const smallModel = getSmallWhitelistedModel(auth, new Set(), {
       featureFlags,
+      whiteListedProviders,
     });
 
     expect(smallModel).not.toBeNull();
-    expect(getModelConfigForWebSummarization(auth, featureFlags)).toEqual({
+    expect(getModelConfigForWebSummarization(
+        auth,
+        featureFlags,
+        await getEffectiveWhiteListedProviders(auth)
+      )).toEqual({
       modelConfiguration: smallModel,
       reasoningEffort: smallModel?.defaultReasoningEffort,
     });

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -1,11 +1,13 @@
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import {
+  getEffectiveWhiteListedProviders,
   getSmallWhitelistedModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { GPT_5_6_LUNA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type {
@@ -41,7 +43,12 @@ export async function summarizeWithLLM({
   const toSummarize = content.slice(0, MAX_CHARACTERS_TO_SUMMARIZE);
 
   const featureFlags = await getFeatureFlags(auth);
-  const modelConfig = getModelConfigForWebSummarization(auth, featureFlags);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const modelConfig = getModelConfigForWebSummarization(
+    auth,
+    featureFlags,
+    whiteListedProviders
+  );
   if (!modelConfig) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate summary")
@@ -104,13 +111,15 @@ export async function summarizeWithLLM({
 
 export function getModelConfigForWebSummarization(
   auth: Authenticator,
-  featureFlags: WhitelistableFeature[]
+  featureFlags: WhitelistableFeature[],
+  whiteListedProviders: ModelProviderIdType[] | null
 ): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: ReasoningEffort;
 } | null {
   const luna = selectEnabledModel(auth, [GPT_5_6_LUNA_MODEL_CONFIG], {
     featureFlags,
+    whiteListedProviders,
   });
   if (luna) {
     return {
@@ -121,6 +130,7 @@ export function getModelConfigForWebSummarization(
 
   const smallModel = getSmallWhitelistedModel(auth, new Set(), {
     featureFlags,
+    whiteListedProviders,
   });
   return smallModel
     ? {

--- a/front/lib/api/actions/servers/image_generation/getImageGenerationLLM.ts
+++ b/front/lib/api/actions/servers/image_generation/getImageGenerationLLM.ts
@@ -1,7 +1,10 @@
 import { ImageGenerationGoogleLLM } from "@app/lib/api/actions/servers/image_generation/clients/google";
 import { ImageGenerationOpenAILLM } from "@app/lib/api/actions/servers/image_generation/clients/openai";
 import type { ImageGenerationLLM } from "@app/lib/api/actions/servers/image_generation/imageGeneration";
-import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  isProviderWhitelistedForAuth,
+} from "@app/lib/api/assistant/models";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -17,26 +20,32 @@ export async function getImageGenerationLLM(
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
 
   // gpt-image-2 is not eligible to EU data residency yet, so EU workspaces fall
   // back to Gemini for image generation if workspace-enabled, or image 1.5.
   const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
 
-  if (!isEuRegion && isProviderWhitelistedForAuth(auth, "openai")) {
+  if (
+    !isEuRegion &&
+    isProviderWhitelistedForAuth(auth, "openai", whiteListedProviders)
+  ) {
     return new ImageGenerationOpenAILLM(auth, {
       modelId: GPT_IMAGE_2_MODEL_ID,
       credentials,
     });
   }
 
-  if (isProviderWhitelistedForAuth(auth, "google_ai_studio")) {
+  if (
+    isProviderWhitelistedForAuth(auth, "google_ai_studio", whiteListedProviders)
+  ) {
     return new ImageGenerationGoogleLLM(auth, {
       modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
       credentials,
     });
   }
 
-  if (isProviderWhitelistedForAuth(auth, "openai")) {
+  if (isProviderWhitelistedForAuth(auth, "openai", whiteListedProviders)) {
     return new ImageGenerationOpenAILLM(auth, {
       modelId: GPT_IMAGE_1_5_MODEL_ID,
       credentials,

--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getFastestWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { Result } from "@app/types/shared/result";
@@ -81,7 +84,8 @@ export async function getSuggestedAgentsForContent(
 ): Promise<Result<LightAgentConfigurationType[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = getFastestWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastestWhitelistedModel(auth, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error("Error suggesting agents: failed to find a whitelisted model.")

--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -1,6 +1,7 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import {
+  getEffectiveWhiteListedProviders,
   getSmallWhitelistedModel,
   getWhitelistedProviders,
 } from "@app/lib/api/assistant/models";
@@ -67,10 +68,11 @@ export async function getCronTimezoneGeneration(
 ): Promise<Result<ScheduleConfig, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const providers = getWhitelistedProviders(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const providers = getWhitelistedProviders(auth, whiteListedProviders);
   const model = providers.has("openai")
     ? GPT_5_4_MINI_MODEL_CONFIG
-    : getSmallWhitelistedModel(auth);
+    : getSmallWhitelistedModel(auth, undefined, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate cron rule")

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -1,7 +1,10 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { validateWebhookFilter } from "@app/lib/api/assistant/configuration/triggers/webhook_filter_validation";
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getLargeWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -361,7 +364,10 @@ export async function getWebhookFilterGeneration(
     providerSpecificInstructions: string | null;
   }
 ): Promise<Result<{ filter: string }, Error>> {
-  const model = await getLargeWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getLargeWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate filter")

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -34,7 +34,10 @@ import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
-import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  isProviderWhitelistedForAuth,
+} from "@app/lib/api/assistant/models";
 import { enforcePremiumModelLimit } from "@app/lib/api/assistant/premium_model_limit";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
@@ -741,6 +744,8 @@ export async function postUserMessage(
   // The internal `run_agent` path is exempt: some hidden sub-agents are retired.
   const isInternalRunAgent = agenticMessageData?.type === "run_agent";
 
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+
   for (const agentConfig of agentConfigurations) {
     if (!isInternalRunAgent && isRetiredGlobalAgent(agentConfig.sId)) {
       return new Err({
@@ -765,7 +770,8 @@ export async function postUserMessage(
 
     const isProviderEnabled = isProviderWhitelistedForAuth(
       auth,
-      agentConfig.model.providerId
+      agentConfig.model.providerId,
+      whiteListedProviders
     );
     if (!isProviderEnabled) {
       // Stop processing if any agent uses a disabled provider.
@@ -1200,6 +1206,8 @@ export async function editUserMessage(
 
   const agentConfigurations = results[0];
 
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+
   for (const agentConfig of agentConfigurations) {
     if (!canAccessAgent(agentConfig)) {
       return new Err({
@@ -1214,7 +1222,8 @@ export async function editUserMessage(
 
     const isProviderEnabled = isProviderWhitelistedForAuth(
       auth,
-      agentConfig.model.providerId
+      agentConfig.model.providerId,
+      whiteListedProviders
     );
     if (!isProviderEnabled) {
       // Stop processing if any agent uses a disabled provider.

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -7,7 +7,10 @@ import { compactConversation } from "@app/lib/api/assistant/conversation/compact
 import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversation/compaction_attachment_id_replacements";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import { getFileContent } from "@app/lib/api/files/utils";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
@@ -94,7 +97,10 @@ async function getForkCompactionModel(
     };
   }
 
-  const fallbackModel = getSmallWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const fallbackModel = getSmallWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!fallbackModel) {
     return null;
   }

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -2,12 +2,14 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import {
+  getEffectiveWhiteListedProviders,
   getSmallWhitelistedModel,
   getWhitelistedProviders,
 } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
@@ -177,7 +179,8 @@ async function generateConversationTitle(
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = getFastModelConfig(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastModelConfig(auth, whiteListedProviders);
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate title")
@@ -257,9 +260,10 @@ async function generateConversationTitle(
 }
 
 function getFastModelConfig(
-  auth: Authenticator
+  auth: Authenticator,
+  whiteListedProviders: ModelProviderIdType[] | null
 ): ModelConfigurationType | null {
-  const providers = getWhitelistedProviders(auth);
+  const providers = getWhitelistedProviders(auth, whiteListedProviders);
 
   if (providers.has("openai")) {
     return GPT_5_1_MODEL_CONFIG;
@@ -271,5 +275,5 @@ function getFastModelConfig(
     return GEMINI_3_5_FLASH_MODEL_CONFIG;
   }
 
-  return getSmallWhitelistedModel(auth);
+  return getSmallWhitelistedModel(auth, undefined, { whiteListedProviders });
 }

--- a/front/lib/api/assistant/existing_agent_checker.ts
+++ b/front/lib/api/assistant/existing_agent_checker.ts
@@ -1,7 +1,10 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -193,7 +196,10 @@ export async function getSimilarAgents(
     return new Ok({ similar_agents: [] });
   }
 
-  const model = await getSmallWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getSmallWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to check similar agents")

--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -8,6 +8,7 @@ import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/glob
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -306,11 +307,13 @@ export function _getClaude5SonnetGlobalAgent({
   settings,
   mcpServerViews,
   featureFlags,
+  whiteListedProviders,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   featureFlags: WhitelistableFeature[];
+  whiteListedProviders: ModelProviderIdType[] | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -329,7 +332,7 @@ export function _getClaude5SonnetGlobalAgent({
         CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
         CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
       ],
-      { featureFlags }
+      { featureFlags, whiteListedProviders }
     ) ?? CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
 
   return {

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -25,6 +25,7 @@ import {
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -354,10 +355,12 @@ function getEnabledModelConfig(
   auth: Authenticator,
   modelConfiguration: ModelConfigurationType,
   reasoningEffort: ReasoningEffort,
-  featureFlags: WhitelistableFeature[]
+  featureFlags: WhitelistableFeature[],
+  whiteListedProviders: ModelProviderIdType[] | null
 ): ModelConfigWithReasoning | null {
   const model = selectEnabledModel(auth, [modelConfiguration], {
     featureFlags,
+    whiteListedProviders,
   });
 
   return model ? { modelConfiguration: model, reasoningEffort } : null;
@@ -365,10 +368,12 @@ function getEnabledModelConfig(
 
 function getLargeModelFallback(
   auth: Authenticator,
-  featureFlags: WhitelistableFeature[]
+  featureFlags: WhitelistableFeature[],
+  whiteListedProviders: ModelProviderIdType[] | null
 ): ModelConfigWithReasoning | null {
   const modelConfiguration = getLargeWhitelistedModel(auth, undefined, {
     featureFlags,
+    whiteListedProviders,
   });
   if (!modelConfiguration) {
     return null;
@@ -381,13 +386,15 @@ function getLargeModelFallback(
 
 function getDeepDiveModelConfig(
   auth: Authenticator,
-  featureFlags: WhitelistableFeature[]
+  featureFlags: WhitelistableFeature[],
+  whiteListedProviders: ModelProviderIdType[] | null
 ): ModelConfigWithReasoning | null {
   const primaryModelConfig = getEnabledModelConfig(
     auth,
     GPT_5_6_SOL_MODEL_CONFIG,
     "medium",
-    featureFlags
+    featureFlags,
+    whiteListedProviders
   );
   if (primaryModelConfig) {
     return primaryModelConfig;
@@ -399,51 +406,61 @@ function getDeepDiveModelConfig(
       ? CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG
       : CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
     "light",
-    featureFlags
+    featureFlags,
+    whiteListedProviders
   );
 
-  return fallbackModelConfig ?? getLargeModelFallback(auth, featureFlags);
+  return (
+    fallbackModelConfig ??
+    getLargeModelFallback(auth, featureFlags, whiteListedProviders)
+  );
 }
 
 function getDustTaskModelConfig(
   auth: Authenticator,
-  featureFlags: WhitelistableFeature[]
+  featureFlags: WhitelistableFeature[],
+  whiteListedProviders: ModelProviderIdType[] | null
 ): ModelConfigWithReasoning | null {
   return (
     getEnabledModelConfig(
       auth,
       GPT_5_6_LUNA_MODEL_CONFIG,
       "high",
-      featureFlags
+      featureFlags,
+      whiteListedProviders
     ) ??
     getEnabledModelConfig(
       auth,
       CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
       "light",
-      featureFlags
+      featureFlags,
+      whiteListedProviders
     ) ??
-    getLargeModelFallback(auth, featureFlags)
+    getLargeModelFallback(auth, featureFlags, whiteListedProviders)
   );
 }
 
 function getPlanningModelConfig(
   auth: Authenticator,
-  featureFlags: WhitelistableFeature[]
+  featureFlags: WhitelistableFeature[],
+  whiteListedProviders: ModelProviderIdType[] | null
 ): ModelConfigWithReasoning | null {
   return (
     getEnabledModelConfig(
       auth,
       GPT_5_6_SOL_MODEL_CONFIG,
       "high",
-      featureFlags
+      featureFlags,
+      whiteListedProviders
     ) ??
     getEnabledModelConfig(
       auth,
       CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
       "high",
-      featureFlags
+      featureFlags,
+      whiteListedProviders
     ) ??
-    getLargeModelFallback(auth, featureFlags)
+    getLargeModelFallback(auth, featureFlags, whiteListedProviders)
   );
 }
 
@@ -455,17 +472,23 @@ export function _getDeepDiveGlobalAgent(
     mcpServerViews,
     hasSandbox,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     hasSandbox?: boolean;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
-  const modelConfig = getDeepDiveModelConfig(auth, featureFlags);
+  const modelConfig = getDeepDiveModelConfig(
+    auth,
+    featureFlags,
+    whiteListedProviders
+  );
 
   const deepAgent: Omit<
     AgentConfigurationType,
@@ -612,11 +635,13 @@ export function _getDustTaskGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ): AgentConfigurationType | null {
   const name = "dust-task";
@@ -650,7 +675,11 @@ export function _getDustTaskGlobalAgent(
     canEdit: false,
   };
 
-  const modelConfig = getDustTaskModelConfig(auth, featureFlags);
+  const modelConfig = getDustTaskModelConfig(
+    auth,
+    featureFlags,
+    whiteListedProviders
+  );
 
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
@@ -728,9 +757,11 @@ export function _getPlanningAgent(
   {
     settings,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ): AgentConfigurationType | null {
   const name = "dust-planning";
@@ -764,7 +795,11 @@ export function _getPlanningAgent(
     canEdit: false,
   };
 
-  const modelConfig = getPlanningModelConfig(auth, featureFlags);
+  const modelConfig = getPlanningModelConfig(
+    auth,
+    featureFlags,
+    whiteListedProviders
+  );
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
       ...planningAgent,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -32,6 +32,7 @@ import {
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -84,6 +85,9 @@ interface DustLikeGlobalAgentArgs {
   // Workspace feature flags, forwarded to model selection so it runs the exact
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
+  // Effective white-listed providers (kill switches applied), forwarded to
+  // model selection for the same reason.
+  whiteListedProviders: ModelProviderIdType[] | null;
   // When set, the @dust agent defaults to this stream meta-model (the highest
   // one the member's model-tier cap allows) instead of GPT 5.6 Luna.
   autoDefaultModelConfig?: ModelConfigurationType | null;
@@ -259,6 +263,7 @@ function _getDustLikeGlobalAgent(
     hasDeepDive,
     globalAgentContext,
     featureFlags,
+    whiteListedProviders,
   }: DustLikeGlobalAgentArgs,
   {
     agentId,
@@ -297,11 +302,13 @@ function _getDustLikeGlobalAgent(
       preferredModelConfiguration != null &&
       selectEnabledModel(auth, [preferredModelConfiguration], {
         featureFlags,
+        whiteListedProviders,
       }) != null;
 
     if (!auth.isUpgraded()) {
       return getSmallWhitelistedModel(auth, undefined, {
         featureFlags,
+        whiteListedProviders,
       });
     }
 
@@ -310,7 +317,10 @@ function _getDustLikeGlobalAgent(
       return preferredModelConfiguration;
     }
 
-    return getLargeWhitelistedModel(auth, undefined, { featureFlags });
+    return getLargeWhitelistedModel(auth, undefined, {
+      featureFlags,
+      whiteListedProviders,
+    });
   })();
 
   const model: AgentModelConfigurationType = modelConfiguration

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -12,6 +12,7 @@ import {
   getSmallWhitelistedModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -23,10 +24,12 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 export function _getHelperGlobalAgent({
   auth,
   featureFlags,
+  whiteListedProviders,
   mcpServerViews,
 }: {
   auth: Authenticator;
   featureFlags: WhitelistableFeature[];
+  whiteListedProviders: ModelProviderIdType[] | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let prompt = `<primary_goal>
@@ -65,8 +68,14 @@ The user you're interacting with is granted with the role ${role}. Their name is
   }
 
   const modelConfiguration = auth.isUpgraded()
-    ? getLargeWhitelistedModel(auth, undefined, { featureFlags })
-    : getSmallWhitelistedModel(auth, undefined, { featureFlags });
+    ? getLargeWhitelistedModel(auth, undefined, {
+        featureFlags,
+        whiteListedProviders,
+      })
+    : getSmallWhitelistedModel(auth, undefined, {
+        featureFlags,
+        whiteListedProviders,
+      });
 
   const model: AgentModelConfigurationType = modelConfiguration
     ? {

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -13,6 +13,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -34,6 +35,7 @@ function _getManagedDataSourceAgent(
     preFetchedDataSources,
     searchMCPServerView,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     connectorProvider: ConnectorProvider;
@@ -45,11 +47,18 @@ function _getManagedDataSourceAgent(
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ): AgentConfigurationType | null {
   const modelConfiguration = auth.isUpgraded()
-    ? getLargeWhitelistedModel(auth, undefined, { featureFlags })
-    : getSmallWhitelistedModel(auth, undefined, { featureFlags });
+    ? getLargeWhitelistedModel(auth, undefined, {
+        featureFlags,
+        whiteListedProviders,
+      })
+    : getSmallWhitelistedModel(auth, undefined, {
+        featureFlags,
+        whiteListedProviders,
+      });
 
   const model: AgentModelConfigurationType = modelConfiguration
     ? {
@@ -159,11 +168,13 @@ export function _getGoogleDriveGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ): AgentConfigurationType | null {
   const agentId = GLOBAL_AGENTS_SID.GOOGLE_DRIVE;
@@ -182,6 +193,7 @@ export function _getGoogleDriveGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
     featureFlags,
+    whiteListedProviders,
   });
 }
 
@@ -192,11 +204,13 @@ export function _getSlackGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.SLACK;
@@ -215,6 +229,7 @@ export function _getSlackGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
     featureFlags,
+    whiteListedProviders,
   });
 }
 
@@ -225,11 +240,13 @@ export function _getGithubGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.GITHUB;
@@ -248,6 +265,7 @@ export function _getGithubGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
     featureFlags,
+    whiteListedProviders,
   });
 }
 
@@ -258,11 +276,13 @@ export function _getNotionGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.NOTION;
@@ -281,6 +301,7 @@ export function _getNotionGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
     featureFlags,
+    whiteListedProviders,
   });
 }
 
@@ -291,11 +312,13 @@ export function _getIntercomGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     featureFlags,
+    whiteListedProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.INTERCOM;
@@ -314,5 +337,6 @@ export function _getIntercomGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
     featureFlags,
+    whiteListedProviders,
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -113,11 +113,15 @@ import {
   getDataSourcesAndWorkspaceIdForGlobalAgents,
   getMCPServerViewsForGlobalAgents,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  isProviderWhitelistedForAuth,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getDefaultStreamConfigForAuth } from "@app/lib/model_tiers/enabled_models";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import type {
   AgentConfigurationType,
   AgentFetchVariant,
@@ -147,6 +151,7 @@ function getGlobalAgent({
   autoDefaultModelConfig,
   preferSonnet5DefaultModel,
   featureFlags,
+  whiteListedProviders,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -160,6 +165,7 @@ function getGlobalAgent({
   autoDefaultModelConfig: ModelConfigurationType | null;
   preferSonnet5DefaultModel: boolean;
   featureFlags: WhitelistableFeature[];
+  whiteListedProviders: ModelProviderIdType[] | null;
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -171,6 +177,7 @@ function getGlobalAgent({
       agentConfiguration = _getHelperGlobalAgent({
         auth,
         featureFlags,
+        whiteListedProviders,
         mcpServerViews,
       });
       break;
@@ -252,6 +259,7 @@ function getGlobalAgent({
         settings,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET:
@@ -335,6 +343,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.GOOGLE_DRIVE:
@@ -343,6 +352,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.NOTION:
@@ -351,6 +361,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.GITHUB:
@@ -359,6 +370,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.INTERCOM:
@@ -367,6 +379,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST:
@@ -376,6 +389,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
         globalAgentContext,
         autoDefaultModelConfig,
         preferSonnet5DefaultModel,
@@ -388,6 +402,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
         globalAgentContext,
       });
       break;
@@ -398,6 +413,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
         globalAgentContext,
       });
       break;
@@ -408,6 +424,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
         globalAgentContext,
       });
       break;
@@ -418,6 +435,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT:
@@ -427,6 +445,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM:
@@ -436,6 +455,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_HIGH:
@@ -445,6 +465,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED:
@@ -454,6 +475,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED:
@@ -463,6 +485,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE:
@@ -472,6 +495,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_SONNET_EDGE_LIGHT:
@@ -481,6 +505,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_HAIKU:
@@ -490,6 +515,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_LIGHT:
@@ -499,6 +525,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_KIMI:
@@ -508,6 +535,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM:
@@ -517,6 +545,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_KIMI_HIGH:
@@ -526,6 +555,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GLM:
@@ -535,6 +565,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM:
@@ -544,6 +575,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GLM_HIGH:
@@ -553,6 +585,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_PISTACHE:
@@ -562,6 +595,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM:
@@ -571,6 +605,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH:
@@ -580,6 +615,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MINIMAX:
@@ -589,6 +625,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM:
@@ -598,6 +635,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH:
@@ -607,6 +645,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_DEEPSEEK:
@@ -616,6 +655,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE:
@@ -625,6 +665,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH:
@@ -634,6 +675,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_QUICK:
@@ -643,6 +685,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI:
@@ -652,6 +695,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_MEDIUM:
@@ -661,6 +705,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_HIGH:
@@ -670,6 +715,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_LUNA:
@@ -679,6 +725,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_LUNA_MEDIUM:
@@ -688,6 +735,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_LUNA_HIGH:
@@ -697,6 +745,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_NANO_HIGH:
@@ -706,6 +755,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG:
@@ -715,6 +765,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM:
@@ -724,6 +775,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_HIGH:
@@ -733,6 +785,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_LITE:
@@ -742,6 +795,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_PRO:
@@ -751,6 +805,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_PRO_MEDIUM:
@@ -760,6 +815,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_PRO_HIGH:
@@ -769,6 +825,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM:
@@ -778,6 +835,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_NEXT:
@@ -787,6 +845,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM:
@@ -796,6 +855,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_NEXT_HIGH:
@@ -805,6 +865,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_LIONEL:
@@ -814,6 +875,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM:
@@ -823,6 +885,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH:
@@ -832,6 +895,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     // Retired custom-model dust-* agents: their eval models were removed from
@@ -858,6 +922,7 @@ function getGlobalAgent({
           mcpServerViews,
           hasDeepDive,
           featureFlags,
+          whiteListedProviders,
         },
         sId
       );
@@ -869,6 +934,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasSandbox,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
@@ -877,6 +943,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY:
@@ -886,6 +953,7 @@ function getGlobalAgent({
       agentConfiguration = _getPlanningAgent(auth, {
         settings,
         featureFlags,
+        whiteListedProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.SIDEKICK:
@@ -1061,6 +1129,7 @@ export async function getGlobalAgents(
       .filter((sId) => sId !== GLOBAL_AGENTS_SID.REINFORCEMENT);
 
   const flags = await getFeatureFlags(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
 
   if (!isWorkspaceAnalyticsEnabled(owner)) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
@@ -1195,6 +1264,7 @@ export async function getGlobalAgents(
       autoDefaultModelConfig,
       preferSonnet5DefaultModel: flags.includes("dust_agent_sonnet_5_default"),
       featureFlags: flags,
+      whiteListedProviders,
     })
   );
 
@@ -1204,7 +1274,11 @@ export async function getGlobalAgents(
     if (
       agentFetcherResult &&
       agentFetcherResult.scope === "global" &&
-      isProviderWhitelistedForAuth(auth, agentFetcherResult.model.providerId)
+      isProviderWhitelistedForAuth(
+        auth,
+        agentFetcherResult.model.providerId,
+        whiteListedProviders
+      )
     ) {
       globalAgents.push(agentFetcherResult);
     }

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,9 +1,13 @@
 import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getWhitelistedProviders,
+} from "@app/lib/api/assistant/models";
 import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { Authenticator } from "@app/lib/auth";
 import { setWorkspaceMaxAllowedTierName } from "@app/lib/model_tiers/allowed_tiers";
 import * as enabledModels from "@app/lib/model_tiers/enabled_models";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -48,12 +52,53 @@ function mockCredentials(
   ).mockResolvedValue(health);
 }
 
+// Workspace fetches and the WorkspaceType served by the Authenticator carry the configured
+// whiteListedProviders untouched. The global provider kill switches are overlaid only here,
+// when the effective value is resolved for gating.
+describe("getEffectiveWhiteListedProviders", () => {
+  afterEach(async () => {
+    await KillSwitchResource.disableKillSwitch("global_blacklist_openai");
+  });
+
+  it("returns the configured providers when no kill switch is enabled", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["openai", "anthropic"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await expect(getEffectiveWhiteListedProviders(auth)).resolves.toEqual([
+      "openai",
+      "anthropic",
+    ]);
+  });
+
+  it("overlays global provider kill switches without touching the configured value", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["openai", "anthropic"],
+    });
+    await KillSwitchResource.enableKillSwitch("global_blacklist_openai");
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await expect(getEffectiveWhiteListedProviders(auth)).resolves.toEqual([
+      "anthropic",
+    ]);
+    expect(auth.getNonNullableWorkspace().whiteListedProviders).toEqual([
+      "openai",
+      "anthropic",
+    ]);
+  });
+});
+
 describe("getWhitelistedProviders", () => {
   it("returns all providers including noop when whiteListedProviders is null", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
     expect(providers).toEqual(new Set(MODEL_PROVIDER_IDS));
   });
 
@@ -63,7 +108,10 @@ describe("getWhitelistedProviders", () => {
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
     expect(providers).toEqual(new Set(["anthropic", "noop"]));
   });
 
@@ -75,7 +123,10 @@ describe("getWhitelistedProviders", () => {
     ]);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
     expect(providers).toEqual(new Set(["openai", "anthropic", "noop"]));
   });
 
@@ -89,7 +140,10 @@ describe("getWhitelistedProviders", () => {
     ]);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
     expect(providers).toEqual(new Set(["anthropic", "noop"]));
   });
 
@@ -98,7 +152,10 @@ describe("getWhitelistedProviders", () => {
     mockCredentials([]);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
     expect(providers).toEqual(new Set(["noop"]));
   });
 });

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -4,6 +4,7 @@ import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import { GEMINI_3_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
@@ -27,13 +28,25 @@ import {
 } from "@app/types/assistant/models/xai";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
-export function getWhitelistedProviders(
+// Effective white-listed providers for the authenticated workspace: the configured value
+// overlaid with the global provider kill switches. Resolved once at an async boundary and
+// passed into the synchronous gating functions below, like featureFlags.
+export async function getEffectiveWhiteListedProviders(
   auth: Authenticator
-): Set<ModelProviderIdType> {
+): Promise<ModelProviderIdType[] | null> {
   const owner = auth.getNonNullableWorkspace();
+  return WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+    owner.whiteListedProviders
+  );
+}
+
+export function getWhitelistedProviders(
+  auth: Authenticator,
+  whiteListedProvidersInput: ModelProviderIdType[] | null
+): Set<ModelProviderIdType> {
   const plan = auth.getNonNullablePlan();
   const whiteListedProviders = new Set<ModelProviderIdType>(
-    owner.whiteListedProviders ?? MODEL_PROVIDER_IDS
+    whiteListedProvidersInput ?? MODEL_PROVIDER_IDS
   );
 
   // noop never sees user data, always whitelisted.
@@ -71,15 +84,20 @@ export { isProviderWhitelisted } from "@app/lib/api/assistant/provider_whitelist
 
 export function isProviderWhitelistedForAuth(
   auth: Authenticator,
-  providerId: ModelProviderIdType
+  providerId: ModelProviderIdType,
+  whiteListedProviders: ModelProviderIdType[] | null
 ): boolean {
-  return isProviderWhitelisted(getWhitelistedProviders(auth), providerId);
+  return isProviderWhitelisted(
+    getWhitelistedProviders(auth, whiteListedProviders),
+    providerId
+  );
 }
 
 type ModelEnablementContext = Parameters<typeof isModelEnabled>[1];
 
 function getModelEnablementContext(
   auth: Authenticator,
+  whiteListedProviders: ModelProviderIdType[] | null,
   excludeProviders: ReadonlySet<ModelProviderIdType> = new Set(),
   featureFlags: WhitelistableFeature[] = []
 ): ModelEnablementContext {
@@ -90,8 +108,10 @@ function getModelEnablementContext(
     plan: auth.plan(),
     regionalModelsOnly: owner.regionalModelsOnly,
     region: regionConfig.getCurrentRegion(),
-    whitelistedProviders:
-      getWhitelistedProviders(auth).difference(excludeProviders),
+    whitelistedProviders: getWhitelistedProviders(
+      auth,
+      whiteListedProviders
+    ).difference(excludeProviders),
   };
 }
 
@@ -102,23 +122,28 @@ function getModelEnablementContext(
 // chosen model can never be rejected later as "not supported". It falls through
 // to the next candidate instead.
 //
-// The workspace feature flags must be passed in: selection happens in
-// synchronous global-agent builders where they are not otherwise in scope, and
-// using the real flags here is what keeps this check identical to the one
-// enforced at message time rather than a second, divergent check.
+// The workspace feature flags and effective white-listed providers must be
+// passed in: selection happens in synchronous global-agent builders where they
+// are not otherwise in scope, and using the real values here is what keeps this
+// check identical to the one enforced at message time rather than a second,
+// divergent check. Resolve the providers with getEffectiveWhiteListedProviders
+// at the nearest async boundary.
 export function selectEnabledModel(
   auth: Authenticator,
   candidates: ModelConfigurationType[],
   {
     featureFlags,
+    whiteListedProviders,
     excludeProviders = new Set(),
   }: {
     featureFlags: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
     excludeProviders?: ReadonlySet<ModelProviderIdType>;
   }
 ): ModelConfigurationType | null {
   const context = getModelEnablementContext(
     auth,
+    whiteListedProviders,
     excludeProviders,
     featureFlags
   );
@@ -132,9 +157,12 @@ const ORDERED_FAST_MODEL_CONFIGS: ModelConfigurationType[] = [
 ];
 
 export function getFastestWhitelistedModel(
-  auth: Authenticator
+  auth: Authenticator,
+  {
+    whiteListedProviders,
+  }: { whiteListedProviders: ModelProviderIdType[] | null }
 ): ModelConfigurationType | null {
-  const context = getModelEnablementContext(auth);
+  const context = getModelEnablementContext(auth, whiteListedProviders);
 
   return (
     ORDERED_FAST_MODEL_CONFIGS.find((m) => isModelEnabled(m, context)) ??
@@ -145,10 +173,21 @@ export function getFastestWhitelistedModel(
 export function getSmallWhitelistedModel(
   auth: Authenticator,
   excludeProviders: ReadonlySet<ModelProviderIdType> = new Set(),
-  { featureFlags = [] }: { featureFlags?: WhitelistableFeature[] } = {}
+  {
+    featureFlags = [],
+    whiteListedProviders,
+  }: {
+    featureFlags?: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
+  }
 ): ModelConfigurationType | null {
   return _getSmallWhitelistedModel(
-    getModelEnablementContext(auth, excludeProviders, featureFlags)
+    getModelEnablementContext(
+      auth,
+      whiteListedProviders,
+      excludeProviders,
+      featureFlags
+    )
   );
 }
 
@@ -158,10 +197,20 @@ export function getLargeWhitelistedModel(
   {
     forBatch = false,
     featureFlags = [],
-  }: { forBatch?: boolean; featureFlags?: WhitelistableFeature[] } = {}
+    whiteListedProviders,
+  }: {
+    forBatch?: boolean;
+    featureFlags?: WhitelistableFeature[];
+    whiteListedProviders: ModelProviderIdType[] | null;
+  }
 ): ModelConfigurationType | null {
   return _getLargeWhitelistedModel(
-    getModelEnablementContext(auth, excludeProviders, featureFlags),
+    getModelEnablementContext(
+      auth,
+      whiteListedProviders,
+      excludeProviders,
+      featureFlags
+    ),
     { forBatch }
   );
 }

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -1,6 +1,9 @@
 import { getDegradedModelIds } from "@app/lib/api/assistant/degraded_models";
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
-import { selectEnabledModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  selectEnabledModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getAgentAllowedTierNamesOverride } from "@app/lib/model_tiers/agent_tier_overrides";
 import {
@@ -71,6 +74,8 @@ export async function resolveModel(
 
   const requestedConfig = userConfig ?? agentConfig;
 
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+
   let enabled =
     requestedConfig && isModelStreamId(requestedConfig.modelId)
       ? requestedConfig
@@ -83,6 +88,7 @@ export async function resolveModel(
           ]),
           {
             featureFlags,
+            whiteListedProviders,
           }
         );
 

--- a/front/lib/api/assistant/suggestions/description.ts
+++ b/front/lib/api/assistant/suggestions/description.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getFastestWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/assistant";
@@ -53,7 +56,8 @@ export async function getBuilderDescriptionSuggestions(
   auth: Authenticator,
   inputs: BuilderSuggestionInputType
 ): Promise<Result<SuggestionResults, Error>> {
-  const model = getFastestWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastestWhitelistedModel(auth, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error(

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getFastestWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/assistant";
@@ -85,7 +88,8 @@ export async function getBuilderEmojiSuggestions(
   auth: Authenticator,
   inputs: BuilderSuggestionInputType
 ): Promise<Result<SuggestionResults, Error>> {
-  const model = getFastestWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastestWhitelistedModel(auth, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model for emoji suggestions")

--- a/front/lib/api/assistant/suggestions/index.ts
+++ b/front/lib/api/assistant/suggestions/index.ts
@@ -1,4 +1,7 @@
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import { getBuilderDescriptionSuggestions } from "@app/lib/api/assistant/suggestions/description";
 import { getBuilderEmojiSuggestions } from "@app/lib/api/assistant/suggestions/emoji";
 import { getBuilderNameSuggestions } from "@app/lib/api/assistant/suggestions/name";
@@ -22,8 +25,12 @@ async function getModelForSuggestionType(
     case "name":
     case "description":
     case "emoji":
-    case "tags":
-      return getSmallWhitelistedModel(auth);
+    case "tags": {
+      const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+      return getSmallWhitelistedModel(auth, undefined, {
+        whiteListedProviders,
+      });
+    }
 
     default:
       assertNever(type);

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getFastestWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -103,7 +106,8 @@ export async function getBuilderNameSuggestions(
     "- The name should immediately convey what the agent does.";
   const conversation: ModelConversationTypeMultiActions =
     getConversationContext(inputs);
-  const model = getFastestWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastestWhitelistedModel(auth, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model for name suggestions")

--- a/front/lib/api/assistant/suggestions/tags.ts
+++ b/front/lib/api/assistant/suggestions/tags.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getFastestWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/assistant";
@@ -108,7 +111,8 @@ export async function getBuilderTagSuggestions(
   // check both client input AND server auth until frontend bug is fixed.
   const isAdminInput = "isAdmin" in inputs ? inputs.isAdmin : false;
 
-  const model = getFastestWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastestWhitelistedModel(auth, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model for tag suggestions")

--- a/front/lib/api/assistant/tag_manager.ts
+++ b/front/lib/api/assistant/tag_manager.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getLargeWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -118,7 +121,10 @@ export async function getWorkspaceTagSuggestions(
 ): Promise<Result<{ suggestions?: WorkspaceTagSuggestion[] | null }, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = await getLargeWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getLargeWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!model) {
     return new Err(
       new Error(

--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getFastestWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { TemplateResource } from "@app/lib/resources/template_resource";
 import type { Result } from "@app/types/shared/result";
@@ -68,7 +71,8 @@ export async function getSuggestedTemplatesForQuery(
 ): Promise<Result<TemplateResource[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = await getFastestWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getFastestWhitelistedModel(auth, { whiteListedProviders });
   if (!model) {
     return new Err(
       new Error(

--- a/front/lib/api/assistant/voice_agent_finder.ts
+++ b/front/lib/api/assistant/voice_agent_finder.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -127,7 +130,10 @@ export async function findAgentsInMessageGeneration(
   auth: Authenticator,
   inputs: { agentsList: string[]; message: string }
 ): Promise<Result<{ augmentedMessages: AugmentedMessageFromLLM[] }, Error>> {
-  const model = await getSmallWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getSmallWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!model) {
     return new Err(
       new Error(

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -4,7 +4,10 @@ import {
   getMcpServerViewDisplayName,
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getWhitelistedProviders,
+} from "@app/lib/api/assistant/models";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { filterEnabledModels } from "@app/lib/assistant";
@@ -44,10 +47,14 @@ export async function getAvailableModelsForWorkspace(
   auth: Authenticator
 ): Promise<ModelConfigurationType[]> {
   const featureFlags = await getFeatureFlags(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.plan();
   const region = regionConfig.getCurrentRegion();
-  const whitelistedProviders = getWhitelistedProviders(auth);
+  const whitelistedProviders = getWhitelistedProviders(
+    auth,
+    whiteListedProviders
+  );
 
   const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
   return filterEnabledModels(allUsedModels, {

--- a/front/lib/api/llm/index.test.ts
+++ b/front/lib/api/llm/index.test.ts
@@ -1,4 +1,5 @@
 import { getWorkspaceFilter, legacyModelIdToModel } from "@app/lib/api/llm";
+import { getEffectiveWhiteListedProviders } from "@app/lib/api/assistant/models";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getStreamEndpoints } from "@app/lib/llms/stream";
 import type { WorkspaceConfig } from "@app/lib/llms/types/filter";
@@ -37,7 +38,10 @@ describe("getWorkspaceFilter", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const workspaceConfig = await getWorkspaceConfig(auth);
-    const filter = getWorkspaceFilter(auth);
+    const filter = getWorkspaceFilter(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
 
     const flashEndpoints = getStreamEndpoints(workspaceConfig, {
       ...filter,
@@ -63,7 +67,10 @@ describe("getWorkspaceFilter", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const workspaceConfig = await getWorkspaceConfig(auth);
-    const filter = getWorkspaceFilter(auth);
+    const filter = getWorkspaceFilter(
+      auth,
+      await getEffectiveWhiteListedProviders(auth)
+    );
 
     const proEndpoints = getStreamEndpoints(workspaceConfig, {
       ...filter,

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -64,8 +64,13 @@ function getRegionFilter(auth: Authenticator): ValueFilter<Region> | undefined {
   return { eq: EUROPE };
 }
 
-function getWhitelistedProviderIds(auth: Authenticator): ModelProviderIdType[] {
-  const whitelistedProviderIds = [...getWhitelistedProviders(auth)];
+function getWhitelistedProviderIds(
+  auth: Authenticator,
+  whiteListedProviders: ModelProviderIdType[] | null
+): ModelProviderIdType[] {
+  const whitelistedProviderIds = [
+    ...getWhitelistedProviders(auth, whiteListedProviders),
+  ];
   const byok = auth.getNonNullablePlan().isByok;
 
   return byok
@@ -127,9 +132,12 @@ function getLabAndHostFilter(
 }
 
 // Temporary helper while we have both systems
-export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
+export function getWorkspaceFilter(
+  auth: Authenticator,
+  whiteListedProviders: ModelProviderIdType[] | null
+): Where<EndpointConfig> {
   const byok = auth.getNonNullablePlan().isByok;
-  const providerIds = getWhitelistedProviderIds(auth);
+  const providerIds = getWhitelistedProviderIds(auth, whiteListedProviders);
 
   return {
     ...getLabAndHostFilter(providerIds),

--- a/front/lib/api/llm/selectPreferredEndpointForWorkspace.ts
+++ b/front/lib/api/llm/selectPreferredEndpointForWorkspace.ts
@@ -1,3 +1,4 @@
+import { getEffectiveWhiteListedProviders } from "@app/lib/api/assistant/models";
 import { getWorkspaceFilter, legacyModelIdToModel } from "@app/lib/api/llm";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -36,6 +37,7 @@ export async function selectPreferredEndpointForWorkspace<
 ): Promise<T | null> {
   const plan = auth.getNonNullablePlan();
   const featureFlags = await getFeatureFlags(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
 
   const endpoints = getEndpoints(
     {
@@ -44,7 +46,7 @@ export async function selectPreferredEndpointForWorkspace<
       isCreditPriced: isCreditPricedPlanPrefix(plan.code),
     },
     {
-      and: [getWorkspaceFilter(auth), filter],
+      and: [getWorkspaceFilter(auth, whiteListedProviders), filter],
     }
   );
 

--- a/front/lib/api/skills/description_suggestion.ts
+++ b/front/lib/api/skills/description_suggestion.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getLargeWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";
@@ -71,7 +74,10 @@ export async function getSkillDescriptionSuggestion(
   inputs: SkillDescriptionSuggestionInputs
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
-  const model = await getLargeWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getLargeWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
 
   if (!model) {
     return new Err(

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -1,6 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -197,7 +200,10 @@ export async function getSimilarSkills(
     availabilities?: SkillAvailability[];
   }
 ): Promise<Result<{ similar_skills: string[] }, Error>> {
-  const model = await getSmallWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getSmallWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate cron rule")

--- a/front/lib/api/skills/icon_suggestion.ts
+++ b/front/lib/api/skills/icon_suggestion.ts
@@ -1,7 +1,10 @@
 import type { InternalActionIcons } from "@app/components/resources/resources_icons";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getLargeWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";
@@ -109,7 +112,10 @@ export async function getSkillIconSuggestion(
   inputs: SkillIconSuggestionInputs
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
-  const model = await getLargeWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getLargeWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
 
   if (!model) {
     return new Err(

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,4 +1,7 @@
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getWhitelistedProviders,
+} from "@app/lib/api/assistant/models";
 import {
   filterEnabledModels,
   isModelAvailable,
@@ -387,7 +390,10 @@ describe("filterEnabledModels", () => {
       plan: { ...auth.plan()!, hasAdvancedModelAccess: false },
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
 
     expect(result).toEqual([]);
@@ -403,7 +409,10 @@ describe("filterEnabledModels", () => {
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
     expect(result).toContain(model);
   });
@@ -423,7 +432,10 @@ describe("filterEnabledModels", () => {
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
     expect(result).toHaveLength(0);
   });
@@ -442,7 +454,10 @@ describe("filterEnabledModels", () => {
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
     expect(result).toHaveLength(0);
   });
@@ -461,7 +476,10 @@ describe("filterEnabledModels", () => {
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
     expect(result).toContain(model);
   });
@@ -485,7 +503,10 @@ describe("filterEnabledModels", () => {
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
     expect(result).toEqual([openaiModel]);
   });
@@ -503,7 +524,10 @@ describe("filterEnabledModels", () => {
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
-      whitelistedProviders: getWhitelistedProviders(auth),
+      whitelistedProviders: getWhitelistedProviders(
+        auth,
+        await getEffectiveWhiteListedProviders(auth)
+      ),
     });
     expect(result).toContain(model);
   });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1414,7 +1414,7 @@ export class Authenticator {
           ssoEnforced: this._workspace.ssoEnforced,
           regionalModelsOnly: this._workspace.regionalModelsOnly,
           workOSOrganizationId: this._workspace.workOSOrganizationId,
-          whiteListedProviders: this._workspace.whiteListedProviders,
+          whiteListedProviders: this._workspace.configuredWhiteListedProviders,
           defaultEmbeddingProvider: this._workspace.defaultEmbeddingProvider,
           metadata: this._workspace.metadata,
           metronomeCustomerId: this._workspace.metronomeCustomerId ?? null,

--- a/front/lib/notifications/helpers.ts
+++ b/front/lib/notifications/helpers.ts
@@ -6,7 +6,10 @@ import {
   countConversationMessages,
   renderConversationAsText,
 } from "@app/lib/api/assistant/conversation/render_as_text";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import { Authenticator } from "@app/lib/auth";
 import {
@@ -292,7 +295,10 @@ const runConversationSummaryToolCall = async (
 > => {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = await getSmallWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getSmallWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
   if (!model) {
     return new Err(
       new DustError("no_whitelisted_model_found", "No whitelisted model found")

--- a/front/lib/reinforcement/models.ts
+++ b/front/lib/reinforcement/models.ts
@@ -1,4 +1,7 @@
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getLargeWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -15,5 +18,10 @@ export async function getLargeWhitelistedModelWithBatchMode(
     ? new Set<"anthropic">(["anthropic"])
     : new Set<never>();
 
-  return getLargeWhitelistedModel(auth, excludedProviders, { forBatch: true });
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+
+  return getLargeWhitelistedModel(auth, excludedProviders, {
+    forBatch: true,
+    whiteListedProviders,
+  });
 }

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -262,19 +262,20 @@ describe("WorkspaceResource", () => {
         expect(resource?.sId).toBe(workspace.sId);
       });
 
-      it("applies provider kill switches after reading the cached snapshot", async () => {
+      it("keeps the configured whiteListedProviders on cached fetches even when kill switches are enabled", async () => {
         workspace = await WorkspaceFactory.basic({
           whiteListedProviders: ["openai", "anthropic"],
         });
         listEnabledKillSwitches.mockResolvedValue(["global_blacklist_openai"]);
 
         const firstFetch = await WorkspaceResource.fetchById(workspace.sId);
-        expect(firstFetch?.whiteListedProviders).toEqual(["anthropic"]);
-
-        listEnabledKillSwitches.mockResolvedValue([]);
+        expect(firstFetch?.configuredWhiteListedProviders).toEqual([
+          "openai",
+          "anthropic",
+        ]);
 
         const cachedFetch = await WorkspaceResource.fetchById(workspace.sId);
-        expect(cachedFetch?.whiteListedProviders).toEqual([
+        expect(cachedFetch?.configuredWhiteListedProviders).toEqual([
           "openai",
           "anthropic",
         ]);
@@ -316,7 +317,10 @@ describe("WorkspaceResource", () => {
           Object.keys(WorkspaceModel.getAttributes()).sort()
         );
         expect(resource?.name).toBe("fixture-workspace");
-        expect(resource?.whiteListedProviders).toEqual(["openai", "anthropic"]);
+        expect(resource?.configuredWhiteListedProviders).toEqual([
+          "openai",
+          "anthropic",
+        ]);
         expect(resource?.metadata).toEqual({ fixtureKey: "fixtureValue" });
         expect(resource?.createdAt).toEqual(new Date(1755000000000));
         expect(resource?.updatedAt).toEqual(new Date(1755000000000));
@@ -780,7 +784,7 @@ describe("WorkspaceResource", () => {
       expect(result).toContain("mistral");
     });
 
-    it("applies provider kill switches on uncached fetch paths", async () => {
+    it("keeps the configured whiteListedProviders on uncached fetch paths even when kill switches are enabled", async () => {
       workspace = await WorkspaceFactory.basic({
         whiteListedProviders: ["openai", "anthropic"],
       });
@@ -788,7 +792,37 @@ describe("WorkspaceResource", () => {
 
       const [resource] = await WorkspaceResource.fetchByIds([workspace.sId]);
 
-      expect(resource?.whiteListedProviders).toEqual(["anthropic"]);
+      expect(resource?.configuredWhiteListedProviders).toEqual([
+        "openai",
+        "anthropic",
+      ]);
+    });
+  });
+
+  describe("fetchWhiteListedProviders", () => {
+    it("returns the configured value when no kill switches are enabled", async () => {
+      workspace = await WorkspaceFactory.basic({
+        whiteListedProviders: ["openai", "anthropic"],
+      });
+      const resource = await WorkspaceResource.fetchById(workspace.sId);
+
+      await expect(resource?.fetchWhiteListedProviders()).resolves.toEqual([
+        "openai",
+        "anthropic",
+      ]);
+    });
+
+    it("overlays the global provider kill switches", async () => {
+      workspace = await WorkspaceFactory.basic({
+        whiteListedProviders: ["openai", "anthropic"],
+      });
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_openai"]);
+
+      const resource = await WorkspaceResource.fetchById(workspace.sId);
+
+      await expect(resource?.fetchWhiteListedProviders()).resolves.toEqual([
+        "anthropic",
+      ]);
     });
   });
 

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -73,9 +73,15 @@ type WorkspaceModelIdBatchRow = {
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
+// whiteListedProviders is deliberately not exposed: the raw column is ambiguous with the
+// effective value under global provider kill switches. Use `fetchWhiteListedProviders` for
+// gating and `configuredWhiteListedProviders` for serialization and display.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WorkspaceResource
-  extends ReadonlyAttributesType<WorkspaceModel> {}
+  extends Omit<
+    ReadonlyAttributesType<WorkspaceModel>,
+    "whiteListedProviders"
+  > {}
 
 export const WORKSPACE_CONVERSATION_KILL_SWITCH_OPERATIONS = [
   "block",
@@ -244,30 +250,28 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   // Materialization: the single seam where fetched blobs become resources, run by every fetch
-  // path (cached or not). This is where context outside the row is folded in: provider kill
-  // switches here, so a WorkspaceResource always carries the effective whiteListedProviders while
-  // the cache keeps the raw column value. Never persist whiteListedProviders read from a
-  // materialized resource: that would make a temporary kill switch permanent.
-  // TODO(2026-08-21 flav): Move the kill-switch overlay to its consumption points (Authenticator
-  // and model gating) so workspace fetches stay pure and this materialize becomes plain
-  // construction.
+  // path (cached or not). Plain construction: workspace fetches are pure and carry the raw
+  // column values. The kill-switch overlay on whiteListedProviders is applied where the value
+  // is consumed, through `fetchWhiteListedProviders`.
   private static async materialize(
     blobs: Attributes<WorkspaceModel>[]
   ): Promise<WorkspaceResource[]> {
-    if (blobs.length === 0) {
-      return [];
-    }
-    const enabledKillSwitches =
-      await KillSwitchResource.listEnabledKillSwitches();
-    return blobs.map(
-      (blob) =>
-        new WorkspaceResource(WorkspaceModel, {
-          ...blob,
-          whiteListedProviders: WorkspaceResource.filterKillSwitchedProviders(
-            blob.whiteListedProviders,
-            enabledKillSwitches
-          ),
-        })
+    return blobs.map((blob) => new WorkspaceResource(WorkspaceModel, blob));
+  }
+
+  // The configured column value, untouched by kill switches. For serialization and display
+  // only: never use it to decide which providers are usable, that is
+  // `fetchWhiteListedProviders`.
+  get configuredWhiteListedProviders(): ModelProviderIdType[] | null {
+    return this.blob.whiteListedProviders;
+  }
+
+  // Effective providers for LLM gating: the configured value overlaid with the global provider
+  // kill switches. Never persist the returned value: that would make a temporary kill switch
+  // permanent.
+  async fetchWhiteListedProviders(): Promise<ModelProviderIdType[] | null> {
+    return WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+      this.blob.whiteListedProviders
     );
   }
 

--- a/front/lib/workspace.ts
+++ b/front/lib/workspace.ts
@@ -30,7 +30,10 @@ export function renderLightWorkspaceType({
     metronomeCustomerId: workspace.metronomeCustomerId ?? null,
     regionalModelsOnly: workspace.regionalModelsOnly,
     sId: workspace.sId,
-    whiteListedProviders: workspace.whiteListedProviders,
+    whiteListedProviders:
+      "configuredWhiteListedProviders" in workspace
+        ? workspace.configuredWhiteListedProviders
+        : workspace.whiteListedProviders,
     workOSOrganizationId: workspace.workOSOrganizationId,
   };
 }

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -5,7 +5,10 @@ import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversat
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
-import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  isProviderWhitelistedForAuth,
+} from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { Authenticator } from "@app/lib/auth";
@@ -315,7 +318,10 @@ export async function runCompaction(
     return new Err(new Error("Compaction message not found"));
   }
 
-  if (!isProviderWhitelistedForAuth(auth, model.providerId)) {
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  if (
+    !isProviderWhitelistedForAuth(auth, model.providerId, whiteListedProviders)
+  ) {
     return new Err(
       new Error(
         `The model provider ${model.providerId} has been disabled by your workspace admin.`

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -1,7 +1,10 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getEffectiveWhiteListedProviders,
+  getLargeWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import {
   isApiBlocked,
   isProgrammaticApiBlocked,
@@ -219,7 +222,10 @@ async function runReinforcedSkillsStep({
     };
   }
 
-  const model = getLargeWhitelistedModel(auth);
+  const whiteListedProviders = await getEffectiveWhiteListedProviders(auth);
+  const model = getLargeWhitelistedModel(auth, undefined, {
+    whiteListedProviders,
+  });
 
   if (!model) {
     logger.error(


### PR DESCRIPTION
## Description

Workspace fetches become pure: materialization is plain construction and the resource always carries the raw whiteListedProviders column. The global provider kill switches are applied at the consumption point instead. The resource exposes a new fetchWhiteListedProviders instance method that overlays the enabled kill switches on the raw column, and every Authenticator factory resolves it once at construction, next to the existing providers-health resolution. The workspace type served by the Authenticator therefore still carries the effective providers, which keeps model gating and everything downstream unchanged. The constructor parameter is required so a factory cannot silently serve the raw value, and derived authenticators carry the resolved value over like the other resolved fields.

This is the first step of folding the cached resource store into BaseResource: with the overlay gone, workspace materialization has no context to fold in anymore, so the materialization seam can later collapse to the default plain construction.

One deliberate behavior change: a LightWorkspaceType rendered directly from a resource (workspace lists, poke) now carries the configured providers rather than the kill-switch-filtered ones. Model gating never reads from those paths, and the admin providers page arguably should show the configured value.

## Tests

The fetch-path tests now assert that cached and uncached reads keep the raw column value under an active kill switch. A new test on the resource covers the overlay in fetchWhiteListedProviders, and a new Authenticator test asserts the workspace it serves carries the effective providers while the underlying resource keeps the raw ones.

## Risk

Low. The kill-switch lookup is Redis-cached with a five minute TTL and moves from once per workspace fetch to once per Authenticator construction, which is cost-neutral. Kill switches are rare, short-lived emergency states; while one is active, workspaces fetched outside an Authenticator no longer see the overlay, which only affects display surfaces.

## Deploy Plan

Deploy front normally.