### PR TITLE
Poke: show plan chip on seats column instead of icon-only

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1,5 +1,6 @@
 import {
   SEAT_TYPE_ICONS,
+  seatTypeChipColor,
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
@@ -39,6 +40,7 @@ import {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  Chip,
   Clock,
   createSelectionColumn,
   DataTable,
@@ -561,16 +563,19 @@ const seatsIconColumn: ColumnDef<RowData, string> = {
           tooltipTriggerAsChild
           label={tooltipLabel}
           trigger={
-            <span className="flex cursor-default items-center justify-center">
-              <SeatTypeIcon seatType={seatType} />
-            </span>
+            <Chip
+              size="mini"
+              color={seatTypeChipColor(seatType)}
+              label={seatTypeDisplayName(seatType)}
+              className="cursor-default"
+            />
           }
         />
       </DataTable.CellContent>
     );
   },
   meta: {
-    className: "w-16",
+    className: "w-24",
     headerAlign: "center",
   },
 };

--- a/front/components/workspace/billing/seatTypeUtils.ts
+++ b/front/components/workspace/billing/seatTypeUtils.ts
@@ -1,5 +1,6 @@
 import type { MembershipSeatType } from "@app/types/memberships";
 import { toBaseSeatType } from "@app/types/memberships";
+import type { Chip } from "@dust-tt/sparkle";
 import {
   AlertCircle,
   CoinsStacked01,
@@ -8,6 +9,7 @@ import {
   LayersThree01,
   LayersTwo01,
 } from "@dust-tt/sparkle";
+import type React from "react";
 import type { ComponentType } from "react";
 
 const SEAT_TYPE_DISPLAY_NAMES: Record<string, string> = {
@@ -58,6 +60,23 @@ export function seatTypeAvatarColors(seatType: string) {
         iconColor: "text-muted-foreground",
       };
   }
+}
+
+export type SeatChipColor = NonNullable<
+  React.ComponentProps<typeof Chip>["color"]
+>;
+
+// Chip color per plan, matching the seat icon colors used elsewhere (golden
+// for max, blue/highlight for pro, green for the platform seat).
+const SEAT_TYPE_CHIP_COLORS: Record<string, SeatChipColor> = {
+  max: "warning",
+  pro: "highlight",
+  workspace: "success",
+};
+
+export function seatTypeChipColor(seatType: MembershipSeatType): SeatChipColor {
+  const base = toBaseSeatType(seatType);
+  return SEAT_TYPE_CHIP_COLORS[base] ?? "primary";
 }
 
 export function formatAmount(cents: number, currency: string): string {


### PR DESCRIPTION


## Description

Replaces the icon-only seat indicator in the poke members table's with a Chip carrying the plan name.

## Tests

Tested locally 

## Risk


## Deploy Plan

- Deploy front
