### PR TITLE
[Admin Governance] Mirror agent editor additions to grants

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -3,6 +3,7 @@ import {
   updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -162,6 +163,32 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
     const editorIds = data.editors.map((e: UserType) => e.sId);
     expect(editorIds).toContain(agentOwner.sId);
     expect(editorIds).toContain(newEditor.sId);
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const agentGrant = (
+      await GroupPermissionResource.listForWorkspace(auth)
+    ).find(
+      (grant) => grant.grantType === "editor" && grant.resourceType === "agent"
+    );
+    expect(agentGrant).toBeDefined();
+    if (!agentGrant) {
+      throw new Error("Agent editor grant was not created");
+    }
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
+        grantType: "editor",
+        resourceType: "agent",
+        resourceId: agentGrant.resourceId,
+      });
+    expect(grantGroup).not.toBeNull();
+    if (!grantGroup) {
+      throw new Error("Agent editor group was not created");
+    }
+    expect(
+      new Set(
+        (await grantGroup.getActiveMembers(auth)).map((editor) => editor.sId)
+      )
+    ).toEqual(new Set([agentOwner.sId, newEditor.sId]));
   });
 
   it("admin who is not an agent editor can become an editor", async () => {

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -146,7 +146,7 @@ describe("createAgentConfiguration with pending agent", () => {
     }
     const { sId: pendingId } = pendingAgentRes.value;
 
-    const pendingAgentModelId = await AgentResource.fetchModelIdBySId(
+    const pendingAgentModelId = await AgentResource.fetchModelId(
       authenticator,
       pendingId
     );

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -146,13 +146,16 @@ describe("createAgentConfiguration with pending agent", () => {
     }
     const { sId: pendingId } = pendingAgentRes.value;
 
-    const pendingAgentModelId = await AgentResource.fetchModelId(
-      authenticator,
-      pendingId
-    );
-    expect(pendingAgentModelId).not.toBeNull();
-    if (!pendingAgentModelId) {
+    const pendingAgent = await AgentConfigurationModel.findOne({
+      where: { sId: pendingId, workspaceId: workspace.id },
+    });
+    if (!pendingAgent) {
       throw new Error("Pending agent was not created");
+    }
+    const pendingAgentResource =
+      AgentResource.fromAgentConfigurationModel(pendingAgent);
+    if (!pendingAgentResource.id) {
+      throw new Error("Pending agent identity was not created");
     }
     const pendingGrantGroup =
       await GroupPermissionResource.findRegularAutoGroupForGrant(
@@ -160,7 +163,7 @@ describe("createAgentConfiguration with pending agent", () => {
         {
           grantType: "editor",
           resourceType: "agent",
-          resourceId: pendingAgentModelId,
+          resourceId: pendingAgentResource.id,
         }
       );
     expect(pendingGrantGroup).not.toBeNull();

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -134,6 +134,8 @@ describe("createAgentConfiguration with pending agent", () => {
     const { authenticator, workspace, user } = await createResourceTest({
       role: "admin",
     });
+    const newEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, newEditor, { role: "user" });
 
     // Create a pending agent using the helper function
     const pendingAgentRes =
@@ -142,6 +144,32 @@ describe("createAgentConfiguration with pending agent", () => {
       throw pendingAgentRes.error;
     }
     const { sId: pendingId } = pendingAgentRes.value;
+
+    const pendingAgent = await AgentConfigurationModel.findOne({
+      where: { sId: pendingId, workspaceId: workspace.id },
+    });
+    expect(pendingAgent).not.toBeNull();
+    if (!pendingAgent) {
+      throw new Error("Pending agent was not created");
+    }
+    const pendingGrantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(
+        authenticator,
+        {
+          grantType: "editor",
+          resourceType: "agent",
+          resourceId: pendingAgent.agentId,
+        }
+      );
+    expect(pendingGrantGroup).not.toBeNull();
+    if (!pendingGrantGroup) {
+      throw new Error("Pending agent editor grant was not created");
+    }
+    expect(
+      (await pendingGrantGroup.getActiveMembers(authenticator)).map(
+        (editor) => editor.sId
+      )
+    ).toEqual([user.sId]);
 
     // Convert the pending agent to active by passing its sId as agentConfigurationId
     const result = await createAgentConfiguration(authenticator, {
@@ -161,7 +189,7 @@ describe("createAgentConfiguration with pending agent", () => {
       templateId: null,
       requestedSpaceIds: [],
       tags: [],
-      editors: [user.toJSON()],
+      editors: [user.toJSON(), newEditor.toJSON()],
       authorId: user.id,
     });
 
@@ -177,9 +205,20 @@ describe("createAgentConfiguration with pending agent", () => {
       where: { sId: pendingId, workspaceId: workspace.id },
     });
     expect(agent).not.toBeNull();
-    expect(agent!.status).toBe("active");
-    expect(agent!.name).toBe("My New Agent");
-    expect(agent!.version).toBe(0); // Version should remain 0 (updated in place)
+    if (!agent) {
+      throw new Error("Pending agent was not converted");
+    }
+    expect(agent.status).toBe("active");
+    expect(agent.name).toBe("My New Agent");
+    expect(agent.version).toBe(0); // Version should remain 0 (updated in place)
+
+    expect(
+      new Set(
+        (await pendingGrantGroup.getActiveMembers(authenticator)).map(
+          (editor) => editor.sId
+        )
+      )
+    ).toEqual(new Set([user.sId, newEditor.sId]));
   });
 
   it("creates new agent if agentConfigurationId does not exist", async () => {

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -15,6 +15,7 @@ import {
   AgentConfigurationModel,
   AgentModel,
 } from "@app/lib/models/agent/agent";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -145,11 +146,12 @@ describe("createAgentConfiguration with pending agent", () => {
     }
     const { sId: pendingId } = pendingAgentRes.value;
 
-    const pendingAgent = await AgentConfigurationModel.findOne({
-      where: { sId: pendingId, workspaceId: workspace.id },
-    });
-    expect(pendingAgent).not.toBeNull();
-    if (!pendingAgent) {
+    const pendingAgentModelId = await AgentResource.fetchModelIdBySId(
+      authenticator,
+      pendingId
+    );
+    expect(pendingAgentModelId).not.toBeNull();
+    if (!pendingAgentModelId) {
       throw new Error("Pending agent was not created");
     }
     const pendingGrantGroup =
@@ -158,7 +160,7 @@ describe("createAgentConfiguration with pending agent", () => {
         {
           grantType: "editor",
           resourceType: "agent",
-          resourceId: pendingAgent.agentId,
+          resourceId: pendingAgentModelId,
         }
       );
     expect(pendingGrantGroup).not.toBeNull();

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -140,7 +140,7 @@ export async function createPendingAgentConfiguration(
       transaction: t,
       authorId: user.id,
     });
-    await AgentResource.fromAgentConfiguration(agent).grantEditors(auth, {
+    await AgentResource.fromAgentConfigurationModel(agent).grantEditors(auth, {
       editors: [user.toJSON()],
       transaction: t,
     });
@@ -943,7 +943,7 @@ export async function createAgentConfiguration(
           }
         }
 
-        await AgentResource.fromAgentConfiguration(
+        await AgentResource.fromAgentConfigurationModel(
           agentConfigurationInstance
         ).grantEditors(auth, { editors, transaction: t });
       }
@@ -1603,21 +1603,11 @@ export async function updateAgentPermissions(
           return addRes;
         }
 
-        const agentModelId = await AgentResource.fetchModelId(auth, agent.sId, {
-          transaction: t,
-        });
-        assert(agentModelId, "Unexpected: agent identity is missing");
-        assert(
-          agent.versionAuthorId !== null,
-          "Unexpected: custom agent author is missing"
+        const agentResource = await AgentResource.fetchByAgentConfiguration(
+          auth,
+          agent,
+          { transaction: t }
         );
-        const agentResource = AgentResource.fromAgentConfiguration({
-          agentId: agentModelId,
-          authorId: agent.versionAuthorId,
-          sId: agent.sId,
-          scope: agent.scope,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        });
         await agentResource.grantEditors(auth, {
           editors: usersToAdd,
           transaction: t,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -30,7 +30,6 @@ import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
-import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { canReadRequestedSpaces } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -84,30 +83,6 @@ const PENDING_AGENT_PLACEHOLDER_NAME = "__PENDING__";
 const PENDING_AGENT_PLACEHOLDER_DESCRIPTION = "";
 const PENDING_AGENT_PLACEHOLDER_PICTURE_URL =
   "https://dust.tt/static/systemavatar/dust_avatar_full.png";
-
-async function grantAgentEditors(
-  auth: Authenticator,
-  {
-    agentModelId,
-    editors,
-    transaction,
-  }: {
-    agentModelId: ModelId;
-    editors: UserType[];
-    transaction: Transaction;
-  }
-): Promise<void> {
-  const grantResult = await GroupPermissionResource.grantToUsers(auth, {
-    users: editors,
-    grantType: "editor",
-    resourceType: "agent",
-    resourceId: agentModelId,
-    transaction,
-  });
-  if (grantResult.isErr()) {
-    throw grantResult.error;
-  }
-}
 
 /**
  * Creates a pending agent configuration.
@@ -165,8 +140,7 @@ export async function createPendingAgentConfiguration(
       transaction: t,
       authorId: user.id,
     });
-    await grantAgentEditors(auth, {
-      agentModelId: agentIdentity.id,
+    await AgentResource.fromAgentConfiguration(agent).grantEditors(auth, {
       editors: [user.toJSON()],
       transaction: t,
     });
@@ -969,11 +943,9 @@ export async function createAgentConfiguration(
           }
         }
 
-        await grantAgentEditors(auth, {
-          agentModelId: agentConfigurationInstance.agentId,
-          editors,
-          transaction: t,
-        });
+        await AgentResource.fromAgentConfiguration(
+          agentConfigurationInstance
+        ).grantEditors(auth, { editors, transaction: t });
       }
 
       return agentConfigurationInstance;
@@ -1635,8 +1607,18 @@ export async function updateAgentPermissions(
           transaction: t,
         });
         assert(agentModelId, "Unexpected: agent identity is missing");
-        await grantAgentEditors(auth, {
-          agentModelId,
+        assert(
+          agent.versionAuthorId !== null,
+          "Unexpected: custom agent author is missing"
+        );
+        const agentResource = AgentResource.fromAgentConfiguration({
+          agentId: agentModelId,
+          authorId: agent.versionAuthorId,
+          sId: agent.sId,
+          scope: agent.scope,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        });
+        await agentResource.grantEditors(auth, {
           editors: usersToAdd,
           transaction: t,
         });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -88,11 +88,11 @@ const PENDING_AGENT_PLACEHOLDER_PICTURE_URL =
 async function grantAgentEditors(
   auth: Authenticator,
   {
-    agentId,
+    agentModelId,
     editors,
     transaction,
   }: {
-    agentId: ModelId;
+    agentModelId: ModelId;
     editors: UserType[];
     transaction: Transaction;
   }
@@ -101,7 +101,7 @@ async function grantAgentEditors(
     users: editors,
     grantType: "editor",
     resourceType: "agent",
-    resourceId: agentId,
+    resourceId: agentModelId,
     transaction,
   });
   if (grantResult.isErr()) {
@@ -166,7 +166,7 @@ export async function createPendingAgentConfiguration(
       authorId: user.id,
     });
     await grantAgentEditors(auth, {
-      agentId: agentIdentity.id,
+      agentModelId: agentIdentity.id,
       editors: [user.toJSON()],
       transaction: t,
     });
@@ -970,7 +970,7 @@ export async function createAgentConfiguration(
         }
 
         await grantAgentEditors(auth, {
-          agentId: agentConfigurationInstance.agentId,
+          agentModelId: agentConfigurationInstance.agentId,
           editors,
           transaction: t,
         });
@@ -1631,14 +1631,12 @@ export async function updateAgentPermissions(
           return addRes;
         }
 
-        const agentModelId = await AgentResource.fetchModelIdBySId(
-          auth,
-          agent.sId,
-          { transaction: t }
-        );
+        const agentModelId = await AgentResource.fetchModelId(auth, agent.sId, {
+          transaction: t,
+        });
         assert(agentModelId, "Unexpected: agent identity is missing");
         await grantAgentEditors(auth, {
-          agentId: agentModelId,
+          agentModelId,
           editors: usersToAdd,
           transaction: t,
         });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -29,6 +29,7 @@ import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { canReadRequestedSpaces } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -82,6 +83,34 @@ const PENDING_AGENT_PLACEHOLDER_NAME = "__PENDING__";
 const PENDING_AGENT_PLACEHOLDER_DESCRIPTION = "";
 const PENDING_AGENT_PLACEHOLDER_PICTURE_URL =
   "https://dust.tt/static/systemavatar/dust_avatar_full.png";
+
+async function grantAgentEditors(
+  auth: Authenticator,
+  {
+    agentId,
+    editors,
+    transaction,
+  }: {
+    agentId: ModelId;
+    editors: UserType[];
+    transaction: Transaction;
+  }
+): Promise<void> {
+  // Each call serializes on the same grant tuple and reuses its regular_auto group. Agent editor
+  // sets are small, so keeping the existing per-user primitive is preferable to a second writer.
+  for (const editor of editors) {
+    const grantResult = await GroupPermissionResource.grantToUser(auth, {
+      user: editor,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: agentId,
+      transaction,
+    });
+    if (grantResult.isErr()) {
+      throw grantResult.error;
+    }
+  }
+}
 
 /**
  * Creates a pending agent configuration.
@@ -138,6 +167,11 @@ export async function createPendingAgentConfiguration(
     await GroupResource.makeNewAgentEditorsGroup(auth, agent, {
       transaction: t,
       authorId: user.id,
+    });
+    await grantAgentEditors(auth, {
+      agentId: agentIdentity.id,
+      editors: [user.toJSON()],
+      transaction: t,
     });
     await auth.refresh({ transaction: t });
   });
@@ -883,10 +917,13 @@ export async function createAgentConfiguration(
           );
           await auth.refresh({ transaction: t });
           // No need to check on permission here since it was done a few lines above.
-          await group.dangerouslySetMembers(auth, {
+          const setMembersRes = await group.dangerouslySetMembers(auth, {
             users: editors,
             transaction: t,
           });
+          if (setMembersRes.isErr()) {
+            throw setMembersRes.error;
+          }
         } else {
           const group = await GroupResource.fetchByAgentConfiguration({
             auth,
@@ -934,6 +971,12 @@ export async function createAgentConfiguration(
             throw setMembersRes.error;
           }
         }
+
+        await grantAgentEditors(auth, {
+          agentId: agentConfigurationInstance.agentId,
+          editors,
+          transaction: t,
+        });
       }
 
       return agentConfigurationInstance;
@@ -1590,6 +1633,22 @@ export async function updateAgentPermissions(
         if (addRes.isErr()) {
           return addRes;
         }
+
+        // agents.sId is unique, so this resolves one stable ID regardless of version count.
+        const agentIdentity = await AgentModel.findOne({
+          where: {
+            sId: agent.sId,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          attributes: ["id"],
+          transaction: t,
+        });
+        assert(agentIdentity, "Unexpected: agent identity is missing");
+        await grantAgentEditors(auth, {
+          agentId: agentIdentity.id,
+          editors: usersToAdd,
+          transaction: t,
+        });
       }
 
       if (usersToRemove.length > 0) {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -28,6 +28,7 @@ import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -96,19 +97,15 @@ async function grantAgentEditors(
     transaction: Transaction;
   }
 ): Promise<void> {
-  // Each call serializes on the same grant tuple and reuses its regular_auto group. Agent editor
-  // sets are small, so keeping the existing per-user primitive is preferable to a second writer.
-  for (const editor of editors) {
-    const grantResult = await GroupPermissionResource.grantToUser(auth, {
-      user: editor,
-      grantType: "editor",
-      resourceType: "agent",
-      resourceId: agentId,
-      transaction,
-    });
-    if (grantResult.isErr()) {
-      throw grantResult.error;
-    }
+  const grantResult = await GroupPermissionResource.grantToUsers(auth, {
+    users: editors,
+    grantType: "editor",
+    resourceType: "agent",
+    resourceId: agentId,
+    transaction,
+  });
+  if (grantResult.isErr()) {
+    throw grantResult.error;
   }
 }
 
@@ -1634,18 +1631,14 @@ export async function updateAgentPermissions(
           return addRes;
         }
 
-        // agents.sId is unique, so this resolves one stable ID regardless of version count.
-        const agentIdentity = await AgentModel.findOne({
-          where: {
-            sId: agent.sId,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          attributes: ["id"],
-          transaction: t,
-        });
-        assert(agentIdentity, "Unexpected: agent identity is missing");
+        const agentModelId = await AgentResource.fetchModelIdBySId(
+          auth,
+          agent.sId,
+          { transaction: t }
+        );
+        assert(agentModelId, "Unexpected: agent identity is missing");
         await grantAgentEditors(auth, {
-          agentId: agentIdentity.id,
+          agentId: agentModelId,
           editors: usersToAdd,
           transaction: t,
         });

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -16,8 +17,23 @@ describe("AgentResource", () => {
     testContext = await createResourceTest({ role: "user" });
   });
 
+  it("builds a custom agent resource from a rendered configuration", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator
+    );
+
+    const resource = await AgentResource.fetchByAgentConfiguration(
+      testContext.authenticator,
+      agent
+    );
+
+    expect(resource.id).not.toBeNull();
+    expect(resource.sId).toBe(agent.sId);
+    expect(resource.workspaceId).toBe(testContext.workspace.id);
+  });
+
   it("applies author, admin, and editor permissions to custom agents", async () => {
-    const resource = AgentResource.fromAgentConfiguration({
+    const resource = AgentResource.fromAgentConfigurationModel({
       agentId: AGENT_MODEL_ID,
       authorId: testContext.user.id,
       sId: "custom-agent",
@@ -80,7 +96,7 @@ describe("AgentResource", () => {
   });
 
   it("lets workspace members read visible agents without editing them", async () => {
-    const resource = AgentResource.fromAgentConfiguration({
+    const resource = AgentResource.fromAgentConfigurationModel({
       agentId: AGENT_MODEL_ID,
       authorId: testContext.user.id,
       sId: "custom-agent",

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -54,8 +54,6 @@ export class AgentResource implements WithAccessControl {
       "agentId" | "authorId" | "sId" | "scope" | "workspaceId"
     >
   ): AgentResource {
-    assert(configuration.scope !== "global");
-
     return new AgentResource(
       configuration.agentId,
       configuration.sId,

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -1,8 +1,12 @@
 import { globalAgentReaderRoles } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentModel } from "@app/lib/models/agent/agent";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import type {
+  AgentConfigurationScope,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
 import type { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { GrantVerb } from "@app/types/group_permissions";
@@ -44,13 +48,12 @@ export class AgentResource implements WithAccessControl {
     private readonly scope: AgentConfigurationScope
   ) {}
 
-  static fromAgentConfiguration(configuration: {
-    agentId: ModelId;
-    authorId: ModelId;
-    sId: string;
-    scope: AgentConfigurationScope;
-    workspaceId: ModelId;
-  }): AgentResource {
+  static fromAgentConfigurationModel(
+    configuration: Pick<
+      AgentConfigurationModel,
+      "agentId" | "authorId" | "sId" | "scope" | "workspaceId"
+    >
+  ): AgentResource {
     assert(configuration.scope !== "global");
 
     return new AgentResource(
@@ -80,22 +83,38 @@ export class AgentResource implements WithAccessControl {
     );
   }
 
-  static async fetchModelId(
+  static async fetchByAgentConfiguration(
     auth: Authenticator,
-    agentId: string,
+    configuration: Pick<
+      LightAgentConfigurationType,
+      "sId" | "scope" | "versionAuthorId"
+    >,
     { transaction }: { transaction?: Transaction } = {}
-  ): Promise<ModelId | null> {
+  ): Promise<AgentResource> {
+    assert(configuration.scope !== "global");
+    assert(
+      configuration.versionAuthorId !== null,
+      "Unexpected: custom agent author is missing"
+    );
+
     // agents.sId is unique, so this resolves one stable ID regardless of version count.
     const agent = await AgentModel.findOne({
       where: {
-        sId: agentId,
+        sId: configuration.sId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
-      attributes: ["id"],
+      attributes: ["id", "workspaceId"],
       transaction,
     });
+    assert(agent, "Unexpected: agent identity is missing");
 
-    return agent?.id ?? null;
+    return this.fromAgentConfigurationModel({
+      agentId: agent.id,
+      authorId: configuration.versionAuthorId,
+      sId: configuration.sId,
+      scope: configuration.scope,
+      workspaceId: agent.workspaceId,
+    });
   }
 
   async grantEditors(

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -1,5 +1,6 @@
 import { globalAgentReaderRoles } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import type { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
@@ -12,6 +13,7 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
+import type { Transaction } from "sequelize";
 
 // Legacy `canEdit` also allows changing the editor set, so the author fallback mirrors the full
 // editor role rather than granting write alone.
@@ -74,6 +76,24 @@ export class AgentResource implements WithAccessControl {
       null,
       "global"
     );
+  }
+
+  static async fetchModelIdBySId(
+    auth: Authenticator,
+    sId: string,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ModelId | null> {
+    // agents.sId is unique, so this resolves one stable ID regardless of version count.
+    const agent = await AgentModel.findOne({
+      where: {
+        sId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      attributes: ["id"],
+      transaction,
+    });
+
+    return agent?.id ?? null;
   }
 
   getAccessControlLists(auth: Authenticator): AccessControlList[] {

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -1,6 +1,7 @@
 import { globalAgentReaderRoles } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentModel } from "@app/lib/models/agent/agent";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import type { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
@@ -12,6 +13,7 @@ import type {
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
 
@@ -94,6 +96,26 @@ export class AgentResource implements WithAccessControl {
     });
 
     return agent?.id ?? null;
+  }
+
+  async grantEditors(
+    auth: Authenticator,
+    { editors, transaction }: { editors: UserType[]; transaction: Transaction }
+  ): Promise<void> {
+    assert(this.kind === "custom");
+    assert(this.id !== null);
+    assert(auth.getNonNullableWorkspace().id === this.workspaceId);
+
+    const grantResult = await GroupPermissionResource.grantToUsers(auth, {
+      users: editors,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: this.id,
+      transaction,
+    });
+    if (grantResult.isErr()) {
+      throw grantResult.error;
+    }
   }
 
   getAccessControlLists(auth: Authenticator): AccessControlList[] {

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -78,15 +78,15 @@ export class AgentResource implements WithAccessControl {
     );
   }
 
-  static async fetchModelIdBySId(
+  static async fetchModelId(
     auth: Authenticator,
-    sId: string,
+    agentId: string,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<ModelId | null> {
     // agents.sId is unique, so this resolves one stable ID regardless of version count.
     const agent = await AgentModel.findOne({
       where: {
-        sId,
+        sId: agentId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       attributes: ["id"],

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -84,18 +84,18 @@ const setupTestAgents = async (
     user.sId,
     workspace.sId
   );
-  const hiddenAgent = await AgentConfigurationFactory.createTestAgent(auth, {
-    name: `Test Agent 1 ${user.name}`,
-    description: "Hidden test agent",
-    scope: "hidden",
-  });
-  const visibleAgent = await AgentConfigurationFactory.createTestAgent(auth, {
-    name: `Test Agent 2 ${user.name}`,
-    description: "Visible test agent",
-    scope: "visible",
-  });
-
-  return [hiddenAgent, visibleAgent];
+  return Promise.all([
+    AgentConfigurationFactory.createTestAgent(auth, {
+      name: `Test Agent 1 ${user.name}`,
+      description: "Hidden test agent",
+      scope: "hidden",
+    }),
+    AgentConfigurationFactory.createTestAgent(auth, {
+      name: `Test Agent 2 ${user.name}`,
+      description: "Visible test agent",
+      scope: "visible",
+    }),
+  ]);
 };
 
 const dateFromDaysAgo = (days: number) => {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -84,20 +84,18 @@ const setupTestAgents = async (
     user.sId,
     workspace.sId
   );
-  const agents = await Promise.all([
-    AgentConfigurationFactory.createTestAgent(auth, {
-      name: `Test Agent 1 ${user.name}`,
-      description: "Hidden test agent",
-      scope: "hidden",
-    }),
-    AgentConfigurationFactory.createTestAgent(auth, {
-      name: `Test Agent 2 ${user.name}`,
-      description: "Visible test agent",
-      scope: "visible",
-    }),
-  ]);
+  const hiddenAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+    name: `Test Agent 1 ${user.name}`,
+    description: "Hidden test agent",
+    scope: "hidden",
+  });
+  const visibleAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+    name: `Test Agent 2 ${user.name}`,
+    description: "Visible test agent",
+    scope: "visible",
+  });
 
-  return agents;
+  return [hiddenAgent, visibleAgent];
 };
 
 const dateFromDaysAgo = (days: number) => {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -84,7 +84,7 @@ const setupTestAgents = async (
     user.sId,
     workspace.sId
   );
-  return Promise.all([
+  const agents = await Promise.all([
     AgentConfigurationFactory.createTestAgent(auth, {
       name: `Test Agent 1 ${user.name}`,
       description: "Hidden test agent",
@@ -96,6 +96,8 @@ const setupTestAgents = async (
       scope: "visible",
     }),
   ]);
+
+  return agents;
 };
 
 const dateFromDaysAgo = (days: number) => {

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -151,6 +151,14 @@ interface UserGrantSpec {
   transaction?: Transaction;
 }
 
+interface UsersGrantSpec {
+  users: UserType[];
+  grantType: GrantType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+  transaction?: Transaction;
+}
+
 interface EverybodyGrantSpec {
   grantType: GrantType;
   resourceType: GroupPermissionResourceType;
@@ -445,6 +453,29 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     auth: Authenticator,
     { user, grantType, resourceType, resourceId, transaction }: UserGrantSpec
   ): Promise<Result<undefined, Error>> {
+    return this.grantToUsers(auth, {
+      users: [user],
+      grantType,
+      resourceType,
+      resourceId,
+      transaction,
+    });
+  }
+
+  // Batched counterpart of grantToUser: one tuple lookup and one bulk membership write, while
+  // keeping repeat grants idempotent.
+  static async grantToUsers(
+    auth: Authenticator,
+    { users, grantType, resourceType, resourceId, transaction }: UsersGrantSpec
+  ): Promise<Result<undefined, Error>> {
+    if (users.length === 0) {
+      return new Ok(undefined);
+    }
+
+    const uniqueUsers = [
+      ...new Map(users.map((user) => [user.id, user])).values(),
+    ];
+
     return withTransaction(async (t) => {
       await this.getGrantLock(auth, { grantType, resourceType, resourceId }, t);
 
@@ -473,12 +504,22 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         });
       }
 
-      const addResult = await group.dangerouslyAddMember(auth, {
-        user,
+      const activeMembers = await group.getActiveMembers(auth, {
         transaction: t,
       });
-      // Repeat grant for the same user: the desired end state already holds, stay idempotent.
-      if (addResult.isErr() && addResult.error.code !== "user_already_member") {
+      const activeMemberIds = new Set(activeMembers.map((member) => member.id));
+      const usersToAdd = uniqueUsers.filter(
+        (user) => !activeMemberIds.has(user.id)
+      );
+      if (usersToAdd.length === 0) {
+        return new Ok(undefined);
+      }
+
+      const addResult = await group.dangerouslyAddMembers(auth, {
+        users: usersToAdd,
+        transaction: t,
+      });
+      if (addResult.isErr()) {
         return addResult;
       }
 

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,7 +1,6 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ModelIdType,
@@ -37,26 +36,11 @@ export class AgentConfigurationFactory {
     assert(user, "User is required");
 
     const workspace = auth.getNonNullableWorkspace();
-    // Some tests build auth without a membership. Seed the row directly to satisfy editor groups
-    // and grants without running production membership workflows from a test fixture.
-    if (!Authenticator.isMember(auth.role())) {
-      const now = new Date();
-      const membership = await MembershipModel.findOne({
-        where: { userId: user.id, workspaceId: workspace.id, endAt: null },
-      });
-      if (!membership) {
-        await MembershipModel.create({
-          role: "user",
-          origin: "invited",
-          startAt: now,
-          firstUsedAt: now,
-          userId: user.id,
-          workspaceId: workspace.id,
-        });
-      }
-    }
+    // Some legacy tests use an auth without workspace membership. Such users cannot belong to an
+    // editor group, but authorId below still preserves attribution and the author fallback.
+    const editors = Authenticator.isMember(auth.role()) ? [user.toJSON()] : [];
 
-    // Internal auth only bypasses the create capability; explicit author/editors keep attribution.
+    // Internal auth only bypasses the create capability; explicit authorId keeps attribution.
     const internalAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -77,7 +61,7 @@ export class AgentConfigurationFactory {
       templateId: null,
       requestedSpaceIds,
       tags: [], // Added missing tags property
-      editors: [user.toJSON()],
+      editors,
       authorId: user.id,
     });
 

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,6 +1,7 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ModelIdType,
@@ -35,13 +36,29 @@ export class AgentConfigurationFactory {
     const user = auth.user();
     assert(user, "User is required");
 
-    // Test fixture, not a real workflow: many tests construct an Authenticator directly without
-    // ever creating a workspace membership, so `auth` may not hold the create-agent capability
-    // (or any capability at all). `authorId`/`editors` below are explicit, so using an internal
-    // admin authenticator for the actual write doesn't change who the created agent is
-    // attributed to — it only bypasses the capability check for this test fixture.
+    const workspace = auth.getNonNullableWorkspace();
+    // Some tests build auth without a membership. Seed the row directly to satisfy editor groups
+    // and grants without running production membership workflows from a test fixture.
+    if (!Authenticator.isMember(auth.role())) {
+      const now = new Date();
+      const membership = await MembershipModel.findOne({
+        where: { userId: user.id, workspaceId: workspace.id, endAt: null },
+      });
+      if (!membership) {
+        await MembershipModel.create({
+          role: "user",
+          origin: "invited",
+          startAt: now,
+          firstUsedAt: now,
+          userId: user.id,
+          workspaceId: workspace.id,
+        });
+      }
+    }
+
+    // Internal auth only bypasses the create capability; explicit author/editors keep attribution.
     const internalAuth = await Authenticator.internalAdminForWorkspace(
-      auth.getNonNullableWorkspace().sId
+      workspace.sId
     );
 
     const result = await createAgentConfiguration(internalAuth, {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: [Admin Governance design doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)

Follows https://github.com/dust-tt/dust/pull/31649, which introduced the agent permission resource.

Agent editors are currently stored in legacy `agent_editors` groups. As we migrate to `group_permissions`, editor additions made after the backfill must be written to both systems so the data remains comparable.

This PR mirrors additions in the three workflows that can add an editor:

- creating a pending agent grants its creator editor access;
- publishing or updating an agent grants every submitted editor;
- the dedicated editor endpoint grants newly added editors.

The new grants use the stable numeric agent ID and add multiple editors in one batch. Legacy memberships and grants share a database transaction, so either both writes succeed or neither does. Permission reads remain on the legacy system; editor removals and agent-deletion cleanup are left to the next PR.

## Risks

Blast radius: Creating or publishing custom agents and adding agent editors.
Risk: standard

## Deploy Plan

- deploy front

## Tests

- [x] `npm test --workspace front -- lib/resources/agent_resource.test.ts lib/resources/group_permission_resource.test.ts lib/api/assistant/configuration/agent.test.ts` (80 tests)

