### PR TITLE
[infra] fix(prodbox): keep .git in prodbox image via dedicated dockerignore

### DIFF
--- a/dockerfiles/prodbox.Dockerfile.dockerignore
+++ b/dockerfiles/prodbox.Dockerfile.dockerignore
@@ -1,0 +1,53 @@
+# prodbox ships the full repo (COPY . .) AND keeps the .git directory: its
+# entrypoint (prodbox/init.sh) runs `git pull origin main` at container start to
+# fast-forward a running pod to the latest main without a redeploy.
+#
+# A per-Dockerfile dockerignore fully REPLACES the root .dockerignore for this
+# build (they do not merge), so this file mirrors the root ignores while
+# deliberately NOT excluding .git.
+
+# /node_modules
+**/node_modules
+**/target
+
+# misc
+.DS_Store
+**/*.pem
+**/dist
+
+# env files
+**/.env
+**/.env*.local
+
+# typescript
+*.tsbuildinfo
+
+**/Dockerfile*
+.dockerignore
+
+# dependencies
+**/.pnp
+**/.pnp.js
+
+# testing
+**/coverage
+
+# next.js
+**/.next/
+**/out/
+
+# production
+**/build
+
+# debug
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/.pnpm-debug.log*
+
+# vercel
+.vercel
+
+# typescript
+**/*.tsbuildinfo
+**/next-env.d.ts


### PR DESCRIPTION
## Description

PR #29910 ("Speed up Depot image builds") added `.git` to the root
`.dockerignore` to slim the **front** build context. That change also stripped
`.git` from the **prodbox** image: prodbox is built with `COPY . .` and, having
no per-Dockerfile dockerignore of its own, falls back to the root
`.dockerignore`.

prodbox relies on that `.git` directory at runtime — `prodbox/init.sh` runs
`git pull origin main` on container start to fast-forward a running pod to the
latest `main` without a redeploy. Without `.git`, the image is a frozen
build-time snapshot and can no longer self-update.

This PR adds `dockerfiles/prodbox.Dockerfile.dockerignore`, which mirrors the
root ignores but deliberately keeps `.git`. BuildKit/Depot use a per-Dockerfile
dockerignore in place of (not merged with) the root one, so this restores `.git`
for prodbox while leaving front's slim context untouched.

## Tests

No automated tests — this only affects the Docker build context. Verified that:
- prodbox goes through the standard `depot build -f ./dockerfiles/prodbox.Dockerfile ... .` path (`.github/actions/build-image/action.yml`), so the new dockerignore applies.
- front is unaffected: it builds via `front-bake.hcl` and its own `front.Dockerfile.dockerignore`.

## Risk

Low. Scoped to the prodbox image build context only. Reintroduces `.git` into
the prodbox image (a marginally larger image), which is the pre-#29910 behavior.
Trivially rollback-able by deleting the file.

## Deploy Plan

Merge to `main`; the next prodbox image build picks up the new dockerignore and
ships `.git` again, restoring `git pull origin main` in `prodbox/init.sh`.