### PR TITLE
feat(frames): expose Delete for Frame v2 packages in file explorers

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -105,8 +105,8 @@ export function ConversationFileExplorer({
     [openPanel]
   );
 
-  // Only Frame packages are deletable from the conversation explorer; the Pod explorer handles
-  // the rest of a Pod's files.
+  // Only Frame packages get a Delete item here (see `canDelete`); other conversation files stay
+  // non-deletable as before.
   const onDelete = useCallback(
     async (entry: FileExplorerEntry) => {
       if (entry.kind !== "frame_package") {

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -1,7 +1,9 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConfirmContext } from "@app/components/Confirm";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import type {
   FileEntry,
+  FileExplorerEntry,
   FileExplorerPathEntry,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
@@ -10,16 +12,24 @@ import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
+import {
+  downloadFile,
+  getFilePathViewUrl,
+  useDeleteFileByPath,
+} from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import { opensInSidePanel } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, XClose } from "@dust-tt/sparkle";
-import { useCallback, useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 
 const POD_CONVERSATION_SCOPE_ROOTS = ["conversation", "pod"] as const;
+
+function isFramePackageEntry(entry: FileExplorerEntry): boolean {
+  return entry.kind === "frame_package";
+}
 
 interface ConversationFileExplorerProps {
   conversation: ConversationWithoutContentType;
@@ -32,16 +42,24 @@ export function ConversationFileExplorer({
 }: ConversationFileExplorerProps) {
   const { closePanel, openPanel } = useConversationSidePanelContext();
   const { hasFeature } = useFeatureFlags();
+  const confirm = useContext(ConfirmContext);
   const isPod = isPodConversation(conversation);
 
   const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
 
-  const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
-    conversationId: conversation.sId,
-    owner,
-  });
+  const { sandboxFiles, isSandboxFilesLoading, mutateSandboxFiles } =
+    useConversationSandboxFiles({
+      conversationId: conversation.sId,
+      owner,
+    });
 
-  const { files: podFiles, isPodFilesLoading } = usePodFiles({
+  const deleteFileByPath = useDeleteFileByPath({ owner });
+
+  const {
+    files: podFiles,
+    isPodFilesLoading,
+    mutatePodFiles,
+  } = usePodFiles({
     owner,
     podId: isPod ? conversation.spaceId : "",
     disabled: !isPod,
@@ -87,6 +105,34 @@ export function ConversationFileExplorer({
     [openPanel]
   );
 
+  // Only Frame packages are deletable from the conversation explorer; the Pod explorer handles
+  // the rest of a Pod's files.
+  const onDelete = useCallback(
+    async (entry: FileExplorerEntry) => {
+      if (entry.kind !== "frame_package") {
+        return;
+      }
+      const confirmed = await confirm({
+        title: "Delete Frame?",
+        message:
+          `Are you sure you want to delete the Frame "${entry.fileName}"? Its source, ` +
+          "functions, databases and share links will be permanently removed. " +
+          "This action cannot be undone.",
+        validateLabel: "Delete",
+        validateVariant: "warning",
+      });
+      if (confirmed) {
+        // The package entry carries the manifest path; deleting the manifest runs the
+        // package-aware Frame deletion server-side.
+        const result = await deleteFileByPath(entry.path);
+        if (result.isOk()) {
+          await Promise.all([mutateSandboxFiles(), mutatePodFiles()]);
+        }
+      }
+    },
+    [confirm, deleteFileByPath, mutatePodFiles, mutateSandboxFiles]
+  );
+
   return (
     <div className="flex h-panel min-h-0 flex-col">
       <AppLayoutTitle>
@@ -117,6 +163,8 @@ export function ConversationFileExplorer({
           }
           getFileUrl={getFileUrl}
           onCurrentFolderChange={setCurrentFolderPath}
+          onDelete={hasFeature("frames_v2") ? onDelete : undefined}
+          canDelete={isFramePackageEntry}
           onFileDownload={onFileDownload}
           onOpenInteractive={onOpenInteractive}
           onOpenInPanel={onOpenInPanel}

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -205,7 +205,7 @@ describe("FileExplorer navigation", () => {
 });
 
 describe("FileExplorer Frame packages", () => {
-  it("opens the Frame and exposes its source without generic file actions", async () => {
+  it("opens the Frame and exposes only View source and Delete", async () => {
     const user = userEvent.setup();
     mockClientFetch.mockResolvedValue(new Response("preview content"));
     const manifest = makeFile({
@@ -222,6 +222,7 @@ describe("FileExplorer Frame packages", () => {
       path: "status/index.tsx",
     });
     const onOpenInteractive = vi.fn();
+    const onDelete = vi.fn().mockResolvedValue(undefined);
 
     render(
       <ControlledFileExplorer
@@ -230,7 +231,7 @@ describe("FileExplorer Frame packages", () => {
         files={[manifest, source]}
         getFileUrl={(path) => `/files/${path}`}
         isLoading={false}
-        onDelete={vi.fn().mockResolvedValue(undefined)}
+        onDelete={onDelete}
         onFileDownload={vi.fn().mockResolvedValue(undefined)}
         onMoveFile={vi.fn().mockResolvedValue(new Ok(undefined))}
         onOpenInteractive={onOpenInteractive}
@@ -258,8 +259,15 @@ describe("FileExplorer Frame packages", () => {
     expect(screen.getByText("View source")).toBeInTheDocument();
     expect(screen.queryByText("Rename")).not.toBeInTheDocument();
     expect(screen.queryByText("Move to…")).not.toBeInTheDocument();
-    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "frame_package",
+        path: "conversation-c1/status/manifest.json",
+      })
+    );
 
+    await user.click(within(packageRow).getByRole("button"));
     fireEvent.click(screen.getByText("View source"));
     const manifestTitle = await screen.findByText("manifest.json");
     expect(screen.getByText("index.tsx")).toBeInTheDocument();

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -151,6 +151,17 @@ export function FileExplorer({
             setActiveFilter("all");
           },
         });
+        if (onDelete) {
+          items.push({
+            label: "Delete",
+            icon: Trash01,
+            variant: "warning",
+            onClick: (e) => {
+              e.stopPropagation();
+              void onDelete(entry);
+            },
+          });
+        }
         return items;
       }
       if (onRename && (entry.kind === "file" || entry.kind === "folder")) {

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -50,6 +50,8 @@ interface FileExplorerProps {
   isLoading: boolean;
   onCurrentFolderChange: (relativePath: string) => void;
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
+  /** Restricts which entries get a Delete item when `onDelete` is set; all of them by default. */
+  canDelete?: (entry: FileExplorerEntry) => boolean;
   onFileDownload: (entry: FileEntry) => Promise<void>;
   onMoveFile?: (
     entry: FileEntry,
@@ -80,6 +82,7 @@ export function FileExplorer({
   isLoading,
   onCurrentFolderChange,
   onDelete,
+  canDelete,
   onFileDownload,
   onMoveFile,
   onOpenInteractive,
@@ -151,7 +154,7 @@ export function FileExplorer({
             setActiveFilter("all");
           },
         });
-        if (onDelete) {
+        if (onDelete && (canDelete?.(entry) ?? true)) {
           items.push({
             label: "Delete",
             icon: Trash01,
@@ -190,7 +193,7 @@ export function FileExplorer({
           },
         });
       }
-      if (onDelete) {
+      if (onDelete && (canDelete?.(entry) ?? true)) {
         items.push({
           label: entry.kind === "node" ? "Remove" : "Delete",
           icon: Trash01,
@@ -204,6 +207,7 @@ export function FileExplorer({
       return items;
     },
     [
+      canDelete,
       getExtraFileMenuItems,
       onCurrentFolderChange,
       onDelete,

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -535,6 +535,24 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
             await refreshPodFiles();
           }
         }
+      } else if (entry.kind === "frame_package") {
+        const confirmed = await confirm({
+          title: "Delete Frame?",
+          message:
+            `Are you sure you want to delete the Frame "${entry.fileName}"? Its source, ` +
+            "functions, databases and share links will be permanently removed. " +
+            "This action cannot be undone.",
+          validateLabel: "Delete",
+          validateVariant: "warning",
+        });
+        if (confirmed) {
+          // The package entry carries the manifest path; deleting the manifest runs the
+          // package-aware Frame deletion server-side.
+          const result = await deletePodFile(entry.path);
+          if (result.isOk()) {
+            await refreshPodFiles();
+          }
+        }
       } else {
         const confirmed = await confirm({
           title: "Delete file?",

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -29,10 +29,13 @@ import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
-import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
+import {
+  downloadFile,
+  getFilePathViewUrl,
+  useDeleteFileByPath,
+} from "@app/lib/swr/files";
 import {
   useAddPodContextContentNodes,
-  useDeletePodFile,
   useMovePodFile,
   usePodContextAttachments,
   usePodFiles,
@@ -411,10 +414,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     [contentNodeAttachments, connectorProviderByDsvId]
   );
 
-  const deletePodFile = useDeletePodFile({
-    owner,
-    podId: pod.sId,
-  });
+  const deletePodFile = useDeleteFileByPath({ owner });
 
   const removePodContextContentNodes = useRemovePodContextContentNodes({
     owner,

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -300,6 +300,49 @@ export async function writeFileContentByPath({
   }
 }
 
+/** Delete the file or folder at `canonicalPath`; Frame manifests run the package-aware deletion. */
+export function useDeleteFileByPath({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+
+  return async (canonicalPath: string): Promise<Result<void, Error>> => {
+    try {
+      const encoded = canonicalPath
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/");
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/files/path/${encoded}`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to delete file",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: "File deleted",
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to delete file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
 export function useWriteFileContentByPath({
   owner,
 }: {

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -634,54 +634,6 @@ export function useCreatePodFolder({
   };
 }
 
-export function useDeletePodFile({
-  owner,
-  podId: _podId,
-}: {
-  owner: LightWorkspaceType;
-  podId: string;
-}) {
-  const sendNotification = useSendNotification();
-
-  return async (canonicalPath: string): Promise<Result<void, Error>> => {
-    try {
-      const encoded = canonicalPath
-        .split("/")
-        .map(encodeURIComponent)
-        .join("/");
-      const res = await clientFetch(
-        `/api/w/${owner.sId}/files/path/${encoded}`,
-        { method: "DELETE" }
-      );
-
-      if (!res.ok) {
-        const errorData = await getErrorFromResponse(res);
-        sendNotification({
-          type: "error",
-          title: "Failed to delete file",
-          description: errorData.message,
-        });
-        return new Err(new Error(errorData.message));
-      }
-
-      sendNotification({
-        type: "success",
-        title: "File deleted",
-      });
-
-      return new Ok(undefined);
-    } catch (e) {
-      const errorMessage = normalizeError(e).message;
-      sendNotification({
-        type: "error",
-        title: "Failed to delete file",
-        description: errorMessage,
-      });
-      return new Err(new Error(errorMessage));
-    }
-  };
-}
-
 export function useMovePodFile({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
 


### PR DESCRIPTION
## Description

Frame v2 packages in the file explorer only offered "View source" in their "..." menu, so there was no user-facing way to delete a Frame v2. This adds a Delete item for Frame packages in both the Pod file explorer and the conversation file explorer.

Deleting a package deletes its `manifest.json` path through the existing `DELETE /api/w/{wId}/files/path/{canonicalPath}` route. The server resolves that path to the Frame file and runs the package-aware `deleteFrameV2`, which removes the source folder, sandbox, functions and invocations, publications, database replicas and sharing records. No server changes.

- `FileExplorer` adds a Delete item on `frame_package` entries when `onDelete` is set, and gains an optional `canDelete` filter so a caller can restrict which entries are deletable.
- The Pod explorer's delete handler gets a `frame_package` branch with a Frame-specific confirmation.
- The conversation explorer gets a delete handler restricted to Frame packages, gated on the `frames_v2` feature flag, refreshing both conversation and Pod file lists afterwards.
- `useDeletePodFile` moves from `lib/swr/pods.ts` to `lib/swr/files.ts` as `useDeleteFileByPath`, since it never depended on the Pod id.

Not included: deleting a plain folder that contains a Frame still bypasses the Frame cleanup and orphans its identity and sandbox. That is pre-existing and worth a separate change.

## Tests

- `FileExplorer.test.tsx` updated to assert Delete is offered on a Frame package and called with the manifest path.
- Typecheck and biome pass.

## Risk

Low. Client-only change reusing an existing deletion endpoint. Frames in a database-backed file system still fail server-side and surface an error notification.

## Deploy Plan

Deploy normally.