### PR TITLE
[front] fix(poke): grant poke tools access to restricted pod conversations

### DIFF
--- a/front/lib/api/actions/servers/poke/tools/utils.ts
+++ b/front/lib/api/actions/servers/poke/tools/utils.ts
@@ -85,8 +85,10 @@ export async function getTargetAuth(
   workspaceId: string
 ): Promise<Result<Authenticator, MCPError>> {
   try {
-    const targetAuth =
-      await Authenticator.internalAdminForWorkspace(workspaceId);
+    const targetAuth = await Authenticator.internalAdminForWorkspace(
+      workspaceId,
+      { dangerouslyRequestAllGroups: true }
+    );
     return new Ok(targetAuth);
   } catch (err) {
     const normalizedErr = normalizeError(err);


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/10278

## Description

Poke admin tools build their target `Authenticator` in `getTargetAuth` (`front/lib/api/actions/servers/poke/tools/utils.ts`) via `internalAdminForWorkspace(workspaceId)`, which only attaches the workspace **global group**. For restricted (member-only) project/"pod" spaces, the admin *role* alone does not grant the `read` verb — read is resolved from the space's own group grants through `auth.getGrantedVerbs("space", id)`. As a result `ConversationResource.canAccess` returned `conversation_access_restricted` and poke could not read restricted pod conversations.

This passes `{ dangerouslyRequestAllGroups: true }` so all workspace groups are resolved onto the auth, making `auth.can("read", space)` return true for restricted spaces. This matches the established poke pattern already used in `activation_management.ts` and `poke/temporal/activities.ts`.

Note: the `private_conversation_urls_by_default` / `participants_only` participant restriction is a separate layer and is intentionally not addressed here.

## Tests

- `npx tsgo --noEmit` passes.
- Existing poke tools all route through `getTargetAuth`, so the change is centralized.

## Risk

Low. Broadens the group membership of poke's internal admin auth to all workspace groups (same as existing poke flows). Poke access is gated to Dust super users.

## Deploy Plan

Standard deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)