### PR TITLE
Fix duplicate Frame package switch case

### DIFF
--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -126,7 +126,6 @@ export function FileExplorerContent({
         );
 
       case "folder":
-      case "frame_package":
         return null;
 
       default:


### PR DESCRIPTION
## Description

Remove the duplicate, unreachable `frame_package` switch case that triggers a Vite duplicate-case warning.

## Tests

Ran the focused FileExplorer component test locally (4/4).

## Risk

Low. The remaining `frame_package` branch already renders the package card.

## Deploy Plan

Standard deploy.