### PR TITLE
feat(frames): import a Frame v2 zip into a Pod folder from the Files UI

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -242,6 +242,146 @@ describe("GET /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
   });
 });
 
+describe("POST /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeArchive(files: Record<string, string>): Buffer {
+    const zip = new AdmZip();
+    for (const [relPath, content] of Object.entries(files)) {
+      zip.addFile(relPath, Buffer.from(content, "utf-8"));
+    }
+    return zip.toBuffer();
+  }
+
+  function importRequest(
+    workspace: { sId: string },
+    canonicalPath: string,
+    archive: Buffer
+  ) {
+    const body = new FormData();
+    body.append(
+      "file",
+      new File([new Uint8Array(archive)], "my-frame.zip", {
+        type: "application/zip",
+      })
+    );
+    return request(
+      workspace,
+      canonicalPath,
+      { method: "POST", body },
+      "?archive=1"
+    );
+  }
+
+  const manifest = JSON.stringify({
+    version: 1,
+    name: "My Frame",
+    description: "Imported.",
+  });
+
+  it("extracts the files into the folder and registers the Frame", async () => {
+    const { workspace, auth, conversation } = await setup();
+    // Written objects must read back for the registration to find the manifest.
+    fileStorageMock.setFileExists((filePath) =>
+      filePath.includes("/files/my-frame/")
+    );
+
+    const response = await importRequest(
+      workspace,
+      `conversation-${conversation.sId}/my-frame`,
+      makeArchive({ "manifest.json": manifest, "src/index.tsx": "export {};" })
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.fileCount).toBe(2);
+    expect(typeof body.frameId).toBe("string");
+
+    const basePath = `w/${workspace.sId}/conversations/${conversation.sId}/files/my-frame`;
+    expect(fileStorageMock.saveFileCalls).toContainEqual(
+      expect.objectContaining({
+        filePath: `${basePath}/manifest.json`,
+        contentType: "application/json",
+      })
+    );
+    expect(fileStorageMock.saveFileCalls).toContainEqual(
+      expect.objectContaining({ filePath: `${basePath}/src/index.tsx` })
+    );
+
+    const frame = await FileResource.fetchById(auth, body.frameId);
+    expect(frame?.isFrameV2).toBe(true);
+    expect(frame?.mountFilePath).toBe(`${basePath}/manifest.json`);
+  });
+
+  it("imports a plain folder without registering anything", async () => {
+    const { workspace, conversation } = await setup();
+
+    const response = await importRequest(
+      workspace,
+      `conversation-${conversation.sId}/docs`,
+      makeArchive({ "readme.md": "# Hi" })
+    );
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ fileCount: 1, frameId: null });
+  });
+
+  it("returns 409 when the folder already has files", async () => {
+    const { workspace, conversation } = await setup();
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix.endsWith("/files/my-frame/")
+        ? [
+            {
+              name: `${prefix}manifest.json`,
+              metadata: { contentType: "application/json", size: "2" },
+            },
+          ]
+        : null
+    );
+
+    const response = await importRequest(
+      workspace,
+      `conversation-${conversation.sId}/my-frame`,
+      makeArchive({ "manifest.json": manifest })
+    );
+
+    expect(response.status).toBe(409);
+    expect(fileStorageMock.saveFileCalls).toEqual([]);
+  });
+
+  it("rejects archives with unsafe entry paths", async () => {
+    const { workspace, conversation } = await setup();
+
+    // adm-zip normalises names passed to addFile, so rename the entry after the fact.
+    const zip = new AdmZip();
+    zip.addFile("escape.txt", Buffer.from("nope", "utf-8"));
+    zip.getEntries()[0].entryName = "../escape.txt";
+
+    const response = await importRequest(
+      workspace,
+      `conversation-${conversation.sId}/my-frame`,
+      zip.toBuffer()
+    );
+
+    expect(response.status).toBe(400);
+    expect(fileStorageMock.saveFileCalls).toEqual([]);
+  });
+
+  it("requires ?archive=1", async () => {
+    const { workspace, conversation } = await setup();
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/my-frame`,
+      { method: "POST", body: new FormData() }
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
 describe("GET /api/w/:wId/files/path/:canonicalPath?thumbnail=1", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -17,9 +17,15 @@ import AdmZip from "adm-zip";
 import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/lock", () => ({
-  executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
-}));
+vi.mock("@app/lib/lock", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) =>
+      fn()
+    ),
+  };
+});
 
 function makeReadStream() {
   return new PassThrough();
@@ -280,24 +286,42 @@ describe("POST /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
     name: "My Frame",
     description: "Imported.",
   });
+  const uiSource = "export default function MyFrame() { return <p>Ready</p>; }";
 
-  it("extracts the files into the folder and registers the Frame", async () => {
+  it("extracts the files, registers the Frame and publishes it", async () => {
     const { workspace, auth, conversation } = await setup();
-    // Written objects must read back for the registration to find the manifest.
+    // Written objects must read back and list for the registration and the publication to find
+    // the source. The mock's prefix listing does not see writes, so serve the recorded ones; the
+    // folder still lists as empty before the import writes anything.
     fileStorageMock.setFileExists((filePath) =>
       filePath.includes("/files/my-frame/")
+    );
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix.endsWith("/files/my-frame/")
+        ? fileStorageMock.saveFileCalls
+            .filter((call) => call.filePath.startsWith(prefix))
+            .map((call) => ({
+              name: call.filePath,
+              metadata: {
+                contentType: call.contentType ?? "application/octet-stream",
+                size: String(Buffer.byteLength(call.content)),
+              },
+            }))
+        : null
     );
 
     const response = await importRequest(
       workspace,
       `conversation-${conversation.sId}/my-frame`,
-      makeArchive({ "manifest.json": manifest, "src/index.tsx": "export {};" })
+      makeArchive({ "manifest.json": manifest, "index.tsx": uiSource })
     );
 
     expect(response.status).toBe(201);
     const body = await response.json();
     expect(body.fileCount).toBe(2);
-    expect(typeof body.frameId).toBe("string");
+    expect(typeof body.frame.frameId).toBe("string");
+    expect(typeof body.frame.publicationId).toBe("string");
+    expect(body.frame.publishError).toBeNull();
 
     const basePath = `w/${workspace.sId}/conversations/${conversation.sId}/files/my-frame`;
     expect(fileStorageMock.saveFileCalls).toContainEqual(
@@ -307,12 +331,15 @@ describe("POST /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
       })
     );
     expect(fileStorageMock.saveFileCalls).toContainEqual(
-      expect.objectContaining({ filePath: `${basePath}/src/index.tsx` })
+      expect.objectContaining({ filePath: `${basePath}/index.tsx` })
     );
 
-    const frame = await FileResource.fetchById(auth, body.frameId);
+    const frame = await FileResource.fetchById(auth, body.frame.frameId);
     expect(frame?.isFrameV2).toBe(true);
     expect(frame?.mountFilePath).toBe(`${basePath}/manifest.json`);
+    expect(frame?.useCaseMetadata?.activePublicationId).toBe(
+      body.frame.publicationId
+    );
   });
 
   it("imports a plain folder without registering anything", async () => {
@@ -325,7 +352,7 @@ describe("POST /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
     );
 
     expect(response.status).toBe(201);
-    expect(await response.json()).toEqual({ fileCount: 1, frameId: null });
+    expect(await response.json()).toEqual({ fileCount: 1, frame: null });
   });
 
   it("returns 409 when the folder already has files", async () => {

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -1,3 +1,6 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -10,6 +13,7 @@ import {
   frameV2ContentType,
 } from "@app/types/files";
 import { honoApp } from "@front-api/app";
+import AdmZip from "adm-zip";
 import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -59,11 +63,12 @@ async function setup() {
 function request(
   workspace: { sId: string },
   canonicalPath: string,
-  init?: RequestInit
+  init?: RequestInit,
+  query = ""
 ) {
   const segments = canonicalPath.split("/").map(encodeURIComponent).join("/");
   return honoApp.request(
-    `/api/w/${workspace.sId}/files/path/${segments}`,
+    `/api/w/${workspace.sId}/files/path/${segments}${query}`,
     init
   );
 }
@@ -171,6 +176,69 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
       /attachment; filename=/
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});
+
+describe("GET /api/w/:wId/files/path/:canonicalPath?archive=1", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("zips every file under the folder with paths relative to it", async () => {
+    const { workspace, conversation } = await setup();
+
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix.endsWith("/files/my-frame/")
+        ? [
+            {
+              name: `${prefix}manifest.json`,
+              metadata: { contentType: "application/json", size: "2" },
+            },
+            {
+              name: `${prefix}src/index.tsx`,
+              metadata: { contentType: "text/typescript", size: "2" },
+            },
+          ]
+        : null
+    );
+    fileStorageMock.setFileExists((filePath) =>
+      filePath.includes("/files/my-frame/")
+    );
+    fileStorageMock.setFileContent(() => "{}");
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/my-frame`,
+      undefined,
+      "?archive=1"
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      'filename="my-frame.zip"'
+    );
+
+    const zip = new AdmZip(Buffer.from(await response.arrayBuffer()));
+    expect(
+      zip
+        .getEntries()
+        .map((entry) => entry.entryName)
+        .sort()
+    ).toEqual(["manifest.json", "src/index.tsx"]);
+  });
+
+  it("returns 404 for an empty or missing folder", async () => {
+    const { workspace, conversation } = await setup();
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/nope`,
+      undefined,
+      "?archive=1"
+    );
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -4,7 +4,10 @@ import {
   archiveCanonicalFolder,
   convertCanonicalFileToPdf,
   deleteCanonicalFile,
+  FOLDER_ARCHIVE_MAX_ZIP_BYTES,
+  FolderArchiveImportError,
   fetchLinkedFileResource,
+  importCanonicalFolderArchive,
   moveCanonicalFile,
   renameCanonicalFile,
   streamThumbnail,
@@ -21,6 +24,7 @@ import {
   normalizeMimeType,
 } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -43,6 +47,7 @@ const ParamsSchema = z.object({
  *   GET    /api/w/:wId/files/path/pod-{pId}/data.csv?download=1         stream + Content-Disposition
  *   GET    /api/w/:wId/files/path/conversation-{cId}/photo.png?thumbnail=1  stream thumbnail
  *   GET    /api/w/:wId/files/path/pod-{pId}/my-frame?archive=1            zip of the folder
+ *   POST   /api/w/:wId/files/path/pod-{pId}/my-frame?archive=1            create folder from zip
  *   HEAD   /api/w/:wId/files/path/{...canonicalPath}                    metadata only
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"rename", fileName }
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"move",   dest }
@@ -100,6 +105,20 @@ function contentDispositionAttachment(fileName: string): string {
 const putBodyLimit = honoBodyLimit({
   maxSize: WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES,
   onError: putContentTooLargeError,
+});
+
+// Multipart framing (boundary markers, per-part headers) adds a small overhead on top of the zip.
+const MULTIPART_FRAMING_OVERHEAD_BYTES = 64 * 1024;
+const archiveBodyLimit = honoBodyLimit({
+  maxSize: FOLDER_ARCHIVE_MAX_ZIP_BYTES + MULTIPART_FRAMING_OVERHEAD_BYTES,
+  onError: (ctx) =>
+    apiError(ctx, {
+      status_code: 413,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Archive exceeds ${FOLDER_ARCHIVE_MAX_ZIP_BYTES} bytes.`,
+      },
+    }),
 });
 
 /** Resolve and validate the canonical path from the URL, returning an error response if invalid. */
