### PR TITLE
feat(pods): offer Add as Pod tab on Frame packages instead of manifest.json

### DIFF
--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -47,6 +47,7 @@ import type {
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import {
+  frameV2ContentType,
   getSupportedFileExtensions,
   isInteractiveContentType,
 } from "@app/types/files";
@@ -288,13 +289,20 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
 
   const getExtraFileMenuItems = useCallback(
     (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
-      if (!isEditor || isArchived || entry.kind !== "file") {
+      if (
+        !isEditor ||
+        isArchived ||
+        (entry.kind !== "file" && entry.kind !== "frame_package")
+      ) {
         return [];
       }
 
       const items: FileExplorerMenuAction[] = [];
 
-      if (isInteractiveContentType(entry.contentType)) {
+      if (
+        entry.kind === "file" &&
+        isInteractiveContentType(entry.contentType)
+      ) {
         const pinned = isPinned(entry.path);
         items.push({
           label: pinned ? "Unpin from banner" : "Pin as Pod banner",
@@ -306,7 +314,13 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         });
       }
 
-      if (hasFileTabs && isFilePreviewableContentType(entry.contentType)) {
+      // A Frame is added as a tab from its package entry, whose path is the manifest; the
+      // manifest listed inside the source folder does not get the item again.
+      const canBeTab =
+        entry.kind === "frame_package" ||
+        (entry.contentType !== frameV2ContentType &&
+          isFilePreviewableContentType(entry.contentType));
+      if (hasFileTabs && canBeTab) {
         const asTab = isFileTab(entry.path);
         items.push({
           label: asTab ? "Remove from Pod tabs" : "Add as Pod tab",


### PR DESCRIPTION
## Description

In a Pod's Files tab, a Frame v2 package had no "Add as Pod tab" item. The item only appeared after opening "View source" and using it on `manifest.json`. This moves it to the Frame package entry and removes it from the manifest file.

The package entry already carries the manifest path, so the created tab points at the same path as before. The default tab title now comes from the Frame folder name rather than `manifest`.

The "Pin as Pod banner" item is unaffected: Frame v2 manifests were never an interactive content type, so it did not show on them before and still does not.

## Tests

- Typecheck and biome pass.
- Manual: open a Pod's Files tab with a Frame v2, check the "..." menu on the Frame card shows "Add as Pod tab" and the manifest inside "View source" no longer does.

## Risk

Low. Client-only change to which explorer entries expose an existing action.

## Deploy Plan

Deploy normally.