### PR TITLE
[Poke] Show a Frame's sharing scope and grants

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/frames/[frameId]/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/[frameId]/index.test.ts
@@ -103,4 +103,59 @@ describe("GET /api/poke/workspaces/:wId/frames/:frameId", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("returns the Frame's share scope and every grant, revoked included", async () => {
+    const { workspace, frame, adminAuth } = await makeTestFrameFunction({
+      isSuperUser: true,
+    });
+    await frame.setShareScope(adminAuth, "emails_only");
+    await frame.addSharingGrantsAndGetCreatedEmails(adminAuth, {
+      emails: ["active@dust.tt", "revoked@dust.tt"],
+    });
+
+    const grants = await frame.listAllSharingGrants();
+    const toRevoke = grants.find((grant) => grant.email === "revoked@dust.tt");
+    if (!toRevoke) {
+      throw new Error("Expected the grant to revoke to exist.");
+    }
+    const revokeResult = await frame.revokeSharingGrant({
+      grantId: toRevoke.id,
+    });
+    expect(revokeResult.isOk()).toBe(true);
+
+    vi.mocked(loadFramePublicationDescriptor).mockResolvedValue(
+      new Ok({
+        schemaVersion: 1,
+        manifest: { uiEntryPoint: "app.tsx", functions: [], databases: [] },
+        publishedAt: "2026-09-01T00:00:00.000Z",
+        publisherId: null,
+        sourceFiles: [{ path: "app.tsx", contentSha256: "a".repeat(64) }],
+        ui: { bundleSha256: "b".repeat(64) },
+        functions: [],
+        databases: [],
+      } as never)
+    );
+
+    const response = await honoApp.request(frameUrl(workspace.sId, frame.sId));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.sharing).toMatchObject({ scope: "emails_only" });
+    expect(data.sharing.shareUrl).toBeTruthy();
+
+    // Revoked grants must still be returned: they answer "they used to have access". The length
+    // assertion matters — without it, dropping revoked grants would leave `.get()` undefined and
+    // `not.toBeNull()` would pass anyway.
+    expect(data.sharingGrants).toHaveLength(2);
+    const revokedAtByEmail = new Map(
+      data.sharingGrants.map(
+        (grant: { email: string; revokedAt: number | null }) => [
+          grant.email,
+          grant.revokedAt,
+        ]
+      )
+    );
+    expect(revokedAtByEmail.get("active@dust.tt")).toBeNull();
+    expect(revokedAtByEmail.get("revoked@dust.tt")).toEqual(expect.any(Number));
+  });
 });

