### PR TITLE
Rename connected data button to Edit when space already has data

### DIFF
--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -348,16 +348,14 @@ export function EditSpaceManagedDataSourcesViews({
   }
 
   const hasExistingData = filteredDataSourceViews.length > 0;
+  const actionVerb = hasExistingData ? "Edit" : "Add";
+  const label = dataSourceView
+    ? `${actionVerb} data from ${getDisplayNameForDataSource(dataSourceView.dataSource)}`
+    : `${actionVerb} data from connections`;
 
   const addToSpaceButton = (
     <Button
-      label={
-        dataSourceView
-          ? `Add data from ${getDisplayNameForDataSource(dataSourceView.dataSource)}`
-          : hasExistingData
-            ? "Edit data from connections"
-            : "Add data from connections"
-      }
+      label={label}
       variant="primary"
       icon={hasExistingData ? Edit04 : Plus}
       size="sm"

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -34,6 +34,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Edit04,
   InfoCircle,
   Plus,
   Tooltip,
@@ -346,15 +347,19 @@ export function EditSpaceManagedDataSourcesViews({
     );
   }
 
+  const hasExistingData = filteredDataSourceViews.length > 0;
+
   const addToSpaceButton = (
     <Button
       label={
         dataSourceView
           ? `Add data from ${getDisplayNameForDataSource(dataSourceView.dataSource)}`
-          : "Add data from connections"
+          : hasExistingData
+            ? "Edit data from connections"
+            : "Add data from connections"
       }
       variant="primary"
-      icon={Plus}
+      icon={hasExistingData ? Edit04 : Plus}
       size="sm"
       onClick={() => {
         openAddDataModal();


### PR DESCRIPTION
## Description

**Context:**
I wanted to remove some Connections from my Space and couldn't find how. Turns out the solution was to click on "Add data from connections".

<img width="1247" height="311" alt="Screenshot 2026-09-03 at 13 13 03" src="https://github.com/user-attachments/assets/3ebec9f8-afb1-48b4-85ba-4db634bbd1dc" />

**Fix:** 
On a space's Connected Data page, the primary button always read "Add data from connections", even when the space already had connections selected. 
It now reads "Edit data from connections" (with the edit icon) when the space has existing connected data, and keeps "Add" otherwise. The pod-owned `dust_project` source is not counted as existing data.

<img width="1252" height="276" alt="Screenshot 2026-09-03 at 13 13 08" src="https://github.com/user-attachments/assets/73c628e8-61d6-4577-b2d5-6d613664d5d2" />

## Tests

Manual, on a space with and without connected data. `tsgo` and biome pass.
Ex here: https://app.dust.tt/w/0ec9852c2f/spaces/vlt_CvSgrQ4iZlNf/categories/managed#?viewType=all
Versus here: https://pr-31777-merge--app.preview.dust.tt/w/0ec9852c2f/spaces/vlt_CvSgrQ4iZlNf/categories/managed#?viewType=all

(You can edit on my Restricted space to test 👍🏻 )

## Risk

Low, label and icon only.

## Deploy Plan

Deploy front.