### PR TITLE
feat: export messages with new es index

### DIFF
--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -32,6 +32,7 @@ import {
 } from "@app/lib/api/analytics/users_export";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -577,12 +578,18 @@ async function exportMessages({
   timezone: string;
   owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
+  const useConsumptionIndex = await hasFeatureFlag(
+    auth,
+    "message_export_from_consumption_index"
+  );
+
   const result = await fetchMessageExportRows({
     auth,
     owner,
     startDate,
     endDate,
     timezone,
+    useConsumptionIndex,
   });
 
   if (result.isErr()) {

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -13,17 +13,15 @@ import {
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import { MICRO_CREDITS_PER_CREDIT } from "@app/lib/credits/units";
+import { microCreditsToCredits } from "@app/lib/credits/units";
 import type {
   AgentMessageAnalyticsCost,
   AgentMessageAnalyticsModel,
 } from "@app/types/assistant/analytics";
-import type {
-  ModelIdType,
-  ModelProviderIdType,
-  ModelResolutionMethodType,
-  ReasoningEffort,
-} from "@app/types/assistant/models/types";
+import { isModelId } from "@app/types/assistant/models/models";
+import { isModelProviderId } from "@app/types/assistant/models/providers";
+import { isReasoningEffort } from "@app/types/assistant/models/reasoning";
+import { isModelResolutionMethod } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -220,6 +218,35 @@ function firstBucketKey(agg: TermsAgg | undefined): string {
   return buckets[0]?.key ?? "";
 }
 
+function parseAnalyticsModel(
+  bucket: estypes.AggregationsStringTermsBucketKeys | undefined
+): AgentMessageAnalyticsModel | null {
+  if (!bucket) {
+    return null;
+  }
+  const modelId = String(bucket.key[0]);
+  const providerId = String(bucket.key[1]);
+  const resolutionMethod = String(bucket.key[2]);
+  const reasoningEffort = String(bucket.key[3]);
+
+  if (
+    !isModelId(modelId) ||
+    !isModelProviderId(providerId) ||
+    !isReasoningEffort(reasoningEffort)
+  ) {
+    return null;
+  }
+
+  return {
+    model_id: modelId,
+    provider_id: providerId,
+    resolution_method: isModelResolutionMethod(resolutionMethod)
+      ? resolutionMethod
+      : null,
+    reasoning_effort: reasoningEffort,
+  };
+}
+
 function consumptionBucketToDocument(
   messageId: string,
   bucket: ConsumptionMessageBucket
@@ -261,18 +288,9 @@ function consumptionBucketToDocument(
       full_awu: 0,
       llm_awu: 0,
       tool_awu: 0,
-      billable_awu: Math.round(creditMicro / MICRO_CREDITS_PER_CREDIT),
+      billable_awu: Math.round(microCreditsToCredits(creditMicro)),
     },
-    model: primaryModel
-      ? {
-          model_id: String(primaryModel.key[0]) as ModelIdType,
-          provider_id: String(primaryModel.key[1]) as ModelProviderIdType,
-          resolution_method: String(
-            primaryModel.key[2]
-          ) as ModelResolutionMethodType,
-          reasoning_effort: String(primaryModel.key[3]) as ReasoningEffort,
-        }
-      : null,
+    model: parseAnalyticsModel(primaryModel),
   };
 }
 

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -35,15 +35,20 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   message_id: string;
   timestamp: string;
   agent_id: string;
+  // Optional: docs indexed before agent_tag_ids shipped don't carry it.
   agent_tag_ids?: string[];
   conversation_id: string;
+  // Ids of the agent messages that triggered this message through `run_agent`,
+  // direct parent first. Empty or absent for user-initiated messages.
   ancestor_message_ids?: string[];
   user_id: string;
   context_origin: string;
   status: string;
   tools_used?: { server_name: string; tool_name: string }[];
   skills_used?: { skill_name: string }[];
+  // Optional: docs indexed before the cost fields shipped don't carry it.
   cost?: AgentMessageAnalyticsCost;
+  // Optional: docs indexed before the model fields shipped don't carry it.
   model?: AgentMessageAnalyticsModel | null;
 }
 

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -158,10 +158,9 @@ interface ConsumptionMessageAggs {
   };
 }
 
-function buildConsumptionAggregations(): Record<
-  string,
-  estypes.AggregationsAggregationContainer
-> {
+function buildConsumptionAggregations(
+  afterKey?: Record<string, string>
+): Record<string, estypes.AggregationsAggregationContainer> {
   return {
     by_message: {
       composite: {
@@ -169,6 +168,7 @@ function buildConsumptionAggregations(): Record<
         sources: [
           { agent_message_id: { terms: { field: "agent_message_id" } } },
         ],
+        ...(afterKey ? { after: afterKey } : {}),
       },
       aggs: {
         min_completed_at: { min: { field: "completed_at" } },
@@ -309,18 +309,11 @@ async function fetchAllMessageDocumentsFromConsumptionIndex(
   let afterKey: Record<string, string> | undefined;
 
   while (true) {
-    const aggs = buildConsumptionAggregations();
-    if (afterKey) {
-      (
-        aggs.by_message as { composite: { after?: Record<string, string> } }
-      ).composite.after = afterKey;
-    }
-
     const result = await searchConsumptionAnalytics<
       never,
       ConsumptionMessageAggs
     >(query, {
-      aggregations: aggs,
+      aggregations: buildConsumptionAggregations(afterKey),
       size: 0,
     });
 

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -148,7 +148,6 @@ interface ConsumptionMessageBucket {
   conversation_id: TermsAgg;
   user_id: TermsAgg;
   context_origin: TermsAgg;
-  latest_status: estypes.AggregationsTopHitsAggregate;
   total_credit_micro: estypes.AggregationsSumAggregate;
   tools: estypes.AggregationsFilterAggregate & {
     unique_tools: estypes.AggregationsMultiTermsAggregate;
@@ -175,22 +174,49 @@ function buildConsumptionAggregations(
         ],
         ...(afterKey ? { after: afterKey } : {}),
       },
+      // Group all LLM calls and tool calls by agent_message_id:
+      // reconstruct the message-level document from the aggregated fields.
       aggs: {
         min_completed_at: { min: { field: "completed_at" } },
-        agent_id: { terms: { field: "agent.id", size: 1 } },
-        agent_tag_ids: { terms: { field: "agent.tag_ids", size: 100 } },
-        conversation_id: { terms: { field: "conversation_id", size: 1 } },
-        user_id: { terms: { field: "user.id", size: 1 } },
-        context_origin: { terms: { field: "context_origin", size: 1 } },
-        latest_status: {
-          top_hits: {
+        agent_id: {
+          // agent_id is denormalized on every tool/llm calls: keep a single value per message.
+          terms: {
+            field: "agent.id",
             size: 1,
-            sort: [{ completed_at: "desc" }],
-            _source: { includes: ["status"] },
+          },
+        },
+        agent_tag_ids: {
+          // agent_tag_ids is denormalized on every tool/llm calls: we expect a single set of values per message.
+          terms: {
+            field: "agent.tag_ids",
+            size: 100, // keep at most 100 unique tag IDs per message.
+          },
+        },
+
+        conversation_id: {
+          // conversation_id is denormalized on every tool/llm calls: keep a single value per message.
+          terms: {
+            field: "conversation_id",
+            size: 1,
+          },
+        },
+        user_id: {
+          // user_id is denormalized on every tool/llm calls: keep a single value per message.
+          terms: {
+            field: "user.id",
+            size: 1,
+          },
+        },
+        context_origin: {
+          // context_origin is denormalized on every tool/llm calls: keep a single value per message.
+          terms: {
+            field: "context_origin",
+            size: 1,
           },
         },
         total_credit_micro: { sum: { field: "credit_micro" } },
         tools: {
+          // Distinct pairs found across all tool calls, capped at 100 values.
           filter: { exists: { field: "tool.name" } },
           aggs: {
             unique_tools: {
@@ -201,8 +227,16 @@ function buildConsumptionAggregations(
             },
           },
         },
-        skills: { terms: { field: "tool.attributed_skill_ids", size: 100 } },
+        skills: {
+          // Distinct skill ids from this message, capped at 100 values.
+          terms: {
+            field: "tool.attributed_skill_ids",
+            size: 100,
+          },
+        },
         models: {
+          // Distinct tuples found across all LLM and tool calls, capped at 10 values.
+          // In practice models don't change between runs today.
           multi_terms: {
             terms: [
               { field: "model.model_id" },
@@ -256,10 +290,6 @@ function consumptionBucketToDocument(
   messageId: string,
   bucket: ConsumptionMessageBucket
 ): AgentMessageDocument {
-  const statusHit = bucket.latest_status.hits?.hits?.[0]?._source as
-    | { status?: string }
-    | undefined;
-
   const toolBuckets = bucketsToArray(bucket.tools?.unique_tools?.buckets);
 
   const skillBuckets = bucketsToArray(bucket.skills?.buckets);
@@ -270,7 +300,7 @@ function consumptionBucketToDocument(
   const creditMicro = bucket.total_credit_micro.value ?? 0;
 
   return {
-    workspace_id: "",
+    workspace_id: "", // not used by csv export and not fetched by the es aggregation
     message_id: messageId,
     timestamp: bucket.min_completed_at.value_as_string ?? "",
     agent_id: firstBucketKey(bucket.agent_id),
@@ -281,7 +311,7 @@ function consumptionBucketToDocument(
     ancestor_message_ids: [],
     user_id: firstBucketKey(bucket.user_id),
     context_origin: firstBucketKey(bucket.context_origin),
-    status: statusHit?.status ?? "",
+    status: "", // not used by csv export and not fetched by the es aggregation
     tools_used: toolBuckets.map((b) => ({
       server_name: String(b.key[0]),
       tool_name: String(b.key[1]),

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -7,17 +7,29 @@ import {
 import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import { MICRO_CREDITS_PER_CREDIT } from "@app/lib/credits/units";
 import type {
   AgentMessageAnalyticsCost,
   AgentMessageAnalyticsModel,
 } from "@app/types/assistant/analytics";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+  ModelResolutionMethodType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
+import { buildConsumptionScopeQuery } from "./consumption/scope";
 
 const PAGE_SIZE = 10000;
 
@@ -25,20 +37,15 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   message_id: string;
   timestamp: string;
   agent_id: string;
-  // Optional: docs indexed before agent_tag_ids shipped don't carry it.
   agent_tag_ids?: string[];
   conversation_id: string;
-  // Ids of the agent messages that triggered this message through `run_agent`,
-  // direct parent first. Empty or absent for user-initiated messages.
   ancestor_message_ids?: string[];
   user_id: string;
   context_origin: string;
   status: string;
   tools_used?: { server_name: string; tool_name: string }[];
   skills_used?: { skill_name: string }[];
-  // Optional: docs indexed before the cost fields shipped don't carry it.
   cost?: AgentMessageAnalyticsCost;
-  // Optional: docs indexed before the model fields shipped don't carry it.
   model?: AgentMessageAnalyticsModel | null;
 }
 
@@ -123,26 +130,239 @@ async function fetchAllMessageDocuments(
   return new Ok(allDocs);
 }
 
+// Limit page size so we don't exceed the 65536 bucket limits.
+const CONSUMPTION_AGG_PAGE_SIZE = 5000;
+
+type TermsAgg =
+  estypes.AggregationsTermsAggregateBase<estypes.AggregationsStringTermsBucketKeys>;
+
+interface ConsumptionMessageBucket {
+  key: Record<string, string>;
+  doc_count: number;
+  min_completed_at: estypes.AggregationsMinAggregate;
+  agent_id: TermsAgg;
+  agent_tag_ids: TermsAgg;
+  conversation_id: TermsAgg;
+  user_id: TermsAgg;
+  context_origin: TermsAgg;
+  latest_status: estypes.AggregationsTopHitsAggregate;
+  total_credit_micro: estypes.AggregationsSumAggregate;
+  tools: estypes.AggregationsFilterAggregate & {
+    unique_tools: estypes.AggregationsMultiTermsAggregate;
+  };
+  skills: TermsAgg;
+  models: estypes.AggregationsMultiTermsAggregate;
+}
+
+interface ConsumptionMessageAggs {
+  by_message: estypes.AggregationsTermsAggregateBase<ConsumptionMessageBucket> & {
+    after_key?: Record<string, string>;
+  };
+}
+
+function buildConsumptionAggregations(): Record<
+  string,
+  estypes.AggregationsAggregationContainer
+> {
+  return {
+    by_message: {
+      composite: {
+        size: CONSUMPTION_AGG_PAGE_SIZE,
+        sources: [
+          { agent_message_id: { terms: { field: "agent_message_id" } } },
+        ],
+      },
+      aggs: {
+        min_completed_at: { min: { field: "completed_at" } },
+        agent_id: { terms: { field: "agent.id", size: 1 } },
+        agent_tag_ids: { terms: { field: "agent.tag_ids", size: 100 } },
+        conversation_id: { terms: { field: "conversation_id", size: 1 } },
+        user_id: { terms: { field: "user.id", size: 1 } },
+        context_origin: { terms: { field: "context_origin", size: 1 } },
+        latest_status: {
+          top_hits: {
+            size: 1,
+            sort: [{ completed_at: "desc" }],
+            _source: { includes: ["status"] },
+          },
+        },
+        total_credit_micro: { sum: { field: "credit_micro" } },
+        tools: {
+          filter: { exists: { field: "tool.name" } },
+          aggs: {
+            unique_tools: {
+              multi_terms: {
+                terms: [{ field: "tool.server_name" }, { field: "tool.name" }],
+                size: 100,
+              },
+            },
+          },
+        },
+        skills: { terms: { field: "tool.attributed_skill_ids", size: 100 } },
+        models: {
+          multi_terms: {
+            terms: [
+              { field: "model.model_id" },
+              { field: "model.provider_id" },
+              { field: "model.resolution_method" },
+              { field: "model.reasoning_effort" },
+            ],
+            size: 10,
+          },
+        },
+      },
+    },
+  };
+}
+
+function firstBucketKey(agg: TermsAgg | undefined): string {
+  const buckets = bucketsToArray(agg?.buckets);
+  return buckets[0]?.key ?? "";
+}
+
+function consumptionBucketToDocument(
+  messageId: string,
+  bucket: ConsumptionMessageBucket
+): AgentMessageDocument {
+  const statusHit = bucket.latest_status.hits?.hits?.[0]?._source as
+    | { status?: string }
+    | undefined;
+
+  const toolBuckets = bucketsToArray(bucket.tools?.unique_tools?.buckets);
+
+  const skillBuckets = bucketsToArray(bucket.skills?.buckets);
+
+  const modelBuckets = bucketsToArray(bucket.models?.buckets);
+  const primaryModel = modelBuckets[0];
+
+  const creditMicro = bucket.total_credit_micro.value ?? 0;
+
+  return {
+    workspace_id: "",
+    message_id: messageId,
+    timestamp: bucket.min_completed_at.value_as_string ?? "",
+    agent_id: firstBucketKey(bucket.agent_id),
+    agent_tag_ids: bucketsToArray(bucket.agent_tag_ids?.buckets).map(
+      (b) => b.key
+    ),
+    conversation_id: firstBucketKey(bucket.conversation_id),
+    ancestor_message_ids: [],
+    user_id: firstBucketKey(bucket.user_id),
+    context_origin: firstBucketKey(bucket.context_origin),
+    status: statusHit?.status ?? "",
+    tools_used: toolBuckets.map((b) => ({
+      server_name: String(b.key[0]),
+      tool_name: String(b.key[1]),
+    })),
+    skills_used: skillBuckets.map((b) => ({
+      skill_name: b.key,
+    })),
+    cost: {
+      full_awu: 0,
+      llm_awu: 0,
+      tool_awu: 0,
+      billable_awu: Math.round(creditMicro / MICRO_CREDITS_PER_CREDIT),
+    },
+    model: primaryModel
+      ? {
+          model_id: String(primaryModel.key[0]) as ModelIdType,
+          provider_id: String(primaryModel.key[1]) as ModelProviderIdType,
+          resolution_method: String(
+            primaryModel.key[2]
+          ) as ModelResolutionMethodType,
+          reasoning_effort: String(primaryModel.key[3]) as ReasoningEffort,
+        }
+      : null,
+  };
+}
+
+async function fetchAllMessageDocumentsFromConsumptionIndex(
+  auth: Authenticator,
+  startDate: string,
+  endDate: string
+): Promise<Result<AgentMessageDocument[], Error>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate,
+    endDate,
+  });
+
+  const allDocs: AgentMessageDocument[] = [];
+  let afterKey: Record<string, string> | undefined;
+
+  while (true) {
+    const aggs = buildConsumptionAggregations();
+    if (afterKey) {
+      (
+        aggs.by_message as { composite: { after?: Record<string, string> } }
+      ).composite.after = afterKey;
+    }
+
+    const result = await searchConsumptionAnalytics<
+      never,
+      ConsumptionMessageAggs
+    >(query, {
+      aggregations: aggs,
+      size: 0,
+    });
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const byMessage = result.value.aggregations?.by_message;
+    if (!byMessage) {
+      break;
+    }
+
+    const buckets = bucketsToArray(
+      byMessage.buckets
+    ) as ConsumptionMessageBucket[];
+
+    for (const bucket of buckets) {
+      allDocs.push(
+        consumptionBucketToDocument(bucket.key.agent_message_id, bucket)
+      );
+    }
+
+    if (buckets.length < CONSUMPTION_AGG_PAGE_SIZE) {
+      break;
+    }
+
+    afterKey = buckets[buckets.length - 1].key;
+  }
+
+  return new Ok(allDocs);
+}
+
 export async function fetchMessageExportRows({
   auth,
   owner,
   startDate,
   endDate,
   timezone,
+  useConsumptionIndex = false,
 }: {
   auth: Authenticator;
   owner: WorkspaceType;
   startDate: string;
   endDate: string;
   timezone: string;
+  useConsumptionIndex?: boolean;
 }): Promise<Result<MessageExportRow[], Error>> {
-  const query = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    startDate,
-    endDate,
-  });
-
-  const docsResult = await fetchAllMessageDocuments(query);
+  const docsResult = useConsumptionIndex
+    ? await fetchAllMessageDocumentsFromConsumptionIndex(
+        auth,
+        startDate,
+        endDate
+      )
+    : await fetchAllMessageDocuments(
+        buildAgentAnalyticsBaseQuery({
+          workspaceId: owner.sId,
+          startDate,
+          endDate,
+        })
+      );
   if (docsResult.isErr()) {
     return new Err(docsResult.error);
   }

--- a/front/lib/api/analytics/messages_export_consumption.test.ts
+++ b/front/lib/api/analytics/messages_export_consumption.test.ts
@@ -1,0 +1,149 @@
+import { fetchMessageExportRows } from "@app/lib/api/analytics/messages_export";
+import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { MICRO_CREDITS_PER_CREDIT } from "@app/lib/credits/units";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TagFactory } from "@app/tests/utils/TagFactory";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
+});
+
+vi.mock("@app/lib/resources/storage", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/resources/storage")>();
+  return {
+    ...actual,
+    getFrontReplicaDbConnection: () => actual.frontSequelize,
+  };
+});
+
+describe("fetchMessageExportRows (consumption index)", () => {
+  it("maps a composite aggregation response to MessageExportRow fields", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const [tagZeta, tagAlpha] = await Promise.all([
+      TagFactory.create(workspace, { name: "Zeta" }),
+      TagFactory.create(workspace, { name: "Alpha" }),
+    ]);
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: {
+          total: { value: 0, relation: "eq" as const },
+          hits: [] as estypes.SearchHit<ElasticsearchBaseDocument>[],
+        },
+        aggregations: {
+          by_message: {
+            buckets: [
+              {
+                key: { agent_message_id: "msg_42" },
+                doc_count: 3,
+                min_completed_at: {
+                  value_as_string: "2026-07-01T14:30:00.000Z",
+                },
+                agent_id: {
+                  buckets: [{ key: "agent_abc", doc_count: 3 }],
+                },
+                agent_tag_ids: {
+                  buckets: [
+                    { key: tagZeta.sId, doc_count: 3 },
+                    { key: tagAlpha.sId, doc_count: 3 },
+                  ],
+                },
+                conversation_id: {
+                  buckets: [{ key: "conv_xyz", doc_count: 3 }],
+                },
+                parent_message_id: {
+                  buckets: [{ key: "msg_parent", doc_count: 3 }],
+                },
+                user_id: {
+                  buckets: [{ key: "user_99", doc_count: 3 }],
+                },
+                context_origin: {
+                  buckets: [{ key: "slack", doc_count: 3 }],
+                },
+                total_credit_micro: { value: 7 * MICRO_CREDITS_PER_CREDIT },
+                tools: {
+                  doc_count: 2,
+                  unique_tools: {
+                    buckets: [
+                      {
+                        key: ["server_a", "tool_search"],
+                        key_as_string: "server_a|tool_search",
+                        doc_count: 1,
+                      },
+                      {
+                        key: ["server_b", "tool_create"],
+                        key_as_string: "server_b|tool_create",
+                        doc_count: 1,
+                      },
+                    ],
+                  },
+                },
+                skills: {
+                  buckets: [
+                    { key: "skill_code", doc_count: 2 },
+                    { key: "skill_data", doc_count: 1 },
+                  ],
+                },
+                models: {
+                  buckets: [
+                    {
+                      key: ["claude-opus-5", "anthropic", "agent", "medium"],
+                      key_as_string: "claude-opus-5|anthropic|agent|medium",
+                      doc_count: 3,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+      useConsumptionIndex: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toHaveLength(1);
+    const row = result.value[0];
+
+    expect(row.messageId).toBe("msg_42");
+    expect(row.createdAt).toBe("2026-07-01 14:30:00");
+    expect(row.assistantId).toBe("agent_abc");
+    expect(row.assistantTags).toBe("Alpha,Zeta");
+    expect(row.conversationId).toBe("conv_xyz");
+    expect(row.parentMessageId).toBe("msg_parent");
+    expect(row.userId).toBe("user_99");
+    expect(row.source).toBe("slack");
+    expect(row.toolsUsed).toContain("tool_search");
+    expect(row.toolsUsed).toContain("tool_create");
+    expect(row.skillsUsed).toBe("skill_code,skill_data");
+    expect(row.modelId).toBe("claude-opus-5");
+    expect(row.modelProviderId).toBe("anthropic");
+    expect(row.modelResolutionMethod).toBe("agent");
+    expect(row.credits).toBe(7);
+  });
+});

--- a/front/lib/api/analytics/messages_export_consumption.test.ts
+++ b/front/lib/api/analytics/messages_export_consumption.test.ts
@@ -135,7 +135,7 @@ describe("fetchMessageExportRows (consumption index)", () => {
     expect(row.assistantId).toBe("agent_abc");
     expect(row.assistantTags).toBe("Alpha,Zeta");
     expect(row.conversationId).toBe("conv_xyz");
-    expect(row.parentMessageId).toBe("msg_parent");
+    expect(row.parentMessageId).toBe(""); // not yet implemented
     expect(row.userId).toBe("user_99");
     expect(row.source).toBe("slack");
     expect(row.toolsUsed).toContain("tool_search");

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -52,6 +52,11 @@ export const MODEL_RESOLUTION_METHODS = [
 export type ModelResolutionMethodType =
   (typeof MODEL_RESOLUTION_METHODS)[number];
 
+export const isModelResolutionMethod = (
+  value: string
+): value is ModelResolutionMethodType =>
+  MODEL_RESOLUTION_METHODS.includes(value as ModelResolutionMethodType);
+
 // z.object (not z.record) so every reasoning effort key is required.
 const ReasoningEffortSupportSchema = z.object({
   none: z.boolean(),

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -435,6 +435,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "adrsimon",
   },
+  message_export_from_consumption_index: {
+    description:
+      "Use the consumption analytics ES index instead of the message analytics index for message exports.",
+    stage: "ask_owner",
+    owner: "sylvain",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "ask_owner" | "self_serve";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -773,6 +773,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_transcripts"
   | "legacy_dust_apps"
   | "legacy_trigger_limits"
+  | "message_export_from_consumption_index"
   | "netsuite_mcp"
   | "noop_model_feature"
   | "notion_private_integration"


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/10162

Add an alternative way to fetch messages from ES, using `agent_message_consumption` index. This is done by grouping documents by `message_id` on the fly.
Page size is decreased from 10K to 5K to avoid hitting the bucket size limits.
Add a feature flag to toggle between the old and new index.
Note: we still need to add `parent_message_id` in the new index to be iso.

## Tests

tested manually: downloaded a csv with and without the feature flag. 

## Risk

Low. No behavior change yet.

## Deploy Plan

Front only