### PR TITLE
Sparkle: add a unit shorthand to Input's suffix slot

### DIFF
--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -159,6 +159,13 @@ export interface InputProps
   prefix?: React.ReactNode;
   /** Content of a full-height muted box after the field (e.g. a unit or currency). */
   suffix?: React.ReactNode;
+  /**
+   * Shorthand for a `suffix` that is just a unit/currency label (e.g.
+   * "credits/month", "days"): renders it in the muted box with faint text,
+   * so callers don't each re-style that text themselves. Ignored if `suffix`
+   * is also provided.
+   */
+  unit?: React.ReactNode;
 }
 
 /**
@@ -187,11 +194,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       iconRight,
       prefix,
       suffix,
+      unit,
       ...props
     },
     ref
   ) => {
     const size: InputSizeType = typeof rawSize === "number" ? "sm" : rawSize;
+    const resolvedSuffix =
+      suffix ??
+      (unit != null ? <span className="text-faint">{unit}</span> : undefined);
     const state =
       isError || (message && messageStatus === "error")
         ? "error"
@@ -235,7 +246,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               )}
             />
           )}
-          {suffix && <div className={slotBoxVariants({ size })}>{suffix}</div>}
+          {resolvedSuffix && (
+            <div className={slotBoxVariants({ size })}>{resolvedSuffix}</div>
+          )}
         </div>
         {message && (
           <div

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -160,12 +160,11 @@ export interface InputProps
   /** Content of a full-height muted box after the field (e.g. a unit or currency). */
   suffix?: React.ReactNode;
   /**
-   * Shorthand for a `suffix` that is just a unit/currency label (e.g.
-   * "credits/month", "days"): renders it in the muted box with faint text,
-   * so callers don't each re-style that text themselves. Ignored if `suffix`
-   * is also provided.
+   * Renders `suffix` in the muted box's faint text style, for a unit/currency
+   * label (e.g. "credits/month", "days") instead of callers each re-styling
+   * that text themselves.
    */
-  unit?: React.ReactNode;
+  isUnit?: boolean;
 }
 
 /**
@@ -194,15 +193,17 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       iconRight,
       prefix,
       suffix,
-      unit,
+      isUnit,
       ...props
     },
     ref
   ) => {
     const size: InputSizeType = typeof rawSize === "number" ? "sm" : rawSize;
-    const resolvedSuffix =
-      suffix ??
-      (unit != null ? <span className="text-faint">{unit}</span> : undefined);
+    const resolvedSuffix = isUnit ? (
+      <span className="text-faint">{suffix}</span>
+    ) : (
+      suffix
+    );
     const state =
       isError || (message && messageStatus === "error")
         ? "error"

--- a/sparkle/src/stories/Input.stories.tsx
+++ b/sparkle/src/stories/Input.stories.tsx
@@ -124,7 +124,8 @@ export const WithLeadingIcon: Story = {
 
 /**
  * A `prefix` renders static content inside the field before the value —
- * here a currency symbol. Use `unit` for a label shown after the value.
+ * here a currency symbol. Use `suffix` with `isUnit` for a label shown
+ * after the value.
  * @summary Input with a static prefix.
  */
 export const WithPrefix: Story = {
@@ -135,15 +136,16 @@ export const WithPrefix: Story = {
 };
 
 /**
- * `unit` is shorthand for a `suffix` that's just a unit/currency label — it
- * renders in the muted box with faint text automatically, so callers don't
- * need to style that text themselves.
+ * `isUnit` renders `suffix` in the muted box with faint text automatically,
+ * for a unit/currency label, so callers don't need to style that text
+ * themselves.
  * @summary Input with a unit suffix.
  */
 export const WithUnit: Story = {
   args: {
     placeholder: "1,000",
-    unit: "credits/month",
+    suffix: "credits/month",
+    isUnit: true,
   },
 };
 

--- a/sparkle/src/stories/Input.stories.tsx
+++ b/sparkle/src/stories/Input.stories.tsx
@@ -124,13 +124,26 @@ export const WithLeadingIcon: Story = {
 
 /**
  * A `prefix` renders static content inside the field before the value —
- * here a currency symbol. Use `suffix` for a unit shown after the value.
+ * here a currency symbol. Use `unit` for a label shown after the value.
  * @summary Input with a static prefix.
  */
 export const WithPrefix: Story = {
   args: {
     placeholder: "0.00",
     prefix: <span className="text-faint">$</span>,
+  },
+};
+
+/**
+ * `unit` is shorthand for a `suffix` that's just a unit/currency label — it
+ * renders in the muted box with faint text automatically, so callers don't
+ * need to style that text themselves.
+ * @summary Input with a unit suffix.
+ */
+export const WithUnit: Story = {
+  args: {
+    placeholder: "1,000",
+    unit: "credits/month",
   },
 };
 


### PR DESCRIPTION
## Description

Extend Sparkle input component to support unit on the right. Used later in this stack
Also adds an example to Sparkle see below:

<img width="1098" height="323" alt="Capture d’écran 2026-09-03 à 14 40 51" src="https://github.com/user-attachments/assets/b5b1e66e-4eb3-43f4-8c63-d3954d8fac4e" />

## Tests

Localy

## Risk

Low Sparkle only

## Deploy Plan

- Deploy sparkle 
- Deploy front