### PR TITLE
Build-once stops pushing to the regional registries

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -51,10 +51,6 @@ inputs:
   contentful_access_token:
     description: "Contentful access token"
     required: false
-  extra_image_registries:
-    description: "Space-separated <host>/<project>/<repo> prefixes that also receive the image, on top of the primary registry"
-    required: false
-    default: ""
 
 outputs:
   current_version:
@@ -85,16 +81,8 @@ runs:
 
     - name: "Configure GCP Docker Auth"
       shell: bash
-      env:
-        EXTRA_IMAGE_REGISTRIES: ${{ inputs.extra_image_registries }}
       run: |
-        HOSTS="${{ inputs.region }}-docker.pkg.dev"
-        # shellcheck disable=SC2086 # word splitting is the point
-        for registry in $EXTRA_IMAGE_REGISTRIES; do
-          HOSTS="${HOSTS},${registry%%/*}"
-        done
-        HOSTS=$(echo "$HOSTS" | tr ',' '\n' | sort -u | paste -sd, -)
-        gcloud auth configure-docker "$HOSTS" --quiet
+        gcloud auth configure-docker ${{ inputs.region }}-docker.pkg.dev --quiet
 
     - name: "Fetch custom models config"
       if: contains(inputs.component, 'front')
@@ -109,7 +97,6 @@ runs:
       shell: bash
       env:
         DEPOT_TOKEN: ${{ inputs.depot_region == 'eu' && inputs.depot_eu_token || inputs.depot_us_token }}
-        EXTRA_IMAGE_REGISTRIES: ${{ inputs.extra_image_registries }}
       run: |
         COMPONENT="${{ inputs.component }}"
 
@@ -199,16 +186,6 @@ runs:
           LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
         fi
 
-        # Same image, additional registries.
-        EXTRA_TAGS=()
-        # shellcheck disable=SC2086 # word splitting is the point
-        for registry in $EXTRA_IMAGE_REGISTRIES; do
-          EXTRA_TAGS+=("-t" "${registry}/${COMPONENT}:${{ inputs.commit_sha }}")
-          if [[ "$PUSH_LATEST" == "true" ]]; then
-            EXTRA_TAGS+=("-t" "${registry}/${COMPONENT}:latest")
-          fi
-        done
-
         # Special handling for front component: Bake builds both targets in parallel
         # and deduplicates work in their shared base-deps stage.
         if [[ "$BASE_COMPONENT" == "front" ]]; then
@@ -222,17 +199,6 @@ runs:
           FRONT_API_IMAGE_TAG="${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${API_COMPONENT}:${{ inputs.commit_sha }}"
           WORKERS_LATEST_IMAGE_TAG=""
           FRONT_API_LATEST_IMAGE_TAG=""
