### PR TITLE
dust-hive: use predefined models and droid avatars in seeds

### DIFF
--- a/front/scripts/seed/basics/assets/agent.json
+++ b/front/scripts/seed/basics/assets/agent.json
@@ -1,19 +1,26 @@
-[{
-  "name": "HaikuPoet",
-  "description": "A creative agent that writes haikus based on your message topic",
-  "instructions": "You are a creative haiku poet. When the user sends you a message, identify the main topic or theme and respond with a beautiful haiku (5-7-5 syllable pattern) that captures the essence of that topic. Always explain briefly what inspired your haiku.",
-  "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
-},
- {
+[
+  {
+    "name": "HaikuPoet",
+    "description": "A creative agent that writes haikus based on your message topic",
+    "instructions": "You are a creative haiku poet. When the user sends you a message, identify the main topic or theme and respond with a beautiful haiku (5-7-5 syllable pattern) that captures the essence of that topic. Always explain briefly what inspired your haiku.",
+    "pictureUrl": "https://dust.tt/static/droidavatar/Droid_Indigo_1.jpg"
+  },
+  {
     "name": "Soupinou",
     "description": "Very cute yet not super helpful assistant. Mostly sounds like a cat.",
     "instructions": "You are a very cute black cat.",
-    "pictureUrl": "https://dust.tt/static/systemavatar/helper_avatar_full.png"
+    "pictureUrl": "https://dust.tt/static/systemavatar/helper_avatar_full.png",
+    "model": "basic"
   },
   {
     "name": "CityInfo",
     "description": "Returns structured city information as JSON for any given city",
     "instructions": "You are a city information assistant. When the user mentions a city, respond with structured JSON containing the city's details: country, state (if applicable, null otherwise), city name, and zip/postal code.",
-    "pictureUrl": "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
-    "responseFormat": "{\"type\":\"json_schema\",\"json_schema\":{\"name\":\"city_info\",\"schema\":{\"type\":\"object\",\"properties\":{\"country\":{\"type\":\"string\"},\"state\":{\"type\":[\"string\",\"null\"]},\"city\":{\"type\":\"string\"},\"zipcode\":{\"type\":\"string\"}},\"required\":[\"country\",\"state\",\"city\",\"zipcode\"],\"additionalProperties\":false}}}"
-  }]
+    "pictureUrl": "https://dust.tt/static/droidavatar/Droid_Teal_2.jpg",
+    "responseFormat": "{\"type\":\"json_schema\",\"json_schema\":{\"name\":\"city_info\",\"schema\":{\"type\":\"object\",\"properties\":{\"country\":{\"type\":\"string\"},\"state\":{\"type\":[\"string\",\"null\"]},\"city\":{\"type\":\"string\"},\"zipcode\":{\"type\":\"string\"}},\"required\":[\"country\",\"state\",\"city\",\"zipcode\"],\"additionalProperties\":false}}}",
+    "model": {
+      "providerId": "anthropic",
+      "modelId": "claude-sonnet-5"
+    }
+  }
+]

--- a/front/scripts/seed/factories/seedAgent.ts
+++ b/front/scripts/seed/factories/seedAgent.ts
@@ -3,8 +3,19 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
+import {
+  AUTO_COMPLEX_MODEL_ID,
+  AUTO_FAST_MODEL_ID,
+  AUTO_MODEL_ID,
+} from "@app/types/assistant/models/auto";
 
