### PR TITLE
Remove Grok feature flag gates

### DIFF
--- a/front-api/routes/marketing/model_credits.test.ts
+++ b/front-api/routes/marketing/model_credits.test.ts
@@ -26,12 +26,22 @@ describe("GET /api/marketing/model-credits", () => {
       (model: { modelId: string }) => model.modelId
     );
 
-    // Entirely feature-flagged providers (no GA model yet).
+    // Models that remain feature-flagged.
     expect(modelIds).not.toContain("deepseek-chat");
-    expect(modelIds).not.toContain("grok-4.5");
     expect(modelIds).not.toContain("o1");
     // Gated by featureFlag even though plansWithAdvancedModels is also set.
     expect(modelIds).not.toContain("claude-opus-4-6");
+  });
+
+  it("includes released Grok models", async () => {
+    const response = await honoApp.request("/api/marketing/model-credits");
+    const body = await response.json();
+    const modelIds = body.models.map(
+      (model: { modelId: string }) => model.modelId
+    );
+
+    expect(modelIds).toContain("grok-4.5");
+    expect(modelIds).toContain("grok-4.6");
   });
 
   it("excludes legacy models", async () => {

--- a/front-api/routes/v1/w/[wId]/feature_flags.test.ts
+++ b/front-api/routes/v1/w/[wId]/feature_flags.test.ts
@@ -32,7 +32,7 @@ describe("GET /api/v1/w/:wId/feature_flags", () => {
     });
 
     await FeatureFlagFactory.basic(auth, "deepseek_feature");
-    await FeatureFlagFactory.basic(auth, "xai_feature");
+    await FeatureFlagFactory.basic(auth, "show_debug_tools");
 
     const response = await getFeatureFlags(workspace, key);
 
@@ -40,7 +40,7 @@ describe("GET /api/v1/w/:wId/feature_flags", () => {
     expect(await response.json()).toEqual({
       feature_flags: expect.arrayContaining([
         "deepseek_feature",
-        "xai_feature",
+        "show_debug_tools",
       ]),
     });
   });
@@ -62,7 +62,7 @@ describe("GET /api/v1/w/:wId/feature_flags", () => {
     });
 
     const otherWorkspace = await WorkspaceFactory.basic();
-    await FeatureFlagFactory.basic(auth, "xai_feature");
+    await FeatureFlagFactory.basic(auth, "show_debug_tools");
     await FeatureFlagFactory.basic(
       await Authenticator.internalAdminForWorkspace(otherWorkspace.sId),
       "labs_transcripts"
@@ -72,7 +72,7 @@ describe("GET /api/v1/w/:wId/feature_flags", () => {
 
     expect(response.status).toBe(200);
     const { feature_flags } = await response.json();
-    expect(feature_flags).toEqual(expect.arrayContaining(["xai_feature"]));
+    expect(feature_flags).toEqual(expect.arrayContaining(["show_debug_tools"]));
     expect(feature_flags).not.toContain("labs_transcripts");
   });
 });

--- a/front/components/poke/plugins/EnumSelect.test.tsx
+++ b/front/components/poke/plugins/EnumSelect.test.tsx
@@ -25,8 +25,8 @@ const OPTIONS = [
     value: "workspace_default_agent",
   },
   {
-    label: "[Dust only] xai_feature",
-    value: "xai_feature",
+    label: "[Dust only] show_debug_tools",
+    value: "show_debug_tools",
   },
 ] as const;
 
@@ -71,7 +71,7 @@ describe("EnumSelect", () => {
       screen.getByText("[On demand] workspace_default_agent")
     ).toBeVisible();
     expect(
-      screen.queryByText("[Dust only] xai_feature")
+      screen.queryByText("[Dust only] show_debug_tools")
     ).not.toBeInTheDocument();
   });
 });

