### PR TITLE
[front-api] Serve /mcp as public credential-less CORS endpoint

### DIFF
--- a/front-api/middlewares/cors.test.ts
+++ b/front-api/middlewares/cors.test.ts
@@ -13,8 +13,11 @@ function createApp() {
   const app = new Hono();
   app.use("*", cors);
   app.get("/", (ctx) => ctx.text("ok"));
+  app.all("/mcp", (ctx) => ctx.text("ok"));
   return app;
 }
+
+const EXTENSION_ORIGIN = "chrome-extension://adoiifkpgaibbkgbicbdhpeoffmblbeb";
 
 function getExposedHeaders(response: Response): string[] {
   return (
@@ -63,5 +66,44 @@ describe("cors middleware", () => {
     expect(
       response.headers.get("Access-Control-Allow-Headers")?.toLowerCase()
     ).toContain(FRAME_SHARE_TOKEN_HEADER);
+  });
+
+  it("rejects a non-allowlisted origin on regular endpoints", async () => {
+    const response = await createApp().request("/", {
+      headers: { Origin: EXTENSION_ORIGIN },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("X-CORS-Reason")).toBe("origin");
+  });
+
+  it("allows any origin on /mcp without credentials", async () => {
+    // /mcp is Bearer-JWT-only (no cookies), so it is served as a public CORS
+    // endpoint for third-party MCP clients registered via DCR.
+    const response = await createApp().request("/mcp", {
+      method: "POST",
+      headers: { Origin: EXTENSION_ORIGIN },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
+  it("answers /mcp preflight for any origin, echoing requested headers", async () => {
+    const response = await createApp().request("/mcp", {
+      method: "OPTIONS",
+      headers: {
+        Origin: EXTENSION_ORIGIN,
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    expect(
+      response.headers.get("Access-Control-Allow-Headers")?.toLowerCase()
+    ).toContain("authorization");
   });
 });

--- a/front-api/middlewares/cors.ts
+++ b/front-api/middlewares/cors.ts
@@ -21,6 +21,19 @@ const EXPOSE_HEADERS = [
   DUST_FILE_ID_HEADER,
 ].join(", ");
 
+// The MCP server endpoint authenticates strictly through a Bearer JWT in the
+// Authorization header — it never reads cookies or any other ambient
+// credential. Origin allowlisting therefore protects nothing here (the JWT is
+// the security boundary) while blocking legitimate third-party MCP clients
+// (browser extensions, other apps) that register dynamically via DCR. Serve it
+// as a public, credential-less CORS endpoint: any origin, and crucially no
+// Access-Control-Allow-Credentials (which browsers forbid alongside a wildcard
+// origin anyway, and which is unnecessary since the token is an explicit
+// header, not sent via credentials mode).
+function isPublicMcpPath(path: string): boolean {
+  return path === "/mcp" || path.startsWith("/mcp/");
+}
+
 /**
  * Adds the cross-origin headers expected by browser clients to every
  * Hono-served response. Applied globally so `/api/*` and `/sse/*` requests
@@ -35,6 +48,27 @@ export const cors: MiddlewareHandler = async (ctx, next) => {
       return ctx.body(null, 200);
     }
     await next();
+    return;
+  }
+
+  // Public, credential-less CORS for the MCP server endpoint (see above).
+  if (isPublicMcpPath(ctx.req.path)) {
+    if (ctx.req.method === "OPTIONS") {
+      const requested = ctx.req.header("access-control-request-headers");
+      return ctx.body(null, 200, {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": ALLOW_METHODS,
+        "Access-Control-Allow-Headers": requested ?? ALLOWED_HEADERS.join(", "),
+        "Access-Control-Expose-Headers": EXPOSE_HEADERS,
+      });
+    }
+
+    await next();
+
+    ctx.header("Access-Control-Allow-Origin", "*");
+    ctx.header("Access-Control-Allow-Methods", ALLOW_METHODS);
+    ctx.header("Access-Control-Allow-Headers", ALLOWED_HEADERS.join(", "));
+    ctx.header("Access-Control-Expose-Headers", EXPOSE_HEADERS);
     return;
   }
 


### PR DESCRIPTION
## Description

The Dust MCP server endpoint (`POST /mcp`) authenticates **strictly via a Bearer JWT** in the `Authorization` header (`front/lib/api/mcp_server/auth.ts`) — it never reads cookies or any other ambient credential. The global CORS middleware (`front-api/middlewares/cors.ts`) nonetheless ran `/mcp` through the Origin allowlist and returned `403 { X-CORS-Reason: origin }` for any origin not on the list.

For a Bearer-only endpoint the Origin allowlist protects nothing (the JWT is the security boundary; a malicious page can't obtain the token, and non-browser clients ignore CORS anyway) while it blocks legitimate third-party MCP clients — browser extensions and other apps that register dynamically via DCR, which is exactly the audience MCP + OAuth DCR is built for. A customer hit this from a Chrome extension: OAuth/DCR/token exchange all succeeded, but the `initialize` POST was rejected with `403 x-cors-reason: origin`.

This change serves `/mcp` (and `/mcp/*`) as a public, credential-less CORS endpoint:

- `Access-Control-Allow-Origin: *`
- **no** `Access-Control-Allow-Credentials` (browsers forbid `*` + credentials anyway, and it's unnecessary since the token is an explicit header, not sent via credentials mode)
- preflight echoes the client's requested headers

This supersedes per-client origin allowlisting (e.g. #31719) — no extension ID needs whitelisting now or in the future. Scope is `/mcp` only; the `.well-known` OAuth discovery routes and every other endpoint keep the existing allowlist behavior untouched.

Note ([GEN1]): this introduces a second, path-scoped CORS pattern alongside the existing single global allowlist. Justified by MCP's open-client model, but flagging for reviewers.

## Tests

`front-api/middlewares/cors.test.ts` — added:
- non-allowlisted origin still `403`s with `X-CORS-Reason: origin` on regular endpoints (regression guard)
- `/mcp` allows any origin with `ACAO: *` and no `Allow-Credentials`
- `/mcp` preflight answers any origin and echoes requested headers

All 6 tests pass; `tsgo --noEmit` clean.

## Risk

Low. The change only widens CORS for `/mcp`, which is Bearer-JWT-only — no cookie/session auth path exists there, so there is no CSRF/credential-theft surface to open. No behavior change for any other route (allowlist + `x-cors-reason` unchanged). Fully rollback-safe (revert the commit).

## Deploy Plan

Standard front-api deploy. No migration, no config/env change, no ordering constraints. Effective as soon as front-api ships.