### PR TITLE
feat: filter member group name fetch on canRead

### DIFF
--- a/front/lib/api/actions/servers/workspace_management/tools/list_workspace_members.ts
+++ b/front/lib/api/actions/servers/workspace_management/tools/list_workspace_members.ts
@@ -73,7 +73,7 @@ async function buildMemberRows(
   // Skipped entirely unless asked for: it is a query, and group names are verbose.
   const groupNamesByUserId = includeGroups
     ? await GroupResource.listGroupNamesByUserModelIdInWorkspace({
-        workspace: auth.getNonNullableWorkspace(),
+        auth,
         userModelIds: users.map((u) => u.id),
         groupKinds: [...MANAGEABLE_GROUP_KINDS],
       })

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1510,7 +1510,7 @@ export async function getMemberUsage({
   const [groupNamesByUserModelId, maxPoolCapGroupByUserModelId] =
     await Promise.all([
       GroupResource.listGroupNamesByUserModelIdInWorkspace({
-        workspace,
+        auth,
         userModelIds: [userResource.id],
         groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
       }),
@@ -2211,7 +2211,7 @@ export async function getMembersUsage({
         })
       : Promise.resolve(null),
     GroupResource.listGroupNamesByUserModelIdInWorkspace({
-      workspace,
+      auth,
       userModelIds: users.map((u) => u.id),
       groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     }),

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -82,6 +82,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
 
 function getCacheKeyForUser(userId: number, workspaceId: number): string {
@@ -202,7 +203,7 @@ describe("GroupResource", () => {
   });
 
   describe("listGroupNamesByUserModelIdInWorkspace", () => {
-    it("returns regular + provisioned group names per user, sorted, excluding global", async () => {
+    it("returns regular manual + provisioned group names per user, sorted, excluding global", async () => {
       const user2 = await UserFactory.basic();
       await MembershipFactory.associate(workspace, user2, { role: "user" });
       const user3 = await UserFactory.basic();
@@ -211,7 +212,7 @@ describe("GroupResource", () => {
       const sales = await GroupResource.makeNew({
         name: "Sales",
         workspaceId: workspace.id,
-        kind: "regular_auto",
+        kind: "regular_manual",
       });
       await sales.dangerouslyAddMembers(authenticator, {
         users: [user.toJSON()],
@@ -229,8 +230,9 @@ describe("GroupResource", () => {
 
       const result = await GroupResource.listGroupNamesByUserModelIdInWorkspace(
         {
-          workspace,
+          auth: authenticator,
           userModelIds: [user.id, user2.id, user3.id],
+          groupKinds: [...MANAGEABLE_GROUP_KINDS],
         }
       );
 
@@ -243,8 +245,9 @@ describe("GroupResource", () => {
     it("returns an empty map when no user ids are given", async () => {
       const result = await GroupResource.listGroupNamesByUserModelIdInWorkspace(
         {
-          workspace,
+          auth: authenticator,
           userModelIds: [],
+          groupKinds: [...MANAGEABLE_GROUP_KINDS],
         }
       );
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1251,13 +1251,13 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   static async listGroupNamesByUserModelIdInWorkspace({
-    workspace,
+    auth,
     userModelIds,
-    groupKinds = ["regular_auto", "provisioned"],
+    groupKinds,
   }: {
-    workspace: LightWorkspaceType;
+    auth: Authenticator;
     userModelIds: ModelId[];
-    groupKinds?: Exclude<GroupKind, "system">[];
+    groupKinds: UserVisibleGroupKind[];
   }): Promise<Map<ModelId, string[]>> {
     const result = new Map<ModelId, string[]>();
     if (userModelIds.length === 0) {
@@ -1267,7 +1267,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const now = new Date();
     const memberships = await GroupMembershipModel.findAll({
       where: {
-        workspaceId: workspace.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
         userId: userModelIds,
         status: "active",
         startAt: { [Op.lte]: now },
@@ -1279,14 +1279,14 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const groupModelIds = [...new Set(memberships.map((m) => m.groupId))];
-    const groups = await GroupModel.findAll({
+    const groups = await this.baseFetch(auth, {
       where: {
         id: groupModelIds,
-        workspaceId: workspace.id,
         kind: groupKinds,
       },
     });
-    const nameByGroupId = new Map(groups.map((g) => [g.id, g.name]));
+    const readableGroups = groups.filter((group) => group.canRead(auth));
+    const nameByGroupId = new Map(readableGroups.map((g) => [g.id, g.name]));
 
     for (const m of memberships) {
       const name = nameByGroupId.get(m.groupId);


### PR DESCRIPTION
## Description

This PR filters member group names by the requesting user’s `canRead` permissions and requires callers to explicitly provide the group kinds to fetch.

## Tests

Manually.

## Risks
Low. Only user visible groups are fetched and everyone has permission to read them.

## Deploy Plan

Standard deployment.