### PR TITLE
[front] fix: hide workspace seat availability in invite modal

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -98,7 +98,7 @@ function seatBadge(
   }
 
   return (
-    <span className="text-xs text-foreground tabular-nums">
+    <span className="text-xs text-foreground">
       {formatPriceCents(info.priceCents, info.currency, info.billingFrequency)}
     </span>
   );

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -26,7 +26,7 @@ import {
 import { useSeatPlan } from "@app/lib/swr/credits";
 import { isEmailValid } from "@app/lib/utils";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { isMembershipSeatType } from "@app/types/memberships";
+import { isMembershipSeatType, toBaseSeatType } from "@app/types/memberships";
 import type { SubscriptionPerSeatPricing } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
@@ -89,7 +89,7 @@ function seatBadge(
   info: SeatTypeInfo
 ): ReactNode {
   const openCount = includedSeatsOpen(info);
-  if (openCount > 0) {
+  if (toBaseSeatType(seatType) !== "workspace" && openCount > 0) {
     return <Chip size="xs" color="primary" label={`${openCount} Available`} />;
   }
 

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -407,10 +407,10 @@ export function SeatCard({
             />
           </div>
           <span className="truncate text-base font-semibold text-foreground">
-            {stripYearlySuffix(info.name).replace(/\s+Seat$/, "")}
+            {stripYearlySuffix(info.name)}
           </span>
         </div>
-        <div className="shrink-0 tabular-nums">{badge}</div>
+        <div className="shrink-0">{badge}</div>
       </div>
       {info.awuCredits > 0 && (
         <div className="flex items-center gap-2 text-muted-foreground">


### PR DESCRIPTION
## Description

Workspace seats draw from the shared credit pool, so showing an available count derived from per-seat commitments is incorrect.

This PR only shows the available-seat badge for non-workspace seat types. No change for other seat tiers.

Follow-up to https://github.com/dust-tt/dust/pull/31699#discussion_r3916735934.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
