### PR TITLE
dust-hive: add front alias to restart front-api and front-spa-app

### DIFF
--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -179,7 +179,7 @@ external workspace is archived.
 | `stop [NAME] [SERVICE]` | Full stop + remove docker containers, or stop one service |
 | `destroy [NAME] [--force]` | Remove environment completely (multi-select if NAME omitted) |
 | `unregister [NAME] [--force]` | Remove Hive resources while keeping the worktree and branch |
-| `restart [NAME] SERVICE` | Restart a single service |
+| `restart [NAME] SERVICE` | Restart a single service (`front` restarts front-api + front-spa-app) |
 | `open [NAME]` | Open zellij terminal session |
 | `reload [NAME]` | Kill and reopen zellij session |
 | `list` | Show all environments |

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -179,7 +179,7 @@ external workspace is archived.
 | `stop [NAME] [SERVICE]` | Full stop + remove docker containers, or stop one service |
 | `destroy [NAME] [--force]` | Remove environment completely (multi-select if NAME omitted) |
 | `unregister [NAME] [--force]` | Remove Hive resources while keeping the worktree and branch |
-| `restart [NAME] SERVICE` | Restart a single service (`front` restarts front-api + front-spa-app) |
+| `restart [NAME] SERVICE` | Restart a single service (`front` restarts all front-* services) |
 | `open [NAME]` | Open zellij terminal session |
 | `reload [NAME]` | Kill and reopen zellij session |
 | `list` | Show all environments |

--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -5,7 +5,7 @@ import { stopService } from "../lib/process";
 import { restoreTerminal } from "../lib/prompt";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { ALL_SERVICES, isServiceName, type ServiceName } from "../lib/services";
+import { ALL_SERVICES, resolveServices, SERVICE_ALIASES, type ServiceName } from "../lib/services";
 
 async function selectService(): Promise<ServiceName | null> {
   const result = await p.select({
@@ -34,37 +34,41 @@ export async function restartCommand(
   const env = envResult.value;
 
   // Handle service selection
-  let service: ServiceName;
+  let services: readonly ServiceName[];
   if (serviceArg) {
-    // Service provided via CLI argument
-    if (!isServiceName(serviceArg)) {
+    // Service or alias provided via CLI argument
+    const resolved = resolveServices(serviceArg);
+    if (!resolved) {
       console.log(`\nServices: ${ALL_SERVICES.join(", ")}`);
+      console.log(`Aliases: ${Object.keys(SERVICE_ALIASES).join(", ")}`);
       return Err(new CommandError(`Unknown service '${serviceArg}'`));
     }
-    service = serviceArg;
+    services = resolved;
   } else {
     // Interactive selection
     const selected = await selectService();
     if (!selected) {
       return Err(new CommandError("No service selected"));
     }
-    service = selected;
+    services = [selected];
   }
 
   // Restore terminal after all interactive prompts are done
   restoreTerminal();
 
-  logger.info(`Restarting ${service} in '${env.name}'...`);
+  for (const service of services) {
+    logger.info(`Restarting ${service} in '${env.name}'...`);
 
-  const stopped = await stopService(env.name, service);
-  if (!stopped) {
-    logger.info(`${service} was not running`);
+    const stopped = await stopService(env.name, service);
+    if (!stopped) {
+      logger.info(`${service} was not running`);
+    }
+
+    await startService(env, service);
+    await waitForServiceReady(env, service);
+
+    logger.success(`${service} restarted`);
   }
-
-  await startService(env, service);
-  await waitForServiceReady(env, service);
-
-  logger.success(`${service} restarted`);
 
   return Ok(undefined);
 }

--- a/x/henry/dust-hive/src/lib/services.ts
+++ b/x/henry/dust-hive/src/lib/services.ts
@@ -26,7 +26,7 @@ export type ServiceName = (typeof ALL_SERVICES)[number];
 
 // Aliases expanding to several services, e.g. `dust-hive restart front`.
 export const SERVICE_ALIASES = {
-  front: ["front-api", "front-spa-app"],
+  front: ["front-api", "front-workers", "front-spa-poke", "front-spa-app"],
 } as const satisfies Record<string, readonly ServiceName[]>;
 
 export type ServiceAlias = keyof typeof SERVICE_ALIASES;

--- a/x/henry/dust-hive/src/lib/services.ts
+++ b/x/henry/dust-hive/src/lib/services.ts
@@ -24,6 +24,26 @@ export const COLD_STATE_SERVICES = ["sdk", "sparkle"] as const satisfies readonl
 
 export type ServiceName = (typeof ALL_SERVICES)[number];
 
+// Aliases expanding to several services, e.g. `dust-hive restart front`.
+export const SERVICE_ALIASES = {
+  front: ["front-api", "front-spa-app"],
+} as const satisfies Record<string, readonly ServiceName[]>;
+
+export type ServiceAlias = keyof typeof SERVICE_ALIASES;
+
+export function isServiceAlias(value: string | undefined): value is ServiceAlias {
+  return value !== undefined && Object.hasOwn(SERVICE_ALIASES, value);
+}
+
+/**
+ * Resolve a service name or alias to the list of services it designates.
+ */
+export function resolveServices(value: string): readonly ServiceName[] | null {
+  if (isServiceName(value)) return [value];
+  if (isServiceAlias(value)) return SERVICE_ALIASES[value];
+  return null;
+}
+
 /**
  * Type guard to check if a string is a valid service name.
  */


### PR DESCRIPTION
## Description

`dust-hive restart <env> <service>` only accepts a single service, so restarting the front stack means several commands. This adds a `front` alias that restarts every `front-*` service in start order: `front-api`, `front-workers`, `front-spa-poke`, `front-spa-app`.

Aliases live in a `SERVICE_ALIASES` map in `services.ts`, so adding another one is a one-line entry. Unknown names now print both the services and aliases lists. The interactive picker is unchanged.

## Tests

`bun run check` passes (typecheck, lint, tests).

## Risk

None, dev tooling only.

## Deploy Plan

None.