### PR TITLE
[front] fix: tweak user memory prompt to decrease added latency

### DIFF
--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -43,8 +43,9 @@ there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
 Skip reading only for simple requests that do not depend on user-specific
-context. Examples of simple requests include questions with direct answers,
-quick lookups, and calculations.
+context. These include questions with direct answers, quick lookups, and
+calculations, such as "what is the capital of Spain", "what is the weather in
+Paris", or "what is 15% of 240".
 
 Run quick, independent calls to other tools in parallel with the memory read.
 

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -46,6 +46,8 @@ Handle clearly trivial requests directly when their answer is independent of
 user-specific context. This includes straightforward factual lookups,
 translations, calculations, and similarly lightweight requests.
 
+Run quick, independent calls to other tools in parallel with the memory read.
+
 You do not need to provide a query or specify what to retrieve: a single read
 returns the whole memory. Read it once per conversation. Read again only if the
 memory may have changed since.
@@ -60,11 +62,9 @@ an exact snippet of \`MEMORY.md\`:
 </critical_behavior>
 
 <skill_enablement>
-When a request warrants reading memory, use it to inform which skills to enable
-if the choice could depend on user context. If the needed skill and its work are
-independent of memory and quick to run, enable it and start that work in
-parallel with the memory read. For clearly trivial requests whose answer is
-independent of user-specific context, use the needed skill directly.
+Before enabling any skill, read the memory first if you have not already done so
+in this conversation. The memory may contain useful insights to help you decide
+which skills to enable.
 </skill_enablement>
 
 <memory_strategy>

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -44,7 +44,7 @@ where the user lives, which may be in memory.
 
 Skip reading only for simple requests that do not depend on user-specific
 context. Examples of simple requests include questions with direct answers,
-quick lookups, translations, and calculations.
+quick lookups, and calculations.
 
 Run quick, independent calls to other tools in parallel with the memory read.
 

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -42,9 +42,10 @@ about to give a generic "it depends" answer because you lack a personal detail
 there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
-Handle clearly trivial requests directly when their answer is independent of
-user-specific context. This includes straightforward factual lookups,
-translations, calculations, and similarly lightweight requests.
+Skip the memory read only when both conditions hold:
+- The request can be completed with a direct answer or a single lookup, literal
+  translation, or calculation.
+- Personal context plays no role in choosing the action or shaping the result.
 
 Run quick, independent calls to other tools in parallel with the memory read.
 

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -43,8 +43,8 @@ there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
 Skip the memory read only when both:
-- The request can be completed with a direct answer or a single lookup, literal
-  translation, or calculation.
+- The request can be completed with a direct answer, a lookup, a literal
+  translation, or a calculation.
 - Personal context plays no role in choosing the action or shaping the result.
 
 Run quick, independent calls to other tools in parallel with the memory read.

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -42,10 +42,9 @@ about to give a generic "it depends" answer because you lack a personal detail
 there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
-Skip the memory read only when both:
-- The request can be completed with a direct answer, a lookup, a literal
-  translation, or a calculation.
-- Personal context plays no role in choosing the action or shaping the result.
+Skip reading only for simple requests that do not depend on user-specific
+context. Examples of simple requests include questions with direct answers,
+quick lookups, translations, and calculations.
 
 Run quick, independent calls to other tools in parallel with the memory read.
 

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -42,7 +42,7 @@ about to give a generic "it depends" answer because you lack a personal detail
 there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
-Skip the memory read only when both conditions hold:
+Skip the memory read only when both:
 - The request can be completed with a direct answer or a single lookup, literal
   translation, or calculation.
 - Personal context plays no role in choosing the action or shaping the result.

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -42,8 +42,9 @@ about to give a generic "it depends" answer because you lack a personal detail
 there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
-Skip reading for requests that are clearly trivial and do not require any
-user-specific context, even if completing them requires a quick lookup.
+Handle clearly trivial requests directly when their answer is independent of
+user-specific context. This includes straightforward factual lookups,
+translations, calculations, and similarly lightweight requests.
 
 You do not need to provide a query or specify what to retrieve: a single read
 returns the whole memory. Read it once per conversation. Read again only if the
@@ -62,8 +63,8 @@ an exact snippet of \`MEMORY.md\`:
 When a request warrants reading memory, use it to inform which skills to enable
 if the choice could depend on user context. If the needed skill and its work are
 independent of memory and quick to run, enable it and start that work in
-parallel with the memory read. For clearly trivial requests that need no
-user-specific context, use the needed skill directly without reading memory.
+parallel with the memory read. For clearly trivial requests whose answer is
+independent of user-specific context, use the needed skill directly.
 </skill_enablement>
 
 <memory_strategy>

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -42,9 +42,8 @@ about to give a generic "it depends" answer because you lack a personal detail
 there. For example, "how long would it take me to fly to New York" depends on
 where the user lives, which may be in memory.
 
-Skip reading only for simple, fully self-contained requests whose answer cannot
-depend on the user, such as "who is the president of Spain", "translate this to
-French", or "what is 15% of 240".
+Skip reading for requests that are clearly trivial and do not require any
+user-specific context, even if completing them requires a quick lookup.
 
 You do not need to provide a query or specify what to retrieve: a single read
 returns the whole memory. Read it once per conversation. Read again only if the
@@ -60,9 +59,11 @@ an exact snippet of \`MEMORY.md\`:
 </critical_behavior>
 
 <skill_enablement>
-Before enabling any skill, read the memory first if you have not already done so
-in this conversation. The memory may contain useful insights to help you decide
-which skills to enable.
+When a request warrants reading memory, use it to inform which skills to enable
+if the choice could depend on user context. If the needed skill and its work are
+independent of memory and quick to run, enable it and start that work in
+parallel with the memory read. For clearly trivial requests that need no
+user-specific context, use the needed skill directly without reading memory.
 </skill_enablement>
 
 <memory_strategy>
@@ -112,7 +113,7 @@ export const userMemorySkill = {
     "user's preferences, facts, and context across conversations.",
   instructions: USER_MEMORY_INSTRUCTIONS,
   mcpServers: [{ name: USER_MEMORY_SERVER_NAME }],
-  version: 2,
+  version: 3,
   icon: "ActionLightbulbIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);


### PR DESCRIPTION
## Description

Requests that do not need user-specific context should not need to read from user memory all the time (what's the wifi password, what's the name of the prime minister). Pulling the memory in context is not the issue, the issue is more the added latency of the additional step.

This PR  tweaks the instructions in this direction to decentivize using it in certain cases, and also to run it in parallel of another tool when applicable.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
