### PR TITLE
Classify system API keys as programmatic Metronome usage

### DIFF
--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -55,17 +55,23 @@ const PROGRAMMATIC_USAGE_ORIGINS = Object.keys(
     USAGE_ORIGINS_CLASSIFICATION[origin as UserMessageOrigin] === "programmatic"
 );
 
+// Auth methods with no human behind them: a workspace API key, or the workspace's
+// own system key used internally (e.g. sub-agent runs). Both must classify as
+// programmatic, otherwise their usage falls back to the "user" bucket with no
+// real user to attribute it to.
+const PROGRAMMATIC_AUTH_METHODS = ["api_key", "system_api_key"];
+
 export function isProgrammaticUsageFromContext({
   authMethod,
   userMessageOrigin,
 }: {
   // Persisted historical values predate the AuthMethodType union, so keep the input broad and
-  // reproduce the live rule by recognizing the one auth method that changes classification.
+  // reproduce the live rule by recognizing the auth methods that change classification.
   authMethod: string | null;
   userMessageOrigin: UserMessageOrigin;
 }): boolean {
   return (
-    authMethod === "api_key" ||
+    (authMethod !== null && PROGRAMMATIC_AUTH_METHODS.includes(authMethod)) ||
     USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
   );
 }
@@ -108,7 +114,7 @@ export function getProgrammaticUsageFilterClause(): estypes.QueryDslQueryContain
   return {
     bool: {
       should: [
-        { term: { auth_method: "api_key" } },
+        { terms: { auth_method: PROGRAMMATIC_AUTH_METHODS } },
         { bool: { must_not: { exists: { field: "context_origin" } } } },
         { terms: { context_origin: PROGRAMMATIC_USAGE_ORIGINS } },
       ],

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -55,10 +55,7 @@ const PROGRAMMATIC_USAGE_ORIGINS = Object.keys(
     USAGE_ORIGINS_CLASSIFICATION[origin as UserMessageOrigin] === "programmatic"
 );
 
-// Auth methods with no human behind them: a workspace API key, or the workspace's
-// own system key used internally (e.g. sub-agent runs). Both must classify as
-// programmatic, otherwise their usage falls back to the "user" bucket with no
-// real user to attribute it to.
+// Auth methods with no human behind them
 const PROGRAMMATIC_AUTH_METHODS = ["api_key", "system_api_key"];
 
 export function isProgrammaticUsageFromContext({


### PR DESCRIPTION
## Description

`isProgrammaticUsageFromContext` only recognized `authMethod === "api_key"`, missing `"system_api_key"`. 

That usage was falling into the generic "user" bucket with no user to attribute it to, which is exactly what #31720 now catches loudly. Fixing this

**Warning:** Workspace that used `system_api_key` auth this cycle will see its programmatic spend-cap counter jump upward on next resync, since usage previously misbucketed as "user" now counts as "programmatic".   

If a workspace has a configured `monthlyCapAwuCredits`, this could push it over the cap mid-cycle and start blocking programmatic calls that weren't being capped before. Not a bug, but a behavior change that lands the moment this deploys, with no gradual rollout.

## Tests

Covered by existing `lib/api/programmatic_usage/tracking.test.ts` suite (37 tests, all passing).

## Risk

Low — reclassifies a subset of previously-mislabeled "user" usage as "programmatic". No change to billing totals, only to which credit pool an event drains and how it's attributed.

## Deploy Plan

- Front
