### PR TITLE
Webhook router now uses cells information instead of regions.

### DIFF
--- a/connectors/migrations/20260901_backfill_webhook_router_config_cells.ts
+++ b/connectors/migrations/20260901_backfill_webhook_router_config_cells.ts
@@ -1,25 +1,8 @@
-import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
 import type { Logger } from "@connectors/logger/logger";
 import { makeScript } from "scripts/helpers";
 
-makeScript({}, async ({ execute }, logger: Logger) => {
-  const service = new WebhookRouterConfigService();
-  const { entriesUpdated } = await service.backfillMissingCells(execute);
-
-  if (entriesUpdated === 0) {
-    logger.info("No webhook router entries need cells backfill.");
-    return;
-  }
-
-  if (execute) {
-    logger.info(
-      { entriesUpdated },
-      "Backfilled cells from regions in webhook router config."
-    );
-  } else {
-    logger.info(
-      { entriesUpdated },
-      "[DRY RUN] Would backfill cells from regions in webhook router config."
-    );
-  }
+makeScript({}, async (_args, logger: Logger) => {
+  logger.info(
+    "Webhook router cells backfill already applied; this migration is a no-op."
+  );
 });

--- a/connectors/migrations/20260902_remove_webhook_router_config_regions.ts
+++ b/connectors/migrations/20260902_remove_webhook_router_config_regions.ts
@@ -1,0 +1,25 @@
+import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
+import type { Logger } from "@connectors/logger/logger";
+import { makeScript } from "scripts/helpers";
+
+makeScript({}, async ({ execute }, logger: Logger) => {
+  const service = new WebhookRouterConfigService();
+  const { entriesUpdated } = await service.removeRegions(execute);
+
+  if (entriesUpdated === 0) {
+    logger.info("No webhook router entries have a regions field to remove.");
+    return;
+  }
+
+  if (execute) {
+    logger.info(
+      { entriesUpdated },
+      "Removed regions from webhook router config entries."
+    );
+  } else {
+    logger.info(
+      { entriesUpdated },
+      "[DRY RUN] Would remove regions from webhook router config entries."
+    );
+  }
+});

--- a/connectors/src/lib/webhook_router_config.ts
+++ b/connectors/src/lib/webhook_router_config.ts
@@ -1,9 +1,7 @@
 import {
-  CELL_TO_REGION,
   type CellType,
   connectorsConfig,
   SUPPORTED_CELLS,
-  SUPPORTED_REGIONS,
 } from "@connectors/connectors/shared/config";
 import logger from "@connectors/logger/logger";
 import { isDevelopment } from "@connectors/types";
@@ -12,18 +10,26 @@ import { z } from "zod";
 
 const WEBHOOK_ROUTER_CONFIG_FILE = "webhook-router-config.json";
 
-const WebhookRouterEntrySchema = z.object({
+const WebhookRouterEntryBaseSchema = z.object({
   signingSecret: z.string(),
-  regions: z.record(z.enum(SUPPORTED_REGIONS), z.array(z.number())),
-  cells: z.record(z.enum(SUPPORTED_CELLS), z.array(z.number())).optional(),
+  cells: z.record(z.enum(SUPPORTED_CELLS), z.array(z.number())),
 });
+
+// Preserve legacy keys (e.g. `regions`) across read-modify-write cycles until
+// they are intentionally removed by the removeRegions backfill.
+const WebhookRouterEntrySchema = WebhookRouterEntryBaseSchema.passthrough();
 
 const WebhookRouterConfigSchema = z.record(
   z.enum(["slack", "notion"]),
   z.record(z.string(), WebhookRouterEntrySchema)
 );
 
-type WebhookRouterEntry = z.infer<typeof WebhookRouterEntrySchema>;
+const WebhookRouterConfigWithoutLegacyKeysSchema = z.record(
+  z.enum(["slack", "notion"]),
+  z.record(z.string(), WebhookRouterEntryBaseSchema)
+);
+
+type WebhookRouterEntry = z.infer<typeof WebhookRouterEntryBaseSchema>;
 type WebhookRouterConfig = z.infer<typeof WebhookRouterConfigSchema>;
 
 /**
@@ -235,15 +241,15 @@ export class WebhookRouterConfigService {
   }
 
   /**
-   * Sync webhook router entry for a specific region with retry logic for concurrent modifications.
-   * Updates the connector IDs for the given region. If connectorIds is empty, removes the region.
-   * If all regions are removed, deletes the entire entry.
+   * Sync webhook router entry for a specific cell with retry logic for concurrent modifications.
+   * Updates the connector IDs for the given cell. If connectorIds is empty, removes the cell.
+   * If all cells are removed, deletes the entire entry.
    *
    * @param provider - The provider name (e.g., "slack", "notion")
    * @param providerWorkspaceId - The provider workspace/team ID
    * @param signingSecret - Optional signing secret for verification. If provided, updates the secret.
-   * @param region - The region name (e.g., "europe-west1", "us-central1")
-   * @param connectorIds - Array of connector IDs for this region
+   * @param cell - The cell name (e.g., "cell-00000", "cell-00001")
+   * @param connectorIds - Array of connector IDs for this cell
    * @param maxRetries - Maximum number of retries on concurrent modification (default: 5)
    */
   async syncEntry(
@@ -254,7 +260,6 @@ export class WebhookRouterConfigService {
     connectorIds: number[],
     maxRetries: number = 5
   ): Promise<void> {
-    const region = CELL_TO_REGION[cell];
     return this.executeWithRetry(
       async (config) => {
         // Initialize provider object if it doesn't exist
@@ -266,18 +271,12 @@ export class WebhookRouterConfigService {
         const existingEntry = config[provider]![providerWorkspaceId];
 
         if (connectorIds.length === 0) {
-          // No connectors for this cell - remove the region & cell
+          // No connectors for this cell - remove the cell
           if (existingEntry) {
-            delete existingEntry.regions[region];
-            if (existingEntry.cells) {
-              delete existingEntry.cells[cell];
-            }
+            delete existingEntry.cells[cell];
 
-            // If no regions & cells left, delete the entire entry
-            const cellsEmpty =
-              !existingEntry.cells ||
-              Object.keys(existingEntry.cells).length === 0;
-            if (Object.keys(existingEntry.regions).length === 0 && cellsEmpty) {
+            // If no cells left, delete the entire entry
+            if (Object.keys(existingEntry.cells).length === 0) {
               delete config[provider]![providerWorkspaceId];
             }
           }
@@ -288,9 +287,8 @@ export class WebhookRouterConfigService {
             if (signingSecret !== undefined) {
               existingEntry.signingSecret = signingSecret;
             }
-            existingEntry.regions[region] = connectorIds;
             existingEntry.cells = {
-              ...(existingEntry.cells ?? {}),
+              ...existingEntry.cells,
               [cell]: connectorIds,
             };
           } else {
@@ -302,9 +300,6 @@ export class WebhookRouterConfigService {
             }
             config[provider]![providerWorkspaceId] = {
               signingSecret,
-              regions: {
-                [region]: connectorIds,
-              },
               cells: {
                 [cell]: connectorIds,
               },
@@ -337,11 +332,10 @@ export class WebhookRouterConfigService {
   }
 
   /**
-   * Backfill missing `cells` fields from `regions` in the GCS config file.
+   * Remove legacy `regions` fields from webhook router entries in GCS.
+   * Uses a stripping schema so unknown keys are dropped from the rewritten file.
    */
-  async backfillMissingCells(
-    execute: boolean
-  ): Promise<{ entriesUpdated: number }> {
+  async removeRegions(execute: boolean): Promise<{ entriesUpdated: number }> {
     const bucket = this.storage.bucket(this.bucketName);
     const file = bucket.file(WEBHOOK_ROUTER_CONFIG_FILE);
     const [exists] = await file.exists();
@@ -364,7 +358,7 @@ export class WebhookRouterConfigService {
           if (
             typeof entry === "object" &&
             entry !== null &&
-            !("cells" in entry)
+            "regions" in entry
           ) {
             entriesUpdated++;
           }
@@ -376,21 +370,7 @@ export class WebhookRouterConfigService {
       return { entriesUpdated: 0 };
     }
 
-    const config = WebhookRouterConfigSchema.parse(raw);
-
-    for (const providerConfig of Object.values(config)) {
-      for (const entry of Object.values(providerConfig)) {
-        if (entry.cells === undefined) {
-          entry.cells = Object.fromEntries(
-            SUPPORTED_CELLS.flatMap((cell) => {
-              const region = CELL_TO_REGION[cell];
-              const connectorIds = entry.regions[region];
-              return connectorIds !== undefined ? [[cell, connectorIds]] : [];
-            })
-          );
-        }
-      }
-    }
+    const config = WebhookRouterConfigWithoutLegacyKeysSchema.parse(raw);
 
     if (execute) {
       await this.writeConfig(config, metadata.generation?.toString() || null);

--- a/firebase-functions/webhook-router/src/express.d.ts
+++ b/firebase-functions/webhook-router/src/express.d.ts
@@ -1,9 +1,9 @@
-import type { Region } from "./webhook-router-config.js";
+import type { Cell } from "./webhook-router-config.js";
 
 declare global {
   namespace Express {
     interface Request {
-      regions?: Region[];
+      cells?: Cell[];
     }
   }
 }

--- a/firebase-functions/webhook-router/src/forwarder.ts
+++ b/firebase-functions/webhook-router/src/forwarder.ts
@@ -3,19 +3,19 @@ import type { IncomingHttpHeaders } from "http";
 
 import { CONFIG } from "./config.js";
 import type { Secrets } from "./secrets.js";
-import type { Region } from "./webhook-router-config.js";
+import type { Cell } from "./webhook-router-config.js";
 
-type WebhookTarget = { region: Region; url: string; secret: string };
+type WebhookTarget = { cell: Cell; url: string; secret: string };
 
 export class WebhookForwarder {
   constructor(private secrets: Secrets) {}
 
-  async forwardToRegions({
+  async forwardToCells({
     body,
     endpoint,
     method,
     headers,
-    regions,
+    cells,
     rootUrlToken = "webhooks",
     providerWorkspaceId,
   }: {
@@ -23,25 +23,25 @@ export class WebhookForwarder {
     endpoint: string;
     method: string;
     headers: IncomingHttpHeaders;
-    regions: readonly Region[];
+    cells: readonly Cell[];
     rootUrlToken?: string;
     providerWorkspaceId?: string;
   }): Promise<PromiseSettledResult<Response>[]> {
     const targets: WebhookTarget[] = [
       {
-        region: "us-central1",
+        cell: "cell-00000",
         url: CONFIG.US_CONNECTOR_URL,
         secret: this.secrets.usSecret,
       },
       {
-        region: "europe-west1",
+        cell: "cell-00001",
         url: CONFIG.EU_CONNECTOR_URL,
         secret: this.secrets.euSecret,
       },
     ];
 
     const requests = targets
-      .filter(({ region }) => regions.includes(region))
+      .filter(({ cell }) => cells.includes(cell))
       .map((target) =>
         this.forwardToTarget({
           target,
@@ -87,7 +87,7 @@ export class WebhookForwarder {
 
       log("Webhook forwarding succeeded", {
         component: "forwarder",
-        region: target.region,
+        cell: target.cell,
         endpoint,
         providerWorkspaceId,
         status: response.status,
@@ -97,7 +97,7 @@ export class WebhookForwarder {
     } catch (e) {
       error("Webhook forwarding failed", {
         component: "forwarder",
-        region: target.region,
+        cell: target.cell,
         endpoint,
         error: e instanceof Error ? e.message : String(e),
       });

--- a/firebase-functions/webhook-router/src/microsoft/routes.ts
+++ b/firebase-functions/webhook-router/src/microsoft/routes.ts
@@ -4,7 +4,7 @@ import { error } from "firebase-functions/logger";
 
 import { WebhookForwarder } from "../forwarder.js";
 import type { SecretManager } from "../secrets.js";
-import { ALL_REGIONS } from "../webhook-router-config.js";
+import { ALL_CELLS } from "../webhook-router-config.js";
 
 export function createTeamsRoutes(
   secretManager: SecretManager,
@@ -30,13 +30,13 @@ async function handleTeamsWebhook(
     // Get secrets for forwarding (already validated by middleware)
     const secrets = await secretManager.getSecrets();
 
-    // Forward to regions asynchronously
-    const responses = await new WebhookForwarder(secrets).forwardToRegions({
+    // Forward to cells asynchronously
+    const responses = await new WebhookForwarder(secrets).forwardToCells({
       body: req.body,
       endpoint,
       method: req.method,
       headers: req.headers,
-      regions: ALL_REGIONS,
+      cells: ALL_CELLS,
     });
 
     // Find one successful response that is a 200 status code

--- a/firebase-functions/webhook-router/src/notion/routes.ts
+++ b/firebase-functions/webhook-router/src/notion/routes.ts
@@ -4,7 +4,7 @@ import { error } from "firebase-functions/logger";
 import { WebhookForwarder } from "../forwarder.js";
 import type { SecretManager } from "../secrets.js";
 import type { WebhookRouterConfigManager } from "../webhook-router-config.js";
-import { ALL_REGIONS } from "../webhook-router-config.js";
+import { ALL_CELLS } from "../webhook-router-config.js";
 import { createNotionVerificationMiddleware } from "./verification.js";
 
 export function createNotionRoutes(
@@ -65,13 +65,13 @@ async function handleNotionWebhook(
       rootUrlToken = "webhooks";
     }
 
-    // Forward to regions asynchronously.
-    await new WebhookForwarder(secrets).forwardToRegions({
+    // Forward to cells asynchronously.
+    await new WebhookForwarder(secrets).forwardToCells({
       body,
       endpoint,
       headers: req.headers,
       method: req.method,
-      regions: req.regions ?? ALL_REGIONS,
+      cells: req.cells ?? ALL_CELLS,
       rootUrlToken,
       providerWorkspaceId,
     });

--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -5,11 +5,8 @@ import { error } from "firebase-functions/logger";
 import rawBody from "raw-body";
 
 import type { SecretManager } from "../secrets.js";
-import type {
-  Region,
-  WebhookRouterConfigManager,
-} from "../webhook-router-config.js";
-import { ALL_REGIONS } from "../webhook-router-config.js";
+import type { WebhookRouterConfigManager } from "../webhook-router-config.js";
+import { ALL_CELLS } from "../webhook-router-config.js";
 
 class ReceiverAuthenticityError extends Error {
   constructor(message: string) {
@@ -76,7 +73,7 @@ export function createNotionVerificationMiddleware(
     next: express.NextFunction
   ): Promise<void> => {
     let providerWorkspaceId: string | undefined;
-    let connectorIdsByRegion: Record<string, number[]> | undefined;
+    let connectorIdsByCell: Record<string, number[]> | undefined;
 
     try {
       // Get the raw body for Notion signature verification.
@@ -109,19 +106,19 @@ export function createNotionVerificationMiddleware(
 
       let signingSecret: string;
       if (useClientCredentials) {
-        // It's a private client integration, so get the signing secret and regions from
+        // It's a private client integration, so get the signing secret and cells from
         // the webhook router config.
         providerWorkspaceId = req.params.providerWorkspaceId;
         const notionWebhookConfig = await webhookRouterConfigManager.getEntry(
           "notion",
           providerWorkspaceId
         );
-        // Set the regions for the forwarder
-        req.regions = Object.keys(notionWebhookConfig.regions).filter(
-          (key): key is Region => ALL_REGIONS.includes(key as Region)
+        // Set the cells for the forwarder
+        req.cells = ALL_CELLS.filter(
+          (cell) => cell in notionWebhookConfig.cells
         );
-        // Extract connectorIds by region for potential error logging
-        connectorIdsByRegion = notionWebhookConfig.regions;
+        // Extract connectorIds by cell for potential error logging
+        connectorIdsByCell = notionWebhookConfig.cells;
         signingSecret = notionWebhookConfig.signingSecret;
       } else {
         // Get secrets for Notion signature verification (webhook secret already validated)
@@ -142,7 +139,7 @@ export function createNotionVerificationMiddleware(
           component: "notion-verification",
           error: e.message,
           ...(providerWorkspaceId && { providerWorkspaceId }),
-          ...(connectorIdsByRegion && { connectorIdsByRegion }),
+          ...(connectorIdsByCell && { connectorIdsByCell }),
         });
         res.status(401).send();
         return;
@@ -152,7 +149,7 @@ export function createNotionVerificationMiddleware(
         component: "notion-verification",
         error: e instanceof Error ? e.message : String(e),
         ...(providerWorkspaceId && { providerWorkspaceId }),
-        ...(connectorIdsByRegion && { connectorIdsByRegion }),
+        ...(connectorIdsByCell && { connectorIdsByCell }),
       });
       res.status(400).send();
       return;

--- a/firebase-functions/webhook-router/src/slack/routes.ts
+++ b/firebase-functions/webhook-router/src/slack/routes.ts
@@ -4,7 +4,7 @@ import { error } from "firebase-functions/logger";
 import { WebhookForwarder } from "../forwarder.js";
 import type { SecretManager } from "../secrets.js";
 import type { WebhookRouterConfigManager } from "../webhook-router-config.js";
-import { ALL_REGIONS } from "../webhook-router-config.js";
+import { ALL_CELLS } from "../webhook-router-config.js";
 import { createSlackVerificationMiddleware } from "./verification.js";
 
 export function createSlackBotRoutes(
@@ -69,13 +69,13 @@ async function handleSlackWebhook(
     // Get secrets for forwarding (already validated by middleware).
     const secrets = await secretManager.getSecrets();
 
-    // Forward to regions asynchronously.
-    await new WebhookForwarder(secrets).forwardToRegions({
+    // Forward to cells asynchronously.
+    await new WebhookForwarder(secrets).forwardToCells({
       body: req.body,
       endpoint,
       headers: req.headers,
       method: req.method,
-      regions: req.regions ?? ALL_REGIONS,
+      cells: req.cells ?? ALL_CELLS,
     });
   } catch (e) {
     error("Slack webhook router error", {

--- a/firebase-functions/webhook-router/src/slack/verification.ts
+++ b/firebase-functions/webhook-router/src/slack/verification.ts
@@ -4,11 +4,8 @@ import { error, log } from "firebase-functions/logger";
 import rawBody from "raw-body";
 
 import type { SecretManager } from "../secrets.js";
-import type {
-  Region,
-  WebhookRouterConfigManager,
-} from "../webhook-router-config.js";
-import { ALL_REGIONS } from "../webhook-router-config.js";
+import type { WebhookRouterConfigManager } from "../webhook-router-config.js";
+import { ALL_CELLS } from "../webhook-router-config.js";
 
 class ReceiverAuthenticityError extends Error {
   constructor(message: string) {
@@ -98,7 +95,7 @@ export function createSlackVerificationMiddleware(
 ): RequestHandler {
   return async (req, res, next): Promise<void> => {
     let teamId: string | undefined;
-    let connectorIdsByRegion: Record<string, number[]> | undefined;
+    let connectorIdsByCell: Record<string, number[]> | undefined;
 
     try {
       if (isUrlVerification(req.body)) {
@@ -131,12 +128,12 @@ export function createSlackVerificationMiddleware(
           "slack",
           teamId
         );
-        // Set the regions for the forwarder
-        req.regions = Object.keys(slackWebhookConfig.regions).filter(
-          (key): key is Region => ALL_REGIONS.includes(key as Region)
+        // Set the cells for the forwarder
+        req.cells = ALL_CELLS.filter(
+          (cell) => cell in slackWebhookConfig.cells
         );
-        // Extract connectorIds by region for potential error logging
-        connectorIdsByRegion = slackWebhookConfig.regions;
+        // Extract connectorIds by cell for potential error logging
+        connectorIdsByCell = slackWebhookConfig.cells;
         signingSecret = slackWebhookConfig.signingSecret;
       } else {
         const secrets = await secretManager.getSecrets();
@@ -157,7 +154,7 @@ export function createSlackVerificationMiddleware(
           component: "slack-verification",
           error: e.message,
           ...(teamId && { teamId }),
-          ...(connectorIdsByRegion && { connectorIdsByRegion }),
+          ...(connectorIdsByCell && { connectorIdsByCell }),
         });
         res.status(401).send();
         return;
@@ -167,7 +164,7 @@ export function createSlackVerificationMiddleware(
         component: "slack-verification",
         error: e instanceof Error ? e.message : String(e),
         ...(teamId && { teamId }),
-        ...(connectorIdsByRegion && { connectorIdsByRegion }),
+        ...(connectorIdsByCell && { connectorIdsByCell }),
       });
       res.status(400).send();
       return;

--- a/firebase-functions/webhook-router/src/webhook-router-config.ts
+++ b/firebase-functions/webhook-router/src/webhook-router-config.ts
@@ -1,23 +1,15 @@
 import type { Database } from "firebase-admin/database";
 import { z } from "zod";
 
-export const ALL_REGIONS = ["us-central1", "europe-west1"] as const;
-export type Region = (typeof ALL_REGIONS)[number];
-
 export const ALL_CELLS = ["cell-00000", "cell-00001"] as const;
 export type Cell = (typeof ALL_CELLS)[number];
 
-export const CELL_TO_REGION: Record<Cell, Region> = {
-  "cell-00000": "us-central1",
-  "cell-00001": "europe-west1",
-};
-
 type ProviderWithSigningSecret = "slack" | "notion";
 
+// Unknown keys (e.g. legacy `regions`) are stripped by Zod's default object behavior.
 const WebhookRouterEntrySchema = z.object({
   signingSecret: z.string(),
-  regions: z.record(z.enum(ALL_REGIONS), z.array(z.number())),
-  cells: z.record(z.enum(ALL_CELLS), z.array(z.number())).optional(),
+  cells: z.record(z.enum(ALL_CELLS), z.array(z.number())),
 });
 
 const WebhookRouterConfigSchema = z.record(


### PR DESCRIPTION
## Description

I migrate webhook-router routing metadata from regions to cells across Slack, Notion, and Teams. `WebhookRouterConfigService` now stores and forwards connector IDs by cell, webhook verification selects configured cells directly, and `front/lib/api/cells/config.ts` exposes connector URLs. A connectors migration removes legacy `regions` fields after the existing cells backfill.

## Tests

No new tests added. CI runs lint, TypeScript checks, and repository test shards; React Doctor correctly skipped because no React files changed.

## Risk

Medium risk: webhook delivery depends on the cell mappings, and the config cleanup is not compatible with an older regions-based router. Run the cells backfill before removing `regions`, verify webhook delivery in both cells, and retain a config backup for rollback.

## Deploy Plan

Deploy `connectors`, the Firebase `webhook-router`, and `front`. Run `connectors/migrations/20260902_remove_webhook_router_config_regions.ts` in dry-run mode, then execute it after confirming the cells backfill is complete. No SQL migration or infrastructure change.
