### PR TITLE
dust-hive: add more data to governance seed

### DIFF
--- a/front/scripts/seed/factories/seedAgent.ts
+++ b/front/scripts/seed/factories/seedAgent.ts
@@ -1,7 +1,5 @@
-import {
-  createAgentConfiguration,
-  searchAgentConfigurationsByName,
-} from "@app/lib/api/assistant/configuration/agent";
+import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -27,11 +25,17 @@ export async function seedAgent(
   const { auth, user, execute, logger } = ctx;
   const { skills = [], additionalEditors = [], owner, spaces = [] } = options;
 
-  const existingAgents = await searchAgentConfigurationsByName(
-    auth,
-    agentAsset.name
-  );
-  const existingAgent = existingAgents.find((a) => a.name === agentAsset.name);
+  // Looked up on the model rather than through the context user's view: seeded agents may be
+  // unpublished or require spaces the context user is not a member of, and a re-run must still
+  // find them (agent names are unique among a workspace's active agents).
+  const existingAgent = await AgentConfigurationModel.findOne({
+    attributes: ["sId"],
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      name: agentAsset.name,
+      status: "active",
+    },
+  });
 
   if (existingAgent) {
     logger.info(

--- a/front/scripts/seed/governance/assets/agents.json
+++ b/front/scripts/seed/governance/assets/agents.json
@@ -17,5 +17,12 @@
     "description": "Alfred's published agent, restricted to a space the current user cannot access.",
     "instructions": "You answer questions using the documents of the private space.",
     "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+  },
+  "alfredUnpublishedPrivateSpaceAgent": {
+    "name": "AlfredVaultDraft",
+    "description": "Alfred's unpublished agent, restricted to a space the current user cannot access.",
+    "instructions": "You are Alfred's work in progress agent over the documents of the private space.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png",
+    "scope": "hidden"
   }
 }

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -111,6 +111,11 @@ describe("governance seed script integration test", () => {
       assets.agents.alfredPrivateSpaceAgent,
       { owner: alfred, spaces: privateSpace ? [privateSpace] : [] }
     );
+    const alfredUnpublishedPrivateSpaceAgent = await seedAgent(
+      ctx,
+      assets.agents.alfredUnpublishedPrivateSpaceAgent,
+      { owner: alfred, spaces: privateSpace ? [privateSpace] : [] }
+    );
 
     // The groups hold the expected members, with the expected kinds.
     for (const [name, kind, expectedMembers] of [
@@ -184,10 +189,12 @@ describe("governance seed script integration test", () => {
       new Set([alfred!.sId])
     );
 
-    // Alfred's two agents are authored by Alfred, unpublished for the first one and requiring the
-    // private space for the second one. Neither shows up in the current user's list view.
+    // Alfred's three agents are authored by Alfred: unpublished for the first one, requiring the
+    // private space for the second one, and both for the third one. None shows up in the current
+    // user's list view.
     expect(alfredUnpublishedAgent).toBeDefined();
     expect(alfredPrivateSpaceAgent).toBeDefined();
+    expect(alfredUnpublishedPrivateSpaceAgent).toBeDefined();
 
     const alfredAuth = await Authenticator.fromUserIdAndWorkspaceId(
       alfred!.sId,
@@ -207,6 +214,21 @@ describe("governance seed script integration test", () => {
     expect(privateSpaceConfiguration!.scope).toBe("visible");
     expect(privateSpaceConfiguration!.versionAuthorId).toBe(alfred!.id);
     expect(privateSpaceConfiguration!.requestedSpaceIds).toEqual([
+      privateSpace!.sId,
+    ]);
+
+    const unpublishedPrivateSpaceConfiguration = await getAgentConfiguration(
+      alfredAuth,
+      {
+        agentId: alfredUnpublishedPrivateSpaceAgent!.sId,
+        variant: "light",
+      }
+    );
+    expect(unpublishedPrivateSpaceConfiguration!.scope).toBe("hidden");
+    expect(unpublishedPrivateSpaceConfiguration!.versionAuthorId).toBe(
+      alfred!.id
+    );
+    expect(unpublishedPrivateSpaceConfiguration!.requestedSpaceIds).toEqual([
       privateSpace!.sId,
     ]);
   });

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -22,6 +22,7 @@ export interface Assets {
     incidentReporter: AgentAsset;
     alfredUnpublishedAgent: AgentAsset;
     alfredPrivateSpaceAgent: AgentAsset;
+    alfredUnpublishedPrivateSpaceAgent: AgentAsset;
   };
   users: UserAsset[];
   skills: {
@@ -118,9 +119,10 @@ makeScript({}, async ({ execute }, logger) => {
     spaces: restrictedSpace ? [restrictedSpace] : [],
   });
 
-  // 6. Create an agent edited by the current user that uses Alfred's unpublished skill, plus two
+  // 6. Create an agent edited by the current user that uses Alfred's unpublished skill, plus three
   // agents owned by Alfred that the current user does not see: an unpublished one they do not
-  // edit, and a published one requiring the private space they are not a member of.
+  // edit, a published one requiring the private space they are not a member of, and an unpublished
+  // one requiring that same space (both restrictions at once).
   logger.info("Seeding agents...");
   await seedAgent(ctx, agents.incidentReporter, {
     skills: alfredSkill ? [alfredSkill] : [],
@@ -129,6 +131,11 @@ makeScript({}, async ({ execute }, logger) => {
   await seedAgent(ctx, agents.alfredUnpublishedAgent, { owner: alfred });
   logger.info("Seeding Alfred's private space agent...");
   await seedAgent(ctx, agents.alfredPrivateSpaceAgent, {
+    owner: alfred,
+    spaces: privateSpace ? [privateSpace] : [],
+  });
+  logger.info("Seeding Alfred's unpublished private space agent...");
+  await seedAgent(ctx, agents.alfredUnpublishedPrivateSpaceAgent, {
     owner: alfred,
     spaces: privateSpace ? [privateSpace] : [],
   });


### PR DESCRIPTION
## Description

 - Add a new unpublished agent with restricted space
 - make seed idempotent by correctly checking if the agent exists

## Tests

 - udpated seed.test
 - tested locally

## Risk

low

## Deploy Plan

none
