### PR TITLE
Add Frame v2 author permissions

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -55,7 +55,7 @@ Functions are self-contained Bun bundles in `$DUST_FUNCTIONS_DIR`, named
 - `dsbx function get <name>` — prints `{name, description, userIdentity,
   input_schema, output_schema}` (JSON Schema).
 
-Functions may require a current member of their Pod's workspace:
+Set `schema.userIdentity` when a function needs a caller identity:
 
 ```ts
 export const schema = {
@@ -65,10 +65,21 @@ export const schema = {
 };
 ```
 
-Omitting `userIdentity` keeps the function callable without a user.
-Use `interactive_workspace_user_required` when the function must be called
-directly from a logged-in member's live Dust session, rather than by an agent,
-schedule, or API client acting on that member's behalf.
+- `optional` (or omit the field): no user is required.
+- `workspace_user_required`: require a current workspace member.
+- `interactive_workspace_user_required`: require a workspace member calling
+  directly from a live Dust session, rather than through an agent, schedule, or
+  API client acting on that member's behalf.
+- `pod_member_required`: require membership in the owning Pod. Retained for
+  legacy Pod Functions.
+- `frame_author_required`: for Frame v2 functions, require write access to the
+  Frame's source files.
+
+Adding a policy requires a runner-first rollout. Publish a `dsbx` release that
+parses the policy, then update `DSBX_CLI_VERSION` in
+`front/lib/api/sandbox/image/registry.ts` before exposing the policy to Frame
+authors. During a mixed-version rollout, servers deny unknown persisted
+policies, so invocation fails closed until all revisions understand the policy.
 
 ### Unprivileged execution
 

--- a/cli/dust-sandbox/functions-runner/fixtures/frame-author.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/frame-author.ts
@@ -1,0 +1,3 @@
+export const schema = {
+  userIdentity: "frame_author_required",
+};

--- a/cli/dust-sandbox/functions-runner/schema.test.ts
+++ b/cli/dust-sandbox/functions-runner/schema.test.ts
@@ -56,6 +56,11 @@ describe("getFunctionSchema", () => {
     expect(s.userIdentity).toBe("pod_member_required");
   });
 
