### PR TITLE
Poke: open a seat-change preview from the Unblock dropdown's Upgrade seat option

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -9,6 +9,7 @@ import awuPoolCycleHistory from "./awu-pool-cycle-history";
 import awuPoolSummary from "./awu-pool-summary";
 import consumptionExport from "./consumption-export";
 import membersUsage from "./members-usage";
+import seatsPlan from "./seats-plan";
 import topUps from "./top-ups";
 
 // Mounted at /api/poke/workspaces/:wId/credits.
@@ -44,6 +45,7 @@ app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
 app.route("/awu-pool-cycle-history", awuPoolCycleHistory);
 app.route("/consumption-export", consumptionExport);
 app.route("/members-usage", membersUsage);
+app.route("/seats-plan", seatsPlan);
 app.route("/top-ups", topUps);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/seats-plan.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/seats-plan.ts
@@ -1,0 +1,59 @@
+import type {
+  SeatPlanError,
+  SeatPlanResponseBody,
+} from "@app/lib/api/credits/seat_plan";
+import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+export type { SeatPlanResponseBody };
+
+function seatPlanErrorToApi(ctx: Context, err: SeatPlanError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "internal_server_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "currency_resolution_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to resolve currency for seat plan.",
+        },
+      });
+    case "rate_schedule_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to fetch rate schedule for seat products.",
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/poke/workspaces/:wId/credits/seats-plan.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<SeatPlanResponseBody> => {
+  const auth = ctx.get("auth");
+
+  const result = await getSeatPlan(auth);
+  if (result.isErr()) {
+    return seatPlanErrorToApi(ctx, result.error);
+  }
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/seats-plan.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/seats-plan.ts
@@ -17,7 +17,7 @@ function seatPlanErrorToApi(ctx: Context, err: SeatPlanError) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
-          type: "internal_server_error",
+          type: "invalid_request_error",
           message: "Workspace is not configured for Metronome billing.",
         },
       });

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -788,7 +788,7 @@ export function UsagePage() {
     disabled: !isCreditPriced,
   });
 
