### PR TITLE
Persist Frames v2 manifest name and description on the frame file

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/frames/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/index.test.ts
@@ -22,6 +22,8 @@ describe("GET /api/poke/workspaces/:wId/frames", () => {
     expect(data.items[0]).toMatchObject({
       sId: frame.sId,
       fileName: "manifest.json",
+      name: "Task List",
+      description: "Track tasks.",
       status: "ready",
       activePublicationId: "publication-1",
       functionCount: 1,

--- a/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/frames/[frameId]/invocations/[invocationId]/events.test.ts
@@ -46,7 +46,11 @@ describe("GET /api/sse/w/:wId/frames/:frameId/invocations/:invocationId/events",
   it("keeps an invocation streamable after the Frame republishes", async () => {
     const { frame, invocation, sandboxFunction, workspace } =
       await makeTestFrameInvocation();
-    await frame.setActiveFramePublication("publication-2");
+    await frame.setActiveFramePublication({
+      publicationId: "publication-2",
+      name: "Task List",
+      description: "Track tasks.",
+    });
     mockEventStream({
       type: "sandbox_function_invocation_result",
       created: Date.now(),

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -563,7 +563,11 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       frame,
       publicationId: nextPublicationId,
     });
-    await frame.setActiveFramePublication(nextPublicationId);
+    await frame.setActiveFramePublication({
+      publicationId: nextPublicationId,
+      name: "Task List",
+      description: "Track tasks.",
+    });
     const staleInvocation = await postInvocation({
       workspaceId: workspace.sId,
       functionIdOrSlug: sandboxFunction.sId,
@@ -1296,7 +1300,11 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       frame,
       publicationId: "publication-2",
     });
-    await frame.setActiveFramePublication("publication-2");
+    await frame.setActiveFramePublication({
+      publicationId: "publication-2",
+      name: "Task List",
+      description: "Track tasks.",
+    });
     vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
       undefined
     );
@@ -1559,7 +1567,11 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       frame,
       publicationId: "publication-2",
     });
-    await frame.setActiveFramePublication("publication-2");
+    await frame.setActiveFramePublication({
+      publicationId: "publication-2",
+      name: "Task List",
+      description: "Track tasks.",
+    });
     vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
       undefined
     );

--- a/front/components/poke/frames/columns.tsx
+++ b/front/components/poke/frames/columns.tsx
@@ -12,7 +12,8 @@ export function makeColumnsForFrames({
 }): ColumnDef<PokeFrameListItem>[] {
   return [
     {
-      accessorKey: "fileName",
+      id: "name",
+      accessorFn: (row) => row.name ?? "",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Name" />
       ),
@@ -21,7 +22,7 @@ export function makeColumnsForFrames({
           href={`/poke/${owner.sId}/files/${row.original.sId}`}
           className="text-highlight-500"
         >
-          {row.original.fileName}
+          {row.original.name ?? row.original.fileName}
         </LinkWrapper>
       ),
     },

--- a/front/components/poke/frames/view.tsx
+++ b/front/components/poke/frames/view.tsx
@@ -31,7 +31,11 @@ export function ViewFrameTable({ details, owner }: ViewFrameTableProps) {
           </PokeTableRow>
           <PokeTableRow>
             <PokeTableHead>Name</PokeTableHead>
-            <PokeTableCell>{frame.fileName}</PokeTableCell>
+            <PokeTableCell>{frame.name ?? "—"}</PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableHead>Description</PokeTableHead>
+            <PokeTableCell>{frame.description ?? "—"}</PokeTableCell>
           </PokeTableRow>
           <PokeTableRow>
             <PokeTableHead>File status</PokeTableHead>

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -167,7 +167,11 @@ describe("buildAndPublishFramePublication", () => {
   it("validates UI and Tailwind without writing a publication", async () => {
     const { auth, conversation, frame } = await setup();
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
-    await frame.setActiveFramePublication(activePublicationId);
+    await frame.setActiveFramePublication({
+      publicationId: activePublicationId,
+      name: "Task List",
+      description: "Track tasks.",
+    });
 
     const result = await validateFramePublication(auth, {
       conversation,
@@ -430,7 +434,11 @@ describe("buildAndPublishFramePublication", () => {
   it("keeps the active publication when the UI build fails", async () => {
     const { auth, conversation, frame } = await setup();
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
-    await frame.setActiveFramePublication(activePublicationId);
+    await frame.setActiveFramePublication({
+      publicationId: activePublicationId,
+      name: "Task List",
+      description: "Track tasks.",
+    });
 
     const result = await buildAndPublishFramePublication(auth, {
       conversation,

--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -607,6 +607,55 @@ describe("activateFramePublication", () => {
     expect(reloaded?.useCaseMetadata?.activePublicationId).toBe(
       stored.value.publicationId
     );
+    expect(reloaded?.useCaseMetadata?.frameName).toBe("Task List");
+    expect(reloaded?.useCaseMetadata?.frameDescription).toBe("Track tasks.");
+  });
+
+  it("refreshes the stored name and description on republish", async () => {
+    const { auth, frame } = await setupFrame();
+    const first = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+    expect(first.isOk()).toBe(true);
+    if (first.isErr()) {
+      return;
+    }
+    await activateFramePublication(auth, {
+      frame,
+      publicationId: first.value.publicationId,
+    });
+
+    const renamedManifest = FrameManifestSchema.parse({
+      ...manifest,
+      name: "Renamed Tasks",
+      description: "Renamed description.",
+    });
+    const second = await storeFramePublication(auth, {
+      frame,
+      functionArtifacts: [],
+      manifest: renamedManifest,
+      sourceFiles,
+      uiBundleCode,
+    });
+    expect(second.isOk()).toBe(true);
+    if (second.isErr()) {
+      return;
+    }
+    const activated = await activateFramePublication(auth, {
+      frame,
+      publicationId: second.value.publicationId,
+    });
+    expect(activated.isOk()).toBe(true);
+
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.useCaseMetadata?.frameName).toBe("Renamed Tasks");
+    expect(reloaded?.useCaseMetadata?.frameDescription).toBe(
+      "Renamed description."
+    );
   });
 
   it("keeps the active publication when validation fails", async () => {
@@ -949,7 +998,11 @@ describe("publishFramePublication", () => {
   it("keeps the previous publication active when database reconciliation fails", async () => {
     const { auth, frame } = await setupFrame();
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
-    await frame.setActiveFramePublication(activePublicationId);
+    await frame.setActiveFramePublication({
+      publicationId: activePublicationId,
+      name: "Task List",
+      description: "Track tasks.",
+    });
     vi.mocked(reconcileFramePublicationDatabases).mockResolvedValueOnce(
       new Err(
         new SandboxFunctionError(
@@ -984,7 +1037,11 @@ describe("publishFramePublication", () => {
   it("keeps the active publication when function artifact storage fails", async () => {
     const { auth, frame } = await setupFrame();
     const activePublicationId = "b8c2b796-534a-4ad2-a5ad-071da692ca0b";
-    await frame.setActiveFramePublication(activePublicationId);
+    await frame.setActiveFramePublication({
+      publicationId: activePublicationId,
+      name: "Task List",
+      description: "Track tasks.",
+    });
     fileStorageMock.setFileSaveFails((filePath) =>
       filePath.endsWith("/functions/add-task.ts")
     );

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -553,7 +553,14 @@ export async function activateFramePublication(
   await withTransaction(async (transaction) => {
     // Updating the Frame first serializes concurrent activations. None of the
     // new publication state becomes visible until the transaction commits.
-    await frame.setActiveFramePublication(publicationId, transaction);
+    await frame.setActiveFramePublication(
+      {
+        publicationId,
+        name: descriptor.value.manifest.name,
+        description: descriptor.value.manifest.description,
+      },
+      transaction
+    );
     await frame.persistAuthorizedFileAccess(allowlist.value, { transaction });
     await SandboxFunctionResource.createForFramePublication(
       auth,
@@ -580,7 +587,7 @@ export async function activateFramePublication(
       buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
       buildAuditLogTarget("frame", {
         sId: frame.sId,
-        name: frame.fileName,
+        name: descriptor.value.manifest.name,
       }),
     ],
     context: getAuditLogContext(auth),

--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -27,6 +27,9 @@ import { removeNulls } from "@app/types/shared/utils/general";
 export type PokeFrameListItem = {
   sId: string;
   fileName: string;
+  // Manifest name and description of the active publication; null until first publish.
+  name: string | null;
+  description: string | null;
   status: FileStatus;
   mountFilePath: string | null;
   activePublicationId: string | null;
@@ -62,6 +65,8 @@ function toPokeFrameListItem(
   return {
     sId: frame.sId,
     fileName: frame.fileName,
+    name: frame.useCaseMetadata?.frameName ?? null,
+    description: frame.useCaseMetadata?.frameDescription ?? null,
     status: frame.status,
     mountFilePath: frame.mountFilePath,
     activePublicationId: frame.useCaseMetadata?.activePublicationId ?? null,

--- a/front/lib/api/sandbox_functions/frame_share_capability.test.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.test.ts
@@ -25,7 +25,11 @@ describe("resolveActiveFrameFunctionForUse", () => {
       SandboxFunctionResource,
       "fetchByFramePublicationAndSlug"
     ).mockImplementationOnce(async (...args) => {
-      await frame.setActiveFramePublication("publication-2");
+      await frame.setActiveFramePublication({
+        publicationId: "publication-2",
+        name: "Task List",
+        description: "Track tasks.",
+      });
       return fetchFunction(...args);
     });
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1061,7 +1061,11 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   async setActiveFramePublication(
-    publicationId: string,
+    {
+      publicationId,
+      name,
+      description,
+    }: { publicationId: string; name: string; description: string },
     transaction?: Transaction
   ) {
     return this.update(
@@ -1069,6 +1073,8 @@ export class FileResource extends BaseResource<FileModel> {
         useCaseMetadata: {
           ...this.useCaseMetadata,
           activePublicationId: publicationId,
+          frameName: name,
+          frameDescription: description,
         },
       },
       transaction

--- a/front/lib/resources/sandbox_function_frame_invocation.test.ts
+++ b/front/lib/resources/sandbox_function_frame_invocation.test.ts
@@ -7,7 +7,11 @@ import { describe, expect, it } from "vitest";
 describe("SandboxFunctionResource.fetchInvocationByFrameAndId", () => {
   it("resolves the invocation after the Frame republishes", async () => {
     const { auth, frame, invocation } = await makeTestFrameInvocation();
-    await frame.setActiveFramePublication("publication-2");
+    await frame.setActiveFramePublication({
+      publicationId: "publication-2",
+      name: "Task List",
+      description: "Track tasks.",
+    });
 
     await expect(
       SandboxFunctionResource.fetchInvocationByFrameAndId(auth, {

--- a/front/tests/utils/FrameFunctionFactory.ts
+++ b/front/tests/utils/FrameFunctionFactory.ts
@@ -38,6 +38,8 @@ export async function makeTestFrameFunction({
     useCaseMetadata: {
       spaceId: space.sId,
       activePublicationId: publicationId,
+      frameName: "Task List",
+      frameDescription: "Track tasks.",
     },
   });
   await frame.setShareScope(adminAuth, shareScope);

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -64,6 +64,10 @@ export type FileUseCaseMetadata = {
   frameEntryRelPath?: string;
   // Immutable Frames v2 publication currently served by the Frame.
   activePublicationId?: string;
+  // Name and description from the manifest of the active publication. Refreshed on every
+  // activation, so they describe what is served, not what the source folder currently says.
+  frameName?: string;
+  frameDescription?: string;
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

At publication activation, the frame's `useCaseMetadata` now records `frameName` and `frameDescription` from the manifest of the publication being served, next to `activePublicationId`. The values are refreshed on every activation, so they describe what is served rather than the current source folder. No migration: this follows the existing pattern of frame-specific state living in the JSONB.

Poke's frames list and detail view show the name and description. The list column falls back to the filename for frames that have never been published, and the useless `manifest.json` file column is gone. The `frame.publication_activated` audit target now uses the manifest name instead of `manifest.json`.

`setActiveFramePublication` takes `{ publicationId, name, description }`; test call sites were updated. Frames published before this change have a null name until their next publish; no backfill.

## Tests

- `publication_storage.test.ts`: activation stores both fields; a republish with a renamed manifest overwrites them.
- Poke frames list test asserts the new fields.

## Risk

Low. Additive JSONB fields, Poke-only UI change.

## Deploy Plan

Deploy front.