### PR TITLE
[front] feat: flag over-allocated seats in metronome seat-state audit

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -745,7 +745,7 @@ async function fetchPerUserUsageCreditsForMembersTable({
   }
 }
 
-async function fetchConsumedAwuCreditsFromMetronomeByUserId({
+export async function fetchConsumedAwuCreditsFromMetronomeByUserId({
   workspaceId,
   metronomeCustomerId,
   metronomeContractId,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -370,7 +370,7 @@ export async function resolveMetronomeCycle(
 // `cycle` forces the window instead of resolving the Metronome contract billing
 // period — used by workspaces that have no contract to anchor one on (see
 // `spendLimitCycleOverrideForAuth`).
-export async function fetchConsumedAwuCreditsByUserId({
+async function fetchConsumedAwuCreditsByUserId({
   workspace,
   userIds,
   freeSeatUserIds,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -370,7 +370,7 @@ export async function resolveMetronomeCycle(
 // `cycle` forces the window instead of resolving the Metronome contract billing
 // period — used by workspaces that have no contract to anchor one on (see
 // `spendLimitCycleOverrideForAuth`).
-async function fetchConsumedAwuCreditsByUserId({
+export async function fetchConsumedAwuCreditsByUserId({
   workspace,
   userIds,
   freeSeatUserIds,

--- a/front/lib/metronome/stacked_seat_credits.ts
+++ b/front/lib/metronome/stacked_seat_credits.ts
@@ -38,16 +38,26 @@ import { Err, Ok } from "@app/types/shared/result";
  * each individual materialized credit id. We map each materialized credit id to a
  * seat type once per contract, then for each seat:
  *
- *  - empty every STRAY credit fully (a credit whose seat type ≠ the seat's tier),
- *  - carry the consumption that was charged to those strays onto the HOME credit,
- *    so the seat nets `homeAllocation − totalConsumed` instead of a full home
- *    allowance plus forgiven stray usage.
+ *  - empty every STRAY credit fully (a credit whose seat type ≠ the seat's tier);
+ *  - drive the HOME credit to `max(0, homeAllocation − currentPeriodUsage)`, using
+ *    Metronome's authoritative per-user AWU usage.
  *
- * Without the carry, consumption billed to the stray credit is forgiven when the
- * stray is emptied and the seat ends over-credited by that amount. Both figures
- * are exact — observed per-seat credit balances vs. deterministic tier
- * allocations, not an ES/usage estimate. Idempotent by construction: a re-run
- * reads every stray at 0 (no stray consumption left to carry) and emits nothing.
+ * The home step is what keeps the seat correct: consumption billed to a stray is
+ * otherwise forgiven when the stray is emptied, leaving the seat over-credited by
+ * that amount (a seat that spent 69 AWU against its stray would end at a full home
+ * 8000 instead of 7931). Because the target is ABSOLUTE (allocation − usage) not a
+ * relative debit, the whole pass is idempotent and self-correcting:
+ *
+ *  - a healthy seat is a no-op — its home already equals allocation − usage;
+ *  - a partial Metronome failure (one credit's write lands, another doesn't) is
+ *    just retried next run, never double-debiting;
+ *  - it even RECOVERS a stray already emptied by an earlier no-carry run, whose
+ *    consumption is no longer visible in any balance but is still in the usage
+ *    figure — the home debit recomputes correctly from usage alone.
+ *
+ * Stray DETECTION stays exact/per-credit (the credit id names its tier, never
+ * ambiguous); only the home target uses usage. Never adds credit and never drives
+ * a slice negative (both the empty and the home target floor at 0).
  */
 
 // A credit-bearing tier's recurring credit, resolved to its materialized credit
@@ -174,20 +184,25 @@ export async function buildSeatCreditTierMap({
 }
 
 /**
- * Pure detection. For each seat, empty every stray seat credit fully and carry
- * the consumption those strays absorbed onto the home credit so the seat nets
- * `homeAllocation − totalConsumed`. A credit id absent from `tierByCreditId`
- * (excess/pool/unrecognized) is left untouched; a seat with no stray is skipped,
- * so re-runs are idempotent.
+ * Pure detection. For each seat, empty every stray seat credit fully and drive
+ * the home credit to `max(0, homeAllocation − usage)`. A credit id absent from
+ * `tierByCreditId` (excess/pool/unrecognized) is left untouched. Emits nothing for
+ * a healthy seat (no stray, home already at its usage-based target), and — because
+ * the home target is absolute — re-runs are idempotent and recover a seat whose
+ * stray was already emptied without a carry.
  */
 export function computeStackedSeatCreditAdjustments({
   seatBalances,
   currentSeatTypeBySeatId,
   tierByCreditId,
+  usageBySeatId,
 }: {
   seatBalances: MetronomeSeatBalance[];
   currentSeatTypeBySeatId: Map<string, MembershipSeatType>;
   tierByCreditId: Map<string, TierCredit>;
+  // Current-period Metronome per-user AWU consumption (authoritative). Drives the
+  // home credit to its correct balance; a missing entry is treated as 0 usage.
+  usageBySeatId: Map<string, number>;
 }): SeatCreditAdjustment[] {
   const awuCreditTypeId = getCreditTypeAwuId();
   const adjustments: SeatCreditAdjustment[] = [];
@@ -210,9 +225,6 @@ export function computeStackedSeatCreditAdjustments({
     const strays = mapped.filter(
       (m) => m.tier.seatType !== homeSeatType && m.balanceAwu > 0
     );
-    if (strays.length === 0) {
-      continue;
-    }
     const home = mapped.find((m) => m.tier.seatType === homeSeatType) ?? null;
 
     // Empty every stray credit's slice for this seat.
@@ -229,16 +241,19 @@ export function computeStackedSeatCreditAdjustments({
       });
     }
 
-    // Carry the stray-charged consumption onto the home credit. `strayConsumed`
-    // is what the strays absorbed (allocation − remaining); the home is debited
-    // by that, capped at its own balance so it never goes negative. Skipped when
-    // the home credit isn't present (nothing to debit).
+    // Drive the home credit to its correct balance: allocation − current-period
+    // usage. This absolute, usage-based target is what makes the whole pass
+    // idempotent and recovers consumption that leaked onto a stray — including a
+    // stray already emptied by an earlier no-carry run, whose consumption is no
+    // longer visible in any credit balance but is still in the usage figure. It
+    // is a no-op for a healthy seat: its home balance already equals allocation −
+    // usage, so the debit is 0. Never adds credit (debit floors at 0) and never
+    // drives the home negative (target floors at 0). Skipped when the home credit
+    // isn't present.
     if (home) {
-      const strayConsumed = strays.reduce(
-        (sum, s) => sum + Math.max(0, s.tier.allocation - s.balanceAwu),
-        0
-      );
-      const homeDebit = Math.min(home.balanceAwu, strayConsumed);
+      const usageAwu = usageBySeatId.get(seat.seat_id) ?? 0;
+      const targetHomeBalanceAwu = Math.max(0, home.tier.allocation - usageAwu);
+      const homeDebit = home.balanceAwu - targetHomeBalanceAwu;
       if (homeDebit > 0) {
         adjustments.push({
           seatId: seat.seat_id,
@@ -257,29 +272,32 @@ export function computeStackedSeatCreditAdjustments({
   return adjustments;
 }
 
-// Apply a set of same-kind adjustments, batched into ONE ledger write per
-// (credit, segment). Returns which seats were successfully written and counts.
-async function applyAdjustmentBatches({
+/**
+ * Apply seat-credit adjustments, batched into ONE ledger write per (credit,
+ * segment) with a per-seat delta map. No-op when there is nothing to apply; a
+ * per-batch failure is logged and skipped.
+ *
+ * No cross-credit ordering or gating is needed: the stray empty targets 0 and the
+ * home carry targets an ABSOLUTE usage-based balance (allocation − usage), so both
+ * are idempotent. A partial failure (one credit's batch fails, another succeeds)
+ * is simply retried on the next run — the home debit recomputes to 0 once the home
+ * already sits at its target, so a user is never double-debited.
+ */
+async function applyStackedSeatCreditAdjustments({
   workspaceId,
   metronomeCustomerId,
   metronomeContractId,
   adjustments,
-  reasonSuffix,
   logger,
-  pace,
+  pace = NO_PACING,
 }: {
   workspaceId: string;
   metronomeCustomerId: string;
   metronomeContractId: string;
   adjustments: SeatCreditAdjustment[];
-  reasonSuffix: string;
   logger: Logger;
-  pace: PaceFn;
-}): Promise<{
-  succeededSeatIds: Set<string>;
-  appliedAdjustmentCount: number;
-  batchedAdjustCalls: number;
-}> {
+  pace?: PaceFn;
+}): Promise<{ appliedAdjustmentCount: number; batchedAdjustCalls: number }> {
   const batches = new Map<
     string,
     {
@@ -308,7 +326,6 @@ async function applyAdjustmentBatches({
     batches.set(key, batch);
   }
 
-  const succeededSeatIds = new Set<string>();
   let appliedAdjustmentCount = 0;
   let batchedAdjustCalls = 0;
   for (const batch of batches.values()) {
@@ -320,7 +337,7 @@ async function applyAdjustmentBatches({
         creditId: batch.creditId,
         segmentId: batch.segmentId,
         perSeatAmounts,
-        reason: `Stacked-credit correction: ${reasonSuffix} on ${batch.creditSeatType} seat credit`,
+        reason: `Stacked-credit correction on ${batch.creditSeatType} seat credit (empty stray / carry consumption)`,
         timestamp: batch.timestamp,
         alignToHour: false,
       })
@@ -340,9 +357,6 @@ async function applyAdjustmentBatches({
     }
     batchedAdjustCalls += 1;
     appliedAdjustmentCount += batch.perSeatAmounts.size;
-    for (const seatId of batch.perSeatAmounts.keys()) {
-      succeededSeatIds.add(seatId);
-    }
     logger.info(
       {
         workspaceId,
@@ -355,99 +369,7 @@ async function applyAdjustmentBatches({
       "[StackedSeatCredits] applied batched correction"
     );
   }
-  return { succeededSeatIds, appliedAdjustmentCount, batchedAdjustCalls };
-}
-
-/**
- * Apply seat-credit adjustments in two ordered phases so a partial Metronome
- * failure can never over-debit a user: empty every stray FIRST, then carry
- * consumption ONLY for seats whose strays all emptied successfully.
- *
- * The empty and carry for a seat land on DIFFERENT credits (two separate ledger
- * writes), so they are not atomic. Emptying first and gating the carry on the
- * empty's success means the worst-case partial failure is the ORIGINAL (small)
- * over-credit — the safe direction — never a double-carry that would strip a user
- * of credit they are owed. A dropped carry is re-attempted on a later run only if
- * the stray still has a balance; once a stray reads 0 the seat is skipped, so we
- * never re-derive a stale consumption figure and double-debit.
- */
-async function applyStackedSeatCreditAdjustments({
-  workspaceId,
-  metronomeCustomerId,
-  metronomeContractId,
-  adjustments,
-  logger,
-  pace = NO_PACING,
-}: {
-  workspaceId: string;
-  metronomeCustomerId: string;
-  metronomeContractId: string;
-  adjustments: SeatCreditAdjustment[];
-  logger: Logger;
-  pace?: PaceFn;
-}): Promise<{ appliedAdjustmentCount: number; batchedAdjustCalls: number }> {
-  const empties = adjustments.filter((a) => a.kind === "empty_stray");
-  const carries = adjustments.filter((a) => a.kind === "carry_consumption");
-
-  // How many stray-empties each seat needs; the carry is safe only once ALL of
-  // them succeed.
-  const expectedEmptiesBySeat = new Map<string, number>();
-  for (const a of empties) {
-    expectedEmptiesBySeat.set(
-      a.seatId,
-      (expectedEmptiesBySeat.get(a.seatId) ?? 0) + 1
-    );
-  }
-  const succeededEmptiesBySeat = new Map<string, number>();
-
-  const emptyResult = await applyAdjustmentBatches({
-    workspaceId,
-    metronomeCustomerId,
-    metronomeContractId,
-    adjustments: empties,
-    reasonSuffix: "empty stray",
-    logger,
-    pace,
-  });
-  // A successful empty batch may cover multiple seats; count per seat.
-  for (const a of empties) {
-    if (emptyResult.succeededSeatIds.has(a.seatId)) {
-      succeededEmptiesBySeat.set(
-        a.seatId,
-        (succeededEmptiesBySeat.get(a.seatId) ?? 0) + 1
-      );
-    }
-  }
-
-  const carriesToApply = carries.filter(
-    (a) =>
-      (succeededEmptiesBySeat.get(a.seatId) ?? 0) >=
-      (expectedEmptiesBySeat.get(a.seatId) ?? 0)
-  );
-  const droppedCarryCount = carries.length - carriesToApply.length;
-  if (droppedCarryCount > 0) {
-    logger.warn(
-      { workspaceId, droppedCarryCount },
-      "[StackedSeatCredits] deferring consumption carry for seats whose stray empty failed"
-    );
-  }
-
-  const carryResult = await applyAdjustmentBatches({
-    workspaceId,
-    metronomeCustomerId,
-    metronomeContractId,
-    adjustments: carriesToApply,
-    reasonSuffix: "carry consumption",
-    logger,
-    pace,
-  });
-
-  return {
-    appliedAdjustmentCount:
-      emptyResult.appliedAdjustmentCount + carryResult.appliedAdjustmentCount,
-    batchedAdjustCalls:
-      emptyResult.batchedAdjustCalls + carryResult.batchedAdjustCalls,
-  };
+  return { appliedAdjustmentCount, batchedAdjustCalls };
 }
 
 function summarizeAdjustments(
@@ -497,6 +419,7 @@ export async function correctStackedSeatCreditsFromBalances({
   contract,
   seatBalances,
   currentSeatTypeBySeatId,
+  usageBySeatId,
   execute,
   logger,
   pace = NO_PACING,
@@ -507,6 +430,7 @@ export async function correctStackedSeatCreditsFromBalances({
   contract: CachedContract;
   seatBalances: MetronomeSeatBalance[];
   currentSeatTypeBySeatId: Map<string, MembershipSeatType>;
+  usageBySeatId: Map<string, number>;
   execute: boolean;
   logger: Logger;
   pace?: PaceFn;
@@ -525,6 +449,7 @@ export async function correctStackedSeatCreditsFromBalances({
     seatBalances,
     currentSeatTypeBySeatId,
     tierByCreditId: tierMapRes.value,
+    usageBySeatId,
   });
   const totals = summarizeAdjustments(adjustments);
 

--- a/front/lib/metronome/stacked_seat_credits.ts
+++ b/front/lib/metronome/stacked_seat_credits.ts
@@ -1,0 +1,574 @@
+import {
+  adjustSeatCreditBalances,
+  findSeatCreditSegmentForPeriod,
+  invalidateCachedCustomerPerUserCreditBalances,
+} from "@app/lib/metronome/client";
+import type { ContractCreditType } from "@app/lib/metronome/constants";
+import {
+  CONTRACT_CREDIT_TYPE_EXCESS,
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  CONTRACT_CREDIT_TYPE_POOL,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import {
+  getAwuAllocationForSeatType,
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
+import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
+import type { Logger } from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Shared detection + correction for "stacked" per-seat AWU credits: a seat that
+ * holds a live balance on a per-seat recurring credit belonging to a DIFFERENT
+ * seat type than the seat's current tier (e.g. a max seat still carrying the pro
+ * credit after a pro→max upgrade stranded the origin grant).
+ *
+ * Both the backfill script (`fix_metronome_stacked_seat_credits.ts`) and the
+ * `credit.segment.start`-triggered reconcile go through this module so detection
+ * can never drift between the one-off cleanup and the ongoing guard.
+ *
+ * The key primitive is the per-seat `credits[]` breakdown on `MetronomeSeatBalance`
+ * (populated with `include_credits_and_commits`): it gives each seat's balance on
+ * each individual materialized credit id. We map each materialized credit id to a
+ * seat type once per contract, then for each seat:
+ *
+ *  - empty every STRAY credit fully (a credit whose seat type ≠ the seat's tier),
+ *  - carry the consumption that was charged to those strays onto the HOME credit,
+ *    so the seat nets `homeAllocation − totalConsumed` instead of a full home
+ *    allowance plus forgiven stray usage.
+ *
+ * Without the carry, consumption billed to the stray credit is forgiven when the
+ * stray is emptied and the seat ends over-credited by that amount. Both figures
+ * are exact — observed per-seat credit balances vs. deterministic tier
+ * allocations, not an ES/usage estimate. Idempotent by construction: a re-run
+ * reads every stray at 0 (no stray consumption left to carry) and emits nothing.
+ */
+
+// A credit-bearing tier's recurring credit, resolved to its materialized credit
+// id + segment for the current period.
+interface TierCredit {
+  seatType: MembershipSeatType;
+  recurringCreditId: string;
+  // Materialized credit id for the current segment (matches seat.credits[].id).
+  creditId: string;
+  segmentId: string;
+  // Full per-seat allocation for the period (e.g. 8000 pro, 40000 max), used to
+  // derive consumption as allocation − balance.
+  allocation: number;
+  // Shared, in-segment entry time so all seats on this credit batch into one
+  // ledger write.
+  adjustmentTimestamp: Date;
+}
+
+// One per-seat ledger delta on a specific seat credit. `empty_stray` zeroes a
+// stray credit's slice; `carry_consumption` debits the home credit by the usage
+// that had been charged to the seat's strays.
+export interface SeatCreditAdjustment {
+  seatId: string;
+  homeSeatType: MembershipSeatType;
+  // Seat type of the credit being adjusted (the stray's type for `empty_stray`,
+  // the home type for `carry_consumption`).
+  creditSeatType: MembershipSeatType;
+  creditId: string;
+  segmentId: string;
+  adjustmentTimestamp: Date;
+  // Negative: the amount debited from this seat's slice of the credit.
+  deltaAwu: number;
+  kind: "empty_stray" | "carry_consumption";
+}
+
+// Wraps each Metronome call so a bulk caller (the backfill script over ~200
+// workspaces) can rate-limit; defaults to a passthrough for the single-workspace
+// webhook path.
+export type PaceFn = <T>(fn: () => Promise<T>) => Promise<T>;
+const NO_PACING: PaceFn = (fn) => fn();
+
+export interface StackedSeatCreditsSummary {
+  // Adjustments detected (regardless of whether they were applied).
+  adjustments: SeatCreditAdjustment[];
+  emptiedStrayCount: number;
+  carriedConsumptionCount: number;
+  totalEmptiedAwu: number;
+  totalCarriedAwu: number;
+  // Set on execute: successful per-seat deltas applied and batched ledger writes.
+  appliedAdjustmentCount: number;
+  batchedAdjustCalls: number;
+}
+
+/**
+ * Resolve each credit-bearing tier's recurring credit to its MATERIALIZED credit
+ * id + segment (and per-seat allocation) for the current period, indexed BY that
+ * credit id. `findSeatCreditSegmentForPeriod` returns the materialized credit id
+ * (the same id seats carry in `credits[].id`), which is what names each credit's
+ * tier: a credit id whose tier ≠ the seat's current tier is stray, regardless of
+ * which family it belongs to (so pro-vs-pro_yearly is never ambiguous).
+ */
+export async function buildSeatCreditTierMap({
+  metronomeCustomerId,
+  metronomeContractId,
+  contract,
+  logger,
+  pace = NO_PACING,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  contract: CachedContract;
+  logger: Logger;
+  pace?: PaceFn;
+}): Promise<Result<Map<string, TierCredit>, Error>> {
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+
+  const tierByCreditId = new Map<string, TierCredit>();
+  for (const [seatType, sub] of seatSubscriptions) {
+    if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
+      continue;
+    }
+    const recurringCredit = (contract.recurring_credits ?? []).find(
+      (c) => c.subscription_config?.subscription_id === sub.id
+    );
+    if (!recurringCredit?.id) {
+      continue;
+    }
+    const segRes = await pace(() =>
+      findSeatCreditSegmentForPeriod({
+        metronomeCustomerId,
+        metronomeContractId,
+        recurringCreditId: recurringCredit.id,
+      })
+    );
+    if (segRes.isErr()) {
+      return new Err(segRes.error);
+    }
+    const segment = segRes.value;
+    if (!segment) {
+      logger.warn(
+        { seatType, recurringCreditId: recurringCredit.id },
+        "[StackedSeatCredits] no active seat credit segment for tier — skipping tier"
+      );
+      continue;
+    }
+    tierByCreditId.set(segment.creditId, {
+      seatType,
+      recurringCreditId: recurringCredit.id,
+      creditId: segment.creditId,
+      segmentId: segment.segmentId,
+      allocation: getAwuAllocationForSeatType(
+        contract,
+        seatType,
+        productSeatTypes
+      ),
+      adjustmentTimestamp: new Date(segment.segmentStartingAt),
+    });
+  }
+  return new Ok(tierByCreditId);
+}
+
+/**
+ * Pure detection. For each seat, empty every stray seat credit fully and carry
+ * the consumption those strays absorbed onto the home credit so the seat nets
+ * `homeAllocation − totalConsumed`. A credit id absent from `tierByCreditId`
+ * (excess/pool/unrecognized) is left untouched; a seat with no stray is skipped,
+ * so re-runs are idempotent.
+ */
+export function computeStackedSeatCreditAdjustments({
+  seatBalances,
+  currentSeatTypeBySeatId,
+  tierByCreditId,
+}: {
+  seatBalances: MetronomeSeatBalance[];
+  currentSeatTypeBySeatId: Map<string, MembershipSeatType>;
+  tierByCreditId: Map<string, TierCredit>;
+}): SeatCreditAdjustment[] {
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const adjustments: SeatCreditAdjustment[] = [];
+
+  for (const seat of seatBalances) {
+    const homeSeatType = currentSeatTypeBySeatId.get(seat.seat_id);
+    if (!homeSeatType) {
+      continue;
+    }
+
+    // Resolve the seat's balance on each of its recognized seat-credit tiers.
+    const mapped = (seat.credits ?? []).flatMap((c) => {
+      if (c.credit_type_id !== awuCreditTypeId) {
+        return [];
+      }
+      const tier = tierByCreditId.get(c.id);
+      return tier ? [{ balanceAwu: c.balance, tier }] : [];
+    });
+
+    const strays = mapped.filter(
+      (m) => m.tier.seatType !== homeSeatType && m.balanceAwu > 0
+    );
+    if (strays.length === 0) {
+      continue;
+    }
+    const home = mapped.find((m) => m.tier.seatType === homeSeatType) ?? null;
+
+    // Empty every stray credit's slice for this seat.
+    for (const stray of strays) {
+      adjustments.push({
+        seatId: seat.seat_id,
+        homeSeatType,
+        creditSeatType: stray.tier.seatType,
+        creditId: stray.tier.creditId,
+        segmentId: stray.tier.segmentId,
+        adjustmentTimestamp: stray.tier.adjustmentTimestamp,
+        deltaAwu: -stray.balanceAwu,
+        kind: "empty_stray",
+      });
+    }
+
+    // Carry the stray-charged consumption onto the home credit. `strayConsumed`
+    // is what the strays absorbed (allocation − remaining); the home is debited
+    // by that, capped at its own balance so it never goes negative. Skipped when
+    // the home credit isn't present (nothing to debit).
+    if (home) {
+      const strayConsumed = strays.reduce(
+        (sum, s) => sum + Math.max(0, s.tier.allocation - s.balanceAwu),
+        0
+      );
+      const homeDebit = Math.min(home.balanceAwu, strayConsumed);
+      if (homeDebit > 0) {
+        adjustments.push({
+          seatId: seat.seat_id,
+          homeSeatType,
+          creditSeatType: home.tier.seatType,
+          creditId: home.tier.creditId,
+          segmentId: home.tier.segmentId,
+          adjustmentTimestamp: home.tier.adjustmentTimestamp,
+          deltaAwu: -homeDebit,
+          kind: "carry_consumption",
+        });
+      }
+    }
+  }
+
+  return adjustments;
+}
+
+// Apply a set of same-kind adjustments, batched into ONE ledger write per
+// (credit, segment). Returns which seats were successfully written and counts.
+async function applyAdjustmentBatches({
+  workspaceId,
+  metronomeCustomerId,
+  metronomeContractId,
+  adjustments,
+  reasonSuffix,
+  logger,
+  pace,
+}: {
+  workspaceId: string;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  adjustments: SeatCreditAdjustment[];
+  reasonSuffix: string;
+  logger: Logger;
+  pace: PaceFn;
+}): Promise<{
+  succeededSeatIds: Set<string>;
+  appliedAdjustmentCount: number;
+  batchedAdjustCalls: number;
+}> {
+  const batches = new Map<
+    string,
+    {
+      creditId: string;
+      segmentId: string;
+      creditSeatType: MembershipSeatType;
+      timestamp: Date;
+      // Sum of per-seat deltas (a seat appears at most once per credit, summed
+      // defensively).
+      perSeatAmounts: Map<string, number>;
+    }
+  >();
+  for (const a of adjustments) {
+    const key = `${a.creditId}:${a.segmentId}`;
+    const batch = batches.get(key) ?? {
+      creditId: a.creditId,
+      segmentId: a.segmentId,
+      creditSeatType: a.creditSeatType,
+      timestamp: a.adjustmentTimestamp,
+      perSeatAmounts: new Map<string, number>(),
+    };
+    batch.perSeatAmounts.set(
+      a.seatId,
+      (batch.perSeatAmounts.get(a.seatId) ?? 0) + a.deltaAwu
+    );
+    batches.set(key, batch);
+  }
+
+  const succeededSeatIds = new Set<string>();
+  let appliedAdjustmentCount = 0;
+  let batchedAdjustCalls = 0;
+  for (const batch of batches.values()) {
+    const perSeatAmounts = Object.fromEntries(batch.perSeatAmounts);
+    const adjustRes = await pace(() =>
+      adjustSeatCreditBalances({
+        metronomeCustomerId,
+        metronomeContractId,
+        creditId: batch.creditId,
+        segmentId: batch.segmentId,
+        perSeatAmounts,
+        reason: `Stacked-credit correction: ${reasonSuffix} on ${batch.creditSeatType} seat credit`,
+        timestamp: batch.timestamp,
+        alignToHour: false,
+      })
+    );
+    if (adjustRes.isErr()) {
+      logger.error(
+        {
+          workspaceId,
+          creditSeatType: batch.creditSeatType,
+          creditId: batch.creditId,
+          seatCount: batch.perSeatAmounts.size,
+          err: adjustRes.error.message,
+        },
+        "[StackedSeatCredits] batched correction failed"
+      );
+      continue;
+    }
+    batchedAdjustCalls += 1;
+    appliedAdjustmentCount += batch.perSeatAmounts.size;
+    for (const seatId of batch.perSeatAmounts.keys()) {
+      succeededSeatIds.add(seatId);
+    }
+    logger.info(
+      {
+        workspaceId,
+        creditSeatType: batch.creditSeatType,
+        creditId: batch.creditId,
+        seatCount: batch.perSeatAmounts.size,
+        totalAwu: [...batch.perSeatAmounts.values()].reduce((s, d) => s + d, 0),
+        timestamp: batch.timestamp.toISOString(),
+      },
+      "[StackedSeatCredits] applied batched correction"
+    );
+  }
+  return { succeededSeatIds, appliedAdjustmentCount, batchedAdjustCalls };
+}
+
+/**
+ * Apply seat-credit adjustments in two ordered phases so a partial Metronome
+ * failure can never over-debit a user: empty every stray FIRST, then carry
+ * consumption ONLY for seats whose strays all emptied successfully.
+ *
+ * The empty and carry for a seat land on DIFFERENT credits (two separate ledger
+ * writes), so they are not atomic. Emptying first and gating the carry on the
+ * empty's success means the worst-case partial failure is the ORIGINAL (small)
+ * over-credit — the safe direction — never a double-carry that would strip a user
+ * of credit they are owed. A dropped carry is re-attempted on a later run only if
+ * the stray still has a balance; once a stray reads 0 the seat is skipped, so we
+ * never re-derive a stale consumption figure and double-debit.
+ */
+async function applyStackedSeatCreditAdjustments({
+  workspaceId,
+  metronomeCustomerId,
+  metronomeContractId,
+  adjustments,
+  logger,
+  pace = NO_PACING,
+}: {
+  workspaceId: string;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  adjustments: SeatCreditAdjustment[];
+  logger: Logger;
+  pace?: PaceFn;
+}): Promise<{ appliedAdjustmentCount: number; batchedAdjustCalls: number }> {
+  const empties = adjustments.filter((a) => a.kind === "empty_stray");
+  const carries = adjustments.filter((a) => a.kind === "carry_consumption");
+
+  // How many stray-empties each seat needs; the carry is safe only once ALL of
+  // them succeed.
+  const expectedEmptiesBySeat = new Map<string, number>();
+  for (const a of empties) {
+    expectedEmptiesBySeat.set(
+      a.seatId,
+      (expectedEmptiesBySeat.get(a.seatId) ?? 0) + 1
+    );
+  }
+  const succeededEmptiesBySeat = new Map<string, number>();
+
+  const emptyResult = await applyAdjustmentBatches({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId,
+    adjustments: empties,
+    reasonSuffix: "empty stray",
+    logger,
+    pace,
+  });
+  // A successful empty batch may cover multiple seats; count per seat.
+  for (const a of empties) {
+    if (emptyResult.succeededSeatIds.has(a.seatId)) {
+      succeededEmptiesBySeat.set(
+        a.seatId,
+        (succeededEmptiesBySeat.get(a.seatId) ?? 0) + 1
+      );
+    }
+  }
+
+  const carriesToApply = carries.filter(
+    (a) =>
+      (succeededEmptiesBySeat.get(a.seatId) ?? 0) >=
+      (expectedEmptiesBySeat.get(a.seatId) ?? 0)
+  );
+  const droppedCarryCount = carries.length - carriesToApply.length;
+  if (droppedCarryCount > 0) {
+    logger.warn(
+      { workspaceId, droppedCarryCount },
+      "[StackedSeatCredits] deferring consumption carry for seats whose stray empty failed"
+    );
+  }
+
+  const carryResult = await applyAdjustmentBatches({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId,
+    adjustments: carriesToApply,
+    reasonSuffix: "carry consumption",
+    logger,
+    pace,
+  });
+
+  return {
+    appliedAdjustmentCount:
+      emptyResult.appliedAdjustmentCount + carryResult.appliedAdjustmentCount,
+    batchedAdjustCalls:
+      emptyResult.batchedAdjustCalls + carryResult.batchedAdjustCalls,
+  };
+}
+
+function summarizeAdjustments(
+  adjustments: SeatCreditAdjustment[]
+): Pick<
+  StackedSeatCreditsSummary,
+  | "emptiedStrayCount"
+  | "carriedConsumptionCount"
+  | "totalEmptiedAwu"
+  | "totalCarriedAwu"
+> {
+  let emptiedStrayCount = 0;
+  let carriedConsumptionCount = 0;
+  let totalEmptiedAwu = 0;
+  let totalCarriedAwu = 0;
+  for (const a of adjustments) {
+    if (a.kind === "empty_stray") {
+      emptiedStrayCount += 1;
+      totalEmptiedAwu += -a.deltaAwu;
+    } else {
+      carriedConsumptionCount += 1;
+      totalCarriedAwu += -a.deltaAwu;
+    }
+  }
+  return {
+    emptiedStrayCount,
+    carriedConsumptionCount,
+    totalEmptiedAwu,
+    totalCarriedAwu,
+  };
+}
+
+/**
+ * Detect and (when `execute`) correct stacked seat credits for a workspace,
+ * given per-seat balances already read once by the caller (with `credits[]`) and
+ * each seat's current tier. Single entry point for both the backfill script and
+ * the webhook reconcile.
+ *
+ * On execute, after applying it busts the per-user credit-balance Redis caches
+ * (free-seat/pool/excess) — a manual ledger entry does NOT fire the Metronome
+ * webhook that normally invalidates them, so nothing else clears them.
+ */
+export async function correctStackedSeatCreditsFromBalances({
+  workspaceId,
+  metronomeCustomerId,
+  metronomeContractId,
+  contract,
+  seatBalances,
+  currentSeatTypeBySeatId,
+  execute,
+  logger,
+  pace = NO_PACING,
+}: {
+  workspaceId: string;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  contract: CachedContract;
+  seatBalances: MetronomeSeatBalance[];
+  currentSeatTypeBySeatId: Map<string, MembershipSeatType>;
+  execute: boolean;
+  logger: Logger;
+  pace?: PaceFn;
+}): Promise<Result<StackedSeatCreditsSummary, Error>> {
+  const tierMapRes = await buildSeatCreditTierMap({
+    metronomeCustomerId,
+    metronomeContractId,
+    contract,
+    logger,
+    pace,
+  });
+  if (tierMapRes.isErr()) {
+    return new Err(tierMapRes.error);
+  }
+  const adjustments = computeStackedSeatCreditAdjustments({
+    seatBalances,
+    currentSeatTypeBySeatId,
+    tierByCreditId: tierMapRes.value,
+  });
+  const totals = summarizeAdjustments(adjustments);
+
+  if (!execute || adjustments.length === 0) {
+    return new Ok({
+      adjustments,
+      ...totals,
+      appliedAdjustmentCount: 0,
+      batchedAdjustCalls: 0,
+    });
+  }
+
+  const { appliedAdjustmentCount, batchedAdjustCalls } =
+    await applyStackedSeatCreditAdjustments({
+      workspaceId,
+      metronomeCustomerId,
+      metronomeContractId,
+      adjustments,
+      logger,
+      pace,
+    });
+
+  if (appliedAdjustmentCount > 0) {
+    const contractCreditTypes: ContractCreditType[] = [
+      CONTRACT_CREDIT_TYPE_FREE_SEAT,
+      CONTRACT_CREDIT_TYPE_POOL,
+      CONTRACT_CREDIT_TYPE_EXCESS,
+    ];
+    for (const contractCreditType of contractCreditTypes) {
+      await invalidateCachedCustomerPerUserCreditBalances({
+        metronomeCustomerId,
+        contractCreditType,
+      });
+    }
+    logger.info(
+      { workspaceId, metronomeCustomerId },
+      "[StackedSeatCredits] invalidated cached per-user credit balances"
+    );
+  }
+
+  return new Ok({
+    adjustments,
+    ...totals,
+    appliedAdjustmentCount,
+    batchedAdjustCalls,
+  });
+}

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -174,11 +174,30 @@ export interface MetronomeUsageWithGroupsResponse {
 
 export interface MetronomeSeatBalance {
   seat_id: string;
+  // Aggregated per credit TYPE (AWU currency) — a single number per type.
   balances: Array<{
     credit_type_id: string;
     balance: number;
     starting_balance: number;
   }>;
+  // Per individual CREDIT (only present with `include_credits_and_commits`).
+  // Distinct from `balances`: this breaks the same total down by the specific
+  // credit id, so a stray seat credit (e.g. a pro credit still held by a max
+  // seat) is directly visible and can be emptied by id.
+  credits?: Array<{
+    id: string;
+    credit_type_id: string;
+    balance: number;
+  }>;
+}
+
+function isMetronomeAwuBalanceRow(b: unknown): boolean {
+  return (
+    typeof b === "object" &&
+    b !== null &&
+    typeof (b as Record<string, unknown>)["credit_type_id"] === "string" &&
+    typeof (b as Record<string, unknown>)["balance"] === "number"
+  );
 }
 
 export function isMetronomeSeatBalance(v: unknown): v is MetronomeSeatBalance {
@@ -192,12 +211,28 @@ export function isMetronomeSeatBalance(v: unknown): v is MetronomeSeatBalance {
   if (!Array.isArray(obj["balances"])) {
     return false;
   }
-  return obj["balances"].every(
-    (b) =>
-      typeof b === "object" &&
-      b !== null &&
-      typeof (b as Record<string, unknown>)["credit_type_id"] === "string" &&
-      typeof (b as Record<string, unknown>)["balance"] === "number" &&
-      typeof (b as Record<string, unknown>)["starting_balance"] === "number"
-  );
+  if (
+    !obj["balances"].every(
+      (b) =>
+        isMetronomeAwuBalanceRow(b) &&
+        typeof (b as Record<string, unknown>)["starting_balance"] === "number"
+    )
+  ) {
+    return false;
+  }
+  // `credits` is optional; when present each row must carry an id + balance so
+  // it can be mapped to a seat type and emptied by credit id.
+  if (obj["credits"] !== undefined) {
+    if (
+      !Array.isArray(obj["credits"]) ||
+      !obj["credits"].every(
+        (c) =>
+          isMetronomeAwuBalanceRow(c) &&
+          typeof (c as Record<string, unknown>)["id"] === "string"
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -485,6 +485,16 @@ async function auditWorkspace(
       candidateSeatTypeById.set(seatId, seatType);
     }
   }
+  // Seats currently assigned per tier — the stray is an actively-used tier, so
+  // dormant tiers (e.g. pro_yearly/max_yearly with 0 seats) are ignored when
+  // labelling the stray.
+  const assignedCountByTier = new Map<MembershipSeatType, number>();
+  for (const seatType of seatTypeBySeatId.values()) {
+    assignedCountByTier.set(
+      seatType,
+      (assignedCountByTier.get(seatType) ?? 0) + 1
+    );
+  }
   const RECONCILE_TOLERANCE_AWU = 1000;
   const candidateSeatIds = [...candidateSeatTypeById.keys()];
   const consumedByUserId = await fetchConsumedAwuCreditsFromMetronomeByUserId({
@@ -519,7 +529,7 @@ async function auditWorkspace(
       continue;
     }
     const strayCandidates = creditBearingSeatTypes.filter(
-      (t) => t !== homeSeatType
+      (t) => t !== homeSeatType && (assignedCountByTier.get(t) ?? 0) > 0
     );
     overAllocatedSeats.push({
       seatId,

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -17,8 +17,8 @@
  *   npx tsx scripts/audit_metronome_seat_state.ts --workspaceId <wId>
  */
 import config from "@app/lib/api/config";
-import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
 import {
+  findSeatCreditSegmentForPeriod,
   getMetronomeClient,
   getMetronomeSubscriptionSeatState,
   listMetronomeSeatBalances,
@@ -30,6 +30,7 @@ import {
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
+import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -458,90 +459,120 @@ async function auditWorkspace(
     "[SeatAudit] seat balances summary"
   );
 
-  // Over-allocation (credit-stacking) detection, usage-based.
+  // Over-allocation (credit-stacking) detection — grant-history based.
   //
-  // A seat should hold `max(0, allocation - consumed)` AWU (the same target
-  // `carryConsumptionToNewSeatCredits` reconciles to). Anything above that is a
-  // stray grant a prior seat-type change / seat-sync crash never emptied. We use
-  // the seat's CONSUMED AWU (from the analytics index, the same figure the poke
-  // members table shows) rather than Metronome's `starting_balance`: when the
-  // stray grant is fully consumed Metronome DROPS it from `starting_balance`
-  // (it reads back at the allocation), so a starting_balance-only check misses
-  // seats that already spent through the phantom grant. `currentBalance -
-  // max(0, allocation - consumed)` catches them and self-caps: for
-  // consumed > allocation the over-grant is bounded by the remaining balance
-  // (the rest was overspent and is unrecoverable).
+  // A per-seat recurring credit grants exactly its allocation (8000 pro, 40000
+  // max, and the same for the _yearly variants) to whoever is assigned to its
+  // subscription at the credit segment start — that cycle's recurrence. If a
+  // seat later moves to another tier without empty-origin zeroing the old grant,
+  // it keeps that stray grant. So a seat is stacked iff it holds a grant from a
+  // tier it is NOT currently on, which we read straight from Metronome: each
+  // credit-bearing tier's subscription assignment AT its credit segment start,
+  // cross-referenced against the seat's current tier.
   //
-  // Threshold is generous (real stacks are >= 7500 AWU: pro-on-free 7500,
-  // pro-on-max 8000, max-on-pro 40000) so small analytics-vs-Metronome
-  // consumption skew on healthy seats never trips a false positive.
-  const STACKING_DETECTION_THRESHOLD_AWU = 1000;
-  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
-    workspace: lightWorkspace,
-    userIds: [...seatTypeBySeatId.keys()],
-    freeSeatUserIds: [...seatTypeBySeatId]
-      .filter(([, t]) => t === "free")
-      .map(([id]) => id),
-  });
-  const overAllocatedSeats: Array<{
+  // This is authoritative and needs neither `starting_balance` (Metronome drops
+  // a stray grant from it once fully consumed) nor analytics consumption (which
+  // can lag Metronome). Each tier is checked independently, so same-family
+  // stacks — e.g. pro + pro_yearly, two 8000 grants on one seat — are caught,
+  // and one seat can surface several stray grants.
+  const currentAwuBalanceForSeat = (seatId: string): number =>
+    (balanceBySeatId.get(seatId) ?? [])
+      .filter((b) => b.credit_type_id === awuCreditTypeId)
+      .reduce((sum, b) => sum + b.balance, 0);
+
+  const strayGrants: Array<{
     seatId: string;
-    seatType: MembershipSeatType;
-    allocation: number;
-    startingBalance: number;
-    currentBalance: number;
-    consumedAwu: number;
-    targetBalance: number;
-    overGrantedAwu: number;
+    homeSeatType: MembershipSeatType | "unassigned";
+    strayType: MembershipSeatType;
+    strayAllocationAwu: number;
+    currentBalanceAwu: number;
   }> = [];
-  for (const [seatId, seatType] of seatTypeBySeatId) {
-    const allocation = allocationBySeatType.get(seatType);
-    if (allocation === undefined || allocation <= 0) {
+  for (const { seatType, subId } of seatSubscriptions) {
+    // Only recurring per-seat credit tiers (pro/max families); free/workspace/
+    // none carry no such credit and cannot be a stray grant source.
+    if (!getSeatCreditNameForSeatType(seatType)) {
       continue;
     }
-    const awuEntries = (balanceBySeatId.get(seatId) ?? []).filter(
-      (b) => b.credit_type_id === awuCreditTypeId
+    const recurringCredit = (contract.recurring_credits ?? []).find(
+      (c) => c.subscription_config?.subscription_id === subId
     );
-    if (awuEntries.length === 0) {
+    if (!recurringCredit?.id) {
       continue;
     }
-    const startingBalance = awuEntries.reduce(
-      (sum, b) => sum + b.starting_balance,
-      0
+    const allocation = allocationBySeatType.get(seatType) ?? 0;
+    const segRes = await paceMetronome(() =>
+      findSeatCreditSegmentForPeriod({
+        metronomeCustomerId,
+        metronomeContractId: contractId,
+        recurringCreditId: recurringCredit.id,
+      })
     );
-    const currentBalance = awuEntries.reduce((sum, b) => sum + b.balance, 0);
-    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
-    const targetBalance = Math.max(0, allocation - consumedAwu);
-    const overGrantedAwu = currentBalance - targetBalance;
-    if (overGrantedAwu > STACKING_DETECTION_THRESHOLD_AWU) {
-      overAllocatedSeats.push({
+    const segment = segRes.isOk() ? segRes.value : null;
+    if (!segment) {
+      logger.warn(
+        {
+          workspaceId,
+          seatType,
+          err: segRes.isErr() ? segRes.error.message : "no active segment",
+        },
+        "[SeatAudit] no credit segment for tier — skipping stray-grant check"
+      );
+      continue;
+    }
+    // Who this credit granted to = who was assigned to its subscription at the
+    // segment start.
+    const grantStateRes = await paceMetronome(() =>
+      getMetronomeSubscriptionSeatState({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: subId,
+        coveringDate: new Date(segment.segmentStartingAt),
+      })
+    );
+    if (grantStateRes.isErr()) {
+      logger.error(
+        { workspaceId, seatType, err: grantStateRes.error.message },
+        "[SeatAudit] failed to read grant-time seat assignment — skipping tier"
+      );
+      continue;
+    }
+    for (const seatId of grantStateRes.value.assignedSeatIds) {
+      const home = seatTypeBySeatId.get(seatId);
+      if (home === seatType) {
+        // Grant is legitimate — the seat is still on this tier.
+        continue;
+      }
+      strayGrants.push({
         seatId,
-        seatType,
-        allocation,
-        startingBalance,
-        currentBalance,
-        consumedAwu,
-        targetBalance,
-        overGrantedAwu,
+        homeSeatType: home ?? "unassigned",
+        strayType: seatType,
+        strayAllocationAwu: allocation,
+        currentBalanceAwu: currentAwuBalanceForSeat(seatId),
       });
     }
   }
-  overAllocatedSeats.sort((a, b) => b.overGrantedAwu - a.overGrantedAwu);
-  const totalOverGrantedAwu = overAllocatedSeats.reduce(
-    (sum, s) => sum + s.overGrantedAwu,
+  strayGrants.sort((a, b) => b.strayAllocationAwu - a.strayAllocationAwu);
+  const affectedSeatIds = new Set(strayGrants.map((g) => g.seatId));
+  const totalOverGrantedAwu = strayGrants.reduce(
+    (sum, g) => sum + g.strayAllocationAwu,
     0
   );
+  const byTransition = new Map<string, number>();
+  for (const g of strayGrants) {
+    const key = `${g.homeSeatType}<-${g.strayType}`;
+    byTransition.set(key, (byTransition.get(key) ?? 0) + 1);
+  }
   logger.info(
     {
       workspaceId,
       contractId,
       allocationBySeatType: Object.fromEntries(allocationBySeatType),
-      // Sanity check: how many seats got analytics consumption. A low number vs
-      // seatIdsChecked means the analytics read degraded and the count below is
-      // an undercount (falls back toward starting_balance behaviour).
-      seatsWithConsumption: consumedByUserId.size,
-      overAllocatedSeatCount: overAllocatedSeats.length,
+      // One entry per stray grant; a seat with two stray grants counts twice.
+      strayGrantCount: strayGrants.length,
+      affectedSeatCount: affectedSeatIds.size,
       totalOverGrantedAwu,
-      overAllocatedSeats,
+      byTransition: Object.fromEntries(byTransition),
+      strayGrants,
     },
     "[SeatAudit] over-allocated seats (credit stacking)"
   );

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -17,6 +17,7 @@
  *   npx tsx scripts/audit_metronome_seat_state.ts --workspaceId <wId>
  */
 import config from "@app/lib/api/config";
+import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
 import {
   getMetronomeClient,
   getMetronomeSubscriptionSeatState,
@@ -457,32 +458,40 @@ async function auditWorkspace(
     "[SeatAudit] seat balances summary"
   );
 
-  // Over-allocation (credit-stacking) detection. `starting_balance` is the
-  // total AWU granted to the seat this cycle, independent of how much has been
-  // consumed — so a seat granted MORE than its seat-type allocation is holding
-  // a leftover grant that a prior seat-type change never emptied (the pro→max
-  // stacking: 40000 max allocation + an orphaned 8000 pro grant =
-  // starting_balance 48000). This is the exact population `syncSeatCount` can
-  // no longer self-heal (empty-origin sees the user already converged on the
-  // new seat), so it needs a targeted credit correction.
+  // Over-allocation (credit-stacking) detection, usage-based.
   //
-  // A seat's AWU may be split across MULTIPLE balance entries (one per recurring
-  // credit — e.g. a stacked seat with a separate pro and max entry), so SUM all
-  // AWU-type entries rather than taking the first. `awuEntryCount` is emitted as
-  // a diagnostic: if some stacked seats show 2 entries, the split shape is real;
-  // if a fully-consumed stray grant is dropped by Metronome (single entry with
-  // starting_balance back at the allocation), starting_balance-based detection
-  // undercounts and we need a usage-based pass instead.
-  const AWU_OVER_ALLOCATION_TOLERANCE = 1;
-  const awuEntryCountHistogram = new Map<number, number>();
+  // A seat should hold `max(0, allocation - consumed)` AWU (the same target
+  // `carryConsumptionToNewSeatCredits` reconciles to). Anything above that is a
+  // stray grant a prior seat-type change / seat-sync crash never emptied. We use
+  // the seat's CONSUMED AWU (from the analytics index, the same figure the poke
+  // members table shows) rather than Metronome's `starting_balance`: when the
+  // stray grant is fully consumed Metronome DROPS it from `starting_balance`
+  // (it reads back at the allocation), so a starting_balance-only check misses
+  // seats that already spent through the phantom grant. `currentBalance -
+  // max(0, allocation - consumed)` catches them and self-caps: for
+  // consumed > allocation the over-grant is bounded by the remaining balance
+  // (the rest was overspent and is unrecoverable).
+  //
+  // Threshold is generous (real stacks are >= 7500 AWU: pro-on-free 7500,
+  // pro-on-max 8000, max-on-pro 40000) so small analytics-vs-Metronome
+  // consumption skew on healthy seats never trips a false positive.
+  const STACKING_DETECTION_THRESHOLD_AWU = 1000;
+  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
+    workspace: lightWorkspace,
+    userIds: [...seatTypeBySeatId.keys()],
+    freeSeatUserIds: [...seatTypeBySeatId]
+      .filter(([, t]) => t === "free")
+      .map(([id]) => id),
+  });
   const overAllocatedSeats: Array<{
     seatId: string;
     seatType: MembershipSeatType;
     allocation: number;
     startingBalance: number;
     currentBalance: number;
+    consumedAwu: number;
+    targetBalance: number;
     overGrantedAwu: number;
-    awuEntryCount: number;
   }> = [];
   for (const [seatId, seatType] of seatTypeBySeatId) {
     const allocation = allocationBySeatType.get(seatType);
@@ -492,10 +501,6 @@ async function auditWorkspace(
     const awuEntries = (balanceBySeatId.get(seatId) ?? []).filter(
       (b) => b.credit_type_id === awuCreditTypeId
     );
-    awuEntryCountHistogram.set(
-      awuEntries.length,
-      (awuEntryCountHistogram.get(awuEntries.length) ?? 0) + 1
-    );
     if (awuEntries.length === 0) {
       continue;
     }
@@ -504,16 +509,19 @@ async function auditWorkspace(
       0
     );
     const currentBalance = awuEntries.reduce((sum, b) => sum + b.balance, 0);
-    const overGrantedAwu = startingBalance - allocation;
-    if (overGrantedAwu > AWU_OVER_ALLOCATION_TOLERANCE) {
+    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
+    const targetBalance = Math.max(0, allocation - consumedAwu);
+    const overGrantedAwu = currentBalance - targetBalance;
+    if (overGrantedAwu > STACKING_DETECTION_THRESHOLD_AWU) {
       overAllocatedSeats.push({
         seatId,
         seatType,
         allocation,
         startingBalance,
         currentBalance,
+        consumedAwu,
+        targetBalance,
         overGrantedAwu,
-        awuEntryCount: awuEntries.length,
       });
     }
   }
@@ -527,10 +535,10 @@ async function auditWorkspace(
       workspaceId,
       contractId,
       allocationBySeatType: Object.fromEntries(allocationBySeatType),
-      // How many AWU balance entries seats carry: >1 means the split (stacked)
-      // shape exists and summing catches it; all 1s means fully-consumed stray
-      // grants are dropped and starting_balance detection undercounts.
-      awuEntryCountHistogram: Object.fromEntries(awuEntryCountHistogram),
+      // Sanity check: how many seats got analytics consumption. A low number vs
+      // seatIdsChecked means the analytics read degraded and the count below is
+      // an undercount (falls back toward starting_balance behaviour).
+      seatsWithConsumption: consumedByUserId.size,
       overAllocatedSeatCount: overAllocatedSeats.length,
       totalOverGrantedAwu,
       overAllocatedSeats,

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -17,9 +17,8 @@
  *   npx tsx scripts/audit_metronome_seat_state.ts --workspaceId <wId>
  */
 import config from "@app/lib/api/config";
-import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
+import { fetchConsumedAwuCreditsFromMetronomeByUserId } from "@app/lib/api/credits/members_usage";
 import {
-  findSeatCreditSegmentForPeriod,
   getMetronomeClient,
   getMetronomeSubscriptionSeatState,
   listMetronomeSeatBalances,
@@ -460,116 +459,58 @@ async function auditWorkspace(
     "[SeatAudit] seat balances summary"
   );
 
-  // Over-allocation (credit-stacking) detection — grant-history + reconcile.
+  // Over-allocation (credit-stacking) detection — consumption-based reconcile.
   //
-  // WHO is stacked is authoritative and ES-free: a per-seat recurring credit
-  // grants exactly its allocation (8000 pro, 40000 max, same for _yearly) to
-  // whoever is on its subscription at the credit segment start, so a seat holds
-  // a stray grant iff it appears in a tier's grant-time assignment but is now on
-  // a different tier. Each tier is checked independently, so same-family stacks
-  // (pro + pro_yearly) and multi-stray seats are caught; a seat granted by
-  // several tiers is recorded once (first stray tier).
-  //
-  // HOW MUCH is over-granted is what the idempotent correction reconciles away:
-  // target = max(0, homeAllocation - consumed); over = max(0, currentBalance -
-  // target). `consumed` is the analytics figure (the same one poke shows). It
-  // only sizes the amount on already-proven-stacked seats and can only shrink
-  // it, so analytics lag never over-counts, and it never touches a healthy seat.
+  // A seat should hold max(0, homeAllocation - consumed); anything above that is
+  // a stray grant from a tier it moved off that was never emptied. Detection is
+  // by consumption, NOT grant-time assignment: a seat's stray grant can sit in
+  // an EARLIER credit segment than the current one (it moved tier before the
+  // latest segment started), so grant-history under-detects it. `consumed` is
+  // Metronome's OWN per-user usage (authoritative, not ES). A legit seat has
+  // balance ≈ allocation - consumed, so its over is ~0; only a seat carrying an
+  // extra grant exceeds the threshold, so a healthy seat is never flagged.
   const currentAwuBalanceForSeat = (seatId: string): number =>
     (balanceBySeatId.get(seatId) ?? [])
       .filter((b) => b.credit_type_id === awuCreditTypeId)
       .reduce((sum, b) => sum + b.balance, 0);
 
-  const strayTierBySeat = new Map<string, MembershipSeatType>();
-  const homeBySeat = new Map<string, MembershipSeatType | "unassigned">();
-  for (const { seatType, subId } of seatSubscriptions) {
-    // Only recurring per-seat credit tiers (pro/max families); free/workspace/
-    // none carry no such credit and cannot be a stray grant source.
-    if (!getSeatCreditNameForSeatType(seatType)) {
-      continue;
-    }
-    const recurringCredit = (contract.recurring_credits ?? []).find(
-      (c) => c.subscription_config?.subscription_id === subId
-    );
-    if (!recurringCredit?.id) {
-      continue;
-    }
-    const segRes = await paceMetronome(() =>
-      findSeatCreditSegmentForPeriod({
-        metronomeCustomerId,
-        metronomeContractId: contractId,
-        recurringCreditId: recurringCredit.id,
-      })
-    );
-    const segment = segRes.isOk() ? segRes.value : null;
-    if (!segment) {
-      logger.warn(
-        {
-          workspaceId,
-          seatType,
-          err: segRes.isErr() ? segRes.error.message : "no active segment",
-        },
-        "[SeatAudit] no credit segment for tier — skipping stray-grant check"
-      );
-      continue;
-    }
-    // Who this credit granted to = who was assigned to its subscription at the
-    // segment start.
-    const grantStateRes = await paceMetronome(() =>
-      getMetronomeSubscriptionSeatState({
-        metronomeCustomerId,
-        contractId,
-        subscriptionId: subId,
-        coveringDate: new Date(segment.segmentStartingAt),
-      })
-    );
-    if (grantStateRes.isErr()) {
-      logger.error(
-        { workspaceId, seatType, err: grantStateRes.error.message },
-        "[SeatAudit] failed to read grant-time seat assignment — skipping tier"
-      );
-      continue;
-    }
-    for (const seatId of grantStateRes.value.assignedSeatIds) {
-      const home = seatTypeBySeatId.get(seatId) ?? "unassigned";
-      if (home === seatType || strayTierBySeat.has(seatId)) {
-        continue;
-      }
-      strayTierBySeat.set(seatId, seatType);
-      homeBySeat.set(seatId, home);
+  const creditBearingSeatTypes = seatSubscriptions
+    .map(({ seatType }) => seatType)
+    .filter((seatType) => getSeatCreditNameForSeatType(seatType));
+  // Candidate seats: those currently on a credit-bearing tier (a free/none home
+  // has no recurring credit of its own; its stray is handled separately).
+  const candidateSeatTypeById = new Map<string, MembershipSeatType>();
+  for (const [seatId, seatType] of seatTypeBySeatId) {
+    if (creditBearingSeatTypes.includes(seatType)) {
+      candidateSeatTypeById.set(seatId, seatType);
     }
   }
-
-  // Size each affected seat's over-grant via reconcile-to-target.
   const RECONCILE_TOLERANCE_AWU = 1000;
-  const affectedSeatIds = [...strayTierBySeat.keys()];
-  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
-    workspace: lightWorkspace,
-    userIds: affectedSeatIds,
-    freeSeatUserIds: affectedSeatIds.filter(
-      (id) => seatTypeBySeatId.get(id) === "free"
-    ),
+  const candidateSeatIds = [...candidateSeatTypeById.keys()];
+  const consumedByUserId = await fetchConsumedAwuCreditsFromMetronomeByUserId({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+    users: candidateSeatIds.map((sId) => ({
+      sId,
+      seatType: candidateSeatTypeById.get(sId) ?? null,
+    })),
   });
   const overAllocatedSeats: Array<{
     seatId: string;
-    homeSeatType: MembershipSeatType | "unassigned";
-    strayType: MembershipSeatType;
+    homeSeatType: MembershipSeatType;
+    strayType: MembershipSeatType | "ambiguous";
     homeAllocation: number;
     consumedAwu: number;
     currentBalance: number;
     targetBalance: number;
     overGrantedAwu: number;
   }> = [];
-  for (const seatId of affectedSeatIds) {
-    const strayType = strayTierBySeat.get(seatId);
-    const homeSeatType = homeBySeat.get(seatId) ?? "unassigned";
-    if (!strayType) {
+  for (const [seatId, homeSeatType] of candidateSeatTypeById) {
+    const homeAllocation = allocationBySeatType.get(homeSeatType) ?? 0;
+    if (homeAllocation <= 0) {
       continue;
     }
-    const homeAllocation =
-      homeSeatType === "unassigned"
-        ? 0
-        : (allocationBySeatType.get(homeSeatType) ?? 0);
     const consumedAwu = consumedByUserId.get(seatId) ?? 0;
     const currentBalance = currentAwuBalanceForSeat(seatId);
     const targetBalance = Math.max(0, homeAllocation - consumedAwu);
@@ -577,10 +518,14 @@ async function auditWorkspace(
     if (overGrantedAwu <= RECONCILE_TOLERANCE_AWU) {
       continue;
     }
+    const strayCandidates = creditBearingSeatTypes.filter(
+      (t) => t !== homeSeatType
+    );
     overAllocatedSeats.push({
       seatId,
       homeSeatType,
-      strayType,
+      strayType:
+        strayCandidates.length === 1 ? strayCandidates[0] : "ambiguous",
       homeAllocation,
       consumedAwu,
       currentBalance,
@@ -606,10 +551,9 @@ async function auditWorkspace(
       workspaceId,
       contractId,
       allocationBySeatType: Object.fromEntries(allocationBySeatType),
-      // Seats that held a stray grant (grant-history), before sizing by target.
-      seatsWithStrayGrant: strayTierBySeat.size,
-      // Sanity check: a low count vs seatsWithStrayGrant means the analytics
-      // read degraded and the over-grant sizing below is an undercount.
+      candidateSeatCount: candidateSeatIds.length,
+      // Sanity check: a low count vs candidateSeatCount means Metronome's usage
+      // read degraded and the over-grant sizing is an undercount.
       seatsWithConsumption: consumedByUserId.size,
       overAllocatedSeatCount: overAllocatedSeats.length,
       totalOverGrantedAwu,

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -17,6 +17,7 @@
  *   npx tsx scripts/audit_metronome_seat_state.ts --workspaceId <wId>
  */
 import config from "@app/lib/api/config";
+import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
 import {
   findSeatCreditSegmentForPeriod,
   getMetronomeClient,
@@ -459,34 +460,28 @@ async function auditWorkspace(
     "[SeatAudit] seat balances summary"
   );
 
-  // Over-allocation (credit-stacking) detection — grant-history based.
+  // Over-allocation (credit-stacking) detection — grant-history + reconcile.
   //
-  // A per-seat recurring credit grants exactly its allocation (8000 pro, 40000
-  // max, and the same for the _yearly variants) to whoever is assigned to its
-  // subscription at the credit segment start — that cycle's recurrence. If a
-  // seat later moves to another tier without empty-origin zeroing the old grant,
-  // it keeps that stray grant. So a seat is stacked iff it holds a grant from a
-  // tier it is NOT currently on, which we read straight from Metronome: each
-  // credit-bearing tier's subscription assignment AT its credit segment start,
-  // cross-referenced against the seat's current tier.
+  // WHO is stacked is authoritative and ES-free: a per-seat recurring credit
+  // grants exactly its allocation (8000 pro, 40000 max, same for _yearly) to
+  // whoever is on its subscription at the credit segment start, so a seat holds
+  // a stray grant iff it appears in a tier's grant-time assignment but is now on
+  // a different tier. Each tier is checked independently, so same-family stacks
+  // (pro + pro_yearly) and multi-stray seats are caught; a seat granted by
+  // several tiers is recorded once (first stray tier).
   //
-  // This is authoritative and needs neither `starting_balance` (Metronome drops
-  // a stray grant from it once fully consumed) nor analytics consumption (which
-  // can lag Metronome). Each tier is checked independently, so same-family
-  // stacks — e.g. pro + pro_yearly, two 8000 grants on one seat — are caught,
-  // and one seat can surface several stray grants.
+  // HOW MUCH is over-granted is what the idempotent correction reconciles away:
+  // target = max(0, homeAllocation - consumed); over = max(0, currentBalance -
+  // target). `consumed` is the analytics figure (the same one poke shows). It
+  // only sizes the amount on already-proven-stacked seats and can only shrink
+  // it, so analytics lag never over-counts, and it never touches a healthy seat.
   const currentAwuBalanceForSeat = (seatId: string): number =>
     (balanceBySeatId.get(seatId) ?? [])
       .filter((b) => b.credit_type_id === awuCreditTypeId)
       .reduce((sum, b) => sum + b.balance, 0);
 
-  const strayGrants: Array<{
-    seatId: string;
-    homeSeatType: MembershipSeatType | "unassigned";
-    strayType: MembershipSeatType;
-    strayAllocationAwu: number;
-    currentBalanceAwu: number;
-  }> = [];
+  const strayTierBySeat = new Map<string, MembershipSeatType>();
+  const homeBySeat = new Map<string, MembershipSeatType | "unassigned">();
   for (const { seatType, subId } of seatSubscriptions) {
     // Only recurring per-seat credit tiers (pro/max families); free/workspace/
     // none carry no such credit and cannot be a stray grant source.
@@ -499,7 +494,6 @@ async function auditWorkspace(
     if (!recurringCredit?.id) {
       continue;
     }
-    const allocation = allocationBySeatType.get(seatType) ?? 0;
     const segRes = await paceMetronome(() =>
       findSeatCreditSegmentForPeriod({
         metronomeCustomerId,
@@ -537,42 +531,90 @@ async function auditWorkspace(
       continue;
     }
     for (const seatId of grantStateRes.value.assignedSeatIds) {
-      const home = seatTypeBySeatId.get(seatId);
-      if (home === seatType) {
-        // Grant is legitimate — the seat is still on this tier.
+      const home = seatTypeBySeatId.get(seatId) ?? "unassigned";
+      if (home === seatType || strayTierBySeat.has(seatId)) {
         continue;
       }
-      strayGrants.push({
-        seatId,
-        homeSeatType: home ?? "unassigned",
-        strayType: seatType,
-        strayAllocationAwu: allocation,
-        currentBalanceAwu: currentAwuBalanceForSeat(seatId),
-      });
+      strayTierBySeat.set(seatId, seatType);
+      homeBySeat.set(seatId, home);
     }
   }
-  strayGrants.sort((a, b) => b.strayAllocationAwu - a.strayAllocationAwu);
-  const affectedSeatIds = new Set(strayGrants.map((g) => g.seatId));
-  const totalOverGrantedAwu = strayGrants.reduce(
-    (sum, g) => sum + g.strayAllocationAwu,
+
+  // Size each affected seat's over-grant via reconcile-to-target.
+  const RECONCILE_TOLERANCE_AWU = 1000;
+  const affectedSeatIds = [...strayTierBySeat.keys()];
+  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
+    workspace: lightWorkspace,
+    userIds: affectedSeatIds,
+    freeSeatUserIds: affectedSeatIds.filter(
+      (id) => seatTypeBySeatId.get(id) === "free"
+    ),
+  });
+  const overAllocatedSeats: Array<{
+    seatId: string;
+    homeSeatType: MembershipSeatType | "unassigned";
+    strayType: MembershipSeatType;
+    homeAllocation: number;
+    consumedAwu: number;
+    currentBalance: number;
+    targetBalance: number;
+    overGrantedAwu: number;
+  }> = [];
+  for (const seatId of affectedSeatIds) {
+    const strayType = strayTierBySeat.get(seatId);
+    const homeSeatType = homeBySeat.get(seatId) ?? "unassigned";
+    if (!strayType) {
+      continue;
+    }
+    const homeAllocation =
+      homeSeatType === "unassigned"
+        ? 0
+        : (allocationBySeatType.get(homeSeatType) ?? 0);
+    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
+    const currentBalance = currentAwuBalanceForSeat(seatId);
+    const targetBalance = Math.max(0, homeAllocation - consumedAwu);
+    const overGrantedAwu = Math.max(0, currentBalance - targetBalance);
+    if (overGrantedAwu <= RECONCILE_TOLERANCE_AWU) {
+      continue;
+    }
+    overAllocatedSeats.push({
+      seatId,
+      homeSeatType,
+      strayType,
+      homeAllocation,
+      consumedAwu,
+      currentBalance,
+      targetBalance,
+      overGrantedAwu,
+    });
+  }
+  overAllocatedSeats.sort((a, b) => b.overGrantedAwu - a.overGrantedAwu);
+  const totalOverGrantedAwu = overAllocatedSeats.reduce(
+    (sum, s) => sum + s.overGrantedAwu,
     0
   );
-  const byTransition = new Map<string, number>();
-  for (const g of strayGrants) {
-    const key = `${g.homeSeatType}<-${g.strayType}`;
-    byTransition.set(key, (byTransition.get(key) ?? 0) + 1);
+  const byTransition = new Map<string, { count: number; awu: number }>();
+  for (const s of overAllocatedSeats) {
+    const key = `${s.homeSeatType}<-${s.strayType}`;
+    const agg = byTransition.get(key) ?? { count: 0, awu: 0 };
+    agg.count += 1;
+    agg.awu += s.overGrantedAwu;
+    byTransition.set(key, agg);
   }
   logger.info(
     {
       workspaceId,
       contractId,
       allocationBySeatType: Object.fromEntries(allocationBySeatType),
-      // One entry per stray grant; a seat with two stray grants counts twice.
-      strayGrantCount: strayGrants.length,
-      affectedSeatCount: affectedSeatIds.size,
+      // Seats that held a stray grant (grant-history), before sizing by target.
+      seatsWithStrayGrant: strayTierBySeat.size,
+      // Sanity check: a low count vs seatsWithStrayGrant means the analytics
+      // read degraded and the over-grant sizing below is an undercount.
+      seatsWithConsumption: consumedByUserId.size,
+      overAllocatedSeatCount: overAllocatedSeats.length,
       totalOverGrantedAwu,
       byTransition: Object.fromEntries(byTransition),
-      strayGrants,
+      overAllocatedSeats,
     },
     "[SeatAudit] over-allocated seats (credit stacking)"
   );

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -25,6 +25,7 @@ import {
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
+  getAwuAllocationForSeatType,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
@@ -345,6 +346,18 @@ async function auditWorkspace(
   );
 
   const allSeatIds = new Set<string>();
+  // Map every assigned seat to its seat type, and each seat type to the AWU
+  // it is entitled to grant, so we can flag seats holding MORE granted AWU
+  // than their allocation (credit stacking left by an un-emptied origin credit
+  // on a prior seat-type change — e.g. a pro 8000 grant stacked on max 40000).
+  const seatTypeBySeatId = new Map<string, MembershipSeatType>();
+  const allocationBySeatType = new Map<MembershipSeatType, number>();
+  for (const { seatType } of seatSubscriptions) {
+    allocationBySeatType.set(
+      seatType,
+      getAwuAllocationForSeatType(contract, seatType, productSeatTypes)
+    );
+  }
 
   // Per seat subscription: compare Metronome assignment vs Dust desired.
   for (const { seatType, subId } of seatSubscriptions) {
@@ -369,7 +382,10 @@ async function auditWorkspace(
     const missingInMetronome = setDiff([...desired], assignedSet);
     const staleInMetronome = setDiff(assignedSeatIds, desired);
 
-    assignedSeatIds.forEach((id) => allSeatIds.add(id));
+    assignedSeatIds.forEach((id) => {
+      allSeatIds.add(id);
+      seatTypeBySeatId.set(id, seatType);
+    });
     desired.forEach((id) => allSeatIds.add(id));
 
     logger.info(
@@ -439,6 +455,63 @@ async function auditWorkspace(
       seatsNonPositiveBalance,
     },
     "[SeatAudit] seat balances summary"
+  );
+
+  // Over-allocation (credit-stacking) detection. `starting_balance` is the
+  // total AWU granted to the seat this cycle, independent of how much has been
+  // consumed — so a seat granted MORE than its seat-type allocation is holding
+  // a leftover grant that a prior seat-type change never emptied (the pro→max
+  // stacking: 40000 max allocation + an orphaned 8000 pro grant =
+  // starting_balance 48000). This is the exact population `syncSeatCount` can
+  // no longer self-heal (empty-origin sees the user already converged on the
+  // new seat), so it needs a targeted credit correction.
+  const AWU_OVER_ALLOCATION_TOLERANCE = 1;
+  const overAllocatedSeats: Array<{
+    seatId: string;
+    seatType: MembershipSeatType;
+    allocation: number;
+    startingBalance: number;
+    currentBalance: number;
+    overGrantedAwu: number;
+  }> = [];
+  for (const [seatId, seatType] of seatTypeBySeatId) {
+    const allocation = allocationBySeatType.get(seatType);
+    if (allocation === undefined || allocation <= 0) {
+      continue;
+    }
+    const awu = balanceBySeatId
+      .get(seatId)
+      ?.find((b) => b.credit_type_id === awuCreditTypeId);
+    if (!awu) {
+      continue;
+    }
+    const overGrantedAwu = awu.starting_balance - allocation;
+    if (overGrantedAwu > AWU_OVER_ALLOCATION_TOLERANCE) {
+      overAllocatedSeats.push({
+        seatId,
+        seatType,
+        allocation,
+        startingBalance: awu.starting_balance,
+        currentBalance: awu.balance,
+        overGrantedAwu,
+      });
+    }
+  }
+  overAllocatedSeats.sort((a, b) => b.overGrantedAwu - a.overGrantedAwu);
+  const totalOverGrantedAwu = overAllocatedSeats.reduce(
+    (sum, s) => sum + s.overGrantedAwu,
+    0
+  );
+  logger.info(
+    {
+      workspaceId,
+      contractId,
+      allocationBySeatType: Object.fromEntries(allocationBySeatType),
+      overAllocatedSeatCount: overAllocatedSeats.length,
+      totalOverGrantedAwu,
+      overAllocatedSeats,
+    },
+    "[SeatAudit] over-allocated seats (credit stacking)"
   );
 
   if (!probe) {

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -465,7 +465,16 @@ async function auditWorkspace(
   // starting_balance 48000). This is the exact population `syncSeatCount` can
   // no longer self-heal (empty-origin sees the user already converged on the
   // new seat), so it needs a targeted credit correction.
+  //
+  // A seat's AWU may be split across MULTIPLE balance entries (one per recurring
+  // credit — e.g. a stacked seat with a separate pro and max entry), so SUM all
+  // AWU-type entries rather than taking the first. `awuEntryCount` is emitted as
+  // a diagnostic: if some stacked seats show 2 entries, the split shape is real;
+  // if a fully-consumed stray grant is dropped by Metronome (single entry with
+  // starting_balance back at the allocation), starting_balance-based detection
+  // undercounts and we need a usage-based pass instead.
   const AWU_OVER_ALLOCATION_TOLERANCE = 1;
+  const awuEntryCountHistogram = new Map<number, number>();
   const overAllocatedSeats: Array<{
     seatId: string;
     seatType: MembershipSeatType;
@@ -473,27 +482,38 @@ async function auditWorkspace(
     startingBalance: number;
     currentBalance: number;
     overGrantedAwu: number;
+    awuEntryCount: number;
   }> = [];
   for (const [seatId, seatType] of seatTypeBySeatId) {
     const allocation = allocationBySeatType.get(seatType);
     if (allocation === undefined || allocation <= 0) {
       continue;
     }
-    const awu = balanceBySeatId
-      .get(seatId)
-      ?.find((b) => b.credit_type_id === awuCreditTypeId);
-    if (!awu) {
+    const awuEntries = (balanceBySeatId.get(seatId) ?? []).filter(
+      (b) => b.credit_type_id === awuCreditTypeId
+    );
+    awuEntryCountHistogram.set(
+      awuEntries.length,
+      (awuEntryCountHistogram.get(awuEntries.length) ?? 0) + 1
+    );
+    if (awuEntries.length === 0) {
       continue;
     }
-    const overGrantedAwu = awu.starting_balance - allocation;
+    const startingBalance = awuEntries.reduce(
+      (sum, b) => sum + b.starting_balance,
+      0
+    );
+    const currentBalance = awuEntries.reduce((sum, b) => sum + b.balance, 0);
+    const overGrantedAwu = startingBalance - allocation;
     if (overGrantedAwu > AWU_OVER_ALLOCATION_TOLERANCE) {
       overAllocatedSeats.push({
         seatId,
         seatType,
         allocation,
-        startingBalance: awu.starting_balance,
-        currentBalance: awu.balance,
+        startingBalance,
+        currentBalance,
         overGrantedAwu,
+        awuEntryCount: awuEntries.length,
       });
     }
   }
@@ -507,6 +527,10 @@ async function auditWorkspace(
       workspaceId,
       contractId,
       allocationBySeatType: Object.fromEntries(allocationBySeatType),
+      // How many AWU balance entries seats carry: >1 means the split (stacked)
+      // shape exists and summing catches it; all 1s means fully-consumed stray
+      // grants are dropped and starting_balance detection undercounts.
+      awuEntryCountHistogram: Object.fromEntries(awuEntryCountHistogram),
       overAllocatedSeatCount: overAllocatedSeats.length,
       totalOverGrantedAwu,
       overAllocatedSeats,

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -528,9 +528,24 @@ async function auditWorkspace(
     if (overGrantedAwu <= RECONCILE_TOLERANCE_AWU) {
       continue;
     }
-    const strayCandidates = creditBearingSeatTypes.filter(
-      (t) => t !== homeSeatType && (assignedCountByTier.get(t) ?? 0) > 0
+    // Stray tier = the OTHER credit-bearing tier whose allocation equals the
+    // over-grant (which always equals the stray allocation exactly). A
+    // same-family collision (pro + pro_yearly both 8000) is broken by which one
+    // has assigned seats; in-use is only a tiebreaker, since the stray tier can
+    // itself have 0 seats now (the user moved off it).
+    let strayCandidates = creditBearingSeatTypes.filter(
+      (t) =>
+        t !== homeSeatType &&
+        Math.abs((allocationBySeatType.get(t) ?? -1) - overGrantedAwu) <= 200
     );
+    if (strayCandidates.length > 1) {
+      const inUse = strayCandidates.filter(
+        (t) => (assignedCountByTier.get(t) ?? 0) > 0
+      );
+      if (inUse.length === 1) {
+        strayCandidates = inUse;
+      }
+    }
     overAllocatedSeats.push({
       seatId,
       homeSeatType,

--- a/front/scripts/audit_metronome_seat_state.ts
+++ b/front/scripts/audit_metronome_seat_state.ts
@@ -11,19 +11,25 @@
  * assigned seat's live balance, so we can figure out why they won't assign
  * before touching credit state.
  *
+ * It also reports the stacked-credit "would-correct" plan by running the shared
+ * `lib/metronome/stacked_seat_credits` core in read-only mode (execute: false) —
+ * the SAME detection the fix script and the `credit.segment.start` webhook use,
+ * so the audit and the correction can never disagree: strays to empty + the
+ * usage-based home debit that recovers consumption stranded on a stray.
+ *
  * Purely diagnostic — makes only READ calls to Metronome and the DB. There is
  * nothing to --execute; it always just reports.
  *
  *   npx tsx scripts/audit_metronome_seat_state.ts --workspaceId <wId>
  */
 import config from "@app/lib/api/config";
-import { fetchConsumedAwuCreditsFromMetronomeByUserId } from "@app/lib/api/credits/members_usage";
 import {
   getMetronomeClient,
   getMetronomeSubscriptionSeatState,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
@@ -31,6 +37,7 @@ import {
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
+import { correctStackedSeatCreditsFromBalances } from "@app/lib/metronome/stacked_seat_credits";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -459,116 +466,72 @@ async function auditWorkspace(
     "[SeatAudit] seat balances summary"
   );
 
-  // Over-allocation (credit-stacking) detection — consumption-based reconcile.
-  //
-  // A seat should hold max(0, homeAllocation - consumed); anything above that is
-  // a stray grant from a tier it moved off that was never emptied. Detection is
-  // by consumption, NOT grant-time assignment: a seat's stray grant can sit in
-  // an EARLIER credit segment than the current one (it moved tier before the
-  // latest segment started), so grant-history under-detects it. `consumed` is
-  // Metronome's OWN per-user usage (authoritative, not ES). A legit seat has
-  // balance ≈ allocation - consumed, so its over is ~0; only a seat carrying an
-  // extra grant exceeds the threshold, so a healthy seat is never flagged.
-  const currentAwuBalanceForSeat = (seatId: string): number =>
-    (balanceBySeatId.get(seatId) ?? [])
-      .filter((b) => b.credit_type_id === awuCreditTypeId)
-      .reduce((sum, b) => sum + b.balance, 0);
-
+  // Stacked-credit detection — reuse the SHARED core in read-only mode
+  // (execute: false), so the audit reports EXACTLY what the fix script and the
+  // credit.segment.start webhook would correct (strays to empty + the usage-based
+  // home debit), with zero risk of drift between audit and correction. Purely a
+  // dry-run of `correctStackedSeatCreditsFromBalances`: it makes only READ calls
+  // (segment resolution) and returns the adjustments it WOULD apply.
   const creditBearingSeatTypes = seatSubscriptions
     .map(({ seatType }) => seatType)
     .filter((seatType) => getSeatCreditNameForSeatType(seatType));
   // Candidate seats: those currently on a credit-bearing tier (a free/none home
-  // has no recurring credit of its own; its stray is handled separately).
+  // has no recurring credit of its own).
   const candidateSeatTypeById = new Map<string, MembershipSeatType>();
   for (const [seatId, seatType] of seatTypeBySeatId) {
     if (creditBearingSeatTypes.includes(seatType)) {
       candidateSeatTypeById.set(seatId, seatType);
     }
   }
-  // Seats currently assigned per tier — the stray is an actively-used tier, so
-  // dormant tiers (e.g. pro_yearly/max_yearly with 0 seats) are ignored when
-  // labelling the stray.
-  const assignedCountByTier = new Map<MembershipSeatType, number>();
-  for (const seatType of seatTypeBySeatId.values()) {
-    assignedCountByTier.set(
-      seatType,
-      (assignedCountByTier.get(seatType) ?? 0) + 1
+
+  // Current-period per-user AWU usage (Metronome, authoritative) — the core
+  // drives each home credit to allocation - usage.
+  const usageRes = await paceMetronome(() =>
+    fetchPerUserAwuUsage({
+      workspaceId,
+      metronomeCustomerId,
+      userIds: [...candidateSeatTypeById.keys()],
+    })
+  );
+  if (usageRes.isErr()) {
+    logger.error(
+      { workspaceId, err: usageRes.error.message },
+      "[SeatAudit] failed to read per-user usage"
     );
+    return;
   }
-  const RECONCILE_TOLERANCE_AWU = 1000;
-  const candidateSeatIds = [...candidateSeatTypeById.keys()];
-  const consumedByUserId = await fetchConsumedAwuCreditsFromMetronomeByUserId({
+
+  const stackedRes = await correctStackedSeatCreditsFromBalances({
     workspaceId,
     metronomeCustomerId,
     metronomeContractId: contractId,
-    users: candidateSeatIds.map((sId) => ({
-      sId,
-      seatType: candidateSeatTypeById.get(sId) ?? null,
-    })),
+    contract,
+    seatBalances: balancesRes.value,
+    currentSeatTypeBySeatId: candidateSeatTypeById,
+    usageBySeatId: usageRes.value,
+    execute: false,
+    logger,
+    pace: paceMetronome,
   });
-  const overAllocatedSeats: Array<{
-    seatId: string;
-    homeSeatType: MembershipSeatType;
-    strayType: MembershipSeatType | "ambiguous";
-    homeAllocation: number;
-    consumedAwu: number;
-    currentBalance: number;
-    targetBalance: number;
-    overGrantedAwu: number;
-  }> = [];
-  for (const [seatId, homeSeatType] of candidateSeatTypeById) {
-    const homeAllocation = allocationBySeatType.get(homeSeatType) ?? 0;
-    if (homeAllocation <= 0) {
-      continue;
-    }
-    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
-    const currentBalance = currentAwuBalanceForSeat(seatId);
-    const targetBalance = Math.max(0, homeAllocation - consumedAwu);
-    const overGrantedAwu = Math.max(0, currentBalance - targetBalance);
-    if (overGrantedAwu <= RECONCILE_TOLERANCE_AWU) {
-      continue;
-    }
-    // Stray tier = the OTHER credit-bearing tier whose allocation equals the
-    // over-grant (which always equals the stray allocation exactly). A
-    // same-family collision (pro + pro_yearly both 8000) is broken by which one
-    // has assigned seats; in-use is only a tiebreaker, since the stray tier can
-    // itself have 0 seats now (the user moved off it).
-    let strayCandidates = creditBearingSeatTypes.filter(
-      (t) =>
-        t !== homeSeatType &&
-        Math.abs((allocationBySeatType.get(t) ?? -1) - overGrantedAwu) <= 200
+  if (stackedRes.isErr()) {
+    logger.error(
+      { workspaceId, err: stackedRes.error.message },
+      "[SeatAudit] failed to detect stacked seat credits"
     );
-    if (strayCandidates.length > 1) {
-      const inUse = strayCandidates.filter(
-        (t) => (assignedCountByTier.get(t) ?? 0) > 0
-      );
-      if (inUse.length === 1) {
-        strayCandidates = inUse;
-      }
-    }
-    overAllocatedSeats.push({
-      seatId,
-      homeSeatType,
-      strayType:
-        strayCandidates.length === 1 ? strayCandidates[0] : "ambiguous",
-      homeAllocation,
-      consumedAwu,
-      currentBalance,
-      targetBalance,
-      overGrantedAwu,
-    });
+    return;
   }
-  overAllocatedSeats.sort((a, b) => b.overGrantedAwu - a.overGrantedAwu);
-  const totalOverGrantedAwu = overAllocatedSeats.reduce(
-    (sum, s) => sum + s.overGrantedAwu,
-    0
-  );
+  const stacked = stackedRes.value;
+  // Aggregate the stray-empties by transition (homeSeatType <- strayType) for a
+  // quick view of which seat-type change stranded each credit.
   const byTransition = new Map<string, { count: number; awu: number }>();
-  for (const s of overAllocatedSeats) {
-    const key = `${s.homeSeatType}<-${s.strayType}`;
+  for (const a of stacked.adjustments) {
+    if (a.kind !== "empty_stray") {
+      continue;
+    }
+    const key = `${a.homeSeatType}<-${a.creditSeatType}`;
     const agg = byTransition.get(key) ?? { count: 0, awu: 0 };
     agg.count += 1;
-    agg.awu += s.overGrantedAwu;
+    agg.awu += -a.deltaAwu;
     byTransition.set(key, agg);
   }
   logger.info(
@@ -576,16 +539,16 @@ async function auditWorkspace(
       workspaceId,
       contractId,
       allocationBySeatType: Object.fromEntries(allocationBySeatType),
-      candidateSeatCount: candidateSeatIds.length,
-      // Sanity check: a low count vs candidateSeatCount means Metronome's usage
-      // read degraded and the over-grant sizing is an undercount.
-      seatsWithConsumption: consumedByUserId.size,
-      overAllocatedSeatCount: overAllocatedSeats.length,
-      totalOverGrantedAwu,
+      candidateSeatCount: candidateSeatTypeById.size,
+      // Strays to empty and their total; home consumption to carry and its total.
+      emptiedStrayCount: stacked.emptiedStrayCount,
+      totalEmptiedAwu: stacked.totalEmptiedAwu,
+      carriedConsumptionCount: stacked.carriedConsumptionCount,
+      totalCarriedAwu: stacked.totalCarriedAwu,
       byTransition: Object.fromEntries(byTransition),
-      overAllocatedSeats,
+      adjustments: stacked.adjustments,
     },
-    "[SeatAudit] over-allocated seats (credit stacking)"
+    "[SeatAudit] stacked seat credits (read-only would-correct plan)"
   );
 
   if (!probe) {

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -9,22 +9,23 @@
  * candidate and can no longer self-heal it — see `audit_metronome_seat_state.ts`
  * ("over-allocated seats").
  *
- * Detection is grant-history based (authoritative, ES-free): a per-seat
- * recurring credit grants exactly its allocation to whoever is on its
- * subscription at the credit segment start, so a seat holds a stray grant iff it
- * appears in a tier's grant-time assignment but is now on a different tier.
+ * Detection + correction are one IDEMPOTENT reconcile-to-target pass, keyed on
+ * Metronome's OWN per-user consumption (authoritative, not ES). Each seat on a
+ * credit-bearing tier should hold `max(0, homeAllocation - consumed)`; the fix
+ * posts a negative delta to the stray credit equal to the seat's excess above
+ * that target (`max(0, currentBalance - target)`). A seat already at/below
+ * target — fixed by a prior run, empty-origin, or manually — yields ~0 and is
+ * skipped, so re-runs are safe WITHOUT knowing which seats were already fixed.
+ * The claw-back floors at 0, so a healthy seat (balance ≈ allocation - consumed)
+ * is never touched and credit is never added.
  *
- * The correction is IDEMPOTENT via reconcile-to-target: each affected seat
- * should hold `max(0, homeAllocation - consumed)`; the fix posts a negative
- * delta to the stray credit equal to the seat's excess above that target
- * (`max(0, currentBalance - target)`). A seat already at/below target — fixed by
- * a prior run, empty-origin, or manually — yields ~0 and is skipped, so re-runs
- * are safe WITHOUT knowing which seats were already fixed. `consumed` is the
- * analytics figure; because grant-history alone decides WHO is touched and the
- * claw-back is floored at 0, analytics lag can only under-correct — it can never
- * add credit or touch a healthy seat. All corrections on the same stray credit
- * share that credit's segment start as their entry time, so they apply in ONE
- * batched ledger entry per stray credit (write cost is O(stray credits)).
+ * The over-grant equals the STRAY tier's allocation exactly (totalGranted =
+ * homeAllocation + strayAllocation, independent of consumption), which names the
+ * stray tier. Same-family collisions (pro + pro_yearly both 8000) are broken by
+ * which tier has assigned seats — but only as a tiebreaker, since the stray tier
+ * can itself now have 0 seats (the user moved off it). All corrections on the
+ * same stray credit share its segment start as their entry time, so they apply
+ * in ONE batched ledger entry per stray credit (write cost is O(stray credits)).
  *
  * IMPORTANT — read before running with --execute:
  *
@@ -35,13 +36,17 @@
  *    adjusting the stray credit, which can leave THAT pool negative — harmless
  *    for a seat no longer assigned to it (nothing draws from it; it expires next
  *    recurrence).
- *  - Each credit-bearing tier is checked independently, so same-family stacks
- *    (pro + pro_yearly) and seats carrying several stray grants are caught; such
- *    a seat is reconciled once (its whole aggregate to target) on the first
- *    stray credit.
+ *  - A seat whose over-grant matches no single stray tier (multi-stray, or an
+ *    ambiguous same-family collision that in-use can't break) is reported in
+ *    `skippedAmbiguousStrayTiers` and left untouched — needs manual handling.
  *  - `--excludeSeatIds` still exists for belt-and-suspenders, but is not required
  *    for safety: an already-fixed seat is a no-op. Re-run the audit afterwards to
  *    confirm.
+ *
+ * NOTE: this corrects the CURRENT period only. Recurring credits are materialized
+ * one period ahead, so a mid-period move also leaves a stray grant on the NEXT
+ * segment (fixed at the source by `emptyOriginNextPeriodCredits` in seats.ts).
+ * Re-run after that ships to clear any next-period backlog.
  *
  * Dry-run by default (prints the full plan, including per-seat segment/timestamp
  * resolution). Pass --execute to apply. Use --seatId to restrict to a single
@@ -308,17 +313,13 @@ async function fixWorkspace(
     );
   }
   const creditBearingTiers = [...tierBySeatType.values()];
-  const strayInfoBySeat = new Map<
-    string,
-    {
-      homeSeatType: MembershipSeatType;
-      strayType: MembershipSeatType;
-      creditId: string;
-      segmentId: string;
-      adjustmentTimestamp: Date;
-    }
-  >();
-  const skippedAmbiguousStray = new Set<MembershipSeatType>();
+
+  // Candidate seats: currently on a credit-bearing tier (a free/none home has no
+  // recurring credit of its own; its stray is handled separately).
+  const candidates: Array<{
+    seatId: string;
+    homeSeatType: MembershipSeatType;
+  }> = [];
   for (const [seatId, homeSeatType] of seatTypeBySeatId) {
     if (onlySeatId && seatId !== onlySeatId) {
       continue;
@@ -329,59 +330,42 @@ async function fixWorkspace(
     if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
       continue;
     }
-    // Only seats currently on a credit-bearing tier are corrected here (a free/
-    // none home has no recurring credit of its own and an ambiguous stray).
     if (!tierBySeatType.has(homeSeatType)) {
       continue;
     }
-    const strayCandidates = creditBearingTiers.filter(
-      (t) =>
-        t.seatType !== homeSeatType &&
-        (assignedCountByTier.get(t.seatType) ?? 0) > 0
-    );
-    if (strayCandidates.length !== 1) {
-      // Still >1 in-use credit-bearing tier other than home: can't infer which
-      // pool holds the stray grant. Reported and skipped.
-      skippedAmbiguousStray.add(homeSeatType);
-      continue;
-    }
-    const stray = await resolveStrayCredit(strayCandidates[0]);
-    if (!stray) {
-      continue;
-    }
-    strayInfoBySeat.set(seatId, {
-      homeSeatType,
-      strayType: strayCandidates[0].seatType,
-      ...stray,
-    });
+    candidates.push({ seatId, homeSeatType });
   }
 
-  // Phase 2 — reconcile-to-target: each seat should hold max(0, homeAllocation -
-  // consumed); the claw-back is its excess above that. Idempotent — a seat
-  // already at/below target (fixed by a prior run, empty-origin, or manually)
-  // yields ~0 and is skipped, so re-running is safe without knowing which seats
-  // were fixed. `consumed` is Metronome's OWN per-user usage (authoritative, not
-  // ES); the claw-back floors at 0, so it can only under-correct, never add
-  // credit or touch a healthy seat (a legit seat has balance ≈ allocation -
-  // consumed, so its excess is ~0).
-  const RECONCILE_TOLERANCE_AWU = 1000;
-  const affectedSeatIds = [...strayInfoBySeat.keys()];
+  // Metronome's OWN per-user usage (authoritative, not ES).
   const consumedByUserId = await fetchConsumedAwuCreditsFromMetronomeByUserId({
     workspaceId,
     metronomeCustomerId,
     metronomeContractId: contractId,
-    users: affectedSeatIds.map((sId) => ({
-      sId,
-      seatType: seatTypeBySeatId.get(sId) ?? null,
+    users: candidates.map(({ seatId, homeSeatType }) => ({
+      sId: seatId,
+      seatType: homeSeatType,
     })),
   });
+
+  // Reconcile-to-target: each seat should hold max(0, homeAllocation - consumed);
+  // the claw-back is its excess above that. Idempotent — a seat at/below target
+  // (fixed by a prior run, empty-origin, or manually) yields ~0 and is skipped,
+  // so re-running is safe without knowing which seats were fixed. The claw-back
+  // floors at 0, so it can only under-correct, never add credit or touch a
+  // healthy seat (a legit seat has balance ≈ allocation - consumed → excess ~0).
+  //
+  // The over-grant equals the STRAY tier's allocation exactly (totalGranted =
+  // homeAllocation + strayAllocation, independent of consumption), so the amount
+  // identifies the stray family. A same-family collision (pro + pro_yearly both
+  // 8000) is broken by which tier actually has assigned seats; note the stray
+  // tier can itself have 0 seats now (the user was the only one and moved off),
+  // so in-use is only a TIEBREAKER, never the primary filter.
+  const RECONCILE_TOLERANCE_AWU = 1000;
+  const ALLOCATION_MATCH_TOLERANCE_AWU = 200;
   const corrections: SeatCorrection[] = [];
-  for (const seatId of affectedSeatIds) {
-    const info = strayInfoBySeat.get(seatId);
-    if (!info) {
-      continue;
-    }
-    const homeAllocation = allocationBySeatType.get(info.homeSeatType) ?? 0;
+  const skippedAmbiguousStray = new Set<MembershipSeatType>();
+  for (const { seatId, homeSeatType } of candidates) {
+    const homeAllocation = allocationBySeatType.get(homeSeatType) ?? 0;
     const consumedAwu = consumedByUserId.get(seatId) ?? 0;
     const currentBalance = awuBalanceBySeatId.get(seatId) ?? 0;
     const targetBalance = Math.max(0, homeAllocation - consumedAwu);
@@ -389,18 +373,39 @@ async function fixWorkspace(
     if (clawBackAwu <= RECONCILE_TOLERANCE_AWU) {
       continue;
     }
+    let strayCandidates = creditBearingTiers.filter(
+      (t) =>
+        t.seatType !== homeSeatType &&
+        Math.abs(t.allocation - clawBackAwu) <= ALLOCATION_MATCH_TOLERANCE_AWU
+    );
+    if (strayCandidates.length > 1) {
+      const inUse = strayCandidates.filter(
+        (t) => (assignedCountByTier.get(t.seatType) ?? 0) > 0
+      );
+      if (inUse.length === 1) {
+        strayCandidates = inUse;
+      }
+    }
+    if (strayCandidates.length !== 1) {
+      skippedAmbiguousStray.add(homeSeatType);
+      continue;
+    }
+    const stray = await resolveStrayCredit(strayCandidates[0]);
+    if (!stray) {
+      continue;
+    }
     corrections.push({
       seatId,
-      homeSeatType: info.homeSeatType,
-      strayType: info.strayType,
+      homeSeatType,
+      strayType: strayCandidates[0].seatType,
       homeAllocation,
       consumedAwu,
       currentBalance,
       targetBalance,
       clawBackAwu,
-      creditId: info.creditId,
-      segmentId: info.segmentId,
-      adjustmentTimestamp: info.adjustmentTimestamp,
+      creditId: stray.creditId,
+      segmentId: stray.segmentId,
+      adjustmentTimestamp: stray.adjustmentTimestamp,
     });
   }
 
@@ -447,7 +452,7 @@ async function fixWorkspace(
       excludedSeatCount: excludeSeatIds.size,
       // Seats on a credit-bearing tier considered, before the reconcile filter
       // keeps only those over target.
-      candidateSeatCount: strayInfoBySeat.size,
+      candidateSeatCount: candidates.length,
       seatsWithConsumption: consumedByUserId.size,
       correctedSeatCount: corrections.length,
       totalClawBackAwu: corrections.reduce((s, c) => s + c.clawBackAwu, 0),

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -53,7 +53,7 @@
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
  */
 import config from "@app/lib/api/config";
-import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
+import { fetchConsumedAwuCreditsFromMetronomeByUserId } from "@app/lib/api/credits/members_usage";
 import {
   adjustSeatCreditBalances,
   findSeatCreditSegmentForPeriod,
@@ -259,28 +259,22 @@ async function fixWorkspace(
     awuBalanceBySeatId.set(seat.seat_id, balance);
   }
 
-  // Phase 1 — grant history (authoritative, ES-free): which seats hold a stray
-  // grant and on which stray credit. A per-seat recurring credit grants exactly
-  // its allocation to whoever is on its subscription at the credit segment
-  // start, so a seat is stacked iff it appears in a tier's grant-time assignment
-  // but is now on a different tier. Each tier is checked independently, so
-  // same-family stacks (pro + pro_yearly) are caught; a seat granted by several
-  // tiers is owned by the first (reconciled once, on that credit — the single
-  // reconcile brings its whole aggregate to target regardless).
-  const strayInfoBySeat = new Map<
-    string,
-    {
-      homeSeatType: MembershipSeatType | "unassigned";
-      strayType: MembershipSeatType;
-      creditId: string;
-      segmentId: string;
-      // Segment start: a shared, in-segment, hour-aligned entry time at which
-      // the seat held the grant — lets all seats on this credit batch.
-      adjustmentTimestamp: Date;
-    }
+  // Phase 1 — pair each seat on a credit-bearing tier with its stray credit (the
+  // OTHER credit-bearing tier: home max -> stray pro, home pro -> stray max).
+  // Detection is NOT grant-history: a seat's stray grant can sit in an EARLIER
+  // credit segment than the current one (it moved tier before the latest segment
+  // started), so grant-time assignment under-detects it. Reconcile in phase 2
+  // (balance vs homeAllocation - consumed) is what actually flags a seat; this
+  // phase only resolves WHERE the excess would be reversed.
+  const strayCreditByTier = new Map<
+    MembershipSeatType,
+    { creditId: string; segmentId: string; adjustmentTimestamp: Date } | null
   >();
-  const skippedTiersNoSegment: MembershipSeatType[] = [];
-  for (const tier of tierBySeatType.values()) {
+  const resolveStrayCredit = async (tier: StrayTierInfo) => {
+    const cached = strayCreditByTier.get(tier.seatType);
+    if (cached !== undefined) {
+      return cached;
+    }
     const segRes = await paceMetronome(() =>
       findSeatCreditSegmentForPeriod({
         metronomeCustomerId,
@@ -289,83 +283,83 @@ async function fixWorkspace(
       })
     );
     const segment = segRes.isOk() ? segRes.value : null;
-    if (!segment) {
-      logger.warn(
-        {
-          workspaceId,
-          strayType: tier.seatType,
-          err: segRes.isErr() ? segRes.error.message : "no active segment",
-        },
-        "[StackedFix] no credit segment for tier — skipping"
-      );
-      skippedTiersNoSegment.push(tier.seatType);
+    const resolved = segment
+      ? {
+          creditId: segment.creditId,
+          segmentId: segment.segmentId,
+          // Shared, in-segment entry time so all seats on this credit batch.
+          adjustmentTimestamp: new Date(segment.segmentStartingAt),
+        }
+      : null;
+    strayCreditByTier.set(tier.seatType, resolved);
+    return resolved;
+  };
+
+  const creditBearingTiers = [...tierBySeatType.values()];
+  const strayInfoBySeat = new Map<
+    string,
+    {
+      homeSeatType: MembershipSeatType;
+      strayType: MembershipSeatType;
+      creditId: string;
+      segmentId: string;
+      adjustmentTimestamp: Date;
+    }
+  >();
+  const skippedAmbiguousStray = new Set<MembershipSeatType>();
+  for (const [seatId, homeSeatType] of seatTypeBySeatId) {
+    if (onlySeatId && seatId !== onlySeatId) {
       continue;
     }
-    const grantStateRes = await paceMetronome(() =>
-      getMetronomeSubscriptionSeatState({
-        metronomeCustomerId,
-        contractId,
-        subscriptionId: tier.subscriptionId,
-        coveringDate: new Date(segment.segmentStartingAt),
-      })
+    if (excludeSeatIds.has(seatId)) {
+      continue;
+    }
+    if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
+      continue;
+    }
+    // Only seats currently on a credit-bearing tier are corrected here (a free/
+    // none home has no recurring credit of its own and an ambiguous stray).
+    if (!tierBySeatType.has(homeSeatType)) {
+      continue;
+    }
+    const strayCandidates = creditBearingTiers.filter(
+      (t) => t.seatType !== homeSeatType
     );
-    if (grantStateRes.isErr()) {
-      logger.error(
-        {
-          workspaceId,
-          strayType: tier.seatType,
-          err: grantStateRes.error.message,
-        },
-        "[StackedFix] failed to read grant-time assignment — skipping tier"
-      );
-      skippedTiersNoSegment.push(tier.seatType);
+    if (strayCandidates.length !== 1) {
+      // >2 credit-bearing tiers (e.g. yearly variants present): can't infer
+      // which pool holds the stray grant. Reported and skipped.
+      skippedAmbiguousStray.add(homeSeatType);
       continue;
     }
-    const adjustmentTimestamp = new Date(segment.segmentStartingAt);
-    for (const seatId of grantStateRes.value.assignedSeatIds) {
-      if (onlySeatId && seatId !== onlySeatId) {
-        continue;
-      }
-      if (excludeSeatIds.has(seatId)) {
-        continue;
-      }
-      const homeSeatType = seatTypeBySeatId.get(seatId) ?? "unassigned";
-      if (homeSeatType === tier.seatType) {
-        // Grant is legitimate — the seat is still on this tier.
-        continue;
-      }
-      if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
-        continue;
-      }
-      if (strayInfoBySeat.has(seatId)) {
-        continue;
-      }
-      strayInfoBySeat.set(seatId, {
-        homeSeatType,
-        strayType: tier.seatType,
-        creditId: segment.creditId,
-        segmentId: segment.segmentId,
-        adjustmentTimestamp,
-      });
+    const stray = await resolveStrayCredit(strayCandidates[0]);
+    if (!stray) {
+      continue;
     }
+    strayInfoBySeat.set(seatId, {
+      homeSeatType,
+      strayType: strayCandidates[0].seatType,
+      ...stray,
+    });
   }
 
-  // Phase 2 — reconcile-to-target: each affected seat should hold max(0,
-  // homeAllocation - consumed); the claw-back is its excess above that. This is
-  // idempotent — a seat already at/below target (fixed by a prior run,
-  // empty-origin, or manually) yields ~0 and is skipped, so re-running is safe
-  // even without knowing which seats were fixed. `consumed` is the analytics
-  // figure; it only sizes the amount on already-proven-stacked seats and the
-  // claw-back is floored at 0, so analytics lag can only under-correct, never
-  // add credit or touch a healthy seat.
+  // Phase 2 — reconcile-to-target: each seat should hold max(0, homeAllocation -
+  // consumed); the claw-back is its excess above that. Idempotent — a seat
+  // already at/below target (fixed by a prior run, empty-origin, or manually)
+  // yields ~0 and is skipped, so re-running is safe without knowing which seats
+  // were fixed. `consumed` is Metronome's OWN per-user usage (authoritative, not
+  // ES); the claw-back floors at 0, so it can only under-correct, never add
+  // credit or touch a healthy seat (a legit seat has balance ≈ allocation -
+  // consumed, so its excess is ~0).
   const RECONCILE_TOLERANCE_AWU = 1000;
   const affectedSeatIds = [...strayInfoBySeat.keys()];
-  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
-    workspace: lightWorkspace,
-    userIds: affectedSeatIds,
-    freeSeatUserIds: affectedSeatIds.filter(
-      (id) => seatTypeBySeatId.get(id) === "free"
-    ),
+  const consumedByUserId = await fetchConsumedAwuCreditsFromMetronomeByUserId({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+    users: affectedSeatIds.map((sId) => ({
+      sId,
+      seatType: seatTypeBySeatId.get(sId) ?? null,
+    })),
   });
   const corrections: SeatCorrection[] = [];
   for (const seatId of affectedSeatIds) {
@@ -373,10 +367,7 @@ async function fixWorkspace(
     if (!info) {
       continue;
     }
-    const homeAllocation =
-      info.homeSeatType === "unassigned"
-        ? 0
-        : (allocationBySeatType.get(info.homeSeatType) ?? 0);
+    const homeAllocation = allocationBySeatType.get(info.homeSeatType) ?? 0;
     const consumedAwu = consumedByUserId.get(seatId) ?? 0;
     const currentBalance = awuBalanceBySeatId.get(seatId) ?? 0;
     const targetBalance = Math.max(0, homeAllocation - consumedAwu);
@@ -440,15 +431,15 @@ async function fixWorkspace(
       onlySeatId,
       onlyHomeSeatType,
       excludedSeatCount: excludeSeatIds.size,
-      // Seats that held a stray grant (grant-history), before the reconcile
-      // filter drops those already at/below target.
-      seatsWithStrayGrant: strayInfoBySeat.size,
+      // Seats on a credit-bearing tier considered, before the reconcile filter
+      // keeps only those over target.
+      candidateSeatCount: strayInfoBySeat.size,
       seatsWithConsumption: consumedByUserId.size,
       correctedSeatCount: corrections.length,
       totalClawBackAwu: corrections.reduce((s, c) => s + c.clawBackAwu, 0),
       batchedAdjustCalls: batches.size,
       byTransition: Object.fromEntries(byTransition),
-      skippedTiersNoSegment,
+      skippedAmbiguousStrayTiers: [...skippedAmbiguousStray],
       corrections,
     },
     "[StackedFix] correction plan"

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -49,9 +49,16 @@ import {
   findSeatCreditSegmentForPeriod,
   getMetronomeSeatActiveSince,
   getMetronomeSubscriptionSeatState,
+  invalidateCachedCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { ContractCreditType } from "@app/lib/metronome/constants";
+import {
+  CONTRACT_CREDIT_TYPE_EXCESS,
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  CONTRACT_CREDIT_TYPE_POOL,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
@@ -428,6 +435,32 @@ async function fixWorkspace(
       "[StackedFix] corrected stacked seat"
     );
   }
+  // Bust the 1-hour per-user credit-balance Redis cache
+  // (getCachedCustomerPerUserCreditBalances) so poke reflects the corrections
+  // without waiting out the TTL. A manual balance entry does NOT fire the
+  // Metronome credit.create / segment.start webhook that normally invalidates
+  // it, so nothing else clears it. This covers the free-seat / pool surfaces
+  // that read the cache; the pro/max seat balance in the members table is read
+  // LIVE (uncached listMetronomeSeatBalances), so its brief post-correction lag
+  // is Metronome's own seat-balance read model catching up and self-heals.
+  if (applied > 0) {
+    const contractCreditTypes: ContractCreditType[] = [
+      CONTRACT_CREDIT_TYPE_FREE_SEAT,
+      CONTRACT_CREDIT_TYPE_POOL,
+      CONTRACT_CREDIT_TYPE_EXCESS,
+    ];
+    for (const contractCreditType of contractCreditTypes) {
+      await invalidateCachedCustomerPerUserCreditBalances({
+        metronomeCustomerId,
+        contractCreditType,
+      });
+    }
+    logger.info(
+      { workspaceId, metronomeCustomerId },
+      "[StackedFix] invalidated cached per-user credit balances"
+    );
+  }
+
   logger.info(
     { workspaceId, applied, planned: resolved.length },
     "[StackedFix] done"

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -295,6 +295,18 @@ async function fixWorkspace(
     return resolved;
   };
 
+  // How many seats are currently assigned to each tier — used to disambiguate
+  // the stray. A contract can expose dormant tiers (e.g. pro_yearly/max_yearly
+  // with 0 seats); the stray is always an ACTIVELY-USED tier, so ignore the
+  // empty ones. (Removing 8000 from any pro-family credit reconciles the same,
+  // but targeting the in-use one keeps the ledger clean.)
+  const assignedCountByTier = new Map<MembershipSeatType, number>();
+  for (const seatType of seatTypeBySeatId.values()) {
+    assignedCountByTier.set(
+      seatType,
+      (assignedCountByTier.get(seatType) ?? 0) + 1
+    );
+  }
   const creditBearingTiers = [...tierBySeatType.values()];
   const strayInfoBySeat = new Map<
     string,
@@ -323,11 +335,13 @@ async function fixWorkspace(
       continue;
     }
     const strayCandidates = creditBearingTiers.filter(
-      (t) => t.seatType !== homeSeatType
+      (t) =>
+        t.seatType !== homeSeatType &&
+        (assignedCountByTier.get(t.seatType) ?? 0) > 0
     );
     if (strayCandidates.length !== 1) {
-      // >2 credit-bearing tiers (e.g. yearly variants present): can't infer
-      // which pool holds the stray grant. Reported and skipped.
+      // Still >1 in-use credit-bearing tier other than home: can't infer which
+      // pool holds the stray grant. Reported and skipped.
       skippedAmbiguousStray.add(homeSeatType);
       continue;
     }

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -10,26 +10,29 @@
  * ("over-allocated seats").
  *
  * The fix mirrors what empty-origin would have done: post a corrective negative
- * delta to the STRAY recurring credit so the seat's TOTAL granted AWU drops back
- * to its home allocation. We debit exactly `overGrantedAwu = startingBalance -
- * homeAllocation`, which brings the seat's aggregate balance to
- * `homeAllocation - consumed` regardless of which pool consumption came out of
- * (aggregate arithmetic; see the block comment on `planSeatCorrection`).
+ * delta to the STRAY recurring credit so the seat's aggregate AWU drops back to
+ * `max(0, allocation - consumed)`. Detection is usage-based — a seat is stacked
+ * when `currentBalance - max(0, allocation - consumed) > threshold` — because
+ * Metronome DROPS a fully-consumed stray grant from `starting_balance`, so a
+ * starting_balance check misses seats that already spent through the phantom
+ * grant (see audit_metronome_seat_state.ts). The debit is `min(strayAllocation,
+ * currentBalance)`: the whole stray grant still on the balance, capped so the
+ * aggregate never falls below `max(0, allocation - consumed)`.
  *
  * IMPORTANT — read before running with --execute:
  *
  *  - There is NO Metronome read that returns a seat's balance on a SPECIFIC
  *    recurring credit; every read collapses pro/max into one aggregate AWU
  *    number. So we cannot observe the stray pool's balance directly; we debit
- *    the computed `overGrantedAwu`. If the stray pool had some consumption, that
- *    debit can leave the stray pool slightly negative (bounded by the seat's
- *    consumption this cycle). That is harmless for a seat no longer assigned to
- *    the stray tier (nothing draws from it; it expires next recurrence), and the
- *    seat's AGGREGATE lands exactly on `homeAllocation - consumed`.
- *  - Only seats whose `overGrantedAwu` exactly matches another tier's allocation
- *    are auto-classified (e.g. a `max` seat over by 8000 -> stray `pro`). Seats
- *    that don't match a tier (e.g. a `free` seat over by 7500) are reported as
- *    UNCLASSIFIED and never touched — they need separate investigation.
+ *    the stray tier's full allocation (capped at the balance). If the stray pool
+ *    had some consumption, that debit can leave the stray pool slightly negative
+ *    — harmless for a seat no longer assigned to the stray tier (nothing draws
+ *    from it; it expires next recurrence), and the AGGREGATE still lands on
+ *    `max(0, allocation - consumed)`.
+ *  - The stray tier is the UNIQUE credit-bearing tier other than home (home max
+ *    -> stray pro, home pro -> stray max). A non-credit-bearing home like `free`
+ *    has two candidate stray tiers, so it is reported UNCLASSIFIED and never
+ *    touched — those need separate investigation.
  *  - `adjustSeatCreditBalances` does NOT dedup; a second --execute run posts the
  *    delta AGAIN (double-correcting). Run --execute exactly once, and re-run the
  *    audit afterwards to confirm rather than re-running this.
@@ -44,6 +47,7 @@
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
  */
 import config from "@app/lib/api/config";
+import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
 import {
   adjustSeatCreditBalances,
   findSeatCreditSegmentForPeriod,
@@ -74,8 +78,10 @@ import type { MembershipSeatType } from "@app/types/memberships";
 
 import { makeScript } from "./helpers";
 
-// Below this, a seat's over-grant is treated as rounding noise, not stacking.
-const AWU_OVER_ALLOCATION_TOLERANCE = 1;
+// Flag a seat as stacked only above this over-grant. Generous because real
+// stacks are >= 7500 AWU (pro-on-free 7500, pro-on-max 8000, max-on-pro 40000),
+// so small analytics-vs-Metronome consumption skew never trips a false positive.
+const STACKING_DETECTION_THRESHOLD_AWU = 1000;
 
 // Metronome publishes an 11 RPS API limit. Stay well under it so a correction
 // run never adds rate-limit pressure to production traffic on the same key.
@@ -107,7 +113,14 @@ interface SeatCorrection {
   homeAllocation: number;
   startingBalance: number;
   currentBalance: number;
+  consumedAwu: number;
+  // Usage-based over-grant (currentBalance - max(0, allocation - consumed)) —
+  // what flagged the seat as stacked.
   overGrantedAwu: number;
+  // Amount actually debited from the stray credit: the stray grant still on the
+  // balance, min(strayAllocation, currentBalance). Skew-free and never exceeds
+  // the balance.
+  clawBackAwu: number;
   strayType: MembershipSeatType;
   strayRecurringCreditId: string;
   // Resolved lazily during planning; null means the ledger entry cannot be
@@ -250,9 +263,24 @@ async function fixWorkspace(
     }
   }
 
-  // Classify each over-allocated seat. The stray tier is the recurring tier
-  // (other than the seat's home tier) whose allocation exactly equals the
-  // over-grant — that is the credit whose orphaned grant is stacked on top.
+  // Per-user consumed AWU for the current cycle (analytics index) — the same
+  // figure poke shows and the audit uses. Needed because Metronome drops a
+  // fully-consumed stray grant from starting_balance, so detection must key off
+  // consumption, not starting_balance (see audit_metronome_seat_state.ts).
+  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
+    workspace: lightWorkspace,
+    userIds: [...seatTypeBySeatId.keys()],
+    freeSeatUserIds: [...seatTypeBySeatId]
+      .filter(([, t]) => t === "free")
+      .map(([id]) => id),
+  });
+
+  // Classify each stacked seat. A seat should hold max(0, allocation -
+  // consumed); anything above that is a stray grant. The stray tier is the
+  // UNIQUE credit-bearing tier other than home (unambiguous with two tiers:
+  // home max -> stray pro, home pro -> stray max). A non-credit-bearing home
+  // like `free` has two candidate stray tiers, so which pool holds the grant
+  // can't be inferred — reported unclassified and never touched.
   const corrections: SeatCorrection[] = [];
   const unclassified: Array<{
     seatId: string;
@@ -271,26 +299,32 @@ async function fixWorkspace(
     if (homeAllocation === undefined || homeAllocation <= 0 || !awu) {
       continue;
     }
-    const overGrantedAwu = awu.startingBalance - homeAllocation;
-    if (overGrantedAwu <= AWU_OVER_ALLOCATION_TOLERANCE) {
+    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
+    const targetBalance = Math.max(0, homeAllocation - consumedAwu);
+    const overGrantedAwu = awu.balance - targetBalance;
+    if (overGrantedAwu <= STACKING_DETECTION_THRESHOLD_AWU) {
       continue;
     }
-    const strayTier = [...tierBySeatType.values()].find(
-      (t) =>
-        t.seatType !== homeSeatType &&
-        Math.abs(t.allocation - overGrantedAwu) <= AWU_OVER_ALLOCATION_TOLERANCE
+    const strayCandidates = [...tierBySeatType.values()].filter(
+      (t) => t.seatType !== homeSeatType
     );
-    if (!strayTier) {
+    if (strayCandidates.length !== 1) {
       unclassified.push({ seatId, homeSeatType, overGrantedAwu });
       continue;
     }
+    const strayTier = strayCandidates[0];
     corrections.push({
       seatId,
       homeSeatType,
       homeAllocation,
       startingBalance: awu.startingBalance,
       currentBalance: awu.balance,
+      consumedAwu,
       overGrantedAwu,
+      // Remove the whole stray grant still on the balance. For a credit-bearing
+      // home this equals the usage-based over-grant (skew-free), capped so it
+      // never drives the aggregate below max(0, allocation - consumed).
+      clawBackAwu: Math.min(strayTier.allocation, awu.balance),
       strayType: strayTier.seatType,
       strayRecurringCreditId: strayTier.recurringCreditId,
       creditId: null,
@@ -363,10 +397,10 @@ async function fixWorkspace(
 
   const byTransition = new Map<string, { count: number; totalAwu: number }>();
   for (const c of resolved) {
-    const key = `${c.homeSeatType}<-${c.strayType} (-${c.overGrantedAwu})`;
+    const key = `${c.homeSeatType}<-${c.strayType} (-${c.clawBackAwu})`;
     const agg = byTransition.get(key) ?? { count: 0, totalAwu: 0 };
     agg.count += 1;
-    agg.totalAwu += c.overGrantedAwu;
+    agg.totalAwu += c.clawBackAwu;
     byTransition.set(key, agg);
   }
 
@@ -378,7 +412,7 @@ async function fixWorkspace(
       onlySeatId,
       onlyHomeSeatType,
       resolvedCount: resolved.length,
-      resolvedTotalAwu: resolved.reduce((s, c) => s + c.overGrantedAwu, 0),
+      resolvedTotalAwu: resolved.reduce((s, c) => s + c.clawBackAwu, 0),
       byTransition: Object.fromEntries(byTransition),
       unresolvedCount: unresolved.length,
       unresolvedSeatIds: unresolved.map((c) => c.seatId),
@@ -404,7 +438,7 @@ async function fixWorkspace(
         metronomeContractId: contractId,
         creditId: c.creditId as string,
         segmentId: c.segmentId as string,
-        perSeatAmounts: { [c.seatId]: -c.overGrantedAwu },
+        perSeatAmounts: { [c.seatId]: -c.clawBackAwu },
         reason: `Stacked-credit correction: empty orphaned ${c.strayType} grant stacked on ${c.homeSeatType}`,
         timestamp: c.adjustmentTimestamp as Date,
         alignToHour: false,
@@ -429,7 +463,9 @@ async function fixWorkspace(
         seatId: c.seatId,
         homeSeatType: c.homeSeatType,
         strayType: c.strayType,
-        amount: -c.overGrantedAwu,
+        consumedAwu: c.consumedAwu,
+        overGrantedAwu: c.overGrantedAwu,
+        amount: -c.clawBackAwu,
         adjustmentTimestamp: c.adjustmentTimestamp?.toISOString(),
       },
       "[StackedFix] corrected stacked seat"

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -53,18 +53,17 @@ import {
 } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
-import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
 import {
   getAwuAllocationForSeatType,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
+import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 import { makeScript } from "./helpers";
 
@@ -293,11 +292,20 @@ async function fixWorkspace(
     });
   }
 
-  // Resolve the stray credit segment + a valid entry timestamp per seat. The
-  // entry must fall inside the stray credit segment AND at a time the seat is
-  // active in the stray subscription (mirrors resolveSeatAdjustmentTimestamp in
-  // seats.ts). A seat that never had a stray-tier active window this segment
-  // cannot receive the ledger entry this way and is reported unresolved.
+  // Resolve the stray credit segment + a valid entry timestamp per seat.
+  //
+  // The stray grant sits in the CURRENTLY-active stray credit segment (that's
+  // why it still counts toward the balance): the seat was assigned to the stray
+  // tier at that segment's start — the monthly recurrence that granted it —
+  // before converging onto its home tier. So the segment's `starting_at` is a
+  // valid, hour-aligned, in-segment entry time at which the seat held the
+  // stray grant, even though the seat is no longer assigned to the stray
+  // subscription now (which is exactly why `getMetronomeSeatActiveSince` on the
+  // stray subscription returns null for a converged seat — the reason the first
+  // single-seat --execute resolved nothing). We therefore default to the
+  // segment start and only clamp UP to a live stray active-window when one
+  // still exists (a seat still partly on the stray tier). A seat is left
+  // unresolved only when no stray credit segment covers now.
   const segmentCache = new Map<
     string,
     { creditId: string; segmentId: string; segmentStartingAt: string } | null
@@ -320,27 +328,23 @@ async function fixWorkspace(
     }
     c.creditId = seg.creditId;
     c.segmentId = seg.segmentId;
+    const segmentStartMs = new Date(seg.segmentStartingAt).getTime();
+    let timestampMs = segmentStartMs;
     const strayTier = tierBySeatType.get(c.strayType);
-    if (!strayTier) {
-      continue;
+    if (strayTier) {
+      const activeSinceRes = await paceMetronome(() =>
+        getMetronomeSeatActiveSince({
+          metronomeCustomerId,
+          contractId,
+          subscriptionId: strayTier.subscriptionId,
+          seatId: c.seatId,
+        })
+      );
+      if (activeSinceRes.isOk() && activeSinceRes.value) {
+        timestampMs = Math.max(activeSinceRes.value.getTime(), segmentStartMs);
+      }
     }
-    const activeSinceRes = await paceMetronome(() =>
-      getMetronomeSeatActiveSince({
-        metronomeCustomerId,
-        contractId,
-        subscriptionId: strayTier.subscriptionId,
-        seatId: c.seatId,
-      })
-    );
-    if (activeSinceRes.isErr() || !activeSinceRes.value) {
-      continue;
-    }
-    c.adjustmentTimestamp = new Date(
-      Math.max(
-        activeSinceRes.value.getTime(),
-        new Date(seg.segmentStartingAt).getTime()
-      )
-    );
+    c.adjustmentTimestamp = new Date(timestampMs);
   }
 
   const resolved = corrections.filter(
@@ -458,7 +462,8 @@ makeScript(
     await fixWorkspace(workspaceId, {
       execute,
       onlySeatId: seatId ?? null,
-      onlyHomeSeatType: (homeSeatType as MembershipSeatType | undefined) ?? null,
+      onlyHomeSeatType:
+        (homeSeatType as MembershipSeatType | undefined) ?? null,
       logger,
     });
   }

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -1,0 +1,465 @@
+/**
+ * Correct seats that carry MORE granted AWU than their seat-type allocation
+ * ("credit stacking"): a seat holds a live balance on TWO per-seat recurring
+ * AWU credits at once — e.g. both the pro (8000) and the max (40000) credit,
+ * for a total starting balance of 48000. This happens when a seat-type change
+ * (or a seat-sync crash/retry storm) moved the seat onto a new tier without
+ * `emptyOriginSeatCreditsForTransfers` ever zeroing the origin (stray) credit.
+ * Once the seat has converged on the new tier, `syncSeatCount` sees no transfer
+ * candidate and can no longer self-heal it — see `audit_metronome_seat_state.ts`
+ * ("over-allocated seats").
+ *
+ * The fix mirrors what empty-origin would have done: post a corrective negative
+ * delta to the STRAY recurring credit so the seat's TOTAL granted AWU drops back
+ * to its home allocation. We debit exactly `overGrantedAwu = startingBalance -
+ * homeAllocation`, which brings the seat's aggregate balance to
+ * `homeAllocation - consumed` regardless of which pool consumption came out of
+ * (aggregate arithmetic; see the block comment on `planSeatCorrection`).
+ *
+ * IMPORTANT — read before running with --execute:
+ *
+ *  - There is NO Metronome read that returns a seat's balance on a SPECIFIC
+ *    recurring credit; every read collapses pro/max into one aggregate AWU
+ *    number. So we cannot observe the stray pool's balance directly; we debit
+ *    the computed `overGrantedAwu`. If the stray pool had some consumption, that
+ *    debit can leave the stray pool slightly negative (bounded by the seat's
+ *    consumption this cycle). That is harmless for a seat no longer assigned to
+ *    the stray tier (nothing draws from it; it expires next recurrence), and the
+ *    seat's AGGREGATE lands exactly on `homeAllocation - consumed`.
+ *  - Only seats whose `overGrantedAwu` exactly matches another tier's allocation
+ *    are auto-classified (e.g. a `max` seat over by 8000 -> stray `pro`). Seats
+ *    that don't match a tier (e.g. a `free` seat over by 7500) are reported as
+ *    UNCLASSIFIED and never touched — they need separate investigation.
+ *  - `adjustSeatCreditBalances` does NOT dedup; a second --execute run posts the
+ *    delta AGAIN (double-correcting). Run --execute exactly once, and re-run the
+ *    audit afterwards to confirm rather than re-running this.
+ *
+ * Dry-run by default (prints the full plan, including per-seat segment/timestamp
+ * resolution). Pass --execute to apply. Use --seatId to restrict to a single
+ * seat (validate the mechanics on one before a bulk run), and --homeSeatType to
+ * scope to seats currently of a given tier (e.g. only the confident `max` set).
+ *
+ *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId>
+ *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --seatId <userId>
+ *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
+ */
+import config from "@app/lib/api/config";
+import {
+  adjustSeatCreditBalances,
+  findSeatCreditSegmentForPeriod,
+  getMetronomeSeatActiveSince,
+  getMetronomeSubscriptionSeatState,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
+import {
+  getAwuAllocationForSeatType,
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { makeScript } from "./helpers";
+
+// Below this, a seat's over-grant is treated as rounding noise, not stacking.
+const AWU_OVER_ALLOCATION_TOLERANCE = 1;
+
+// Metronome publishes an 11 RPS API limit. Stay well under it so a correction
+// run never adds rate-limit pressure to production traffic on the same key.
+const METRONOME_MAX_RPS = 8;
+const METRONOME_MIN_INTERVAL_MS = 1000 / METRONOME_MAX_RPS;
+let metronomeNextSlotAt = 0;
+
+async function paceMetronome<T>(fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const slot = Math.max(now, metronomeNextSlotAt);
+  metronomeNextSlotAt = slot + METRONOME_MIN_INTERVAL_MS;
+  const wait = slot - now;
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
+  }
+  return fn();
+}
+
+interface StrayTierInfo {
+  seatType: MembershipSeatType;
+  subscriptionId: string;
+  recurringCreditId: string;
+  allocation: number;
+}
+
+interface SeatCorrection {
+  seatId: string;
+  homeSeatType: MembershipSeatType;
+  homeAllocation: number;
+  startingBalance: number;
+  currentBalance: number;
+  overGrantedAwu: number;
+  strayType: MembershipSeatType;
+  strayRecurringCreditId: string;
+  // Resolved lazily during planning; null means the ledger entry cannot be
+  // placed (no stray-tier active window or no matching credit segment).
+  creditId: string | null;
+  segmentId: string | null;
+  adjustmentTimestamp: Date | null;
+}
+
+async function fixWorkspace(
+  workspaceId: string,
+  {
+    execute,
+    onlySeatId,
+    onlyHomeSeatType,
+    logger,
+  }: {
+    execute: boolean;
+    onlySeatId: string | null;
+    onlyHomeSeatType: MembershipSeatType | null;
+    logger: Logger;
+  }
+) {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.error({ workspaceId }, "[StackedFix] workspace not found");
+    return;
+  }
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const { metronomeCustomerId } = lightWorkspace;
+  if (!metronomeCustomerId) {
+    logger.error(
+      { workspaceId },
+      "[StackedFix] workspace is not provisioned on Metronome"
+    );
+    return;
+  }
+
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+  const contractId = activeSubscription?.metronomeContractId ?? null;
+  if (!contractId) {
+    logger.error({ workspaceId }, "[StackedFix] no active Metronome contract");
+    return;
+  }
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    logger.error(
+      { workspaceId, contractId },
+      "[StackedFix] could not resolve the active contract from Metronome"
+    );
+    return;
+  }
+
+  // Recurring-credit tiers (pro/max families). `free`/`workspace`/`none` carry
+  // no per-seat recurring credit (getSeatCreditNameForSeatType === null), so
+  // they are neither a home nor a stray tier here.
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
+  ];
+  const tierBySeatType = new Map<MembershipSeatType, StrayTierInfo>();
+  const allocationBySeatType = new Map<MembershipSeatType, number>();
+  for (const [seatType, sub] of seatSubscriptions) {
+    const allocation = getAwuAllocationForSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
+    allocationBySeatType.set(seatType, allocation);
+    if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
+      continue;
+    }
+    const recurringCredit = (contract.recurring_credits ?? []).find(
+      (c) => c.subscription_config?.subscription_id === sub.id
+    );
+    if (recurringCredit?.id) {
+      tierBySeatType.set(seatType, {
+        seatType,
+        subscriptionId: sub.id,
+        recurringCreditId: recurringCredit.id,
+        allocation,
+      });
+    }
+  }
+
+  // Map every assigned seat to its home (current) tier.
+  const seatTypeBySeatId = new Map<string, MembershipSeatType>();
+  for (const [seatType, sub] of seatSubscriptions) {
+    if (!sub.id) {
+      continue;
+    }
+    const stateRes = await paceMetronome(() =>
+      getMetronomeSubscriptionSeatState({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: sub.id as string,
+      })
+    );
+    if (stateRes.isErr()) {
+      logger.error(
+        { workspaceId, seatType, err: stateRes.error.message },
+        "[StackedFix] failed to read Metronome seat state"
+      );
+      continue;
+    }
+    for (const id of stateRes.value.assignedSeatIds) {
+      seatTypeBySeatId.set(id, seatType);
+    }
+  }
+
+  // Read aggregate AWU balances for all assigned seats.
+  const seatIds = [...seatTypeBySeatId.keys()];
+  const balancesRes = await paceMetronome(() =>
+    listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      seatIds,
+    })
+  );
+  if (balancesRes.isErr()) {
+    logger.error(
+      { workspaceId, err: balancesRes.error.message },
+      "[StackedFix] failed to read seat balances"
+    );
+    return;
+  }
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const awuBySeatId = new Map<
+    string,
+    { balance: number; startingBalance: number }
+  >();
+  for (const seat of balancesRes.value) {
+    const awu = seat.balances.find((b) => b.credit_type_id === awuCreditTypeId);
+    if (awu) {
+      awuBySeatId.set(seat.seat_id, {
+        balance: awu.balance,
+        startingBalance: awu.starting_balance,
+      });
+    }
+  }
+
+  // Classify each over-allocated seat. The stray tier is the recurring tier
+  // (other than the seat's home tier) whose allocation exactly equals the
+  // over-grant — that is the credit whose orphaned grant is stacked on top.
+  const corrections: SeatCorrection[] = [];
+  const unclassified: Array<{
+    seatId: string;
+    homeSeatType: MembershipSeatType;
+    overGrantedAwu: number;
+  }> = [];
+  for (const [seatId, homeSeatType] of seatTypeBySeatId) {
+    if (onlySeatId && seatId !== onlySeatId) {
+      continue;
+    }
+    if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
+      continue;
+    }
+    const homeAllocation = allocationBySeatType.get(homeSeatType);
+    const awu = awuBySeatId.get(seatId);
+    if (homeAllocation === undefined || homeAllocation <= 0 || !awu) {
+      continue;
+    }
+    const overGrantedAwu = awu.startingBalance - homeAllocation;
+    if (overGrantedAwu <= AWU_OVER_ALLOCATION_TOLERANCE) {
+      continue;
+    }
+    const strayTier = [...tierBySeatType.values()].find(
+      (t) =>
+        t.seatType !== homeSeatType &&
+        Math.abs(t.allocation - overGrantedAwu) <= AWU_OVER_ALLOCATION_TOLERANCE
+    );
+    if (!strayTier) {
+      unclassified.push({ seatId, homeSeatType, overGrantedAwu });
+      continue;
+    }
+    corrections.push({
+      seatId,
+      homeSeatType,
+      homeAllocation,
+      startingBalance: awu.startingBalance,
+      currentBalance: awu.balance,
+      overGrantedAwu,
+      strayType: strayTier.seatType,
+      strayRecurringCreditId: strayTier.recurringCreditId,
+      creditId: null,
+      segmentId: null,
+      adjustmentTimestamp: null,
+    });
+  }
+
+  // Resolve the stray credit segment + a valid entry timestamp per seat. The
+  // entry must fall inside the stray credit segment AND at a time the seat is
+  // active in the stray subscription (mirrors resolveSeatAdjustmentTimestamp in
+  // seats.ts). A seat that never had a stray-tier active window this segment
+  // cannot receive the ledger entry this way and is reported unresolved.
+  const segmentCache = new Map<
+    string,
+    { creditId: string; segmentId: string; segmentStartingAt: string } | null
+  >();
+  for (const c of corrections) {
+    let seg = segmentCache.get(c.strayRecurringCreditId);
+    if (seg === undefined) {
+      const segRes = await paceMetronome(() =>
+        findSeatCreditSegmentForPeriod({
+          metronomeCustomerId,
+          metronomeContractId: contractId,
+          recurringCreditId: c.strayRecurringCreditId,
+        })
+      );
+      seg = segRes.isOk() ? segRes.value : null;
+      segmentCache.set(c.strayRecurringCreditId, seg);
+    }
+    if (!seg) {
+      continue;
+    }
+    c.creditId = seg.creditId;
+    c.segmentId = seg.segmentId;
+    const strayTier = tierBySeatType.get(c.strayType);
+    if (!strayTier) {
+      continue;
+    }
+    const activeSinceRes = await paceMetronome(() =>
+      getMetronomeSeatActiveSince({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: strayTier.subscriptionId,
+        seatId: c.seatId,
+      })
+    );
+    if (activeSinceRes.isErr() || !activeSinceRes.value) {
+      continue;
+    }
+    c.adjustmentTimestamp = new Date(
+      Math.max(
+        activeSinceRes.value.getTime(),
+        new Date(seg.segmentStartingAt).getTime()
+      )
+    );
+  }
+
+  const resolved = corrections.filter(
+    (c) => c.creditId && c.segmentId && c.adjustmentTimestamp
+  );
+  const unresolved = corrections.filter(
+    (c) => !c.creditId || !c.segmentId || !c.adjustmentTimestamp
+  );
+
+  const byTransition = new Map<string, { count: number; totalAwu: number }>();
+  for (const c of resolved) {
+    const key = `${c.homeSeatType}<-${c.strayType} (-${c.overGrantedAwu})`;
+    const agg = byTransition.get(key) ?? { count: 0, totalAwu: 0 };
+    agg.count += 1;
+    agg.totalAwu += c.overGrantedAwu;
+    byTransition.set(key, agg);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      contractId,
+      execute,
+      onlySeatId,
+      onlyHomeSeatType,
+      resolvedCount: resolved.length,
+      resolvedTotalAwu: resolved.reduce((s, c) => s + c.overGrantedAwu, 0),
+      byTransition: Object.fromEntries(byTransition),
+      unresolvedCount: unresolved.length,
+      unresolvedSeatIds: unresolved.map((c) => c.seatId),
+      unclassifiedCount: unclassified.length,
+      unclassified,
+    },
+    "[StackedFix] correction plan"
+  );
+
+  if (!execute) {
+    logger.info(
+      { workspaceId },
+      "[StackedFix] dry run — pass --execute to apply the plan above"
+    );
+    return;
+  }
+
+  let applied = 0;
+  for (const c of resolved) {
+    const adjustRes = await paceMetronome(() =>
+      adjustSeatCreditBalances({
+        metronomeCustomerId,
+        metronomeContractId: contractId,
+        creditId: c.creditId as string,
+        segmentId: c.segmentId as string,
+        perSeatAmounts: { [c.seatId]: -c.overGrantedAwu },
+        reason: `Stacked-credit correction: empty orphaned ${c.strayType} grant stacked on ${c.homeSeatType}`,
+        timestamp: c.adjustmentTimestamp as Date,
+        alignToHour: false,
+      })
+    );
+    if (adjustRes.isErr()) {
+      logger.error(
+        {
+          workspaceId,
+          seatId: c.seatId,
+          strayType: c.strayType,
+          err: adjustRes.error.message,
+        },
+        "[StackedFix] failed to correct seat — skipping"
+      );
+      continue;
+    }
+    applied += 1;
+    logger.info(
+      {
+        workspaceId,
+        seatId: c.seatId,
+        homeSeatType: c.homeSeatType,
+        strayType: c.strayType,
+        amount: -c.overGrantedAwu,
+        adjustmentTimestamp: c.adjustmentTimestamp?.toISOString(),
+      },
+      "[StackedFix] corrected stacked seat"
+    );
+  }
+  logger.info(
+    { workspaceId, applied, planned: resolved.length },
+    "[StackedFix] done"
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+      describe: "sId of the workspace to correct",
+    },
+    seatId: {
+      type: "string",
+      describe:
+        "Restrict to a single seat (userId) — validate the mechanics on one " +
+        "before a bulk run",
+    },
+    homeSeatType: {
+      type: "string",
+      describe:
+        "Restrict to seats currently of this tier (e.g. 'max' for the " +
+        "confident pro-on-max set)",
+    },
+  },
+  async ({ workspaceId, seatId, homeSeatType, execute }, logger) => {
+    if (!config.getMetronomeApiKey()) {
+      logger.error({}, "[StackedFix] METRONOME_API_KEY is not configured");
+      return;
+    }
+    await fixWorkspace(workspaceId, {
+      execute,
+      onlySeatId: seatId ?? null,
+      onlyHomeSeatType: (homeSeatType as MembershipSeatType | undefined) ?? null,
+      logger,
+    });
+  }
+);

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -9,33 +9,34 @@
  * candidate and can no longer self-heal it — see `audit_metronome_seat_state.ts`
  * ("over-allocated seats").
  *
- * The fix mirrors what empty-origin would have done: post a corrective negative
- * delta to the STRAY recurring credit so the seat's aggregate AWU drops back to
- * `max(0, allocation - consumed)`. Detection is usage-based — a seat is stacked
- * when `currentBalance - max(0, allocation - consumed) > threshold` — because
- * Metronome DROPS a fully-consumed stray grant from `starting_balance`, so a
- * starting_balance check misses seats that already spent through the phantom
- * grant (see audit_metronome_seat_state.ts). The debit is `min(strayAllocation,
- * currentBalance)`: the whole stray grant still on the balance, capped so the
- * aggregate never falls below `max(0, allocation - consumed)`.
+ * Detection is grant-history based (authoritative, ES-free): a per-seat
+ * recurring credit grants exactly its allocation to whoever is on its
+ * subscription at the credit segment start, so a seat holds a stray grant iff it
+ * appears in a tier's grant-time assignment but is now on a different tier. The
+ * fix posts a corrective negative delta to that stray credit — `min(stray
+ * allocation, current aggregate balance)` — reversing the stray grant still on
+ * the balance so the seat's aggregate AWU drops back to `max(0, homeAllocation -
+ * consumed)`. All stray grants on the same stray credit share that credit's
+ * segment start as a valid entry time, so they are applied in ONE batched ledger
+ * entry per stray credit (write cost is O(stray credits), not O(seats)).
  *
  * IMPORTANT — read before running with --execute:
  *
  *  - There is NO Metronome read that returns a seat's balance on a SPECIFIC
  *    recurring credit; every read collapses pro/max into one aggregate AWU
- *    number. So we cannot observe the stray pool's balance directly; we debit
- *    the stray tier's full allocation (capped at the balance). If the stray pool
- *    had some consumption, that debit can leave the stray pool slightly negative
- *    — harmless for a seat no longer assigned to the stray tier (nothing draws
- *    from it; it expires next recurrence), and the AGGREGATE still lands on
- *    `max(0, allocation - consumed)`.
- *  - The stray tier is the UNIQUE credit-bearing tier other than home (home max
- *    -> stray pro, home pro -> stray max). A non-credit-bearing home like `free`
- *    has two candidate stray tiers, so it is reported UNCLASSIFIED and never
- *    touched — those need separate investigation.
- *  - `adjustSeatCreditBalances` does NOT dedup; a second --execute run posts the
- *    delta AGAIN (double-correcting). Run --execute exactly once, and re-run the
- *    audit afterwards to confirm rather than re-running this.
+ *    number. We debit the stray allocation capped at the aggregate balance, so
+ *    the aggregate never goes negative; if the stray pool itself had some
+ *    consumption the debit can leave THAT pool slightly negative — harmless for
+ *    a seat no longer assigned to the stray tier (nothing draws from it; it
+ *    expires next recurrence).
+ *  - Each credit-bearing tier is checked independently, so same-family stacks
+ *    (pro + pro_yearly = two 8000 grants) and seats carrying several stray
+ *    grants are all corrected, each on its own stray credit.
+ *  - `adjustSeatCreditBalances` does NOT dedup, and grant-history cannot tell a
+ *    still-present stray grant from one already emptied. So a seat corrected in a
+ *    prior run (or manually) would be corrected AGAIN. Run --execute exactly
+ *    once per cohort, pass already-fixed seats via --excludeSeatIds, and re-run
+ *    the audit afterwards to confirm rather than re-running this.
  *
  * Dry-run by default (prints the full plan, including per-seat segment/timestamp
  * resolution). Pass --execute to apply. Use --seatId to restrict to a single
@@ -47,11 +48,9 @@
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
  */
 import config from "@app/lib/api/config";
-import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
 import {
   adjustSeatCreditBalances,
   findSeatCreditSegmentForPeriod,
-  getMetronomeSeatActiveSince,
   getMetronomeSubscriptionSeatState,
   invalidateCachedCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
@@ -77,11 +76,6 @@ import type { Logger } from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 
 import { makeScript } from "./helpers";
-
-// Flag a seat as stacked only above this over-grant. Generous because real
-// stacks are >= 7500 AWU (pro-on-free 7500, pro-on-max 8000, max-on-pro 40000),
-// so small analytics-vs-Metronome consumption skew never trips a false positive.
-const STACKING_DETECTION_THRESHOLD_AWU = 1000;
 
 // Metronome publishes an 11 RPS API limit. Stay well under it so a correction
 // run never adds rate-limit pressure to production traffic on the same key.
@@ -109,25 +103,18 @@ interface StrayTierInfo {
 
 interface SeatCorrection {
   seatId: string;
-  homeSeatType: MembershipSeatType;
-  homeAllocation: number;
-  startingBalance: number;
-  currentBalance: number;
-  consumedAwu: number;
-  // Usage-based over-grant (currentBalance - max(0, allocation - consumed)) —
-  // what flagged the seat as stacked.
-  overGrantedAwu: number;
-  // Amount actually debited from the stray credit: the stray grant still on the
-  // balance, min(strayAllocation, currentBalance). Skew-free and never exceeds
-  // the balance.
-  clawBackAwu: number;
+  // Current tier, or "unassigned" if the seat holds a grant but is no longer on
+  // any seat in the workspace.
+  homeSeatType: MembershipSeatType | "unassigned";
   strayType: MembershipSeatType;
-  strayRecurringCreditId: string;
-  // Resolved lazily during planning; null means the ledger entry cannot be
-  // placed (no stray-tier active window or no matching credit segment).
-  creditId: string | null;
-  segmentId: string | null;
-  adjustmentTimestamp: Date | null;
+  strayAllocation: number;
+  currentBalance: number;
+  // Debited from the stray credit: the stray grant still on the balance,
+  // min(strayAllocation, currentBalance) — never exceeds the balance.
+  clawBackAwu: number;
+  creditId: string;
+  segmentId: string;
+  adjustmentTimestamp: Date;
 }
 
 async function fixWorkspace(
@@ -136,11 +123,13 @@ async function fixWorkspace(
     execute,
     onlySeatId,
     onlyHomeSeatType,
+    excludeSeatIds,
     logger,
   }: {
     execute: boolean;
     onlySeatId: string | null;
     onlyHomeSeatType: MembershipSeatType | null;
+    excludeSeatIds: Set<string>;
     logger: Logger;
   }
 ) {
@@ -183,14 +172,7 @@ async function fixWorkspace(
     ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
   ];
   const tierBySeatType = new Map<MembershipSeatType, StrayTierInfo>();
-  const allocationBySeatType = new Map<MembershipSeatType, number>();
   for (const [seatType, sub] of seatSubscriptions) {
-    const allocation = getAwuAllocationForSeatType(
-      contract,
-      seatType,
-      productSeatTypes
-    );
-    allocationBySeatType.set(seatType, allocation);
     if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
       continue;
     }
@@ -202,7 +184,11 @@ async function fixWorkspace(
         seatType,
         subscriptionId: sub.id,
         recurringCreditId: recurringCredit.id,
-        allocation,
+        allocation: getAwuAllocationForSeatType(
+          contract,
+          seatType,
+          productSeatTypes
+        ),
       });
     }
   }
@@ -248,156 +234,139 @@ async function fixWorkspace(
     );
     return;
   }
+  // Current aggregate AWU balance per seat — only used to cap each claw-back at
+  // what the seat still holds, so a correction never drives the balance negative.
   const awuCreditTypeId = getCreditTypeAwuId();
-  const awuBySeatId = new Map<
-    string,
-    { balance: number; startingBalance: number }
-  >();
+  const awuBalanceBySeatId = new Map<string, number>();
   for (const seat of balancesRes.value) {
-    const awu = seat.balances.find((b) => b.credit_type_id === awuCreditTypeId);
-    if (awu) {
-      awuBySeatId.set(seat.seat_id, {
-        balance: awu.balance,
-        startingBalance: awu.starting_balance,
+    const balance = seat.balances
+      .filter((b) => b.credit_type_id === awuCreditTypeId)
+      .reduce((sum, b) => sum + b.balance, 0);
+    awuBalanceBySeatId.set(seat.seat_id, balance);
+  }
+
+  // Grant-history stacked-seat detection (authoritative, ES-free). Each
+  // credit-bearing tier grants exactly its allocation to whoever is on its
+  // subscription at the credit segment start; a seat holds a stray grant iff it
+  // appears in a tier's grant-time assignment but is now on a different tier.
+  // (See audit_metronome_seat_state.ts for why starting_balance / analytics
+  // consumption are both unreliable here.) Each tier is checked independently,
+  // so same-family stacks (pro + pro_yearly) and multi-stray seats are caught.
+  //
+  // Every stray grant on the same stray credit shares that credit's segment
+  // start as a valid entry time, so they are corrected in ONE batched ledger
+  // entry (adjustSeatCreditBalances with a per-seat amounts map) — the write
+  // cost is O(stray credits), not O(seats).
+  const corrections: SeatCorrection[] = [];
+  const skippedTiersNoSegment: MembershipSeatType[] = [];
+  for (const tier of tierBySeatType.values()) {
+    const segRes = await paceMetronome(() =>
+      findSeatCreditSegmentForPeriod({
+        metronomeCustomerId,
+        metronomeContractId: contractId,
+        recurringCreditId: tier.recurringCreditId,
+      })
+    );
+    const segment = segRes.isOk() ? segRes.value : null;
+    if (!segment) {
+      logger.warn(
+        {
+          workspaceId,
+          strayType: tier.seatType,
+          err: segRes.isErr() ? segRes.error.message : "no active segment",
+        },
+        "[StackedFix] no credit segment for tier — skipping"
+      );
+      skippedTiersNoSegment.push(tier.seatType);
+      continue;
+    }
+    const grantStateRes = await paceMetronome(() =>
+      getMetronomeSubscriptionSeatState({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: tier.subscriptionId,
+        coveringDate: new Date(segment.segmentStartingAt),
+      })
+    );
+    if (grantStateRes.isErr()) {
+      logger.error(
+        {
+          workspaceId,
+          strayType: tier.seatType,
+          err: grantStateRes.error.message,
+        },
+        "[StackedFix] failed to read grant-time assignment — skipping tier"
+      );
+      skippedTiersNoSegment.push(tier.seatType);
+      continue;
+    }
+    // Segment start: a shared, in-segment, hour-aligned entry time at which
+    // every granted seat held the grant — lets all seats on this credit batch.
+    const adjustmentTimestamp = new Date(segment.segmentStartingAt);
+    for (const seatId of grantStateRes.value.assignedSeatIds) {
+      if (onlySeatId && seatId !== onlySeatId) {
+        continue;
+      }
+      if (excludeSeatIds.has(seatId)) {
+        continue;
+      }
+      const homeSeatType = seatTypeBySeatId.get(seatId) ?? null;
+      if (homeSeatType === tier.seatType) {
+        // Grant is legitimate — the seat is still on this tier.
+        continue;
+      }
+      if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
+        continue;
+      }
+      const currentBalance = awuBalanceBySeatId.get(seatId) ?? 0;
+      if (currentBalance <= 0) {
+        // Nothing left on the balance to reclaim (already fully consumed and/or
+        // corrected). Skipping keeps the aggregate from going negative.
+        continue;
+      }
+      corrections.push({
+        seatId,
+        homeSeatType: homeSeatType ?? "unassigned",
+        strayType: tier.seatType,
+        strayAllocation: tier.allocation,
+        currentBalance,
+        // Remove the stray grant still on the balance, capped at the balance so
+        // the aggregate never drops below max(0, homeAllocation - consumed).
+        clawBackAwu: Math.min(tier.allocation, currentBalance),
+        creditId: segment.creditId,
+        segmentId: segment.segmentId,
+        adjustmentTimestamp,
       });
     }
   }
 
-  // Per-user consumed AWU for the current cycle (analytics index) — the same
-  // figure poke shows and the audit uses. Needed because Metronome drops a
-  // fully-consumed stray grant from starting_balance, so detection must key off
-  // consumption, not starting_balance (see audit_metronome_seat_state.ts).
-  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
-    workspace: lightWorkspace,
-    userIds: [...seatTypeBySeatId.keys()],
-    freeSeatUserIds: [...seatTypeBySeatId]
-      .filter(([, t]) => t === "free")
-      .map(([id]) => id),
-  });
-
-  // Classify each stacked seat. A seat should hold max(0, allocation -
-  // consumed); anything above that is a stray grant. The stray tier is the
-  // UNIQUE credit-bearing tier other than home (unambiguous with two tiers:
-  // home max -> stray pro, home pro -> stray max). A non-credit-bearing home
-  // like `free` has two candidate stray tiers, so which pool holds the grant
-  // can't be inferred — reported unclassified and never touched.
-  const corrections: SeatCorrection[] = [];
-  const unclassified: Array<{
-    seatId: string;
-    homeSeatType: MembershipSeatType;
-    overGrantedAwu: number;
-  }> = [];
-  for (const [seatId, homeSeatType] of seatTypeBySeatId) {
-    if (onlySeatId && seatId !== onlySeatId) {
-      continue;
-    }
-    if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
-      continue;
-    }
-    const homeAllocation = allocationBySeatType.get(homeSeatType);
-    const awu = awuBySeatId.get(seatId);
-    if (homeAllocation === undefined || homeAllocation <= 0 || !awu) {
-      continue;
-    }
-    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
-    const targetBalance = Math.max(0, homeAllocation - consumedAwu);
-    const overGrantedAwu = awu.balance - targetBalance;
-    if (overGrantedAwu <= STACKING_DETECTION_THRESHOLD_AWU) {
-      continue;
-    }
-    const strayCandidates = [...tierBySeatType.values()].filter(
-      (t) => t.seatType !== homeSeatType
-    );
-    if (strayCandidates.length !== 1) {
-      unclassified.push({ seatId, homeSeatType, overGrantedAwu });
-      continue;
-    }
-    const strayTier = strayCandidates[0];
-    corrections.push({
-      seatId,
-      homeSeatType,
-      homeAllocation,
-      startingBalance: awu.startingBalance,
-      currentBalance: awu.balance,
-      consumedAwu,
-      overGrantedAwu,
-      // Remove the whole stray grant still on the balance. For a credit-bearing
-      // home this equals the usage-based over-grant (skew-free), capped so it
-      // never drives the aggregate below max(0, allocation - consumed).
-      clawBackAwu: Math.min(strayTier.allocation, awu.balance),
-      strayType: strayTier.seatType,
-      strayRecurringCreditId: strayTier.recurringCreditId,
-      creditId: null,
-      segmentId: null,
-      adjustmentTimestamp: null,
-    });
-  }
-
-  // Resolve the stray credit segment + a valid entry timestamp per seat.
-  //
-  // The stray grant sits in the CURRENTLY-active stray credit segment (that's
-  // why it still counts toward the balance): the seat was assigned to the stray
-  // tier at that segment's start — the monthly recurrence that granted it —
-  // before converging onto its home tier. So the segment's `starting_at` is a
-  // valid, hour-aligned, in-segment entry time at which the seat held the
-  // stray grant, even though the seat is no longer assigned to the stray
-  // subscription now (which is exactly why `getMetronomeSeatActiveSince` on the
-  // stray subscription returns null for a converged seat — the reason the first
-  // single-seat --execute resolved nothing). We therefore default to the
-  // segment start and only clamp UP to a live stray active-window when one
-  // still exists (a seat still partly on the stray tier). A seat is left
-  // unresolved only when no stray credit segment covers now.
-  const segmentCache = new Map<
+  // Group corrections by stray credit segment — one batched ledger entry each.
+  const batches = new Map<
     string,
-    { creditId: string; segmentId: string; segmentStartingAt: string } | null
+    {
+      creditId: string;
+      segmentId: string;
+      strayType: MembershipSeatType;
+      timestamp: Date;
+      items: SeatCorrection[];
+    }
   >();
   for (const c of corrections) {
-    let seg = segmentCache.get(c.strayRecurringCreditId);
-    if (seg === undefined) {
-      const segRes = await paceMetronome(() =>
-        findSeatCreditSegmentForPeriod({
-          metronomeCustomerId,
-          metronomeContractId: contractId,
-          recurringCreditId: c.strayRecurringCreditId,
-        })
-      );
-      seg = segRes.isOk() ? segRes.value : null;
-      segmentCache.set(c.strayRecurringCreditId, seg);
-    }
-    if (!seg) {
-      continue;
-    }
-    c.creditId = seg.creditId;
-    c.segmentId = seg.segmentId;
-    const segmentStartMs = new Date(seg.segmentStartingAt).getTime();
-    let timestampMs = segmentStartMs;
-    const strayTier = tierBySeatType.get(c.strayType);
-    if (strayTier) {
-      const activeSinceRes = await paceMetronome(() =>
-        getMetronomeSeatActiveSince({
-          metronomeCustomerId,
-          contractId,
-          subscriptionId: strayTier.subscriptionId,
-          seatId: c.seatId,
-        })
-      );
-      if (activeSinceRes.isOk() && activeSinceRes.value) {
-        timestampMs = Math.max(activeSinceRes.value.getTime(), segmentStartMs);
-      }
-    }
-    c.adjustmentTimestamp = new Date(timestampMs);
+    const key = `${c.creditId}:${c.segmentId}`;
+    const batch = batches.get(key) ?? {
+      creditId: c.creditId,
+      segmentId: c.segmentId,
+      strayType: c.strayType,
+      timestamp: c.adjustmentTimestamp,
+      items: [],
+    };
+    batch.items.push(c);
+    batches.set(key, batch);
   }
 
-  const resolved = corrections.filter(
-    (c) => c.creditId && c.segmentId && c.adjustmentTimestamp
-  );
-  const unresolved = corrections.filter(
-    (c) => !c.creditId || !c.segmentId || !c.adjustmentTimestamp
-  );
-
   const byTransition = new Map<string, { count: number; totalAwu: number }>();
-  for (const c of resolved) {
-    const key = `${c.homeSeatType}<-${c.strayType} (-${c.clawBackAwu})`;
+  for (const c of corrections) {
+    const key = `${c.homeSeatType}<-${c.strayType}`;
     const agg = byTransition.get(key) ?? { count: 0, totalAwu: 0 };
     agg.count += 1;
     agg.totalAwu += c.clawBackAwu;
@@ -411,13 +380,14 @@ async function fixWorkspace(
       execute,
       onlySeatId,
       onlyHomeSeatType,
-      resolvedCount: resolved.length,
-      resolvedTotalAwu: resolved.reduce((s, c) => s + c.clawBackAwu, 0),
+      excludedSeatCount: excludeSeatIds.size,
+      strayGrantCount: corrections.length,
+      affectedSeatCount: new Set(corrections.map((c) => c.seatId)).size,
+      totalClawBackAwu: corrections.reduce((s, c) => s + c.clawBackAwu, 0),
+      batchedAdjustCalls: batches.size,
       byTransition: Object.fromEntries(byTransition),
-      unresolvedCount: unresolved.length,
-      unresolvedSeatIds: unresolved.map((c) => c.seatId),
-      unclassifiedCount: unclassified.length,
-      unclassified,
+      skippedTiersNoSegment,
+      corrections,
     },
     "[StackedFix] correction plan"
   );
@@ -430,17 +400,20 @@ async function fixWorkspace(
     return;
   }
 
-  let applied = 0;
-  for (const c of resolved) {
+  let appliedSeats = 0;
+  for (const batch of batches.values()) {
+    const perSeatAmounts = Object.fromEntries(
+      batch.items.map((c) => [c.seatId, -c.clawBackAwu])
+    );
     const adjustRes = await paceMetronome(() =>
       adjustSeatCreditBalances({
         metronomeCustomerId,
         metronomeContractId: contractId,
-        creditId: c.creditId as string,
-        segmentId: c.segmentId as string,
-        perSeatAmounts: { [c.seatId]: -c.clawBackAwu },
-        reason: `Stacked-credit correction: empty orphaned ${c.strayType} grant stacked on ${c.homeSeatType}`,
-        timestamp: c.adjustmentTimestamp as Date,
+        creditId: batch.creditId,
+        segmentId: batch.segmentId,
+        perSeatAmounts,
+        reason: `Stacked-credit correction: empty orphaned ${batch.strayType} grant`,
+        timestamp: batch.timestamp,
         alignToHour: false,
       })
     );
@@ -448,29 +421,29 @@ async function fixWorkspace(
       logger.error(
         {
           workspaceId,
-          seatId: c.seatId,
-          strayType: c.strayType,
+          strayType: batch.strayType,
+          creditId: batch.creditId,
+          seatCount: batch.items.length,
           err: adjustRes.error.message,
         },
-        "[StackedFix] failed to correct seat — skipping"
+        "[StackedFix] batched correction failed"
       );
       continue;
     }
-    applied += 1;
+    appliedSeats += batch.items.length;
     logger.info(
       {
         workspaceId,
-        seatId: c.seatId,
-        homeSeatType: c.homeSeatType,
-        strayType: c.strayType,
-        consumedAwu: c.consumedAwu,
-        overGrantedAwu: c.overGrantedAwu,
-        amount: -c.clawBackAwu,
-        adjustmentTimestamp: c.adjustmentTimestamp?.toISOString(),
+        strayType: batch.strayType,
+        creditId: batch.creditId,
+        seatCount: batch.items.length,
+        totalAwu: batch.items.reduce((s, c) => s + c.clawBackAwu, 0),
+        timestamp: batch.timestamp.toISOString(),
       },
-      "[StackedFix] corrected stacked seat"
+      "[StackedFix] applied batched correction"
     );
   }
+
   // Bust the 1-hour per-user credit-balance Redis cache
   // (getCachedCustomerPerUserCreditBalances) so poke reflects the corrections
   // without waiting out the TTL. A manual balance entry does NOT fire the
@@ -479,7 +452,7 @@ async function fixWorkspace(
   // that read the cache; the pro/max seat balance in the members table is read
   // LIVE (uncached listMetronomeSeatBalances), so its brief post-correction lag
   // is Metronome's own seat-balance read model catching up and self-heals.
-  if (applied > 0) {
+  if (appliedSeats > 0) {
     const contractCreditTypes: ContractCreditType[] = [
       CONTRACT_CREDIT_TYPE_FREE_SEAT,
       CONTRACT_CREDIT_TYPE_POOL,
@@ -498,7 +471,7 @@ async function fixWorkspace(
   }
 
   logger.info(
-    { workspaceId, applied, planned: resolved.length },
+    { workspaceId, appliedSeats, plannedSeats: corrections.length },
     "[StackedFix] done"
   );
 }
@@ -522,8 +495,17 @@ makeScript(
         "Restrict to seats currently of this tier (e.g. 'max' for the " +
         "confident pro-on-max set)",
     },
+    excludeSeatIds: {
+      type: "string",
+      describe:
+        "Comma-separated seat ids (userIds) to skip — e.g. seats already " +
+        "corrected manually, since adjustSeatCreditBalances does not dedup",
+    },
   },
-  async ({ workspaceId, seatId, homeSeatType, execute }, logger) => {
+  async (
+    { workspaceId, seatId, homeSeatType, excludeSeatIds, execute },
+    logger
+  ) => {
     if (!config.getMetronomeApiKey()) {
       logger.error({}, "[StackedFix] METRONOME_API_KEY is not configured");
       return;
@@ -533,6 +515,12 @@ makeScript(
       onlySeatId: seatId ?? null,
       onlyHomeSeatType:
         (homeSeatType as MembershipSeatType | undefined) ?? null,
+      excludeSeatIds: new Set(
+        (excludeSeatIds ?? "")
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      ),
       logger,
     });
   }

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -12,31 +12,36 @@
  * Detection is grant-history based (authoritative, ES-free): a per-seat
  * recurring credit grants exactly its allocation to whoever is on its
  * subscription at the credit segment start, so a seat holds a stray grant iff it
- * appears in a tier's grant-time assignment but is now on a different tier. The
- * fix posts a corrective negative delta to that stray credit — `min(stray
- * allocation, current aggregate balance)` — reversing the stray grant still on
- * the balance so the seat's aggregate AWU drops back to `max(0, homeAllocation -
- * consumed)`. All stray grants on the same stray credit share that credit's
- * segment start as a valid entry time, so they are applied in ONE batched ledger
- * entry per stray credit (write cost is O(stray credits), not O(seats)).
+ * appears in a tier's grant-time assignment but is now on a different tier.
+ *
+ * The correction is IDEMPOTENT via reconcile-to-target: each affected seat
+ * should hold `max(0, homeAllocation - consumed)`; the fix posts a negative
+ * delta to the stray credit equal to the seat's excess above that target
+ * (`max(0, currentBalance - target)`). A seat already at/below target — fixed by
+ * a prior run, empty-origin, or manually — yields ~0 and is skipped, so re-runs
+ * are safe WITHOUT knowing which seats were already fixed. `consumed` is the
+ * analytics figure; because grant-history alone decides WHO is touched and the
+ * claw-back is floored at 0, analytics lag can only under-correct — it can never
+ * add credit or touch a healthy seat. All corrections on the same stray credit
+ * share that credit's segment start as their entry time, so they apply in ONE
+ * batched ledger entry per stray credit (write cost is O(stray credits)).
  *
  * IMPORTANT — read before running with --execute:
  *
  *  - There is NO Metronome read that returns a seat's balance on a SPECIFIC
- *    recurring credit; every read collapses pro/max into one aggregate AWU
- *    number. We debit the stray allocation capped at the aggregate balance, so
- *    the aggregate never goes negative; if the stray pool itself had some
- *    consumption the debit can leave THAT pool slightly negative — harmless for
- *    a seat no longer assigned to the stray tier (nothing draws from it; it
- *    expires next recurrence).
+ *    recurring credit (per_group_amounts is write-only), so exact per-credit
+ *    idempotency is impossible; reconcile-to-target on the aggregate is how we
+ *    get idempotency instead. The delta drives the aggregate to target by
+ *    adjusting the stray credit, which can leave THAT pool negative — harmless
+ *    for a seat no longer assigned to it (nothing draws from it; it expires next
+ *    recurrence).
  *  - Each credit-bearing tier is checked independently, so same-family stacks
- *    (pro + pro_yearly = two 8000 grants) and seats carrying several stray
- *    grants are all corrected, each on its own stray credit.
- *  - `adjustSeatCreditBalances` does NOT dedup, and grant-history cannot tell a
- *    still-present stray grant from one already emptied. So a seat corrected in a
- *    prior run (or manually) would be corrected AGAIN. Run --execute exactly
- *    once per cohort, pass already-fixed seats via --excludeSeatIds, and re-run
- *    the audit afterwards to confirm rather than re-running this.
+ *    (pro + pro_yearly) and seats carrying several stray grants are caught; such
+ *    a seat is reconciled once (its whole aggregate to target) on the first
+ *    stray credit.
+ *  - `--excludeSeatIds` still exists for belt-and-suspenders, but is not required
+ *    for safety: an already-fixed seat is a no-op. Re-run the audit afterwards to
+ *    confirm.
  *
  * Dry-run by default (prints the full plan, including per-seat segment/timestamp
  * resolution). Pass --execute to apply. Use --seatId to restrict to a single
@@ -48,6 +53,7 @@
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
  */
 import config from "@app/lib/api/config";
+import { fetchConsumedAwuCreditsByUserId } from "@app/lib/api/credits/members_usage";
 import {
   adjustSeatCreditBalances,
   findSeatCreditSegmentForPeriod,
@@ -107,10 +113,13 @@ interface SeatCorrection {
   // any seat in the workspace.
   homeSeatType: MembershipSeatType | "unassigned";
   strayType: MembershipSeatType;
-  strayAllocation: number;
+  homeAllocation: number;
+  consumedAwu: number;
   currentBalance: number;
-  // Debited from the stray credit: the stray grant still on the balance,
-  // min(strayAllocation, currentBalance) — never exceeds the balance.
+  targetBalance: number;
+  // Reconcile amount debited from the stray credit: max(0, currentBalance -
+  // target). Idempotent — a seat already at/below target (fixed by a prior run,
+  // empty-origin, or manually) yields ~0 and is skipped.
   clawBackAwu: number;
   creditId: string;
   segmentId: string;
@@ -172,7 +181,16 @@ async function fixWorkspace(
     ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
   ];
   const tierBySeatType = new Map<MembershipSeatType, StrayTierInfo>();
+  // Allocation for EVERY seat type (incl. free), used to size each seat's
+  // reconcile target from its current (home) tier.
+  const allocationBySeatType = new Map<MembershipSeatType, number>();
   for (const [seatType, sub] of seatSubscriptions) {
+    const allocation = getAwuAllocationForSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
+    allocationBySeatType.set(seatType, allocation);
     if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
       continue;
     }
@@ -184,11 +202,7 @@ async function fixWorkspace(
         seatType,
         subscriptionId: sub.id,
         recurringCreditId: recurringCredit.id,
-        allocation: getAwuAllocationForSeatType(
-          contract,
-          seatType,
-          productSeatTypes
-        ),
+        allocation,
       });
     }
   }
@@ -245,19 +259,26 @@ async function fixWorkspace(
     awuBalanceBySeatId.set(seat.seat_id, balance);
   }
 
-  // Grant-history stacked-seat detection (authoritative, ES-free). Each
-  // credit-bearing tier grants exactly its allocation to whoever is on its
-  // subscription at the credit segment start; a seat holds a stray grant iff it
-  // appears in a tier's grant-time assignment but is now on a different tier.
-  // (See audit_metronome_seat_state.ts for why starting_balance / analytics
-  // consumption are both unreliable here.) Each tier is checked independently,
-  // so same-family stacks (pro + pro_yearly) and multi-stray seats are caught.
-  //
-  // Every stray grant on the same stray credit shares that credit's segment
-  // start as a valid entry time, so they are corrected in ONE batched ledger
-  // entry (adjustSeatCreditBalances with a per-seat amounts map) — the write
-  // cost is O(stray credits), not O(seats).
-  const corrections: SeatCorrection[] = [];
+  // Phase 1 — grant history (authoritative, ES-free): which seats hold a stray
+  // grant and on which stray credit. A per-seat recurring credit grants exactly
+  // its allocation to whoever is on its subscription at the credit segment
+  // start, so a seat is stacked iff it appears in a tier's grant-time assignment
+  // but is now on a different tier. Each tier is checked independently, so
+  // same-family stacks (pro + pro_yearly) are caught; a seat granted by several
+  // tiers is owned by the first (reconciled once, on that credit — the single
+  // reconcile brings its whole aggregate to target regardless).
+  const strayInfoBySeat = new Map<
+    string,
+    {
+      homeSeatType: MembershipSeatType | "unassigned";
+      strayType: MembershipSeatType;
+      creditId: string;
+      segmentId: string;
+      // Segment start: a shared, in-segment, hour-aligned entry time at which
+      // the seat held the grant — lets all seats on this credit batch.
+      adjustmentTimestamp: Date;
+    }
+  >();
   const skippedTiersNoSegment: MembershipSeatType[] = [];
   for (const tier of tierBySeatType.values()) {
     const segRes = await paceMetronome(() =>
@@ -300,8 +321,6 @@ async function fixWorkspace(
       skippedTiersNoSegment.push(tier.seatType);
       continue;
     }
-    // Segment start: a shared, in-segment, hour-aligned entry time at which
-    // every granted seat held the grant — lets all seats on this credit batch.
     const adjustmentTimestamp = new Date(segment.segmentStartingAt);
     for (const seatId of grantStateRes.value.assignedSeatIds) {
       if (onlySeatId && seatId !== onlySeatId) {
@@ -310,7 +329,7 @@ async function fixWorkspace(
       if (excludeSeatIds.has(seatId)) {
         continue;
       }
-      const homeSeatType = seatTypeBySeatId.get(seatId) ?? null;
+      const homeSeatType = seatTypeBySeatId.get(seatId) ?? "unassigned";
       if (homeSeatType === tier.seatType) {
         // Grant is legitimate — the seat is still on this tier.
         continue;
@@ -318,26 +337,66 @@ async function fixWorkspace(
       if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
         continue;
       }
-      const currentBalance = awuBalanceBySeatId.get(seatId) ?? 0;
-      if (currentBalance <= 0) {
-        // Nothing left on the balance to reclaim (already fully consumed and/or
-        // corrected). Skipping keeps the aggregate from going negative.
+      if (strayInfoBySeat.has(seatId)) {
         continue;
       }
-      corrections.push({
-        seatId,
-        homeSeatType: homeSeatType ?? "unassigned",
+      strayInfoBySeat.set(seatId, {
+        homeSeatType,
         strayType: tier.seatType,
-        strayAllocation: tier.allocation,
-        currentBalance,
-        // Remove the stray grant still on the balance, capped at the balance so
-        // the aggregate never drops below max(0, homeAllocation - consumed).
-        clawBackAwu: Math.min(tier.allocation, currentBalance),
         creditId: segment.creditId,
         segmentId: segment.segmentId,
         adjustmentTimestamp,
       });
     }
+  }
+
+  // Phase 2 — reconcile-to-target: each affected seat should hold max(0,
+  // homeAllocation - consumed); the claw-back is its excess above that. This is
+  // idempotent — a seat already at/below target (fixed by a prior run,
+  // empty-origin, or manually) yields ~0 and is skipped, so re-running is safe
+  // even without knowing which seats were fixed. `consumed` is the analytics
+  // figure; it only sizes the amount on already-proven-stacked seats and the
+  // claw-back is floored at 0, so analytics lag can only under-correct, never
+  // add credit or touch a healthy seat.
+  const RECONCILE_TOLERANCE_AWU = 1000;
+  const affectedSeatIds = [...strayInfoBySeat.keys()];
+  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
+    workspace: lightWorkspace,
+    userIds: affectedSeatIds,
+    freeSeatUserIds: affectedSeatIds.filter(
+      (id) => seatTypeBySeatId.get(id) === "free"
+    ),
+  });
+  const corrections: SeatCorrection[] = [];
+  for (const seatId of affectedSeatIds) {
+    const info = strayInfoBySeat.get(seatId);
+    if (!info) {
+      continue;
+    }
+    const homeAllocation =
+      info.homeSeatType === "unassigned"
+        ? 0
+        : (allocationBySeatType.get(info.homeSeatType) ?? 0);
+    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
+    const currentBalance = awuBalanceBySeatId.get(seatId) ?? 0;
+    const targetBalance = Math.max(0, homeAllocation - consumedAwu);
+    const clawBackAwu = Math.max(0, currentBalance - targetBalance);
+    if (clawBackAwu <= RECONCILE_TOLERANCE_AWU) {
+      continue;
+    }
+    corrections.push({
+      seatId,
+      homeSeatType: info.homeSeatType,
+      strayType: info.strayType,
+      homeAllocation,
+      consumedAwu,
+      currentBalance,
+      targetBalance,
+      clawBackAwu,
+      creditId: info.creditId,
+      segmentId: info.segmentId,
+      adjustmentTimestamp: info.adjustmentTimestamp,
+    });
   }
 
   // Group corrections by stray credit segment — one batched ledger entry each.
@@ -381,8 +440,11 @@ async function fixWorkspace(
       onlySeatId,
       onlyHomeSeatType,
       excludedSeatCount: excludeSeatIds.size,
-      strayGrantCount: corrections.length,
-      affectedSeatCount: new Set(corrections.map((c) => c.seatId)).size,
+      // Seats that held a stray grant (grant-history), before the reconcile
+      // filter drops those already at/below target.
+      seatsWithStrayGrant: strayInfoBySeat.size,
+      seatsWithConsumption: consumedByUserId.size,
+      correctedSeatCount: corrections.length,
       totalClawBackAwu: corrections.reduce((s, c) => s + c.clawBackAwu, 0),
       batchedAdjustCalls: batches.size,
       byTransition: Object.fromEntries(byTransition),

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -9,46 +9,52 @@
  * candidate and can no longer self-heal it — see `audit_metronome_seat_state.ts`
  * ("over-allocated seats").
  *
- * Detection + correction are EXACT and per-credit. The seat-balances read
- * (`include_credits_and_commits`) returns, for each seat, a `credits[]` array
- * with that seat's balance on EACH individual credit id (not just the aggregate
- * per credit type). We map each materialized credit id to its seat type once per
- * contract (via `findSeatCreditSegmentForPeriod` per credit-bearing tier, whose
- * `creditId` is the materialized id), then for each seat empty exactly the
- * credits whose seat type ≠ the seat's CURRENT tier. The negative delta equals
- * that seat's own per-seat balance on the stray credit, driving it to 0.
+ * Detection + correction are EXACT and per-credit, and live in the shared
+ * `lib/metronome/stacked_seat_credits` core (also used by the
+ * `credit.segment.start` webhook reconcile, so the two can never drift). The
+ * seat-balances read (`include_credits_and_commits`) returns, for each seat, a
+ * `credits[]` array with that seat's balance on EACH individual credit id (not
+ * just the aggregate per credit type). We map each materialized credit id to its
+ * seat type once per contract (via `findSeatCreditSegmentForPeriod` per
+ * credit-bearing tier, whose `creditId` is the materialized id), then for each
+ * seat:
  *
- * This is inherently IDEMPOTENT: a re-run reads the stray credit's per-seat
- * balance as 0 and emits nothing. No consumption estimate, no allocation
- * matching, no same-family ambiguity — the credit id itself names the stray
- * tier, so a pro-vs-pro_yearly collision is never a question. All corrections on
- * the same stray credit share its segment start as their entry time, so they
- * apply in ONE batched ledger entry per stray credit (write cost is O(stray
- * credits)).
+ *  - empty every STRAY credit (seat type ≠ the seat's current tier) fully, and
+ *  - carry the consumption those strays absorbed onto the HOME credit — debiting
+ *    it by `min(homeBalance, Σ strayConsumed)` — so the seat nets
+ *    `homeAllocation − totalConsumed` instead of a full home allowance plus the
+ *    stray usage forgiven. (Without the carry a seat that spent, say, 69 AWU
+ *    against its stray would end at a full home 8000 instead of 7931.)
+ *
+ * Both figures are exact (observed per-seat balances vs. deterministic tier
+ * allocations, not an ES estimate) and inherently IDEMPOTENT: a re-run reads
+ * every stray at 0, so there is no stray consumption left to carry and nothing
+ * is emitted. No allocation matching, no same-family ambiguity — the credit id
+ * itself names each credit's tier, so a pro-vs-pro_yearly collision is never a
+ * question. Deltas on the same credit batch into ONE ledger entry.
  *
  * A credit id that maps to no credit-bearing tier (the contract's "Excess" or
- * pool credit, or a tier we don't recognize) is left untouched — only credits
- * whose seat type is known AND differs from the seat's current tier are emptied.
+ * pool credit, or a tier we don't recognize) is left untouched.
  *
  * IMPORTANT — read before running with --execute:
  *
- *  - Emptying the stray credit's per-seat balance can leave THAT pool's slice at
- *    0 (never negative — we debit exactly the balance). Harmless for a seat no
- *    longer assigned to that tier: nothing draws from it and it expires next
- *    recurrence.
+ *  - Debits never drive a slice negative (a stray is debited exactly its
+ *    balance; the home carry is capped at the home balance). Harmless for a seat
+ *    no longer assigned to a stray tier: nothing draws from it and it expires
+ *    next recurrence.
  *  - `--excludeSeatIds` still exists for belt-and-suspenders, but is not required
- *    for safety: an already-emptied seat reads 0 and is a no-op. Re-run the audit
- *    afterwards to confirm.
+ *    for safety: an already-corrected seat reads 0 strays and is a no-op. Re-run
+ *    the audit afterwards to confirm.
  *
  * NOTE: this corrects the CURRENT period only. Recurring credits are materialized
  * one period ahead, so a mid-period move also leaves a stray grant on the NEXT
- * segment (fixed at the source by `emptyOriginNextPeriodCredits` in seats.ts).
- * Re-run after that ships to clear any next-period backlog.
+ * segment; the `credit.segment.start` webhook reconcile cleans each segment as it
+ * becomes current, so a backfill re-run is only needed for the current period.
  *
- * Dry-run by default (prints the full plan, including per-seat credit/segment
- * resolution). Pass --execute to apply. Use --seatId to restrict to a single
- * seat (validate the mechanics on one before a bulk run), and --homeSeatType to
- * scope to seats currently of a given tier (e.g. only the confident `max` set).
+ * Dry-run by default (prints the full plan, including every per-seat adjustment).
+ * Pass --execute to apply. Use --seatId to restrict to a single seat (validate
+ * the mechanics on one before a bulk run), and --homeSeatType to scope to seats
+ * currently of a given tier (e.g. only the confident `max` set).
  *
  * `--allWorkspaces` runs across every workspace that currently has a
  * max/max_yearly/pro_yearly seat (the only ones that can carry a stacked
@@ -63,25 +69,16 @@
  */
 import config from "@app/lib/api/config";
 import {
-  adjustSeatCreditBalances,
-  findSeatCreditSegmentForPeriod,
   getMetronomeSubscriptionSeatState,
-  invalidateCachedCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
-import type { ContractCreditType } from "@app/lib/metronome/constants";
-import {
-  CONTRACT_CREDIT_TYPE_EXCESS,
-  CONTRACT_CREDIT_TYPE_FREE_SEAT,
-  CONTRACT_CREDIT_TYPE_POOL,
-  getCreditTypeAwuId,
-} from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
+import { correctStackedSeatCreditsFromBalances } from "@app/lib/metronome/stacked_seat_credits";
 import { Op } from "@app/lib/resources/storage/data_types";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -108,33 +105,6 @@ async function paceMetronome<T>(fn: () => Promise<T>): Promise<T> {
     await new Promise((r) => setTimeout(r, wait));
   }
   return fn();
-}
-
-// A credit-bearing tier's recurring credit, resolved to its materialized credit
-// id + segment for the current period.
-interface TierCredit {
-  seatType: MembershipSeatType;
-  recurringCreditId: string;
-  // Materialized credit id for the current segment (matches seat.credits[].id).
-  creditId: string;
-  segmentId: string;
-  // Shared, in-segment entry time so all seats on this credit batch into one
-  // ledger write.
-  adjustmentTimestamp: Date;
-}
-
-interface SeatCorrection {
-  seatId: string;
-  // The seat's current (home) tier.
-  homeSeatType: MembershipSeatType;
-  // Seat type of the stray credit being emptied (named by the credit id itself).
-  strayType: MembershipSeatType;
-  // The seat's exact per-seat balance on the stray credit — debited in full so
-  // the pool slice lands on 0.
-  strayBalanceAwu: number;
-  creditId: string;
-  segmentId: string;
-  adjustmentTimestamp: Date;
 }
 
 async function fixWorkspace(
@@ -184,73 +154,28 @@ async function fixWorkspace(
     return;
   }
 
-  // Recurring-credit tiers (pro/max families). `free`/`workspace`/`none` carry
-  // no per-seat recurring credit (getSeatCreditNameForSeatType === null), so
-  // they are neither a home nor a stray tier here.
+  // Credit-bearing tiers (pro/max families). `free`/`workspace`/`none` carry no
+  // per-seat recurring credit (getSeatCreditNameForSeatType === null), so they
+  // are never a valid home tier for a stacked seat here.
   const productSeatTypes = await getProductSeatTypes();
   const seatSubscriptions = [
     ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
   ];
-  const recurringCreditByTier = new Map<
-    MembershipSeatType,
-    { subscriptionId: string; recurringCreditId: string }
-  >();
+  const creditBearingHomeTypes = new Set<MembershipSeatType>();
   for (const [seatType, sub] of seatSubscriptions) {
-    if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
-      continue;
-    }
-    const recurringCredit = (contract.recurring_credits ?? []).find(
-      (c) => c.subscription_config?.subscription_id === sub.id
-    );
-    if (recurringCredit?.id) {
-      recurringCreditByTier.set(seatType, {
-        subscriptionId: sub.id,
-        recurringCreditId: recurringCredit.id,
-      });
+    if (
+      sub.id &&
+      getSeatCreditNameForSeatType(seatType) &&
+      (contract.recurring_credits ?? []).some(
+        (c) => c.subscription_config?.subscription_id === sub.id
+      )
+    ) {
+      creditBearingHomeTypes.add(seatType);
     }
   }
 
-  // Resolve each credit-bearing tier's recurring credit to its MATERIALIZED
-  // credit id + segment for the current period, and index BY that credit id.
-  // findSeatCreditSegmentForPeriod returns the materialized credit id (the same
-  // id seats carry in `credits[].id`), which is what names the stray tier below:
-  // a credit id whose tier ≠ the seat's current tier is stray, no matter which
-  // family it belongs to (so pro-vs-pro_yearly is never ambiguous).
-  const tierByCreditId = new Map<string, TierCredit>();
-  for (const [seatType, { recurringCreditId }] of recurringCreditByTier) {
-    const segRes = await paceMetronome(() =>
-      findSeatCreditSegmentForPeriod({
-        metronomeCustomerId,
-        metronomeContractId: contractId,
-        recurringCreditId,
-      })
-    );
-    if (segRes.isErr()) {
-      logger.error(
-        { workspaceId, seatType, err: segRes.error.message },
-        "[StackedFix] failed to resolve seat credit segment for tier"
-      );
-      return;
-    }
-    const segment = segRes.value;
-    if (!segment) {
-      logger.warn(
-        { workspaceId, seatType, recurringCreditId },
-        "[StackedFix] no active seat credit segment for tier — skipping tier"
-      );
-      continue;
-    }
-    tierByCreditId.set(segment.creditId, {
-      seatType,
-      recurringCreditId,
-      creditId: segment.creditId,
-      segmentId: segment.segmentId,
-      // Shared, in-segment entry time so all seats on this credit batch.
-      adjustmentTimestamp: new Date(segment.segmentStartingAt),
-    });
-  }
-
-  // Map every assigned seat to its home (current) tier.
+  // Map every assigned seat to its home (current) tier from Metronome's own
+  // per-subscription assignment.
   const seatTypeBySeatId = new Map<string, MembershipSeatType>();
   for (const [seatType, sub] of seatSubscriptions) {
     if (!sub.id) {
@@ -276,12 +201,8 @@ async function fixWorkspace(
   }
 
   // Candidate seats: currently on a credit-bearing tier (a free/none home has no
-  // recurring credit of its own; its stray is handled separately). Apply the CLI
-  // filters here.
-  const candidates: Array<{
-    seatId: string;
-    homeSeatType: MembershipSeatType;
-  }> = [];
+  // recurring credit of its own). Apply the CLI filters here.
+  const currentSeatTypeBySeatId = new Map<string, MembershipSeatType>();
   for (const [seatId, homeSeatType] of seatTypeBySeatId) {
     if (onlySeatId && seatId !== onlySeatId) {
       continue;
@@ -292,22 +213,20 @@ async function fixWorkspace(
     if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
       continue;
     }
-    if (!recurringCreditByTier.has(homeSeatType)) {
+    if (!creditBearingHomeTypes.has(homeSeatType)) {
       continue;
     }
-    candidates.push({ seatId, homeSeatType });
+    currentSeatTypeBySeatId.set(seatId, homeSeatType);
   }
 
-  // Read per-seat, per-credit balances for the candidate seats. `credits[]` is
-  // populated by `include_credits_and_commits` and gives each seat's balance on
-  // each individual credit id — the aggregate `balances[]` cannot distinguish a
-  // seat's pro slice from its max slice.
-  const awuCreditTypeId = getCreditTypeAwuId();
+  // Read per-seat, per-credit balances once (credits[] via
+  // include_credits_and_commits), then delegate detection + correction to the
+  // shared core so the backfill and the webhook reconcile can never drift.
   const balancesRes = await paceMetronome(() =>
     listMetronomeSeatBalances({
       metronomeCustomerId,
       metronomeContractId: contractId,
-      seatIds: candidates.map((c) => c.seatId),
+      seatIds: [...currentSeatTypeBySeatId.keys()],
     })
   );
   if (balancesRes.isErr()) {
@@ -317,76 +236,26 @@ async function fixWorkspace(
     );
     return;
   }
-  // seatId -> [{ creditId, balanceAwu }] for AWU credits only.
-  const seatCreditsBySeatId = new Map<
-    string,
-    Array<{ creditId: string; balanceAwu: number }>
-  >();
-  for (const seat of balancesRes.value) {
-    seatCreditsBySeatId.set(
-      seat.seat_id,
-      (seat.credits ?? [])
-        .filter((c) => c.credit_type_id === awuCreditTypeId)
-        .map((c) => ({ creditId: c.id, balanceAwu: c.balance }))
+
+  const result = await correctStackedSeatCreditsFromBalances({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+    contract,
+    seatBalances: balancesRes.value,
+    currentSeatTypeBySeatId,
+    execute,
+    logger,
+    pace: paceMetronome,
+  });
+  if (result.isErr()) {
+    logger.error(
+      { workspaceId, err: result.error.message },
+      "[StackedFix] failed to correct stacked seat credits"
     );
+    return;
   }
-
-  // For each candidate seat, empty exactly the credits whose seat type differs
-  // from the seat's current tier. A credit id absent from `tierByCreditId`
-  // (excess/pool/unrecognized) is left untouched, and a stray already at 0
-  // (prior run / empty-origin) is a no-op — so re-runs are idempotent.
-  const corrections: SeatCorrection[] = [];
-  for (const { seatId, homeSeatType } of candidates) {
-    const seatCredits = seatCreditsBySeatId.get(seatId) ?? [];
-    for (const { creditId, balanceAwu } of seatCredits) {
-      const tier = tierByCreditId.get(creditId);
-      if (!tier || tier.seatType === homeSeatType || balanceAwu <= 0) {
-        continue;
-      }
-      corrections.push({
-        seatId,
-        homeSeatType,
-        strayType: tier.seatType,
-        strayBalanceAwu: balanceAwu,
-        creditId: tier.creditId,
-        segmentId: tier.segmentId,
-        adjustmentTimestamp: tier.adjustmentTimestamp,
-      });
-    }
-  }
-
-  // Group corrections by stray credit segment — one batched ledger entry each.
-  const batches = new Map<
-    string,
-    {
-      creditId: string;
-      segmentId: string;
-      strayType: MembershipSeatType;
-      timestamp: Date;
-      items: SeatCorrection[];
-    }
-  >();
-  for (const c of corrections) {
-    const key = `${c.creditId}:${c.segmentId}`;
-    const batch = batches.get(key) ?? {
-      creditId: c.creditId,
-      segmentId: c.segmentId,
-      strayType: c.strayType,
-      timestamp: c.adjustmentTimestamp,
-      items: [],
-    };
-    batch.items.push(c);
-    batches.set(key, batch);
-  }
-
-  const byTransition = new Map<string, { count: number; totalAwu: number }>();
-  for (const c of corrections) {
-    const key = `${c.homeSeatType}<-${c.strayType}`;
-    const agg = byTransition.get(key) ?? { count: 0, totalAwu: 0 };
-    agg.count += 1;
-    agg.totalAwu += c.strayBalanceAwu;
-    byTransition.set(key, agg);
-  }
+  const summary = result.value;
 
   logger.info(
     {
@@ -396,12 +265,14 @@ async function fixWorkspace(
       onlySeatId,
       onlyHomeSeatType,
       excludedSeatCount: excludeSeatIds.size,
-      candidateSeatCount: candidates.length,
-      correctedSeatCount: corrections.length,
-      totalEmptiedAwu: corrections.reduce((s, c) => s + c.strayBalanceAwu, 0),
-      batchedAdjustCalls: batches.size,
-      byTransition: Object.fromEntries(byTransition),
-      corrections,
+      candidateSeatCount: currentSeatTypeBySeatId.size,
+      emptiedStrayCount: summary.emptiedStrayCount,
+      carriedConsumptionCount: summary.carriedConsumptionCount,
+      totalEmptiedAwu: summary.totalEmptiedAwu,
+      totalCarriedAwu: summary.totalCarriedAwu,
+      batchedAdjustCalls: summary.batchedAdjustCalls,
+      appliedAdjustmentCount: summary.appliedAdjustmentCount,
+      adjustments: summary.adjustments,
     },
     "[StackedFix] correction plan"
   );
@@ -414,78 +285,12 @@ async function fixWorkspace(
     return;
   }
 
-  let appliedSeats = 0;
-  for (const batch of batches.values()) {
-    const perSeatAmounts = Object.fromEntries(
-      batch.items.map((c) => [c.seatId, -c.strayBalanceAwu])
-    );
-    const adjustRes = await paceMetronome(() =>
-      adjustSeatCreditBalances({
-        metronomeCustomerId,
-        metronomeContractId: contractId,
-        creditId: batch.creditId,
-        segmentId: batch.segmentId,
-        perSeatAmounts,
-        reason: `Stacked-credit correction: empty orphaned ${batch.strayType} grant`,
-        timestamp: batch.timestamp,
-        alignToHour: false,
-      })
-    );
-    if (adjustRes.isErr()) {
-      logger.error(
-        {
-          workspaceId,
-          strayType: batch.strayType,
-          creditId: batch.creditId,
-          seatCount: batch.items.length,
-          err: adjustRes.error.message,
-        },
-        "[StackedFix] batched correction failed"
-      );
-      continue;
-    }
-    appliedSeats += batch.items.length;
-    logger.info(
-      {
-        workspaceId,
-        strayType: batch.strayType,
-        creditId: batch.creditId,
-        seatCount: batch.items.length,
-        totalAwu: batch.items.reduce((s, c) => s + c.strayBalanceAwu, 0),
-        timestamp: batch.timestamp.toISOString(),
-      },
-      "[StackedFix] applied batched correction"
-    );
-  }
-
-  // Bust the 1-hour per-user credit-balance Redis cache
-  // (getCachedCustomerPerUserCreditBalances) so poke reflects the corrections
-  // without waiting out the TTL. A manual balance entry does NOT fire the
-  // Metronome credit.create / segment.start webhook that normally invalidates
-  // it, so nothing else clears it. This covers the free-seat / pool surfaces
-  // that read the cache; the pro/max seat balance in the members table is read
-  // LIVE (uncached listMetronomeSeatBalances), so its brief post-correction lag
-  // is Metronome's own seat-balance read model catching up and self-heals.
-  if (appliedSeats > 0) {
-    const contractCreditTypes: ContractCreditType[] = [
-      CONTRACT_CREDIT_TYPE_FREE_SEAT,
-      CONTRACT_CREDIT_TYPE_POOL,
-      CONTRACT_CREDIT_TYPE_EXCESS,
-    ];
-    for (const contractCreditType of contractCreditTypes) {
-      await invalidateCachedCustomerPerUserCreditBalances({
-        metronomeCustomerId,
-        contractCreditType,
-      });
-    }
-    logger.info(
-      { workspaceId, metronomeCustomerId },
-      "[StackedFix] invalidated cached per-user credit balances"
-    );
-  }
-
   logger.info(
-    { workspaceId, appliedSeats, plannedSeats: corrections.length },
+    {
+      workspaceId,
+      appliedAdjustmentCount: summary.appliedAdjustmentCount,
+      batchedAdjustCalls: summary.batchedAdjustCalls,
+    },
     "[StackedFix] done"
   );
 }

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -50,9 +50,16 @@
  * seat (validate the mechanics on one before a bulk run), and --homeSeatType to
  * scope to seats currently of a given tier (e.g. only the confident `max` set).
  *
+ * `--allWorkspaces` runs across every workspace that currently has a
+ * max/max_yearly/pro_yearly seat (the only ones that can carry a stacked
+ * credit), sequentially, dry-run unless --execute. No need to iterate all
+ * workspaces — a plain pro-monthly workspace has no stray credit to empty.
+ *
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId>
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --seatId <userId>
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
+ *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --allWorkspaces
+ *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --allWorkspaces --execute
  */
 import config from "@app/lib/api/config";
 import {
@@ -75,11 +82,14 @@ import {
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { getSeatCreditNameForSeatType } from "@app/lib/metronome/seats";
+import { Op } from "@app/lib/resources/storage/data_types";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 import { makeScript } from "./helpers";
 
@@ -480,18 +490,53 @@ async function fixWorkspace(
   );
 }
 
+// Only workspaces that CURRENTLY have at least one max / max_yearly / pro_yearly
+// seat can carry a stacked credit: stacking is a pro->max (or yearly) upgrade
+// that stranded the origin credit, so the affected seat is on the higher/yearly
+// tier now. A plain pro-monthly-only workspace has no max credit to stray, so
+// there is no need to iterate every workspace. Matches:
+//   select distinct "workspaceId" from memberships
+//   where "seatType" in ('max','max_yearly','pro_yearly')
+const STACKED_RISK_SEAT_TYPES: MembershipSeatType[] = [
+  "max",
+  "max_yearly",
+  "pro_yearly",
+];
+
+async function listStackedRiskWorkspaceIds(): Promise<string[]> {
+  const rows = await MembershipModel.findAll({
+    attributes: ["workspaceId"],
+    where: { seatType: { [Op.in]: STACKED_RISK_SEAT_TYPES } },
+    group: ["workspaceId"],
+    raw: true,
+  });
+  const workspaces = await WorkspaceResource.fetchByModelIds(
+    rows.map((r) => r.workspaceId)
+  );
+  return workspaces.map((w) => w.sId);
+}
+
 makeScript(
   {
     workspaceId: {
       type: "string",
-      demandOption: true,
-      describe: "sId of the workspace to correct",
+      describe:
+        "sId of a single workspace to correct. Omit and pass --allWorkspaces " +
+        "to run across every at-risk workspace instead.",
+    },
+    allWorkspaces: {
+      type: "boolean",
+      default: false,
+      describe:
+        "Run on ALL workspaces that currently have at least one " +
+        "max/max_yearly/pro_yearly seat (the only ones that can carry a " +
+        "stacked credit). Processed sequentially; --seatId is ignored.",
     },
     seatId: {
       type: "string",
       describe:
         "Restrict to a single seat (userId) — validate the mechanics on one " +
-        "before a bulk run",
+        "before a bulk run. Single-workspace mode only.",
     },
     homeSeatType: {
       type: "string",
@@ -507,16 +552,22 @@ makeScript(
     },
   },
   async (
-    { workspaceId, seatId, homeSeatType, excludeSeatIds, execute },
+    {
+      workspaceId,
+      allWorkspaces,
+      seatId,
+      homeSeatType,
+      excludeSeatIds,
+      execute,
+    },
     logger
   ) => {
     if (!config.getMetronomeApiKey()) {
       logger.error({}, "[StackedFix] METRONOME_API_KEY is not configured");
       return;
     }
-    await fixWorkspace(workspaceId, {
+    const sharedOptions = {
       execute,
-      onlySeatId: seatId ?? null,
       onlyHomeSeatType:
         (homeSeatType as MembershipSeatType | undefined) ?? null,
       excludeSeatIds: new Set(
@@ -526,6 +577,56 @@ makeScript(
           .filter((s) => s.length > 0)
       ),
       logger,
+    };
+
+    if (allWorkspaces) {
+      if (seatId) {
+        logger.warn(
+          {},
+          "[StackedFix] --seatId is ignored in --allWorkspaces mode"
+        );
+      }
+      const workspaceIds = await listStackedRiskWorkspaceIds();
+      logger.info(
+        { workspaceCount: workspaceIds.length, execute },
+        "[StackedFix] running across all at-risk workspaces (max/max_yearly/pro_yearly)"
+      );
+      // Sequential on purpose: the Metronome RPS pacer is process-global, and a
+      // single workspace already fans out several paced calls — running
+      // workspaces one at a time keeps request pressure and the DB connection
+      // pool bounded. A per-workspace failure is logged and skipped, never
+      // aborting the whole run.
+      for (const [index, wId] of workspaceIds.entries()) {
+        logger.info(
+          { workspaceId: wId, index: index + 1, total: workspaceIds.length },
+          "[StackedFix] processing workspace"
+        );
+        try {
+          await fixWorkspace(wId, { ...sharedOptions, onlySeatId: null });
+        } catch (err) {
+          logger.error(
+            { workspaceId: wId, err: normalizeError(err).message },
+            "[StackedFix] workspace failed — skipping"
+          );
+        }
+      }
+      logger.info(
+        { workspaceCount: workspaceIds.length, execute },
+        "[StackedFix] all at-risk workspaces done"
+      );
+      return;
+    }
+
+    if (!workspaceId) {
+      logger.error(
+        {},
+        "[StackedFix] provide --workspaceId <wId> or --allWorkspaces"
+      );
+      return;
+    }
+    await fixWorkspace(workspaceId, {
+      ...sharedOptions,
+      onlySeatId: seatId ?? null,
     });
   }
 );

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -9,46 +9,43 @@
  * candidate and can no longer self-heal it — see `audit_metronome_seat_state.ts`
  * ("over-allocated seats").
  *
- * Detection + correction are one IDEMPOTENT reconcile-to-target pass, keyed on
- * Metronome's OWN per-user consumption (authoritative, not ES). Each seat on a
- * credit-bearing tier should hold `max(0, homeAllocation - consumed)`; the fix
- * posts a negative delta to the stray credit equal to the seat's excess above
- * that target (`max(0, currentBalance - target)`). A seat already at/below
- * target — fixed by a prior run, empty-origin, or manually — yields ~0 and is
- * skipped, so re-runs are safe WITHOUT knowing which seats were already fixed.
- * The claw-back floors at 0, so a healthy seat (balance ≈ allocation - consumed)
- * is never touched and credit is never added.
+ * Detection + correction are EXACT and per-credit. The seat-balances read
+ * (`include_credits_and_commits`) returns, for each seat, a `credits[]` array
+ * with that seat's balance on EACH individual credit id (not just the aggregate
+ * per credit type). We map each materialized credit id to its seat type once per
+ * contract (via `findSeatCreditSegmentForPeriod` per credit-bearing tier, whose
+ * `creditId` is the materialized id), then for each seat empty exactly the
+ * credits whose seat type ≠ the seat's CURRENT tier. The negative delta equals
+ * that seat's own per-seat balance on the stray credit, driving it to 0.
  *
- * The over-grant equals the STRAY tier's allocation exactly (totalGranted =
- * homeAllocation + strayAllocation, independent of consumption), which names the
- * stray tier. Same-family collisions (pro + pro_yearly both 8000) are broken by
- * which tier has assigned seats — but only as a tiebreaker, since the stray tier
- * can itself now have 0 seats (the user moved off it). All corrections on the
- * same stray credit share its segment start as their entry time, so they apply
- * in ONE batched ledger entry per stray credit (write cost is O(stray credits)).
+ * This is inherently IDEMPOTENT: a re-run reads the stray credit's per-seat
+ * balance as 0 and emits nothing. No consumption estimate, no allocation
+ * matching, no same-family ambiguity — the credit id itself names the stray
+ * tier, so a pro-vs-pro_yearly collision is never a question. All corrections on
+ * the same stray credit share its segment start as their entry time, so they
+ * apply in ONE batched ledger entry per stray credit (write cost is O(stray
+ * credits)).
+ *
+ * A credit id that maps to no credit-bearing tier (the contract's "Excess" or
+ * pool credit, or a tier we don't recognize) is left untouched — only credits
+ * whose seat type is known AND differs from the seat's current tier are emptied.
  *
  * IMPORTANT — read before running with --execute:
  *
- *  - There is NO Metronome read that returns a seat's balance on a SPECIFIC
- *    recurring credit (per_group_amounts is write-only), so exact per-credit
- *    idempotency is impossible; reconcile-to-target on the aggregate is how we
- *    get idempotency instead. The delta drives the aggregate to target by
- *    adjusting the stray credit, which can leave THAT pool negative — harmless
- *    for a seat no longer assigned to it (nothing draws from it; it expires next
- *    recurrence).
- *  - A seat whose over-grant matches no single stray tier (multi-stray, or an
- *    ambiguous same-family collision that in-use can't break) is reported in
- *    `skippedAmbiguousStrayTiers` and left untouched — needs manual handling.
+ *  - Emptying the stray credit's per-seat balance can leave THAT pool's slice at
+ *    0 (never negative — we debit exactly the balance). Harmless for a seat no
+ *    longer assigned to that tier: nothing draws from it and it expires next
+ *    recurrence.
  *  - `--excludeSeatIds` still exists for belt-and-suspenders, but is not required
- *    for safety: an already-fixed seat is a no-op. Re-run the audit afterwards to
- *    confirm.
+ *    for safety: an already-emptied seat reads 0 and is a no-op. Re-run the audit
+ *    afterwards to confirm.
  *
  * NOTE: this corrects the CURRENT period only. Recurring credits are materialized
  * one period ahead, so a mid-period move also leaves a stray grant on the NEXT
  * segment (fixed at the source by `emptyOriginNextPeriodCredits` in seats.ts).
  * Re-run after that ships to clear any next-period backlog.
  *
- * Dry-run by default (prints the full plan, including per-seat segment/timestamp
+ * Dry-run by default (prints the full plan, including per-seat credit/segment
  * resolution). Pass --execute to apply. Use --seatId to restrict to a single
  * seat (validate the mechanics on one before a bulk run), and --homeSeatType to
  * scope to seats currently of a given tier (e.g. only the confident `max` set).
@@ -58,7 +55,6 @@
  *   npx tsx scripts/fix_metronome_stacked_seat_credits.ts --workspaceId <wId> --homeSeatType max --execute
  */
 import config from "@app/lib/api/config";
-import { fetchConsumedAwuCreditsFromMetronomeByUserId } from "@app/lib/api/credits/members_usage";
 import {
   adjustSeatCreditBalances,
   findSeatCreditSegmentForPeriod,
@@ -75,7 +71,6 @@ import {
 } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
-  getAwuAllocationForSeatType,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
@@ -105,27 +100,28 @@ async function paceMetronome<T>(fn: () => Promise<T>): Promise<T> {
   return fn();
 }
 
-interface StrayTierInfo {
+// A credit-bearing tier's recurring credit, resolved to its materialized credit
+// id + segment for the current period.
+interface TierCredit {
   seatType: MembershipSeatType;
-  subscriptionId: string;
   recurringCreditId: string;
-  allocation: number;
+  // Materialized credit id for the current segment (matches seat.credits[].id).
+  creditId: string;
+  segmentId: string;
+  // Shared, in-segment entry time so all seats on this credit batch into one
+  // ledger write.
+  adjustmentTimestamp: Date;
 }
 
 interface SeatCorrection {
   seatId: string;
-  // Current tier, or "unassigned" if the seat holds a grant but is no longer on
-  // any seat in the workspace.
-  homeSeatType: MembershipSeatType | "unassigned";
+  // The seat's current (home) tier.
+  homeSeatType: MembershipSeatType;
+  // Seat type of the stray credit being emptied (named by the credit id itself).
   strayType: MembershipSeatType;
-  homeAllocation: number;
-  consumedAwu: number;
-  currentBalance: number;
-  targetBalance: number;
-  // Reconcile amount debited from the stray credit: max(0, currentBalance -
-  // target). Idempotent — a seat already at/below target (fixed by a prior run,
-  // empty-origin, or manually) yields ~0 and is skipped.
-  clawBackAwu: number;
+  // The seat's exact per-seat balance on the stray credit — debited in full so
+  // the pool slice lands on 0.
+  strayBalanceAwu: number;
   creditId: string;
   segmentId: string;
   adjustmentTimestamp: Date;
@@ -185,17 +181,11 @@ async function fixWorkspace(
   const seatSubscriptions = [
     ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
   ];
-  const tierBySeatType = new Map<MembershipSeatType, StrayTierInfo>();
-  // Allocation for EVERY seat type (incl. free), used to size each seat's
-  // reconcile target from its current (home) tier.
-  const allocationBySeatType = new Map<MembershipSeatType, number>();
+  const recurringCreditByTier = new Map<
+    MembershipSeatType,
+    { subscriptionId: string; recurringCreditId: string }
+  >();
   for (const [seatType, sub] of seatSubscriptions) {
-    const allocation = getAwuAllocationForSeatType(
-      contract,
-      seatType,
-      productSeatTypes
-    );
-    allocationBySeatType.set(seatType, allocation);
     if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
       continue;
     }
@@ -203,13 +193,51 @@ async function fixWorkspace(
       (c) => c.subscription_config?.subscription_id === sub.id
     );
     if (recurringCredit?.id) {
-      tierBySeatType.set(seatType, {
-        seatType,
+      recurringCreditByTier.set(seatType, {
         subscriptionId: sub.id,
         recurringCreditId: recurringCredit.id,
-        allocation,
       });
     }
+  }
+
+  // Resolve each credit-bearing tier's recurring credit to its MATERIALIZED
+  // credit id + segment for the current period, and index BY that credit id.
+  // findSeatCreditSegmentForPeriod returns the materialized credit id (the same
+  // id seats carry in `credits[].id`), which is what names the stray tier below:
+  // a credit id whose tier ≠ the seat's current tier is stray, no matter which
+  // family it belongs to (so pro-vs-pro_yearly is never ambiguous).
+  const tierByCreditId = new Map<string, TierCredit>();
+  for (const [seatType, { recurringCreditId }] of recurringCreditByTier) {
+    const segRes = await paceMetronome(() =>
+      findSeatCreditSegmentForPeriod({
+        metronomeCustomerId,
+        metronomeContractId: contractId,
+        recurringCreditId,
+      })
+    );
+    if (segRes.isErr()) {
+      logger.error(
+        { workspaceId, seatType, err: segRes.error.message },
+        "[StackedFix] failed to resolve seat credit segment for tier"
+      );
+      return;
+    }
+    const segment = segRes.value;
+    if (!segment) {
+      logger.warn(
+        { workspaceId, seatType, recurringCreditId },
+        "[StackedFix] no active seat credit segment for tier — skipping tier"
+      );
+      continue;
+    }
+    tierByCreditId.set(segment.creditId, {
+      seatType,
+      recurringCreditId,
+      creditId: segment.creditId,
+      segmentId: segment.segmentId,
+      // Shared, in-segment entry time so all seats on this credit batch.
+      adjustmentTimestamp: new Date(segment.segmentStartingAt),
+    });
   }
 
   // Map every assigned seat to its home (current) tier.
@@ -237,85 +265,9 @@ async function fixWorkspace(
     }
   }
 
-  // Read aggregate AWU balances for all assigned seats.
-  const seatIds = [...seatTypeBySeatId.keys()];
-  const balancesRes = await paceMetronome(() =>
-    listMetronomeSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId: contractId,
-      seatIds,
-    })
-  );
-  if (balancesRes.isErr()) {
-    logger.error(
-      { workspaceId, err: balancesRes.error.message },
-      "[StackedFix] failed to read seat balances"
-    );
-    return;
-  }
-  // Current aggregate AWU balance per seat — only used to cap each claw-back at
-  // what the seat still holds, so a correction never drives the balance negative.
-  const awuCreditTypeId = getCreditTypeAwuId();
-  const awuBalanceBySeatId = new Map<string, number>();
-  for (const seat of balancesRes.value) {
-    const balance = seat.balances
-      .filter((b) => b.credit_type_id === awuCreditTypeId)
-      .reduce((sum, b) => sum + b.balance, 0);
-    awuBalanceBySeatId.set(seat.seat_id, balance);
-  }
-
-  // Phase 1 — pair each seat on a credit-bearing tier with its stray credit (the
-  // OTHER credit-bearing tier: home max -> stray pro, home pro -> stray max).
-  // Detection is NOT grant-history: a seat's stray grant can sit in an EARLIER
-  // credit segment than the current one (it moved tier before the latest segment
-  // started), so grant-time assignment under-detects it. Reconcile in phase 2
-  // (balance vs homeAllocation - consumed) is what actually flags a seat; this
-  // phase only resolves WHERE the excess would be reversed.
-  const strayCreditByTier = new Map<
-    MembershipSeatType,
-    { creditId: string; segmentId: string; adjustmentTimestamp: Date } | null
-  >();
-  const resolveStrayCredit = async (tier: StrayTierInfo) => {
-    const cached = strayCreditByTier.get(tier.seatType);
-    if (cached !== undefined) {
-      return cached;
-    }
-    const segRes = await paceMetronome(() =>
-      findSeatCreditSegmentForPeriod({
-        metronomeCustomerId,
-        metronomeContractId: contractId,
-        recurringCreditId: tier.recurringCreditId,
-      })
-    );
-    const segment = segRes.isOk() ? segRes.value : null;
-    const resolved = segment
-      ? {
-          creditId: segment.creditId,
-          segmentId: segment.segmentId,
-          // Shared, in-segment entry time so all seats on this credit batch.
-          adjustmentTimestamp: new Date(segment.segmentStartingAt),
-        }
-      : null;
-    strayCreditByTier.set(tier.seatType, resolved);
-    return resolved;
-  };
-
-  // How many seats are currently assigned to each tier — used to disambiguate
-  // the stray. A contract can expose dormant tiers (e.g. pro_yearly/max_yearly
-  // with 0 seats); the stray is always an ACTIVELY-USED tier, so ignore the
-  // empty ones. (Removing 8000 from any pro-family credit reconciles the same,
-  // but targeting the in-use one keeps the ledger clean.)
-  const assignedCountByTier = new Map<MembershipSeatType, number>();
-  for (const seatType of seatTypeBySeatId.values()) {
-    assignedCountByTier.set(
-      seatType,
-      (assignedCountByTier.get(seatType) ?? 0) + 1
-    );
-  }
-  const creditBearingTiers = [...tierBySeatType.values()];
-
   // Candidate seats: currently on a credit-bearing tier (a free/none home has no
-  // recurring credit of its own; its stray is handled separately).
+  // recurring credit of its own; its stray is handled separately). Apply the CLI
+  // filters here.
   const candidates: Array<{
     seatId: string;
     homeSeatType: MembershipSeatType;
@@ -330,83 +282,67 @@ async function fixWorkspace(
     if (onlyHomeSeatType && homeSeatType !== onlyHomeSeatType) {
       continue;
     }
-    if (!tierBySeatType.has(homeSeatType)) {
+    if (!recurringCreditByTier.has(homeSeatType)) {
       continue;
     }
     candidates.push({ seatId, homeSeatType });
   }
 
-  // Metronome's OWN per-user usage (authoritative, not ES).
-  const consumedByUserId = await fetchConsumedAwuCreditsFromMetronomeByUserId({
-    workspaceId,
-    metronomeCustomerId,
-    metronomeContractId: contractId,
-    users: candidates.map(({ seatId, homeSeatType }) => ({
-      sId: seatId,
-      seatType: homeSeatType,
-    })),
-  });
-
-  // Reconcile-to-target: each seat should hold max(0, homeAllocation - consumed);
-  // the claw-back is its excess above that. Idempotent — a seat at/below target
-  // (fixed by a prior run, empty-origin, or manually) yields ~0 and is skipped,
-  // so re-running is safe without knowing which seats were fixed. The claw-back
-  // floors at 0, so it can only under-correct, never add credit or touch a
-  // healthy seat (a legit seat has balance ≈ allocation - consumed → excess ~0).
-  //
-  // The over-grant equals the STRAY tier's allocation exactly (totalGranted =
-  // homeAllocation + strayAllocation, independent of consumption), so the amount
-  // identifies the stray family. A same-family collision (pro + pro_yearly both
-  // 8000) is broken by which tier actually has assigned seats; note the stray
-  // tier can itself have 0 seats now (the user was the only one and moved off),
-  // so in-use is only a TIEBREAKER, never the primary filter.
-  const RECONCILE_TOLERANCE_AWU = 1000;
-  const ALLOCATION_MATCH_TOLERANCE_AWU = 200;
-  const corrections: SeatCorrection[] = [];
-  const skippedAmbiguousStray = new Set<MembershipSeatType>();
-  for (const { seatId, homeSeatType } of candidates) {
-    const homeAllocation = allocationBySeatType.get(homeSeatType) ?? 0;
-    const consumedAwu = consumedByUserId.get(seatId) ?? 0;
-    const currentBalance = awuBalanceBySeatId.get(seatId) ?? 0;
-    const targetBalance = Math.max(0, homeAllocation - consumedAwu);
-    const clawBackAwu = Math.max(0, currentBalance - targetBalance);
-    if (clawBackAwu <= RECONCILE_TOLERANCE_AWU) {
-      continue;
-    }
-    let strayCandidates = creditBearingTiers.filter(
-      (t) =>
-        t.seatType !== homeSeatType &&
-        Math.abs(t.allocation - clawBackAwu) <= ALLOCATION_MATCH_TOLERANCE_AWU
+  // Read per-seat, per-credit balances for the candidate seats. `credits[]` is
+  // populated by `include_credits_and_commits` and gives each seat's balance on
+  // each individual credit id — the aggregate `balances[]` cannot distinguish a
+  // seat's pro slice from its max slice.
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const balancesRes = await paceMetronome(() =>
+    listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      seatIds: candidates.map((c) => c.seatId),
+    })
+  );
+  if (balancesRes.isErr()) {
+    logger.error(
+      { workspaceId, err: balancesRes.error.message },
+      "[StackedFix] failed to read seat balances"
     );
-    if (strayCandidates.length > 1) {
-      const inUse = strayCandidates.filter(
-        (t) => (assignedCountByTier.get(t.seatType) ?? 0) > 0
-      );
-      if (inUse.length === 1) {
-        strayCandidates = inUse;
+    return;
+  }
+  // seatId -> [{ creditId, balanceAwu }] for AWU credits only.
+  const seatCreditsBySeatId = new Map<
+    string,
+    Array<{ creditId: string; balanceAwu: number }>
+  >();
+  for (const seat of balancesRes.value) {
+    seatCreditsBySeatId.set(
+      seat.seat_id,
+      (seat.credits ?? [])
+        .filter((c) => c.credit_type_id === awuCreditTypeId)
+        .map((c) => ({ creditId: c.id, balanceAwu: c.balance }))
+    );
+  }
+
+  // For each candidate seat, empty exactly the credits whose seat type differs
+  // from the seat's current tier. A credit id absent from `tierByCreditId`
+  // (excess/pool/unrecognized) is left untouched, and a stray already at 0
+  // (prior run / empty-origin) is a no-op — so re-runs are idempotent.
+  const corrections: SeatCorrection[] = [];
+  for (const { seatId, homeSeatType } of candidates) {
+    const seatCredits = seatCreditsBySeatId.get(seatId) ?? [];
+    for (const { creditId, balanceAwu } of seatCredits) {
+      const tier = tierByCreditId.get(creditId);
+      if (!tier || tier.seatType === homeSeatType || balanceAwu <= 0) {
+        continue;
       }
+      corrections.push({
+        seatId,
+        homeSeatType,
+        strayType: tier.seatType,
+        strayBalanceAwu: balanceAwu,
+        creditId: tier.creditId,
+        segmentId: tier.segmentId,
+        adjustmentTimestamp: tier.adjustmentTimestamp,
+      });
     }
-    if (strayCandidates.length !== 1) {
-      skippedAmbiguousStray.add(homeSeatType);
-      continue;
-    }
-    const stray = await resolveStrayCredit(strayCandidates[0]);
-    if (!stray) {
-      continue;
-    }
-    corrections.push({
-      seatId,
-      homeSeatType,
-      strayType: strayCandidates[0].seatType,
-      homeAllocation,
-      consumedAwu,
-      currentBalance,
-      targetBalance,
-      clawBackAwu,
-      creditId: stray.creditId,
-      segmentId: stray.segmentId,
-      adjustmentTimestamp: stray.adjustmentTimestamp,
-    });
   }
 
   // Group corrections by stray credit segment — one batched ledger entry each.
@@ -438,7 +374,7 @@ async function fixWorkspace(
     const key = `${c.homeSeatType}<-${c.strayType}`;
     const agg = byTransition.get(key) ?? { count: 0, totalAwu: 0 };
     agg.count += 1;
-    agg.totalAwu += c.clawBackAwu;
+    agg.totalAwu += c.strayBalanceAwu;
     byTransition.set(key, agg);
   }
 
@@ -450,15 +386,11 @@ async function fixWorkspace(
       onlySeatId,
       onlyHomeSeatType,
       excludedSeatCount: excludeSeatIds.size,
-      // Seats on a credit-bearing tier considered, before the reconcile filter
-      // keeps only those over target.
       candidateSeatCount: candidates.length,
-      seatsWithConsumption: consumedByUserId.size,
       correctedSeatCount: corrections.length,
-      totalClawBackAwu: corrections.reduce((s, c) => s + c.clawBackAwu, 0),
+      totalEmptiedAwu: corrections.reduce((s, c) => s + c.strayBalanceAwu, 0),
       batchedAdjustCalls: batches.size,
       byTransition: Object.fromEntries(byTransition),
-      skippedAmbiguousStrayTiers: [...skippedAmbiguousStray],
       corrections,
     },
     "[StackedFix] correction plan"
@@ -475,7 +407,7 @@ async function fixWorkspace(
   let appliedSeats = 0;
   for (const batch of batches.values()) {
     const perSeatAmounts = Object.fromEntries(
-      batch.items.map((c) => [c.seatId, -c.clawBackAwu])
+      batch.items.map((c) => [c.seatId, -c.strayBalanceAwu])
     );
     const adjustRes = await paceMetronome(() =>
       adjustSeatCreditBalances({
@@ -509,7 +441,7 @@ async function fixWorkspace(
         strayType: batch.strayType,
         creditId: batch.creditId,
         seatCount: batch.items.length,
-        totalAwu: batch.items.reduce((s, c) => s + c.clawBackAwu, 0),
+        totalAwu: batch.items.reduce((s, c) => s + c.strayBalanceAwu, 0),
         timestamp: batch.timestamp.toISOString(),
       },
       "[StackedFix] applied batched correction"

--- a/front/scripts/fix_metronome_stacked_seat_credits.ts
+++ b/front/scripts/fix_metronome_stacked_seat_credits.ts
@@ -20,31 +20,30 @@
  * seat:
  *
  *  - empty every STRAY credit (seat type ≠ the seat's current tier) fully, and
- *  - carry the consumption those strays absorbed onto the HOME credit — debiting
- *    it by `min(homeBalance, Σ strayConsumed)` — so the seat nets
- *    `homeAllocation − totalConsumed` instead of a full home allowance plus the
- *    stray usage forgiven. (Without the carry a seat that spent, say, 69 AWU
- *    against its stray would end at a full home 8000 instead of 7931.)
+ *  - drive the HOME credit to `max(0, homeAllocation − currentPeriodUsage)` using
+ *    Metronome's authoritative per-user usage, so consumption that leaked onto a
+ *    stray isn't forgiven when the stray is emptied. (Without it a seat that spent
+ *    69 AWU against its stray would end at a full home 8000 instead of 7931.)
  *
- * Both figures are exact (observed per-seat balances vs. deterministic tier
- * allocations, not an ES estimate) and inherently IDEMPOTENT: a re-run reads
- * every stray at 0, so there is no stray consumption left to carry and nothing
- * is emitted. No allocation matching, no same-family ambiguity — the credit id
- * itself names each credit's tier, so a pro-vs-pro_yearly collision is never a
- * question. Deltas on the same credit batch into ONE ledger entry.
+ * Stray detection stays exact/per-credit — the credit id itself names each
+ * credit's tier, so a pro-vs-pro_yearly collision is never a question — and only
+ * the home target uses usage. Because that target is ABSOLUTE (allocation −
+ * usage) the pass is IDEMPOTENT and self-correcting: a healthy seat is a no-op
+ * (home already equals allocation − usage), and a RE-RUN even recovers a seat
+ * whose stray was already emptied by an earlier no-carry run — the missing home
+ * debit recomputes from usage alone (the stray balance is gone, but the usage
+ * figure isn't). Deltas on the same credit batch into ONE ledger entry.
  *
  * A credit id that maps to no credit-bearing tier (the contract's "Excess" or
  * pool credit, or a tier we don't recognize) is left untouched.
  *
  * IMPORTANT — read before running with --execute:
  *
- *  - Debits never drive a slice negative (a stray is debited exactly its
- *    balance; the home carry is capped at the home balance). Harmless for a seat
- *    no longer assigned to a stray tier: nothing draws from it and it expires
- *    next recurrence.
+ *  - Never adds credit and never drives a slice negative: a stray is debited
+ *    exactly its balance, and the home target floors at 0.
  *  - `--excludeSeatIds` still exists for belt-and-suspenders, but is not required
- *    for safety: an already-corrected seat reads 0 strays and is a no-op. Re-run
- *    the audit afterwards to confirm.
+ *    for safety: an already-corrected seat is a no-op. Re-run the audit
+ *    afterwards to confirm.
  *
  * NOTE: this corrects the CURRENT period only. Recurring credits are materialized
  * one period ahead, so a mid-period move also leaves a stray grant on the NEXT
@@ -72,6 +71,7 @@ import {
   getMetronomeSubscriptionSeatState,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getProductSeatTypes,
@@ -237,6 +237,24 @@ async function fixWorkspace(
     return;
   }
 
+  // Current-period per-user AWU usage (Metronome, authoritative) — drives each
+  // home credit to allocation − usage, recovering consumption that leaked onto a
+  // (possibly already-emptied) stray.
+  const usageRes = await paceMetronome(() =>
+    fetchPerUserAwuUsage({
+      workspaceId,
+      metronomeCustomerId,
+      userIds: [...currentSeatTypeBySeatId.keys()],
+    })
+  );
+  if (usageRes.isErr()) {
+    logger.error(
+      { workspaceId, err: usageRes.error.message },
+      "[StackedFix] failed to read per-user usage"
+    );
+    return;
+  }
+
   const result = await correctStackedSeatCreditsFromBalances({
     workspaceId,
     metronomeCustomerId,
@@ -244,6 +262,7 @@ async function fixWorkspace(
     contract,
     seatBalances: balancesRes.value,
     currentSeatTypeBySeatId,
+    usageBySeatId: usageRes.value,
     execute,
     logger,
     pace: paceMetronome,

--- a/front/scripts/probe_metronome_seat_balances_raw.ts
+++ b/front/scripts/probe_metronome_seat_balances_raw.ts
@@ -1,0 +1,166 @@
+/**
+ * Read-only probe: dump the RAW `/v1/contracts/seatBalances/list` response for a
+ * single seat, WITHOUT the trimming `listMetronomeSeatBalances` applies (its
+ * typed `MetronomeSeatBalance` keeps only `balances[{credit_type_id, balance,
+ * starting_balance}]` — i.e. aggregated per credit TYPE).
+ *
+ * The question we're answering: with `include_credits_and_commits: true`, does
+ * each seat entry break its balance down per individual CREDIT (a `credit_id` /
+ * `credits[]` / `commits[]` structure), or only per credit type? If per-credit
+ * rows are present we can detect a stray seat credit directly (map each credit
+ * to a seat type via `subscription_config.subscription_id`, flag any that don't
+ * match the user's current seat); if not, we stay on the aggregate-vs-allocation
+ * reconcile.
+ *
+ * Purely diagnostic — one READ call. Logs the full raw entry for the seat.
+ *
+ *   npx tsx scripts/probe_metronome_seat_balances_raw.ts --workspaceId <wId> --seatId <userId>
+ */
+import config from "@app/lib/api/config";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { makeScript } from "./helpers";
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+      describe: "sId of the workspace",
+    },
+    seatIds: {
+      type: "string",
+      demandOption: true,
+      describe:
+        "Comma-separated seat ids (= user sIds) to dump raw seat balances " +
+        "for. Pass 2+ seats on a MULTI-user workspace to prove credits[] is " +
+        "per-seat (each seat's credits[] differs and sums to that seat's own " +
+        "aggregate) rather than a workspace-wide roll-up.",
+    },
+  },
+  async ({ workspaceId, seatIds: seatIdsArg }, logger) => {
+    const seatIds = seatIdsArg
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (!config.getMetronomeApiKey()) {
+      logger.error({}, "[SeatBalancesProbe] METRONOME_API_KEY is not configured");
+      return;
+    }
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      logger.error({ workspaceId }, "[SeatBalancesProbe] workspace not found");
+      return;
+    }
+    const { metronomeCustomerId } = renderLightWorkspaceType({ workspace });
+    if (!metronomeCustomerId) {
+      logger.error(
+        { workspaceId },
+        "[SeatBalancesProbe] workspace not provisioned on Metronome"
+      );
+      return;
+    }
+    const activeSubscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    const contractId = activeSubscription?.metronomeContractId ?? null;
+    if (!contractId) {
+      logger.error(
+        { workspaceId },
+        "[SeatBalancesProbe] no active Metronome contract"
+      );
+      return;
+    }
+
+    // Log the contract's recurring credits so we can map any credit_id in the
+    // response back to a seat type via subscription_config.subscription_id.
+    const contract = await getActiveContract(workspaceId);
+    logger.info(
+      {
+        workspaceId,
+        contractId,
+        recurringCredits: (contract?.recurring_credits ?? []).map((c) => ({
+          creditId: c.id,
+          name: c.product?.name,
+          subscriptionId: c.subscription_config?.subscription_id,
+        })),
+      },
+      "[SeatBalancesProbe] recurring credits on contract (credit_id → subscription)"
+    );
+
+    // The exact request `listMetronomeSeatBalances` makes, but we keep the raw
+    // untyped response instead of narrowing to MetronomeSeatBalance. Query one
+    // seat at a time so each response is unambiguously scoped to that seat_id —
+    // this is what proves credits[] is per-seat, not a workspace roll-up: two
+    // seats on the same contract must return DIFFERENT credits[].
+    for (const seatId of seatIds) {
+      try {
+        const raw = await getMetronomeClient().post<{ data?: unknown[] }>(
+          "/v1/contracts/seatBalances/list",
+          {
+            body: {
+              customer_id: metronomeCustomerId,
+              contract_id: contractId,
+              include_credits_and_commits: true,
+              covering_date: new Date().toISOString(),
+              limit: 100,
+              seat_ids: [seatId],
+            },
+          }
+        );
+        const entries = raw.data ?? [];
+        // Compact per-seat comparison: the aggregate AWU balance (balances[])
+        // next to the per-credit breakdown (credits[]) and its sum. If credits[]
+        // is genuinely this seat's, its sum equals the seat's own aggregate; if
+        // it were a workspace roll-up, the sum would exceed one seat's total and
+        // be identical across seats.
+        for (const entry of entries) {
+          const e = entry as {
+            seat_id?: string;
+            balances?: Array<{ credit_type_id?: string; balance?: number }>;
+            credits?: Array<{ id?: string; balance?: number }>;
+          };
+          const aggregateBalance = (e.balances ?? []).reduce(
+            (sum, b) => sum + (b.balance ?? 0),
+            0
+          );
+          const creditsSum = (e.credits ?? []).reduce(
+            (sum, c) => sum + (c.balance ?? 0),
+            0
+          );
+          logger.info(
+            {
+              workspaceId,
+              seatId,
+              entrySeatId: e.seat_id,
+              aggregateBalance,
+              creditsCount: (e.credits ?? []).length,
+              creditsSum,
+              credits: (e.credits ?? []).map((c) => ({
+                id: c.id,
+                balance: c.balance,
+              })),
+            },
+            "[SeatBalancesProbe] per-seat balance breakdown"
+          );
+        }
+        // Also dump each entry in full for the raw record.
+        for (const [index, entry] of entries.entries()) {
+          logger.info(
+            { workspaceId, seatId, index, rawEntry: JSON.stringify(entry) },
+            "[SeatBalancesProbe] raw seatBalances/list entry"
+          );
+        }
+      } catch (err) {
+        logger.error(
+          { workspaceId, seatId, error: normalizeError(err).message },
+          "[SeatBalancesProbe] raw seatBalances/list request failed"
+        );
+      }
+    }
+  }
+);

--- a/front/scripts/probe_metronome_seat_balances_raw.ts
+++ b/front/scripts/probe_metronome_seat_balances_raw.ts
@@ -49,7 +49,10 @@ makeScript(
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
     if (!config.getMetronomeApiKey()) {
-      logger.error({}, "[SeatBalancesProbe] METRONOME_API_KEY is not configured");
+      logger.error(
+        {},
+        "[SeatBalancesProbe] METRONOME_API_KEY is not configured"
+      );
       return;
     }
     const workspace = await WorkspaceResource.fetchById(workspaceId);


### PR DESCRIPTION
## Description

Adds a read-only over-allocation (credit-stacking) detection pass to `front/scripts/audit_metronome_seat_state.ts`.

For every assigned seat, it compares the AWU `starting_balance` (total granted this cycle, independent of consumption) against the seat type's contract allocation (`getAwuAllocationForSeatType`), and logs any seat granted more than its allocation under `"[SeatAudit] over-allocated seats (credit stacking)"` with the affected seat count, total over-granted AWU, and per-seat detail.

Context: when a member changes seat type (e.g. pro→max) during a seat-sync failure/retry storm, the seat assignment can converge on the new type while the origin (pro) seat credit is never emptied — leaving the pro 8000 grant stacked on top of the max 40000 (`starting_balance` 48000). Once the seat has converged, `syncSeatCount`'s `emptyOriginSeatCreditsForTransfers` sees no transfer candidate and can no longer self-heal it, so the stacked credit is invisible to the existing seat-assignment audit. Using `starting_balance` (not the live balance) makes detection exact regardless of how much the user has already consumed.

## Tests

Manual: ran against the affected Enterprise workspace in production (read-only). The existing seat-assignment diff showed a fully-converged workspace (0 stale / 0 missing across pro/max/free), confirming the stacking is only visible at the credit-ledger level — which this new pass surfaces.

No automated tests: this is an operator diagnostic script (`makeScript`), consistent with the rest of the file. It makes only READ calls to Metronome and the DB; there is nothing to `--execute`.

## Risk

Very low. Read-only additive change to a diagnostic script; no production code path imports it. Metronome reads reuse the existing rate-limited (`paceMetronome`) balance fetch already performed by the audit — no additional API calls. Trivially safe to roll back.

## Deploy Plan

No deploy required — operator script run on demand via `npx tsx front/scripts/audit_metronome_seat_state.ts --workspaceId <wId>`. Merges with the next `front` release.