### PR TITLE
Fail loudly on unattributed user usage in Metronome events

### DIFF
--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -79,11 +79,26 @@ describe("Metronome aggregated usage event", () => {
     });
   });
 
-  it("always emits the required billable shape with valid values", () => {
-    // Even with no user / api key / agent, the required properties fall back to
-    // valid, non-empty values so the billable metric's `exists` filters match.
+  it("refuses to emit a user-attributed event with no userId", () => {
+    // A "user" usage_type with no userId means the caller's attribution logic
+    // has a bug (see isProgrammaticUsageFromContext) — it must fail loudly
+    // instead of silently shipping as user_id "unknown".
+    expect(() =>
+      buildUsageEvents({
+        ...commonEventInput,
+        userId: null,
+        runUsages: [usage({ costMicroUsd: 1 })],
+      })
+    ).toThrow(/Refusing to emit a user-attributed Metronome event/);
+  });
+
+  it("falls back to valid, non-empty values for optional identity fields", () => {
+    // Programmatic/free usage legitimately has no userId (system key, no
+    // human). The remaining identity properties still fall back to
+    // non-empty values so the billable metric's `exists` filters match.
     const events = buildUsageEvents({
       ...commonEventInput,
+      usageType: "programmatic",
       userId: null,
       apiKeyName: null,
       agentId: null,
@@ -106,7 +121,7 @@ describe("Metronome aggregated usage event", () => {
     expect(props["user_id"]).toBe("unknown");
     expect(props["api_key_name"]).toBe("unknown");
     expect(props["agent_id"]).toBe("unknown");
-    expect(props["usage_type"]).toBe("user");
+    expect(props["usage_type"]).toBe("programmatic");
   });
 
   it("rounds LLM per model then adds tool weights flat, excluding free/capped", () => {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -220,7 +220,6 @@ export function buildUsageEvents({
   }
 
   // A "user" event with no real user is a bug in the caller's attribution
-  // logic (see isProgrammaticUsageFromContext), not a legitimate case: it
   // would otherwise silently ship as user_id "unknown" and never surface.
   // Programmatic and free-origin usage are allowed to have no userId.
   if (usageType === USAGE_TYPE_USER && !userId) {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -219,6 +219,17 @@ export function buildUsageEvents({
     return [];
   }
 
+  // A "user" event with no real user is a bug in the caller's attribution
+  // logic (see isProgrammaticUsageFromContext), not a legitimate case: it
+  // would otherwise silently ship as user_id "unknown" and never surface.
+  // Programmatic and free-origin usage are allowed to have no userId.
+  if (usageType === USAGE_TYPE_USER && !userId) {
+    throw new Error(
+      `Refusing to emit a user-attributed Metronome event with no userId ` +
+        `(workspaceId=${workspaceId}, agentMessageId=${agentMessageId}, origin=${origin}, authMethod=${authMethod}).`
+    );
+  }
+
   const costAwu = billingPlan.totals.llmBilledCredits + toolBilledCredits;
 
   // Aggregate token counts across models for observability only — the billable


### PR DESCRIPTION
## Description

A `usage_type: "user"` event with no `userId` used to ship to Metronome as `user_id: "unknown"` instead of surfacing the caller's attribution bug. This now throws instead, so the bug fails loudly (a Temporal retry/alert) rather than shipping silently misattributed spend. Programmatic and free-origin usage are unaffected.

Base for #31721, which fixes one caller this check surfaces.

## Tests

Updated `lib/metronome/events.test.ts`: one test asserts the throw fires for a null-userId "user" event, another confirms programmatic usage still falls back to sane placeholder values.

## Risk

Low — no user-facing path touches this code. Worst case, an already-buggy event that used to ship as "unknown" now fails and retries in Temporal instead, surfacing the bug via alerting.

## Deploy Plan

- Front