--- a/front/components/poke/frames/sharing.tsx
+++ b/front/components/poke/frames/sharing.tsx
@@ -1,0 +1,129 @@
+import {
+  PokeTable,
+  PokeTableBody,
+  PokeTableCell,
+  PokeTableCellWithCopy,
+  PokeTableHead,
+  PokeTableRow,
+} from "@app/components/poke/shadcn/ui/table";
+import type { PokeFrameSharing } from "@app/lib/api/poke/frames";
+import type { SharingGrantType } from "@app/types/files";
+import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
+import { Chip } from "@dust-tt/sparkle";
+
+interface FrameSharingSectionProps {
+  sharing: PokeFrameSharing;
+  sharingGrants: SharingGrantType[];
+}
+
+export function FrameSharingSection({
+  sharing,
+  sharingGrants,
+}: FrameSharingSectionProps) {
+  const activeGrants = sharingGrants.filter((grant) => !grant.revokedAt);
+  const revokedGrants = sharingGrants.filter((grant) => grant.revokedAt);
+
+  return (
+    <div className="my-4 flex flex-col rounded-lg border p-4">
+      <h2 className="text-md pb-4 font-bold">Sharing</h2>
+      {!sharing ? (
+        <div className="text-sm text-muted-foreground">
+          No sharing configured.
+        </div>
+      ) : (
+        <PokeTable>
+          <PokeTableBody>
+            <PokeTableRow>
+              <PokeTableHead>Scope</PokeTableHead>
+              <PokeTableCell>{sharing.scope}</PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableHead>Shared at</PokeTableHead>
+              <PokeTableCell>
+                {dateToHumanReadable(new Date(sharing.sharedAt))}
+              </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableHead>Share URL</PokeTableHead>
+              <PokeTableCellWithCopy label={sharing.shareUrl} />
+            </PokeTableRow>
+          </PokeTableBody>
+        </PokeTable>
+      )}
+
+      <GrantList
+        grants={activeGrants}
+        emptyMessage="No active grants."
+        title={`Active grants (${activeGrants.length})`}
+      />
+      {revokedGrants.length > 0 && (
+        <GrantList
+          grants={revokedGrants}
+          emptyMessage="No revoked grants."
+          revoked
+          title={`Revoked grants (${revokedGrants.length})`}
+        />
+      )}
+    </div>
+  );
+}
+
+interface GrantListProps {
+  emptyMessage: string;
+  grants: SharingGrantType[];
+  revoked?: boolean;
+  title: string;
+}
+
+function GrantList({
+  emptyMessage,
+  grants,
+  revoked = false,
+  title,
+}: GrantListProps) {
+  return (
+    <div className="pt-4">
+      <div className="pb-2 text-sm text-muted-foreground">{title}</div>
+      {grants.length === 0 ? (
+        <div className="text-sm text-muted-foreground">{emptyMessage}</div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {grants.map((grant) => (
+            <div
+              key={grant.id}
+              className={`flex items-center justify-between rounded border px-3 py-2 text-sm ${
+                revoked ? "opacity-60" : ""
+              }`}
+            >
+              <span className={`font-mono ${revoked ? "line-through" : ""}`}>
+                {grant.email}
+              </span>
+              <div className="flex items-center gap-3 text-muted-foreground">
+                {grant.blockedByPolicy && (
+                  <Chip color="warning" label="Blocked by policy" size="xs" />
+                )}
+                {grant.revokedAt && (
+                  <span className="text-xs">
+                    Revoked {dateToHumanReadable(new Date(grant.revokedAt))}
+                  </span>
+                )}
+                <span className="text-xs">
+                  Granted {dateToHumanReadable(new Date(grant.grantedAt))}
+                </span>
+                {grant.grantedBy && (
+                  <span className="text-xs">by {grant.grantedBy.fullName}</span>
+                )}
+                {grant.lastViewedAt && (
+                  <span className="text-xs">
+                    Last viewed{" "}
+                    {dateToHumanReadable(new Date(grant.lastViewedAt))}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/poke/pages/FrameV2Page.tsx
+++ b/front/components/poke/pages/FrameV2Page.tsx
@@ -1,6 +1,7 @@
 import { FrameDatabaseDataTable } from "@app/components/poke/frames/databases/table";
 import { FrameFunctionDataTable } from "@app/components/poke/frames/functions/table";
 import { FramePublicationSection } from "@app/components/poke/frames/publication";
+import { FrameSharingSection } from "@app/components/poke/frames/sharing";
 import { FrameStorageTable } from "@app/components/poke/frames/storage";
 import { ViewFrameTable } from "@app/components/poke/frames/view";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -49,6 +50,10 @@ export function FrameV2Page({ frameId }: FrameV2PageProps) {
       </div>
 
       <ViewFrameTable details={details} owner={owner} />
+      <FrameSharingSection
+        sharing={details.sharing}
+        sharingGrants={details.sharingGrants}
+      />
       <FrameStorageTable storage={details.storage} />
       <FramePublicationSection
         publication={details.publication}

--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -26,7 +26,11 @@ import type {
   SandboxFunctionStake,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
-import type { FileStatus } from "@app/types/files";
+import type {
+  FileShareScope,
+  FileStatus,
+  SharingGrantType,
+} from "@app/types/files";
 import type { PokeSandboxType } from "@app/types/poke";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -160,9 +164,23 @@ export type PokeFramePublication = {
   databases: PokeFramePublicationDatabase[];
 };
 
+/**
+ * Who can open the Frame. Four of the six `frame.*` audit actions concern this, and it is the
+ * first thing to look at for "why can this person not open it" — hence surfacing scope, the share
+ * URL and every grant including revoked ones.
+ */
+export type PokeFrameSharing = {
+  scope: FileShareScope;
+  sharedAt: number;
+  shareUrl: string;
+} | null;
+
 export type PokeFrameDetails = {
   frame: PokeFrameListItem;
   sandbox: PokeSandboxType | null;
+  sharing: PokeFrameSharing;
+  // Every grant, revoked included: a revoked grant is the answer to "they used to have access".
+  sharingGrants: SharingGrantType[];
   storage: PokeFrameStorageLocation[];
   publication: PokeFramePublication | null;
   // Set when the active publication exists but its descriptor could not be read from GCS.
@@ -217,13 +235,16 @@ export async function getFrameDetails(
   const owner = auth.getNonNullableWorkspace();
   const publicationId = frame.useCaseMetadata?.activePublicationId ?? null;
 
-  const [functionCounts, authors, sandbox] = await Promise.all([
-    SandboxFunctionResource.countByFrameModelIds(auth, [
-      { frameModelId: frame.id, activePublicationId: publicationId },
-    ]),
-    UserResource.fetchByModelIds(removeNulls([frame.userId])),
-    FrameSandboxAdapter.fetchSandbox(auth, frame),
-  ]);
+  const [functionCounts, authors, sandbox, sharing, sharingGrants] =
+    await Promise.all([
+      SandboxFunctionResource.countByFrameModelIds(auth, [
+        { frameModelId: frame.id, activePublicationId: publicationId },
+      ]),
+      UserResource.fetchByModelIds(removeNulls([frame.userId])),
+      FrameSandboxAdapter.fetchSandbox(auth, frame),
+      frame.getShareInfo(),
+      frame.listAllSharingGrants(),
+    ]);
 
   const [author] = authors;
 
@@ -236,6 +257,8 @@ export async function getFrameDetails(
   const base = {
     frame: listItem,
     sandbox: sandbox ? sandbox.toPokeJSON() : null,
+    sharing,
+    sharingGrants,
     storage: makeStorageLocations(owner.sId, frame),
   };
 


### PR DESCRIPTION
## Description

The Frame page shows no sharing information at all, while the v1 interactive-content page it replaced showed share scope, share URL, and every grant with its blocked-by-policy state. Four of the six `frame.*` audit actions are about access:

```
frame.share_scope_updated · frame.email_grant_added · frame.email_grant_revoked · frame.authorized_files_updated
```

So "why can this person not open this Frame" was unanswerable in Poke — a coverage gap introduced when the file page branched on content type.

This adds `sharing` and `sharingGrants` to the Frame details endpoint (both already available on `FileResource` via `getShareInfo` and `listAllSharingGrants`) and a Sharing section modelled on the cards the v1 page already has.

Revoked grants are returned deliberately, not filtered out: a revoked grant is precisely the answer to "they used to have access, what changed". They render struck through and dimmed, separately from the active ones.

Purely additive and read-only — no new mutation surface.

### One thing worth flagging

`SharingGrantType` carries a numeric model id, which this endpoint now exposes as the v1 files endpoint already did. It is used as a React render key only, never to address anything. Forking the type to drop that one field would leave two near-identical shapes for no practical gain, so I reused it — but it is a second exposure of a pre-existing leak rather than a clean bill of health, and worth a look if you would rather I split it.

## Tests

One endpoint test: sets a share scope, adds two grants, revokes one, then asserts the response carries the scope, a share URL, and **both** grants with the revoked one carrying a `revokedAt`.

The length assertion in that test is load-bearing. Without it, dropping revoked grants from the response would leave the map lookup `undefined`, and `expect(undefined).not.toBeNull()` passes — so the test would have gone green on the exact regression it exists to catch. Same failure shape as the two 404-asserting tests in #31683 that stayed green through a missing route mount.

`front-api` frames suite: 15 files / 92 tests passing. `tsgo --noEmit` clean in `front`, `front-api` and `front-spa`.

Not verified in a browser: Poke has no UI tests by convention and no seeded workspace with shared Frames was available. Every Sparkle and Poke table prop used is verified against component source. Worth an eyeball on a Frame that has both an active and a revoked grant.

## Risk

Low. One additional read on the details endpoint (two batched calls added to an existing `Promise.all`, still a static array well under the limit) and one new read-only page section. No schema change, no migration, no new mutation path. Rollback is a plain revert.

`listAllSharingGrants` asserts `isShareableFrame`, which covers Frames v2 via `isFrameContentType` — verified, so the call cannot throw for a Frame the page can reach.

## Deploy Plan

Nothing special. No migration, no schema change; `front` / `front-api` deploy as normal. No `viz` involvement and no SPA route change.