-import type { AgentAsset, CreatedAgent, SeedContext } from "./types";
+import type {
+  AgentAsset,
+  AgentAssetModel,
+  CreatedAgent,
+  SeedContext,
+} from "./types";
 
 interface SeedAgentOptions {
   skills?: SkillResource[];
@@ -15,6 +26,36 @@ interface SeedAgentOptions {
   // Spaces the agent requires access to. Users who are not members of these spaces do not see
   // the agent at all.
   spaces?: SpaceResource[];
+}
+
+function resolveModel(
+  model: AgentAssetModel = "standard"
+): Pick<
+  AgentModelConfigurationType,
+  "providerId" | "modelId" | "reasoningEffort"
+> {
+  switch (model) {
+    case "basic":
+      return {
+        providerId: AUTO_FAST_MODEL_ID,
+        modelId: AUTO_FAST_MODEL_ID,
+        reasoningEffort: "none",
+      };
+    case "standard":
+      return {
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+        reasoningEffort: "none",
+      };
+    case "premium":
+      return {
+        providerId: AUTO_COMPLEX_MODEL_ID,
+        modelId: AUTO_COMPLEX_MODEL_ID,
+        reasoningEffort: "none",
+      };
+    default:
+      return model;
+  }
 }
 
 export async function seedAgent(
@@ -68,8 +109,7 @@ export async function seedAgent(
       status: "active",
       scope: agentAsset.scope ?? "visible",
       model: {
-        providerId: "anthropic",
-        modelId: "claude-sonnet-4-6",
+        ...resolveModel(agentAsset.model),
         temperature: 0.7,
         responseFormat: agentAsset.responseFormat,
       },

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -2,6 +2,10 @@ import type { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
 import type { AgentSuggestionData } from "@app/types/suggestions/agent_suggestion";
@@ -25,7 +29,16 @@ export interface AgentAsset {
   responseFormat?: string;
   // Defaults to "visible" (published). "hidden" makes the agent visible to its editors only.
   scope?: Exclude<AgentConfigurationScope, "global">;
+  // Either a predefined model (resolved to a concrete model at message time) or a pinned model.
+  // Defaults to "standard".
+  model?: AgentAssetModel;
 }
+
+export type AgentAssetModel =
+  | "basic"
+  | "standard"
+  | "premium"
+  | { providerId: ModelProviderIdType; modelId: ModelIdType };
 
 export interface UserAsset {
   sId: string;

--- a/front/scripts/seed/governance/assets/agents.json
+++ b/front/scripts/seed/governance/assets/agents.json
@@ -3,26 +3,27 @@
     "name": "IncidentReporter",
     "description": "Writes incident postmortems from raw notes.",
     "instructions": "You help engineers turn their raw incident notes into a clean postmortem. Follow the Incident Postmortem skill for the structure of the document.",
-    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+    "pictureUrl": "https://dust.tt/static/droidavatar/Droid_Red_3.jpg",
+    "model": "premium"
   },
   "alfredUnpublishedAgent": {
     "name": "AlfredDraft",
     "description": "Alfred's unpublished agent, only visible to its editors.",
     "instructions": "You are Alfred's work in progress agent. You answer questions about the Wayne Manor operations.",
-    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png",
+    "pictureUrl": "https://dust.tt/static/droidavatar/Droid_Yellow_4.jpg",
     "scope": "hidden"
   },
   "alfredPrivateSpaceAgent": {
     "name": "AlfredVault",
     "description": "Alfred's published agent, restricted to a space the current user cannot access.",
     "instructions": "You answer questions using the documents of the private space.",
-    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+    "pictureUrl": "https://dust.tt/static/droidavatar/Droid_Purple_5.jpg"
   },
   "alfredUnpublishedPrivateSpaceAgent": {
     "name": "AlfredVaultDraft",
     "description": "Alfred's unpublished agent, restricted to a space the current user cannot access.",
     "instructions": "You are Alfred's work in progress agent over the documents of the private space.",
-    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png",
+    "pictureUrl": "https://dust.tt/static/droidavatar/Droid_Green_7.jpg",
     "scope": "hidden"
   }
 }

--- a/front/scripts/seed/inactivity/seedInactivity.ts
+++ b/front/scripts/seed/inactivity/seedInactivity.ts
@@ -21,31 +21,35 @@ import {
 /** Old enough to sit well before any cutoff the allowed thresholds can produce. */
 const LONG_AGO = new Date(Date.now() - 90 * ONE_DAY_MS);
 
-const PICTURE_URL =
-  "https://dust.tt/static/systemavatar/claude_avatar_full.png";
-
-function agentAsset(name: string, description: string): AgentAsset {
+function agentAsset(
+  name: string,
+  description: string,
+  // Droid avatar variant (1 to 8), so each seeded agent gets a different picture.
+  avatarNumber: number
+): AgentAsset {
   return {
     name,
     description,
     instructions: `You are ${name}, seeded to exercise inactive-agent archival.`,
-    pictureUrl: PICTURE_URL,
+    pictureUrl: `https://dust.tt/static/droidavatar/Droid_Sky_${avatarNumber}.jpg`,
   };
 }
 
 // At a 30-day threshold: "Idle Agent" and "Edited Agent" are archivable, the other three are each
 // spared by a different rule.
 const AGENTS: AgentAsset[] = [
-  agentAsset("Idle Agent", "Old and never mentioned: archivable."),
-  agentAsset("Recently Used Agent", "Old but mentioned yesterday."),
+  agentAsset("Idle Agent", "Old and never mentioned: archivable.", 1),
+  agentAsset("Recently Used Agent", "Old but mentioned yesterday.", 2),
   agentAsset(
     "Scheduled Agent",
-    "Old and unmentioned, but a schedule drives it."
+    "Old and unmentioned, but a schedule drives it.",
+    3
   ),
-  agentAsset("Fresh Agent", "Created today, so too young to be disused."),
+  agentAsset("Fresh Agent", "Created today, so too young to be disused.", 4),
   agentAsset(
     "Edited Agent",
-    "First version is old; editing must not postpone archival."
+    "First version is old; editing must not postpone archival.",
+    5
   ),
 ];
 


### PR DESCRIPTION
## Description

Seeded agents were all pinned to Claude Sonnet 4.6 and shared a handful of system avatars.

- Agent seed assets accept an optional `model`: `basic`, `standard`, `premium` (the `auto_fast` / `auto` / `auto_complex` streams) or a pinned `{ providerId, modelId }`. Defaults to `standard`.
- Hardcoded agents get distinct droid avatars

## Tests

 - seed.test.ts still works
 - manually seeded basics and governance locally

## Risk

Low. Dev seed scripts only.

## Deploy Plan

- Nothing to deploy