### PR TITLE
[front] feat: add max seats column to poke switch-contract form

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -294,6 +294,7 @@ export default function SwitchContractDialog({
       {
         selected: boolean;
         minSeats: number;
+        maxSeats?: number;
         rate: number;
         paymentSchedule: { frequency: "one_time" };
       }
@@ -306,6 +307,7 @@ export default function SwitchContractDialog({
       next[seat.seatType] = {
         selected: seat.entitled,
         minSeats: 0,
+        maxSeats: undefined,
         rate,
         paymentSchedule: { frequency: "one_time" },
       };
@@ -610,6 +612,10 @@ export default function SwitchContractDialog({
         const minSeats = Number.isFinite(entry?.minSeats)
           ? (entry?.minSeats ?? 0)
           : 0;
+        const maxSeats =
+          typeof entry?.maxSeats === "number" && Number.isFinite(entry.maxSeats)
+            ? entry.maxSeats
+            : undefined;
         const rate = Number.isFinite(entry?.rate) ? (entry?.rate ?? 0) : 0;
         // If the operator left commitment price blank, default to minSeats * rate
         // (the list value of the committed seats).
@@ -637,6 +643,7 @@ export default function SwitchContractDialog({
         seats[seatType] = {
           selected,
           minSeats,
+          maxSeats,
           rate,
           commitmentPrice,
           paymentSchedule,
@@ -1048,7 +1055,8 @@ export default function SwitchContractDialog({
                         {/* Header row */}
                         <div className="flex items-center gap-3 pb-1 text-xs font-medium text-muted-foreground">
                           <div className="w-32 shrink-0" />
-                          <div className="flex-1">Min seats</div>
+                          <div className="flex-1">Commitment</div>
+                          <div className="flex-1">Max</div>
                           <div className="flex-1">
                             Seat rate
                             {resolvedCurrency
@@ -1109,6 +1117,17 @@ export default function SwitchContractDialog({
                                   hideLabel
                                   type="number"
                                   placeholder="0"
+                                  disabled={!isSelected}
+                                />
+                              </div>
+                              <div className="flex-1">
+                                <InputField
+                                  control={form.control}
+                                  name={`seats.${seatType}.maxSeats`}
+                                  hideLabel
+                                  type="number"
+                                  min="1"
+                                  placeholder="∞"
                                   disabled={!isSelected}
                                 />
                               </div>

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -479,11 +479,13 @@ async function persistSeatFloors(
     if (!isMembershipSeatType(seatType)) {
       continue;
     }
-    if (seat.selected && seat.minSeats > 0) {
+    const maxSeats = seat.maxSeats ?? null;
+    if (seat.selected && (seat.minSeats > 0 || maxSeats !== null)) {
       const result = await WorkspaceSeatLimitResource.upsert({
         workspace,
         seatType,
         minSeats: seat.minSeats,
+        maxSeats,
       });
       if (result.isErr()) {
         return new Err(

--- a/front/types/poke/switch_contract.ts
+++ b/front/types/poke/switch_contract.ts
@@ -52,12 +52,13 @@ const recurringFreeCreditSchema = z
   .min(1, "Recurring free credit must be at least 1 credit");
 
 // Per-seat-type settings for a contract switch, keyed by seat type (see
-// `SwitchContractBodySchema.seats`). `minSeats` is the billing floor
-// persisted to `workspace_seat_limits`. `rate` is the per-seat rate in the
-// currency's MAJOR units (dollars / euros); the server converts it to
-// Metronome's fiat unit via `metronomeAmount`. When `commitmentPrice` is set
-// (also in major units), a contract prepaid commit is created granting
-// `minSeats * rate` of contract credit, invoiced at `commitmentPrice`.
+// `SwitchContractBodySchema.seats`). `minSeats` is the billing floor and
+// `maxSeats` the hard assignment cap (omitted = no cap), both persisted to
+// `workspace_seat_limits`. `rate` is the per-seat rate in the currency's MAJOR
+// units (dollars / euros); the server converts it to Metronome's fiat unit via
+// `metronomeAmount`. When `commitmentPrice` is set (also in major units), a
+// contract prepaid commit is created granting `minSeats * rate` of contract
+// credit, invoiced at `commitmentPrice`.
 const seatEntrySchema = z.object({
   // Whether the seat is entitled on the new contract. `true` (the default,
   // for backward compatibility) entitles and configures the seat; `false`
@@ -65,6 +66,7 @@ const seatEntrySchema = z.object({
   // every known seat so deselections can be turned into disable overrides.
   selected: z.boolean().default(true),
   minSeats: z.number().int().min(0, "Min seats must be ≥ 0"),
+  maxSeats: z.number().int().min(1, "Max seats must be ≥ 1").optional(),
   rate: z.number().min(0, "Rate must be ≥ 0"),
   commitmentPrice: z.number().min(0, "Commitment price must be ≥ 0").optional(),
   paymentSchedule: paymentScheduleSchema,

--- a/front/types/poke/switch_contract.ts
+++ b/front/types/poke/switch_contract.ts
@@ -59,18 +59,31 @@ const recurringFreeCreditSchema = z
 // `metronomeAmount`. When `commitmentPrice` is set (also in major units), a
 // contract prepaid commit is created granting `minSeats * rate` of contract
 // credit, invoiced at `commitmentPrice`.
-const seatEntrySchema = z.object({
-  // Whether the seat is entitled on the new contract. `true` (the default,
-  // for backward compatibility) entitles and configures the seat; `false`
-  // disables a seat the package would otherwise sell. The dialog submits
-  // every known seat so deselections can be turned into disable overrides.
-  selected: z.boolean().default(true),
-  minSeats: z.number().int().min(0, "Min seats must be ≥ 0"),
-  maxSeats: z.number().int().min(1, "Max seats must be ≥ 1").optional(),
-  rate: z.number().min(0, "Rate must be ≥ 0"),
-  commitmentPrice: z.number().min(0, "Commitment price must be ≥ 0").optional(),
-  paymentSchedule: paymentScheduleSchema,
-});
+const seatEntrySchema = z
+  .object({
+    // Whether the seat is entitled on the new contract. `true` (the default,
+    // for backward compatibility) entitles and configures the seat; `false`
+    // disables a seat the package would otherwise sell. The dialog submits
+    // every known seat so deselections can be turned into disable overrides.
+    selected: z.boolean().default(true),
+    minSeats: z.number().int().min(0, "Min seats must be ≥ 0"),
+    maxSeats: z.number().int().min(1, "Max seats must be ≥ 1").optional(),
+    rate: z.number().min(0, "Rate must be ≥ 0"),
+    commitmentPrice: z
+      .number()
+      .min(0, "Commitment price must be ≥ 0")
+      .optional(),
+    paymentSchedule: paymentScheduleSchema,
+  })
+  // The cap can't be below the commitment floor. Enforced here so the form and
+  // endpoint reject it upfront rather than failing later at the resource layer.
+  .refine(
+    ({ minSeats, maxSeats }) => maxSeats === undefined || maxSeats >= minSeats,
+    {
+      path: ["maxSeats"],
+      message: "Max seats must be greater than or equal to commitment",
+    }
+  );
 
 export const SwitchContractBodySchema = z.object({
   planCode: z.string().min(1, "Required"),


### PR DESCRIPTION
## Description

Adds a **Max** (hard assignment cap) column beside the seat commitment floor in the poke **Switch contract** dialog, and renames the **Min seats** header to **Commitment** to match the existing "Seat commitments and limit" modal.

`maxSeats` is threaded through `SwitchContractBodySchema` (new optional field) and persisted server-side via `WorkspaceSeatLimitResource.upsert`, so it writes the same open-ended `workspace_seat_limits` row that seat assignment already reads. The persist condition now also fires when only a cap is set (`minSeats === 0 && maxSeats != null`) so a max-only cap isn't dropped.

No new enforcement logic: the cap is already honored on assignment — `updateMembershipSeatAndTrack` hard-blocks a seat-type change once `currentCount >= maxSeats` (`seat_limit_reached` → 400), and new-member/invite resolution falls back to free/none rather than exceeding the cap.

## Risk

Low. Poke-only admin form. Additive optional schema field (no breaking change to the private API). Existing `maxSeats >= minSeats` validation in `WorkspaceSeatLimitResource` surfaces as a switch-contract error if violated.

## Tests

- `npx tsgo --noEmit` passes.
- `biome check --changed` clean.
- Manual verification of enforcement paths (existing behavior unchanged).

## Deploy Plan

Standard deploy. No migration, no config, no feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)