### PR TITLE
fix(pods): render Frame v2 tabs as Frames instead of manifest previews

### DIFF
--- a/front/components/pod/PodFileTabContent.tsx
+++ b/front/components/pod/PodFileTabContent.tsx
@@ -5,10 +5,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileMetadataFromPath } from "@app/lib/swr/files";
 import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { RichSpaceType } from "@app/types/api/spaces";
-import {
-  isInteractiveContentType,
-  stripMimeParameters,
-} from "@app/types/files";
+import { isFrameContentType, stripMimeParameters } from "@app/types/files";
 import type { PodFileTab } from "@app/types/pod_file_tab";
 import type { WorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
@@ -33,7 +30,7 @@ export function PodFileTabContent({
 
   const isFrame =
     !!metadata?.contentType &&
-    isInteractiveContentType(stripMimeParameters(metadata.contentType));
+    isFrameContentType(stripMimeParameters(metadata.contentType));
 
   // Frames still load via the processed renderable bundle; other previewable
   // files reuse the shared file preview stack (including markdown edit).


### PR DESCRIPTION
## Description

Adding a Frame v2 as a Pod tab showed the raw `manifest.json` instead of launching the Frame. `PodFileTabContent` decided whether a tab is a Frame with `isInteractiveContentType`, which only covers the legacy Frame content types, so Frame v2 fell through to the generic file preview.

Switch to `isFrameContentType`, which also matches the Frame v2 manifest content type. The Frame visualization branch already resolves the renderable content through `usePodFrameRenderableContent` and passes the v2 `frameId` through, the same way `PodPinnedBanner` does, so no other change is needed.

## Tests

- Typecheck and biome pass.
- Manual: add a Frame v2 as a Pod tab, open the tab, the Frame renders instead of the manifest.

## Risk

Low. One-line predicate change in the tab content component.

## Deploy Plan

Deploy normally.