### PR TITLE
Replace heroicons InformationCircleIcon with Sparkle InfoCircle

### DIFF
--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -10,12 +10,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Icon,
+  InfoCircle,
   Input,
   Label,
   SearchInput,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { InformationCircleIcon } from "@heroicons/react/20/solid";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, { useMemo, useState } from "react";
 import { useController } from "react-hook-form";
@@ -73,7 +73,7 @@ function BooleanConfigurationInput({
           <Tooltip
             trigger={
               <Icon
-                visual={InformationCircleIcon}
+                visual={InfoCircle}
                 size="xs"
                 className="cursor-help text-primary-400 hover:text-primary-600"
               />
@@ -133,7 +133,7 @@ function NumberConfigurationInput({
           <Tooltip
             trigger={
               <Icon
-                visual={InformationCircleIcon}
+                visual={InfoCircle}
                 size="xs"
                 className="cursor-help text-primary-400 hover:text-primary-600"
               />
@@ -200,7 +200,7 @@ function StringConfigurationInput({
           <Tooltip
             trigger={
               <Icon
-                visual={InformationCircleIcon}
+                visual={InfoCircle}
                 size="xs"
                 className="cursor-help text-primary-400 hover:text-primary-600"
               />
@@ -278,7 +278,7 @@ function EnumConfigurationInput({
             <Tooltip
               trigger={
                 <Icon
-                  visual={InformationCircleIcon}
+                  visual={InfoCircle}
                   size="xs"
                   className="cursor-help text-primary-400 hover:text-primary-600"
                 />

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -12,6 +12,7 @@ import {
   Checkbox,
   ContentMessage,
   Icon,
+  InfoCircle,
   LinkExternal01,
   Lock01,
   SearchInput,
@@ -26,7 +27,6 @@ import {
   SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
-import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { useController } from "react-hook-form";
@@ -366,7 +366,7 @@ export function SlackSettingsSheet({
                 size="md"
                 variant="warning"
                 title="Admin Access Required"
-                icon={InformationCircleIcon}
+                icon={InfoCircle}
               >
                 <p>
                   Only administrators can enable default agents for specific

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -2,13 +2,12 @@ import { useRunBlock } from "@app/lib/swr/apps";
 import type { AppType, SpecificationBlockType } from "@app/types/app";
 import type { TraceType } from "@app/types/run";
 import type { WorkspaceType } from "@app/types/user";
-import { Button, Clipboard, Hoverable } from "@dust-tt/sparkle";
+import { Button, Clipboard, Hoverable, InfoCircle } from "@dust-tt/sparkle";
 import {
   CheckCircleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   ExclamationCircleIcon,
-  InformationCircleIcon,
 } from "@heroicons/react/20/solid";
 import { useEffect, useState } from "react";
 
@@ -301,7 +300,7 @@ function InnerLogs({ trace }: { trace: TraceType }) {
   return (
     <div className="flex flex-row">
       <div className="flex flex-initial">
-        <InformationCircleIcon className="mt-0.5 h-4 w-4 text-primary-500" />
+        <InfoCircle className="mt-0.5 h-4 w-4 text-primary-500" />
       </div>
       <div className="flex flex-1 font-mono">
         <ValueViewer value={logs} topLevel={true} k={null} block={null} />

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -70,6 +70,7 @@ import {
   DialogTrigger,
   Hoverable,
   Icon,
+  InfoCircle,
   Lock01,
   Page,
   Sheet,
@@ -81,7 +82,6 @@ import {
   Spinner,
   Trash01,
 } from "@dust-tt/sparkle";
-import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type React from "react";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
@@ -380,7 +380,7 @@ function UpdateConnectionOAuthModal({
                 size="md"
                 variant="warning"
                 title="Migration required"
-                icon={InformationCircleIcon}
+                icon={InfoCircle}
               >
                 You are using a legacy way to connect your Slack workspace to
                 Dust. Starting December 2025, all Slack connections require
@@ -406,7 +406,7 @@ function UpdateConnectionOAuthModal({
           {isDataSourceOwner && (
             <div className="mb-4 mt-8 w-full rounded-lg bg-info-50 p-3">
               <div className="flex items-center gap-2 font-medium text-info-800">
-                <Icon visual={InformationCircleIcon} />
+                <Icon visual={InfoCircle} />
                 Important
               </div>
               <div className="copy-sm p-4 text-info-900">
@@ -462,7 +462,7 @@ function UpdateConnectionOAuthModal({
               size="md"
               variant="warning"
               title="You are not the owner of this connection."
-              icon={InformationCircleIcon}
+              icon={InfoCircle}
             >
               Editing permission rights with a different account will likely
               break the existing data structure in Dust and Agents using them.
@@ -507,7 +507,7 @@ function UpdateConnectionOAuthModal({
                 <ContentMessage
                   title="Editing permissions is temporarily disabled"
                   variant="info"
-                  icon={InformationCircleIcon}
+                  icon={InfoCircle}
                 >
                   <ReactMarkdown>
                     {permissionsConfigurable.placeholder ?? ""}
@@ -626,7 +626,7 @@ function DataSourceDeletionModal({
           {isDeletable ? (
             <div className="mb-4 mt-8 w-full rounded-lg bg-info-50 p-3">
               <div className="flex items-center gap-2 font-medium text-info-800">
-                <Icon visual={InformationCircleIcon} />
+                <Icon visual={InfoCircle} />
                 Important
               </div>
               <div className="p-4 text-sm text-info-900">
@@ -638,7 +638,7 @@ function DataSourceDeletionModal({
               className="mb-4 mt-8"
               title="Connection removal requires support"
               variant="warning"
-              icon={InformationCircleIcon}
+              icon={InfoCircle}
             >
               Removing a connection permanently deletes its synced data and may
               break agents or spaces that rely on it. Contact{" "}
@@ -1052,7 +1052,7 @@ export function ConnectorPermissionsModal({
                     <ContentMessage
                       title="Editing permissions is temporarily disabled"
                       variant="info"
-                      icon={InformationCircleIcon}
+                      icon={InfoCircle}
                     >
                       <ReactMarkdown>
                         {permissionsConfigurable.placeholder ?? ""}

--- a/front/components/workspace/ModelTiersInfoModal.tsx
+++ b/front/components/workspace/ModelTiersInfoModal.tsx
@@ -16,9 +16,9 @@ import {
   DialogHeader,
   DialogTitle,
   Icon,
+  InfoCircle,
   Spinner,
 } from "@dust-tt/sparkle";
-import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
@@ -206,7 +206,7 @@ export function ModelTiersInfoButton({ className }: ModelTiersInfoButtonProps) {
       <Button
         variant="ghost"
         size="xs"
-        icon={InformationCircleIcon}
+        icon={InfoCircle}
         tooltip="How model tiers work"
         className={className}
         onClick={(event) => {


### PR DESCRIPTION
## Description

Replace heroicons' `InformationCircleIcon` with Sparkle's `InfoCircle` everywhere it's used, for design-system consistency.

## Tests

## Risk

Low — pure icon swap, no behavior change.

## Deploy Plan

Front