### PR TITLE
[sparkle] DataTable: allow every breakpoint in columnsBreakpoints

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -74,7 +74,7 @@ interface TBaseData {
 }
 
 interface ColumnBreakpoint {
-  [columnId: string]: "xs" | "sm" | "md" | "lg" | "xl";
+  [columnId: string]: keyof typeof breakpoints;
 }
 
 function shouldRenderColumn(


### PR DESCRIPTION
`columnsBreakpoints` only accepted `xs` to `xl` while `breakpoints` also defines `2xl` and `xxs`. The type now derives from the `breakpoints` map, so `2xl` can be used and the two stay in sync.

Need this to update a table on the Usage page 🙏🏻 