### PR TITLE
Build once for every non-front component

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,12 +147,14 @@ jobs:
 
   # Components on the build-once path: one build, pushed to the global registry and, for
   # now, to both regional registries so the regional values files keep resolving.
+  # Front and marketing stay on the regional matrix: their images still bake
+  # region-specific NEXT_PUBLIC_* values at build time.
   build-once:
     permissions:
       contents: read
       id-token: write
     needs: [prepare, notify-start]
-    if: ${{ !failure() && !cancelled() && inputs.component == 'connectors' }}
+    if: ${{ !failure() && !cancelled() && contains(fromJSON('["connectors","core","oauth","viz","prodbox","dante","egress-proxy","sparkle-storybook"]'), inputs.component) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -211,7 +213,7 @@ jobs:
       contents: read
       id-token: write
     needs: [prepare, notify-start, create-matrix, verify-sandbox-images]
-    if: ${{ !failure() && !cancelled() && inputs.component != 'connectors' && (needs.verify-sandbox-images.result == 'success' || needs.verify-sandbox-images.result == 'skipped') }}
+    if: ${{ !failure() && !cancelled() && !contains(fromJSON('["connectors","core","oauth","viz","prodbox","dante","egress-proxy","sparkle-storybook"]'), inputs.component) && (needs.verify-sandbox-images.result == 'success' || needs.verify-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description

Extends the single-build path from #31716 to core, oauth, viz, prodbox, dante, egress-proxy and sparkle-storybook. Each of those Dockerfiles takes no region-specific build args, so the two regional legs were producing the same image twice. They now build once and push to the global `dust-images` repository plus, for now, both regional repositories, exactly as connectors already does.

Front, front-edge, front-sse, marketing and marketing-edge stay on the regional matrix. Their images still bake region-specific `NEXT_PUBLIC_*` values at build time, so the same image cannot serve both regions until those move to runtime config.

## Tests


## Risk

A component in the list that fails to build stops before the deploy job, same as today. Rollback is reverting this PR, which puts everything back on the regional matrix. The regional repositories keep receiving every tag, so the dust-infra values files and `revert.yml` work either way.

## Deploy Plan

Merge. The next deploy of each listed component pushes to three registries under one tag. The matching dust-infra change points the values files at the global one.