@@ -542,6 +561,102 @@ app.put(
     return new Response(null, {
       status: writeResult.value.created ? 201 : 200,
     });
+  }
+);
+
+/**
+ * Create the folder at canonicalPath from a zip of its files (multipart `file` field), the inverse
+ * of `GET ?archive=1`. A Frame manifest at the archive root registers the Frame.
+ */
+app.post(
+  "/:canonicalPath{.+}",
+  archiveBodyLimit,
+  validate("param", ParamsSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { canonicalPath } = ctx.req.valid("param");
+    const archive = ctx.req.query("archive");
+    if (!archive || archive === "0") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "POST on a canonical path requires ?archive=1.",
+        },
+      });
+    }
+
+    const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
+    if (err) {
+      return err;
+    }
+
+    let body: Awaited<ReturnType<typeof ctx.req.parseBody>>;
+    try {
+      body = await ctx.req.parseBody();
+    } catch (parseErr) {
+      // Without a Content-Length header the body limit surfaces as a thrown error mid-read; let it
+      // propagate so the middleware turns it into its 413 response.
+      if (parseErr instanceof Error && parseErr.name === "BodyLimitError") {
+        throw parseErr;
+      }
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `File upload failed: ${normalizeError(parseErr).message}`,
+        },
+      });
+    }
+
+    const uploaded = body.file;
+    if (!(uploaded instanceof File)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "A 'file' field holding the archive is required.",
+        },
+      });
+    }
+
+    const importResult = await importCanonicalFolderArchive(
+      auth,
+      dustFs,
+      canonicalPath,
+      Buffer.from(await uploaded.arrayBuffer())
+    );
+    if (importResult.isErr()) {
+      const e = importResult.error;
+      if (!(e instanceof FolderArchiveImportError)) {
+        return apiError(ctx, mapDustFsError(e));
+      }
+      const code = e.code;
+      switch (code) {
+        case "invalid_archive":
+        case "invalid_frame":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: { type: "invalid_request_error", message: e.message },
+          });
+        case "already_exists":
+          return apiError(ctx, {
+            status_code: 409,
+            api_error: { type: "invalid_request_error", message: e.message },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: { type: "internal_server_error", message: e.message },
+          });
+        default:
+          assertNever(code);
+      }
+    }
+
+    requestDustProjectIncrementalSyncForScopedPath(auth, canonicalPath);
+
+    return ctx.json(importResult.value, 201);
   }
 );
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
+  archiveCanonicalFolder,
   convertCanonicalFileToPdf,
   deleteCanonicalFile,
   fetchLinkedFileResource,