--- a/front/lib/llms/stream/endpoints/xai_grok_four_dot_five_global_xai.ts
+++ b/front/lib/llms/stream/endpoints/xai_grok_four_dot_five_global_xai.ts
@@ -5,9 +5,7 @@ import { XaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/model_constructors/s
 export class DustXaiGrokFourDotFiveGlobalXaiStream extends WithDustGrok45Config(
   XaiGrokFourDotFiveGlobalXaiStream
 ) {
-  static readonly endpointFilter = {
-    featureFlags: { contains: "xai_feature" as const },
-  };
+  static readonly endpointFilter = {};
 }
 
 defineDustStreamEndpoint(DustXaiGrokFourDotFiveGlobalXaiStream);

--- a/front/lib/llms/stream/endpoints/xai_grok_four_dot_six_global_xai.ts
+++ b/front/lib/llms/stream/endpoints/xai_grok_four_dot_six_global_xai.ts
@@ -5,9 +5,7 @@ import { XaiGrokFourDotSixGlobalXaiStream } from "@app/lib/model_constructors/st
 export class DustXaiGrokFourDotSixGlobalXaiStream extends WithDustGrok46Config(
   XaiGrokFourDotSixGlobalXaiStream
 ) {
-  static readonly endpointFilter = {
-    featureFlags: { contains: "xai_feature" as const },
-  };
+  static readonly endpointFilter = {};
 }
 
 defineDustStreamEndpoint(DustXaiGrokFourDotSixGlobalXaiStream);

--- a/front/lib/model_constructors/providers/xai/models/grok_four_dot_six.test.ts
+++ b/front/lib/model_constructors/providers/xai/models/grok_four_dot_six.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment node
 
 import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing";
+import { DustXaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/llms/stream/endpoints/xai_grok_four_dot_five_global_xai";
 import { DustXaiGrokFourDotSixGlobalXaiStream } from "@app/lib/llms/stream/endpoints/xai_grok_four_dot_six_global_xai";
+import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import { XaiGrokFourDotSixGlobalXaiStream } from "@app/lib/model_constructors/stream/endpoints/xai_grok_four_dot_six_global_xai";
+import { GROK_4_5, GROK_4_6 } from "@app/lib/model_constructors/types/models";
 import {
   GROK_4_6_MODEL_CONFIG,
   GROK_4_6_MODEL_ID,
@@ -39,6 +42,23 @@ describe("Grok 4.6 model configuration", () => {
       GROK_4_6_MODEL_CONFIG.contextSize -
         GROK_4_6_MODEL_CONFIG.generationTokensCount
     ).toBe(EXPECTED_MAX_INPUT_TOKENS);
+  });
+
+  it.each([
+    [DustXaiGrokFourDotFiveGlobalXaiStream, GROK_4_5],
+    [DustXaiGrokFourDotSixGlobalXaiStream, GROK_4_6],
+  ])("makes %s available without feature flags", (endpoint, model) => {
+    expect(
+      isEndpointAvailable(
+        endpoint,
+        {
+          featureFlags: [],
+          isCreditPriced: false,
+          isEnterprise: false,
+        },
+        { model: { eq: model } }
+      )
+    ).toBe(true);
   });
 
   it("uses documented reasoning efforts with high as the default", () => {

--- a/front/types/assistant/models/xai.ts
+++ b/front/types/assistant/models/xai.ts
@@ -40,9 +40,6 @@ export const GROK_3_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -71,9 +68,6 @@ export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -105,9 +99,6 @@ export const GROK_4_5_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "high",
   supportsResponseFormat: true,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -144,9 +135,6 @@ export const GROK_4_6_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "high",
   useNativeLightReasoning: true,
   supportsResponseFormat: true,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   // xAI lists only US clusters (us-east-1 and us-west-2) at launch:
   // https://docs.x.ai/developers/models/grok-4.6 (2026-08-12).
@@ -178,9 +166,6 @@ export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -210,9 +195,6 @@ export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -241,9 +223,6 @@ export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -272,9 +251,6 @@ export const GROK_4_1_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   },
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfOneOf: {
-    featureFlag: "xai_feature",
-  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
@@ -305,9 +281,6 @@ export const GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType =
     },
     defaultReasoningEffort: "none",
     supportsResponseFormat: false,
-    availableIfOneOf: {
-      featureFlag: "xai_feature",
-    },
     tokenizer: { type: "tiktoken", base: "o200k_base" },
     regionalAvailability: {
       "us-central1": true,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -177,11 +177,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "flvndvd",
   },
-  xai_feature: {
-    description: "Access to xAI models in the agent builder",
-    stage: "self_serve",
-    owner: "fontanierh",
-  },
   noop_model_feature: {
     description: "Access to noop model in the agent builder",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -805,7 +805,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "usage_data_api"
   | "pricing_groups"
   | "workspace_analytics"
-  | "xai_feature"
   | "conversations_slack_notifications"
   | "collapsible_messages"
   | "conversation_consumption_details"


### PR DESCRIPTION
## Description

Make Grok models generally available by removing the `xai_feature` requirement from model metadata and active stream endpoints. Remove the retired flag from the registry and SDK known values.

## Tests

Added coverage for public model credits and endpoint selection without feature flags. Updated feature-flag API and picker test fixtures.

## Risk

Low. Provider whitelist and regional availability checks are unchanged.

## Deploy Plan

Standard deploy.