### PR TITLE
feat: filter user group listing on canRead and make bypass explicit

### DIFF
--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -4,7 +4,7 @@ import type {
 } from "@app/lib/api/workspace";
 import { searchMembers } from "@app/lib/api/workspace";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
-import { GROUP_KINDS } from "@app/types/groups";
+import { USER_VISIBLE_GROUP_KINDS } from "@app/types/groups";
 import { ActiveRoleSchema, toLightUserWithWorkspace } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -19,7 +19,7 @@ const SearchMembersQuerySchema = z.object({
   limit: z.coerce.number().int().min(0).max(150).catch(DEFAULT_PAGE_LIMIT),
   searchTerm: z.string().optional(),
   searchEmails: z.string().optional(),
-  groupKind: z.enum(GROUP_KINDS).exclude(["system"]).optional(),
+  groupKind: z.enum(USER_VISIBLE_GROUP_KINDS).optional(),
   // Restricts the results to the members holding that role.
   role: ActiveRoleSchema.optional(),
   // Deprecated: the builder-role filter was removed; accepted but ignored to

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -41,7 +41,6 @@ import {
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 
 export type BilledRunUsage = RunUsageWithRunKeyType & {
@@ -136,13 +135,13 @@ async function loadAgentTagIds(
 }
 
 async function loadAnalyticsUser({
+  auth,
   completedAt,
   userId,
-  workspace,
 }: {
+  auth: Authenticator;
   completedAt: Date;
   userId: string | null;
-  workspace: LightWorkspaceType;
 }): Promise<AgentMessageConsumptionAnalyticsUser | null> {
   if (userId === null) {
     return null;
@@ -155,8 +154,8 @@ async function loadAnalyticsUser({
   );
 
   const groups = await GroupResource.listUserGroupsInWorkspace({
+    auth,
     user,
-    workspace,
     groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     at: completedAt,
   });
@@ -271,9 +270,9 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
   });
   const agentTagIds = await loadAgentTagIds(auth, agentMessage);
   const user = await loadAnalyticsUser({
+    auth,
     completedAt: agentMessage.completedAt,
     userId: triggeringUserMessage.userId,
-    workspace,
   });
 
   const resolvedModel = resolvedModelFromAgentMessageRow({

--- a/front/lib/api/groups/members.ts
+++ b/front/lib/api/groups/members.ts
@@ -44,8 +44,8 @@ export async function getMemberGroups(
   }
 
   const groups = await GroupResource.listUserGroupsInWorkspace({
+    auth,
     user,
-    workspace: auth.getNonNullableWorkspace(),
     groupKinds: [...MANAGEABLE_GROUP_KINDS],
   });
 

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -319,17 +319,14 @@ describe("determineUserRoleFromGroups", () => {
     );
   });
 
-  // determineUserRoleFromGroups matches groups by name, not by kind, so a
-  // regular_auto group named after the reserved group exercises the same logic
-  // while allowing members to be added through the standard factory API.
   async function addUserToRoleGroup(name: string) {
-    const group = await GroupFactory.regularAuto(workspace, name);
+    const group = await GroupFactory.provisioned(workspace, name);
     await GroupFactory.withMembers(adminAuthenticator, group, [user]);
     return group;
   }
 
   it("returns 'user' when the user is in no role-granting group", async () => {
-    const role = await determineUserRoleFromGroups(workspace, user);
+    const role = await determineUserRoleFromGroups(adminAuthenticator, user);
 
     expect(role).toBe("user");
   });
@@ -337,7 +334,7 @@ describe("determineUserRoleFromGroups", () => {
   it("returns 'admin' when the user is in the dust-admins group", async () => {
     await addUserToRoleGroup(ADMIN_GROUP_NAME);
 
-    const role = await determineUserRoleFromGroups(workspace, user);
+    const role = await determineUserRoleFromGroups(adminAuthenticator, user);
 
     expect(role).toBe("admin");
   });
@@ -345,7 +342,7 @@ describe("determineUserRoleFromGroups", () => {
   it("grants 'manager' from the dust-managers group", async () => {
     await addUserToRoleGroup(MANAGER_GROUP_NAME);
 
-    const role = await determineUserRoleFromGroups(workspace, user);
+    const role = await determineUserRoleFromGroups(adminAuthenticator, user);
 
     expect(role).toBe("manager");
   });
@@ -354,7 +351,7 @@ describe("determineUserRoleFromGroups", () => {
     await addUserToRoleGroup(ADMIN_GROUP_NAME);
     await addUserToRoleGroup(MANAGER_GROUP_NAME);
 
-    const role = await determineUserRoleFromGroups(workspace, user);
+    const role = await determineUserRoleFromGroups(adminAuthenticator, user);
 
     expect(role).toBe("admin");
   });

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -13,7 +13,6 @@ import type { MembershipRoleType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type {
-  LightWorkspaceType,
   UserType,
   UserTypeWithExtensionWorkspaces,
   UserTypeWithWorkspaces,
@@ -292,13 +291,14 @@ export async function getUserWithWorkspaces<T extends boolean>(
 }
 
 export async function determineUserRoleFromGroups(
-  workspace: LightWorkspaceType,
+  auth: Authenticator,
   user: UserResource
 ): Promise<MembershipRoleType> {
-  // Get all groups the user is a member of.
+  // Only directory-provisioned groups grant a role
   const userGroups = await GroupResource.listUserGroupsInWorkspace({
+    auth,
     user,
-    workspace,
+    groupKinds: ["provisioned"],
   });
 
   let atLeastManager = false;

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -23,7 +23,7 @@ import type { EmailProviderType } from "@app/lib/utils/email_provider_detection"
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
-import type { GroupKind } from "@app/types/groups";
+import type { UserVisibleGroupKind } from "@app/types/groups";
 import type {
   MembershipOriginType,
   MembershipRoleType,
@@ -321,7 +321,7 @@ export async function searchMembers(
   options: {
     searchTerm?: string;
     searchEmails?: string[];
-    groupKind?: Exclude<GroupKind, "system">;
+    groupKind?: UserVisibleGroupKind;
     role?: ActiveRoleType;
   },
   paginationParams: SearchMembersPaginationParams
@@ -402,8 +402,8 @@ export async function searchMembers(
 
       if (options.groupKind) {
         const groupsResult = await GroupResource.listUserGroupsInWorkspace({
+          auth,
           user: u,
-          workspace: owner,
           groupKinds: [options.groupKind],
         });
 

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -298,8 +298,8 @@ describe("GroupResource", () => {
       });
 
       const inFebruary = await GroupResource.listUserGroupsInWorkspace({
+        auth: authenticator,
         user: member,
-        workspace,
         groupKinds: ["regular_manual"],
         at: FEBRUARY,
       });
@@ -307,8 +307,8 @@ describe("GroupResource", () => {
 
       // Omitting `at` defaults to now, after the membership ended.
       const today = await GroupResource.listUserGroupsInWorkspace({
+        auth: authenticator,
         user: member,
-        workspace,
         groupKinds: ["regular_manual"],
       });
       expect(today).toEqual([]);
@@ -345,8 +345,8 @@ describe("GroupResource", () => {
       // left in March is still resolvable in February. This is what analytics
       // reindexing of their past messages depends on.
       const inFebruary = await GroupResource.listUserGroupsInWorkspace({
+        auth: authenticator,
         user: member,
-        workspace,
         groupKinds: ["regular_manual"],
         at: FEBRUARY,
       });
@@ -354,8 +354,8 @@ describe("GroupResource", () => {
 
       // Today they are no longer a workspace member.
       const today = await GroupResource.listUserGroupsInWorkspace({
+        auth: authenticator,
         user: member,
-        workspace,
         groupKinds: ["regular_manual"],
       });
       expect(today).toEqual([]);
@@ -382,8 +382,8 @@ describe("GroupResource", () => {
       });
 
       const inJanuary = await GroupResource.listUserGroupsInWorkspace({
+        auth: authenticator,
         user: member,
-        workspace,
         groupKinds: ["regular_manual"],
         at: JANUARY,
       });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1125,14 +1125,14 @@ export class GroupResource extends BaseResource<GroupModel> {
   private static async listUserGroupModelIdsInWorkspace({
     user,
     workspace,
-    groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
+    groupKinds,
     transaction,
     dangerouslySkipMembershipCheck = false,
     at = new Date(),
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
-    groupKinds?: Exclude<GroupKind, "system">[];
+    groupKinds: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
     dangerouslySkipMembershipCheck?: boolean;
     at?: Date;
@@ -1203,38 +1203,51 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   // Warning, this function can be very memory hungry if there are a lot of groups (such as a workspace with a lot of agents and editors groups).
   // If you can, just use the listUserGroupModelIdsInWorkspace instead that returns only the ids of the groups.
-  static async listUserGroupsInWorkspace({
+  static async listUserGroupsInWorkspace(params: {
+    auth: Authenticator;
+    user: UserResource;
+    groupKinds: UserVisibleGroupKind[];
+    transaction?: Transaction;
+    at?: Date;
+  }): Promise<GroupResource[]> {
+    const groups = await this.dangerouslyListAllUserGroupsInWorkspace(params);
+
+    return groups.filter((group) => group.canRead(params.auth));
+  }
+
+  /**
+   * Same as `listUserGroupsInWorkspace`, but also accepts the internal kinds that are never
+   * surfaced to users. Reserved for system flows that must act on a user's whole membership
+   * set, such as directory-sync deprovisioning.
+   */
+  static async dangerouslyListAllUserGroupsInWorkspace({
+    auth,
     user,
-    workspace,
-    groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
+    groupKinds,
     transaction,
     at,
   }: {
+    auth: Authenticator;
     user: UserResource;
-    workspace: LightWorkspaceType;
-    groupKinds?: Exclude<GroupKind, "system">[];
+    groupKinds: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
     at?: Date;
   }): Promise<GroupResource[]> {
     const { groupModelIds } = await this.listUserGroupModelIdsInWorkspace({
       user,
-      workspace,
+      workspace: auth.getNonNullableWorkspace(),
       groupKinds,
       transaction,
       at,
     });
 
-    const groups = await GroupModel.findAll({
-      where: {
-        id: {
-          [Op.in]: groupModelIds,
-        },
-        workspaceId: workspace.id,
-      },
+    if (groupModelIds.length === 0) {
+      return [];
+    }
+
+    return this.dangerouslyFetchByModelIds(auth, groupModelIds, {
       transaction,
     });
-
-    return groups.map((group) => new this(GroupModel, group.get()));
   }
 
   static async listGroupNamesByUserModelIdInWorkspace({

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -14,8 +14,7 @@ import type {
   PutUserSpendLimitResponseBody,
 } from "@app/types/api/users/spend_limit";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
-import type { GroupKind } from "@app/types/groups";
-import { isGroupKind } from "@app/types/groups";
+import type { UserVisibleGroupKind } from "@app/types/groups";
 import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
 import { MEMBERSHIP_SEAT_TYPES, PAID_SEAT_TYPES } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -136,7 +135,7 @@ export function useSearchMembers<
   searchTerm: string;
   pageIndex: number;
   pageSize: number;
-  groupKind?: Exclude<GroupKind, "system">;
+  groupKind?: UserVisibleGroupKind;
   role?: ActiveRoleType;
   disabled?: boolean;
 }) {
@@ -162,7 +161,7 @@ export function useSearchMembers<
     limit: pageSize.toString(),
   });
 
-  if (groupKind && isGroupKind(groupKind)) {
+  if (groupKind) {
     searchParams.set("groupKind", groupKind);
   }
 

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -234,7 +234,7 @@ async function handleRoleAssignmentForGroup(
   }
 
   if (action === "add") {
-    const newRole = await determineUserRoleFromGroups(workspace, user);
+    const newRole = await determineUserRoleFromGroups(auth, user);
 
     if (newRole !== currentMembership.role) {
       const updateResult = await MembershipResource.updateMembershipRole({
@@ -282,7 +282,7 @@ async function handleRoleAssignmentForGroup(
       });
     }
   } else if (action === "remove") {
-    const newRole = await determineUserRoleFromGroups(workspace, user);
+    const newRole = await determineUserRoleFromGroups(auth, user);
 
     if (newRole !== currentMembership.role) {
       const updateResult = await MembershipResource.updateMembershipRole({
@@ -1322,9 +1322,9 @@ async function revokeWorkOSUserMembership(
   triggersDeleted: boolean
 ) {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const groups = await GroupResource.listUserGroupsInWorkspace({
+  const groups = await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
+    auth,
     user,
-    workspace,
     groupKinds: GROUP_KINDS.filter((k) => k !== "system" && k !== "global"),
   });
 


### PR DESCRIPTION
## Description

This PR adds canRead checks when listing user groups and makes internal bypasses explicit.


## Tests

Manually.

## Risks
We are adding a canRead check that was not present before. There should be no change as currently every role can read every group kind different from system and agent_editors, which are not group kinds fetched by the updated method.

## Deploy Plan

Standard deployment.