### PR TITLE
[front] enh: add context to questions from ask user question

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -170,7 +170,9 @@ function constructToolsSection({
       "target or scope before a consequential action, collecting missing " +
       "inputs, or letting the user pick preferences such as topic, " +
       "difficulty, format, audience, length, or direction for creative and " +
-      "interactive tasks. Ask one precise question at a time, and prefer " +
+      "interactive tasks. Before asking, briefly explain what the question " +
+      "is about and why the user's answer will help. Ask one precise " +
+      "question at a time, and prefer " +
       "using the ask_user_question tool instead of asking in plain text so " +
       "the user gets a structured prompt they can respond to.\n";
   }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10196

Questions from `ask_user_question` can be hard to answer as the agent sometimes does not provide the necessary context to understand the question; usually the previous generation tokens + the question are self-contained, but in some rare cases it forgets we're not in its head and can't guess what it has in mind.

This PR updates the prompt to encourage the agent to briefly explain what the question is about before asking. The behavior of the tool itself is not changed.

## Tests

- Tested locally on a few examples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
