### PR TITLE
Add service_tier dimension to LLM latency metrics

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -14,6 +14,7 @@ import {
   emitLLMTimeToFirstTokenMs,
   llmAttemptLogFields,
   requestedReasoningEffortTag,
+  serviceTierTags,
 } from "@app/lib/api/llm/telemetry";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
@@ -46,6 +47,7 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
 import { getUsageType } from "@app/lib/metronome/events";
 import type { UsageType } from "@app/lib/metronome/types";
+import type { ServiceTier } from "@app/lib/model_constructors/types/input/configuration";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { statsDMetrics } from "@app/lib/utils/statsd";
@@ -172,29 +174,41 @@ export abstract class LLM<
     ];
   }
 
+  // Latency tags additionally carry the requested reasoning effort and the
+  // processing tier the provider billed, so llm_duration_ms,
+  // llm_time_to_first_event_ms and llm_time_to_first_token_ms can be compared
+  // across service tiers (for example flex versus default) on the same model.
   private getLatencyTelemetryTags({
+    serviceTier,
     surface,
   }: {
+    serviceTier: ServiceTier | undefined;
     surface: "stream" | "batch";
   }): string[] {
     return [
       ...this.getTelemetryTags({ surface }),
       requestedReasoningEffortTag(this.reasoningEffort),
+      ...serviceTierTags(serviceTier),
     ];
   }
 
   private emitStreamAttemptTelemetry({
     durationMs,
+    serviceTier,
     timeToFirstEventMs,
     timeToFirstTokenMs,
     ...outcomeTelemetry
   }: {
     durationMs: number;
+    serviceTier: ServiceTier | undefined;
     timeToFirstEventMs: number | undefined;
     timeToFirstTokenMs: number | undefined;
   } & LLMAttemptOutcomeTelemetry): void {
     const baseTags = this.getTelemetryTags({ surface: "stream" });
-    const latencyTags = this.getLatencyTelemetryTags({ surface: "stream" });
+    const latencyTags = this.getLatencyTelemetryTags({
+      serviceTier,
+      surface: "stream",
+    });
 
     switch (outcomeTelemetry.outcome) {
       case "error":
@@ -341,9 +355,7 @@ export abstract class LLM<
         if (currentEvent.type === "token_usage") {
           emitTokenUsageMetrics(currentEvent.content, [
             ...metricTags,
-            ...(currentEvent.content.serviceTier
-              ? [`service_tier:${currentEvent.content.serviceTier}`]
-              : []),
+            ...serviceTierTags(currentEvent.content.serviceTier),
           ]);
         }
 
@@ -373,6 +385,7 @@ export abstract class LLM<
           timeToFirstEventMs,
           timeToFirstTokenMs,
           requestedReasoningEffort: this.reasoningEffort,
+          serviceTier: tokenUsage?.serviceTier,
           surface: "stream",
         });
 
