### PR TITLE
fix(tools): load 1Password-managed .env correctly in start-mprocs.sh

### DIFF
--- a/tools/start-mprocs.sh
+++ b/tools/start-mprocs.sh
@@ -3,6 +3,34 @@
 # Where the script is defined, absolute path
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
+# Load the repo-root .env into the environment without `source`-ing it as shell
+# code: the file is a 1Password-managed KEY=VALUE dump, not valid shell (it can
+# contain a bare doc-comment line and unquoted/unescaped JSON values), so
+# `source`/`eval` on it either fails outright or silently drops every
+# assignment. Line-by-line regex extraction only ever assigns literal values.
+load_env_file() {
+  local file="$1"
+  # NB: -e, not -f — this repo's .env is a 1Password-managed named pipe, not a
+  # regular file, and -f would always report it missing.
+  [ -e "$file" ] || return 0
+  local line key value
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      key="${BASH_REMATCH[1]}"
+      value="${BASH_REMATCH[2]}"
+      export "$key=$value"
+    fi
+  done < "$file"
+}
+load_env_file "$SCRIPT_DIR/../.env"
+
+# 1Password only gives us the GCP credentials as inline JSON; front-api reads
+# SERVICE_ACCOUNT as a file path (same materialization dev/scripts/common.sh
+# does for the container workflow).
+if [ -n "${GCP_SERVICE_ACCOUNT:-}" ]; then
+  printf '%s' "$GCP_SERVICE_ACCOUNT" > "${SERVICE_ACCOUNT:-/tmp/dust-dev-sa.json}"
+  export SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-/tmp/dust-dev-sa.json}"
+fi
 
 # Skip the Docker daemon check when already running inside a container.
 if [ ! -f /.dockerenv ]; then


### PR DESCRIPTION
## Description

Fixing the broken 1-password manage env and mprocs caused by GCP_SERVICE_ACCOUNT format.

## Tests

tested localy

## Risk

None — dev tooling only, not shipped code. Affects local Mac dev environment setup exclusively.

## Deploy Plan

- None (local dev script, no deploy)