-          WORKERS_EXTRA_TAGS=""
-          FRONT_API_EXTRA_TAGS=""
-          # shellcheck disable=SC2086 # word splitting is the point
-          for registry in $EXTRA_IMAGE_REGISTRIES; do
-            WORKERS_EXTRA_TAGS+="${WORKERS_EXTRA_TAGS:+,}${registry}/${COMPONENT}-workers:${{ inputs.commit_sha }}"
-            FRONT_API_EXTRA_TAGS+="${FRONT_API_EXTRA_TAGS:+,}${registry}/${API_COMPONENT}:${{ inputs.commit_sha }}"
-            if [[ "$PUSH_LATEST" == "true" ]]; then
-              WORKERS_EXTRA_TAGS+=",${registry}/${COMPONENT}-workers:latest"
-              FRONT_API_EXTRA_TAGS+=",${registry}/${API_COMPONENT}:latest"
-            fi
-          done
 
           BAKE_OVERRIDES=(
             --set "*.args.COMMIT_HASH=${{ inputs.commit_sha }}"
@@ -253,7 +219,6 @@ runs:
 
           export WORKERS_IMAGE_TAG FRONT_API_IMAGE_TAG
           export WORKERS_LATEST_IMAGE_TAG FRONT_API_LATEST_IMAGE_TAG
-          export WORKERS_EXTRA_TAGS FRONT_API_EXTRA_TAGS
 
           FRONT_BUILD_STARTED_SECONDS=$SECONDS
           depot bake \
@@ -274,7 +239,6 @@ runs:
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
             "${LATEST_TAGS[@]}" \
-            "${EXTRA_TAGS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             --build-arg DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,8 +145,7 @@ jobs:
             echo "matrix=[\"${{ inputs.regions }}\"]" >> "$GITHUB_OUTPUT"
           fi
 
-  # Components on the build-once path: one build, pushed to the global registry and, for
-  # now, to both regional registries so the regional values files keep resolving.
+  # Components on the build-once path: one build, pushed to the global registry.
   # Marketing stays on the regional matrix: next build inlines region-specific
   # NEXT_PUBLIC_* values into its client bundle.
   build-once:
@@ -178,9 +177,6 @@ jobs:
           # Global registry, lives in the dust-infra project next to the helm charts.
           project_id: dust-infra
           region: us-central1
-          extra_image_registries: >-
-            us-central1-docker.pkg.dev/${{ secrets.GCLOUD_US_PROJECT_ID }}/dust-images
-            europe-west1-docker.pkg.dev/${{ secrets.GCLOUD_EU_PROJECT_ID }}/dust-images
           virtuoso_license_key: ${{ secrets.VIRTUOSO_LICENSE_KEY }}
           contentful_space_id: ${{ secrets.CONTENTFUL_SPACE_ID }}
           contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}

--- a/dockerfiles/front-bake.hcl
+++ b/dockerfiles/front-bake.hcl
@@ -6,20 +6,11 @@ variable "WORKERS_LATEST_IMAGE_TAG" {
   default = ""
 }
 
-# Comma-separated, same image pushed to additional registries.
-variable "WORKERS_EXTRA_TAGS" {
-  default = ""
-}
-
 variable "FRONT_API_IMAGE_TAG" {
   default = ""
 }
 
 variable "FRONT_API_LATEST_IMAGE_TAG" {
-  default = ""
-}
-
-variable "FRONT_API_EXTRA_TAGS" {
   default = ""
 }
 
@@ -36,11 +27,11 @@ target "_front-base" {
 target "workers" {
   inherits = ["_front-base"]
   target   = "workers"
-  tags     = compact(concat([WORKERS_IMAGE_TAG, WORKERS_LATEST_IMAGE_TAG], split(",", WORKERS_EXTRA_TAGS)))
+  tags     = compact([WORKERS_IMAGE_TAG, WORKERS_LATEST_IMAGE_TAG])
 }
 
 target "front-api" {
   inherits = ["_front-base"]
   target   = "front-api"
-  tags     = compact(concat([FRONT_API_IMAGE_TAG, FRONT_API_LATEST_IMAGE_TAG], split(",", FRONT_API_EXTRA_TAGS)))
+  tags     = compact([FRONT_API_IMAGE_TAG, FRONT_API_LATEST_IMAGE_TAG])
 }


### PR DESCRIPTION
## Description

The build-once job stops pushing every image to the two regional registries. Since dust-tt/dust-infra#1014, #1015 and #1016 every release on the build-once path pulls from the global `dust-infra/dust-images` repo, and with dust-tt/dust#31788 revert and list-tags read from it too, so the regional copies have no reader left. The `extra_image_registries` input, the extra tag loops in the build action and the extra tag variables in the front bake file were only there for that transition and go away. The Docker auth step goes back to the single registry host.

Marketing is untouched, it still builds per region through the regional job with its own project.

## Tests

`actionlint` passes on the workflow. `docker buildx bake --print` on the bake file shows one tag per target again. Not exercised end to end, the first build-once deploy after merge is the check.

## Risk

None on the pull side, nothing reads the regional repos for these components anymore. Merge after dust-tt/dust#31788 so revert does not look for new tags in a repo that stopped receiving them. Rollback is a revert of this PR.

## Deploy Plan

Merge after #31788. Then dust-infra drops the transitional writer roles on the two regional projects, which only existed for these extra tags.
