### PR TITLE
feat(frames): download a Frame v2 package as a zip from the file explorer

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -1,3 +1,6 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -10,6 +13,7 @@ import {
   frameV2ContentType,
 } from "@app/types/files";
 import { honoApp } from "@front-api/app";
+import AdmZip from "adm-zip";
 import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -59,11 +63,12 @@ async function setup() {
 function request(
   workspace: { sId: string },
   canonicalPath: string,
-  init?: RequestInit
+  init?: RequestInit,
+  query = ""
 ) {
   const segments = canonicalPath.split("/").map(encodeURIComponent).join("/");
   return honoApp.request(
-    `/api/w/${workspace.sId}/files/path/${segments}`,
+    `/api/w/${workspace.sId}/files/path/${segments}${query}`,
     init
   );
 }
@@ -171,6 +176,69 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
       /attachment; filename=/
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});
+
+describe("GET /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("zips every file under the folder with paths relative to it", async () => {
+    const { workspace, conversation } = await setup();
+
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix.endsWith("/files/my-frame/")
+        ? [
+            {
+              name: `${prefix}manifest.json`,
+              metadata: { contentType: "application/json", size: "2" },
+            },
+            {
+              name: `${prefix}src/index.tsx`,
+              metadata: { contentType: "text/typescript", size: "2" },
+            },
+          ]
+        : null
+    );
+    fileStorageMock.setFileExists((filePath) =>
+      filePath.includes("/files/my-frame/")
+    );
+    fileStorageMock.setFileContent(() => "{}");
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/my-frame`,
+      undefined,
+      "?archive=1"
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      'filename="my-frame.zip"'
+    );
+
+    const zip = new AdmZip(Buffer.from(await response.arrayBuffer()));
+    expect(
+      zip
+        .getEntries()
+        .map((entry) => entry.entryName)
+        .sort()
+    ).toEqual(["manifest.json", "src/index.tsx"]);
+  });
+
+  it("returns 404 for an empty or missing folder", async () => {
+    const { workspace, conversation } = await setup();
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/nope`,
+      undefined,
+      "?archive=1"
+    );
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
+  archiveCanonicalFolder,
   convertCanonicalFileToPdf,
   deleteCanonicalFile,
   fetchLinkedFileResource,
@@ -41,6 +42,7 @@ const ParamsSchema = z.object({
  *   GET    /api/w/:wId/files/path/conversation-{cId}/report.pdf         stream inline
  *   GET    /api/w/:wId/files/path/pod-{pId}/data.csv?download=1         stream + Content-Disposition
  *   GET    /api/w/:wId/files/path/conversation-{cId}/photo.png?thumbnail=1  stream thumbnail
+ *   GET    /api/w/:wId/files/path/pod-{pId}/my-frame?archive=1            zip of the folder
  *   HEAD   /api/w/:wId/files/path/{...canonicalPath}                    metadata only
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"rename", fileName }
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"move",   dest }
@@ -188,7 +190,46 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
 
   const thumbnail = ctx.req.query("thumbnail");
   const download = ctx.req.query("download");
+  const archive = ctx.req.query("archive");
   const previewPdf = ctx.req.query("preview") === "pdf";
