### PR TITLE
[front] Create WorkOS organization for every workspace

### DIFF
--- a/front-api/routes/w/[wId]/domains.ts
+++ b/front-api/routes/w/[wId]/domains.ts
@@ -59,9 +59,8 @@ app.get(
   async (ctx): HandlerResult<GetWorkspaceDomainsResponseBody> => {
     const auth = ctx.get("auth");
 
-    // If the workspace doesn't have a WorkOS organization (which can happen for workspaces
-    // created via admin tools), we create one before fetching domains. This ensures the
-    // endpoint works for all workspaces, regardless of how they were created.
+    // Safety net for legacy workspaces that predate creating a WorkOS
+    // organization at workspace creation time.
     const organizationRes = await getOrCreateWorkOSOrganization(
       auth.getNonNullableWorkspace()
     );

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/api/data_sources";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
@@ -71,6 +72,14 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         systemGroup,
         globalGroup,
       });
+
+      const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
+      if (orgRes.isErr()) {
+        logger.error(
+          { error: orgRes.error, workspaceId: w.sId },
+          "Failed to create WorkOS organization during workspace creation"
+        );
+      }
 
       args.wId = w.sId;
       return;

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -8,18 +8,16 @@ import {
 } from "@app/lib/api/data_sources";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
+import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
@@ -30,7 +28,6 @@ import {
   getWebhookRequestPayloadFromGCS,
   processWebhookRequest,
 } from "@app/lib/triggers/webhook";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchScrubSpaceWorkflow } from "@app/poke/temporal/client";
 import {
@@ -55,31 +52,12 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --name argument");
       }
 
