### PR TITLE
feat(pods): offer Pin as Pod banner on Frame v2 packages

### DIFF
--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -302,10 +302,11 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
 
       const items: FileExplorerMenuAction[] = [];
 
-      if (
-        entry.kind === "file" &&
-        isInteractiveContentType(entry.contentType)
-      ) {
+      // Legacy Frames pin from their file; a Frame v2 pins from its package entry (manifest path).
+      const canBePinned =
+        entry.kind === "frame_package" ||
+        isInteractiveContentType(entry.contentType);
+      if (canBePinned) {
         const pinned = isPinned(entry.path);
         items.push({
           label: pinned ? "Unpin from banner" : "Pin as Pod banner",


### PR DESCRIPTION
## Description

In a Pod's Files tab, a Frame v2 package had no "Pin as Pod banner" item. The pin item was gated on `isInteractiveContentType`, which only covers legacy Frame content types, so Frame v2 manifests never got it. This offers the item on the Frame package entry.

No server or banner changes: the package entry's path is the manifest path, `validatePinnedFramePath` only checks the path exists in the Pod, and `PodPinnedBanner` already resolves Frame v2 content and passes the `frameId` through.

## Tests

- Typecheck and biome pass.
- Manual: in a Pod with a Frame v2, the Frame card's "..." menu shows "Pin as Pod banner"; pinning renders the Frame in the Pod banner and the item flips to "Unpin from banner".

## Risk

Low. Client-only change exposing an existing action on one more entry kind.

## Deploy Plan

Deploy normally.