@@ -41,6 +42,7 @@ const ParamsSchema = z.object({
  *   GET    /api/w/:wId/files/path/conversation-{cId}/report.pdf         stream inline
  *   GET    /api/w/:wId/files/path/pod-{pId}/data.csv?download=1         stream + Content-Disposition
  *   GET    /api/w/:wId/files/path/conversation-{cId}/photo.png?thumbnail=1  stream thumbnail
+ *   GET    /api/w/:wId/files/path/pod-{pId}/my-frame?archive=1            zip of the folder
  *   HEAD   /api/w/:wId/files/path/{...canonicalPath}                    metadata only
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"rename", fileName }
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"move",   dest }
@@ -188,7 +190,46 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
 
   const thumbnail = ctx.req.query("thumbnail");
   const download = ctx.req.query("download");
+  const archive = ctx.req.query("archive");
   const previewPdf = ctx.req.query("preview") === "pdf";
+
+  // ?archive=1 downloads the folder at canonicalPath as a zip.
+  if (archive && archive !== "0") {
+    const archiveResult = await archiveCanonicalFolder(dustFs, canonicalPath);
+    if (archiveResult.isErr()) {
+      const e = archiveResult.error;
+      switch (e.code) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: { type: "file_not_found", message: e.message },
+          });
+        case "too_large":
+          return apiError(ctx, {
+            status_code: 413,
+            api_error: { type: "invalid_request_error", message: e.message },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: { type: "internal_server_error", message: e.message },
+          });
+        default:
+          assertNever(e.code);
+      }
+    }
+
+    const { fileName, content } = archiveResult.value;
+    return new Response(new Uint8Array(content), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": contentDispositionAttachment(fileName),
+        "Content-Length": String(content.length),
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
 
   // ?preview=pdf converts Office files to PDF via Gotenberg's LibreOffice route.
   if (previewPdf) {

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -14,6 +14,7 @@ import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   downloadFile,
+  downloadFolderArchive,
   getFilePathViewUrl,
   useDeleteFileByPath,
 } from "@app/lib/swr/files";
@@ -86,7 +87,15 @@ export function ConversationFileExplorer({
     [owner]
   );
 
-  const onFileDownload = useFileDownload({ getFileResponse });
+  const getFolderArchiveResponse = useCallback(
+    (folderPath: string) => downloadFolderArchive(owner, folderPath),
+    [owner]
+  );
+
+  const onFileDownload = useFileDownload({
+    getFileResponse,
+    getFolderArchiveResponse,
+  });
 
   const onOpenInteractive = useCallback(
     (entry: { fileId: string }) =>

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -257,6 +257,7 @@ describe("FileExplorer Frame packages", () => {
     }
     await user.click(within(packageRow).getByRole("button"));
     expect(screen.getByText("View source")).toBeInTheDocument();
+    expect(screen.getByText("Download")).toBeInTheDocument();
     expect(screen.queryByText("Rename")).not.toBeInTheDocument();
     expect(screen.queryByText("Move to…")).not.toBeInTheDocument();
     fireEvent.click(screen.getByText("Delete"));

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -20,6 +20,7 @@ import type {
   FolderEntry,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
+import type { DownloadableEntry } from "@app/components/file_explorer/useFileDownload";
 import {
   buildFolderTree,
   countFoldersInTree,
@@ -52,7 +53,7 @@ interface FileExplorerProps {
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   /** Restricts which entries get a Delete item when `onDelete` is set; all of them by default. */
   canDelete?: (entry: FileExplorerEntry) => boolean;
-  onFileDownload: (entry: FileEntry) => Promise<void>;
+  onFileDownload: (entry: DownloadableEntry) => Promise<void>;
   onMoveFile?: (
     entry: FileEntry,
     parentRelativePath: string

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -15,6 +15,7 @@ import type {
   FolderEntry,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
+import type { DownloadableEntry } from "@app/components/file_explorer/useFileDownload";
 import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CardGrid, ScrollArea, Spinner } from "@dust-tt/sparkle";
@@ -34,7 +35,7 @@ interface FileExplorerContentProps {
   onFolderNavigate: (node: FileSystemTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
   onFramePackageOpen: (entry: FramePackageEntry) => void;
-  onFileDownload: (entry: FileEntry) => Promise<void>;
+  onFileDownload: (entry: DownloadableEntry) => Promise<void>;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
   onNodeOpen: (entry: ContentNodeEntry) => void;
   getFileMenuItems?: (entry: FileExplorerEntry) => FileExplorerMenuAction[];
@@ -121,6 +122,7 @@ export function FileExplorerContent({
             searchFolderPath={searchFolderPath}
             viewMode={viewMode}
             onOpen={onFramePackageOpen}
+            onDownload={onFileDownload}
             extraMenuItems={getFileMenuItems?.(entry)}
           />
         );

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -452,6 +452,7 @@ interface FileExplorerFramePackageCardProps {
   searchFolderPath?: string;
   viewMode: ViewMode;
   onOpen: (entry: FramePackageEntry) => void;
+  onDownload: (entry: FramePackageEntry) => Promise<void>;
   extraMenuItems?: FileExplorerMenuAction[];
 }
 
@@ -460,6 +461,7 @@ export function FileExplorerFramePackageCard({
   searchFolderPath,
   viewMode,
   onOpen,
+  onDownload,
   extraMenuItems,
 }: FileExplorerFramePackageCardProps) {
   const title =
@@ -475,6 +477,7 @@ export function FileExplorerFramePackageCard({
       title={title}
       subtitle="Frame"
       onOpen={() => onOpen(entry)}
+      onDownload={() => onDownload(entry)}
       extraMenuItems={extraMenuItems}
     />
   );

--- a/front/components/file_explorer/useFileDownload.ts
+++ b/front/components/file_explorer/useFileDownload.ts
@@ -1,21 +1,40 @@
-import type { FileEntry } from "@app/components/file_explorer/types";
+import type {
+  FileEntry,
+  FramePackageEntry,
+} from "@app/components/file_explorer/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import path from "path";
 import { useCallback, useRef } from "react";
 
+export type DownloadableEntry = FileEntry | FramePackageEntry;
+
+/**
+ * Files download as-is. A Frame package downloads its whole source folder as a zip, fetched
+ * through `getFolderArchiveResponse` with the folder's canonical path.
+ */
 export function useFileDownload({
   getFileResponse,
+  getFolderArchiveResponse,
 }: {
   getFileResponse: (path: string) => Promise<Response>;
-}): (entry: FileEntry) => Promise<void> {
+  getFolderArchiveResponse: (folderPath: string) => Promise<Response>;
+}): (entry: DownloadableEntry) => Promise<void> {
   const sendNotification = useSendNotification();
   const blobUrlRef = useRef<string | null>(null);
 
   return useCallback(
-    async (entry: FileEntry) => {
+    async (entry: DownloadableEntry) => {
       try {
-        const res = await getFileResponse(entry.path);
+        const isPackage = entry.kind === "frame_package";
+        // The package entry's path is its manifest; the archive covers the manifest's folder.
+        const res = isPackage
+          ? await getFolderArchiveResponse(path.posix.dirname(entry.path))
+          : await getFileResponse(entry.path);
+        const downloadName = isPackage
+          ? `${entry.fileName}.zip`
+          : entry.fileName;
 
         const blob = await res.blob();
 
@@ -28,7 +47,7 @@ export function useFileDownload({
 
         const a = document.createElement("a");
         a.href = url;
-        a.download = entry.fileName;
+        a.download = downloadName;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
@@ -42,6 +61,6 @@ export function useFileDownload({
         });
       }
     },
-    [getFileResponse, sendNotification]
+    [getFileResponse, getFolderArchiveResponse, sendNotification]
   );
 }

--- a/front/components/file_explorer/useFileDownload.ts
+++ b/front/components/file_explorer/useFileDownload.ts
@@ -2,10 +2,10 @@ import type {
   FileEntry,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
+import { getParentFolderRelativePath } from "@app/components/file_explorer/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import path from "path";
 import { useCallback, useRef } from "react";
 
 export type DownloadableEntry = FileEntry | FramePackageEntry;
@@ -30,7 +30,9 @@ export function useFileDownload({
         const isPackage = entry.kind === "frame_package";
         // The package entry's path is its manifest; the archive covers the manifest's folder.
         const res = isPackage
-          ? await getFolderArchiveResponse(path.posix.dirname(entry.path))
+          ? await getFolderArchiveResponse(
+              getParentFolderRelativePath(entry.path)
+            )
           : await getFileResponse(entry.path);
         const downloadName = isPackage
           ? `${entry.fileName}.zip`

--- a/front/components/pod/files/ImportFrameDialog.tsx
+++ b/front/components/pod/files/ImportFrameDialog.tsx
@@ -1,0 +1,134 @@
+import { useImportFolderArchive } from "@app/lib/swr/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface ImportFrameDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImported: () => void | Promise<void>;
+  owner: LightWorkspaceType;
+  /** Canonical scoped path of the folder the Frame folder is created in, e.g. `pod-{id}/apps`. */
+  parentCanonicalPath: string;
+}
+
+function defaultFolderName(fileName: string): string {
+  return fileName.replace(/\.zip$/i, "");
+}
+
+export function ImportFrameDialog({
+  isOpen,
+  onClose,
+  onImported,
+  owner,
+  parentCanonicalPath,
+}: ImportFrameDialogProps) {
+  const [archive, setArchive] = useState<File | null>(null);
+  const [folderName, setFolderName] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const importFolderArchive = useImportFolderArchive({ owner });
+
+  useEffect(() => {
+    if (isOpen) {
+      setArchive(null);
+      setFolderName("");
+    }
+  }, [isOpen]);
+
+  const trimmedFolderName = folderName.trim();
+  const canImport =
+    archive !== null && trimmedFolderName.length > 0 && !isImporting;
+
+  const handleImport = useCallback(async () => {
+    if (!archive || !trimmedFolderName || isImporting) {
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      const result = await importFolderArchive({
+        folderCanonicalPath: `${parentCanonicalPath}/${trimmedFolderName}`,
+        file: archive,
+      });
+      if (result.isOk()) {
+        await onImported();
+        onClose();
+      }
+    } finally {
+      setIsImporting(false);
+    }
+  }, [
+    archive,
+    importFolderArchive,
+    isImporting,
+    onClose,
+    onImported,
+    parentCanonicalPath,
+    trimmedFolderName,
+  ]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import Frame</DialogTitle>
+          <DialogDescription>
+            Upload a Frame zip, as downloaded from a Frame's menu. Its files are
+            extracted into a new folder here.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-3">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".zip,application/zip"
+              onChange={(e) => {
+                const selected = e.target.files?.[0] ?? null;
+                setArchive(selected);
+                if (selected && !trimmedFolderName) {
+                  setFolderName(defaultFolderName(selected.name));
+                }
+              }}
+            />
+            <Input
+              placeholder="Folder name"
+              value={folderName}
+              onChange={(e) => setFolderName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleImport();
+                }
+              }}
+            />
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          rightButtonProps={{
+            label: "Import",
+            variant: "primary",
+            onClick: handleImport,
+            disabled: !canImport,
+            isLoading: isImporting,
+          }}
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            disabled: isImporting,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pod/files/ImportFrameDialog.tsx
+++ b/front/components/pod/files/ImportFrameDialog.tsx
@@ -1,6 +1,7 @@
 import { useImportFolderArchive } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -9,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Upload01,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -87,12 +89,16 @@ export function ImportFrameDialog({
             extracted into a new folder here.
           </DialogDescription>
         </DialogHeader>
-        <DialogContainer>
-          <div className="flex flex-col gap-3">
+        <DialogContainer className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+              Frame archive (.zip)
+            </span>
             <input
               ref={fileInputRef}
               type="file"
               accept=".zip,application/zip"
+              className="hidden"
               onChange={(e) => {
                 const selected = e.target.files?.[0] ?? null;
                 setArchive(selected);
@@ -101,6 +107,18 @@ export function ImportFrameDialog({
                 }
               }}
             />
+            <Button
+              label={archive ? archive.name : "Choose archive"}
+              icon={Upload01}
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+              Folder name
+            </span>
             <Input
               placeholder="Folder name"
               value={folderName}

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -19,6 +19,7 @@ import {
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { CreateFolderDialog } from "@app/components/pod/files/CreateFolderDialog";
 import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
+import { ImportFrameDialog } from "@app/components/pod/files/ImportFrameDialog";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import { RenameFileDialog } from "@app/components/pod/files/RenameFileDialog";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
@@ -100,6 +101,8 @@ interface AttachKnowledgeDropdownProps {
   buttonLabel: string;
   isDisabled: boolean;
   onCreateFolderClick: () => void;
+  /** Absent when Frames v2 are not enabled for the workspace. */
+  onImportFrameClick?: () => void;
   onUploadFileClick: () => void;
   onShowCompanyDataClick: () => void;
 }
@@ -108,6 +111,7 @@ function AttachKnowledgeDropdown({
   buttonLabel,
   isDisabled,
   onCreateFolderClick,
+  onImportFrameClick,
   onUploadFileClick,
   onShowCompanyDataClick,
 }: AttachKnowledgeDropdownProps) {
@@ -137,6 +141,13 @@ function AttachKnowledgeDropdown({
           label="Upload file"
           onClick={onUploadFileClick}
         />
+        {onImportFrameClick && (
+          <DropdownMenuItem
+            icon={UploadCloud02}
+            label="Import Frame"
+            onClick={onImportFrameClick}
+          />
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -151,6 +162,7 @@ function AttachKnowledgeButton({
   canManuallyManagePodFiles,
   isDisabled,
   onCreateFolderClick,
+  onImportFrameClick,
   onShowCompanyDataClick,
   onUploadFileClick,
 }: AttachKnowledgeButtonProps) {
@@ -160,6 +172,7 @@ function AttachKnowledgeButton({
         buttonLabel={buttonLabel}
         isDisabled={isDisabled}
         onCreateFolderClick={onCreateFolderClick}
+        onImportFrameClick={onImportFrameClick}
         onShowCompanyDataClick={onShowCompanyDataClick}
         onUploadFileClick={onUploadFileClick}
       />
@@ -174,6 +187,7 @@ function AttachKnowledgeButton({
             buttonLabel={buttonLabel}
             isDisabled={isDisabled}
             onCreateFolderClick={onCreateFolderClick}
+            onImportFrameClick={onImportFrameClick}
             onShowCompanyDataClick={onShowCompanyDataClick}
             onUploadFileClick={onUploadFileClick}
           />
@@ -262,6 +276,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
   const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
+  const [showImportFrameDialog, setShowImportFrameDialog] = useState(false);
   const [itemToRename, setItemToRename] = useState<
     | { kind: "file"; path: string; name: string }
     | { kind: "folder"; path: string; name: string }
@@ -671,6 +686,10 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     setShowCreateFolderDialog(true);
   }, []);
 
+  const handleImportFrameClick = useCallback(() => {
+    setShowImportFrameDialog(true);
+  }, []);
+
   const handleShowCompanyDataClick = useCallback(() => {
     setActiveOverlay(
       globalSpaceDSVs.length === 0 ? "noCompanyData" : "companyData"
@@ -774,6 +793,9 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
       canManuallyManagePodFiles={canManuallyManagePodKnowledge}
       isDisabled={isAddKnowledgeDisabled}
       onCreateFolderClick={handleCreateFolderClick}
+      onImportFrameClick={
+        hasFeature("frames_v2") ? handleImportFrameClick : undefined
+      }
       onShowCompanyDataClick={handleShowCompanyDataClick}
       onUploadFileClick={handleUploadFileClick}
     />
@@ -839,6 +861,18 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         owner={owner}
         parentRelativePath={currentFolderPath}
         podId={pod.sId}
+      />
+
+      <ImportFrameDialog
+        isOpen={showImportFrameDialog}
+        onClose={() => setShowImportFrameDialog(false)}
+        onImported={() => void refreshPodFiles()}
+        owner={owner}
+        parentCanonicalPath={
+          currentFolderPath
+            ? `pod-${pod.sId}/${currentFolderPath}`
+            : `pod-${pod.sId}`
+        }
       />
 
       {globalSpace && (

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -31,6 +31,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import {
   downloadFile,
+  downloadFolderArchive,
   getFilePathViewUrl,
   useDeleteFileByPath,
 } from "@app/lib/swr/files";
@@ -641,7 +642,15 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     [owner]
   );
 
-  const onFileDownload = useFileDownload({ getFileResponse });
+  const getFolderArchiveResponse = useCallback(
+    (folderPath: string) => downloadFolderArchive(owner, folderPath),
+    [owner]
+  );
+
+  const onFileDownload = useFileDownload({
+    getFileResponse,
+    getFolderArchiveResponse,
+  });
 
   const handleCloseOverlay = useCallback(() => {
     setActiveOverlay(null);

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -6,10 +6,12 @@
 
 import type { DustFileSystem } from "@app/lib/api/file_system";
 import { decodeBuffer } from "@app/lib/api/files/utils";
+import { registerFrameV2FromSourceUsingFileSystem } from "@app/lib/api/frames/register_from_source";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
@@ -26,6 +28,7 @@ import {
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import AdmZip from "adm-zip";
 import path from "path";
 import type { Readable } from "stream";
@@ -658,6 +661,194 @@ export async function archiveCanonicalFolder(
   return new Ok({
     fileName: `${path.posix.basename(prefix.slice(0, -1))}.zip`,
     content: zip.toBuffer(),
+  });
+}
+
+export const FOLDER_ARCHIVE_MAX_ZIP_BYTES = 20 * 1024 * 1024; // 20 MB
+const FOLDER_ARCHIVE_MAX_ENTRY_COUNT = 1000;
+// Archive entries carry no content type; unknown extensions are stored as opaque bytes.
+const FOLDER_ARCHIVE_DEFAULT_CONTENT_TYPE = "application/octet-stream";
+// `contentTypeFromFileName` returns the first format claiming an extension, and an internal Dust
+// format claims `.json` ahead of plain JSON. A Frame manifest must be stored as plain JSON.
+const FOLDER_ARCHIVE_EXTENSION_CONTENT_TYPES: Record<string, string> = {
+  ".json": "application/json",
+};
+
+function folderArchiveEntryContentType(relPath: string): string {
+  const fileName = path.posix.basename(relPath);
+  const extension = path.posix.extname(fileName).toLowerCase();
+  return (
+    FOLDER_ARCHIVE_EXTENSION_CONTENT_TYPES[extension] ??
+    contentTypeFromFileName(fileName) ??
+    FOLDER_ARCHIVE_DEFAULT_CONTENT_TYPE
+  );
+}
+
+type FolderArchiveImportErrorCode =
+  | "invalid_archive"
+  | "already_exists"
+  | "invalid_frame"
+  | "internal";
+
+export class FolderArchiveImportError extends Error {
+  constructor(
+    readonly code: FolderArchiveImportErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "FolderArchiveImportError";
+  }
+}
+
+/**
+ * Validate a folder archive (as produced by `archiveCanonicalFolder`) and return its files by
+ * relative path. Rejects zip-slip entries (`..`, absolute paths, backslashes) and oversized archives
+ * before anything is written.
+ */
+function parseFolderArchive(
+  zipBuffer: Buffer
+): Result<Map<string, Buffer>, FolderArchiveImportError> {
+  if (zipBuffer.length > FOLDER_ARCHIVE_MAX_ZIP_BYTES) {
+    return new Err(
+      new FolderArchiveImportError(
+        "invalid_archive",
+        `Archive exceeds ${FOLDER_ARCHIVE_MAX_ZIP_BYTES} bytes.`
+      )
+    );
+  }
+
+  let zip: AdmZip;
+  try {
+    zip = new AdmZip(zipBuffer);
+  } catch (err) {
+    return new Err(
+      new FolderArchiveImportError(
+        "invalid_archive",
+        `Not a readable zip: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const entries = zip.getEntries().filter((entry) => !entry.isDirectory);
+  if (entries.length === 0) {
+    return new Err(
+      new FolderArchiveImportError("invalid_archive", "Archive is empty.")
+    );
+  }
+  if (entries.length > FOLDER_ARCHIVE_MAX_ENTRY_COUNT) {
+    return new Err(
+      new FolderArchiveImportError(
+        "invalid_archive",
+        `Archive holds more than ${FOLDER_ARCHIVE_MAX_ENTRY_COUNT} files.`
+      )
+    );
+  }
+
+  const totalUncompressedBytes = entries.reduce(
+    (total, entry) => total + entry.header.size,
+    0
+  );
+  if (totalUncompressedBytes > FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES) {
+    return new Err(
+      new FolderArchiveImportError(
+        "invalid_archive",
+        `Archive expands past ${FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES} bytes.`
+      )
+    );
+  }
+
+  const files = new Map<string, Buffer>();
+  for (const entry of entries) {
+    const name = entry.entryName;
+    const segments = name.split("/");
+    if (
+      name.startsWith("/") ||
+      name.includes("\\") ||
+      segments.some((segment) => segment === ".." || segment === "")
+    ) {
+      return new Err(
+        new FolderArchiveImportError(
+          "invalid_archive",
+          `Unsafe entry path '${name}'.`
+        )
+      );
+    }
+    files.set(name, entry.getData());
+  }
+
+  return new Ok(files);
+}
+
+/**
+ * Create the folder at `folderPath` from a zip of its files (the inverse of
+ * `archiveCanonicalFolder`). The folder must not exist yet. When the archive root holds a Frame
+ * manifest, the Frame is registered so it shows up as a package; publishing is a separate step.
+ */
+export async function importCanonicalFolderArchive(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  folderPath: string,
+  zipBuffer: Buffer
+): Promise<
+  Result<
+    { fileCount: number; frameId: string | null },
+    FolderArchiveImportError | DustFileSystemError
+  >
+> {
+  const writeAccess = dustFs.checkWriteAccess(folderPath);
+  if (writeAccess.isErr()) {
+    return writeAccess;
+  }
+
+  const existingResult = await dustFs.list(folderPath, { maxFiles: 1 });
+  if (existingResult.isErr()) {
+    return existingResult;
+  }
+  if (existingResult.value.length > 0) {
+    return new Err(
+      new FolderArchiveImportError(
+        "already_exists",
+        `A folder already exists at '${path.posix.basename(folderPath)}'.`
+      )
+    );
+  }
+
+  const parsed = parseFolderArchive(zipBuffer);
+  if (parsed.isErr()) {
+    return parsed;
+  }
+
+  for (const [relPath, content] of parsed.value) {
+    const writeResult = await dustFs.write(
+      `${folderPath}/${relPath}`,
+      content,
+      folderArchiveEntryContentType(relPath)
+    );
+    if (writeResult.isErr()) {
+      return writeResult;
+    }
+  }
+
+  if (!parsed.value.has(FRAME_MANIFEST_FILE)) {
+    return new Ok({ fileCount: parsed.value.size, frameId: null });
+  }
+
+  const registration = await registerFrameV2FromSourceUsingFileSystem(auth, {
+    dustFs,
+    manifestPath: `${folderPath}/${FRAME_MANIFEST_FILE}`,
+  });
+  if (registration.isErr()) {
+    return new Err(
+      new FolderArchiveImportError(
+        "invalid_frame",
+        `Files were imported but the Frame could not be registered: ${registration.error.message}`
+      )
+    );
+  }
+
+  return new Ok({
+    fileCount: parsed.value.size,
+    frameId: registration.value.frame.sId,
   });
 }
 

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -6,12 +6,19 @@
 
 import type { DustFileSystem } from "@app/lib/api/file_system";
 import { decodeBuffer } from "@app/lib/api/files/utils";
+import { withFrameBuildConversation } from "@app/lib/api/frames/build_conversation";
+import { publishFrameV2FromSource } from "@app/lib/api/frames/publish_from_source";
 import { registerFrameV2FromSourceUsingFileSystem } from "@app/lib/api/frames/register_from_source";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
-import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import {
+  FRAME_MANIFEST_FILE,
+  parseFrameManifest,
+} from "@app/types/api/frame_manifest";
 import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
@@ -779,10 +786,95 @@ function parseFolderArchive(
   return new Ok(files);
 }
 
+export type ImportedFrame = {
+  frameId: string;
+  publicationId: string | null;
+  // Set when the Frame was registered but its first publication failed, e.g. a build error.
+  publishError: string | null;
+};
+
+export type ImportCanonicalFolderArchiveResult = {
+  fileCount: number;
+  frame: ImportedFrame | null;
+};
+
+/**
+ * Publish a freshly registered Frame. Publishing builds in a conversation sandbox: a Frame in a
+ * conversation mount builds in that conversation, one in a Pod mount in a short-lived build
+ * conversation of the Pod.
+ */
+async function publishImportedFrame(
+  auth: Authenticator,
+  {
+    dustFs,
+    frame,
+    manifestPath,
+    needsBuildSandbox,
+  }: {
+    dustFs: DustFileSystem;
+    frame: FileResource;
+    manifestPath: string;
+    // Only Frames declaring functions need a sandbox to build; UI-only Frames build in-process.
+    needsBuildSandbox: boolean;
+  }
+): Promise<Result<{ publicationId: string }, Error>> {
+  const mount = dustFs
+    .getMounts()
+    .find(
+      (candidate) =>
+        manifestPath.startsWith(`${candidate.scopedPrefix}/`) &&
+        candidate.permissions.canWrite
+    );
+  if (!mount) {
+    return new Err(new Error("Frame source mount not found."));
+  }
+
+  switch (mount.kind) {
+    case "conversation": {
+      const conversation = await ConversationResource.fetchById(auth, mount.id);
+      if (!conversation) {
+        return new Err(new Error("Frame source conversation not found."));
+      }
+      return publishFrameV2FromSource(auth, {
+        conversation: conversation.toJSON(),
+        frame,
+        manifestPath,
+      });
+    }
+    case "pod": {
+      if (!needsBuildSandbox) {
+        return publishFrameV2FromSource(auth, {
+          conversation: null,
+          frame,
+          manifestPath,
+        });
+      }
+      const pod = await SpaceResource.fetchById(auth, mount.id);
+      if (!pod?.isProject()) {
+        return new Err(new Error("Frame source Pod not found."));
+      }
+      return withFrameBuildConversation(
+        auth,
+        {
+          pod,
+          title: `Frame import: ${frame.useCaseMetadata?.frameName ?? frame.sId}`,
+        },
+        (conversation) =>
+          publishFrameV2FromSource(auth, { conversation, frame, manifestPath })
+      );
+    }
+    default:
+      return new Err(
+        new Error(`Frames cannot be published from a ${mount.kind} mount.`)
+      );
+  }
+}
+
 /**
  * Create the folder at `folderPath` from a zip of its files (the inverse of
  * `archiveCanonicalFolder`). The folder must not exist yet. When the archive root holds a Frame
- * manifest, the Frame is registered so it shows up as a package; publishing is a separate step.
+ * manifest, the Frame is registered and published; a failed publication is reported on the
+ * result rather than failing the import, since the files and the Frame identity are in place.
  */
 export async function importCanonicalFolderArchive(
   auth: Authenticator,
@@ -791,7 +883,7 @@ export async function importCanonicalFolderArchive(
   zipBuffer: Buffer
 ): Promise<
   Result<
-    { fileCount: number; frameId: string | null },
+    ImportCanonicalFolderArchiveResult,
     FolderArchiveImportError | DustFileSystemError
   >
 > {
@@ -830,12 +922,13 @@ export async function importCanonicalFolderArchive(
   }
 
   if (!parsed.value.has(FRAME_MANIFEST_FILE)) {
-    return new Ok({ fileCount: parsed.value.size, frameId: null });
+    return new Ok({ fileCount: parsed.value.size, frame: null });
   }
 
+  const manifestPath = `${folderPath}/${FRAME_MANIFEST_FILE}`;
   const registration = await registerFrameV2FromSourceUsingFileSystem(auth, {
     dustFs,
-    manifestPath: `${folderPath}/${FRAME_MANIFEST_FILE}`,
+    manifestPath,
   });
   if (registration.isErr()) {
     return new Err(
@@ -845,10 +938,38 @@ export async function importCanonicalFolderArchive(
       )
     );
   }
+  const { frame } = registration.value;
+
+  // Registration already validated the manifest, so it parses here.
+  const manifest = parseFrameManifest(
+    parsed.value.get(FRAME_MANIFEST_FILE) ?? Buffer.alloc(0)
+  );
+  const publication = await publishImportedFrame(auth, {
+    dustFs,
+    frame,
+    manifestPath,
+    needsBuildSandbox: manifest.isOk() && manifest.value.functions.length > 0,
+  });
+  if (publication.isErr()) {
+    logger.warn(
+      {
+        error: publication.error.message,
+        frameId: frame.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Imported Frame could not be published"
+    );
+  }
 
   return new Ok({
     fileCount: parsed.value.size,
-    frameId: registration.value.frame.sId,
+    frame: {
+      frameId: frame.sId,
+      publicationId: publication.isOk()
+        ? publication.value.publicationId
+        : null,
+      publishError: publication.isErr() ? publication.error.message : null,
+    },
   });
 }
 

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -26,6 +26,7 @@ import {
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import AdmZip from "adm-zip";
 import path from "path";
 import type { Readable } from "stream";
 
@@ -585,6 +586,78 @@ export async function convertCanonicalFileToPdf(
   return new Ok({
     pdfBuffer: conversionResult.value,
     pdfFileName: fileName.replace(/\.[^.]+$/, ".pdf"),
+  });
+}
+
+const FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES = 100 * 1024 * 1024; // 100 MB
+
+type FolderArchiveErrorCode = "not_found" | "too_large" | "internal";
+
+export class FolderArchiveError extends Error {
+  constructor(
+    readonly code: FolderArchiveErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "FolderArchiveError";
+  }
+}
+
+/**
+ * Zip every file under the folder at `folderPath` (recursively), with paths relative to the folder.
+ * Used to download a whole folder, e.g. a Frame's source package, in one go.
+ */
+export async function archiveCanonicalFolder(
+  dustFs: DustFileSystem,
+  folderPath: string
+): Promise<Result<{ fileName: string; content: Buffer }, FolderArchiveError>> {
+  const listResult = await dustFs.list(folderPath);
+  if (listResult.isErr()) {
+    return new Err(
+      new FolderArchiveError("internal", listResult.error.message)
+    );
+  }
+
+  const prefix = `${folderPath.replace(/\/+$/, "")}/`;
+  const fileEntries = listResult.value.flatMap((entry) =>
+    !entry.isDirectory && entry.path.startsWith(prefix) ? [entry] : []
+  );
+  if (fileEntries.length === 0) {
+    return new Err(
+      new FolderArchiveError("not_found", "Folder not found or empty.")
+    );
+  }
+
+  // Fail before reading any bytes rather than after buffering them all into memory.
+  const totalSizeBytes = fileEntries.reduce(
+    (total, entry) => total + entry.sizeBytes,
+    0
+  );
+  if (totalSizeBytes > FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES) {
+    return new Err(
+      new FolderArchiveError(
+        "too_large",
+        `Folder is too large to download: its files total ${totalSizeBytes} bytes, ` +
+          `over the ${FOLDER_ARCHIVE_MAX_UNCOMPRESSED_BYTES}-byte limit.`
+      )
+    );
+  }
+
+  const zip = new AdmZip();
+  for (const entry of fileEntries) {
+    const relPath = entry.path.slice(prefix.length);
+    const contentResult = await dustFs.readBuffer(entry.path);
+    if (contentResult.isErr() || contentResult.value === null) {
+      return new Err(
+        new FolderArchiveError("internal", `Could not read '${relPath}'.`)
+      );
+    }
+    zip.addFile(relPath, contentResult.value);
+  }
+
+  return new Ok({
+    fileName: `${path.posix.basename(prefix.slice(0, -1))}.zip`,
+    content: zip.toBuffer(),
   });
 }
 

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -69,7 +69,9 @@ async function buildFramePublication(
     manifest,
     sourceFiles,
   }: {
-    conversation: ConversationWithoutContentType;
+    // Function bundles build in this conversation's sandbox; null when the caller has none, which
+    // only UI-only Frames can publish.
+    conversation: ConversationWithoutContentType | null;
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
   }
@@ -102,6 +104,15 @@ async function buildFramePublication(
       functionArtifacts: [],
       uiBundleCode: uiBundle.value,
     });
+  }
+
+  if (!conversation) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        "Building Frame functions requires a conversation sandbox."
+      )
+    );
   }
 
   const ensureResult = await ensureConversationSandboxReadyWithScope(
@@ -187,7 +198,9 @@ export async function validateFramePublication(
     manifest,
     sourceFiles,
   }: {
-    conversation: ConversationWithoutContentType;
+    // Function bundles build in this conversation's sandbox; null when the caller has none, which
+    // only UI-only Frames can publish.
+    conversation: ConversationWithoutContentType | null;
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
   }
@@ -231,7 +244,9 @@ export async function buildAndPublishFramePublication(
     manifest,
     sourceFiles,
   }: {
-    conversation: ConversationWithoutContentType;
+    // Function bundles build in this conversation's sandbox; null when the caller has none, which
+    // only UI-only Frames can publish.
+    conversation: ConversationWithoutContentType | null;
     frame: FileResource;
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];

--- a/front/lib/api/frames/build_conversation.ts
+++ b/front/lib/api/frames/build_conversation.ts
@@ -1,0 +1,55 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+
+/**
+ * Run `fn` with a short-lived conversation in `pod`, for Frame builds that happen outside any
+ * conversation (e.g. an import from the Files UI). Function bundles are built in the invoking
+ * conversation's sandbox, and neither the Frame's own sandbox nor the legacy Pod sandbox is
+ * configured for that.
+ *
+ * The conversation is created with `test` visibility, which Pod conversation lists and new-
+ * conversation notifications already exclude. Its sandbox is destroyed and the conversation
+ * soft-deleted once `fn` returns, whatever the outcome.
+ */
+export async function withFrameBuildConversation<T, E>(
+  auth: Authenticator,
+  {
+    pod,
+    title,
+  }: {
+    pod: SpaceResource;
+    title: string;
+  },
+  fn: (conversation: ConversationWithoutContentType) => Promise<Result<T, E>>
+): Promise<Result<T, E>> {
+  const conversation = await createConversation(auth, {
+    title,
+    visibility: "test",
+    spaceId: pod.id,
+  });
+
+  try {
+    return await fn(conversation.toJSON());
+  } finally {
+    const cleanup = await ConversationSandboxAdapter.deleteSandbox(
+      auth,
+      conversation
+    );
+    if (cleanup.isErr()) {
+      logger.error(
+        {
+          conversationId: conversation.sId,
+          error: cleanup.error.message,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Failed to delete the Frame build conversation sandbox"
+      );
+    }
+    await conversation.updateVisibilityToDeleted(auth);
+  }
+}

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -403,7 +403,7 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
     frame,
     manifestPath,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | null;
     frame: FileResource;
     manifestPath: string;
   }
@@ -435,7 +435,8 @@ export async function publishFrameV2FromSource(
     frame,
     manifestPath,
   }: {
-    conversation: ConversationWithoutContentType;
+    // Null publishes without a build sandbox, which only UI-only Frames support.
+    conversation: ConversationWithoutContentType | null;
     frame: FileResource;
     manifestPath: string;
   }

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -444,7 +444,11 @@ export async function downloadFolderArchive(
 
 export type ImportFolderArchiveResult = {
   fileCount: number;
-  frameId: string | null;
+  frame: {
+    frameId: string;
+    publicationId: string | null;
+    publishError: string | null;
+  } | null;
 };
 
 /** Create the folder at `folderCanonicalPath` from a zip of its files, registering a Frame if any. */
@@ -485,13 +489,21 @@ export function useImportFolderArchive({
       }
 
       const result: ImportFolderArchiveResult = await res.json();
-      sendNotification({
-        type: "success",
-        title: result.frameId ? "Frame imported" : "Folder imported",
-        description: result.frameId
-          ? "Its source is in place; publish it to make it available."
-          : `${result.fileCount} file(s) imported.`,
-      });
+      if (!result.frame) {
+        sendNotification({
+          type: "success",
+          title: "Folder imported",
+          description: `${result.fileCount} file(s) imported.`,
+        });
+      } else if (result.frame.publishError) {
+        sendNotification({
+          type: "info",
+          title: "Frame imported but not published",
+          description: result.frame.publishError,
+        });
+      } else {
+        sendNotification({ type: "success", title: "Frame imported" });
+      }
       return new Ok(result);
     } catch (e) {
       const errorMessage = normalizeError(e).message;

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -422,6 +422,26 @@ export async function downloadFile(
   return res;
 }
 
+/** Fetch a zip of every file under `folderCanonicalPath`. */
+export async function downloadFolderArchive(
+  owner: LightWorkspaceType,
+  folderCanonicalPath: string
+): Promise<Response> {
+  const encoded = folderCanonicalPath
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
+  const url = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/path/${encoded}?archive=1`;
+
+  const res = await clientFetch(url);
+  if (!res.ok) {
+    const errorData = await getErrorFromResponse(res);
+    throw new Error(errorData.message);
+  }
+
+  return res;
+}
+
 export function useFileProcessedContent({
   owner,
   fileId,

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -442,6 +442,69 @@ export async function downloadFolderArchive(
   return res;
 }
 
+export type ImportFolderArchiveResult = {
+  fileCount: number;
+  frameId: string | null;
+};
+
+/** Create the folder at `folderCanonicalPath` from a zip of its files, registering a Frame if any. */
+export function useImportFolderArchive({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async ({
+    folderCanonicalPath,
+    file,
+  }: {
+    folderCanonicalPath: string;
+    file: File;
+  }): Promise<Result<ImportFolderArchiveResult, Error>> => {
+    try {
+      const encoded = folderCanonicalPath
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/");
+      const body = new FormData();
+      body.append("file", file);
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/files/path/${encoded}?archive=1`,
+        { method: "POST", body }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to import Frame",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const result: ImportFolderArchiveResult = await res.json();
+      sendNotification({
+        type: "success",
+        title: result.frameId ? "Frame imported" : "Folder imported",
+        description: result.frameId
+          ? "Its source is in place; publish it to make it available."
+          : `${result.fileCount} file(s) imported.`,
+      });
+      return new Ok(result);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to import Frame",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
 export function useFileProcessedContent({
   owner,
   fileId,


### PR DESCRIPTION
## Description

Stacked on #31765 (Download on Frame packages); retarget to main once that merges.

This adds the inverse of the download: a Frame zip can be imported into a Pod, including a different Pod from the one it was downloaded from, from the Files tab's Add menu.

Server: `POST /api/w/{wId}/files/path/{canonicalFolder}?archive=1` takes the zip as a multipart `file` field and creates the folder from it. It refuses when the folder already has files (409), rejects zip-slip entries, empty archives, and archives over the size and entry-count limits (400 / 413), and writes each entry through `DustFileSystem` so mount write access applies. When the archive root holds a `manifest.json`, the Frame is registered through `registerFrameV2FromSourceUsingFileSystem`, so it appears as a Frame package right away. Entries are stored with a content type derived from their extension; `.json` is pinned to plain JSON because an internal Dust format claims that extension first in the format table.

Client: "Import Frame" in the Pod Add menu, gated on the `frames_v2` flag. The dialog takes the zip and a folder name defaulting to the zip's basename, imports into the current folder, and refreshes the explorer.

Publishing: the imported Frame is published as part of the import, so it renders right away. The UI bundle is built in-process with esbuild and needs no sandbox, so the build path now accepts a null conversation and only requires one when the manifest declares functions, which `dsbx function build` compiles inside a sandbox (it also runs the module's top-level code to extract schemas). For a Pod import whose manifest declares functions, a short-lived conversation is created in the Pod with `test` visibility, which Pod conversation lists and new-conversation notifications already exclude, its sandbox is used for the build, and it is torn down afterwards: sandbox destroyed, conversation soft-deleted. A failed publication does not fail the import, since the files and the Frame identity are in place; it is reported on the result and surfaced in the notification.

## Tests

- Route tests: import extracts files with the expected paths and content types, registers a Frame v2 at the manifest path and publishes it (active publication set on the Frame); a plain folder imports without registration; an existing folder returns 409 with nothing written; an unsafe `..` entry returns 400 with nothing written; POST without `?archive=1` returns 400.
- Typecheck for front and front-api, biome pass.

## Risk

Low to moderate. New write endpoint, but it reuses the existing file system write path and Frame registration, and validates the archive before writing anything.

## Deploy Plan

Deploy normally, after #31765.