+
+  // ?archive=1 downloads the folder at canonicalPath as a zip.
+  if (archive && archive !== "0") {
+    const archiveResult = await archiveCanonicalFolder(dustFs, canonicalPath);
+    if (archiveResult.isErr()) {
+      const e = archiveResult.error;
+      switch (e.code) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: { type: "file_not_found", message: e.message },
+          });
+        case "too_large":
+          return apiError(ctx, {
+            status_code: 413,
+            api_error: { type: "invalid_request_error", message: e.message },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: { type: "internal_server_error", message: e.message },
+          });
+        default:
+          assertNever(e.code);
+      }
+    }
+
+    const { fileName, content } = archiveResult.value;
+    return new Response(new Uint8Array(content), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": contentDispositionAttachment(fileName),
+        "Content-Length": String(content.length),
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
 
   // ?preview=pdf converts Office files to PDF via Gotenberg's LibreOffice route.
   if (previewPdf) {

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -14,6 +14,7 @@ import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   downloadFile,
+  downloadFolderArchive,
   getFilePathViewUrl,
   useDeleteFileByPath,
 } from "@app/lib/swr/files";
@@ -86,7 +87,15 @@ export function ConversationFileExplorer({
     [owner]
   );
 
-  const onFileDownload = useFileDownload({ getFileResponse });
+  const getFolderArchiveResponse = useCallback(
+    (folderPath: string) => downloadFolderArchive(owner, folderPath),
+    [owner]
+  );
+
+  const onFileDownload = useFileDownload({
+    getFileResponse,
+    getFolderArchiveResponse,
+  });
 
   const onOpenInteractive = useCallback(
     (entry: { fileId: string }) =>

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -257,6 +257,7 @@ describe("FileExplorer Frame packages", () => {
     }
     await user.click(within(packageRow).getByRole("button"));
     expect(screen.getByText("View source")).toBeInTheDocument();
+    expect(screen.getByText("Download")).toBeInTheDocument();
     expect(screen.queryByText("Rename")).not.toBeInTheDocument();
     expect(screen.queryByText("Move to…")).not.toBeInTheDocument();
     fireEvent.click(screen.getByText("Delete"));

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -20,6 +20,7 @@ import type {
   FolderEntry,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
+import type { DownloadableEntry } from "@app/components/file_explorer/useFileDownload";
 import {
   buildFolderTree,
   countFoldersInTree,
@@ -52,7 +53,7 @@ interface FileExplorerProps {
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   /** Restricts which entries get a Delete item when `onDelete` is set; all of them by default. */
   canDelete?: (entry: FileExplorerEntry) => boolean;
-  onFileDownload: (entry: FileEntry) => Promise<void>;
+  onFileDownload: (entry: DownloadableEntry) => Promise<void>;
   onMoveFile?: (
     entry: FileEntry,
     parentRelativePath: string

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -15,6 +15,7 @@ import type {
   FolderEntry,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
+import type { DownloadableEntry } from "@app/components/file_explorer/useFileDownload";
 import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CardGrid, ScrollArea, Spinner } from "@dust-tt/sparkle";
@@ -34,7 +35,7 @@ interface FileExplorerContentProps {
   onFolderNavigate: (node: FileSystemTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
   onFramePackageOpen: (entry: FramePackageEntry) => void;
-  onFileDownload: (entry: FileEntry) => Promise<void>;
+  onFileDownload: (entry: DownloadableEntry) => Promise<void>;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
   onNodeOpen: (entry: ContentNodeEntry) => void;
   getFileMenuItems?: (entry: FileExplorerEntry) => FileExplorerMenuAction[];
@@ -121,6 +122,7 @@ export function FileExplorerContent({
             searchFolderPath={searchFolderPath}
             viewMode={viewMode}
             onOpen={onFramePackageOpen}
+            onDownload={onFileDownload}
             extraMenuItems={getFileMenuItems?.(entry)}
           />
         );

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -452,6 +452,7 @@ interface FileExplorerFramePackageCardProps {
   searchFolderPath?: string;
   viewMode: ViewMode;
   onOpen: (entry: FramePackageEntry) => void;
+  onDownload: (entry: FramePackageEntry) => Promise<void>;
   extraMenuItems?: FileExplorerMenuAction[];
 }
 
@@ -460,6 +461,7 @@ export function FileExplorerFramePackageCard({
   searchFolderPath,
   viewMode,
   onOpen,
+  onDownload,
   extraMenuItems,
 }: FileExplorerFramePackageCardProps) {
   const title =
@@ -475,6 +477,7 @@ export function FileExplorerFramePackageCard({
       title={title}
       subtitle="Frame"
       onOpen={() => onOpen(entry)}
+      onDownload={() => onDownload(entry)}
       extraMenuItems={extraMenuItems}
     />
   );

--- a/front/components/file_explorer/useFileDownload.ts
+++ b/front/components/file_explorer/useFileDownload.ts
@@ -1,21 +1,40 @@
-import type { FileEntry } from "@app/components/file_explorer/types";
+import type {
+  FileEntry,
+  FramePackageEntry,
+} from "@app/components/file_explorer/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import path from "path";
 import { useCallback, useRef } from "react";
 
+export type DownloadableEntry = FileEntry | FramePackageEntry;
+
+/**
+ * Files download as-is. A Frame package downloads its whole source folder as a zip, fetched
+ * through `getFolderArchiveResponse` with the folder's canonical path.
+ */
 export function useFileDownload({
   getFileResponse,
+  getFolderArchiveResponse,
 }: {
   getFileResponse: (path: string) => Promise<Response>;
-}): (entry: FileEntry) => Promise<void> {
+  getFolderArchiveResponse: (folderPath: string) => Promise<Response>;
+}): (entry: DownloadableEntry) => Promise<void> {
   const sendNotification = useSendNotification();
   const blobUrlRef = useRef<string | null>(null);
 
   return useCallback(
-    async (entry: FileEntry) => {
+    async (entry: DownloadableEntry) => {
       try {
-        const res = await getFileResponse(entry.path);
+        const isPackage = entry.kind === "frame_package";
+        // The package entry's path is its manifest; the archive covers the manifest's folder.
+        const res = isPackage
+          ? await getFolderArchiveResponse(path.posix.dirname(entry.path))
+          : await getFileResponse(entry.path);
+        const downloadName = isPackage
+          ? `${entry.fileName}.zip`
+          : entry.fileName;
 
         const blob = await res.blob();
 
@@ -28,7 +47,7 @@ export function useFileDownload({
 
         const a = document.createElement("a");
         a.href = url;
-        a.download = entry.fileName;
+        a.download = downloadName;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
@@ -42,6 +61,6 @@ export function useFileDownload({
         });
       }
     },
-    [getFileResponse, sendNotification]
+    [getFileResponse, getFolderArchiveResponse, sendNotification]
   );
 }

--- a/front/components/file_explorer/useFileDownload.ts
+++ b/front/components/file_explorer/useFileDownload.ts
@@ -2,10 +2,10 @@ import type {
   FileEntry,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
+import { getParentFolderRelativePath } from "@app/components/file_explorer/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import path from "path";
 import { useCallback, useRef } from "react";
 
 export type DownloadableEntry = FileEntry | FramePackageEntry;
@@ -30,7 +30,9 @@ export function useFileDownload({
         const isPackage = entry.kind === "frame_package";
         // The package entry's path is its manifest; the archive covers the manifest's folder.
         const res = isPackage
-          ? await getFolderArchiveResponse(path.posix.dirname(entry.path))
+          ? await getFolderArchiveResponse(
+              getParentFolderRelativePath(entry.path)
+            )
           : await getFileResponse(entry.path);
         const downloadName = isPackage
           ? `${entry.fileName}.zip`

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -31,6 +31,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import {
   downloadFile,
+  downloadFolderArchive,
   getFilePathViewUrl,
   useDeleteFileByPath,
 } from "@app/lib/swr/files";
@@ -641,7 +642,15 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     [owner]
   );
 
-  const onFileDownload = useFileDownload({ getFileResponse });
+  const getFolderArchiveResponse = useCallback(
+    (folderPath: string) => downloadFolderArchive(owner, folderPath),
+    [owner]
+  );
+
+  const onFileDownload = useFileDownload({
+    getFileResponse,
+    getFolderArchiveResponse,
+  });
 
   const handleCloseOverlay = useCallback(() => {
     setActiveOverlay(null);

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -26,6 +26,7 @@ import {
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import AdmZip from "adm-zip";
 import path from "path";
 import type { Readable } from "stream";
 
@@ -585,6 +586,78 @@ export async function convertCanonicalFileToPdf(
   return new Ok({
     pdfBuffer: conversionResult.value,
     pdfFileName: fileName.replace(/\.[^.]+$/, ".pdf"),
+  });
+}
+
+const FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES = 100 * 1024 * 1024; // 100 MB
+
+type FolderArchiveErrorCode = "not_found" | "too_large" | "internal";
+
+export class FolderArchiveError extends Error {
+  constructor(
+    readonly code: FolderArchiveErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "FolderArchiveError";
+  }
+}
+
+/**
+ * Zip every file under the folder at `folderPath` (recursively), with paths relative to the folder.
+ * Used to download a whole folder, e.g. a Frame's source package, in one go.
+ */
+export async function archiveCanonicalFolder(
+  dustFs: DustFileSystem,
+  folderPath: string
+): Promise<Result<{ fileName: string; content: Buffer }, FolderArchiveError>> {
+  const listResult = await dustFs.list(folderPath);
+  if (listResult.isErr()) {
+    return new Err(
+      new FolderArchiveError("internal", listResult.error.message)
+    );
+  }
+
+  const prefix = `${folderPath.replace(/\/+$/, "")}/`;
+  const fileEntries = listResult.value.flatMap((entry) =>
+    !entry.isDirectory && entry.path.startsWith(prefix) ? [entry] : []
+  );
+  if (fileEntries.length === 0) {
+    return new Err(
+      new FolderArchiveError("not_found", "Folder not found or empty.")
+    );
+  }
+
+  // Fail before reading any bytes rather than after buffering them all into memory.
+  const totalSizeBytes = fileEntries.reduce(
+    (total, entry) => total + entry.sizeBytes,
+    0
+  );
+  if (totalSizeBytes > FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES) {
+    return new Err(
+      new FolderArchiveError(
+        "too_large",
+        `Folder is too large to download: its files total ${totalSizeBytes} bytes, ` +
+          `over the ${FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES}-byte limit.`
+      )
+    );
+  }
+
+  const zip = new AdmZip();
+  for (const entry of fileEntries) {
+    const relPath = entry.path.slice(prefix.length);
+    const contentResult = await dustFs.readBuffer(entry.path);
+    if (contentResult.isErr() || contentResult.value === null) {
+      return new Err(
+        new FolderArchiveError("internal", `Could not read '${relPath}'.`)
+      );
+    }
+    zip.addFile(relPath, contentResult.value);
+  }
+
+  return new Ok({
+    fileName: `${path.posix.basename(prefix.slice(0, -1))}.zip`,
+    content: zip.toBuffer(),
   });
 }
 

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -422,6 +422,26 @@ export async function downloadFile(
   return res;
 }
 
+/** Fetch a zip of every file under `folderCanonicalPath`. */
+export async function downloadFolderArchive(
+  owner: LightWorkspaceType,
+  folderCanonicalPath: string
+): Promise<Response> {
+  const encoded = folderCanonicalPath
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
+  const url = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/path/${encoded}?archive=1`;
+
+  const res = await clientFetch(url);
+  if (!res.ok) {
+    const errorData = await getErrorFromResponse(res);
+    throw new Error(errorData.message);
+  }
+
+  return res;
+}
+
 export function useFileProcessedContent({
   owner,
   fileId,


### PR DESCRIPTION
## Description

Regular files have a Download item in the file explorer's "..." menu, but Frame v2 packages did not. This adds Download to Frame package entries. It downloads the whole source folder as a zip named after the folder, in both the Pod file explorer and the conversation file explorer.

Server: `GET /api/w/{wId}/files/path/{canonicalPath}?archive=1` zips every file under the folder at that path, with entry paths relative to the folder. The listing and reads go through `DustFileSystem`, so mount read access applies as for any other read. Empty or missing folders return 404, and folders over 100 MB uncompressed return 413 before any bytes are read. The route is `@ignoreswagger`, as before.

Client: `useFileDownload` accepts Frame package entries and fetches the archive of the manifest's folder, saving it as `<folder>.zip`. `FileExplorerFramePackageCard` gets the same `onDownload` wiring as file cards.

## Tests

- Route tests: archive zips the listed files with relative paths and the right headers; a missing folder returns 404. The test file now pins `@vitest-environment node`, as the Pod app export test does, since adm-zip needs Node builtins.
- Explorer test asserts Download appears on a Frame package.
- Typecheck for front and front-api, biome pass.

## Risk

Low. New opt-in query parameter on an existing read route; downloads are bounded by a size limit.

## Deploy Plan

Deploy normally.