### PR TITLE
feat: explicit group acl bypasses and resource-owned membership changes

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
@@ -18,56 +19,38 @@ app.post(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    if (!space.isProject()) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "You can only leave Pods, not regular spaces.",
-        },
-      });
-    }
-
-    if (!space.isMember(auth)) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "You are not a member of this Pod.",
-        },
-      });
-    }
-
-    const user = auth.getNonNullableUser();
-
-    const groupsToLeave = await space.fetchRegularAutoGroups(auth);
-    const editorGroup = await space.fetchManualEditorGroup(auth);
-
-    if (editorGroup) {
-      const activeEditors = await editorGroup.getActiveMembers(auth);
-      const isUserEditor = activeEditors.some((m) => m.sId === user.sId);
-      if (isUserEditor && activeEditors.length === 1) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "You cannot leave this Pod as you are the last editor. Please add another editor first.",
-          },
-        });
-      }
-    }
-
-    for (const group of groupsToLeave) {
-      const result = await group.leaveGroup(auth);
-      if (result.isErr() && result.error.code !== "user_not_member") {
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: result.error.message,
-          },
-        });
+    const result = await space.leave(auth);
+    if (result.isErr()) {
+      switch (result.error.code) {
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
+        case "user_not_member":
+        case "group_requirements_not_met":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: result.error.message,
+            },
+          });
+        case "unauthorized":
+        case "user_not_found":
+        case "system_or_global_group":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: result.error.message,
+            },
+          });
+        default:
+          assertNever(result.error.code);
       }
     }
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -19,7 +19,7 @@ app.post(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    const result = await space.leave(auth);
+    const result = await space.leavePod(auth);
     if (result.isErr()) {
       switch (result.error.code) {
         case "invalid_request_error":

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -284,7 +284,7 @@ export async function createAndTrackMembership({
 
   if (prevRevokedAt) {
     const restoredCount =
-      await GroupResource.restoreGroupMembershipsRevokedWith({
+      await GroupResource.dangerouslyRestoreGroupMembershipsRevokedWith({
         user,
         workspace: w,
         revokedAt: prevRevokedAt,

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -496,7 +496,8 @@ describe("GroupResource", () => {
       });
       expect(membership?.status).toBe("active");
 
-      const affectedUserIds = await regularGroup.suspendMembers(authenticator);
+      const affectedUserIds =
+        await regularGroup.dangerouslySuspendMembers(authenticator);
 
       expect(affectedUserIds).toContain(user.id);
 
@@ -524,7 +525,7 @@ describe("GroupResource", () => {
       const cacheKey = getCacheKeyForUser(user.id, workspace.id);
       expect(inMemoryCache.has(cacheKey)).toBe(true);
 
-      await regularGroup.suspendMembers(authenticator);
+      await regularGroup.dangerouslySuspendMembers(authenticator);
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
     });
@@ -541,7 +542,7 @@ describe("GroupResource", () => {
         users: [user.toJSON()],
       });
 
-      await regularGroup.suspendMembers(authenticator);
+      await regularGroup.dangerouslySuspendMembers(authenticator);
       const suspendedMembership = await GroupMembershipModel.findOne({
         where: {
           groupId: regularGroup.id,
@@ -551,7 +552,8 @@ describe("GroupResource", () => {
       });
       expect(suspendedMembership?.status).toBe("suspended");
 
-      const affectedUserIds = await regularGroup.restoreMembers(authenticator);
+      const affectedUserIds =
+        await regularGroup.dangerouslyRestoreMembers(authenticator);
 
       expect(affectedUserIds).toContain(user.id);
 
@@ -575,13 +577,13 @@ describe("GroupResource", () => {
         users: [user.toJSON()],
       });
 
-      await regularGroup.suspendMembers(authenticator);
+      await regularGroup.dangerouslySuspendMembers(authenticator);
 
       await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
       const cacheKey = getCacheKeyForUser(user.id, workspace.id);
       expect(inMemoryCache.has(cacheKey)).toBe(true);
 
-      await regularGroup.restoreMembers(authenticator);
+      await regularGroup.dangerouslyRestoreMembers(authenticator);
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
     });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1314,7 +1314,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    * query to the caller's group ids keeps this to a single row-bounded query
    * regardless of how many groups the workspace has.
    */
-  static async listGroupModelIdsByUserModelIdInWorkspace({
+  static async dangerouslyListGroupModelIdsByUserModelIdInWorkspace({
     workspace,
     userModelIds,
     groupModelIds,
@@ -1913,67 +1913,6 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
-   * Allows the authenticated user to leave the group.
-   *
-   * Unlike removeMembers(), this method does not require admin/editor permissions.
-   * Users can always remove themselves from groups they are members of.
-   *
-   * Only works for "regular_auto" groups.
-   * TODO(remy): Replace this with dangerouslyRemoveMembers once available
-   */
-  async leaveGroup(
-    auth: Authenticator,
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<
-    Result<undefined, DustError<"user_not_member" | "system_or_global_group">>
-  > {
-    const user = auth.getNonNullableUser();
-    const workspace = auth.getNonNullableWorkspace();
-
-    if (!this.isRegularAuto()) {
-      return new Err(
-        new DustError(
-          "system_or_global_group",
-          "Users can only leave regular groups."
-        )
-      );
-    }
-
-    const now = new Date();
-
-    const [updatedCount] = await GroupMembershipModel.update(
-      { endAt: now },
-      {
-        where: {
-          groupId: this.id,
-          userId: user.id,
-          workspaceId: workspace.id,
-          startAt: { [Op.lte]: now },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
-        },
-        transaction,
-      }
-    );
-
-    if (updatedCount === 0) {
-      return new Err(
-        new DustError("user_not_member", "User is not a member of this group.")
-      );
-    }
-
-    const userId = user.id;
-    const workspaceId = workspace.id;
-    invalidateCacheAfterCommit(transaction, async () => {
-      await GroupResource.invalidateGroupIdsCacheForUser({
-        user: { id: userId },
-        workspace: { id: workspaceId },
-      });
-    });
-
-    return new Ok(undefined);
-  }
-
-  /**
    * WARNING: Permissions are not checked inside this function and must be checked before calling it.
    */
   async dangerouslySetMembers(
@@ -2036,11 +1975,18 @@ export class GroupResource extends BaseResource<GroupModel> {
   /**
    * Suspends all active members of this group.
    * Returns array of affected user ModelIds.
+   *
+   * Only regular_auto group members can be suspended: it is how a space keeps its
+   * manual members on record while it runs in group management mode.
    */
-  async suspendMembers(
+  async dangerouslySuspendMembers(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<ModelId[]> {
+    assert(
+      this.isRegularAuto(),
+      `You can't suspend members of ${this.kind} groups.`
+    );
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const affectedMemberships = await GroupMembershipModel.findAll({
@@ -2098,7 +2044,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    *
    * Returns the number of group memberships restored.
    */
-  static async restoreGroupMembershipsRevokedWith({
+  static async dangerouslyRestoreGroupMembershipsRevokedWith({
     user,
     workspace,
     revokedAt,
@@ -2199,11 +2145,17 @@ export class GroupResource extends BaseResource<GroupModel> {
   /**
    * Restores all suspended members of this group.
    * Returns array of affected user ModelIds.
+   *
+   * Counterpart of `dangerouslySuspendMembers`, so regular_auto only.
    */
-  async restoreMembers(
+  async dangerouslyRestoreMembers(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<ModelId[]> {
+    assert(
+      this.isRegularAuto(),
+      `You can't restore members of ${this.kind} groups.`
+    );
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const affectedMemberships = await GroupMembershipModel.findAll({
@@ -2691,7 +2643,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
     });
 
-    return provisionedGroups;
+    const readableGroups = provisionedGroups.filter((group) =>
+      group.canRead(auth)
+    );
+
+    return readableGroups;
   }
 
   /**

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1313,6 +1313,10 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Users with no matching membership are absent from the map. Restricting the
    * query to the caller's group ids keeps this to a single row-bounded query
    * regardless of how many groups the workspace has.
+   *
+   * Dangerous: deliberately skips the `canRead` check on the groups — a space's
+   * grants mix regular_auto and non-regular_auto groups and the caller needs
+   * membership for both, so it authorizes the owning space instead.
    */
   static async dangerouslyListGroupModelIdsByUserModelIdInWorkspace({
     workspace,
@@ -1978,6 +1982,9 @@ export class GroupResource extends BaseResource<GroupModel> {
    *
    * Only regular_auto group members can be suspended: it is how a space keeps its
    * manual members on record while it runs in group management mode.
+   *
+   * Dangerous: no permission check — the owning space authorizes the
+   * management-mode switch.
    */
   async dangerouslySuspendMembers(
     auth: Authenticator,
@@ -2043,6 +2050,10 @@ export class GroupResource extends BaseResource<GroupModel> {
    * user already has an active membership.
    *
    * Returns the number of group memberships restored.
+   *
+   * Dangerous: deliberately skips the `canRead` check on the groups — it
+   * restores regular_auto memberships together with provisioned and manual
+   * ones, so no per-group check applies.
    */
   static async dangerouslyRestoreGroupMembershipsRevokedWith({
     user,
@@ -2146,7 +2157,9 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Restores all suspended members of this group.
    * Returns array of affected user ModelIds.
    *
-   * Counterpart of `dangerouslySuspendMembers`, so regular_auto only.
+   * Counterpart of `dangerouslySuspendMembers`, so regular_auto only, and
+   * dangerous for the same reason: no permission check, the owning space
+   * authorizes the switch.
    */
   async dangerouslyRestoreMembers(
     auth: Authenticator,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1714,7 +1714,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * always leave on their own. Projects only, as membership in the other space
    * kinds is not opt-out.
    */
-  async leave(
+  async leavePod(
     auth: Authenticator
   ): Promise<
     Result<

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1707,6 +1707,72 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new Ok(users);
   }
 
+  /**
+   * Removes the authenticated user from this space's auto-created groups.
+   *
+   * Unlike `removeMembers`, no admin permission is required: a member may
+   * always leave on their own. Projects only, as membership in the other space
+   * kinds is not opt-out.
+   */
+  async leave(
+    auth: Authenticator
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "invalid_request_error"
+        | "user_not_member"
+        | "group_requirements_not_met"
+        | "unauthorized"
+        | "user_not_found"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    if (!this.isProject()) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          "You can only leave Pods, not regular spaces."
+        )
+      );
+    }
+
+    if (!this.isMember(auth)) {
+      return new Err(
+        new DustError("user_not_member", "You are not a member of this Pod.")
+      );
+    }
+
+    const user = auth.getNonNullableUser();
+
+    const editorGroup = await this.fetchManualEditorGroup(auth);
+    if (editorGroup) {
+      const activeEditors = await editorGroup.getActiveMembers(auth);
+      if (activeEditors.length === 1 && activeEditors[0].sId === user.sId) {
+        return new Err(
+          new DustError(
+            "group_requirements_not_met",
+            "You cannot leave this Pod as you are the last editor. Please add another editor first."
+          )
+        );
+      }
+    }
+
+    const groups = await this.fetchRegularAutoGroups(auth);
+    for (const group of groups) {
+      const removeRes = await group.dangerouslyRemoveMember(auth, {
+        user: user.toJSON(),
+      });
+      // A member of the space is not necessarily one of its editors.
+      if (removeRes.isErr() && removeRes.error.code !== "user_not_member") {
+        return removeRes;
+      }
+    }
+
+    return new Ok(undefined);
+  }
+
   // The space's manual editor group (project spaces only): the regular_auto group holding the
   // `admin` grant on this space in `group_permissions`. Read from `group_permissions` rather than
   // `group_vaults` (being removed). Returns null for non-project spaces and for provisioned mode,
@@ -1925,7 +1991,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // For each user, the groups they are an active member of among the spaces' grant groups. One
     // query, whatever the number of users and spaces.
     const groupModelIdsByUser =
-      await GroupResource.listGroupModelIdsByUserModelIdInWorkspace({
+      await GroupResource.dangerouslyListGroupModelIdsByUserModelIdInWorkspace({
         workspace,
         userModelIds,
         groupModelIds: [...new Set(grants.map((grant) => grant.groupId))],
@@ -2337,7 +2403,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const groups = await this.fetchRegularAutoGroups(auth, transaction);
 
     for (const group of groups) {
-      await group.suspendMembers(auth, { transaction });
+      await group.dangerouslySuspendMembers(auth, { transaction });
     }
   }
 
@@ -2351,7 +2417,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const groups = await this.fetchRegularAutoGroups(auth, transaction);
 
     for (const group of groups) {
-      await group.restoreMembers(auth, { transaction });
+      await group.dangerouslyRestoreMembers(auth, { transaction });
     }
   }
 

--- a/front/migrations/20260828_restore_skill_editor_memberships.ts
+++ b/front/migrations/20260828_restore_skill_editor_memberships.ts
@@ -125,7 +125,7 @@ async function restoreWorkspaceSkillEditors(
       continue;
     }
 
-    const restoredUserIds = await group.restoreMembers(auth);
+    const restoredUserIds = await group.dangerouslyRestoreMembers(auth);
     membershipsRestored += restoredUserIds.length;
 
     logger.info(


### PR DESCRIPTION
## Description

This PR centralizes project leave behavior in `SpaceResource.leave`, makes group membership operations explicitly privileged through `dangerously*` methods, and filters provisioned groups by `canRead` before returning them.

## Tests

Manually.

## Risks
Low. Same behavior is mantained.

## Deploy Plan

Standard deployment.