### PR TITLE
Poke: add off-pace indicator column after credit usage

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/members-usage.test.ts
@@ -11,7 +11,7 @@ vi.mock("@app/lib/api/credits/members_usage", async () => {
 });
 
 function membersUsageUrl(wId: string) {
-  return `/api/w/${wId}/credits/members-usage`;
+  return `/api/poke/workspaces/${wId}/credits/members-usage`;
 }
 
 const MEMBER_USAGE = {
@@ -35,7 +35,7 @@ const MEMBER_USAGE = {
   seatType: "max" as const,
   seatBalanceAwu: 100,
   seatUsageTarget: null,
-  overallUsageTarget: null,
+  overallUsageTarget: "critical" as const,
   spendLimitAlertId: null,
   spendLimitAwuCredits: null,
   rateLimiterSpendAwuCredits: null,
@@ -55,40 +55,10 @@ beforeEach(() => {
   });
 });
 
-describe("GET /api/w/[wId]/credits/members-usage", () => {
-  it("returns 403 when the caller is not a manager", async () => {
+describe("GET /api/poke/workspaces/[wId]/credits/members-usage", () => {
+  it("returns members usage including the off-pace target, with alert links requested", async () => {
     const { workspace } = await createPrivateApiMockRequest({
-      method: "GET",
-      role: "user",
-    });
-
-    const response = await honoApp.request(membersUsageUrl(workspace.sId));
-
-    expect(response.status).toBe(403);
-    expect((await response.json()).error.type).toBe("workspace_auth_error");
-    expect(membersUsage.getMembersUsage).not.toHaveBeenCalled();
-  });
-
-  it("allows a manager to read members usage", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
-      method: "GET",
-      role: "manager",
-    });
-
-    const response = await honoApp.request(membersUsageUrl(workspace.sId));
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      members: [MEMBER_USAGE],
-      total: 1,
-      creditsResetAt: CREDITS_RESET_AT,
-    });
-    expect(membersUsage.getMembersUsage).toHaveBeenCalled();
-  });
-
-  it("allows an admin to read members usage", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
-      method: "GET",
+      isSuperUser: true,
       role: "admin",
     });
 
@@ -100,5 +70,11 @@ describe("GET /api/w/[wId]/credits/members-usage", () => {
       total: 1,
       creditsResetAt: CREDITS_RESET_AT,
     });
+    expect(membersUsage.getMembersUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeAlertLinks: true,
+        includeSeatBalance: true,
+      })
+    );
   });
 });

--- a/front-api/routes/poke/workspaces/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/members-usage.test.ts
@@ -1,5 +1,6 @@
 import * as membersUsage from "@app/lib/api/credits/members_usage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { makeMemberUsage } from "@app/tests/utils/MemberUsageFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,36 +15,7 @@ function membersUsageUrl(wId: string) {
   return `/api/poke/workspaces/${wId}/credits/members-usage`;
 }
 
-const MEMBER_USAGE = {
-  billingFrequency: "ANNUAL" as const,
-  consumedAwuCredits: 100,
-  consumedFromAllowanceAwuCredits: 50,
-  consumedFromPoolAwuCredits: 50,
-  creditState: "normal" as const,
-  email: "member1@example.com",
-  freeCreditEmptyAlert: null,
-  freeCreditLowAlert: null,
-  groups: [],
-  image: null,
-  memberUsageLimit: null,
-  name: "Member One",
-  nearLimit: false,
-  nextCreditResetAt: null,
-  sId: "member1",
-  scheduledSeatChangeAt: null,
-  scheduledSeatType: null,
-  seatType: "max" as const,
-  seatBalanceAwu: 100,
-  seatUsageTarget: null,
-  overallUsageTarget: "critical" as const,
-  spendLimitAlertId: null,
-  spendLimitAwuCredits: null,
-  rateLimiterSpendAwuCredits: null,
-  metronomeConsumedAwuCredits: null,
-  spendLimitSource: "default" as const,
-  spendLimitGroupName: null,
-  spendLimitWarningAlertId: null,
-};
+const MEMBER_USAGE = makeMemberUsage({ overallUsageTarget: "critical" });
 
 const CREDITS_RESET_AT = "2026-08-01T00:00:00.000Z";
 

--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -1,5 +1,6 @@
 import * as membersUsage from "@app/lib/api/credits/members_usage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { makeMemberUsage } from "@app/tests/utils/MemberUsageFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,36 +15,7 @@ function membersUsageUrl(wId: string) {
   return `/api/w/${wId}/credits/members-usage`;
 }
 
