### PR TITLE
feat(ConversationPicker): feat(ConversationPicker): new conversation picker component

### DIFF
--- a/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
+++ b/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
@@ -11,38 +11,60 @@ import { InputBar } from "@app/components/assistant/conversation/input_bar/Input
 import type { VirtuosoMessageListContext } from "@app/components/assistant/conversation/types";
 import { useAnalyticsConversation } from "@app/hooks/useAnalyticsConversation";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import { timeAgoFrom } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type {
+  ConversationListItemType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
+  ArrowLeft,
   Button,
   ConversationMessageAvatar,
   ConversationMessageContainer,
   ConversationMessageContent,
   ConversationMessageTitle,
-  Icon,
+  ConversationPicker,
   Robot,
   Spinner,
+  Tabs,
+  TabsList,
+  TabsTrigger,
   XClose,
 } from "@dust-tt/sparkle";
+
 import { useMemo } from "react";
 
 interface AnalyticsConversationPanelHeaderProps {
   onClose: () => void;
+  onBack?: () => void;
 }
 
 function AnalyticsConversationPanelHeader({
   onClose,
+  onBack,
 }: AnalyticsConversationPanelHeaderProps) {
   return (
     <div className="flex h-14 w-full items-center justify-between px-2">
-      <div className="flex min-w-0 items-center gap-1.5 px-2">
-        <Icon visual={Robot} size="sm" className="shrink-0" />
-        <span className="line-clamp-1 text-sm font-medium">Analyst</span>
-      </div>
+      {onBack && (
+        <Button
+          icon={ArrowLeft}
+          size="sm"
+          variant="ghost-secondary"
+          tooltip="Back to conversations"
+          onClick={onBack}
+        />
+      )}
+      <Tabs value="analyst">
+        <TabsList>
+          <TabsTrigger value="analyst" label="Analyst" icon={Robot} />
+        </TabsList>
+      </Tabs>
       <Button
         icon={XClose}
         size="sm"
@@ -85,10 +107,13 @@ function AnalyticsConversationGreeting({
 interface AnalyticsConversationPanelBodyProps {
   owner: WorkspaceType;
   user: UserType;
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
+  isConversationLoading: boolean;
+  pastConversations: ConversationListItemType[];
   createConversation: ReturnType<
     typeof useAnalyticsConversation
   >["createConversation"];
+  pickConversation: (conversationId: string) => void;
   resetConversation: () => void;
   disabled: boolean;
 }
@@ -97,7 +122,10 @@ function AnalyticsConversationPanelBody({
   owner,
   user,
   conversation,
+  isConversationLoading,
+  pastConversations,
   createConversation,
+  pickConversation,
   resetConversation,
   disabled,
 }: AnalyticsConversationPanelBodyProps) {
@@ -157,16 +185,29 @@ function AnalyticsConversationPanelBody({
               agentBuilderContext={analystAgentContext}
               key={conversation.sId}
             />
+          ) : isConversationLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner size="md" />
+            </div>
           ) : (
             <div className="mx-auto w-full max-w-conversation px-5 pt-6 md:pt-10">
               <AnalyticsConversationGreeting
                 agentConfiguration={analystAgentConfiguration}
               />
+              <ConversationPicker
+                className="mt-4"
+                items={pastConversations.map((pastConversation) => ({
+                  id: pastConversation.sId,
+                  title: getConversationDisplayTitle(pastConversation),
+                  timeLabel: timeAgoFrom(pastConversation.updated),
+                }))}
+                onPick={pickConversation}
+              />
             </div>
           )}
         </div>
 
-        {!conversation && (
+        {!conversation && !isConversationLoading && (
           <div className="relative z-20 mx-auto flex w-full flex-shrink-0 flex-col px-5 pt-4 pb-6 md:max-w-[calc(var(--container-conversation)+0.5rem)] md:px-1">
             <InputBar
               owner={owner}
@@ -214,13 +255,22 @@ export function AnalyticsConversationPanel({
   onClose,
   disabled = false,
 }: AnalyticsConversationPanelProps) {
-  const { conversation, createConversation, resetConversation } =
-    useAnalyticsConversation({ owner, user });
+  const {
+    conversation,
+    isConversationLoading,
+    pastConversations,
+    createConversation,
+    pickConversation,
+    resetConversation,
+  } = useAnalyticsConversation({ owner, user, disabled });
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       <div className="sticky top-0 z-10 flex items-center border-b border-border bg-panel-background/80 backdrop-blur-sm">
-        <AnalyticsConversationPanelHeader onClose={onClose} />
+        <AnalyticsConversationPanelHeader
+          onClose={onClose}
+          onBack={conversation ? resetConversation : undefined}
+        />
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
         <FilePreviewProvider owner={owner}>
@@ -234,7 +284,10 @@ export function AnalyticsConversationPanel({
                   owner={owner}
                   user={user}
                   conversation={conversation}
+                  isConversationLoading={isConversationLoading}
+                  pastConversations={pastConversations}
                   createConversation={createConversation}
+                  pickConversation={pickConversation}
                   resetConversation={resetConversation}
                   disabled={disabled}
                 />

--- a/front/hooks/useAnalyticsConversation.ts
+++ b/front/hooks/useAnalyticsConversation.ts
@@ -1,15 +1,15 @@
+import { useConversation } from "@app/hooks/conversations/useConversation";
 import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DustError } from "@app/lib/error";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 /**
  * Creates and holds the single conversation for the Analytics conversation
@@ -17,22 +17,40 @@ import { useCallback, useState } from "react";
  * on submit with the first message deferred, so `ConversationViewer` mounts
  * right away and renders its own optimistic placeholders (see
  * useCreateConversationWithMessage).
+ *
+ * Panel conversations are tagged with `analyticsPanel` in their metadata so
+ * past ones can be listed and resumed from the panel's empty state.
  */
 export function useAnalyticsConversation({
   owner,
   user,
+  disabled,
 }: {
   owner: WorkspaceType;
   user: UserType | null;
+  disabled: boolean;
 }) {
   const sendNotification = useSendNotification();
   const [conversation, setConversation] = useState<ConversationType | null>(
     null
   );
+  const [pickedConversationId, setPickedConversationId] = useState<
+    string | null
+  >(null);
 
-  const { mutateConversations } = useConversations({
+  const { conversations, mutateConversations } = useConversations({
     workspaceId: owner.sId,
-    options: { disabled: true },
+    options: { disabled },
+  });
+
+  const pastConversations = useMemo(
+    () => conversations.filter((c) => c.metadata?.analyticsPanel === true),
+    [conversations]
+  );
+
+  const { conversation: pickedConversation } = useConversation({
+    conversationId: pickedConversationId,
+    workspaceId: owner.sId,
   });
 
   const createConversationWithMessage = useCreateConversationWithMessage({
@@ -55,7 +73,7 @@ export function useAnalyticsConversation({
           contentFragments,
           richMentions: mentions,
         },
-        title: `Ask ${GLOBAL_AGENTS_SID.ANALYST}`,
+        metadata: { analyticsPanel: true },
         deferMessage: true,
       });
 
@@ -73,6 +91,7 @@ export function useAnalyticsConversation({
       }
 
       setConversation(result.value);
+      setPickedConversationId(null);
       await mutateConversations(
         (currentData) => [result.value, ...(currentData ?? [])],
         { revalidate: false }
@@ -83,13 +102,22 @@ export function useAnalyticsConversation({
     [createConversationWithMessage, mutateConversations, sendNotification]
   );
 
+  const pickConversation = useCallback((conversationId: string) => {
+    setConversation(null);
+    setPickedConversationId(conversationId);
+  }, []);
+
   const resetConversation = useCallback(() => {
     setConversation(null);
+    setPickedConversationId(null);
   }, []);
 
   return {
-    conversation,
+    conversation: conversation ?? pickedConversation ?? null,
+    isConversationLoading: pickedConversationId !== null && !pickedConversation,
+    pastConversations,
     createConversation,
+    pickConversation,
     resetConversation,
   };
 }

--- a/sparkle/src/components/ConversationPicker.tsx
+++ b/sparkle/src/components/ConversationPicker.tsx
@@ -1,0 +1,73 @@
+import {
+  ListGroup,
+  ListItem,
+  ListItemSection,
+} from "@sparkle/components/ListItem";
+import { cn } from "@sparkle/lib/utils";
+import React from "react";
+
+export interface ConversationPickerItem {
+  id: string;
+  title: string;
+  /** Formatted timestamp shown on the right of the title (e.g. "2h"). */
+  timeLabel?: string;
+}
+
+export interface ConversationPickerProps {
+  /** Conversations to offer, most recent first. */
+  items: ConversationPickerItem[];
+  /** Called with the id of the picked conversation. */
+  onPick: (id: string) => void;
+  /** Section header displayed above the list. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * A compact list of past conversations to resume, shown for instance when a
+ * conversation panel opens on an empty state. Renders nothing when there is no
+ * conversation to offer.
+ *
+ * @example
+ * ```tsx
+ * <ConversationPicker
+ *   items={[{ id: "c1", title: "Top agents by spend", timeLabel: "2h" }]}
+ *   onPick={(id) => openConversation(id)}
+ * />
+ * ```
+ * @summary Compact picker of past conversations to resume.
+ */
+export function ConversationPicker({
+  items,
+  onPick,
+  label = "Recent conversations",
+  className,
+}: ConversationPickerProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex w-full flex-col", className)}>
+      <ListItemSection>{label}</ListItemSection>
+      <ListGroup>
+        {items.map((item) => (
+          <ListItem
+            key={item.id}
+            itemsAlignment="center"
+            onClick={() => onPick(item.id)}
+          >
+            <span className="heading-sm min-w-0 flex-1 truncate text-foreground">
+              {item.title}
+            </span>
+            {item.timeLabel && (
+              <span className="shrink-0 text-xs font-normal text-muted-foreground">
+                {item.timeLabel}
+              </span>
+            )}
+          </ListItem>
+        ))}
+      </ListGroup>
+    </div>
+  );
+}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -92,6 +92,11 @@ export {
   ConversationMessageContent,
   ConversationMessageTitle,
 } from "./ConversationMessages";
+export {
+  ConversationPicker,
+  type ConversationPickerItem,
+  type ConversationPickerProps,
+} from "./ConversationPicker";
 export { Counter } from "./Counter";
 export type { DataTableMoreButtonProps, MenuItem } from "./DataTable";
 export {

--- a/sparkle/src/stories/ConversationPicker.stories.tsx
+++ b/sparkle/src/stories/ConversationPicker.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { fn } from "storybook/test";
+
+import { ConversationPicker } from "../index_with_tw_base";
+
+const meta = {
+  title: "Components/ConversationPicker",
+  component: ConversationPicker,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `A compact list of past conversations to resume, shown for instance when a conversation panel opens on an empty state.
+
+**When to use**
+- On the empty state of an embedded conversation surface (side panel, popover) so the user can pick up a previous thread instead of starting over.
+
+**Guidelines**
+- Pass items most recent first, already filtered to the surface's scope.
+- Format **timeLabel** yourself (e.g. "2h", "3d"); the component renders it as-is.
+- With an empty **items** array the component renders nothing, so it can be composed unconditionally.`,
+      },
+    },
+  },
+} satisfies Meta<typeof ConversationPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A few recent conversations with relative timestamps, under the default label.
+ *
+ * @summary Recent conversations to resume.
+ */
+export const Basic: Story = {
+  args: {
+    items: [
+      { id: "c1", title: "Top agents by credit spend", timeLabel: "2h" },
+      { id: "c2", title: "Weekly active builders trend", timeLabel: "1d" },
+      { id: "c3", title: "March usage vs February", timeLabel: "6d" },
+    ],
+    onPick: fn(),
+  },
+  render: (args) => (
+    <div className="w-[360px]">
+      <ConversationPicker {...args} />
+    </div>
+  ),
+};
+
+/**
+ * A custom section label and an item without a timestamp.
+ *
+ * @summary Custom label, optional timestamps.
+ */
+export const CustomLabel: Story = {
+  args: {
+    label: "Pick up where you left off",
+    items: [
+      { id: "c1", title: "Top agents by credit spend", timeLabel: "2h" },
+      { id: "c2", title: "Weekly active builders trend" },
+    ],
+    onPick: fn(),
+  },
+  render: (args) => (
+    <div className="w-[360px]">
+      <ConversationPicker {...args} />
+    </div>
+  ),
+};


### PR DESCRIPTION
## Description

ConversationPicker component to allow selecting a previous conversation. 
Conversations items should be passed to the component and therefore, the filtering responsibility falls to the caller / parent component. 

Added in the side conversation panel of the Analytics view. 

### Screenshots
#### Component
<img width="373" height="192" alt="image" src="https://github.com/user-attachments/assets/839216f1-b705-4e1d-ab57-c7adc995be30" />

#### Analytics View
<img width="1261" height="1296" alt="image" src="https://github.com/user-attachments/assets/d97ee6be-80a4-4b7d-9df7-40926511b32d" />


## Tests

Tested locally. 

## Risk

Low. 

## Deploy Plan

Classic deploy. 
