### PR TITLE
[front] usage members table: drop secondary columns before Name on narrow screens

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -526,7 +526,7 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
     );
   },
   meta: {
-    className: "w-36",
+    className: "w-32",
   },
 };
 
@@ -823,7 +823,7 @@ function buildCreditPlanColumns({
     })(),
     {
       ...buildPoolCreditUsageColumn(creditsResetAt, variant),
-      meta: { className: "w-64" },
+      meta: { className: "w-56" },
     },
   ];
 }
@@ -855,6 +855,16 @@ function buildColumns({
     ...(showSeatAndCredits || showModelTiersColumn ? [actionsColumn] : []),
   ];
 }
+
+// The table is fixed layout and Name is the only column without a set width,
+// so it absorbs every shrink. Drop the secondary columns first as the window
+// narrows, most dispensable at the widest breakpoint.
+const COLUMNS_BREAKPOINTS = {
+  groups: "2xl",
+  modelTiers: "xl",
+  seatType: "xl",
+  consumedFromPoolAwuCredits: "lg",
+} as const;
 
 // "compact" is the Poke Pool Usage page layout: no "Up to " prefix on the
 // Models tier summary, a "Models" header instead of "Models tier". "legacy"
@@ -1130,6 +1140,7 @@ export function MembersUsageTable({
         <DataTable
           data={rows}
           columns={columns}
+          columnsBreakpoints={COLUMNS_BREAKPOINTS}
           pagination={pagination}
           setPagination={setPagination}
           totalRowCount={totalRowCount}


### PR DESCRIPTION
The members table on the Usage page is fixed layout and Name is the only column without a set width, so on narrow windows Name shrank to nothing while every other column kept its width.

Secondary columns now drop first as the window narrows, keeping Name readable:
- Groups below 2xl (1536px),
- Models tier and Seat below xl (1280px),
- Credits usage below lg (1024px).

Seat goes from `w-36` to `w-32` and Credits usage from `w-64` to `w-56` so Name gets ~200px at each step with the sidebar open.

Test on https://pr-31728-merge--app.preview.dust.tt/w/0ec9852c2f/usage versus https://app.dust.tt/w/0ec9852c2f/usage