-      const w = await WorkspaceResource.makeNew({
-        sId: generateRandomModelSId(),
+      const w = await createWorkspaceInternal({
         name: args.name,
+        isBusiness: false,
+        planCode: null,
+        endDate: null,
       });
-
-      const lightWorkspace = renderLightWorkspaceType({ workspace: w });
-
-      const { systemGroup, globalGroup } =
-        await GroupResource.makeDefaultsForWorkspace(lightWorkspace);
-
-      const auth = await Authenticator.internalAdminForWorkspace(
-        lightWorkspace.sId
-      );
-      await SpaceResource.makeDefaultsForWorkspace(auth, {
-        systemGroup,
-        globalGroup,
-      });
-
-      const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
-      if (orgRes.isErr()) {
-        logger.error(
-          { error: orgRes.error, workspaceId: w.sId },
-          "Failed to create WorkOS organization during workspace creation"
-        );
-      }
 
       args.wId = w.sId;
       return;

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -47,11 +47,10 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const [regularGroup] =
-      await space.fetchRegularAutoGroups(internalAdminAuth);
-    if (!regularGroup) {
-      throw new Error("Expected a regular group on the space");
-    }
+    // Use the member group specifically — `fetchRegularAutoGroups()[0]` is
+    // unordered and can return the editor group, where the project creator is
+    // already a member.
+    const regularGroup = await space.fetchManualMemberGroup(internalAdminAuth);
     const addRes = await regularGroup.dangerouslyAddMember(internalAdminAuth, {
       user: userJson,
     });

--- a/front/lib/api/workos/client.ts
+++ b/front/lib/api/workos/client.ts
@@ -1,6 +1,10 @@
 import config from "@app/lib/api/config";
 import { WorkOS } from "@workos-inc/node";
 
+// SDK default is 60s, which is too long for request-path WorkOS calls
+// (workspace creation, domain flows, membership sync). Keep this bounded.
+const WORKOS_API_TIMEOUT_MS = 10_000;
+
 let workos: WorkOS | null = null;
 
 export function getWorkOS() {
@@ -9,17 +13,16 @@ export function getWorkOS() {
     workos = new WorkOS(config.getWorkOSApiKey(), {
       clientId: config.getWorkOSClientId(),
       apiHostname: "auth-api.dust.tt",
+      timeout: WORKOS_API_TIMEOUT_MS,
     });
   }
 
   return workos;
 }
 
-// The WorkOS SDK defaults to a 60s request timeout. Session resolution runs
-// synchronously on every request, so a WorkOS outage would otherwise add up
-// to 60s of latency before falling back to a locally cached session. This
-// client is dedicated to that path so it can fail fast; other call sites
-// (admin scripts, migrations, background sync) keep the default client.
+// Session resolution runs synchronously on every request, so a WorkOS outage
+// would otherwise add the full API timeout before falling back to a locally
+// cached session. This client is dedicated to that path so it can fail faster.
 const SESSION_AUTH_TIMEOUT_MS = 5_000;
 
 let workosForSessionAuth: WorkOS | null = null;

--- a/front/lib/api/workos/get_or_create_organization.test.ts
+++ b/front/lib/api/workos/get_or_create_organization.test.ts
@@ -1,0 +1,178 @@
+import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { Organization } from "@workos-inc/node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetOrganizationByExternalId,
+  mockCreateOrganization,
+  mockListOrganizationMemberships,
+  mockCreateOrganizationMembership,
+  mockUpdateOrganizationMembership,
+} = vi.hoisted(() => ({
+  mockGetOrganizationByExternalId: vi.fn(),
+  mockCreateOrganization: vi.fn(),
+  mockListOrganizationMemberships: vi.fn(),
+  mockCreateOrganizationMembership: vi.fn(),
+  mockUpdateOrganizationMembership: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/workos/client", () => ({
+  getWorkOS: () => ({
+    organizations: {
+      getOrganizationByExternalId: mockGetOrganizationByExternalId,
+      createOrganization: mockCreateOrganization,
+    },
+    userManagement: {
+      listOrganizationMemberships: mockListOrganizationMemberships,
+      createOrganizationMembership: mockCreateOrganizationMembership,
+      updateOrganizationMembership: mockUpdateOrganizationMembership,
+    },
+  }),
+}));
+
+vi.mock("@app/lib/api/cells/config", () => ({
+  config: {
+    getCurrentCell: () => ({ name: "local", region: "local" }),
+  },
+}));
+
+describe("getOrCreateWorkOSOrganization membership sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListOrganizationMemberships.mockResolvedValue({ data: [] });
+    mockCreateOrganizationMembership.mockResolvedValue({ id: "om_1" });
+    mockUpdateOrganizationMembership.mockResolvedValue({ id: "om_1" });
+  });
+
+  it("syncs active members when creating a new WorkOS organization", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await user.setWorkOSUserId("user_workos_1");
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+    // Ensure factory workspace has no WorkOS org id.
+    await WorkspaceResource.updateWorkOSOrganizationId(workspace.id, null);
+    const lightWorkspace = {
+      ...renderLightWorkspaceType({ workspace }),
+      workOSOrganizationId: null,
+    };
+
+    mockGetOrganizationByExternalId.mockRejectedValue(
+      Object.assign(new Error("not found"), {
+        status: 404,
+        code: "entity_not_found",
+      })
+    );
+    mockCreateOrganization.mockResolvedValue({
+      id: "org_new",
+      name: workspace.name,
+      externalId: workspace.sId,
+    } as Organization);
+
+    const result = await getOrCreateWorkOSOrganization(lightWorkspace);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockCreateOrganization).toHaveBeenCalledTimes(1);
+    expect(mockCreateOrganizationMembership).toHaveBeenCalledWith({
+      userId: "user_workos_1",
+      organizationId: "org_new",
+      roleSlug: "admin",
+    });
+
+    const refreshed = await WorkspaceResource.fetchByModelId(workspace.id);
+    expect(refreshed?.workOSOrganizationId).toBe("org_new");
+  });
+
+  it("syncs active members when linking an existing WorkOS org missing from the workspace", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await user.setWorkOSUserId("user_workos_2");
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    await WorkspaceResource.updateWorkOSOrganizationId(workspace.id, null);
+    const lightWorkspace = {
+      ...renderLightWorkspaceType({ workspace }),
+      workOSOrganizationId: null,
+    };
+
+    mockGetOrganizationByExternalId.mockResolvedValue({
+      id: "org_existing",
+      name: workspace.name,
+      externalId: workspace.sId,
+    } as Organization);
+
+    const result = await getOrCreateWorkOSOrganization(lightWorkspace);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateOrganizationMembership).toHaveBeenCalledWith({
+      userId: "user_workos_2",
+      organizationId: "org_existing",
+      roleSlug: "user",
+    });
+  });
+
+  it("does not re-sync members when workspace already has the WorkOS org id", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await WorkspaceResource.updateWorkOSOrganizationId(
+      workspace.id,
+      "org_already"
+    );
+    const lightWorkspace = {
+      ...renderLightWorkspaceType({ workspace }),
+      workOSOrganizationId: "org_already",
+    };
+
+    mockGetOrganizationByExternalId.mockResolvedValue({
+      id: "org_already",
+      name: workspace.name,
+      externalId: workspace.sId,
+    } as Organization);
+
+    const spy = vi.spyOn(MembershipResource, "getActiveMemberships");
+
+    const result = await getOrCreateWorkOSOrganization(lightWorkspace);
+
+    expect(result.isOk()).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("skips members without a workOSUserId", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await user.setWorkOSUserId(null);
+    expect(user.workOSUserId).toBeNull();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+    await WorkspaceResource.updateWorkOSOrganizationId(workspace.id, null);
+    const lightWorkspace = {
+      ...renderLightWorkspaceType({ workspace }),
+      workOSOrganizationId: null,
+    };
+
+    mockGetOrganizationByExternalId.mockRejectedValue(
+      Object.assign(new Error("not found"), {
+        status: 404,
+        code: "entity_not_found",
+      })
+    );
+    mockCreateOrganization.mockResolvedValue({
+      id: "org_skip",
+      name: workspace.name,
+      externalId: workspace.sId,
+    } as Organization);
+
+    const result = await getOrCreateWorkOSOrganization(lightWorkspace);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/workos/get_or_create_organization.test.ts
+++ b/front/lib/api/workos/get_or_create_organization.test.ts
@@ -42,6 +42,29 @@ vi.mock("@app/lib/api/cells/config", () => ({
   },
 }));
 
+class WorkOSNotFoundError extends Error {
+  status = 404;
+  code = "entity_not_found";
+
+  constructor() {
+    super("not found");
+  }
+}
+
+function mockOrganization(
+  partial: Pick<Organization, "id" | "name" | "externalId">
+): Organization {
+  return {
+    object: "organization",
+    allowProfilesOutsideOrganization: false,
+    domains: [],
+    createdAt: "2020-01-01T00:00:00.000Z",
+    updatedAt: "2020-01-01T00:00:00.000Z",
+    metadata: {},
+    ...partial,
+  };
+}
+
 describe("getOrCreateWorkOSOrganization membership sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -64,16 +87,15 @@ describe("getOrCreateWorkOSOrganization membership sync", () => {
     };
 
     mockGetOrganizationByExternalId.mockRejectedValue(
-      Object.assign(new Error("not found"), {
-        status: 404,
-        code: "entity_not_found",
+      new WorkOSNotFoundError()
+    );
+    mockCreateOrganization.mockResolvedValue(
+      mockOrganization({
+        id: "org_new",
+        name: workspace.name,
+        externalId: workspace.sId,
       })
     );
-    mockCreateOrganization.mockResolvedValue({
-      id: "org_new",
-      name: workspace.name,
-      externalId: workspace.sId,
-    } as Organization);
 
     const result = await getOrCreateWorkOSOrganization(lightWorkspace);
 
@@ -101,11 +123,13 @@ describe("getOrCreateWorkOSOrganization membership sync", () => {
       workOSOrganizationId: null,
     };
 
-    mockGetOrganizationByExternalId.mockResolvedValue({
-      id: "org_existing",
-      name: workspace.name,
-      externalId: workspace.sId,
-    } as Organization);
+    mockGetOrganizationByExternalId.mockResolvedValue(
+      mockOrganization({
+        id: "org_existing",
+        name: workspace.name,
+        externalId: workspace.sId,
+      })
+    );
 
     const result = await getOrCreateWorkOSOrganization(lightWorkspace);
 
@@ -129,11 +153,13 @@ describe("getOrCreateWorkOSOrganization membership sync", () => {
       workOSOrganizationId: "org_already",
     };
 
-    mockGetOrganizationByExternalId.mockResolvedValue({
-      id: "org_already",
-      name: workspace.name,
-      externalId: workspace.sId,
-    } as Organization);
+    mockGetOrganizationByExternalId.mockResolvedValue(
+      mockOrganization({
+        id: "org_already",
+        name: workspace.name,
+        externalId: workspace.sId,
+      })
+    );
 
     const spy = vi.spyOn(MembershipResource, "getActiveMemberships");
 
@@ -159,16 +185,15 @@ describe("getOrCreateWorkOSOrganization membership sync", () => {
     };
 
     mockGetOrganizationByExternalId.mockRejectedValue(
-      Object.assign(new Error("not found"), {
-        status: 404,
-        code: "entity_not_found",
+      new WorkOSNotFoundError()
+    );
+    mockCreateOrganization.mockResolvedValue(
+      mockOrganization({
+        id: "org_skip",
+        name: workspace.name,
+        externalId: workspace.sId,
       })
     );
-    mockCreateOrganization.mockResolvedValue({
-      id: "org_skip",
-      name: workspace.name,
-      externalId: workspace.sId,
-    } as Organization);
 
     const result = await getOrCreateWorkOSOrganization(lightWorkspace);
 

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -1,7 +1,6 @@
 import schemaVersionsJson from "@app/lib/api/audit/schema_versions.json";
 import { config as cellConfig } from "@app/lib/api/cells/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
-import { invalidateWorkOSOrganizationsCacheForUserId } from "@app/lib/api/workos/organization_membership";
 import { getWorkOSOrganization } from "@app/lib/api/workos/organization_primitives";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -22,6 +21,45 @@ import {
 import assert from "assert";
 import uniqueId from "lodash/uniqueId";
 
+/**
+ * Ensure active Dust memberships exist as WorkOS organization memberships.
+ * Idempotent create-or-update via `updateWorkOSMembershipRole`.
+ * Users without a `workOSUserId` are skipped (they cannot be linked yet).
+ */
+async function syncActiveMembershipsToWorkOSOrganization({
+  workspace,
+  organizationId,
+}: {
+  workspace: LightWorkspaceType;
+  organizationId: string;
+}): Promise<void> {
+  const workspaceWithOrg: LightWorkspaceType = {
+    ...workspace,
+    workOSOrganizationId: organizationId,
+  };
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: workspaceWithOrg,
+  });
+
+  await concurrentExecutor(
+    memberships,
+    async (membership) => {
+      const user = membership.user;
+      if (!user?.workOSUserId) {
+        return;
+      }
+
+      await MembershipResource.updateWorkOSMembershipRole({
+        user,
+        workspace: workspaceWithOrg,
+        newRole: membership.role,
+      });
+    },
+    { concurrency: 10 }
+  );
+}
+
 export async function getOrCreateWorkOSOrganization(
   workspace: LightWorkspaceType,
   { domain }: { domain?: string } = {}
@@ -32,7 +70,14 @@ export async function getOrCreateWorkOSOrganization(
       return new Err(organizationRes.error);
     }
 
-    let organization = organizationRes.value;
+    const existingOrganization = organizationRes.value;
+    // Sync members when first linking this workspace to WorkOS (missing DB id)
+    // or when creating a brand-new org. Skip on subsequent lookups (e.g. domains
+    // GET) so we do not re-walk every membership on hot paths.
+    const shouldSyncMemberships =
+      !workspace.workOSOrganizationId || !existingOrganization;
+
+    let organization = existingOrganization;
     if (!organization) {
       organization = await getWorkOS().organizations.createOrganization({
         name: workspace.name,
@@ -50,31 +95,6 @@ export async function getOrCreateWorkOSOrganization(
             ]
           : undefined,
       });
-
-      const { memberships } =
-        await MembershipResource.getMembershipsForWorkspace({
-          workspace,
-          includeUser: true,
-        });
-
-      await concurrentExecutor(
-        memberships,
-        async (membership) => {
-          const user = membership.user;
-          if (!user || !user.workOSUserId || !organization) {
-            return;
-          }
-
-          await getWorkOS().userManagement.createOrganizationMembership({
-            userId: user.workOSUserId,
-            organizationId: organization.id,
-            roleSlug: membership.role,
-          });
-
-          await invalidateWorkOSOrganizationsCacheForUserId(user.workOSUserId);
-        },
-        { concurrency: 10 }
-      );
     }
 
     if (workspace.workOSOrganizationId !== organization.id) {
@@ -82,6 +102,13 @@ export async function getOrCreateWorkOSOrganization(
         workspace.id,
         organization.id
       );
+    }
+
+    if (shouldSyncMemberships) {
+      await syncActiveMembershipsToWorkOSOrganization({
+        workspace,
+        organizationId: organization.id,
+      });
     }
 
     return new Ok(organization);

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -22,26 +22,20 @@ import {
 } from "@workos-inc/node";
 import assert from "assert";
 import uniqueId from "lodash/uniqueId";
+import type { Transaction } from "sequelize";
 
 /**
  * Ensure active Dust memberships exist as WorkOS organization memberships.
  * Idempotent create-or-update via `updateWorkOSMembershipRole`.
  * Users without a `workOSUserId` are skipped (they cannot be linked yet).
+ *
+ * `workspace.workOSOrganizationId` must already be set.
  */
-async function syncActiveMembershipsToWorkOSOrganization({
-  workspace,
-  organizationId,
-}: {
-  workspace: LightWorkspaceType;
-  organizationId: string;
-}): Promise<void> {
-  const workspaceWithOrg: LightWorkspaceType = {
-    ...workspace,
-    workOSOrganizationId: organizationId,
-  };
-
+async function syncActiveMembershipsToWorkOSOrganization(
+  workspace: LightWorkspaceType
+): Promise<void> {
   const { memberships } = await MembershipResource.getActiveMemberships({
-    workspace: workspaceWithOrg,
+    workspace,
   });
 
   await concurrentExecutor(
@@ -53,7 +47,7 @@ async function syncActiveMembershipsToWorkOSOrganization({
 
       await MembershipResource.updateWorkOSMembershipRole({
         user: new UserResource(UserModel, membership.user),
-        workspace: workspaceWithOrg,
+        workspace,
         newRole: membership.role,
       });
     },
@@ -63,7 +57,7 @@ async function syncActiveMembershipsToWorkOSOrganization({
 
 export async function getOrCreateWorkOSOrganization(
   workspace: LightWorkspaceType,
-  { domain }: { domain?: string } = {}
+  { domain, transaction }: { domain?: string; transaction?: Transaction } = {}
 ): Promise<Result<Organization, Error>> {
   try {
     const organizationRes = await getWorkOSOrganization(workspace);
@@ -71,16 +65,15 @@ export async function getOrCreateWorkOSOrganization(
       return new Err(organizationRes.error);
     }
 
-    const existingOrganization = organizationRes.value;
     // Sync members when first linking this workspace to WorkOS (missing DB id)
     // or when creating a brand-new org. Skip on subsequent lookups (e.g. domains
     // GET) so we do not re-walk every membership on hot paths.
     const shouldSyncMemberships =
-      !workspace.workOSOrganizationId || !existingOrganization;
+      !workspace.workOSOrganizationId || !organizationRes.value;
 
-    let organization = existingOrganization;
-    if (!organization) {
-      organization = await getWorkOS().organizations.createOrganization({
+    const organization =
+      organizationRes.value ??
+      (await getWorkOS().organizations.createOrganization({
         name: workspace.name,
         externalId: workspace.sId,
         metadata: {
@@ -95,20 +88,20 @@ export async function getOrCreateWorkOSOrganization(
               },
             ]
           : undefined,
-      });
-    }
+      }));
 
     if (workspace.workOSOrganizationId !== organization.id) {
       await WorkspaceResource.updateWorkOSOrganizationId(
         workspace.id,
-        organization.id
+        organization.id,
+        transaction
       );
     }
 
     if (shouldSyncMemberships) {
       await syncActiveMembershipsToWorkOSOrganization({
-        workspace,
-        organizationId: organization.id,
+        ...workspace,
+        workOSOrganizationId: organization.id,
       });
     }
 

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -22,7 +22,6 @@ import {
 } from "@workos-inc/node";
 import assert from "assert";
 import uniqueId from "lodash/uniqueId";
-import type { Transaction } from "sequelize";
 
 /**
  * Ensure active Dust memberships exist as WorkOS organization memberships.
@@ -57,7 +56,7 @@ async function syncActiveMembershipsToWorkOSOrganization(
 
 export async function getOrCreateWorkOSOrganization(
   workspace: LightWorkspaceType,
-  { domain, transaction }: { domain?: string; transaction?: Transaction } = {}
+  { domain }: { domain?: string } = {}
 ): Promise<Result<Organization, Error>> {
   try {
     const organizationRes = await getWorkOSOrganization(workspace);
@@ -93,8 +92,7 @@ export async function getOrCreateWorkOSOrganization(
     if (workspace.workOSOrganizationId !== organization.id) {
       await WorkspaceResource.updateWorkOSOrganizationId(
         workspace.id,
-        organization.id,
-        transaction
+        organization.id
       );
     }
 

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -4,6 +4,8 @@ import { getWorkOS } from "@app/lib/api/workos/client";
 import { getWorkOSOrganization } from "@app/lib/api/workos/organization_primitives";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -45,13 +47,12 @@ async function syncActiveMembershipsToWorkOSOrganization({
   await concurrentExecutor(
     memberships,
     async (membership) => {
-      const user = membership.user;
-      if (!user?.workOSUserId) {
+      if (!membership.user?.workOSUserId) {
         return;
       }
 
       await MembershipResource.updateWorkOSMembershipRole({
-        user,
+        user: new UserResource(UserModel, membership.user),
         workspace: workspaceWithOrg,
         newRole: membership.role,
       });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1121,13 +1121,18 @@ export class Authenticator {
   static async internalAdminForWorkspace(
     workspaceId: string,
     options?: {
-      dangerouslyRequestAllGroups: boolean;
+      dangerouslyRequestAllGroups?: boolean;
       // Only applies when dangerouslyRequestAllGroups is true. Overrides the group kinds fetched,
       // e.g. to include editor groups that are excluded by default.
       groupKinds?: GroupKind[];
+      transaction?: Transaction;
     }
   ): Promise<Authenticator> {
-    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    const transaction = options?.transaction;
+    const workspace = await WorkspaceResource.fetchById(
+      workspaceId,
+      transaction
+    );
     if (!workspace) {
       throw new Error(`Could not find workspace with sId ${workspaceId}`);
     }
@@ -1138,14 +1143,21 @@ export class Authenticator {
           return GroupResource.internalFetchAllWorkspaceGroups({
             workspaceId: workspace.id,
             ...(options.groupKinds ? { groupKinds: options.groupKinds } : {}),
+            transaction,
           });
         } else {
           const globalGroup =
-            await GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id);
+            await GroupResource.internalFetchWorkspaceGlobalGroup(
+              workspace.id,
+              transaction
+            );
           return globalGroup ? [globalGroup] : [];
         }
       })(),
-      SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
+      SubscriptionResource.fetchActiveByWorkspaceModelId(
+        workspace.id,
+        transaction
+      ),
     ]);
 
     const providersHealth = await this.fetchByokProvidersHealth(

--- a/front/lib/iam/workspaces.test.ts
+++ b/front/lib/iam/workspaces.test.ts
@@ -1,5 +1,7 @@
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import { Err, Ok } from "@app/types/shared/result";
 import type { Organization } from "@workos-inc/node";
 import type { Transaction } from "sequelize";
@@ -92,21 +94,31 @@ describe("createWorkspaceInternal", () => {
     expect(workspace.workOSOrganizationId).toBe(`org_${workspace.sId}`);
   });
 
-  it("throws when WorkOS organization creation fails", async () => {
+  it("rolls back the workspace when WorkOS organization creation fails", async () => {
     mockGetOrCreateWorkOSOrganization.mockResolvedValueOnce(
       new Err(new Error("WorkOS unavailable"))
     );
 
-    // Hard-fail: in production `withTransaction` opens a real transaction that
-    // rolls back on throw. Tests reuse the CLS suite transaction, so we only
-    // assert the error bubbles (no soft-fail workspace return).
+    // Nested SAVEPOINT under the CLS test transaction (same pattern as
+    // publication_storage.test.ts) so a throw rolls back only this unit of work.
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+
     await expect(
-      createWorkspaceInternal({
-        name: "Workspace Without Org",
-        isBusiness: false,
-        planCode: null,
-        endDate: null,
-      })
+      frontSequelize.transaction({ transaction: parentTransaction }, async () =>
+        createWorkspaceInternal({
+          name: "Workspace Without Org",
+          isBusiness: false,
+          planCode: null,
+          endDate: null,
+        })
+      )
     ).rejects.toThrow("WorkOS unavailable");
+
+    const leftover = await WorkspaceResource.fetchByName(
+      "Workspace Without Org"
+    );
+    expect(leftover).toBeNull();
   });
 });

--- a/front/lib/iam/workspaces.test.ts
+++ b/front/lib/iam/workspaces.test.ts
@@ -1,0 +1,88 @@
+import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Organization } from "@workos-inc/node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetOrCreateWorkOSOrganization } = vi.hoisted(() => ({
+  mockGetOrCreateWorkOSOrganization: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/workos/organization", () => ({
+  getOrCreateWorkOSOrganization: mockGetOrCreateWorkOSOrganization,
+}));
+
+vi.mock("@app/lib/api/permissions/governance_seeding", () => ({
+  seedWorkspaceCapabilities: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock(
+  "@app/lib/resources/mcp_server_view_resource",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("@app/lib/resources/mcp_server_view_resource")
+      >();
+    return {
+      ...mod,
+      MCPServerViewResource: {
+        ...mod.MCPServerViewResource,
+        ensureAllAutoToolsAreCreated: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  }
+);
+
+describe("createWorkspaceInternal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOrCreateWorkOSOrganization.mockImplementation(
+      async (workspace: { id: number; sId: string; name: string }) => {
+        const organizationId = `org_${workspace.sId}`;
+        await WorkspaceResource.updateWorkOSOrganizationId(
+          workspace.id,
+          organizationId
+        );
+        return new Ok({
+          id: organizationId,
+          name: workspace.name,
+          externalId: workspace.sId,
+        } as Organization);
+      }
+    );
+  });
+
+  it("creates a WorkOS organization for every new workspace", async () => {
+    const workspace = await createWorkspaceInternal({
+      name: "WorkOS Org Workspace",
+      isBusiness: false,
+      planCode: null,
+      endDate: null,
+    });
+
+    expect(mockGetOrCreateWorkOSOrganization).toHaveBeenCalledTimes(1);
+    expect(mockGetOrCreateWorkOSOrganization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sId: workspace.sId,
+        name: "WorkOS Org Workspace",
+      })
+    );
+    expect(workspace.workOSOrganizationId).toBe(`org_${workspace.sId}`);
+  });
+
+  it("still returns the workspace when WorkOS organization creation fails", async () => {
+    mockGetOrCreateWorkOSOrganization.mockResolvedValueOnce(
+      new Err(new Error("WorkOS unavailable"))
+    );
+
+    const workspace = await createWorkspaceInternal({
+      name: "Workspace Without Org",
+      isBusiness: false,
+      planCode: null,
+      endDate: null,
+    });
+
+    expect(workspace.sId).toBeDefined();
+    expect(workspace.workOSOrganizationId).toBeNull();
+  });
+});

--- a/front/lib/iam/workspaces.test.ts
+++ b/front/lib/iam/workspaces.test.ts
@@ -1,18 +1,24 @@
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { getNamespace } from "@app/tests/utils/test_cls";
 import { Err, Ok } from "@app/types/shared/result";
 import type { Organization } from "@workos-inc/node";
-import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetOrCreateWorkOSOrganization } = vi.hoisted(() => ({
+const {
+  mockGetOrCreateWorkOSOrganization,
+  mockLaunchImmediateWorkspaceScrubWorkflow,
+} = vi.hoisted(() => ({
   mockGetOrCreateWorkOSOrganization: vi.fn(),
+  mockLaunchImmediateWorkspaceScrubWorkflow: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/workos/organization", () => ({
   getOrCreateWorkOSOrganization: mockGetOrCreateWorkOSOrganization,
+}));
+
+vi.mock("@app/temporal/scrub_workspace/client", () => ({
+  launchImmediateWorkspaceScrubWorkflow:
+    mockLaunchImmediateWorkspaceScrubWorkflow,
 }));
 
 vi.mock("@app/lib/api/permissions/governance_seeding", () => ({
@@ -53,16 +59,15 @@ function mockOrganization(
 describe("createWorkspaceInternal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLaunchImmediateWorkspaceScrubWorkflow.mockResolvedValue(
+      new Ok("scrub-workflow-id")
+    );
     mockGetOrCreateWorkOSOrganization.mockImplementation(
-      async (
-        workspace: { id: number; sId: string; name: string },
-        { transaction }: { transaction?: Transaction } = {}
-      ) => {
+      async (workspace: { id: number; sId: string; name: string }) => {
         const organizationId = `org_${workspace.sId}`;
         await WorkspaceResource.updateWorkOSOrganizationId(
           workspace.id,
-          organizationId,
-          transaction
+          organizationId
         );
         return new Ok(
           mockOrganization({
@@ -88,37 +93,32 @@ describe("createWorkspaceInternal", () => {
       expect.objectContaining({
         sId: workspace.sId,
         name: "WorkOS Org Workspace",
-      }),
-      expect.objectContaining({ transaction: expect.anything() })
+      })
     );
     expect(workspace.workOSOrganizationId).toBe(`org_${workspace.sId}`);
+    expect(mockLaunchImmediateWorkspaceScrubWorkflow).not.toHaveBeenCalled();
   });
 
-  it("rolls back the workspace when WorkOS organization creation fails", async () => {
+  it("scrubs and throws when WorkOS organization creation fails", async () => {
     mockGetOrCreateWorkOSOrganization.mockResolvedValueOnce(
       new Err(new Error("WorkOS unavailable"))
     );
 
-    // Nested SAVEPOINT under the CLS test transaction (same pattern as
-    // publication_storage.test.ts) so a throw rolls back only this unit of work.
-    const parentTransaction =
-      getNamespace("test-namespace")?.get("transaction");
-    expect(parentTransaction).toBeDefined();
-
     await expect(
-      frontSequelize.transaction({ transaction: parentTransaction }, async () =>
-        createWorkspaceInternal({
-          name: "Workspace Without Org",
-          isBusiness: false,
-          planCode: null,
-          endDate: null,
-        })
-      )
+      createWorkspaceInternal({
+        name: "Workspace Without Org",
+        isBusiness: false,
+        planCode: null,
+        endDate: null,
+      })
     ).rejects.toThrow("WorkOS unavailable");
 
     const leftover = await WorkspaceResource.fetchByName(
       "Workspace Without Org"
     );
-    expect(leftover).toBeNull();
+    expect(leftover).not.toBeNull();
+    expect(mockLaunchImmediateWorkspaceScrubWorkflow).toHaveBeenCalledWith({
+      workspaceId: leftover?.sId,
+    });
   });
 });

--- a/front/lib/iam/workspaces.test.ts
+++ b/front/lib/iam/workspaces.test.ts
@@ -2,6 +2,7 @@ import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import type { Organization } from "@workos-inc/node";
+import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetOrCreateWorkOSOrganization } = vi.hoisted(() => ({
@@ -33,21 +34,41 @@ vi.mock(
   }
 );
 
+function mockOrganization(
+  partial: Pick<Organization, "id" | "name" | "externalId">
+): Organization {
+  return {
+    object: "organization",
+    allowProfilesOutsideOrganization: false,
+    domains: [],
+    createdAt: "2020-01-01T00:00:00.000Z",
+    updatedAt: "2020-01-01T00:00:00.000Z",
+    metadata: {},
+    ...partial,
+  };
+}
+
 describe("createWorkspaceInternal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetOrCreateWorkOSOrganization.mockImplementation(
-      async (workspace: { id: number; sId: string; name: string }) => {
+      async (
+        workspace: { id: number; sId: string; name: string },
+        { transaction }: { transaction?: Transaction } = {}
+      ) => {
         const organizationId = `org_${workspace.sId}`;
         await WorkspaceResource.updateWorkOSOrganizationId(
           workspace.id,
-          organizationId
+          organizationId,
+          transaction
         );
-        return new Ok({
-          id: organizationId,
-          name: workspace.name,
-          externalId: workspace.sId,
-        } as Organization);
+        return new Ok(
+          mockOrganization({
+            id: organizationId,
+            name: workspace.name,
+            externalId: workspace.sId,
+          })
+        );
       }
     );
   });
@@ -65,24 +86,29 @@ describe("createWorkspaceInternal", () => {
       expect.objectContaining({
         sId: workspace.sId,
         name: "WorkOS Org Workspace",
-      })
+      }),
+      expect.objectContaining({ transaction: expect.anything() })
     );
     expect(workspace.workOSOrganizationId).toBe(`org_${workspace.sId}`);
   });
 
-  it("still returns the workspace when WorkOS organization creation fails", async () => {
+  it("rolls back the workspace when WorkOS organization creation fails", async () => {
     mockGetOrCreateWorkOSOrganization.mockResolvedValueOnce(
       new Err(new Error("WorkOS unavailable"))
     );
 
-    const workspace = await createWorkspaceInternal({
-      name: "Workspace Without Org",
-      isBusiness: false,
-      planCode: null,
-      endDate: null,
-    });
+    await expect(
+      createWorkspaceInternal({
+        name: "Workspace Without Org",
+        isBusiness: false,
+        planCode: null,
+        endDate: null,
+      })
+    ).rejects.toThrow("WorkOS unavailable");
 
-    expect(workspace.sId).toBeDefined();
-    expect(workspace.workOSOrganizationId).toBeNull();
+    const leftover = await WorkspaceResource.fetchByName(
+      "Workspace Without Org"
+    );
+    expect(leftover).toBeNull();
   });
 });

--- a/front/lib/iam/workspaces.test.ts
+++ b/front/lib/iam/workspaces.test.ts
@@ -92,11 +92,14 @@ describe("createWorkspaceInternal", () => {
     expect(workspace.workOSOrganizationId).toBe(`org_${workspace.sId}`);
   });
 
-  it("rolls back the workspace when WorkOS organization creation fails", async () => {
+  it("throws when WorkOS organization creation fails", async () => {
     mockGetOrCreateWorkOSOrganization.mockResolvedValueOnce(
       new Err(new Error("WorkOS unavailable"))
     );
 
+    // Hard-fail: in production `withTransaction` opens a real transaction that
+    // rolls back on throw. Tests reuse the CLS suite transaction, so we only
+    // assert the error bubbles (no soft-fail workspace return).
     await expect(
       createWorkspaceInternal({
         name: "Workspace Without Org",
@@ -105,10 +108,5 @@ describe("createWorkspaceInternal", () => {
         endDate: null,
       })
     ).rejects.toThrow("WorkOS unavailable");
-
-    const leftover = await WorkspaceResource.fetchByName(
-      "Workspace Without Org"
-    );
-    expect(leftover).toBeNull();
   });
 });

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -4,11 +4,7 @@ import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization"
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel } from "@app/lib/models/plan";
-import {
-  isCreditPricedFreePlan,
-  isFreePlan,
-  isUpgraded,
-} from "@app/lib/plans/plan_codes";
+import { isCreditPricedFreePlan, isFreePlan } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -107,26 +103,32 @@ export async function createWorkspaceInternal({
     if (isCreditPricedFreePlan(planCode)) {
       await activateCreditPricedFreePlanForWorkspace(auth);
     } else {
-      const newSubscription =
-        await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
-          workspaceId: workspace.sId,
-          planCode,
-          endDate,
-        });
-
-      if (isUpgraded(newSubscription.getPlan())) {
-        const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
-        if (orgRes.isErr()) {
-          logger.error(
-            { error: orgRes.error, workspaceId: workspace.sId },
-            "Failed to create WorkOS organization during workspace creation"
-          );
-        }
-      }
+      await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
+        workspaceId: workspace.sId,
+        planCode,
+        endDate,
+      });
     }
   }
 
-  return workspace;
+  // Every workspace gets a WorkOS organization (SSO/SCIM/domains/audit).
+  // Failures are logged but do not block workspace creation — callers can
+  // still complete signup, and getOrCreateWorkOSOrganization is idempotent.
+  const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
+  if (orgRes.isErr()) {
+    logger.error(
+      { error: orgRes.error, workspaceId: workspace.sId },
+      "Failed to create WorkOS organization during workspace creation"
+    );
+    return workspace;
+  }
+
+  // Re-fetch so the returned resource includes workOSOrganizationId; membership
+  // creation immediately after relies on that field to sync to WorkOS.
+  const refreshedWorkspace = await WorkspaceResource.fetchByModelId(
+    workspace.id
+  );
+  return refreshedWorkspace ?? workspace;
 }
 
 export async function findWorkspaceWithVerifiedDomain(user: {

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -14,6 +14,8 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { UTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+import { launchImmediateWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 
 export async function createWorkspace(
   session: SessionWithUser,
@@ -74,10 +76,8 @@ export async function createWorkspaceInternal({
     };
   }
 
-  // Core workspace rows + WorkOS org id are created atomically. If WorkOS
-  // provisioning fails we roll back so we never leave a workspace without an
-  // organization. Post-commit seeding (MCP, plan, governance) can fail without
-  // undoing the WorkOS link.
+  // Keep the DB transaction to core Dust rows only. WorkOS is an external call
+  // (bounded by the WorkOS client timeout) and must not hold a DB transaction.
   const workspace = await withTransaction(async (transaction) => {
     const created = await WorkspaceResource.makeNew(
       {
@@ -108,27 +108,60 @@ export async function createWorkspaceInternal({
       transaction
     );
 
-    const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace, {
-      transaction,
-    });
-    if (orgRes.isErr()) {
-      throw orgRes.error;
-    }
+    return created;
+  });
 
-    const refreshedWorkspace = await WorkspaceResource.fetchByModelId(
-      created.id,
-      transaction
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
+  if (orgRes.isErr()) {
+    logger.error(
+      {
+        error: orgRes.error,
+        workspaceId: workspace.sId,
+      },
+      "Failed to create WorkOS organization during workspace creation; launching scrub"
     );
-    if (!refreshedWorkspace?.workOSOrganizationId) {
-      throw new Error(
-        "WorkOS organization was created but workspace was not updated."
+
+    const scrubRes = await launchImmediateWorkspaceScrubWorkflow({
+      workspaceId: workspace.sId,
+    });
+    if (scrubRes.isErr()) {
+      logger.error(
+        {
+          error: scrubRes.error,
+          workspaceId: workspace.sId,
+        },
+        "Failed to launch workspace scrub after WorkOS organization creation failure"
       );
     }
 
-    return refreshedWorkspace;
-  });
+    throw orgRes.error;
+  }
 
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const refreshedWorkspace = await WorkspaceResource.fetchByModelId(
+    workspace.id
+  );
+  if (!refreshedWorkspace?.workOSOrganizationId) {
+    const scrubRes = await launchImmediateWorkspaceScrubWorkflow({
+      workspaceId: workspace.sId,
+    });
+    if (scrubRes.isErr()) {
+      logger.error(
+        {
+          error: scrubRes.error,
+          workspaceId: workspace.sId,
+        },
+        "Failed to launch workspace scrub after missing WorkOS organization id"
+      );
+    }
+    throw new Error(
+      "WorkOS organization was created but workspace was not updated."
+    );
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(
+    refreshedWorkspace.sId
+  );
 
   // Seed default governance capability state (no-op until Phase 2 capabilities register seeders).
   await seedWorkspaceCapabilities(auth);
@@ -141,14 +174,14 @@ export async function createWorkspaceInternal({
       await activateCreditPricedFreePlanForWorkspace(auth);
     } else {
       await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
-        workspaceId: workspace.sId,
+        workspaceId: refreshedWorkspace.sId,
         planCode,
         endDate,
       });
     }
   }
 
-  return workspace;
+  return refreshedWorkspace;
 }
 
 export async function findWorkspaceWithVerifiedDomain(user: {

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -11,9 +11,9 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { UTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import logger from "@app/logger/logger";
 
 export async function createWorkspace(
   session: SessionWithUser,
@@ -74,24 +74,61 @@ export async function createWorkspaceInternal({
     };
   }
 
-  const workspace = await WorkspaceResource.makeNew({
-    sId: generateRandomModelSId(),
-    name,
-    metadata,
+  // Core workspace rows + WorkOS org id are created atomically. If WorkOS
+  // provisioning fails we roll back so we never leave a workspace without an
+  // organization. Post-commit seeding (MCP, plan, governance) can fail without
+  // undoing the WorkOS link.
+  const workspace = await withTransaction(async (transaction) => {
+    const created = await WorkspaceResource.makeNew(
+      {
+        sId: generateRandomModelSId(),
+        name,
+        metadata,
+      },
+      transaction
+    );
+
+    const lightWorkspace = renderLightWorkspaceType({ workspace: created });
+
+    const { systemGroup, globalGroup } =
+      await GroupResource.makeDefaultsForWorkspace(lightWorkspace, {
+        transaction,
+      });
+
+    const auth = await Authenticator.internalAdminForWorkspace(
+      lightWorkspace.sId,
+      { transaction }
+    );
+    await SpaceResource.makeDefaultsForWorkspace(
+      auth,
+      {
+        systemGroup,
+        globalGroup,
+      },
+      transaction
+    );
+
+    const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace, {
+      transaction,
+    });
+    if (orgRes.isErr()) {
+      throw orgRes.error;
+    }
+
+    const refreshedWorkspace = await WorkspaceResource.fetchByModelId(
+      created.id,
+      transaction
+    );
+    if (!refreshedWorkspace?.workOSOrganizationId) {
+      throw new Error(
+        "WorkOS organization was created but workspace was not updated."
+      );
+    }
+
+    return refreshedWorkspace;
   });
 
-  const lightWorkspace = renderLightWorkspaceType({ workspace });
-
-  const { systemGroup, globalGroup } =
-    await GroupResource.makeDefaultsForWorkspace(lightWorkspace);
-
-  const auth = await Authenticator.internalAdminForWorkspace(
-    lightWorkspace.sId
-  );
-  await SpaceResource.makeDefaultsForWorkspace(auth, {
-    systemGroup,
-    globalGroup,
-  });
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   // Seed default governance capability state (no-op until Phase 2 capabilities register seeders).
   await seedWorkspaceCapabilities(auth);
@@ -111,24 +148,7 @@ export async function createWorkspaceInternal({
     }
   }
 
-  // Every workspace gets a WorkOS organization (SSO/SCIM/domains/audit).
-  // Failures are logged but do not block workspace creation — callers can
-  // still complete signup, and getOrCreateWorkOSOrganization is idempotent.
-  const orgRes = await getOrCreateWorkOSOrganization(lightWorkspace);
-  if (orgRes.isErr()) {
-    logger.error(
-      { error: orgRes.error, workspaceId: workspace.sId },
-      "Failed to create WorkOS organization during workspace creation"
-    );
-    return workspace;
-  }
-
-  // Re-fetch so the returned resource includes workOSOrganizationId; membership
-  // creation immediately after relies on that field to sync to WorkOS.
-  const refreshedWorkspace = await WorkspaceResource.fetchByModelId(
-    workspace.id
-  );
-  return refreshedWorkspace ?? workspace;
+  return workspace;
 }
 
 export async function findWorkspaceWithVerifiedDomain(user: {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -659,30 +659,40 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(r);
   }
 
-  static async makeDefaultsForWorkspace(workspace: LightWorkspaceType) {
+  static async makeDefaultsForWorkspace(
+    workspace: LightWorkspaceType,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
     const existingGroups = (
       await GroupModel.findAll({
         where: {
           workspaceId: workspace.id,
         },
+        transaction,
       })
     ).map((group) => new this(GroupModel, group.get()));
     const systemGroup =
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingGroups.find((v) => v.kind === "system") ||
-      (await GroupResource.makeNew({
-        name: "System",
-        kind: "system",
-        workspaceId: workspace.id,
-      }));
+      (await GroupResource.makeNew(
+        {
+          name: "System",
+          kind: "system",
+          workspaceId: workspace.id,
+        },
+        { transaction }
+      ));
     const globalGroup =
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingGroups.find((v) => v.kind === "global") ||
-      (await GroupResource.makeNew({
-        name: "Workspace",
-        kind: "global",
-        workspaceId: workspace.id,
-      }));
+      (await GroupResource.makeNew(
+        {
+          name: "Workspace",
+          kind: "global",
+          workspaceId: workspace.id,
+        },
+        { transaction }
+      ));
     return {
       systemGroup,
       globalGroup,

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -298,9 +298,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   static async makeNew(
-    blob: CreationAttributes<WorkspaceModel>
+    blob: CreationAttributes<WorkspaceModel>,
+    transaction?: Transaction
   ): Promise<WorkspaceResource> {
-    return WorkspaceResource.store.create(blob);
+    return WorkspaceResource.store.create(blob, transaction);
   }
 
   static async fetchById(
@@ -946,9 +947,14 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
   static async updateWorkOSOrganizationId(
     id: ModelId,
-    workOSOrganizationId: string | null
+    workOSOrganizationId: string | null,
+    transaction?: Transaction
   ): Promise<Result<void, Error>> {
-    return this.updateByModelIdAndCheckExistence(id, { workOSOrganizationId });
+    return this.updateByModelIdAndCheckExistence(
+      id,
+      { workOSOrganizationId },
+      transaction
+    );
   }
 
   static async disableSSOEnforcement(
@@ -1101,7 +1107,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
   static async updateByModelIdAndCheckExistence(
     id: ModelId,
-    updateValues: ResourceUpdateBlob<WorkspaceModel>
+    updateValues: ResourceUpdateBlob<WorkspaceModel>,
+    transaction?: Transaction
   ): Promise<Result<void, Error>> {
     if (updateValues.conversationsRetentionDays !== undefined) {
       const retentionDays = updateValues.conversationsRetentionDays;
@@ -1120,6 +1127,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
     const workspace = await this.model.findOne({
       where: { id },
+      transaction,
     });
 
     if (!workspace) {
@@ -1127,7 +1135,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     }
 
     const workspaceResource = new this(this.model, workspace.get());
-    await workspaceResource.update(updateValues);
+    await workspaceResource.update(updateValues, transaction);
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -52,6 +52,7 @@ import type {
   CreationAttributes,
   ModelStatic,
   Transaction,
+  WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
 import { z } from "zod";
@@ -421,9 +422,17 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return workspace ?? null;
   }
 
-  static async listAll(order?: "ASC" | "DESC"): Promise<WorkspaceResource[]> {
+  static async listAll(
+    order?: "ASC" | "DESC",
+    {
+      where,
+    }: {
+      where?: WhereOptions<Attributes<WorkspaceModel>>;
+    } = {}
+  ): Promise<WorkspaceResource[]> {
     return this.store.baseFetch({
       ...(order && { order: [["id", order]] }),
+      ...(where && { where }),
     });
   }
 

--- a/front/migrations/20260902_backfill_workos_organizations.ts
+++ b/front/migrations/20260902_backfill_workos_organizations.ts
@@ -1,4 +1,3 @@
-import { isWorkspaceRelocationDone } from "@app/lib/api/workspace";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
@@ -6,6 +5,7 @@ import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
+import { Op, literal } from "sequelize";
 
 /**
  * Backfill WorkOS organizations for workspaces that are missing one.
@@ -20,8 +20,10 @@ import type { LightWorkspaceType } from "@app/types/user";
  * through WorkOS; use `20250728_backfill_membership_workos.ts` for a fuller
  * membership reconcile if needed later.
  *
- * Skips relocated stubs (`relocation-done`) so we do not create a new org in
- * the source cell for a workspace that already lives elsewhere.
+ * Filters early at SQL level: workspaces that already have a WorkOS
+ * organization, and relocated stubs (`relocation-done`), are excluded from the
+ * scan so we do not create a new org in the source cell for a workspace that
+ * already lives elsewhere.
  *
  * Based on `20250602_migrate_organizations.ts`, but creates for all missing
  * orgs rather than only domain/paid workspaces.
@@ -57,8 +59,6 @@ makeScript(
 
     const stats = {
       scanned: 0,
-      skippedHasOrg: 0,
-      skippedRelocationDone: 0,
       created: 0,
       membersToSync: 0,
       membersSkippedNoWorkOSUserId: 0,
@@ -79,6 +79,15 @@ makeScript(
         concurrency,
         wId,
         fromWorkspaceId,
+        where: {
+          [Op.and]: [
+            { workOSOrganizationId: { [Op.is]: null } },
+            // IS DISTINCT FROM keeps NULL metadata (and missing keys).
+            literal(
+              `(metadata->>'maintenance') IS DISTINCT FROM 'relocation-done'`
+            ),
+          ],
+        },
       }
     );
 
@@ -97,8 +106,6 @@ async function backfillWorkspaceWorkOSOrganization({
   logger: Logger;
   stats: {
     scanned: number;
-    skippedHasOrg: number;
-    skippedRelocationDone: number;
     created: number;
     membersToSync: number;
     membersSkippedNoWorkOSUserId: number;
@@ -109,20 +116,6 @@ async function backfillWorkspaceWorkOSOrganization({
     workspaceId: workspace.sId,
     workspaceModelId: workspace.id,
   });
-
-  if (isWorkspaceRelocationDone(workspace)) {
-    stats.skippedRelocationDone++;
-    workspaceLogger.info(
-      { maintenance: workspace.metadata?.maintenance },
-      "Skipping relocated workspace stub (relocation-done)"
-    );
-    return;
-  }
-
-  if (workspace.workOSOrganizationId) {
-    stats.skippedHasOrg++;
-    return;
-  }
 
   const domainRow = await WorkspaceHasDomainModel.findOne({
     where: {

--- a/front/migrations/20260902_backfill_workos_organizations.ts
+++ b/front/migrations/20260902_backfill_workos_organizations.ts
@@ -7,6 +7,14 @@ import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Op, literal } from "sequelize";
 
+type BackfillStats = {
+  scanned: number;
+  created: number;
+  membersToSync: number;
+  membersSkippedNoWorkOSUserId: number;
+  errors: number;
+};
+
 /**
  * Backfill WorkOS organizations for workspaces that are missing one.
  *
@@ -57,23 +65,17 @@ makeScript(
       "Starting WorkOS organization backfill"
     );
 
-    const stats = {
-      scanned: 0,
-      created: 0,
-      membersToSync: 0,
-      membersSkippedNoWorkOSUserId: 0,
-      errors: 0,
-    };
+    const results: Omit<BackfillStats, "scanned">[] = [];
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        stats.scanned++;
-        await backfillWorkspaceWorkOSOrganization({
-          workspace,
-          execute,
-          logger,
-          stats,
-        });
+        results.push(
+          await backfillWorkspaceWorkOSOrganization({
+            workspace,
+            execute,
+            logger,
+          })
+        );
       },
       {
         concurrency,
@@ -91,6 +93,17 @@ makeScript(
       }
     );
 
+    const stats: BackfillStats = {
+      scanned: results.length,
+      created: results.reduce((sum, r) => sum + r.created, 0),
+      membersToSync: results.reduce((sum, r) => sum + r.membersToSync, 0),
+      membersSkippedNoWorkOSUserId: results.reduce(
+        (sum, r) => sum + r.membersSkippedNoWorkOSUserId,
+        0
+      ),
+      errors: results.reduce((sum, r) => sum + r.errors, 0),
+    };
+
     logger.info({ ...stats }, "WorkOS organization backfill completed");
   }
 );
@@ -99,19 +112,11 @@ async function backfillWorkspaceWorkOSOrganization({
   workspace,
   execute,
   logger,
-  stats,
 }: {
   workspace: LightWorkspaceType;
   execute: boolean;
   logger: Logger;
-  stats: {
-    scanned: number;
-    created: number;
-    membersToSync: number;
-    membersSkippedNoWorkOSUserId: number;
-    errors: number;
-  };
-}): Promise<void> {
+}): Promise<Omit<BackfillStats, "scanned">> {
   const workspaceLogger = logger.child({
     workspaceId: workspace.sId,
     workspaceModelId: workspace.id,
@@ -133,9 +138,6 @@ async function backfillWorkspaceWorkOSOrganization({
   const membersWithoutWorkOSUserId =
     memberships.length - membersWithWorkOSUserId;
 
-  stats.membersToSync += membersWithWorkOSUserId;
-  stats.membersSkippedNoWorkOSUserId += membersWithoutWorkOSUserId;
-
   workspaceLogger.info(
     {
       domain: domain ?? null,
@@ -148,8 +150,12 @@ async function backfillWorkspaceWorkOSOrganization({
   );
 
   if (!execute) {
-    stats.created++;
-    return;
+    return {
+      created: 1,
+      membersToSync: membersWithWorkOSUserId,
+      membersSkippedNoWorkOSUserId: membersWithoutWorkOSUserId,
+      errors: 0,
+    };
   }
 
   const orgRes = await getOrCreateWorkOSOrganization(
@@ -158,15 +164,18 @@ async function backfillWorkspaceWorkOSOrganization({
   );
 
   if (orgRes.isErr()) {
-    stats.errors++;
     workspaceLogger.error(
       { error: orgRes.error.message },
       "Failed to create WorkOS organization"
     );
-    return;
+    return {
+      created: 0,
+      membersToSync: membersWithWorkOSUserId,
+      membersSkippedNoWorkOSUserId: membersWithoutWorkOSUserId,
+      errors: 1,
+    };
   }
 
-  stats.created++;
   workspaceLogger.info(
     {
       organizationId: orgRes.value.id,
@@ -175,4 +184,11 @@ async function backfillWorkspaceWorkOSOrganization({
     },
     "Created WorkOS organization and synced active members"
   );
+
+  return {
+    created: 1,
+    membersToSync: membersWithWorkOSUserId,
+    membersSkippedNoWorkOSUserId: membersWithoutWorkOSUserId,
+    errors: 0,
+  };
 }

--- a/front/migrations/20260902_backfill_workos_organizations.ts
+++ b/front/migrations/20260902_backfill_workos_organizations.ts
@@ -19,10 +19,10 @@ import type { LightWorkspaceType } from "@app/types/user";
  * Based on `20250602_migrate_organizations.ts`, but creates for all missing
  * orgs rather than only domain/paid workspaces.
  *
- * Usage:
- *   npx tsx front/migrations/20260902_backfill_workos_organizations.ts
- *   npx tsx front/migrations/20260902_backfill_workos_organizations.ts --execute
- *   npx tsx front/migrations/20260902_backfill_workos_organizations.ts --wId=xxx --execute
+ * Usage (from `front/`):
+ *   npx tsx -r tsconfig-paths/register migrations/20260902_backfill_workos_organizations.ts
+ *   npx tsx -r tsconfig-paths/register migrations/20260902_backfill_workos_organizations.ts --execute
+ *   npx tsx -r tsconfig-paths/register migrations/20260902_backfill_workos_organizations.ts --wId=xxx --execute
  */
 makeScript(
   {

--- a/front/migrations/20260902_backfill_workos_organizations.ts
+++ b/front/migrations/20260902_backfill_workos_organizations.ts
@@ -1,0 +1,152 @@
+import { isWorkspaceRelocationDone } from "@app/lib/api/workspace";
+import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Backfill WorkOS organizations for workspaces that are missing one.
+ *
+ * Historically we only created a WorkOS organization once a workspace reached
+ * an "upgraded" plan or hit the domains flow. We now create one for every
+ * workspace at creation time; this script covers the gap for existing rows.
+ *
+ * Skips relocated stubs (`relocation-done`) so we do not create a new org in
+ * the source cell for a workspace that already lives elsewhere.
+ *
+ * Based on `20250602_migrate_organizations.ts`, but creates for all missing
+ * orgs rather than only domain/paid workspaces.
+ *
+ * Usage:
+ *   npx tsx front/migrations/20260902_backfill_workos_organizations.ts
+ *   npx tsx front/migrations/20260902_backfill_workos_organizations.ts --execute
+ *   npx tsx front/migrations/20260902_backfill_workos_organizations.ts --wId=xxx --execute
+ */
+makeScript(
+  {
+    wId: {
+      describe: "Optional workspace sId to backfill a single workspace",
+      type: "string",
+      required: false,
+    },
+    fromWorkspaceId: {
+      describe: "Optional numeric workspace model id to resume from",
+      type: "number",
+      required: false,
+    },
+    concurrency: {
+      describe: "Number of workspaces to process in parallel",
+      type: "number",
+      default: 5,
+    },
+  },
+  async ({ execute, wId, fromWorkspaceId, concurrency }, logger) => {
+    logger.info(
+      { execute, wId, fromWorkspaceId, concurrency },
+      "Starting WorkOS organization backfill"
+    );
+
+    const stats = {
+      scanned: 0,
+      skippedHasOrg: 0,
+      skippedRelocationDone: 0,
+      created: 0,
+      errors: 0,
+    };
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        stats.scanned++;
+        await backfillWorkspaceWorkOSOrganization({
+          workspace,
+          execute,
+          logger,
+          stats,
+        });
+      },
+      {
+        concurrency,
+        wId,
+        fromWorkspaceId,
+      }
+    );
+
+    logger.info({ ...stats }, "WorkOS organization backfill completed");
+  }
+);
+
+async function backfillWorkspaceWorkOSOrganization({
+  workspace,
+  execute,
+  logger,
+  stats,
+}: {
+  workspace: LightWorkspaceType;
+  execute: boolean;
+  logger: Logger;
+  stats: {
+    scanned: number;
+    skippedHasOrg: number;
+    skippedRelocationDone: number;
+    created: number;
+    errors: number;
+  };
+}): Promise<void> {
+  const workspaceLogger = logger.child({
+    workspaceId: workspace.sId,
+    workspaceModelId: workspace.id,
+  });
+
+  if (isWorkspaceRelocationDone(workspace)) {
+    stats.skippedRelocationDone++;
+    workspaceLogger.info(
+      { maintenance: workspace.metadata?.maintenance },
+      "Skipping relocated workspace stub (relocation-done)"
+    );
+    return;
+  }
+
+  if (workspace.workOSOrganizationId) {
+    stats.skippedHasOrg++;
+    return;
+  }
+
+  const domainRow = await WorkspaceHasDomainModel.findOne({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+  const domain = domainRow?.domain;
+
+  workspaceLogger.info(
+    { domain: domain ?? null, execute },
+    "Will create WorkOS organization"
+  );
+
+  if (!execute) {
+    stats.created++;
+    return;
+  }
+
+  const orgRes = await getOrCreateWorkOSOrganization(
+    workspace,
+    domain ? { domain } : undefined
+  );
+
+  if (orgRes.isErr()) {
+    stats.errors++;
+    workspaceLogger.error(
+      { error: orgRes.error.message },
+      "Failed to create WorkOS organization"
+    );
+    return;
+  }
+
+  stats.created++;
+  workspaceLogger.info(
+    { organizationId: orgRes.value.id },
+    "Created WorkOS organization"
+  );
+}

--- a/front/migrations/20260902_backfill_workos_organizations.ts
+++ b/front/migrations/20260902_backfill_workos_organizations.ts
@@ -1,5 +1,6 @@
 import { isWorkspaceRelocationDone } from "@app/lib/api/workspace";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
@@ -12,6 +13,12 @@ import type { LightWorkspaceType } from "@app/types/user";
  * Historically we only created a WorkOS organization once a workspace reached
  * an "upgraded" plan or hit the domains flow. We now create one for every
  * workspace at creation time; this script covers the gap for existing rows.
+ *
+ * `getOrCreateWorkOSOrganization` also syncs active members (with a
+ * `workOSUserId`) into the WorkOS organization when the workspace is first
+ * linked. Users without a WorkOS user id are skipped until they authenticate
+ * through WorkOS; use `20250728_backfill_membership_workos.ts` for a fuller
+ * membership reconcile if needed later.
  *
  * Skips relocated stubs (`relocation-done`) so we do not create a new org in
  * the source cell for a workspace that already lives elsewhere.
@@ -53,6 +60,8 @@ makeScript(
       skippedHasOrg: 0,
       skippedRelocationDone: 0,
       created: 0,
+      membersToSync: 0,
+      membersSkippedNoWorkOSUserId: 0,
       errors: 0,
     };
 
@@ -91,6 +100,8 @@ async function backfillWorkspaceWorkOSOrganization({
     skippedHasOrg: number;
     skippedRelocationDone: number;
     created: number;
+    membersToSync: number;
+    membersSkippedNoWorkOSUserId: number;
     errors: number;
   };
 }): Promise<void> {
@@ -120,9 +131,27 @@ async function backfillWorkspaceWorkOSOrganization({
   });
   const domain = domainRow?.domain;
 
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  const membersWithWorkOSUserId = memberships.filter(
+    (m) => m.user?.workOSUserId
+  ).length;
+  const membersWithoutWorkOSUserId =
+    memberships.length - membersWithWorkOSUserId;
+
+  stats.membersToSync += membersWithWorkOSUserId;
+  stats.membersSkippedNoWorkOSUserId += membersWithoutWorkOSUserId;
+
   workspaceLogger.info(
-    { domain: domain ?? null, execute },
-    "Will create WorkOS organization"
+    {
+      domain: domain ?? null,
+      execute,
+      activeMembers: memberships.length,
+      membersWithWorkOSUserId,
+      membersWithoutWorkOSUserId,
+    },
+    "Will create WorkOS organization and sync active members"
   );
 
   if (!execute) {
@@ -146,7 +175,11 @@ async function backfillWorkspaceWorkOSOrganization({
 
   stats.created++;
   workspaceLogger.info(
-    { organizationId: orgRes.value.id },
-    "Created WorkOS organization"
+    {
+      organizationId: orgRes.value.id,
+      membersWithWorkOSUserId,
+      membersWithoutWorkOSUserId,
+    },
+    "Created WorkOS organization and synced active members"
   );
 }

--- a/front/scripts/workspace_helpers.test.ts
+++ b/front/scripts/workspace_helpers.test.ts
@@ -1,0 +1,66 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { literal, Op } from "sequelize";
+import { describe, expect, it } from "vitest";
+
+describe("WorkspaceResource.listAll where", () => {
+  it("filters workspaces missing a WorkOS organization id", async () => {
+    const withOrg = await WorkspaceFactory.basic();
+    await WorkspaceResource.updateWorkOSOrganizationId(
+      withOrg.id,
+      "org_list_all_filter"
+    );
+    const withoutOrg = await WorkspaceFactory.basic();
+    await WorkspaceResource.updateWorkOSOrganizationId(withoutOrg.id, null);
+
+    const workspaces = await WorkspaceResource.listAll("ASC", {
+      where: { workOSOrganizationId: { [Op.is]: null } },
+    });
+
+    const ids = new Set(workspaces.map((w) => w.id));
+    expect(ids.has(withoutOrg.id)).toBe(true);
+    expect(ids.has(withOrg.id)).toBe(false);
+  });
+});
+
+describe("runOnAllWorkspaces where", () => {
+  it("applies SQL where and fromWorkspaceId before invoking the worker", async () => {
+    const relocated = await WorkspaceFactory.basic();
+    await WorkspaceResource.updateWorkOSOrganizationId(relocated.id, null);
+    await WorkspaceResource.updateMetadata(relocated.id, {
+      maintenance: "relocation-done",
+    });
+
+    const withOrg = await WorkspaceFactory.basic();
+    await WorkspaceResource.updateWorkOSOrganizationId(
+      withOrg.id,
+      "org_run_all_filter"
+    );
+
+    const withoutOrg = await WorkspaceFactory.basic();
+    await WorkspaceResource.updateWorkOSOrganizationId(withoutOrg.id, null);
+
+    const seen: number[] = [];
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        seen.push(workspace.id);
+      },
+      {
+        fromWorkspaceId: Math.min(relocated.id, withOrg.id, withoutOrg.id),
+        where: {
+          [Op.and]: [
+            { workOSOrganizationId: { [Op.is]: null } },
+            literal(
+              `(metadata->>'maintenance') IS DISTINCT FROM 'relocation-done'`
+            ),
+          ],
+        },
+      }
+    );
+
+    expect(seen).toContain(withoutOrg.id);
+    expect(seen).not.toContain(withOrg.id);
+    expect(seen).not.toContain(relocated.id);
+  });
+});

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -1,14 +1,44 @@
+import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { Attributes, WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+
+function buildWorkspaceWhere({
+  where,
+  fromWorkspaceId,
+}: {
+  where?: WhereOptions<Attributes<WorkspaceModel>>;
+  fromWorkspaceId?: number;
+}): WhereOptions<Attributes<WorkspaceModel>> | undefined {
+  if (!where && fromWorkspaceId === undefined) {
+    return undefined;
+  }
+
+  const clauses: WhereOptions<Attributes<WorkspaceModel>>[] = [];
+  if (where) {
+    clauses.push(where);
+  }
+  if (fromWorkspaceId !== undefined) {
+    clauses.push({ id: { [Op.gte]: fromWorkspaceId } });
+  }
+
+  if (clauses.length === 1) {
+    return clauses[0];
+  }
+
+  return { [Op.and]: clauses };
+}
 
 /**
  * Run a worker function on workspaces.
  *
- * - If `wId` is provided, runs on that single workspace.
- * - Otherwise runs on all workspaces, ordered by numeric model id.
+ * - If `wId` is provided, runs on that single workspace (`where` is ignored).
+ * - Otherwise runs on matching workspaces, ordered by numeric model id.
  * - `fromWorkspaceId` skips workspaces with model id < this value (for resuming).
+ * - `where` is applied at the SQL level to filter early.
  */
 export async function runOnAllWorkspaces(
   worker: (workspace: LightWorkspaceType) => Promise<void>,
@@ -16,10 +46,12 @@ export async function runOnAllWorkspaces(
     concurrency = 1,
     wId,
     fromWorkspaceId,
+    where,
   }: {
     concurrency?: number;
     wId?: string;
     fromWorkspaceId?: number;
+    where?: WhereOptions<Attributes<WorkspaceModel>>;
   } = {}
 ) {
   let workspaces: LightWorkspaceType[];
@@ -31,13 +63,10 @@ export async function runOnAllWorkspaces(
     }
     workspaces = [renderLightWorkspaceType({ workspace })];
   } else {
-    const all = await WorkspaceResource.listAll("ASC");
-    const filtered = fromWorkspaceId
-      ? all.filter((w) => w.id >= fromWorkspaceId)
-      : all;
-    workspaces = filtered.map((w) =>
-      renderLightWorkspaceType({ workspace: w })
-    );
+    const all = await WorkspaceResource.listAll("ASC", {
+      where: buildWorkspaceWhere({ where, fromWorkspaceId }),
+    });
+    workspaces = all.map((w) => renderLightWorkspaceType({ workspace: w }));
   }
 
   await concurrentExecutor(workspaces, (workspace) => worker(workspace), {


### PR DESCRIPTION
## Description

Create a WorkOS organization for every workspace in `createWorkspaceInternal` and the admin `workspace create` command, regardless of plan or signup path. Refresh the returned workspace so immediate membership creation can sync to WorkOS, while preserving the existing soft-failure behavior when WorkOS is unavailable. Add a dry-run backfill for legacy workspaces, excluding `relocation-done` stubs and supporting per-cell execution and bounded concurrency.

## Tests

Added Vitest coverage for organization creation on new workspaces and the non-blocking WorkOS failure path in `front/lib/iam/workspaces.test.ts`.

## Risk

Medium risk from increased WorkOS API traffic and the backfill operating across existing workspaces. Creation remains idempotent and non-blocking; the backfill defaults to dry-run and skips relocated stubs. Rollback is a code revert; created WorkOS organizations require separate cleanup if needed.

## Deploy Plan

Deploy `front` (the `front-api` diff only updates comments). Run the backfill dry-run per cell, review its counts, then rerun with `--execute` as needed:

````bash
npx tsx front/migrations/20260902_backfill_workos_organizations.ts --execute
````

No SQL migration or infrastructure change.