### PR TITLE
Build connectors once, push to the global registry

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -51,6 +51,10 @@ inputs:
   contentful_access_token:
     description: "Contentful access token"
     required: false
+  extra_image_registries:
+    description: "Space-separated <host>/<project>/<repo> prefixes that also receive the image, on top of the primary registry"
+    required: false
+    default: ""
 
 outputs:
   current_version:
@@ -81,7 +85,16 @@ runs:
 
     - name: "Configure GCP Docker Auth"
       shell: bash
-      run: gcloud auth configure-docker ${{ inputs.region }}-docker.pkg.dev --quiet
+      env:
+        EXTRA_IMAGE_REGISTRIES: ${{ inputs.extra_image_registries }}
+      run: |
+        HOSTS="${{ inputs.region }}-docker.pkg.dev"
+        # shellcheck disable=SC2086 # word splitting is the point
+        for registry in $EXTRA_IMAGE_REGISTRIES; do
+          HOSTS="${HOSTS},${registry%%/*}"
+        done
+        HOSTS=$(echo "$HOSTS" | tr ',' '\n' | sort -u | paste -sd, -)
+        gcloud auth configure-docker "$HOSTS" --quiet
 
     - name: "Fetch custom models config"
       if: contains(inputs.component, 'front')
@@ -96,6 +109,7 @@ runs:
       shell: bash
       env:
         DEPOT_TOKEN: ${{ inputs.depot_region == 'eu' && inputs.depot_eu_token || inputs.depot_us_token }}
+        EXTRA_IMAGE_REGISTRIES: ${{ inputs.extra_image_registries }}
       run: |
         COMPONENT="${{ inputs.component }}"
 
@@ -178,10 +192,22 @@ runs:
 
         # Tag with 'latest' for main branch prod non-canary builds
         LATEST_TAGS=()
+        PUSH_LATEST=false
         if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
+          PUSH_LATEST=true
           REGISTRY="${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images"
           LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
         fi
+
+        # Same image, additional registries (single-target builds only).
+        EXTRA_TAGS=()
+        # shellcheck disable=SC2086 # word splitting is the point
+        for registry in $EXTRA_IMAGE_REGISTRIES; do
+          EXTRA_TAGS+=("-t" "${registry}/${COMPONENT}:${{ inputs.commit_sha }}")
+          if [[ "$PUSH_LATEST" == "true" ]]; then
+            EXTRA_TAGS+=("-t" "${registry}/${COMPONENT}:latest")
+          fi
+        done
 
         # Special handling for front component: Bake builds both targets in parallel
         # and deduplicates work in their shared base-deps stage.
@@ -236,6 +262,7 @@ runs:
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
             "${LATEST_TAGS[@]}" \
+            "${EXTRA_TAGS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             --build-arg DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,12 +145,73 @@ jobs:
             echo "matrix=[\"${{ inputs.regions }}\"]" >> "$GITHUB_OUTPUT"
           fi
 
+  # Components on the build-once path: one build, pushed to the global registry and, for
+  # now, to both regional registries so the regional values files keep resolving.
+  build-once:
+    permissions:
+      contents: read
+      id-token: write
+    needs: [prepare, notify-start]
+    if: ${{ !failure() && !cancelled() && inputs.component == 'connectors' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
+
+      - name: Build Image
+        id: build
+        uses: ./.github/actions/build-image
+        with:
+          commit_sha_long: ${{ needs.prepare.outputs.long_sha }}
+          commit_sha: ${{ needs.prepare.outputs.short_sha }}
+          component: ${{ inputs.component }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          depot_eu_project_id: ${{ secrets.DEPOT_EU_PROJECT_ID }}
+          depot_eu_token: ${{ secrets.DEPOT_EU_PROJECT_TOKEN }}
+          depot_region: ${{ inputs.depot_region }}
+          depot_us_project_id: ${{ secrets.DEPOT_PROJECT_ID }}
+          depot_us_token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
+          # Global registry, lives in the dust-infra project next to the helm charts.
+          project_id: dust-infra
+          region: us-central1
+          extra_image_registries: >-
+            us-central1-docker.pkg.dev/${{ secrets.GCLOUD_US_PROJECT_ID }}/dust-images
+            europe-west1-docker.pkg.dev/${{ secrets.GCLOUD_EU_PROJECT_ID }}/dust-images
+          workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
+
+      - name: Notify build success
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "build_success"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
+          component: ${{ inputs.component }}
+          image_tag: ${{ needs.prepare.outputs.short_sha }}
+          region: ${{ inputs.regions }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          current_version: ${{ steps.build.outputs.current_version }}
+          commit_diff: ${{ steps.build.outputs.commit_diff }}
+          commit_count: ${{ steps.build.outputs.commit_count }}
+
+      - name: Notify Failure
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "failure"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          component: ${{ inputs.component }}
+          image_tag: ${{ needs.prepare.outputs.short_sha }}
+          region: ${{ inputs.regions }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
+
   build:
     permissions:
       contents: read
       id-token: write
     needs: [prepare, notify-start, create-matrix, verify-sandbox-images]
-    if: ${{ !failure() && !cancelled() && (needs.verify-sandbox-images.result == 'success' || needs.verify-sandbox-images.result == 'skipped') }}
+    if: ${{ !failure() && !cancelled() && inputs.component != 'connectors' && (needs.verify-sandbox-images.result == 'success' || needs.verify-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -224,6 +285,7 @@ jobs:
         prepare,
         notify-start,
         build,
+        build-once,
         deploy-app,
         deploy-poke,
         verify-sandbox-images,


### PR DESCRIPTION
## Description

Connectors is built twice per deploy today, once per region, with the two legs pushing identical images to two regional registries. This adds a single build job for connectors that authenticates against the dust-infra project and pushes one image to the new global `dust-images` repository from https://github.com/dust-tt/dust-infra/pull/1010. The regional build matrix is skipped for connectors and unchanged for every other component.

For now the same build is also tagged into both regional registries, through a new `extra_image_registries` input on the build-image action. That keeps the regional values files in dust-infra, `revert.yml` and `list-tags` working without any ordering constraints. The regional tags go away once dust-infra points the connectors values at the global repository.

Connectors goes first because its Dockerfile takes no region-specific build args. The front images still bake three region-specific URLs into the runtime env, which is why they cannot follow yet.

## Tests

I gave up testing GH action a long time ago 🙈 

## Risk

Only the connectors component is affected. If the new job fails, the deploy job does not run and the currently deployed image stays. Rollback is reverting this PR, which puts connectors back on the regional matrix.

## Deploy Plan

1. dust-infra applies the registry, the build identity and the pull grants (https://github.com/dust-tt/dust-infra/pull/1010).
2. Merge this PR.
3. Deploy connectors as usual. The image lands in the global registry and both regional ones under the same tag.
