### PR TITLE
feat: prefer auth-scoped group fetches and make group acl bypasses explicit

### DIFF
--- a/front-api/routes/w/[wId]/governance-permissions.test.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.test.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import type {
@@ -8,7 +7,6 @@ import type {
   PatchGovernancePermissionResponseBody,
 } from "@app/types/api/governance";
 import { honoApp } from "@front-api/app";
-import assert from "assert";
 import { describe, expect, it } from "vitest";
 
 function getGovernancePermissions(workspace: { sId: string }) {
@@ -99,10 +97,6 @@ describe("GET /api/w/:wId/governance-permissions", () => {
 
     // Set up grant state with an internal admin auth, independent of the request user.
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      workspace.id
-    );
-    assert(globalGroup, "global group should exist");
 
     await GroupPermissionResource.setForEverybody(auth, {
       grantType: "create",

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -928,7 +928,7 @@ describe("createAgentMessages", () => {
       const globalGroupRes =
         await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
       expect(globalGroupRes.isOk()).toBe(true);
-      if (!globalGroupRes.isOk()) {
+      if (globalGroupRes.isErr()) {
         throw new Error("Failed to fetch global group");
       }
       const globalGroup = globalGroupRes.value;

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1340,7 +1340,7 @@ describe("createAgentMessages", () => {
       const globalGroupRes =
         await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
       expect(globalGroupRes.isOk()).toBe(true);
-      if (!globalGroupRes.isOk()) {
+      if (globalGroupRes.isErr()) {
         throw new Error("Failed to fetch global group");
       }
       const globalGroup = globalGroupRes.value;

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -68,12 +68,12 @@ describe("Authenticator.hasWorkspacePermission", () => {
   });
 
   it("returns true for everybody when the global group holds the grant", async () => {
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      workspace.id
-    );
-    if (!globalGroup) {
+    const globalGroupRes =
+      await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+    if (globalGroupRes.isErr()) {
       throw new Error("global group should exist");
     }
+    const globalGroup = globalGroupRes.value;
     await GroupPermissionResource.grantTypeWide(adminAuth, {
       group: globalGroup,
       ...CAPABILITY,

--- a/front/lib/model_tiers/allowed_tiers.ts
+++ b/front/lib/model_tiers/allowed_tiers.ts
@@ -130,12 +130,11 @@ async function getWorkspaceMaxAllowedTierName(
 async function getExplicitWorkspaceTierNames(
   auth: Authenticator
 ): Promise<ModelsTierName[]> {
-  const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-    auth.getNonNullableWorkspace().id
-  );
-  if (!globalGroup) {
+  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+  if (globalGroupRes.isErr()) {
     return [];
   }
+  const globalGroup = globalGroupRes.value;
 
   const grants = await GroupPermissionResource.listForGroups(
     auth.getNonNullableWorkspace(),

--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -25,11 +25,9 @@ describe("GroupPermissionResource — governance state (reads)", () => {
     groupB = await GroupFactory.regularAuto(workspace, "B");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const fetched = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      workspace.id
-    );
-    assert(fetched, "global group should exist");
-    globalGroup = fetched;
+    const fetched = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    assert(fetched.isOk(), "global group should exist");
+    globalGroup = fetched.value;
   });
 
   const stateOf = async (capability: typeof CAPABILITY) =>

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -1059,12 +1059,12 @@ describe("GroupPermissionResource", () => {
 
   describe("grantToEverybody / revokeFromEverybody", () => {
     it("grants and revokes an instance-level permission on the global group", async () => {
-      const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-        workspace.id
-      );
-      if (!globalGroup) {
+      const globalGroupRes =
+        await GroupResource.fetchWorkspaceGlobalGroup(auth);
+      if (globalGroupRes.isErr()) {
         throw new Error("global group should exist");
       }
+      const globalGroup = globalGroupRes.value;
 
       await GroupPermissionResource.grantToEverybody(auth, {
         grantType: "reader",

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -554,10 +554,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     auth: Authenticator,
     { grantType, resourceType, resourceId, transaction }: EverybodyGrantSpec
   ): Promise<void> {
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      auth.getNonNullableWorkspace().id
-    );
-    assert(globalGroup, "Workspace is missing its global group.");
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    assert(globalGroupRes.isOk(), "Workspace is missing its global group.");
+    const globalGroup = globalGroupRes.value;
 
     await this.grant(auth, {
       group: globalGroup,
@@ -573,10 +572,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     auth: Authenticator,
     { grantType, resourceType, resourceId, transaction }: EverybodyGrantSpec
   ): Promise<void> {
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      auth.getNonNullableWorkspace().id
-    );
-    assert(globalGroup, "Workspace is missing its global group.");
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    assert(globalGroupRes.isOk(), "Workspace is missing its global group.");
+    const globalGroup = globalGroupRes.value;
 
     await this.revoke(auth, {
       group: globalGroup,
@@ -1091,9 +1089,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const globalGroup =
-      await GroupResource.internalFetchWorkspaceGlobalGroup(workspaceId);
-    assert(globalGroup, "Workspace is missing its global group.");
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    assert(globalGroupRes.isOk(), "Workspace is missing its global group.");
+    const globalGroup = globalGroupRes.value;
 
     // One query: every type-wide (-1) row for the requested capabilities.
     const rows = await GroupPermissionModel.findAll({
@@ -1220,10 +1218,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     capability: CapabilitySpec,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
-    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
-      auth.getNonNullableWorkspace().id
-    );
-    assert(globalGroup, "Workspace is missing its global group.");
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    assert(globalGroupRes.isOk(), "Workspace is missing its global group.");
+    const globalGroup = globalGroupRes.value;
 
     await withTransaction(async (t) => {
       await this.getGrantLock(

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -973,6 +973,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     return !!group;
   }
 
+  // Fetches a group by name across every kind, without an ACL check: the result
+  // may be a group the caller cannot read, so never use it to grant access.
+  // Only for name-conflict handling, where (workspaceId, name) being unique
+  // forces us to see the colliding row whatever its kind.
+  // Prefer groupExistsByName when a boolean is enough.
   static async dangerouslyFetchByName(
     auth: Authenticator,
     name: string

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -973,7 +973,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return !!group;
   }
 
-  static async fetchByName(
+  static async dangerouslyFetchByName(
     auth: Authenticator,
     name: string
   ): Promise<GroupResource | null> {
@@ -982,9 +982,6 @@ export class GroupResource extends BaseResource<GroupModel> {
         name,
       },
     });
-    if (group && !group.canRead(auth)) {
-      return null;
-    }
 
     return group ?? null;
   }
@@ -1075,27 +1072,6 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const [group] = groups;
     return group;
-  }
-
-  // Fetches the system group without any ACL check. Only used in scripts and
-  // system-flow plumbing — the system group is deny-all in `getAccessControlLists`
-  // and must never be exposed to interactive callers.
-  static async dangerouslyFetchWorkspaceSystemGroup(
-    auth: Authenticator
-  ): Promise<Result<GroupResource, DustError>> {
-    const [group] = await this.baseFetch(auth, {
-      where: {
-        kind: "system",
-      },
-    });
-
-    if (!group) {
-      return new Err(
-        new DustError("group_not_found", "System group not found")
-      );
-    }
-
-    return new Ok(group);
   }
 
   static async fetchWorkspaceGlobalGroup(

--- a/front/migrations/20240731_backfill_keys.ts
+++ b/front/migrations/20240731_backfill_keys.ts
@@ -1,3 +1,4 @@
+/*
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
@@ -51,3 +52,4 @@ makeScript({}, async ({ execute }, logger) => {
     await backfillApiKeys(workspace, logger, execute);
   });
 });
+*/

--- a/front/migrations/20240829_backfill_keys_without_group_id.ts
+++ b/front/migrations/20240829_backfill_keys_without_group_id.ts
@@ -1,3 +1,4 @@
+/*
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
@@ -62,3 +63,4 @@ makeScript({}, async ({ execute }, logger) => {
     );
   }
 });
+*/

--- a/front/scripts/cleanup_orphaned_pod_groups.ts
+++ b/front/scripts/cleanup_orphaned_pod_groups.ts
@@ -67,7 +67,7 @@ export async function cleanupOrphanedPodGroups(
     const groups: GroupResource[] = [];
 
     for (const groupName of expectedGroupNames) {
-      const group = await GroupResource.fetchByName(auth, groupName);
+      const group = await GroupResource.dangerouslyFetchByName(auth, groupName);
       if (!group) {
         continue;
       }

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -90,7 +90,10 @@ async function createProject(
   }
 
   const memberGroupName = `${PROJECT_GROUP_PREFIX} ${projectName}`;
-  let memberGroup = await GroupResource.fetchByName(auth, memberGroupName);
+  let memberGroup = await GroupResource.dangerouslyFetchByName(
+    auth,
+    memberGroupName
+  );
   if (!memberGroup) {
     memberGroup = await GroupResource.makeNew({
       name: memberGroupName,
@@ -100,7 +103,10 @@ async function createProject(
   }
 
   const editorGroupName = `${PROJECT_EDITOR_GROUP_PREFIX} ${projectName}`;
-  let editorGroup = await GroupResource.fetchByName(auth, editorGroupName);
+  let editorGroup = await GroupResource.dangerouslyFetchByName(
+    auth,
+    editorGroupName
+  );
   if (!editorGroup) {
     editorGroup = await GroupResource.makeNew(
       {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -692,7 +692,10 @@ async function handleGroupUpsert(
   const { data: eventData } = event;
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  const groupByName = await GroupResource.fetchByName(auth, eventData.name);
+  const groupByName = await GroupResource.dangerouslyFetchByName(
+    auth,
+    eventData.name
+  );
   if (groupByName && groupByName.workOSGroupId !== eventData.id) {
     // Conflict - another group with the same name already exists.
 


### PR DESCRIPTION
## Description

This PR makes sure that the internal fetch methods of the group resource are used only when there is no authenticator. Moreover it removes the canRead check from the `fetchByName` method and renames it to `dangerouslyFetchByName`. This is needed because its callers also need to fetch regular_auto groups.

## Tests
Manually.

## Risks
Low. Same behavior is maintained.

## Deploy Plan
Standard deployment.