### PR TITLE
feat: log parameters of v1/w/:wId/analytics/export

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.ts
@@ -82,6 +82,7 @@ import {
   exportTable,
   stringifyExportTableAsCsv,
 } from "@app/lib/api/analytics/export_tables";
+import logger from "@app/logger/logger";
 import { GetAnalyticsExportRequestSchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -122,6 +123,19 @@ app.get("/", ensureIsAdmin(), async (ctx) => {
   }
 
   const owner = auth.getNonNullableWorkspace();
+
+  logger.info(
+    {
+      workspaceId: owner.sId,
+      table: q.data.table,
+      startDate: q.data.startDate,
+      endDate: q.data.endDate,
+      timezone: q.data.timezone ?? "UTC",
+      format: q.data.format ?? "csv",
+    },
+    "Analytics export requested."
+  );
+
   const result = await exportTable({
     auth,
     table: q.data.table,


### PR DESCRIPTION
## Description

Log query param so we get visibility on which tables / periods are requested.

## Tests

curl'ed locally and see the logs in console.

```
curl --location 'http://localhost:3000/api/v1/w/AYjP6ks68g/analytics/export?table=messages&startDate=2026-09-01&endDate=2026-09-04' \
--header 'Authorization: Bearer sk-****'
```
```
[11:41:56.722] INFO (17154): Analytics export requested. {"workspaceId":"AYjP6ks68g","table":"messages","startDate":"2026-09-01","endDate":"2026-09-04","timezone":"UTC","format":"csv"}
```

## Risk

Low

## Deploy Plan

Front