-const MEMBER_USAGE = {
-  billingFrequency: "ANNUAL" as const,
-  consumedAwuCredits: 100,
-  consumedFromAllowanceAwuCredits: 50,
-  consumedFromPoolAwuCredits: 50,
-  creditState: "normal" as const,
-  email: "member1@example.com",
-  freeCreditEmptyAlert: null,
-  freeCreditLowAlert: null,
-  groups: [],
-  image: null,
-  memberUsageLimit: null,
-  name: "Member One",
-  nearLimit: false,
-  nextCreditResetAt: null,
-  sId: "member1",
-  scheduledSeatChangeAt: null,
-  scheduledSeatType: null,
-  seatType: "max" as const,
-  seatBalanceAwu: 100,
-  seatUsageTarget: null,
-  overallUsageTarget: null,
-  spendLimitAlertId: null,
-  spendLimitAwuCredits: null,
-  rateLimiterSpendAwuCredits: null,
-  metronomeConsumedAwuCredits: null,
-  spendLimitSource: "default" as const,
-  spendLimitGroupName: null,
-  spendLimitWarningAlertId: null,
-};
+const MEMBER_USAGE = makeMemberUsage();
 
 const CREDITS_RESET_AT = "2026-08-01T00:00:00.000Z";
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -156,6 +156,7 @@ function memberFromUpgradeRequest(
     creditState: "capped",
     nearLimit: false,
     seatUsageTarget: null,
+    overallUsageTarget: null,
   };
 }
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -29,6 +29,7 @@ import {
 import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
+import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -40,6 +41,7 @@ import {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  AlertCircle,
   Chip,
   Clock,
   CoinsStacked03,
@@ -96,6 +98,7 @@ type RowData = {
   scheduledSeatChangeAt: string | null;
   isTotalAllowedUsagePending: boolean;
   isSeatChangePending: boolean;
+  overallUsageTarget: CreditUsageTarget | null;
   modelTiersSummary: string;
   hasUserLevelModelTiersOverride: boolean;
   menuItems: MenuItem[];
@@ -730,6 +733,52 @@ function buildPoolCreditUsageColumn(
   };
 }
 
+// Poke-only: flags a member whose total consumption (seat + pool/overage) is
+// running ahead of the billing cycle's elapsed time, using the same
+// `overallUsageTarget` pace classification the API derives from
+// `computeCreditUsageStatus`.
+const offPaceColumn: ColumnDef<RowData, string> = {
+  id: "overallUsageTarget" as const,
+  header: "",
+  enableSorting: false,
+  accessorFn: (row) => row.overallUsageTarget ?? "",
+  cell: (info: Info) => {
+    const { overallUsageTarget } = info.row.original;
+    if (
+      overallUsageTarget !== "elevated" &&
+      overallUsageTarget !== "critical"
+    ) {
+      return <DataTable.CellContent className="justify-center" />;
+    }
+    const isCritical = overallUsageTarget === "critical";
+    return (
+      <DataTable.CellContent className="justify-center">
+        <Tooltip
+          tooltipTriggerAsChild
+          label={
+            isCritical
+              ? "Consuming credits well ahead of the billing cycle's pace"
+              : "Consuming credits ahead of the billing cycle's pace"
+          }
+          trigger={
+            <span className="flex cursor-default items-center justify-center">
+              <Icon
+                visual={AlertCircle}
+                size="sm"
+                className={isCritical ? "text-red-500" : "text-warning-500"}
+              />
+            </span>
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-10",
+    headerAlign: "center",
+  },
+};
+
 function buildModelTiersColumn(
   variant: MembersUsageTableVariant
 ): ColumnDef<RowData, string> {
@@ -817,6 +866,7 @@ function buildCreditPlanColumns({
       ...buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool),
       meta: { className: "w-56" },
     },
+    ...(variant === "compact" ? [offPaceColumn] : []),
   ];
 }
 
@@ -985,6 +1035,7 @@ export function MembersUsageTable({
             m.sId
           ),
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
+          overallUsageTarget: m.overallUsageTarget,
           modelTiersSummary: (() => {
             const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
             switch (variant) {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -733,10 +733,6 @@ function buildPoolCreditUsageColumn(
   };
 }
 
-// Poke-only: flags a member whose total consumption (seat + pool/overage) is
-// running ahead of the billing cycle's elapsed time, using the same
-// `overallUsageTarget` pace classification the API derives from
-// `computeCreditUsageStatus`.
 const offPaceColumn: ColumnDef<RowData, string> = {
   id: "overallUsageTarget" as const,
   header: "",

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -176,6 +176,11 @@ export type MemberUsageType = {
   // their seat allowance faster than a linear pace would predict. Poke-only
   // (null otherwise, or when the billing cycle can't be resolved).
   seatUsageTarget: CreditUsageTarget | null;
+  // Same pace classification as `seatUsageTarget`, but against the member's
+  // total effective spend limit (seat allowance + pool/overage) rather than
+  // just the seat allowance. Poke-only (null otherwise, or when the billing
+  // cycle or effective limit can't be resolved).
+  overallUsageTarget: CreditUsageTarget | null;
   // Per-user fair-use AWU credit usage (credits, with decimals) backed by the
   // microCredit rate-limit counter. Applies to non-credit-based plans
   // (free/trial) where a fair-use limit is set. Null when the plan carries no
@@ -1640,6 +1645,7 @@ export async function getMemberUsage({
     creditState: membership.creditState,
     nearLimit: false,
     seatUsageTarget: null,
+    overallUsageTarget: null,
   };
 
   return {
@@ -2511,6 +2517,17 @@ export async function getMembersUsage({
             nowMs: Date.now(),
           })?.target ?? null)
         : null;
+    // Same pace classification, but against the total effective limit (seat
+    // allowance + pool/overage) rather than just the seat allowance.
+    const overallUsageTarget =
+      billingCycle && effectiveSpendLimitAwuCredits !== null
+        ? (computeCreditUsageStatus({
+            consumedAwuCredits: totalConsumedCredits,
+            limitAwuCredits: effectiveSpendLimitAwuCredits,
+            billingCycle,
+            nowMs: Date.now(),
+          })?.target ?? null)
+        : null;
 
     return [
       {
@@ -2557,6 +2574,7 @@ export async function getMembersUsage({
         nearLimit,
         fairUse: fairUseByUserId.get(userId) ?? null,
         seatUsageTarget,
+        overallUsageTarget,
       },
     ];
   });

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -177,9 +177,7 @@ export type MemberUsageType = {
   // (null otherwise, or when the billing cycle can't be resolved).
   seatUsageTarget: CreditUsageTarget | null;
   // Same pace classification as `seatUsageTarget`, but against the member's
-  // total effective spend limit (seat allowance + pool/overage) rather than
-  // just the seat allowance. Poke-only (null otherwise, or when the billing
-  // cycle or effective limit can't be resolved).
+  // total effective spend limit (seat allowance + pool/overage).
   overallUsageTarget: CreditUsageTarget | null;
   // Per-user fair-use AWU credit usage (credits, with decimals) backed by the
   // microCredit rate-limit counter. Applies to non-credit-based plans
@@ -2517,8 +2515,6 @@ export async function getMembersUsage({
             nowMs: Date.now(),
           })?.target ?? null)
         : null;
-    // Same pace classification, but against the total effective limit (seat
-    // allowance + pool/overage) rather than just the seat allowance.
     const overallUsageTarget =
       billingCycle && effectiveSpendLimitAwuCredits !== null
         ? (computeCreditUsageStatus({

--- a/front/tests/utils/MemberUsageFactory.ts
+++ b/front/tests/utils/MemberUsageFactory.ts
@@ -1,0 +1,40 @@
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+
+// Plain data builder (no DB writes) for `MemberUsageType`, the shape
+// `getMembersUsage`/`getMemberUsage` return. Used to stub `getMembersUsage`
+// in route tests without repeating every field at each call site.
+export function makeMemberUsage(
+  overrides: Partial<MemberUsageType> = {}
+): MemberUsageType {
+  return {
+    billingFrequency: "ANNUAL",
+    consumedAwuCredits: 100,
+    consumedFromAllowanceAwuCredits: 50,
+    consumedFromPoolAwuCredits: 50,
+    creditState: "normal",
+    email: "member1@example.com",
+    freeCreditEmptyAlert: null,
+    freeCreditLowAlert: null,
+    groups: [],
+    image: null,
+    memberUsageLimit: null,
+    name: "Member One",
+    nearLimit: false,
+    nextCreditResetAt: null,
+    sId: "member1",
+    scheduledSeatChangeAt: null,
+    scheduledSeatType: null,
+    seatType: "max",
+    seatBalanceAwu: 100,
+    seatUsageTarget: null,
+    overallUsageTarget: null,
+    spendLimitAlertId: null,
+    spendLimitAwuCredits: null,
+    rateLimiterSpendAwuCredits: null,
+    metronomeConsumedAwuCredits: null,
+    spendLimitSource: "default",
+    spendLimitGroupName: null,
+    spendLimitWarningAlertId: null,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Description

Add a titleless column to the usage members table. Display a warning icon when an user is off pace, warning if elevated, red if critical.

This global off pace score is computed using the user max limit (seat + max overage) rather than juste the seat.

Hide this under compact not to affect the current app displayed table.

## Tests

Localy 

## Risk

Low - additive only

## Deploy Plan

- Deploy front
