### PR TITLE
Track blocked trigger executions in PostHog

### DIFF
--- a/front/lib/tracking/posthog/server.ts
+++ b/front/lib/tracking/posthog/server.ts
@@ -23,30 +23,14 @@ function getClient(): PostHog | null {
 }
 
 export class PostHogServerSideTracking {
-  static trackTriggerBlocked({
-    userId,
-    workspaceId,
-    conversationId,
-    triggerId,
-    triggerKind,
-    triggerOrigin,
-    triggerExecutionMode,
-    agentConfigurationId,
-    webhookRequestId,
-    errorType,
-    statusCode,
+  static trackEvent({
+    distinctId,
+    event,
+    properties,
   }: {
-    userId: string;
-    workspaceId?: string;
-    conversationId: string;
-    triggerId: string;
-    triggerKind: string;
-    triggerOrigin: string;
-    triggerExecutionMode: string;
-    agentConfigurationId: string;
-    webhookRequestId?: number;
-    errorType: string;
-    statusCode: number;
+    distinctId: string;
+    event: string;
+    properties?: Record<string, string | number | boolean>;
   }): void {
     const client = getClient();
     if (!client) {
@@ -54,26 +38,11 @@ export class PostHogServerSideTracking {
     }
 
     try {
-      client.capture({
-        distinctId: userId,
-        event: "trigger_blocked",
-        properties: {
-          workspace_id: workspaceId,
-          conversation_id: conversationId,
-          trigger_id: triggerId,
-          trigger_kind: triggerKind,
-          trigger_origin: triggerOrigin,
-          trigger_execution_mode: triggerExecutionMode,
-          agent_configuration_id: agentConfigurationId,
-          ...(webhookRequestId ? { webhook_request_id: webhookRequestId } : {}),
-          error_type: errorType,
-          status_code: statusCode,
-        },
-      });
+      client.capture({ distinctId, event, properties });
     } catch (err) {
       logger.error(
-        { userId, workspaceId, triggerId, err },
-        "Failed to track blocked trigger on PostHog"
+        { distinctId, event, err },
+        "Failed to capture event on PostHog"
       );
     }
   }

--- a/front/lib/tracking/posthog/server.ts
+++ b/front/lib/tracking/posthog/server.ts
@@ -23,6 +23,61 @@ function getClient(): PostHog | null {
 }
 
 export class PostHogServerSideTracking {
+  static trackTriggerBlocked({
+    userId,
+    workspaceId,
+    conversationId,
+    triggerId,
+    triggerKind,
+    triggerOrigin,
+    triggerExecutionMode,
+    agentConfigurationId,
+    webhookRequestId,
+    errorType,
+    statusCode,
+  }: {
+    userId: string;
+    workspaceId?: string;
+    conversationId: string;
+    triggerId: string;
+    triggerKind: string;
+    triggerOrigin: string;
+    triggerExecutionMode: string;
+    agentConfigurationId: string;
+    webhookRequestId?: number;
+    errorType: string;
+    statusCode: number;
+  }): void {
+    const client = getClient();
+    if (!client) {
+      return;
+    }
+
+    try {
+      client.capture({
+        distinctId: userId,
+        event: "trigger_blocked",
+        properties: {
+          workspace_id: workspaceId,
+          conversation_id: conversationId,
+          trigger_id: triggerId,
+          trigger_kind: triggerKind,
+          trigger_origin: triggerOrigin,
+          trigger_execution_mode: triggerExecutionMode,
+          agent_configuration_id: agentConfigurationId,
+          ...(webhookRequestId ? { webhook_request_id: webhookRequestId } : {}),
+          error_type: errorType,
+          status_code: statusCode,
+        },
+      });
+    } catch (err) {
+      logger.error(
+        { userId, workspaceId, triggerId, err },
+        "Failed to track blocked trigger on PostHog"
+      );
+    }
+  }
+
   /**
    * Alias an anonymous device ID to an identified user so that all pre-signup
    * events captured with `dust_anonymous_id` are merged into the user's

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -167,18 +167,14 @@ async function createConversationForAgentConfiguration({
       errorType === "rate_limit_error" ||
       errorType === "no_seat"
     ) {
-      PostHogServerSideTracking.trackTriggerBlocked({
-        userId: auth.getNonNullableUser().sId,
-        workspaceId: auth.workspace()?.sId,
-        conversationId: newConversation.sId,
-        triggerId: trigger.sId,
-        triggerKind: trigger.kind,
-        triggerOrigin: trigger.origin,
-        triggerExecutionMode: trigger.executionMode,
-        agentConfigurationId: trigger.agentConfigurationId,
-        webhookRequestId: webhookRequest?.id,
-        errorType,
-        statusCode: messageRes.error.status_code,
+      PostHogServerSideTracking.trackEvent({
+        distinctId: auth.getNonNullableUser().sId,
+        event: "trigger_blocked",
+        properties: {
+          workspace_id: auth.getNonNullableWorkspace().sId,
+          trigger_id: trigger.sId,
+          error_type: errorType,
+        },
       });
     }
 

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -18,6 +18,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
+import { PostHogServerSideTracking } from "@app/lib/tracking/posthog/server";
 import { getWebhookRequestPayloadFromGCS } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { makeTriggerScheduleId } from "@app/temporal/triggers/schedule_client";
@@ -158,6 +159,29 @@ async function createConversationForAgentConfiguration({
   });
 
   if (messageRes.isErr()) {
+    const { type: errorType } = messageRes.error.api_error;
+    if (
+      errorType === "plan_message_limit_exceeded" ||
+      errorType === "credits_exhausted" ||
+      errorType === "user_cap_reached" ||
+      errorType === "rate_limit_error" ||
+      errorType === "no_seat"
+    ) {
+      PostHogServerSideTracking.trackTriggerBlocked({
+        userId: auth.getNonNullableUser().sId,
+        workspaceId: auth.workspace()?.sId,
+        conversationId: newConversation.sId,
+        triggerId: trigger.sId,
+        triggerKind: trigger.kind,
+        triggerOrigin: trigger.origin,
+        triggerExecutionMode: trigger.executionMode,
+        agentConfigurationId: trigger.agentConfigurationId,
+        webhookRequestId: webhookRequest?.id,
+        errorType,
+        statusCode: messageRes.error.status_code,
+      });
+    }
+
     logger.error(
       {
         agentConfigurationId: trigger.agentConfigurationId,


### PR DESCRIPTION
## Description

Instrument blocked trigger executions with a `trigger_blocked` PostHog event. The event is emitted when trigger-created message posting is rejected by a usage or access limit, after the orphan conversation has been created but before any user or agent message is persisted.

## Tests

## Risk

Low. The PostHog call is best-effort and is wrapped in its own error handling. It does not change trigger execution, limit enforcement, or retry behavior. The event is only emitted for limit-related and no-seat errors.

## Deploy Plan

Normal. Verify that the events are sent post-deploy