### PR TITLE
[front] Frames v2: rename Frames from the file explorer

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -11,6 +11,8 @@ import {
   WriteCanonicalFileContentError,
   writeCanonicalFileContent,
 } from "@app/lib/api/files/file_system_ops";
+import type { FrameSourceMoveError } from "@app/lib/api/frames/move_source_paths";
+import { isFrameSourceMoveError } from "@app/lib/api/frames/move_source_paths";
 import { requestDustProjectIncrementalSyncForScopedPath } from "@app/lib/api/projects/request_incremental_sync";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
@@ -389,7 +391,12 @@ app.patch(
           data.fileName
         );
         if (renameResult.isErr()) {
-          return apiError(ctx, mapDustFsError(renameResult.error));
+          return apiError(
+            ctx,
+            isFrameSourceMoveError(renameResult.error)
+              ? mapFrameSourceMoveError(renameResult.error)
+              : mapDustFsError(renameResult.error)
+          );
         }
         break;
       }
@@ -525,6 +532,32 @@ app.delete(
     return new Response(null, { status: 204 });
   }
 );
+
+function mapFrameSourceMoveError(err: FrameSourceMoveError) {
+  switch (err.code) {
+    case "invalid_source":
+      return {
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: err.message },
+      } as const;
+
+    case "conflict":
+      return {
+        status_code: 409,
+        api_error: { type: "invalid_request_error", message: err.message },
+      } as const;
+
+    case "copy_failed":
+    case "commit_failed":
+      return {
+        status_code: 500,
+        api_error: { type: "internal_server_error", message: err.message },
+      } as const;
+
+    default:
+      assertNever(err.code);
+  }
+}
 
 function mapDustFsError(err: DustFileSystemError) {
   switch (err.code) {

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -1,13 +1,20 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { ConfirmContext } from "@app/components/Confirm";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
+import type { RenameMountItem } from "@app/components/file_explorer/RenameFileDialog";
+import { RenameFileDialog } from "@app/components/file_explorer/RenameFileDialog";
 import type {
   FileEntry,
   FileExplorerEntry,
   FileExplorerPathEntry,
+  FolderEntry,
+  FramePackageEntry,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
-import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
+import {
+  getParentFolderRelativePath,
+  withVirtualExplorerPath,
+} from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
@@ -23,7 +30,7 @@ import { isPodConversation } from "@app/types/assistant/conversation";
 import { opensInSidePanel } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, XClose } from "@dust-tt/sparkle";
-import { useCallback, useContext, useMemo } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 const POD_CONVERSATION_SCOPE_ROOTS = ["conversation", "pod"] as const;
 
@@ -46,6 +53,9 @@ export function ConversationFileExplorer({
   const isPod = isPodConversation(conversation);
 
   const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
+  const [frameToRename, setFrameToRename] = useState<RenameMountItem | null>(
+    null
+  );
 
   const { sandboxFiles, isSandboxFilesLoading, mutateSandboxFiles } =
     useConversationSandboxFiles({
@@ -133,6 +143,27 @@ export function ConversationFileExplorer({
     [confirm, deleteFileByPath, mutatePodFiles, mutateSandboxFiles]
   );
 
+  // Only Frame packages get a Rename item here (see `canRename`), matching Delete.
+  const onRename = useCallback(
+    (entry: FileEntry | FolderEntry | FramePackageEntry) => {
+      if (entry.kind !== "frame_package") {
+        return;
+      }
+      // The package entry carries the manifest path; the Frame is renamed through its source
+      // folder, which the server moves as a whole.
+      setFrameToRename({
+        kind: "frame",
+        path: getParentFolderRelativePath(entry.path),
+        name: entry.fileName,
+      });
+    },
+    []
+  );
+
+  const onFrameRenamed = useCallback(() => {
+    void Promise.all([mutateSandboxFiles(), mutatePodFiles()]);
+  }, [mutatePodFiles, mutateSandboxFiles]);
+
   return (
     <div className="flex h-panel min-h-0 flex-col">
       <AppLayoutTitle>
@@ -165,6 +196,8 @@ export function ConversationFileExplorer({
           onCurrentFolderChange={setCurrentFolderPath}
           onDelete={hasFeature("frames_v2") ? onDelete : undefined}
           canDelete={isFramePackageEntry}
+          onRename={hasFeature("frames_v2") ? onRename : undefined}
+          canRename={isFramePackageEntry}
           onFileDownload={onFileDownload}
           onOpenInteractive={onOpenInteractive}
           onOpenInPanel={onOpenInPanel}
@@ -172,6 +205,14 @@ export function ConversationFileExplorer({
           virtualScopeRoots={isPod ? POD_CONVERSATION_SCOPE_ROOTS : undefined}
         />
       </div>
+
+      <RenameFileDialog
+        isOpen={frameToRename !== null}
+        onClose={() => setFrameToRename(null)}
+        onRenamed={onFrameRenamed}
+        owner={owner}
+        item={frameToRename}
+      />
     </div>
   );
 }

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -59,7 +59,9 @@ interface FileExplorerProps {
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId | FramePackageEntry) => void;
   onOpenInPanel?: (entry: FileEntry) => boolean;
-  onRename?: (entry: FileEntry | FolderEntry) => void;
+  onRename?: (entry: FileEntry | FolderEntry | FramePackageEntry) => void;
+  /** Restricts which entries get a Rename item when `onRename` is set; all of them by default. */
+  canRename?: (entry: FileExplorerEntry) => boolean;
   owner?: LightWorkspaceType;
   getExtraFileMenuItems?: (
     entry: FileExplorerEntry
@@ -88,6 +90,7 @@ export function FileExplorer({
   onOpenInteractive,
   onOpenInPanel,
   onRename,
+  canRename,
   owner,
   getExtraFileMenuItems,
   virtualScopeRoots,
@@ -154,6 +157,16 @@ export function FileExplorer({
             setActiveFilter("all");
           },
         });
+        if (onRename && (canRename?.(entry) ?? true)) {
+          items.push({
+            label: "Rename",
+            icon: Edit04,
+            onClick: (e) => {
+              e.stopPropagation();
+              onRename(entry);
+            },
+          });
+        }
         if (onDelete && (canDelete?.(entry) ?? true)) {
           items.push({
             label: "Delete",
@@ -167,7 +180,11 @@ export function FileExplorer({
         }
         return items;
       }
-      if (onRename && (entry.kind === "file" || entry.kind === "folder")) {
+      if (
+        onRename &&
+        (entry.kind === "file" || entry.kind === "folder") &&
+        (canRename?.(entry) ?? true)
+      ) {
         items.push({
           label: "Rename",
           icon: Edit04,
@@ -208,6 +225,7 @@ export function FileExplorer({
     },
     [
       canDelete,
+      canRename,
       getExtraFileMenuItems,
       onCurrentFolderChange,
       onDelete,

--- a/front/components/file_explorer/RenameFileDialog.tsx
+++ b/front/components/file_explorer/RenameFileDialog.tsx
@@ -1,4 +1,4 @@
-import { useRenamePodFile } from "@app/lib/swr/pods";
+import { useRenameFileByPath } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -32,16 +32,32 @@ function splitFileName(fileName: string): {
   };
 }
 
-type RenameMountItem =
+/**
+ * `path` is the canonical scoped path of the item to rename. For a Frame it is the source folder
+ * of the Frame package; the server moves the whole package along with it.
+ */
+export type RenameMountItem =
   | { kind: "file"; path: string; name: string }
-  | { kind: "folder"; path: string; name: string };
+  | { kind: "folder"; path: string; name: string }
+  | { kind: "frame"; path: string; name: string };
+
+const DIALOG_TITLES: Record<RenameMountItem["kind"], string> = {
+  file: "Rename file",
+  folder: "Rename folder",
+  frame: "Rename Frame",
+};
+
+const INPUT_PLACEHOLDERS: Record<RenameMountItem["kind"], string> = {
+  file: "Enter new file name...",
+  folder: "Enter new folder name...",
+  frame: "Enter new Frame name...",
+};
 
 interface RenameFileDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onRenamed: () => void;
   owner: LightWorkspaceType;
-  podId: string;
   item: RenameMountItem | null;
 }
 
@@ -50,14 +66,13 @@ export function RenameFileDialog({
   onClose,
   onRenamed,
   owner,
-  podId,
   item,
 }: RenameFileDialogProps) {
   const [name, setName] = useState<string>("");
   const [isRenaming, setIsRenaming] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const renameFile = useRenamePodFile({ owner, podId });
+  const renameFile = useRenameFileByPath({ owner });
 
   const extension = useMemo(() => {
     if (!item || item.kind !== "file") {
@@ -107,6 +122,8 @@ export function RenameFileDialog({
     }
   }, [item, name, extension, isRenaming, renameFile, onRenamed, onClose]);
 
+  const kind = item?.kind ?? "file";
+
   return (
     <Dialog
       open={isOpen}
@@ -118,15 +135,13 @@ export function RenameFileDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>
-            {item?.kind === "folder" ? "Rename folder" : "Rename file"}
-          </DialogTitle>
+          <DialogTitle>{DIALOG_TITLES[kind]}</DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          {item?.kind === "folder" ? (
+          <div className="flex items-center gap-1">
             <Input
               ref={inputRef}
-              placeholder="Enter new folder name..."
+              placeholder={INPUT_PLACEHOLDERS[kind]}
               value={name}
               disabled={isRenaming}
               onChange={(e) => setName(e.target.value)}
@@ -137,28 +152,10 @@ export function RenameFileDialog({
                 }
               }}
             />
-          ) : (
-            <div className="flex items-center gap-1">
-              <Input
-                ref={inputRef}
-                placeholder="Enter new file name..."
-                value={name}
-                disabled={isRenaming}
-                onChange={(e) => setName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void handleRename();
-                  }
-                }}
-              />
-              {extension && (
-                <span className="text-sm text-muted-foreground">
-                  {extension}
-                </span>
-              )}
-            </div>
-          )}
+            {kind === "file" && extension && (
+              <span className="text-sm text-muted-foreground">{extension}</span>
+            )}
+          </div>
         </DialogContainer>
         <DialogFooter
           rightButtonProps={{

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -4,15 +4,19 @@ import {
 } from "@app/components/assistant/conversation/FileUploaderContext";
 import { ConfirmContext } from "@app/components/Confirm";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
+import type { RenameMountItem } from "@app/components/file_explorer/RenameFileDialog";
+import { RenameFileDialog } from "@app/components/file_explorer/RenameFileDialog";
 import type {
   ContentNodeEntry,
   FileEntry,
   FileExplorerEntry,
   FileExplorerMenuAction,
   FolderEntry,
+  FramePackageEntry,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import {
+  getParentFolderRelativePath,
   isFilePreviewableContentType,
   joinMountRelativePath,
 } from "@app/components/file_explorer/utils";
@@ -20,7 +24,6 @@ import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { CreateFolderDialog } from "@app/components/pod/files/CreateFolderDialog";
 import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
-import { RenameFileDialog } from "@app/components/pod/files/RenameFileDialog";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
@@ -261,11 +264,9 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
   const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
-  const [itemToRename, setItemToRename] = useState<
-    | { kind: "file"; path: string; name: string }
-    | { kind: "folder"; path: string; name: string }
-    | null
-  >(null);
+  const [itemToRename, setItemToRename] = useState<RenameMountItem | null>(
+    null
+  );
   const [activeOverlay, setActiveOverlay] = useState<
     "companyData" | "noCompanyData" | null
   >(null);
@@ -594,11 +595,19 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
   );
 
   const onRename = useCallback(
-    (entry: FileEntry | FolderEntry) => {
+    (entry: FileEntry | FolderEntry | FramePackageEntry) => {
       if (entry.kind === "file") {
         setItemToRename({
           kind: "file",
           path: entry.path,
+          name: entry.fileName,
+        });
+      } else if (entry.kind === "frame_package") {
+        // The package entry carries the manifest path; the Frame is renamed through its source
+        // folder, which the server moves as a whole.
+        setItemToRename({
+          kind: "frame",
+          path: getParentFolderRelativePath(entry.path),
           name: entry.fileName,
         });
       } else {
@@ -819,7 +828,6 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         onClose={() => setShowRenameDialog(false)}
         onRenamed={() => void refreshPodFiles()}
         owner={owner}
-        podId={pod.sId}
         item={itemToRename}
       />
 

--- a/front/lib/api/files/file_system_ops.test.ts
+++ b/front/lib/api/files/file_system_ops.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/files/gcs_mount/files", async (importActual) => ({
+  ...(await importActual<
+    typeof import("@app/lib/api/files/gcs_mount/files")
+  >()),
+  emitGCSMountFileMovedAuditLog: vi.fn(),
+}));
+
+vi.mock("@app/lib/lock", async (importActual) => ({
+  ...(await importActual<typeof import("@app/lib/lock")>()),
+  executeWithLockResult: async <T>(_name: string, cb: () => Promise<T>) => cb(),
+}));
+
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { renameCanonicalFile } from "@app/lib/api/files/file_system_ops";
+import {
+  frameManifest,
+  setupFrameSourceStorageTest,
+} from "@app/lib/api/frames/source_storage.test_utils";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import assert from "assert";
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  vi.restoreAllMocks();
+});
+
+async function setupFrameRename() {
+  const c = await setupFrameSourceStorageTest();
+  const storage = getPrivateUploadBucket();
+  vi.mocked(getPrivateUploadBucket).mockReturnValue(storage);
+  vi.spyOn(storage, "copyFile").mockImplementation(async (source, target) => {
+    const content = fileStorageMock.getObject(source);
+    if (content !== undefined) {
+      fileStorageMock.setObject(target, content);
+    }
+    return { destinationGeneration: "mock" } as never;
+  });
+  const fsResult = await DustFileSystem.fromScopedPath(
+    c.auth,
+    c.sourceDirectoryPath
+  );
+  assert(fsResult.isOk(), fsResult.isErr() ? fsResult.error.message : "");
+  return { ...c, dustFs: fsResult.value };
+}
+
+describe("renameCanonicalFile", () => {
+  it("renames a registered Frame source folder through the Frame move", async () => {
+    const c = await setupFrameRename();
+
+    const renamed = await renameCanonicalFile(
+      c.auth,
+      c.dustFs,
+      c.sourceDirectoryPath,
+      "Renamed"
+    );
+
+    assert(renamed.isOk(), renamed.isErr() ? renamed.error.message : "");
+    expect(renamed.value).toEqual({
+      dest: `conversation-${c.conversation.sId}/Renamed`,
+      sourceDeletionFailed: false,
+    });
+
+    const destinationMountDirectory = c.sourceMountDirectory.replace(
+      "/Status",
+      "/Renamed"
+    );
+    const reloaded = await FileResource.fetchById(c.auth, c.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${destinationMountDirectory}/${FRAME_MANIFEST_FILE}`
+    );
+    expect(reloaded?.fileName).toBe(FRAME_MANIFEST_FILE);
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBeUndefined();
+    expect(
+      fileStorageMock.getObject(
+        `${destinationMountDirectory}/${FRAME_MANIFEST_FILE}`
+      )
+    ).toBe(frameManifest);
+  });
+
+  it("rejects a Frame name containing a path separator", async () => {
+    const c = await setupFrameRename();
+
+    const renamed = await renameCanonicalFile(
+      c.auth,
+      c.dustFs,
+      c.sourceDirectoryPath,
+      "nested/Renamed"
+    );
+
+    expect(renamed.isErr() && renamed.error).toMatchObject({
+      code: "invalid_path",
+    });
+    const reloaded = await FileResource.fetchById(c.auth, c.frame.sId);
+    expect(reloaded?.mountFilePath).toBe(c.sourceObjects[0]);
+  });
+
+  it("no-ops when the Frame keeps its name", async () => {
+    const c = await setupFrameRename();
+
+    const renamed = await renameCanonicalFile(
+      c.auth,
+      c.dustFs,
+      c.sourceDirectoryPath,
+      "Status"
+    );
+
+    assert(renamed.isOk(), renamed.isErr() ? renamed.error.message : "");
+    expect(renamed.value.dest).toBe(c.sourceDirectoryPath);
+    expect(fileStorageMock.getObject(c.sourceObjects[0])).toBe(frameManifest);
+  });
+});

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -6,10 +6,13 @@
 
 import type { DustFileSystem } from "@app/lib/api/file_system";
 import { decodeBuffer } from "@app/lib/api/files/utils";
+import { moveFrameV2SourceUsingFileSystem } from "@app/lib/api/frames/move_source";
+import type { FrameSourceMoveError } from "@app/lib/api/frames/move_source_paths";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
@@ -277,8 +280,28 @@ function inferDestMountInfo(
 }
 
 /**
+ * Return the registered Frames v2 manifest when `scopedPath` is the source folder of a Frame.
+ * The explorer surfaces such a folder as a single Frame package entry.
+ */
+async function fetchFrameV2AtSourceDirectory(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  scopedPath: string
+): Promise<FileResource | undefined> {
+  const manifest = await fetchLinkedFileResource(
+    auth,
+    dustFs,
+    `${scopedPath}/${FRAME_MANIFEST_FILE}`
+  );
+  return manifest?.isFrameV2 ? manifest : undefined;
+}
+
+/**
  * Rename a file at `scopedPath` to `newFileName` (same directory) and sync the
  * linked FileResource record if one exists.
+ *
+ * When `scopedPath` is the source folder of a registered Frame, the rename goes through the
+ * Frame source move so the Frame identity, publication and Pod tabs follow the folder.
  *
  * Returns the same result shape as `DustFileSystem.rename()`.
  */
@@ -288,13 +311,28 @@ export async function renameCanonicalFile(
   scopedPath: string,
   newFileName: string
 ): Promise<
-  Result<{ dest: string; sourceDeletionFailed: boolean }, DustFileSystemError>
+  Result<
+    { dest: string; sourceDeletionFailed: boolean },
+    DustFileSystemError | FrameSourceMoveError
+  >
 > {
   const linkedFileResource = await fetchLinkedFileResource(
     auth,
     dustFs,
     scopedPath
   );
+
+  if (!linkedFileResource) {
+    const frame = await fetchFrameV2AtSourceDirectory(auth, dustFs, scopedPath);
+    if (frame) {
+      return renameFrameV2SourceDirectory(
+        auth,
+        dustFs,
+        scopedPath,
+        newFileName
+      );
+    }
+  }
 
   const renameResult = await dustFs.rename(scopedPath, newFileName);
   if (renameResult.isErr()) {
@@ -317,6 +355,51 @@ export async function renameCanonicalFile(
   }
 
   return renameResult;
+}
+
+async function renameFrameV2SourceDirectory(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  sourceDirectoryPath: string,
+  newFolderName: string
+): Promise<
+  Result<
+    { dest: string; sourceDeletionFailed: boolean },
+    DustFileSystemError | FrameSourceMoveError
+  >
+> {
+  // Mirrors the file name check of `DustFileSystem.rename()`: a separator would nest the folder.
+  if (
+    !newFolderName ||
+    newFolderName.includes("/") ||
+    newFolderName.includes("\\")
+  ) {
+    return new Err(
+      new DustFileSystemError(
+        "invalid_path",
+        "newFileName must be a non-empty string without path separators."
+      )
+    );
+  }
+
+  const dest = `${path.posix.dirname(sourceDirectoryPath)}/${newFolderName}`;
+  if (dest === sourceDirectoryPath) {
+    return new Ok({ dest, sourceDeletionFailed: false });
+  }
+
+  const moveResult = await moveFrameV2SourceUsingFileSystem(auth, {
+    destinationDirectoryPath: dest,
+    dustFs,
+    sourceDirectoryPath,
+  });
+  if (moveResult.isErr()) {
+    return moveResult;
+  }
+
+  return new Ok({
+    dest,
+    sourceDeletionFailed: moveResult.value.sourceDeletionFailed,
+  });
 }
 
 /**

--- a/front/lib/api/frames/move_source.test.ts
+++ b/front/lib/api/frames/move_source.test.ts
@@ -22,7 +22,11 @@ vi.mock("@app/lib/lock", async (importActual) => ({
   },
 }));
 
-import { moveFrameV2Source } from "@app/lib/api/frames/move_source";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  moveFrameV2Source,
+  moveFrameV2SourceUsingFileSystem,
+} from "@app/lib/api/frames/move_source";
 import {
   getFramePublishLockName,
   getFrameSourceLockName,
@@ -31,10 +35,18 @@ import {
   frameManifest,
   setupFrameSourceStorageTest,
 } from "@app/lib/api/frames/source_storage.test_utils";
+import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { getPodFilesBasePath } from "@app/types/mount_path";
+import { DEFAULT_POD_FILE_TAB_ICON } from "@app/types/pod_file_tab";
 import assert from "assert";
 
 beforeEach(() => {
@@ -95,5 +107,101 @@ describe("moveFrameV2Source", () => {
       `release:${getFramePublishLockName(c.frame.sId)}`,
       `release:${getFrameSourceLockName(c.frame.sId)}`,
     ]);
+  });
+
+  it("repoints Pod tabs and the pinned Frame when moving a Pod Frame", async () => {
+    const { globalGroup, user, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    await SpaceFactory.attachGroup(space, globalGroup, "project_editor");
+    // Group grants are resolved when the authenticator is built, so build it after attaching.
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    assert(auth);
+
+    const sourceDirectoryPath = `pod-${space.sId}/Status`;
+    const destinationDirectoryPath = `pod-${space.sId}/Renamed`;
+    const sourceManifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const destinationManifestPath = `${destinationDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const podFilesBasePath = getPodFilesBasePath({
+      workspaceId: workspace.sId,
+      podId: space.sId,
+    });
+    const sourceObjects = [
+      `${podFilesBasePath}Status/${FRAME_MANIFEST_FILE}`,
+      `${podFilesBasePath}Status/index.tsx`,
+    ];
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(frameManifest),
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+      mountFilePath: sourceObjects[0],
+    });
+    await frame.markFrameV2AsReadyFromMount(auth);
+    fileStorageMock.setObject(sourceObjects[0], frameManifest);
+    fileStorageMock.setObject(sourceObjects[1], "ui source");
+    fileStorageMock.setFileExists(
+      (filePath) => fileStorageMock.getObject(filePath) !== undefined
+    );
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      sourceObjects
+        .filter(
+          (name) =>
+            name.startsWith(prefix) &&
+            fileStorageMock.getObject(name) !== undefined
+        )
+        .map((name) => ({
+          name,
+          metadata: { contentType: "text/plain", size: "10" },
+        }))
+    );
+    const storage = getPrivateUploadBucket();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(storage);
+    vi.spyOn(storage, "copyFile").mockImplementation(async (source, target) => {
+      const content = fileStorageMock.getObject(source);
+      if (content !== undefined) {
+        fileStorageMock.setObject(target, content);
+      }
+      return { destinationGeneration: "mock" } as never;
+    });
+
+    await ProjectMetadataResource.makeNew(auth, space, {
+      pinnedFramePath: sourceManifestPath,
+      frameTabs: [
+        {
+          path: sourceManifestPath,
+          title: "Status",
+          icon: DEFAULT_POD_FILE_TAB_ICON,
+        },
+      ],
+      tabsOrder: ["files", sourceManifestPath],
+    });
+
+    const fsResult = await DustFileSystem.forPod(auth, space);
+    assert(fsResult.isOk(), fsResult.isErr() ? fsResult.error.message : "");
+
+    const moved = await moveFrameV2SourceUsingFileSystem(auth, {
+      destinationDirectoryPath,
+      dustFs: fsResult.value,
+      sourceDirectoryPath,
+    });
+
+    assert(moved.isOk(), moved.isErr() ? moved.error.message : undefined);
+    const reloaded = await FileResource.fetchById(auth, frame.sId);
+    expect(reloaded?.mountFilePath).toBe(
+      `${podFilesBasePath}Renamed/${FRAME_MANIFEST_FILE}`
+    );
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+    expect(metadata?.pinnedFramePath).toBe(destinationManifestPath);
+    expect(metadata?.frameTabs?.map((tab) => tab.path)).toEqual([
+      destinationManifestPath,
+    ]);
+    expect(metadata?.tabsOrder).toEqual(["files", destinationManifestPath]);
   });
 });

--- a/front/lib/api/frames/move_source.ts
+++ b/front/lib/api/frames/move_source.ts
@@ -16,6 +16,8 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -37,20 +39,42 @@ type FrameSourceMove = {
 };
 
 /**
- * Move a registered Frames v2 source folder within one GCS mount.
+ * Pod tabs and the pinned Frame reference a Frame by its manifest scoped path. Repoint them so the
+ * Pod navigation keeps working after the source folder moves.
+ */
+async function renamePodFramePath(
+  auth: Authenticator,
+  frame: FileResource,
+  { fromPath, toPath }: { fromPath: string; toPath: string }
+): Promise<void> {
+  if (frame.useCase !== "project_context") {
+    return;
+  }
+  const spaceId = frame.useCaseMetadata?.spaceId;
+  const space = spaceId ? await SpaceResource.fetchById(auth, spaceId) : null;
+  if (!space) {
+    return;
+  }
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+  await metadata?.renameFramePath(fromPath, toPath);
+}
+
+/**
+ * Move a registered Frames v2 source folder within one GCS mount, through an already authorized
+ * filesystem covering both the source and destination paths.
  *
  * This intentionally uses a non-transactional copy, DB update, then source delete sequence.
  * Until the DB update succeeds, the source FileResource path remains authoritative.
  */
-export async function moveFrameV2Source(
+export async function moveFrameV2SourceUsingFileSystem(
   auth: Authenticator,
   {
-    conversation,
     destinationDirectoryPath,
+    dustFs,
     sourceDirectoryPath,
   }: {
-    conversation: ConversationWithoutContentType;
     destinationDirectoryPath: string;
+    dustFs: DustFileSystem;
     sourceDirectoryPath: string;
   }
 ): Promise<Result<FrameSourceMove, MoveFrameV2SourceError>> {
@@ -63,14 +87,6 @@ export async function moveFrameV2Source(
   }
   const paths = pathsResult.value;
 
-  const fsResult = await DustFileSystem.forAgentLoop(auth, {
-    conversation,
-    scopedPaths: [paths.sourceDirectoryPath, paths.destinationDirectoryPath],
-  });
-  if (fsResult.isErr()) {
-    return fsResult;
-  }
-  const dustFs = fsResult.value;
   if (!dustFs.isGCSBacked()) {
     return moveError(
       "invalid_source",
@@ -171,6 +187,11 @@ export async function moveFrameV2Source(
       );
     }
 
+    await renamePodFramePath(auth, freshFrame, {
+      fromPath: paths.sourceManifestPath,
+      toPath: paths.destinationManifestPath,
+    });
+
     const deleted = await deleteFrameSourceStorage(
       snapshot.value.sourceMountPrefix
     );
@@ -213,4 +234,41 @@ export async function moveFrameV2Source(
       : new Err(locked.error);
   }
   return locked;
+}
+
+/** Move a registered Frames v2 source folder from within the invoking conversation's mounts. */
+export async function moveFrameV2Source(
+  auth: Authenticator,
+  {
+    conversation,
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  }: {
+    conversation: ConversationWithoutContentType;
+    destinationDirectoryPath: string;
+    sourceDirectoryPath: string;
+  }
+): Promise<Result<FrameSourceMove, MoveFrameV2SourceError>> {
+  const pathsResult = resolveFrameSourceMovePaths({
+    destinationDirectoryPath,
+    sourceDirectoryPath,
+  });
+  if (pathsResult.isErr()) {
+    return pathsResult;
+  }
+  const paths = pathsResult.value;
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [paths.sourceDirectoryPath, paths.destinationDirectoryPath],
+  });
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  return moveFrameV2SourceUsingFileSystem(auth, {
+    destinationDirectoryPath,
+    dustFs: fsResult.value,
+    sourceDirectoryPath,
+  });
 }

--- a/front/lib/api/frames/move_source_paths.ts
+++ b/front/lib/api/frames/move_source_paths.ts
@@ -21,6 +21,12 @@ export class FrameSourceMoveError extends Error {
   }
 }
 
+export function isFrameSourceMoveError(
+  err: unknown
+): err is FrameSourceMoveError {
+  return err instanceof FrameSourceMoveError;
+}
+
 export type FrameSourceMovePaths = {
   auditEvent: {
     parentRelativePath: string;

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -6,6 +6,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { DEFAULT_POD_FILE_TAB_ICON } from "@app/types/pod_file_tab";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -57,6 +58,79 @@ describe("ProjectMetadataResource", () => {
 
       expect(metadata.description).toBe("Full metadata");
       expect(metadata.sId).toMatch(/^pmd_/);
+    });
+  });
+
+  describe("renameFramePath", () => {
+    it("repoints the pinned Frame, file tabs and tabs order", async () => {
+      const fromPath = "pod-abc/Status/manifest.json";
+      const toPath = "pod-abc/Renamed/manifest.json";
+      const otherPath = "pod-abc/Other/manifest.json";
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        {
+          pinnedFramePath: fromPath,
+          frameTabs: [
+            {
+              path: fromPath,
+              title: "Status",
+              icon: DEFAULT_POD_FILE_TAB_ICON,
+            },
+            {
+              path: otherPath,
+              title: "Other",
+              icon: DEFAULT_POD_FILE_TAB_ICON,
+            },
+          ],
+          tabsOrder: ["files", fromPath, otherPath],
+        }
+      );
+
+      await metadata.renameFramePath(fromPath, toPath);
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        projectSpace
+      );
+      expect(reloaded?.pinnedFramePath).toBe(toPath);
+      expect(reloaded?.frameTabs?.map((tab) => tab.path)).toEqual([
+        toPath,
+        otherPath,
+      ]);
+      expect(reloaded?.tabsOrder).toEqual(["files", toPath, otherPath]);
+    });
+
+    it("leaves metadata referencing other Frames untouched", async () => {
+      const otherPath = "pod-abc/Other/manifest.json";
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        {
+          pinnedFramePath: otherPath,
+          frameTabs: [
+            {
+              path: otherPath,
+              title: "Other",
+              icon: DEFAULT_POD_FILE_TAB_ICON,
+            },
+          ],
+          tabsOrder: ["files", otherPath],
+        }
+      );
+
+      await metadata.renameFramePath(
+        "pod-abc/Status/manifest.json",
+        "pod-abc/Renamed/manifest.json"
+      );
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        projectSpace
+      );
+      expect(reloaded?.pinnedFramePath).toBe(otherPath);
+      expect(reloaded?.frameTabs?.map((tab) => tab.path)).toEqual([otherPath]);
+      expect(reloaded?.tabsOrder).toEqual(["files", otherPath]);
     });
   });
 

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -221,6 +221,30 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     );
   }
 
+  /** Point the pinned Frame and file tabs referencing `fromPath` at `toPath` after a move. */
+  async renameFramePath(
+    fromPath: string,
+    toPath: string,
+    transaction?: Transaction
+  ): Promise<void> {
+    const frameTabs = (this.frameTabs ?? []).map((tab) =>
+      tab.path === fromPath ? { ...tab, path: toPath } : tab
+    );
+    const tabsOrder = (this.tabsOrder ?? []).map((entry) =>
+      entry === fromPath ? toPath : entry
+    );
+
+    await this.update(
+      {
+        pinnedFramePath:
+          this.pinnedFramePath === fromPath ? toPath : this.pinnedFramePath,
+        frameTabs,
+        tabsOrder,
+      },
+      transaction
+    );
+  }
+
   async updateDefaultAgentId(
     defaultAgentId: string | null,
     transaction?: Transaction

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -343,6 +343,55 @@ export function useDeleteFileByPath({ owner }: { owner: LightWorkspaceType }) {
   };
 }
 
+export function useRenameFileByPath({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+
+  return async (
+    canonicalPath: string,
+    newFileName: string
+  ): Promise<Result<void, Error>> => {
+    try {
+      const encoded = canonicalPath
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/");
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/files/path/${encoded}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "rename", fileName: newFileName }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to rename file",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: `File renamed to "${newFileName}"`,
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to rename file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
 export function useWriteFileContentByPath({
   owner,
 }: {

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -525,61 +525,6 @@ export function useRemovePodContextContentNodes({
   };
 }
 
-export function useRenamePodFile({
-  owner,
-  podId: _podId,
-}: {
-  owner: LightWorkspaceType;
-  podId: string;
-}) {
-  const sendNotification = useSendNotification();
-
-  return async (
-    canonicalPath: string,
-    newFileName: string
-  ): Promise<Result<void, Error>> => {
-    try {
-      const encoded = canonicalPath
-        .split("/")
-        .map(encodeURIComponent)
-        .join("/");
-      const res = await clientFetch(
-        `/api/w/${owner.sId}/files/path/${encoded}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "rename", fileName: newFileName }),
-        }
-      );
-
-      if (!res.ok) {
-        const errorData = await getErrorFromResponse(res);
-        sendNotification({
-          type: "error",
-          title: "Failed to rename file",
-          description: errorData.message,
-        });
-        return new Err(new Error(errorData.message));
-      }
-
-      sendNotification({
-        type: "success",
-        title: `File renamed to "${newFileName}"`,
-      });
-
-      return new Ok(undefined);
-    } catch (e) {
-      const errorMessage = normalizeError(e).message;
-      sendNotification({
-        type: "error",
-        title: "Failed to rename file",
-        description: errorMessage,
-      });
-      return new Err(new Error(errorMessage));
-    }
-  };
-}
-
 export function useCreatePodFolder({
   owner,
   podId,


### PR DESCRIPTION
## Description

Adds a **Rename** action on Frame v2 package entries in the file explorer (Pod files and conversation files). Until now a Frame folder could only be renamed as a plain folder, which moved the bytes in GCS but left the manifest \`FileResource.mountFilePath\`, the Pod file tabs and the pinned Frame pointing at the old path.

- \`renameCanonicalFile\` detects a registered Frame at \`<path>/manifest.json\` and delegates to the Frame source move (\`moveFrameV2Source\`, merged in #31532 / #31552 without a production caller). No new API: the explorer keeps calling \`PATCH /files/path/... {action:"rename"}\`, and the route maps Frame move errors to 400/409/500.
- \`moveFrameV2SourceUsingFileSystem\` is split out so callers that already hold an authorized \`DustFileSystem\` (the Pod explorer has no conversation) can use it; \`moveFrameV2Source\` keeps its conversation-based signature.
- The move now repoints Pod metadata (\`pinnedFramePath\`, \`frameTabs\`, \`tabsOrder\`) via a new \`ProjectMetadataResource.renameFramePath\`, so Pod navigation keeps working after a rename or move.
- UI: \`RenameFileDialog\` moves next to the explorer with a \`frame\` kind and a shared \`useRenameFileByPath\` hook (replacing the Pod-only \`useRenamePodFile\`). \`FileExplorer\` gets a \`canRename\` filter mirroring \`canDelete\`; the conversation panel only offers Rename on Frame packages, like Delete.

Not covered here: renaming a parent folder that contains a Frame, and the MCP \`move\` tool on a Frame folder, still leave the Frame stale. Both would need the same delegation.

## Tests

- \`renameCanonicalFile\` on a Frame source folder: mount path updated, storage moved, separator rejected, same-name no-op.
- \`moveFrameV2SourceUsingFileSystem\` on a Pod Frame repoints tabs and the pinned Frame.
- \`ProjectMetadataResource.renameFramePath\` unit coverage.
- Existing move, edge-case and \`/files/path\` route suites pass. \`tsgo\` passes for front, front-api and front-spa.

## Risk

Low. The Frame path only triggers when a registered Frame manifest sits directly under the renamed folder; plain files and folders keep the previous behavior. The Frame move itself remains intentionally non-crash-safe (see #31532).

## Deploy Plan

Standard deploy.