@@ -383,6 +396,7 @@ export abstract class LLM<
           this.emitStreamAttemptTelemetry({
             outcome: "error",
             durationMs,
+            serviceTier: tokenUsage?.serviceTier,
             timeToFirstEventMs,
             timeToFirstTokenMs,
             errorType,
@@ -422,6 +436,7 @@ export abstract class LLM<
           this.emitStreamAttemptTelemetry({
             outcome,
             durationMs,
+            serviceTier: tokenUsage?.serviceTier,
             timeToFirstEventMs,
             timeToFirstTokenMs,
           });
@@ -762,7 +777,10 @@ export abstract class LLM<
         buffer.addEvent(event);
 
         if (event.type === "token_usage") {
-          emitTokenUsageMetrics(event.content, metricTags);
+          emitTokenUsageMetrics(event.content, [
+            ...metricTags,
+            ...serviceTierTags(event.content.serviceTier),
+          ]);
         }
 
         if (event.type === "error") {

--- a/front/lib/api/llm/telemetry.ts
+++ b/front/lib/api/llm/telemetry.ts
@@ -3,6 +3,7 @@
  * the same normalized values so their dimensions cannot drift.
  */
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
+import type { ServiceTier } from "@app/lib/model_constructors/types/input/configuration";
 import type { ErrorSource } from "@app/lib/model_constructors/types/output/events";
 import { statsDMetrics } from "@app/lib/utils/statsd";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
@@ -25,6 +26,15 @@ export function requestedReasoningEffortTag(
   requestedReasoningEffort: ReasoningEffort | null
 ): string {
   return `requested_reasoning_effort:${requestedReasoningEffort ?? "none"}`;
+}
+
+// The processing tier the provider reports having billed the response at. Only
+// tagged when the provider reports one, so series for providers that never
+// report a tier are left untouched.
+export function serviceTierTags(
+  serviceTier: ServiceTier | undefined
+): string[] {
+  return serviceTier ? [`service_tier:${serviceTier}`] : [];
 }
 
 export function emitLLMDurationMs({
@@ -89,24 +99,28 @@ export function llmAttemptLogFields({
   timeToFirstEventMs,
   timeToFirstTokenMs,
   requestedReasoningEffort,
+  serviceTier,
   surface,
 }: {
   durationMs?: number;
   timeToFirstEventMs?: number;
   timeToFirstTokenMs?: number;
   requestedReasoningEffort: ReasoningEffort | null;
+  serviceTier?: ServiceTier;
   surface: LLMTelemetrySurface;
 }): {
   durationMs?: number;
   timeToFirstEventMs?: number;
   timeToFirstTokenMs?: number;
   requestedReasoningEffort: ReasoningEffort | null;
+  serviceTier?: ServiceTier;
   surface: LLMTelemetrySurface;
 } {
   return {
     ...(durationMs !== undefined ? { durationMs } : {}),
     ...(timeToFirstEventMs !== undefined ? { timeToFirstEventMs } : {}),
     ...(timeToFirstTokenMs !== undefined ? { timeToFirstTokenMs } : {}),
+    ...(serviceTier !== undefined ? { serviceTier } : {}),
     requestedReasoningEffort,
     surface,
   };


### PR DESCRIPTION
## Description

Adds the provider-reported `service_tier` as a dimension on the LLM latency metrics, so flex and default processing can be compared on the same model.

Context: `openai_flex_processing` has been enabled on our workspace since 2026-08-28 and is working (14,335 flex-served runs across 935 agent messages, exactly 50% billing factor, 4 fallbacks total, 0 timeouts). But its latency impact is currently unmeasurable in Datadog. `service_tier` was only added to `emitTokenUsageMetrics`, so `llm_duration_ms`, `llm_time_to_first_event_ms` and `llm_time_to_first_token_ms` pool flex and default into the same series. Because the flag is `dust_only`, flex is ~1.6% of the trigger pool's OpenAI calls, so nothing short of a 6x regression would be visible at that aggregation.

Changes:

- `telemetry.ts`: new `serviceTierTags()` helper, alongside the existing `requestedReasoningEffortTag()`. It emits `service_tier:<tier>` only when the provider reports one, so series for providers that never report a tier are untouched.
- `telemetry.ts`: `llmAttemptLogFields()` accepts an optional `serviceTier`, keeping metrics and structured logs on the same normalized values as the file header requires.
- `llm.ts`: `getLatencyTelemetryTags()` takes the reported tier and appends the tag; `emitStreamAttemptTelemetry()` threads it through from `buffer.currentOutput.tokenUsage`, which is already destructured at both emit sites.
- `llm.ts`: the inline tag construction at the stream `token_usage` site now uses the shared helper (behavior-identical refactor), and the batch `token_usage` site gets the same tag, which it was previously missing.

No UI changes.

## Tests

No local validation was run in the Computer: the clone is a shallow sparse checkout without `node_modules`, so `tsc`, `eslint` and the test suite could not run. Validation is delegated to PR CI.

What was checked locally:

- `git diff` reviewed line by line; `git diff --check` clean.
- Confirmed `ServiceTier` is exported from `@app/lib/model_constructors/types/input/configuration` and that `TokenUsage.serviceTier` is `ServiceTier | undefined`, matching the new parameter types.
- Confirmed all three `getLatencyTelemetryTags` / `emitStreamAttemptTelemetry` call sites were updated, and that the two existing `llmAttemptLogFields` callers still typecheck by construction (the new field is optional).
- Verified no added line exceeds the 80 column print width.

Suggested post-deploy verification: `avg:llm_duration_ms{provider_id:openai,service_tier:flex}` vs `{service_tier:default}` grouped by `model_id`, scoped to `kube_deployment:front-agent-loop-schedules-worker-deployment`.

## Risk

Low. Telemetry only, no behavioral change to inference, routing, pricing or the flex fallback path.

The one real consequence is a metric series split. Adding a tag to `llm_duration_ms`, `llm_time_to_first_event_ms` and `llm_time_to_first_token_ms` splits their existing series for providers that report a tier, i.e. OpenAI Responses. The counter metrics `llm_interaction.count`, `llm_success.count` and `llm_error.count` are deliberately left alone: only `getLatencyTelemetryTags` changed, not `getTelemetryTags`.

Practical impact:

- Space aggregations (`avg:`, `sum:`) across the whole metric are unaffected.
- Existing dashboards or monitors that group `llm_duration_ms` by tag will see OpenAI rows split into `flex` and `default` from the deploy onward.
- Anthropic and other providers that do not report a tier emit no new tag, so their series are unchanged.
- Custom metric tag configuration may need `service_tier` allowed on the latency metrics for group-by to work, as is already the case on `llm_usage.*`.

Safe to roll back: reverting restores the previous tag set, at the cost of another series split at revert time.

## Deploy Plan

Standard `front` deploy, no migration, no config or feature flag needed. Order does not matter and it can ship with any other change.

After deploy, confirm `llm_duration_ms` reports both `service_tier:flex` and `service_tier:default` on OpenAI, then let it run a week to get a clean flex-versus-default latency read on `openai_flex_processing` before deciding whether to widen the flag beyond `dust_only`.
