### PR TITLE
[front] Fix accent-insensitive consumption search

### DIFF
--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -260,12 +260,26 @@ describe("consumption top rankings", () => {
   });
 
   it.each([
-    ["AGENT 080", { terms: { "agent.attributed_id": ["agent80"] } }],
-    ["missing", { match_none: {} }],
-  ])("filters the ranking for search %s", async (search, expectedFilter) => {
+    [
+      "AGENT 080",
+      "Pagination Agent 080",
+      { terms: { "agent.attributed_id": ["agent80"] } },
+    ],
+    [
+      "developpeur",
+      "Développeur",
+      { terms: { "agent.attributed_id": ["agent80"] } },
+    ],
+    [
+      "développeur",
+      "Developpeur",
+      { terms: { "agent.attributed_id": ["agent80"] } },
+    ],
+    ["missing", "Pagination Agent 080", { match_none: {} }],
+  ])("filters the ranking for search %s", async (search, label, expectedFilter) => {
     const { auth } = await setup();
     vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue([
-      { value: "agent80", label: "Pagination Agent 080", pictureUrl: null },
+      { value: "agent80", label, pictureUrl: null },
     ]);
     mockLabels({});
     mockAggs({

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -25,6 +25,7 @@ import {
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { microCreditsToCredits } from "@app/lib/credits/units";
+import { removeDiacritics } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type { Result } from "@app/types/shared/result";
@@ -156,7 +157,7 @@ async function resolveConsumptionTopSearchFilter(
     return null;
   }
 
-  const normalizedSearch = search?.trim().toLowerCase();
+  const normalizedSearch = removeDiacritics(search?.trim() ?? "").toLowerCase();
   if (!normalizedSearch) {
     return null;
   }
@@ -174,7 +175,9 @@ async function resolveConsumptionTopSearchFilter(
   // analytics documents so Elasticsearch can perform this search directly.
   const catalog = await listConsumptionFacetCatalogDimension(auth, dimension);
   const matchingValues = catalog
-    .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
+    .filter((entry) =>
+      removeDiacritics(entry.label).toLowerCase().includes(normalizedSearch)
+    )
     .map((entry) => entry.value);
 
   return buildConsumptionTopSearchTermsQuery(


### PR DESCRIPTION
## Description

Make analytics consumption attribution search ignore diacritics in both the query and catalog labels. This lets searches such as `developpeur` match `Développeur`, and vice versa.

## Tests

- Added regression coverage for accented labels and accented queries.
- `npm run test -- lib/api/analytics/consumption/top.test.ts` (26 tests pass).
- Biome check passes on both changed files.
- The full front typecheck currently fails on unrelated existing Sparkle prop/type mismatches on `main` (`grow`, `2xl`, and `xs`).

## Risk

Low. The change only normalizes strings before the existing in-memory catalog substring match. The Elasticsearch query and stored values remain unchanged.

## Deploy Plan

Deploy with the regular front release. No migration or backfill is required.
