### PR TITLE
Poke: show Upgrade seat and Edit spend limit options in the Unblock dropdown

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -51,6 +51,10 @@ import {
   CoinsStacked03,
   createSelectionColumn,
   DataTable,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Icon,
   LoadingBlock,
   ProgressBar,
@@ -753,7 +757,28 @@ const offPaceColumn: ColumnDef<RowData, string> = {
             onClick={(event) => event.stopPropagation()}
             onPointerDown={(event) => event.stopPropagation()}
           >
-            <Button variant="highlight" size="xs" label="Unblock" isSelect />
+            <DropdownMenu modal={false}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="highlight"
+                  size="xs"
+                  label="Unblock"
+                  isSelect
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  label="Upgrade seat"
+                  disabled
+                  description="Not available from Poke yet"
+                />
+                <DropdownMenuItem
+                  label="Edit spend limit"
+                  disabled
+                  description="Not available from Poke yet"
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </DataTable.CellContent>
       );


### PR DESCRIPTION

## Description

Wraps the usage page Unblock button in a dropdown listing "Upgrade seat" and "Edit spend limit", both disabled placeholders wired up in later stacked PRs.

**Visual:**
<img width="1375" height="320" alt="Capture d’écran 2026-09-03 à 14 35 54" src="https://github.com/user-attachments/assets/dc6c4dfb-9554-4241-830d-b37a876c4a05" />

## Tests

Local testing

## Risk

Low UI only on poke

## Deploy Plan

Deploy front
