### PR TITLE
Rename poke pool-usage page to Credits usage, label pool/credit columns

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -132,7 +132,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
 
 export function PoolUsagePage() {
   const owner = useWorkspace();
-  usePokePageMetadata({ name: owner.name, subtitle: "Pool Usage" });
+  usePokePageMetadata({ name: owner.name, subtitle: "Credits Usage" });
 
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
@@ -182,6 +182,9 @@ export function PoolUsagePage() {
       ? sort.id
       : "name";
   const orderDirection = sort?.desc ? "desc" : "asc";
+
+  const { awuPoolCurrentCycle } = usePokeAwuPoolCurrentCycle({ owner });
+  const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
 
   const {
     members,
@@ -311,7 +314,7 @@ export function PoolUsagePage() {
       <Page.Header
         title={
           <div className="flex w-full items-center justify-between gap-4">
-            <Page.H variant="h3">Pool usage</Page.H>
+            <Page.H variant="h3">Credits usage</Page.H>
             <Button
               label="Breakdown in analytics"
               iconRight={LinkExternal01}
@@ -379,6 +382,7 @@ export function PoolUsagePage() {
                   seatChangePendingMemberIds={EMPTY_PENDING_MEMBER_IDS}
                   isSeatBased
                   showSpendLimit
+                  hasPool={hasPool}
                   readOnly
                   onChangeSeat={noopOnMember}
                   onRemoveSeat={noopOnMember}

--- a/front/components/poke/workspace/WorkspacePoolUsageButton.tsx
+++ b/front/components/poke/workspace/WorkspacePoolUsageButton.tsx
@@ -34,7 +34,7 @@ export function WorkspacePoolUsageButton({
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="text-sm font-semibold text-foreground">
-          Pool Usage
+          Credits Usage
         </span>
         <span className="text-xs text-muted-foreground">
           Review member seats and credit pool consumption.

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -42,6 +42,7 @@ import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Chip,
   Clock,
+  CoinsStacked03,
   createSelectionColumn,
   DataTable,
   Icon,
@@ -676,14 +677,22 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
 
 function buildPoolCreditUsageColumn(
   creditsResetAt: string | null,
-  variant: MembersUsageTableVariant
+  variant: MembersUsageTableVariant,
+  hasPool: boolean
 ): ColumnDef<RowData, string> {
   return {
     id: "consumedFromPoolAwuCredits" as const,
     header: () => (
       <div className="flex flex-col">
-        <span>Credits usage this month</span>
-        {creditsResetAt && (
+        {variant === "compact" ? (
+          <span className="flex items-center gap-1">
+            <Icon visual={CoinsStacked03} size="xs" />
+            {hasPool ? "Pool usage" : "Credit usage"}
+          </span>
+        ) : (
+          <span>Credits usage this month</span>
+        )}
+        {variant !== "compact" && creditsResetAt && (
           <span className="text-xs font-normal text-muted-foreground">
             Limits reset on{" "}
             {new Date(creditsResetAt).toLocaleDateString("en-US", {
@@ -786,9 +795,11 @@ const actionsColumn: ColumnDef<RowData, string> = {
 function buildCreditPlanColumns({
   creditsResetAt,
   variant,
+  hasPool,
 }: {
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
+  hasPool: boolean;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(() => {
@@ -803,7 +814,7 @@ function buildCreditPlanColumns({
       }
     })(),
     {
-      ...buildPoolCreditUsageColumn(creditsResetAt, variant),
+      ...buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool),
       meta: { className: "w-56" },
     },
   ];
@@ -816,6 +827,7 @@ function buildColumns({
   showSeatAndCredits,
   creditsResetAt,
   variant,
+  hasPool,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
@@ -823,6 +835,7 @@ function buildColumns({
   showSeatAndCredits: boolean;
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
+  hasPool: boolean;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
@@ -830,7 +843,7 @@ function buildColumns({
     ...(showGroupsColumn ? [groupsColumn] : []),
     ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
     ...(showSeatAndCredits
-      ? buildCreditPlanColumns({ creditsResetAt, variant })
+      ? buildCreditPlanColumns({ creditsResetAt, variant, hasPool })
       : []),
     // Every row action belongs to one of these two groups.
     ...(showSeatAndCredits || showModelTiersColumn ? [actionsColumn] : []),
@@ -880,6 +893,9 @@ interface MembersUsageTableProps {
   ) => void;
   showModelTiersColumn?: boolean;
   variant?: MembersUsageTableVariant;
+  // Whether the workspace has an active credit pool. Only affects the
+  // "compact" (poke) variant's credit column header.
+  hasPool?: boolean;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
   userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
   groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
@@ -915,6 +931,7 @@ export function MembersUsageTable({
   onSetUserModelTier,
   showModelTiersColumn = false,
   variant = "legacy",
+  hasPool = true,
   userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
   userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
   groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
@@ -1087,6 +1104,7 @@ export function MembersUsageTable({
         showSeatAndCredits,
         creditsResetAt,
         variant,
+        hasPool,
       }),
     [
       enableSelection,
@@ -1095,6 +1113,7 @@ export function MembersUsageTable({
       showSeatAndCredits,
       creditsResetAt,
       variant,
+      hasPool,
     ]
   );
 

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -78,7 +78,7 @@ export function WorkspaceCreditUsageValueCards({
     >
       {showPoolCard && (
         <SummaryCard
-          label="Remaining credits pool"
+          label="Remaining credits in the pool"
           value={formatCredits(totalRemainingCredits)}
           hint={null}
         />
@@ -93,7 +93,7 @@ export function WorkspaceCreditUsageValueCards({
         hint={cycleDayLabel}
       />
       <SummaryCard
-        label="Programmatic / Other usage this cycle"
+        label="Programmatic usage this cycle"
         value={
           typeof programmaticConsumedCredits === "number"
             ? formatCredits(programmaticConsumedCredits)
@@ -154,7 +154,12 @@ export function WorkspaceCreditPoolCycleHistoryTable({
         : "Unknown cycle",
     consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
   }));
-  return <DataTable data={rows} columns={CYCLE_HISTORY_COLUMNS} />;
+  return (
+    <>
+      <Page.H variant="h5">Previous cycles</Page.H>
+      <DataTable data={rows} columns={CYCLE_HISTORY_COLUMNS} />
+    </>
+  );
 }
 
 interface WorkspaceCreditPoolHistoryProps {
@@ -228,7 +233,7 @@ export function WorkspaceCreditPoolSection({
 
   return (
     <Page.Vertical gap="xs" align="stretch">
-      <Page.H variant="h4">Credit usage</Page.H>
+      <Page.H variant="h4">Credit consumption</Page.H>
 
       {cardsStatus === "error" ? (
         <ContentMessage


### PR DESCRIPTION
## Description

A set of minor UI changes as part of usage-pool page QA review. 
Keep column renames under compact condition not to pollute the current usage page in the app.

## Tests

Tested localy

## Risk

Low

## Deploy Plan

- deploy front