+  test("accepts the frame_author_required user identity policy", async () => {
+    const s = await getFunctionSchema(fx("frame-author.ts"));
+    expect(s.userIdentity).toBe("frame_author_required");
+  });
+
   test("rejects an unknown user identity policy", async () => {
     await expect(
       getFunctionSchema(fx("invalid-user-identity.ts"))

--- a/cli/dust-sandbox/functions-runner/schema.ts
+++ b/cli/dust-sandbox/functions-runner/schema.ts
@@ -10,7 +10,8 @@ export interface FunctionSchema {
     | "optional"
     | "workspace_user_required"
     | "interactive_workspace_user_required"
-    | "pod_member_required";
+    | "pod_member_required"
+    | "frame_author_required";
   input_schema: Record<string, unknown> | null;
   output_schema: Record<string, unknown> | null;
 }
@@ -24,13 +25,15 @@ function parseUserIdentityPolicy(
   if (
     value === "workspace_user_required" ||
     value === "interactive_workspace_user_required" ||
-    value === "pod_member_required"
+    value === "pod_member_required" ||
+    value === "frame_author_required"
   ) {
     return value;
   }
   throw new Error(
     "`schema.userIdentity` must be `optional`, `workspace_user_required`, " +
-      "`interactive_workspace_user_required`, or `pod_member_required`"
+      "`interactive_workspace_user_required`, `pod_member_required`, or " +
+      "`frame_author_required`"
   );
 }
 

--- a/front-api/routes/w/[wId]/frames/[frameId]/index.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/index.ts
@@ -2,10 +2,12 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import functions from "./functions";
 import invocations from "./invocations";
+import permissions from "./permissions";
 
 const app = workspaceApp();
 
 app.route("/functions", functions);
 app.route("/invocations", invocations);
+app.route("/permissions", permissions);
 
 export default app;

--- a/front-api/routes/w/[wId]/frames/[frameId]/permissions.test.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/permissions.test.ts
@@ -1,0 +1,82 @@
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/w/:wId/frames/:frameId/permissions", () => {
+  it("returns whether the current user can modify the Frame v2 source", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "frames_v2");
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/${frame.sId}/permissions`
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ isFrameAuthor: true });
+  });
+
+  it("fails closed when the Frame v2 source has no writable scoped path", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "frames_v2");
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/${frame.sId}/permissions`
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ isFrameAuthor: false });
+  });
+
+  it("does not expose the permissions contract for a legacy Frame", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "frames_v2");
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "legacy.tsx",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/frames/${frame.sId}/permissions`
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/w/[wId]/frames/[frameId]/permissions.ts
+++ b/front-api/routes/w/[wId]/frames/[frameId]/permissions.ts
@@ -1,0 +1,34 @@
+import { canWriteFrameV2Source } from "@app/lib/api/frames/permissions";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { GetFramePermissionsResponseBody } from "@app/types/api/frame_permissions";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  frameId: z.string(),
+});
+
+// Mounted at /api/w/:wId/frames/:frameId/permissions.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { frameId } = ctx.req.valid("param");
+  const frame = await FileResource.fetchById(auth, frameId);
+
+  if (!frame?.isFrameV2) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "Frame not found." },
+    });
+  }
+
+  return ctx.json<GetFramePermissionsResponseBody>({
+    isFrameAuthor: await canWriteFrameV2Source(auth, frame),
+  });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -21,6 +21,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type {
   SandboxFunctionInvocationEvent,
   SandboxFunctionUserIdentityPolicy,
@@ -31,6 +32,10 @@ import {
   frameV2ContentType,
   sandboxFunctionContentType,
 } from "@app/types/files";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -168,10 +173,12 @@ async function createFramePublicationFunction({
   adminAuth,
   frame,
   publicationId,
+  userIdentity = "optional",
 }: {
   adminAuth: Authenticator;
   frame: Awaited<ReturnType<typeof FileFactory.create>>;
   publicationId: string;
+  userIdentity?: SandboxFunctionUserIdentityPolicy;
 }) {
   await withTransaction((transaction) =>
     SandboxFunctionResource.createForFramePublication(
@@ -183,7 +190,7 @@ async function createFramePublicationFunction({
           {
             name: "run-function",
             description: "Run the Frame function.",
-            userIdentity: "optional",
+            userIdentity,
             executionMode: "durable",
             defaultStake: "low",
             bundleCode: "export default () => ({ ok: true });",
@@ -211,10 +218,16 @@ async function setupFrameV2Function({
   shareScope = "workspace_and_emails",
   featureFlag = "frames_v2",
   standalone = false,
+  userIdentity = "optional",
+  addCallerToSpace = false,
+  withSourcePath = userIdentity === "frame_author_required",
 }: {
   shareScope?: FileShareScope;
   featureFlag?: "frames_v2" | "sandbox_functions";
   standalone?: boolean;
+  userIdentity?: SandboxFunctionUserIdentityPolicy;
+  addCallerToSpace?: boolean;
+  withSourcePath?: boolean;
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
     role: "admin",
@@ -228,24 +241,43 @@ async function setupFrameV2Function({
       })
     : null;
   const publicationId = "publication-1";
+  const sourceMountPath = conversation
+    ? `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}App/${FRAME_MANIFEST_FILE}`
+    : `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: space.sId,
+      })}App/${FRAME_MANIFEST_FILE}`;
+  // A ready conversation file normally claims a source mount automatically. Omit its conversation
+  // scope only for the missing-source fixture so the Resource lifecycle leaves it unmounted.
+  const sourceScopeMetadata = conversation
+    ? userIdentity === "frame_author_required" && !withSourcePath
+      ? {}
+      : { conversationId: conversation.sId }
+    : { spaceId: space.sId };
   const frame = await FileFactory.create(adminAuth, null, {
     contentType: frameV2ContentType,
-    fileName: "app.frame.json",
+    fileName: FRAME_MANIFEST_FILE,
     fileSize: 100,
     status: "ready",
-    useCase: "conversation",
+    useCase:
+      userIdentity === "frame_author_required" && !standalone
+        ? "project_context"
+        : "conversation",
     useCaseMetadata: {
-      ...(conversation
-        ? { conversationId: conversation.sId }
-        : { spaceId: space.sId }),
+      ...sourceScopeMetadata,
       activePublicationId: publicationId,
     },
+    mountFilePath: withSourcePath ? sourceMountPath : null,
   });
   await frame.setShareScope(adminAuth, shareScope);
   const sandboxFunction = await createFramePublicationFunction({
     adminAuth,
     frame,
     publicationId,
+    userIdentity,
   });
 
   // The last mock request owns the route session.
@@ -253,6 +285,16 @@ async function setupFrameV2Function({
     role: "user",
     workspace,
   });
+  if (addCallerToSpace) {
+    const [memberGroup] = await space.fetchRegularAutoGroups(adminAuth);
+    if (!memberGroup) {
+      throw new Error("Expected the project member group to exist.");
+    }
+    const addMemberResult = await memberGroup.dangerouslyAddMember(adminAuth, {
+      user: user.toJSON(),
+    });
+    expect(addMemberResult.isOk()).toBe(true);
+  }
   return {
     adminAuth,
     frame,
@@ -545,6 +587,73 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         status: "created",
       },
     });
+  });
+
+  it("allows a standalone conversation author to invoke a frame-author-required function", async () => {
+    const { workspace, frame } = await setupFrameV2Function({
+      standalone: true,
+      userIdentity: "frame_author_required",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+
+    expect(response.status).toBe(201);
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("allows a Pod source writer to invoke a frame-author-required function", async () => {
+    const { workspace, frame } = await setupFrameV2Function({
+      addCallerToSpace: true,
+      userIdentity: "frame_author_required",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+
+    expect(response.status).toBe(201);
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("denies a readable Pod user who cannot write a frame-author-required function's source", async () => {
+    const { adminAuth, workspace, frame, space } = await setupFrameV2Function({
+      userIdentity: "frame_author_required",
+    });
+    const globalGroupResult =
+      await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+    expect(globalGroupResult.isOk()).toBe(true);
+    if (globalGroupResult.isOk()) {
+      await SpaceFactory.attachGroup(space, globalGroupResult.value);
+    }
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+
+    expect(response.status).toBe(401);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("denies frame-author-required invocation when the source path is missing", async () => {
+    const { workspace, frame, sandboxFunction } = await setupFrameV2Function({
+      standalone: true,
+      userIdentity: "frame_author_required",
+      withSourcePath: false,
+    });
+    expect(sandboxFunction.userIdentity).toBe("frame_author_required");
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: `${frame.sId}/run-function`,
+    });
+
+    expect(response.status).toBe(401);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
   });
 
   it("keeps an in-flight Frame invocation streamable after a new publication activates", async () => {

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -54,6 +54,7 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: true,
         isWorkspaceMember: true,
+        isFrameAuthor: false,
         isPodEditor: false,
         isPodMember: false,
         user,
@@ -72,6 +73,7 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: true,
         isWorkspaceMember: true,
+        isFrameAuthor: false,
         isPodEditor: true,
         isPodMember: false,
         user,
@@ -90,6 +92,7 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: true,
         isWorkspaceMember: true,
+        isFrameAuthor: false,
         isPodEditor: false,
         isPodMember: true,
         user,
@@ -108,6 +111,7 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: false,
         isWorkspaceMember: false,
+        isFrameAuthor: false,
         isPodEditor: false,
         isPodMember: false,
         user: null,
@@ -123,6 +127,7 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: true,
         isWorkspaceMember: true,
+        isFrameAuthor: false,
         isPodEditor: false,
         isPodMember: false,
         user,
@@ -161,6 +166,116 @@ describe("getSandboxFunctionInvocationAccessError", () => {
 });
 
 describe("VisualizationActionIframe", () => {
+  it("resolves Frame author status only when the iframe requests identity", async () => {
+    mocks.clientFetch.mockResolvedValue(
+      new Response(JSON.stringify({ isFrameAuthor: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const { container } = render(
+      createElement(VisualizationActionIframe, {
+        agentConfigurationId: null,
+        canInvokeFunctions: true,
+        conversationId: null,
+        frameId: "fil_frame",
+        scopedUserIdentity,
+        viewer: null,
+        visualization: {
+          code: "export default function Frame() {}",
+          complete: true,
+          identifier: "viz-fil_frame",
+        },
+        vizUrl: "https://viz.dust.tt",
+        workspaceId: "w_current",
+      })
+    );
+    const iframe = container.querySelector("iframe");
+    if (!iframe?.contentWindow) {
+      throw new Error("Expected the visualization iframe to be mounted.");
+    }
+    const postMessage = vi
+      .spyOn(iframe.contentWindow, "postMessage")
+      .mockImplementation(() => {});
+
+    expect(mocks.clientFetch).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframe.contentWindow,
+        data: {
+          command: "getUserIdentity",
+          identifier: "viz-fil_frame",
+          messageUniqueId: "message-identity",
+          params: null,
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(mocks.clientFetch).toHaveBeenCalledWith(
+        "/api/w/w_current/frames/fil_frame/permissions"
+      );
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({ isFrameAuthor: true }),
+        }),
+        { targetOrigin: "*" }
+      );
+    });
+  });
+
+  it("fails Frame author status closed when permission lookup fails", async () => {
+    mocks.clientFetch.mockResolvedValue(new Response(null, { status: 500 }));
+
+    const { container } = render(
+      createElement(VisualizationActionIframe, {
+        agentConfigurationId: null,
+        canInvokeFunctions: true,
+        conversationId: null,
+        frameId: "fil_frame",
+        scopedUserIdentity,
+        viewer: null,
+        visualization: {
+          code: "export default function Frame() {}",
+          complete: true,
+          identifier: "viz-fil_frame",
+        },
+        vizUrl: "https://viz.dust.tt",
+        workspaceId: "w_current",
+      })
+    );
+    const iframe = container.querySelector("iframe");
+    if (!iframe?.contentWindow) {
+      throw new Error("Expected the visualization iframe to be mounted.");
+    }
+    const postMessage = vi
+      .spyOn(iframe.contentWindow, "postMessage")
+      .mockImplementation(() => {});
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframe.contentWindow,
+        data: {
+          command: "getUserIdentity",
+          identifier: "viz-fil_frame",
+          messageUniqueId: "message-identity",
+          params: null,
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({ isFrameAuthor: false }),
+        }),
+        { targetOrigin: "*" }
+      );
+    });
+  });
+
   it("routes a Frames v2 call through the rendered Frame identity", async () => {
     mocks.clientFetch.mockResolvedValue(
       new Response(

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -12,6 +12,7 @@ import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { FrameFunctionReferenceScope } from "@app/types/api/frame_function_reference";
 import { resolveFrameFunctionReference } from "@app/types/api/frame_function_reference";
+import type { GetFramePermissionsResponseBody } from "@app/types/api/frame_permissions";
 import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -95,6 +96,7 @@ export function getFrameRuntimeAccess(
       ? {
           isAuthenticated: true,
           isWorkspaceMember: true,
+          isFrameAuthor: false,
           isPodEditor: scopedUserIdentity.isPodEditor ?? false,
           isPodMember: scopedUserIdentity.isPodMember ?? false,
           user: scopedUserIdentity.user,
@@ -102,6 +104,7 @@ export function getFrameRuntimeAccess(
       : {
           isAuthenticated: false,
           isWorkspaceMember: false,
+          isFrameAuthor: false,
           isPodEditor: false,
           isPodMember: false,
           user: null,
@@ -131,6 +134,37 @@ export function getSandboxFunctionInvocationAccessError(
         code: "not_supported",
         message: "Function calls are not available in this Frame.",
       };
+}
+
+async function resolveFrameUserIdentity({
+  frameId,
+  userIdentity,
+  workspaceId,
+}: {
+  frameId: string | undefined;
+  userIdentity: UserIdentityState;
+  workspaceId: string;
+}): Promise<UserIdentityState> {
+  if (!frameId || !userIdentity.isAuthenticated) {
+    return userIdentity;
+  }
+
+  try {
+    const response = await clientFetch(
+      `/api/w/${workspaceId}/frames/${encodeURIComponent(frameId)}/permissions`
+    );
+    if (!response.ok) {
+      return userIdentity;
+    }
+
+    const permissions: GetFramePermissionsResponseBody = await response.json();
+    return {
+      ...userIdentity,
+      isFrameAuthor: permissions.isFrameAuthor === true,
+    };
+  } catch {
+    return userIdentity;
+  }
 }
 
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
@@ -422,7 +456,7 @@ function useVisualizationDataHandler({
   setErrorMessage,
   visualization,
   vizIframeRef,
-  userIdentity,
+  resolveUserIdentity,
   waitForSandboxFunctionInvocationResult,
   workspaceId,
 }: {
@@ -441,7 +475,7 @@ function useVisualizationDataHandler({
   setErrorMessage: (v: SetStateAction<string | null>) => void;
   visualization: Visualization;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
-  userIdentity: UserIdentityState;
+  resolveUserIdentity: () => Promise<UserIdentityState>;
   waitForSandboxFunctionInvocationResult: (params: {
     functionId: string;
     invocationId: string;
@@ -559,7 +593,7 @@ function useVisualizationDataHandler({
         }
 
         case "getUserIdentity":
-          sendResponseToIframe(data, userIdentity, event.source);
+          sendResponseToIframe(data, await resolveUserIdentity(), event.source);
           break;
 
         case "getFile":
@@ -637,7 +671,7 @@ function useVisualizationDataHandler({
     setCodeDrawerOpened,
     visualization.identifier,
     vizIframeRef,
-    userIdentity,
+    resolveUserIdentity,
     sendNotification,
     waitForSandboxFunctionInvocationResult,
     workspaceId,
@@ -847,6 +881,16 @@ export const VisualizationActionIframe = forwardRef<
     );
   }, [canInvokeFunctions, scopedUserIdentity, workspaceId]);
 
+  const resolveUserIdentity = useCallback(
+    () =>
+      resolveFrameUserIdentity({
+        frameId: props.frameId,
+        userIdentity: runtimeAccess.userIdentity,
+        workspaceId,
+      }),
+    [props.frameId, runtimeAccess.userIdentity, workspaceId]
+  );
+
   const isPublic = visualization.accessToken !== undefined;
 
   const getFileBlob = useCallback(
@@ -974,7 +1018,7 @@ export const VisualizationActionIframe = forwardRef<
     setErrorMessage,
     visualization,
     vizIframeRef,
-    userIdentity: runtimeAccess.userIdentity,
+    resolveUserIdentity,
     waitForSandboxFunctionInvocationResult,
     workspaceId,
   });

--- a/front/components/pod/PodFileTabContent.tsx
+++ b/front/components/pod/PodFileTabContent.tsx
@@ -3,6 +3,7 @@ import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization
 import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileMetadataFromPath } from "@app/lib/swr/files";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import {
   isInteractiveContentType,
@@ -83,7 +84,7 @@ function PodFileTabVisualization({
   framePath: string;
   vizUrl: string | null;
 }) {
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, fileContentType, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath,
@@ -116,6 +117,11 @@ function PodFileTabVisualization({
           identifier={`viz-frame-tab-${fileId}`}
           isPodEditor={podInfo.isEditor}
           isPodMember={podInfo.isMember}
+          frameId={
+            getFrameFunctionReferenceKind(fileContentType) === "v2"
+              ? fileId
+              : undefined
+          }
           framePath={framePath}
         />
       </div>

--- a/front/components/pod/PodFrameVisualization.test.tsx
+++ b/front/components/pod/PodFrameVisualization.test.tsx
@@ -1,0 +1,46 @@
+import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization";
+import type { LightWorkspaceType } from "@app/types/user";
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  iframe: vi.fn((_props: unknown) => null),
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe",
+  async () => {
+    const { forwardRef } =
+      await vi.importActual<typeof import("react")>("react");
+    return {
+      AuthenticatedVisualizationActionIframe: forwardRef((props, _ref) => {
+        mocks.iframe(props);
+        return null;
+      }),
+    };
+  }
+);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PodFrameVisualization", () => {
+  it("passes the stable Frame v2 identity to the iframe host", () => {
+    render(
+      <PodFrameVisualization
+        owner={{ sId: "w_current" } as LightWorkspaceType}
+        spaceId="spc_pod"
+        fileContent="export default function Frame() {}"
+        vizUrl="https://viz.dust.tt"
+        identifier="viz-frame"
+        frameId="fil_frame"
+        framePath="pod-spc_pod/Admin/Admin.frame.json"
+      />
+    );
+
+    expect(mocks.iframe).toHaveBeenCalledWith(
+      expect.objectContaining({ frameId: "fil_frame" })
+    );
+  });
+});

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -10,6 +10,8 @@ interface PodFrameVisualizationProps {
   identifier: string;
   isPodEditor?: boolean;
   isPodMember?: boolean;
+  /** Stable FileResource identity for Frame v2; omitted for legacy Frames. */
+  frameId?: string;
   /** Scoped path of the Frame, so one inside an app folder can call its functions by bare name. */
   framePath?: string | null;
 }
@@ -26,6 +28,7 @@ export function PodFrameVisualization({
   identifier,
   isPodEditor,
   isPodMember,
+  frameId,
   framePath,
 }: PodFrameVisualizationProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -43,6 +46,7 @@ export function PodFrameVisualization({
       conversationId={null}
       spaceId={spaceId}
       framePath={framePath}
+      frameId={frameId}
       isInDrawer={true}
       isPodEditor={isPodEditor}
       isPodMember={isPodMember}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -4,6 +4,7 @@ import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableCo
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import logger from "@app/logger/logger";
+import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -143,7 +144,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     isEditor: podInfo.isEditor,
   });
 
-  const { fileId, fileContent, isLoading, isNotFound } =
+  const { fileId, fileContent, fileContentType, isLoading, isNotFound } =
     usePodFrameRenderableContent({
       owner,
       framePath: pinnedFramePath,
@@ -204,6 +205,10 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     identifier: `viz-banner-${fileId}`,
     isPodEditor: podInfo.isEditor,
     isPodMember: podInfo.isMember,
+    frameId:
+      getFrameFunctionReferenceKind(fileContentType) === "v2"
+        ? fileId
+        : undefined,
     framePath: pinnedFramePath,
   };
 

--- a/front/hooks/usePodFrameRenderableContent.ts
+++ b/front/hooks/usePodFrameRenderableContent.ts
@@ -20,12 +20,17 @@ export function usePodFrameRenderableContent({
 }) {
   const isDisabled = disabled || !framePath;
 
-  const { fileId, isFileIdLoading, isFileIdNotFound, fileIdError } =
-    useFileIdFromPath({
-      owner,
-      filePath: framePath,
-      disabled: isDisabled,
-    });
+  const {
+    fileId,
+    fileContentType,
+    isFileIdLoading,
+    isFileIdNotFound,
+    fileIdError,
+  } = useFileIdFromPath({
+    owner,
+    filePath: framePath,
+    disabled: isDisabled,
+  });
 
   const {
     fileContent,
@@ -39,6 +44,7 @@ export function usePodFrameRenderableContent({
 
   return {
     fileId,
+    fileContentType,
     fileContent: fileContent ?? null,
     isLoading:
       !isDisabled && (isFileIdLoading || (!!fileId && isFileContentLoading)),

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -114,25 +114,31 @@ The same decision rule applies regardless of where the data came from:
 ### useUserIdentity Reference
 
 - Import \`useUserIdentity\` from \`@dust/react-hooks\` to know who is viewing the Frame.
-- It returns \`{ isAuthenticated, isWorkspaceMember, isPodMember, isPodEditor, user, isLoading, error }\`. When \`isAuthenticated\` is true, \`user\` is \`{ sId, firstName, lastName, fullName, image }\`; otherwise \`user\` is \`null\`.
+- It returns \`{ isAuthenticated, isWorkspaceMember, isFrameAuthor, isPodMember, isPodEditor, user, isLoading, error }\`. When \`isAuthenticated\` is true, \`user\` is \`{ sId, firstName, lastName, fullName, image }\`; otherwise \`user\` is \`null\`.
 - \`isAuthenticated\` is only true for a signed-in member of the workspace that owns the Frame. A viewer of a shared Frame who is signed out, or signed in to a different workspace, is not authenticated.
+- \`isFrameAuthor\` is true when the viewer can modify the Frame v2 source files. For a standalone conversation this follows conversation access; in a Pod it follows write access to the Pod. Use it to show author-only controls, and declare the functions behind those controls with \`frame_author_required\` so the server enforces the same capability.
 - \`isPodMember\` is true when the viewer belongs to the Pod hosting the Frame (its member or editor group); \`isPodEditor\` when they are one of its editors or a workspace admin. Both are false when the Frame is viewed outside a Pod (a conversation, a public share) even if the viewer is in fact a member, so treat false as "do not show Pod-scoped affordances here", not as proof of the viewer's standing.
-- \`isPodMember\` mirrors the predicate of the \`pod_member_required\` function policy: a Frame whose button calls a function declared \`pod_member_required\` should render that button only when \`isPodMember\` is true, instead of letting non-members discover the restriction through a failed call.
+- \`pod_member_required\` remains available for legacy Pod-specific code. New Frame v2 author controls should use \`isFrameAuthor\` and \`frame_author_required\` instead.
 - Render the \`isLoading\` state, and treat \`error\` and the unauthenticated case identically: fall back to the unauthenticated view rather than showing an error.
 - A Frame cannot sign anyone in. The viewer is already authenticated to Dust or they are not, and nothing the Frame renders can change that. When a Frame only makes sense for an authenticated member, render a plain view saying the content is unavailable to them, rather than a login prompt or a button that will not work.
 
 \`\`\`tsx
 import { useUserIdentity } from "@dust/react-hooks";
 
-const { user, isAuthenticated, isLoading } = useUserIdentity();
+const { user, isAuthenticated, isFrameAuthor, isLoading } = useUserIdentity();
 
 if (isLoading) { return <Spinner />; }
 if (!isAuthenticated) { return <UnavailableToViewer />; }
-return <p>Welcome back, {user.firstName}</p>;
+return (
+  <>
+    <p>Welcome back, {user.firstName}</p>
+    {isFrameAuthor && <AdminPanel />}
+  </>
+);
 \`\`\`
 
-- Use it for presentation only: greet the viewer by name, or highlight the rows that are theirs.
-- It tells you who is looking, not what they are allowed to do. Do not build access control out of client-side code: whatever a Frame renders, its viewer can read. Protect Frame-owned state in server functions.
+- Use it for presentation: greet the viewer, highlight their rows, or hide author-only controls.
+- Client-side conditions are not access control: whatever a Frame renders, its viewer can inspect. Protect every author-only operation with a server function declared \`frame_author_required\`.
 
 ### Interaction Rules
 

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -51,7 +51,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
       "`schema` with zod `input` and `output`. Set `schema.userIdentity` to `optional`, " +
       "`workspace_user_required`, `interactive_workspace_user_required`, or " +
-      "`pod_member_required`. It is bundled on the " +
+      "`pod_member_required`; Frame v2 functions may also use `frame_author_required`. It is bundled on the " +
       "pod sandbox (only `zod` is available to import), and its contract is extracted from the " +
       "`schema` export. The published slug is prefixed with the app the source lives in, so " +
       "re-publishing the same name from the same app replaces the previous version while another " +

--- a/front/lib/api/frames/permissions.test.ts
+++ b/front/lib/api/frames/permissions.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+
+import { canWriteFrameV2Source } from "@app/lib/api/frames/permissions";
+import { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
+import type { LightWorkspaceType } from "@app/types/user";
+import { describe, expect, it } from "vitest";
+
+async function makeWorkspaceMember(
+  workspace: LightWorkspaceType
+): Promise<UserResource> {
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "user" });
+  return user;
+}
+
+async function addPodMember(
+  adminAuth: Authenticator,
+  pod: SpaceResource,
+  user: UserResource
+): Promise<void> {
+  const group = await pod.fetchManualMemberGroup(adminAuth);
+  if (!group) {
+    throw new Error("Expected the Pod member group to exist.");
+  }
+  const result = await group.dangerouslyAddMember(adminAuth, {
+    user: user.toJSON(),
+  });
+  expect(result.isOk()).toBe(true);
+}
+
+describe("canWriteFrameV2Source", () => {
+  it("allows a user who can access a standalone conversation", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    await expect(canWriteFrameV2Source(auth, frame)).resolves.toBe(true);
+  });
+
+  it("allows a Pod member because Pod membership grants source write access", async () => {
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const member = await makeWorkspaceMember(workspace);
+    await addPodMember(adminAuth, pod, member);
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      member.sId,
+      workspace.sId
+    );
+    const frame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+      mountFilePath: `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: pod.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    await expect(canWriteFrameV2Source(memberAuth, frame)).resolves.toBe(true);
+  });
+
+  it("denies a workspace member without write access to the source Pod", async () => {
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const outsider = await makeWorkspaceMember(workspace);
+    const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      outsider.sId,
+      workspace.sId
+    );
+    const frame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+      mountFilePath: `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: pod.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    await expect(canWriteFrameV2Source(outsiderAuth, frame)).resolves.toBe(
+      false
+    );
+  });
+
+  it("denies callers without a user", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    await expect(canWriteFrameV2Source(userlessAuth, frame)).resolves.toBe(
+      false
+    );
+  });
+
+  it("denies legacy Frames and Frame v2 files without a scoped source path", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const legacyFrame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "legacy.tsx",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+    });
+    const unscopedFrame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    await expect(canWriteFrameV2Source(auth, legacyFrame)).resolves.toBe(false);
+    await expect(canWriteFrameV2Source(auth, unscopedFrame)).resolves.toBe(
+      false
+    );
+  });
+});

--- a/front/lib/api/frames/permissions.ts
+++ b/front/lib/api/frames/permissions.ts
@@ -1,0 +1,35 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+
+/**
+ * Whether the authenticated user can modify the source files backing a Frame v2.
+ *
+ * The file system owns this decision: conversation access and Pod write access are
+ * resolved from the Frame's canonical scoped source path.
+ */
+export async function canWriteFrameV2Source(
+  auth: Authenticator,
+  frame: FileResource
+): Promise<boolean> {
+  const user = auth.user();
+  const workspace = auth.getNonNullableWorkspace();
+  if (!user || !frame.isFrameV2 || frame.workspaceId !== workspace.id) {
+    return false;
+  }
+
+  const sourcePath = frame.toScopedPath(auth);
+  if (!sourcePath) {
+    return false;
+  }
+
+  const fileSystemResult = await DustFileSystem.fromScopedPath(
+    auth,
+    sourcePath
+  );
+  if (fileSystemResult.isErr()) {
+    return false;
+  }
+
+  return fileSystemResult.value.checkWriteAccess(sourcePath).isOk();
+}

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.105",
+      tag: "0.8.106",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.56/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.57/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.105";
-const DSBX_CLI_VERSION = "0.1.56";
+const DUST_BASE_IMAGE_VERSION = "0.8.106";
+const DSBX_CLI_VERSION = "0.1.57";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -62,7 +62,7 @@ const BUNDLE_CONTENT = "export default {/*bundle*/};";
 const validSchemaFile = JSON.stringify({
   name: "greet",
   description: "Greet someone.",
-  userIdentity: "interactive_workspace_user_required",
+  userIdentity: "frame_author_required",
   input_schema: { type: "object", properties: { name: { type: "string" } } },
   output_schema: {
     type: "object",
@@ -120,9 +120,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.value.bundleCode).toBe(BUNDLE_CONTENT);
-    expect(result.value.userIdentity).toBe(
-      "interactive_workspace_user_required"
-    );
+    expect(result.value.userIdentity).toBe("frame_author_required");
     expect(result.value.inputSchema).toEqual({
       type: "object",
       properties: { name: { type: "string" } },

--- a/front/lib/api/sandbox_functions/workspace_user.test.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.test.ts
@@ -8,7 +8,13 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { frameV2ContentType } from "@app/types/files";
+import {
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+} from "@app/types/mount_path";
 import type { LightWorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
 
@@ -235,5 +241,128 @@ describe("authorizeSandboxFunctionInvocation for Frames", () => {
     });
 
     expect(authorization.authorized).toBe(false);
+  });
+
+  it("authorizes a standalone conversation Frame author", async () => {
+    const { workspace, adminAuth } = await setup();
+    const conversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const frame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const authorization = await authorizeSandboxFunctionInvocation(adminAuth, {
+      userIdentity: "frame_author_required",
+      origin: "interactive_session",
+      owner: { kind: "frame", frame },
+    });
+
+    expect(authorization.authorized).toBe(true);
+  });
+
+  it("authorizes a Pod member who can write the Frame source", async () => {
+    const { workspace, adminAuth, space } = await setup();
+    const member = await makeWorkspaceMember(workspace);
+    await addToSpaceGroup(adminAuth, space, "member", member);
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      member.sId,
+      workspace.sId
+    );
+    const frame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+      mountFilePath: `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: space.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const authorization = await authorizeSandboxFunctionInvocation(memberAuth, {
+      userIdentity: "frame_author_required",
+      origin: "interactive_session",
+      owner: { kind: "frame", frame },
+    });
+
+    expect(authorization.authorized).toBe(true);
+  });
+
+  it("denies a workspace member who cannot write the Frame source", async () => {
+    const { workspace, adminAuth, space } = await setup();
+    const outsider = await makeWorkspaceMember(workspace);
+    const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      outsider.sId,
+      workspace.sId
+    );
+    const frame = await FileFactory.create(adminAuth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 10,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+      mountFilePath: `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: space.sId,
+      })}Admin/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const authorization = await authorizeSandboxFunctionInvocation(
+      outsiderAuth,
+      {
+        userIdentity: "frame_author_required",
+        origin: "interactive_session",
+        owner: { kind: "frame", frame },
+      }
+    );
+
+    expect(authorization.authorized).toBe(false);
+  });
+
+  it("denies frame_author_required for legacy Pod Functions", async () => {
+    const { adminAuth, space } = await setup();
+
+    const authorization = await authorizeSandboxFunctionInvocation(adminAuth, {
+      userIdentity: "frame_author_required",
+      origin: "interactive_session",
+      owner: { kind: "pod", space },
+    });
+
+    expect(authorization.authorized).toBe(false);
+  });
+});
+
+describe("authorizeSandboxFunctionInvocation across server revisions", () => {
+  it("fails closed for a policy persisted by a newer server revision", async () => {
+    const { adminAuth, space } = await setup();
+    const persistedPolicy =
+      "future_policy" as SandboxFunctionUserIdentityPolicy;
+
+    const authorization = await authorizeSandboxFunctionInvocation(adminAuth, {
+      userIdentity: persistedPolicy,
+      origin: "interactive_session",
+      owner: { kind: "pod", space },
+    });
+
+    expect(authorization.authorized).toBe(false);
+    if (!authorization.authorized) {
+      expect(authorization.errorMessage).toContain(
+        "unsupported user identity policy"
+      );
+    }
   });
 });

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,3 +1,4 @@
+import { canWriteFrameV2Source } from "@app/lib/api/frames/permissions";
 import type { SandboxFunctionInvocationErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
@@ -135,6 +136,17 @@ export async function authorizeSandboxFunctionInvocation(
         ? { authorized: true, user, runtimeSpaceId, pod }
         : authorizationError(
             `This ${functionKind} requires a member of its Pod.`
+          );
+    }
+    case "frame_author_required": {
+      const authorized =
+        user !== null &&
+        frame !== null &&
+        (await canWriteFrameV2Source(auth, frame));
+      return authorized
+        ? { authorized: true, user, runtimeSpaceId, pod }
+        : authorizationError(
+            "This Frame function requires permission to modify its source files."
           );
     }
     default:

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -115,6 +115,11 @@ function userIdentityPolicyStrength(
       // The pod-scoped audience ranks above the workspace-wide, session-bound policy: a publish
       // moving to it always commits the policy before exposing the new bundle.
       return 3;
+    case "frame_author_required":
+      // Source write access is the strictest policy. On a Frame outside a Pod it is scoped to
+      // conversation access; inside a Pod it follows the Pod's write permission. A legacy Pod
+      // Function cannot satisfy it and therefore fails closed.
+      return 4;
     default:
       // The stored policy can be a value this revision does not know: one from a newer revision
       // in a mixed-version deploy, or a retired policy (e.g. `pod_editor_required`). Rank it

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -273,7 +273,11 @@ The \`schema.userIdentity\` policy decides whether the function may run:
 - \`workspace_user_required\` requires a current member of the owning workspace.
 - \`interactive_workspace_user_required\` additionally requires the member's live Dust session;
   delegated agents, schedules, and API clients are refused.
-- \`pod_member_required\` requires membership in the Pod when the Frame belongs to one.
+- \`frame_author_required\` requires the caller to be able to modify the Frame v2 source files. In a
+  standalone conversation this follows conversation access; in a Pod it follows write access to the
+  Pod. Use this for author-only or admin functions.
+- \`pod_member_required\` remains available for legacy Pod-specific functions. Do not use it for new
+  Frame v2 author controls.
 
 Frame UI calls are available only to authenticated members of the owning workspace; guest or link
 viewers must get a typed authorization error. A function policy can impose a stricter requirement.
@@ -281,8 +285,9 @@ viewers must get a typed authorization error. A function policy can impose a str
 Use \`currentUser()\` from \`@dust/pod\` for the trusted caller. It returns
 \`{ sId, firstName, lastName, fullName, image, isPodMember, isPodEditor }\`, or \`null\` under the
 optional policy when there is no user. Never accept a caller \`userId\` as function input: the caller
-can forge it. The frontend's \`useUserIdentity\` hook is for presentation only; authorization belongs
-in the function policy and server logic.
+can forge it. The frontend's \`useUserIdentity\` hook also returns \`isFrameAuthor\`; use that flag to
+show author-only UI, but enforce every author-only operation with \`frame_author_required\` because
+client-side conditions are not access control.
 
 ## Calling a function from the Frame UI
 

--- a/front/types/api/frame_permissions.ts
+++ b/front/types/api/frame_permissions.ts
@@ -1,0 +1,3 @@
+export type GetFramePermissionsResponseBody = {
+  isFrameAuthor: boolean;
+};

--- a/front/types/api/frame_publication.test.ts
+++ b/front/types/api/frame_publication.test.ts
@@ -36,7 +36,7 @@ const publication = {
     {
       name: "add-task",
       bundleSha256: SHA256,
-      userIdentity: "workspace_user_required",
+      userIdentity: "frame_author_required",
       inputSchema: { type: "object" },
       outputSchema: { type: "object" },
     },

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -20,6 +20,7 @@ export const SANDBOX_FUNCTION_USER_IDENTITY_POLICIES = [
   "workspace_user_required",
   "interactive_workspace_user_required",
   "pod_member_required",
+  "frame_author_required",
 ] as const;
 
 export type SandboxFunctionUserIdentityPolicy =

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -41,6 +41,9 @@ export type UserIdentityState =
       // Whether the viewer belongs to one of the Pod's groups (member or editor). Display-only,
       // like isPodEditor: gate what the Frame shows, never what the server allows.
       isPodMember: boolean;
+      // Whether the viewer can modify the source files backing this Frame v2. Display-only: use
+      // frame_author_required to enforce the same capability on a server-side function.
+      isFrameAuthor: boolean;
       user: WorkspaceUserIdentity;
     }
   | {
@@ -48,6 +51,7 @@ export type UserIdentityState =
       isWorkspaceMember: false;
       isPodEditor: false;
       isPodMember: false;
+      isFrameAuthor: false;
       user: null;
     };
 

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -54,6 +54,7 @@ export class CacheDataAPI implements VisualizationDataAPI {
     return {
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isFrameAuthor: false,
       isPodEditor: false,
       isPodMember: false,
       user: null,

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -104,12 +104,52 @@ describe("sandbox function data APIs", () => {
     });
   });
 
+  it("defaults Frame authorship to false for hosts that omit it", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+    const api = new RPCDataAPI(sendMessage);
+
+    await expect(api.getUserIdentity()).resolves.toMatchObject({
+      isFrameAuthor: false,
+    });
+  });
+
+  it("keeps Frame authorship from hosts that provide it", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      isFrameAuthor: true,
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+    const api = new RPCDataAPI(sendMessage);
+
+    await expect(api.getUserIdentity()).resolves.toMatchObject({
+      isFrameAuthor: true,
+    });
+  });
+
   it("returns no identity from the public cache", async () => {
     const api = new CacheDataAPI();
 
     await expect(api.getUserIdentity()).resolves.toEqual({
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isFrameAuthor: false,
       isPodEditor: false,
       isPodMember: false,
       user: null,

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -44,6 +44,7 @@ export class RPCDataAPI implements VisualizationDataAPI {
       return {
         isAuthenticated: false as const,
         isWorkspaceMember: false as const,
+        isFrameAuthor: false as const,
         isPodEditor: false as const,
         isPodMember: false as const,
         user: null,
@@ -51,6 +52,7 @@ export class RPCDataAPI implements VisualizationDataAPI {
     }
     return {
       ...identity,
+      isFrameAuthor: identity.isFrameAuthor === true,
       isPodEditor: identity.isPodEditor === true,
       isPodMember: identity.isPodMember === true,
     };

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -49,6 +49,9 @@ describe("useUserIdentity", () => {
     dataAPI.getUserIdentity = vi.fn().mockResolvedValue({
       isAuthenticated: true,
       isWorkspaceMember: true,
+      isFrameAuthor: false,
+      isPodEditor: false,
+      isPodMember: false,
       user: {
         sId: "usr_123",
         firstName: "Ada",
@@ -65,6 +68,7 @@ describe("useUserIdentity", () => {
     expect(result.current).toMatchObject({
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isFrameAuthor: false,
       isLoading: true,
       user: null,
     });
@@ -73,6 +77,7 @@ describe("useUserIdentity", () => {
     expect(result.current).toMatchObject({
       isAuthenticated: true,
       isWorkspaceMember: true,
+      isFrameAuthor: false,
       user: { sId: "usr_123", fullName: "Ada Lovelace" },
     });
   });
@@ -91,6 +96,7 @@ describe("useUserIdentity", () => {
     expect(result.current).toMatchObject({
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isFrameAuthor: false,
       user: null,
       error: new Error("Frame host unavailable"),
     });

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -161,6 +161,7 @@ export function useUserIdentity(): UseUserIdentityResult {
       error: result.error,
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isFrameAuthor: false,
       isPodEditor: false,
       isPodMember: false,
       isLoading: !result.error,

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -29,6 +29,9 @@ export type UserIdentityState =
       // Whether the viewer belongs to one of the Pod's groups (member or editor). Display-only,
       // like isPodEditor: gate what the Frame shows, never what the server allows.
       isPodMember: boolean;
+      // Whether the viewer can modify the source files backing this Frame v2. Display-only: use
+      // frame_author_required to enforce the same capability on a server-side function.
+      isFrameAuthor: boolean;
       user: WorkspaceUserIdentity;
     }
   | {
@@ -36,6 +39,7 @@ export type UserIdentityState =
       isWorkspaceMember: false;
       isPodEditor: false;
       isPodMember: false;
+      isFrameAuthor: false;
       user: null;
     };
 


### PR DESCRIPTION
## Description

- Add `frame_author_required` for Frame v2 functions. The server derives the decision from write access to the Frame's canonical source path.
- Expose `isFrameAuthor` through `useUserIdentity()` so Frames can hide author-only controls. Server function policy remains the authorization boundary.
- Preserve `pod_member_required` for legacy Pod Functions.
- Deny missing source paths, legacy owners, unauthenticated callers, and unknown cross-version policies.
- Thread stable Frame v2 file IDs through every Frame host and keep older visualization hosts compatible by defaulting the new flag to false.

## Rollout

- [x] Bump the CLI to `dsbx` 0.1.57 and the image to `dust-base` 0.8.106.
- [ ] Publish the `dsbx-v0.1.57` release.
- [ ] After merge, build `dust-base:0.8.106` from `main` before deploying the front changes.

The current 0.1.56 runner rejects functions that declare the new policy. Older server revisions deny unknown persisted policies, so mixed-version invocation fails closed.

## Test plan

- `front`: 63 focused authorization, publication, iframe, and Pod rendering tests
- `front-api`: 66 invocation tests and 15 Frame permission/governance tests
- `viz`: 31 RPC and hook tests
- `functions-runner`: 126 tests and bundle build
- `dust-sandbox`: 408 Rust tests
- `sandbox image registry`: 21 tests
- `npx tsgo --noEmit` in `front` and `front-api`
- `npx tsc --noEmit --target es2022` in `viz`
- Swagger annotation lint, Biome, diff check, and pre-commit hooks