-  const { seatPlans } = useSeatPlan({
+  const { seatPlans, isSeatPlanLoading, isSeatPlanError } = useSeatPlan({
     workspaceId: owner.sId,
     disabled: !isCreditPriced,
   });
@@ -1418,6 +1418,8 @@ export function UsagePage() {
         member={changeSeatMember}
         owner={owner}
         seatPlans={seatPlans}
+        isSeatPlanLoading={isSeatPlanLoading}
+        isSeatPlanError={!!isSeatPlanError}
         onSavingChange={handleSeatChangePendingChange}
         onSaved={handleSeatMutationSaved}
       />

--- a/front/components/poke/credits/PokeChangeSeatModal.tsx
+++ b/front/components/poke/credits/PokeChangeSeatModal.tsx
@@ -78,7 +78,7 @@ function getBadge(
   if (toBaseSeatType(seatType) === "workspace") {
     return (
       <span className="text-xs text-foreground">
-        {price} · User can spend credits from the workspace pool.
+        {price} · User can spend credits from the workspace&nbsp;pool.
       </span>
     );
   }
@@ -88,7 +88,7 @@ function getBadge(
       {price} ·{" "}
       {openCount > 0
         ? `${openCount} included seat${pluralize(openCount)} open`
-        : "No included seats left — this will add a new billed seat"}
+        : "No included seats left, this will add a new billed seat"}
     </span>
   );
 }

--- a/front/components/poke/credits/PokeChangeSeatModal.tsx
+++ b/front/components/poke/credits/PokeChangeSeatModal.tsx
@@ -1,0 +1,248 @@
+import { BillingPeriodSwitch } from "@app/components/pages/onboarding/SubscriptionPlans";
+import {
+  formatPriceCents,
+  getAvailableFrequencies,
+  groupSeatTypesByFrequency,
+  includedSeatsOpen,
+  SeatCard,
+  sortSeatTypes,
+} from "@app/components/workspace/SeatCard";
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import type {
+  SeatPlanResponseBody,
+  SeatTypeInfo,
+} from "@app/lib/api/credits/seat_plan";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { isMembershipSeatType, toBaseSeatType } from "@app/types/memberships";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import {
+  AlertCircle,
+  Chip,
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useEffect, useRef, useState } from "react";
+
+interface PokeChangeSeatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  member: MemberUsageType | null;
+  // Live seat-plan catalog for the workspace (see usePokeSeatPlan) — the
+  // same source of truth the customer-facing ChangeSeatModal uses, so the
+  // picker shows real seat cards, pricing, and included-seat counts.
+  seatPlans: SeatPlanResponseBody;
+  isSeatPlanLoading: boolean;
+  isSeatPlanError: boolean;
+}
+
+// Poke has no working write route for member seat changes yet, so Validate
+// is wired to nothing but a notice rather than an actual mutation — mirrors
+// PokeMemberSpendLimitModal's Save behavior.
+function useUnavailableSeatChangeSave() {
+  const sendNotification = useSendNotification();
+  return () =>
+    sendNotification({
+      title: "Not available from Poke yet",
+      description: "Changing a member's seat from Poke isn't supported yet.",
+      type: "info",
+    });
+}
+
+// Mirrors ChangeSeatModal's getBadge: a "Current" chip for the member's own
+// seat, otherwise the price plus how many already-committed seats are free
+// to absorb this move before it starts a new billed seat.
+function getBadge(
+  seatType: MembershipSeatType,
+  info: SeatTypeInfo,
+  isCurrent: boolean
+): React.ReactNode {
+  if (isCurrent) {
+    return <Chip size="xs" color="highlight" label="Current" />;
+  }
+  const price =
+    info.billingFrequency === "annual" ? (
+      <>
+        {formatPriceCents(info.priceCents / 12, info.currency, "monthly")} ·
+        billed annually
+      </>
+    ) : (
+      formatPriceCents(info.priceCents, info.currency, info.billingFrequency)
+    );
+  if (toBaseSeatType(seatType) === "workspace") {
+    return (
+      <span className="text-xs text-foreground">
+        {price} · User can spend credits from the workspace pool.
+      </span>
+    );
+  }
+  const openCount = includedSeatsOpen(info);
+  return (
+    <span className="text-xs text-foreground">
+      {price} ·{" "}
+      {openCount > 0
+        ? `${openCount} included seat${pluralize(openCount)} open`
+        : "No included seats left — this will add a new billed seat"}
+    </span>
+  );
+}
+
+export function PokeChangeSeatModal({
+  isOpen,
+  onClose,
+  member,
+  seatPlans,
+  isSeatPlanLoading,
+  isSeatPlanError,
+}: PokeChangeSeatModalProps) {
+  // Keep the last non-null member so the dialog can render its content
+  // through the exit animation after the parent has cleared `member`. Set in
+  // an effect, not during render: React can replay or discard a render, so a
+  // write during render could leak a member from an abandoned render into
+  // the exit-animation snapshot.
+  const lastMemberRef = useRef<MemberUsageType | null>(null);
+  useEffect(() => {
+    if (member) {
+      lastMemberRef.current = member;
+    }
+  }, [member]);
+  const displayedMember = member ?? lastMemberRef.current;
+
+  const notifySaveUnavailable = useUnavailableSeatChangeSave();
+
+  // "free" seats are never a selectable target, same as the customer modal.
+  // Also restrict to monthly/annual plans: BillingPeriodSwitch only offers
+  // those two cadences, so a weekly/quarterly-only seat plan would either
+  // show under the wrong tab label or leave a tab with no cards.
+  const seatTypes = sortSeatTypes(
+    Object.keys(seatPlans)
+      .filter(isMembershipSeatType)
+      .filter((s) => s !== "free")
+      .filter((s) => {
+        const frequency = seatPlans[s]?.billingFrequency;
+        return frequency === "monthly" || frequency === "annual";
+      })
+  );
+  const seatTypesByFrequency = groupSeatTypesByFrequency(seatTypes, seatPlans);
+  const availableFrequencies = getAvailableFrequencies(seatTypesByFrequency);
+
+  const displayedMemberId = displayedMember?.sId ?? null;
+  const currentSeatType = displayedMember?.seatType ?? null;
+  const currentFrequency =
+    currentSeatType && seatPlans[currentSeatType]
+      ? seatPlans[currentSeatType].billingFrequency
+      : null;
+  const initialFrequency =
+    (currentFrequency && seatTypesByFrequency[currentFrequency].length > 0
+      ? currentFrequency
+      : availableFrequencies[0]) ?? "monthly";
+
+  const [selectedSeat, setSelectedSeat] = useState<MembershipSeatType | null>(
+    currentSeatType ?? seatTypes[0] ?? null
+  );
+  const [activeFrequency, setActiveFrequency] = useState(initialFrequency);
+
+  // Reset the selection and active tab to the member's current seat each
+  // time the dialog opens for a (possibly different) member.
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedSeat(currentSeatType ?? seatTypes[0] ?? null);
+      setActiveFrequency(initialFrequency);
+    }
+  }, [isOpen, currentSeatType, seatTypes[0], initialFrequency]);
+
+  const displayedFirstName =
+    displayedMember?.name?.trim().split(/\s+/)[0] ?? null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md" className="font-sans">
+        <DialogHeader>
+          <DialogTitle>
+            {displayedFirstName
+              ? `Change seat for ${displayedFirstName}`
+              : "Change seat"}
+          </DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          {isSeatPlanLoading ? (
+            <div className="flex justify-center py-6">
+              <Spinner />
+            </div>
+          ) : isSeatPlanError || seatTypes.length === 0 ? (
+            <ContentMessage
+              title="No seat plans available"
+              icon={AlertCircle}
+              variant="warning"
+            >
+              <p>
+                Could not load a seat-plan catalog for this workspace, or it
+                isn&apos;t configured for seat-based billing.
+              </p>
+            </ContentMessage>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {availableFrequencies.length > 1 && (
+                <div className="mb-1 self-start">
+                  {/* Remount per member so the uncontrolled switch picks up
+                      the member's current billing frequency as its default. */}
+                  <BillingPeriodSwitch
+                    key={displayedMemberId ?? "none"}
+                    defaultValue={
+                      currentFrequency === "annual" ? "yearly" : "monthly"
+                    }
+                    onValueChange={(period) =>
+                      setActiveFrequency(
+                        period === "yearly" ? "annual" : "monthly"
+                      )
+                    }
+                  />
+                </div>
+              )}
+
+              {seatTypesByFrequency[activeFrequency].map((seatType) => {
+                const info = seatPlans[seatType];
+                if (!info) {
+                  return null;
+                }
+                return (
+                  <SeatCard
+                    key={seatType}
+                    seatType={seatType}
+                    info={info}
+                    isSelected={selectedSeat === seatType}
+                    badge={getBadge(
+                      seatType,
+                      info,
+                      seatType === currentSeatType
+                    )}
+                    onClick={() => setSelectedSeat(seatType)}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Validate",
+            variant: "highlight",
+            disabled: !selectedSeat || isSeatPlanLoading || isSeatPlanError,
+            onClick: notifySaveUnavailable,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/poke/credits/PokeChangeSeatModal.tsx
+++ b/front/components/poke/credits/PokeChangeSeatModal.tsx
@@ -101,11 +101,6 @@ export function PokeChangeSeatModal({
   isSeatPlanLoading,
   isSeatPlanError,
 }: PokeChangeSeatModalProps) {
-  // Keep the last non-null member so the dialog can render its content
-  // through the exit animation after the parent has cleared `member`. Set in
-  // an effect, not during render: React can replay or discard a render, so a
-  // write during render could leak a member from an abandoned render into
-  // the exit-animation snapshot.
   const lastMemberRef = useRef<MemberUsageType | null>(null);
   useEffect(() => {
     if (member) {
@@ -116,10 +111,6 @@ export function PokeChangeSeatModal({
 
   const notifySaveUnavailable = useUnavailableSeatChangeSave();
 
-  // "free" seats are never a selectable target, same as the customer modal.
-  // Also restrict to monthly/annual plans: BillingPeriodSwitch only offers
-  // those two cadences, so a weekly/quarterly-only seat plan would either
-  // show under the wrong tab label or leave a tab with no cards.
   const seatTypes = sortSeatTypes(
     Object.keys(seatPlans)
       .filter(isMembershipSeatType)

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -1,3 +1,4 @@
+import { PokeChangeSeatModal } from "@app/components/poke/credits/PokeChangeSeatModal";
 import { PokeTopUpsHistoryTable } from "@app/components/poke/credits/PokeTopUpsHistoryTable";
 import {
   SEAT_TYPE_ICONS,
@@ -17,6 +18,7 @@ import {
   usePokeAwuPoolCurrentCycle,
   usePokeAwuPoolCycleHistory,
   usePokeMembersUsage,
+  usePokeSeatPlan,
 } from "@app/poke/swr/credits";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeGroups } from "@app/poke/swr/groups";
@@ -139,6 +141,8 @@ export function PoolUsagePage() {
   const [seatTypeFilter, setSeatTypeFilter] =
     useState<MembershipSeatType | null>(null);
   const [groupFilter, setGroupFilter] = useState<string | null>(null);
+  const [changeSeatRecapMember, setChangeSeatRecapMember] =
+    useState<MemberUsageType | null>(null);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -202,6 +206,10 @@ export function PoolUsagePage() {
     orderDirection,
     seatType: seatTypeFilter ?? undefined,
     groupId: groupFilter ?? undefined,
+  });
+
+  const { seatPlans, isSeatPlanLoading, isSeatPlanError } = usePokeSeatPlan({
+    owner,
   });
 
   const { data: allGroups } = usePokeGroups({ owner });
@@ -385,6 +393,7 @@ export function PoolUsagePage() {
                   hasPool={hasPool}
                   readOnly
                   onChangeSeat={noopOnMember}
+                  onOpenChangeSeatRecap={setChangeSeatRecapMember}
                   onRemoveSeat={noopOnMember}
                   onEditSpendLimit={noopOnMember}
                   pagination={pagination}
@@ -409,6 +418,15 @@ export function PoolUsagePage() {
           </TabsContent>
         </Tabs>
       </div>
+
+      <PokeChangeSeatModal
+        isOpen={!!changeSeatRecapMember}
+        member={changeSeatRecapMember}
+        seatPlans={seatPlans}
+        isSeatPlanLoading={isSeatPlanLoading}
+        isSeatPlanError={!!isSeatPlanError}
+        onClose={() => setChangeSeatRecapMember(null)}
+      />
     </main>
   );
 }

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -37,14 +37,17 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import {
+  AlertCircle,
   Avatar,
   Chip,
+  ContentMessage,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { useEffect, useRef, useState } from "react";
 
@@ -77,6 +80,8 @@ interface ChangeSeatModalProps {
   member: MemberUsageType | null;
   owner: WorkspaceType;
   seatPlans: SeatPlanResponseBody;
+  isSeatPlanLoading?: boolean;
+  isSeatPlanError?: boolean;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
   // Fired once the seat change has been persisted successfully (not on cancel
   // or a no-op close). Used to resolve a linked upgrade request as approved.
@@ -89,6 +94,8 @@ export function ChangeSeatModal({
   member,
   owner,
   seatPlans,
+  isSeatPlanLoading = false,
+  isSeatPlanError = false,
   onSavingChange,
   onSaved,
 }: ChangeSeatModalProps) {
@@ -102,20 +109,32 @@ export function ChangeSeatModal({
   const isSubscriptionCancelled =
     isSubscriptionCancellationScheduled(subscription);
   // Keep the last non-null member so the dialog can render its content through
-  // the exit animation after the parent has cleared `member`.
+  // the exit animation after the parent has cleared `member`. Set in an
+  // effect, not during render: React can replay or discard a render, so a
+  // write during render could leak a member from an abandoned render into
+  // the exit-animation snapshot.
   const lastMemberRef = useRef<MemberUsageType | null>(null);
-  if (member) {
-    lastMemberRef.current = member;
-  }
+  useEffect(() => {
+    if (member) {
+      lastMemberRef.current = member;
+    }
+  }, [member]);
   const displayedMember = member ?? lastMemberRef.current;
 
   // "free" seats are not user-selectable — a member can never be switched to
   // a Free seat from this modal. Filter the API response so the option never
   // appears in the picker even if it's returned by the seat plans endpoint.
+  // Also restrict to monthly/annual plans: BillingPeriodSwitch only offers
+  // those two cadences, so a weekly/quarterly-only seat plan would either
+  // show under the wrong tab label or leave a tab with no cards.
   const seatTypes = sortSeatTypes(
     Object.keys(seatPlans)
       .filter(isMembershipSeatType)
       .filter((s) => s !== "free")
+      .filter((s) => {
+        const frequency = seatPlans[s]?.billingFrequency;
+        return frequency === "monthly" || frequency === "annual";
+      })
   );
   const firstSeatType = seatTypes[0] ?? null;
   const displayedMemberId = displayedMember?.sId ?? null;
@@ -390,85 +409,99 @@ export function ChangeSeatModal({
           </div>
         </DialogHeader>
         <DialogContainer>
-          <div className="flex flex-col gap-3">
-            {availableFrequencies.length > 1 && (
-              <div className="mb-1 self-start">
-                {/* Remount per member so the uncontrolled switch picks up the
+          {isSeatPlanLoading ? (
+            <div className="flex justify-center py-6">
+              <Spinner />
+            </div>
+          ) : isSeatPlanError || seatTypes.length === 0 ? (
+            <ContentMessage
+              title="No seat plans available"
+              icon={AlertCircle}
+              variant="warning"
+            >
+              <p>We couldn&apos;t load the seat plans for this workspace.</p>
+            </ContentMessage>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {availableFrequencies.length > 1 && (
+                <div className="mb-1 self-start">
+                  {/* Remount per member so the uncontrolled switch picks up the
                     member's current billing frequency as its default. */}
-                <BillingPeriodSwitch
-                  key={displayedMemberId ?? "none"}
-                  defaultValue={
-                    currentFrequency === "annual" ? "yearly" : "monthly"
-                  }
-                  onValueChange={(period) =>
-                    setActiveFrequency(
-                      period === "yearly" ? "annual" : "monthly"
-                    )
-                  }
-                />
-              </div>
-            )}
+                  <BillingPeriodSwitch
+                    key={displayedMemberId ?? "none"}
+                    defaultValue={
+                      currentFrequency === "annual" ? "yearly" : "monthly"
+                    }
+                    onValueChange={(period) =>
+                      setActiveFrequency(
+                        period === "yearly" ? "annual" : "monthly"
+                      )
+                    }
+                  />
+                </div>
+              )}
 
-            {seatTypesByFrequency[activeFrequency].map((seatType) => {
-              const info = seatPlans[seatType];
-              if (!info) {
-                return null;
-              }
-              return (
-                <SeatCard
-                  key={seatType}
-                  seatType={seatType}
-                  info={info}
-                  isSelected={selectedSeat === seatType}
-                  badge={getBadge(seatType, info)}
-                  onClick={() => setSelectedSeat(seatType)}
-                />
-              );
-            })}
+              {seatTypesByFrequency[activeFrequency].map((seatType) => {
+                const info = seatPlans[seatType];
+                if (!info) {
+                  return null;
+                }
+                return (
+                  <SeatCard
+                    key={seatType}
+                    seatType={seatType}
+                    info={info}
+                    isSelected={selectedSeat === seatType}
+                    badge={getBadge(seatType, info)}
+                    onClick={() => setSelectedSeat(seatType)}
+                  />
+                );
+              })}
 
-            {isSubscriptionCancelled ? (
-              <p className="mt-1 text-xs text-warning-600">
-                Your subscription is scheduled to end and seats can&apos;t be
-                changed until it&apos;s reactivated.
-              </p>
-            ) : (
-              isDeferredChange && (
-                <p className="mt-1 text-xs text-info-600">
-                  The change will take effect at the next credit refresh.
-                </p>
-              )
-            )}
-            {isCancellingScheduledChange && (
-              <p className="mt-1 text-xs text-info-600">
-                Scheduled change to{" "}
-                <span className="capitalize">
-                  {displayedMember?.scheduledSeatType}
-                </span>{" "}
-                will be cancelled.
-              </p>
-            )}
-            {!isSubscriptionCancelled &&
-              selectedSeat &&
-              selectedSeat !== currentSeatType &&
-              (isInvoicePreviewLoading ? (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Estimating invoice impact…
+              {isSubscriptionCancelled ? (
+                <p className="mt-1 text-xs text-warning-600">
+                  Your subscription is scheduled to end and seats can&apos;t be
+                  changed until it&apos;s reactivated.
                 </p>
               ) : (
-                invoicePreview && (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {getInvoiceImpactMessage({
-                      deltaCents: invoiceDeltaCents,
-                      currency: invoicePreview.currency,
-                      targetSeatInfo: selectedSeatInfo ?? null,
-                      moveCount: 1,
-                      isDeferred: isInvoiceDeltaDeferred,
-                      hasAnnualOrigin: currentFrequency === "annual",
-                    })}
+                isDeferredChange && (
+                  <p className="mt-1 text-xs text-info-600">
+                    The change will take effect at the next credit refresh.
                   </p>
                 )
-              ))}
-          </div>
+              )}
+              {isCancellingScheduledChange && (
+                <p className="mt-1 text-xs text-info-600">
+                  Scheduled change to{" "}
+                  <span className="capitalize">
+                    {displayedMember?.scheduledSeatType}
+                  </span>{" "}
+                  will be cancelled.
+                </p>
+              )}
+              {!isSubscriptionCancelled &&
+                selectedSeat &&
+                selectedSeat !== currentSeatType &&
+                (isInvoicePreviewLoading ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Estimating invoice impact…
+                  </p>
+                ) : (
+                  invoicePreview && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {getInvoiceImpactMessage({
+                        deltaCents: invoiceDeltaCents,
+                        currency: invoicePreview.currency,
+                        targetSeatInfo: selectedSeatInfo ?? null,
+                        moveCount: 1,
+                        isDeferred: isInvoiceDeltaDeferred,
+                        hasAnnualOrigin: currentFrequency === "annual",
+                      })}
+                    </p>
+                  )
+                ))}
+            </div>
+          )}
         </DialogContainer>
         <DialogFooter
           leftButtonProps={{
@@ -479,13 +512,16 @@ export function ChangeSeatModal({
           rightButtonProps={{
             label: useCheckoutPath ? "Continue to checkout" : "Validate",
             variant: "primary",
-            disabled: useCheckoutPath
-              ? !selectedSeat || !toCheckoutParams(selectedSeat)
-              : isSaving ||
-                !selectedSeat ||
-                isSubscriptionCancelled ||
-                (selectedSeat === currentSeatType &&
-                  !isCancellingScheduledChange),
+            disabled:
+              isSeatPlanLoading ||
+              isSeatPlanError ||
+              (useCheckoutPath
+                ? !selectedSeat || !toCheckoutParams(selectedSeat)
+                : isSaving ||
+                  !selectedSeat ||
+                  isSubscriptionCancelled ||
+                  (selectedSeat === currentSeatType &&
+                    !isCancellingScheduledChange)),
             onClick: handleValidate,
           }}
         />

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -86,6 +86,10 @@ const EMPTY_MODEL_TIER_DEFINITION_BY_NAME = new Map<
   ModelsTierName,
   ModelsTierDefinition
 >();
+// Stable reference for optional member-callback props so a caller that
+// doesn't pass one (e.g. the customer-facing "legacy" variant) doesn't bust
+// the `rows` useMemo below with a new function identity every render.
+const NOOP_ON_MEMBER = (_member: MemberUsageType) => {};
 
 type RowData = {
   sId: string;
@@ -108,6 +112,7 @@ type RowData = {
   isSeatChangePending: boolean;
   overallUsageTarget: CreditUsageTarget | null;
   creditState: UserCreditState;
+  onOpenChangeSeatRecap: () => void;
   modelTiersSummary: string;
   hasUserLevelModelTiersOverride: boolean;
   menuItems: MenuItem[];
@@ -748,7 +753,8 @@ const offPaceColumn: ColumnDef<RowData, string> = {
   enableSorting: false,
   accessorFn: (row) => row.overallUsageTarget ?? "",
   cell: (info: Info) => {
-    const { overallUsageTarget, creditState } = info.row.original;
+    const { overallUsageTarget, creditState, onOpenChangeSeatRecap } =
+      info.row.original;
 
     if (creditState === "capped") {
       return (
@@ -769,8 +775,7 @@ const offPaceColumn: ColumnDef<RowData, string> = {
               <DropdownMenuContent align="end">
                 <DropdownMenuItem
                   label="Upgrade seat"
-                  disabled
-                  description="Not available from Poke yet"
+                  onClick={onOpenChangeSeatRecap}
                 />
                 <DropdownMenuItem
                   label="Edit spend limit"
@@ -977,6 +982,10 @@ interface MembersUsageTableProps {
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
+  // Poke-only: opens the read-only change-seat recap modal from the
+  // off-pace column's "Unblock" panel. No-op default for the customer-facing
+  // ("legacy") variant, which never renders that column.
+  onOpenChangeSeatRecap?: (member: MemberUsageType) => void;
   onSetUserModelTier?: (
     member: MemberUsageType,
     selection: UserModelTierSelection
@@ -1018,6 +1027,7 @@ export function MembersUsageTable({
   onChangeSeat,
   onRemoveSeat,
   onEditSpendLimit,
+  onOpenChangeSeatRecap = NOOP_ON_MEMBER,
   onSetUserModelTier,
   showModelTiersColumn = false,
   variant = "legacy",
@@ -1077,6 +1087,7 @@ export function MembersUsageTable({
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
           overallUsageTarget: m.overallUsageTarget,
           creditState: m.creditState,
+          onOpenChangeSeatRecap: () => onOpenChangeSeatRecap(m),
           modelTiersSummary: (() => {
             const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
             switch (variant) {
@@ -1183,6 +1194,7 @@ export function MembersUsageTable({
       onChangeSeat,
       onRemoveSeat,
       onEditSpendLimit,
+      onOpenChangeSeatRecap,
       onSetUserModelTier,
     ]
   );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -86,9 +86,6 @@ const EMPTY_MODEL_TIER_DEFINITION_BY_NAME = new Map<
   ModelsTierName,
   ModelsTierDefinition
 >();
-// Stable reference for optional member-callback props so a caller that
-// doesn't pass one (e.g. the customer-facing "legacy" variant) doesn't bust
-// the `rows` useMemo below with a new function identity every render.
 const NOOP_ON_MEMBER = (_member: MemberUsageType) => {};
 
 type RowData = {

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -392,26 +392,27 @@ export function SeatCard({
       onClick={onClick}
       className="w-full flex-col items-stretch gap-2 ring-0"
     >
-      <div className="flex w-full items-center justify-between gap-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <div
-            className={cn(
-              "flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
-              iconBackgroundClass
-            )}
-          >
-            <Icon
-              visual={seatIcon}
-              size="sm"
-              className={getSeatIconColorClass(seatType)}
-            />
-          </div>
-          <span className="truncate text-base font-semibold text-foreground">
-            {stripYearlySuffix(info.name)}
-          </span>
+      <div className="flex w-full items-center gap-2">
+        <div
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
+            iconBackgroundClass
+          )}
+        >
+          <Icon
+            visual={seatIcon}
+            size="sm"
+            className={getSeatIconColorClass(seatType)}
+          />
         </div>
-        <div className="shrink-0">{badge}</div>
+        <span className="min-w-0 flex-1 truncate text-base font-semibold text-foreground">
+          {stripYearlySuffix(info.name)}
+        </span>
       </div>
+      {/* On its own row rather than beside the name: the price/included-seats
+          badge is often too long to share a row with the name at this card
+          width without wrapping onto (and overlapping) the icon. */}
+      <div>{badge}</div>
       {info.awuCredits > 0 && (
         <div className="flex items-center gap-2 text-muted-foreground">
           <Icon

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -8,6 +8,7 @@ import type {
 } from "@app/lib/api/analytics/programmatic_cost";
 import type { GetApiKeysUsageResponseBody } from "@app/lib/api/credits/api_keys_usage";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
+import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type {
@@ -333,5 +334,27 @@ export function usePokeApiKeysUsage({
     isApiKeysUsageLoading: !error && !data && !disabled,
     isApiKeysUsageError: error,
     mutateApiKeysUsage: mutate,
+  };
+}
+
+const EMPTY_SEAT_PLANS: SeatPlanResponseBody = {};
+
+export function usePokeSeatPlan({
+  disabled,
+  owner,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const seatPlanFetcher: Fetcher<SeatPlanResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/credits/seats-plan`,
+    seatPlanFetcher,
+    { disabled }
+  );
+
+  return {
+    seatPlans: data ?? EMPTY_SEAT_PLANS,
+    isSeatPlanLoading: !error && !data && !disabled,
+    isSeatPlanError: error,
   };
 }


### PR DESCRIPTION
## Description

Wires "Upgrade seat" to a new PokeChangeSeatModal seat-tier picker; Validate only shows a "not available from Poke" notice. 

Also fixed a small UI glitch already existing in the component. 

## Tests

- Local testing

## Risk

Low additive only on poke and small ui fix on the app

## Deploy Plan

- Deploy front
