### PR TITLE
[front] enh: add active user count in timeseries endpointt

### DIFF
--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -39,9 +39,14 @@ const PERIOD: ConsumptionPeriod = {
   endDate: new Date(PERIOD_END_MS).toISOString(),
 };
 
-function dayBucket(dayIndex: number, microCredits: number) {
+function dayBucket(
+  dayIndex: number,
+  microCredits: number,
+  activeUsers: number = 0
+) {
   return {
     key: PERIOD_START_MS + dayIndex * DAY_MS,
+    active_users: { value: activeUsers },
     metric: { value: microCredits },
   };
 }
@@ -151,14 +156,41 @@ describe("fetchConsumptionTimeseries", () => {
     });
   });
 
+  it("counts active users in each consumption bucket", async () => {
+    const { auth, period } = await setup();
+    mockBuckets([dayBucket(0, 2_000_000, 4), dayBucket(1, 1_500_000, 2)]);
+
+    const result = await fetchConsumptionTimeseries(auth, {
+      period,
+      granularity: "day",
+      mode: "period",
+    });
+
+    const [, options] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(options?.aggregations?.by_date?.aggs?.active_users).toEqual({
+      cardinality: {
+        field: "user.id",
+        precision_threshold: 40_000,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.points.map((point) => point.activeUsers)).toEqual([
+      4, 2,
+    ]);
+  });
+
   it("zeroes buckets that have not started yet", async () => {
     const { auth, period } = await setup();
     mockBuckets([
-      dayBucket(0, 2_000_000),
-      dayBucket(2, 500_000), // Today, still filling.
+      dayBucket(0, 2_000_000, 2),
+      dayBucket(2, 500_000, 1), // Today, still filling.
       // A future bucket carrying a value: clock skew, or a document indexed
       // ahead of time. Either way it has not happened.
-      dayBucket(3, 9_000_000),
+      dayBucket(3, 9_000_000, 9),
     ]);
 
     const result = await fetchConsumptionTimeseries(auth, {
@@ -174,6 +206,9 @@ describe("fetchConsumptionTimeseries", () => {
     expect(
       result.value.points.map((point) => point.values[TOTAL_GROUP_KEY])
     ).toEqual([2, 0.5, 0]);
+    expect(result.value.points.map((point) => point.activeUsers)).toEqual([
+      2, 1, 0,
+    ]);
   });
 
   it("scopes the query to the requested dimension filters", async () => {
@@ -200,11 +235,11 @@ describe("fetchConsumptionTimeseries", () => {
   it("stops the cumulative total at today rather than plateauing", async () => {
     const { auth, period } = await setup();
     mockBuckets([
-      dayBucket(0, 2_000_000),
-      dayBucket(1, 1_500_000),
-      dayBucket(2, 500_000), // Today, still filling.
-      dayBucket(3, 0), // Not happened yet.
-      dayBucket(4, 0),
+      dayBucket(0, 2_000_000, 2),
+      dayBucket(1, 1_500_000, 3),
+      dayBucket(2, 500_000, 1), // Today, still filling.
+      dayBucket(3, 0, 5), // Not happened yet.
+      dayBucket(4, 0, 5),
     ]);
 
     const result = await fetchConsumptionTimeseries(auth, {
@@ -221,6 +256,10 @@ describe("fetchConsumptionTimeseries", () => {
     expect(
       result.value.points.map((point) => point.values[TOTAL_GROUP_KEY])
     ).toEqual([2, 3.5, 4, 0, 0]);
+    // Active users remain a per-bucket count even when credits accumulate.
+    expect(result.value.points.map((point) => point.activeUsers)).toEqual([
+      2, 3, 1, 0, 0,
+    ]);
   });
 
   describe("breakdown", () => {

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -8,6 +8,7 @@ import type {
 } from "@app/lib/api/analytics/consumption/scope";
 import {
   buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   DEFAULT_CONSUMPTION_METRIC,
@@ -44,6 +45,7 @@ export type ConsumptionTimeseriesGroup = {
 
 export type ConsumptionTimeseriesPoint = {
   timestamp: number;
+  activeUsers: number;
   values: Record<string, number>;
 };
 
@@ -73,6 +75,7 @@ type ConsumptionTimeseriesScope = {
 
 type DateBucket = {
   key: number;
+  active_users?: estypes.AggregationsCardinalityAggregate;
   metric?: estypes.AggregationsSumAggregate;
   by_group?: estypes.AggregationsMultiBucketAggregateBase<ConsumptionGroupBucket>;
 };
@@ -83,6 +86,7 @@ type TimeseriesAggs = {
 
 type ConsumptionMetricBucket = {
   timestamp: number;
+  activeUsers: number;
   total: number;
   // Empty unless the search was given a breakdown, in which case the keys are a
   // subset of the ones it was restricted to.
@@ -152,6 +156,7 @@ async function fetchTimeseries(
 
   const points = bucketsResult.value.map((bucket) => ({
     timestamp: bucket.timestamp,
+    activeUsers: bucket.activeUsers,
     values: { [TOTAL_GROUP_KEY]: bucket.total },
   }));
 
@@ -266,6 +271,12 @@ async function fetchMetricTimeseries(
             },
           },
           aggs: {
+            active_users: {
+              cardinality: {
+                field: CONSUMPTION_DIMENSION_FIELDS.user,
+                precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              },
+            },
             ...metricSubAgg(metric),
             ...(breakdown
               ? {
@@ -297,6 +308,7 @@ async function fetchMetricTimeseries(
   return new Ok(
     buckets.map((bucket) => ({
       timestamp: bucket.key,
+      activeUsers: Math.round(bucket.active_users?.value ?? 0),
       total: metricValue(metric, bucket.metric),
       valueByGroupKey: new Map(
         bucketsToArray<ConsumptionGroupBucket>(bucket.by_group?.buckets).map(
@@ -334,7 +346,11 @@ function buildBreakdownPoints(
     if (hasOthers) {
       values[OTHERS_GROUP_KEY] = otherValues[index];
     }
-    return { timestamp: bucket.timestamp, values };
+    return {
+      timestamp: bucket.timestamp,
+      activeUsers: bucket.activeUsers,
+      values,
+    };
   });
 
   return { points, hasOthers };
@@ -370,6 +386,7 @@ function finalizePoints(
     if (point.timestamp > nowMs) {
       return {
         ...point,
+        activeUsers: 0,
         values: Object.fromEntries(groupKeys.map((key) => [key, 0])),
       };
     }


### PR DESCRIPTION
## Description

This PR exposes the per-bucket active user count in the consumption timeseries endpoint.

One backend change adds a cardinality aggregation per date bucket and returns the count alongside credits. Active users remain a per-bucket count in cumulative mode, and future buckets are zeroed (won't be shown anyway).

The chart overlay is split into the stacked frontend follow-up #31809.

## Tests

- Added tests.
- Tested locally (with the next PR containing the UI).

## Risk

- Low.

## Deploy Plan

- Deploy front.
