### PR TITLE
Poke: open the edit spend limit modal from the Unblock dropdown's option

### DIFF
--- a/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
+++ b/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
@@ -186,7 +186,7 @@ export function PokeMemberSpendLimitModal({
               <p className="text-sm text-muted-foreground">
                 This user can currently consume{" "}
                 {formatCredits(seatAllowanceAwuCredits)} credits from their
-                seat, plus {formatCredits(extraAwuCredits)} on the pool.
+                seat, plus {formatCredits(extraAwuCredits)} on the&nbsp;pool.
               </p>
             </div>
           </div>

--- a/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
+++ b/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
@@ -2,6 +2,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
 import type { GroupType } from "@app/types/groups";
+import { removeNulls } from "@app/types/shared/utils/general";
 import {
   Avatar,
   Chip,
@@ -18,7 +19,7 @@ import {
   Users01,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface PokeMemberSpendLimitModalProps {
   isOpen: boolean;
@@ -36,19 +37,6 @@ type GroupRow = {
   onClick?: () => void;
 };
 
-// Poke has no working write route for per-member or per-group spend limits
-// yet, so Save is wired to nothing but a notice rather than an actual
-// mutation
-function useUnavailableSpendLimitSave() {
-  const sendNotification = useSendNotification();
-  return () =>
-    sendNotification({
-      title: "Not available from Poke yet",
-      description: "Editing spend limits from Poke isn't supported yet.",
-      type: "info",
-    });
-}
-
 export function PokeMemberSpendLimitModal({
   isOpen,
   onClose,
@@ -58,14 +46,25 @@ export function PokeMemberSpendLimitModal({
   // Keep the last non-null member so the dialog can render its content
   // through the exit animation after the parent has cleared `member`.
   const lastMemberRef = useRef<MemberUsageType | null>(null);
-  if (member) {
-    lastMemberRef.current = member;
-  }
+  useEffect(() => {
+    if (member) {
+      lastMemberRef.current = member;
+    }
+  }, [member]);
   const displayedMember = member ?? lastMemberRef.current;
 
-  const notifySaveUnavailable = useUnavailableSpendLimitSave();
+  const sendNotification = useSendNotification();
+  // Poke has no working write route for per-member or per-group spend
+  // limits yet, so Save is wired to nothing but a notice rather than an
+  // actual mutation.
+  const notifySaveUnavailable = () =>
+    sendNotification({
+      title: "Not available from Poke yet",
+      description: "Editing spend limits from Poke isn't supported yet.",
+      type: "info",
+    });
 
-  const [personalLimitInput, setPersonalLimitInput] = useState("");
+  const [personalLimitInput, setPersonalLimitInput] = useState<string>("");
   // Typed group overrides aren't read anywhere yet (Save is a no-op notice,
   // not a real mutation), so they're kept in a ref rather than state
   const groupLimitInputsRef = useRef<Record<string, string>>({});
@@ -82,13 +81,15 @@ export function PokeMemberSpendLimitModal({
     ? String(extraAwuCredits)
     : "0";
 
-  const memberGroups: GroupType[] = (displayedMember?.groups ?? [])
-    .map((groupName) => groups.find((g) => g.name === groupName))
-    .filter((g): g is GroupType => g !== undefined);
+  const memberGroups: GroupType[] = removeNulls(
+    (displayedMember?.groups ?? []).map((groupName) =>
+      groups.find((g) => g.name === groupName)
+    )
+  );
 
   // When there's no personal override, the highest group cap the member is
   // part of is the one currently granting their extra credits.
-  const highestGroupSId = memberGroups.reduce<string | null>(
+  const highestGroupId = memberGroups.reduce<string | null>(
     (highestSId, g) => {
       if (g.poolCapAwuCredits === null) {
         return highestSId;
@@ -107,7 +108,7 @@ export function PokeMemberSpendLimitModal({
     name: g.name,
     poolCapAwuCredits: g.poolCapAwuCredits,
     memberCount: g.memberCount,
-    isHighest: !hasPersonalOverride && g.sId === highestGroupSId,
+    isHighest: !hasPersonalOverride && g.sId === highestGroupId,
   }));
 
   const groupColumns: ColumnDef<GroupRow, string>[] = useMemo(
@@ -121,7 +122,7 @@ export function PokeMemberSpendLimitModal({
             <span
               className={
                 row.original.isHighest
-                  ? "font-semibold text-emerald-600"
+                  ? "font-semibold text-highlight-500"
                   : undefined
               }
             >
@@ -145,7 +146,6 @@ export function PokeMemberSpendLimitModal({
             defaultValue={groupLimitInputsRef.current[row.original.sId] ?? ""}
             onChange={(e) => {
               const cleaned = e.target.value.replace(/[^\d]/g, "");
-              e.target.value = cleaned;
               groupLimitInputsRef.current[row.original.sId] = cleaned;
             }}
             suffix="credits/m."

--- a/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
+++ b/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
@@ -24,9 +24,6 @@ interface PokeMemberSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
   member: MemberUsageType | null;
-  // Cap-eligible groups for the workspace, already fetched by the caller
-  // (e.g. PoolUsagePage's usePokeGroups) — filtered here to the member's own
-  // groups.
   groups: GroupType[];
 }
 
@@ -41,7 +38,7 @@ type GroupRow = {
 
 // Poke has no working write route for per-member or per-group spend limits
 // yet, so Save is wired to nothing but a notice rather than an actual
-// mutation — see the "Unblock" panel this modal is opened from.
+// mutation
 function useUnavailableSpendLimitSave() {
   const sendNotification = useSendNotification();
   return () =>
@@ -70,10 +67,7 @@ export function PokeMemberSpendLimitModal({
 
   const [personalLimitInput, setPersonalLimitInput] = useState("");
   // Typed group overrides aren't read anywhere yet (Save is a no-op notice,
-  // not a real mutation), so they're kept in a ref rather than state — a
-  // state update on every keystroke would recreate `groupColumns` below and
-  // remount the DataTable's input cells, kicking focus out after each
-  // character.
+  // not a real mutation), so they're kept in a ref rather than state
   const groupLimitInputsRef = useRef<Record<string, string>>({});
 
   const seatAllowanceAwuCredits = displayedMember?.memberUsageLimit ?? 0;
@@ -154,7 +148,8 @@ export function PokeMemberSpendLimitModal({
               e.target.value = cleaned;
               groupLimitInputsRef.current[row.original.sId] = cleaned;
             }}
-            unit="credits/m."
+            suffix="credits/m."
+            isUnit
           />
         ),
       },
@@ -218,7 +213,8 @@ export function PokeMemberSpendLimitModal({
                   const cleaned = e.target.value.replace(/[^\d]/g, "");
                   setPersonalLimitInput(cleaned);
                 }}
-                unit="credits/months"
+                suffix="credits/months"
+                isUnit
               />
             </Page.Vertical>
 

--- a/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
+++ b/front/components/poke/credits/PokeMemberSpendLimitModal.tsx
@@ -1,0 +1,251 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import { formatCredits } from "@app/lib/client/credits";
+import type { GroupType } from "@app/types/groups";
+import {
+  Avatar,
+  Chip,
+  DataTable,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  Input,
+  Page,
+  Users01,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useRef, useState } from "react";
+
+interface PokeMemberSpendLimitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  member: MemberUsageType | null;
+  // Cap-eligible groups for the workspace, already fetched by the caller
+  // (e.g. PoolUsagePage's usePokeGroups) — filtered here to the member's own
+  // groups.
+  groups: GroupType[];
+}
+
+type GroupRow = {
+  sId: string;
+  name: string;
+  poolCapAwuCredits: number | null;
+  memberCount: number;
+  isHighest: boolean;
+  onClick?: () => void;
+};
+
+// Poke has no working write route for per-member or per-group spend limits
+// yet, so Save is wired to nothing but a notice rather than an actual
+// mutation — see the "Unblock" panel this modal is opened from.
+function useUnavailableSpendLimitSave() {
+  const sendNotification = useSendNotification();
+  return () =>
+    sendNotification({
+      title: "Not available from Poke yet",
+      description: "Editing spend limits from Poke isn't supported yet.",
+      type: "info",
+    });
+}
+
+export function PokeMemberSpendLimitModal({
+  isOpen,
+  onClose,
+  member,
+  groups,
+}: PokeMemberSpendLimitModalProps) {
+  // Keep the last non-null member so the dialog can render its content
+  // through the exit animation after the parent has cleared `member`.
+  const lastMemberRef = useRef<MemberUsageType | null>(null);
+  if (member) {
+    lastMemberRef.current = member;
+  }
+  const displayedMember = member ?? lastMemberRef.current;
+
+  const notifySaveUnavailable = useUnavailableSpendLimitSave();
+
+  const [personalLimitInput, setPersonalLimitInput] = useState("");
+  // Typed group overrides aren't read anywhere yet (Save is a no-op notice,
+  // not a real mutation), so they're kept in a ref rather than state — a
+  // state update on every keystroke would recreate `groupColumns` below and
+  // remount the DataTable's input cells, kicking focus out after each
+  // character.
+  const groupLimitInputsRef = useRef<Record<string, string>>({});
+
+  const seatAllowanceAwuCredits = displayedMember?.memberUsageLimit ?? 0;
+  const effectiveLimitAwuCredits = displayedMember?.spendLimitAwuCredits ?? 0;
+  const extraAwuCredits = Math.max(
+    0,
+    effectiveLimitAwuCredits - seatAllowanceAwuCredits
+  );
+
+  const hasPersonalOverride = displayedMember?.spendLimitSource === "override";
+  const personalLimitPlaceholder = hasPersonalOverride
+    ? String(extraAwuCredits)
+    : "0";
+
+  const memberGroups: GroupType[] = (displayedMember?.groups ?? [])
+    .map((groupName) => groups.find((g) => g.name === groupName))
+    .filter((g): g is GroupType => g !== undefined);
+
+  // When there's no personal override, the highest group cap the member is
+  // part of is the one currently granting their extra credits.
+  const highestGroupSId = memberGroups.reduce<string | null>(
+    (highestSId, g) => {
+      if (g.poolCapAwuCredits === null) {
+        return highestSId;
+      }
+      const highest = memberGroups.find((h) => h.sId === highestSId);
+      if (!highest || g.poolCapAwuCredits > (highest.poolCapAwuCredits ?? -1)) {
+        return g.sId;
+      }
+      return highestSId;
+    },
+    null
+  );
+
+  const memberGroupRows: GroupRow[] = memberGroups.map((g) => ({
+    sId: g.sId,
+    name: g.name,
+    poolCapAwuCredits: g.poolCapAwuCredits,
+    memberCount: g.memberCount,
+    isHighest: !hasPersonalOverride && g.sId === highestGroupSId,
+  }));
+
+  const groupColumns: ColumnDef<GroupRow, string>[] = useMemo(
+    () => [
+      {
+        id: "name",
+        header: "Group",
+        accessorFn: (row) => row.name,
+        cell: ({ row }) => (
+          <DataTable.CellContent>
+            <span
+              className={
+                row.original.isHighest
+                  ? "font-semibold text-emerald-600"
+                  : undefined
+              }
+            >
+              {row.original.name}
+            </span>
+          </DataTable.CellContent>
+        ),
+      },
+      {
+        id: "poolCapAwuCredits",
+        header: "Limit",
+        accessorFn: (row) => String(row.poolCapAwuCredits ?? ""),
+        meta: { className: "w-40" },
+        cell: ({ row }) => (
+          <Input
+            size="xs"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            placeholder={String(row.original.poolCapAwuCredits ?? 0)}
+            defaultValue={groupLimitInputsRef.current[row.original.sId] ?? ""}
+            onChange={(e) => {
+              const cleaned = e.target.value.replace(/[^\d]/g, "");
+              e.target.value = cleaned;
+              groupLimitInputsRef.current[row.original.sId] = cleaned;
+            }}
+            unit="credits/m."
+          />
+        ),
+      },
+      {
+        id: "memberCount",
+        header: "Members",
+        accessorFn: (row) => row.memberCount.toString(),
+        meta: { headerAlign: "right" },
+        cell: ({ row }) => (
+          <span className="block text-right text-sm text-muted-foreground">
+            {row.original.memberCount.toLocaleString()}
+          </span>
+        ),
+      },
+    ],
+    []
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md" className="font-sans">
+        <DialogHeader>
+          <div className="flex flex-col gap-2">
+            <Avatar
+              visual={displayedMember?.image ?? undefined}
+              name={displayedMember?.name}
+              size="md"
+              isRounded
+            />
+            <div>
+              <DialogTitle>
+                Edit spend limit for {displayedMember?.name}
+              </DialogTitle>
+              <p className="text-sm text-muted-foreground">
+                This user can currently consume{" "}
+                {formatCredits(seatAllowanceAwuCredits)} credits from their
+                seat, plus {formatCredits(extraAwuCredits)} on the pool.
+              </p>
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-5">
+            <Page.Vertical gap="xs" align="stretch">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-foreground">
+                  Personal limit
+                </span>
+                {hasPersonalOverride && (
+                  <Chip size="mini" color="highlight" label="Highest" />
+                )}
+              </div>
+              <Input
+                size="sm"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                placeholder={personalLimitPlaceholder}
+                value={personalLimitInput}
+                onChange={(e) => {
+                  const cleaned = e.target.value.replace(/[^\d]/g, "");
+                  setPersonalLimitInput(cleaned);
+                }}
+                unit="credits/months"
+              />
+            </Page.Vertical>
+
+            {memberGroupRows.length > 0 && (
+              <Page.Vertical gap="xs" align="stretch">
+                <span className="flex items-center gap-1 text-sm font-medium text-foreground">
+                  <Icon visual={Users01} size="xs" />
+                  Group limit
+                </span>
+                <DataTable data={memberGroupRows} columns={groupColumns} />
+              </Page.Vertical>
+            )}
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Validate",
+            variant: "highlight",
+            onClick: notifySaveUnavailable,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -1,4 +1,5 @@
 import { PokeChangeSeatModal } from "@app/components/poke/credits/PokeChangeSeatModal";
+import { PokeMemberSpendLimitModal } from "@app/components/poke/credits/PokeMemberSpendLimitModal";
 import { PokeTopUpsHistoryTable } from "@app/components/poke/credits/PokeTopUpsHistoryTable";
 import {
   SEAT_TYPE_ICONS,
@@ -142,6 +143,8 @@ export function PoolUsagePage() {
     useState<MembershipSeatType | null>(null);
   const [groupFilter, setGroupFilter] = useState<string | null>(null);
   const [changeSeatRecapMember, setChangeSeatRecapMember] =
+    useState<MemberUsageType | null>(null);
+  const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -394,6 +397,7 @@ export function PoolUsagePage() {
                   readOnly
                   onChangeSeat={noopOnMember}
                   onOpenChangeSeatRecap={setChangeSeatRecapMember}
+                  onOpenSpendLimitRecap={setSpendLimitRecapMember}
                   onRemoveSeat={noopOnMember}
                   onEditSpendLimit={noopOnMember}
                   pagination={pagination}
@@ -426,6 +430,13 @@ export function PoolUsagePage() {
         isSeatPlanLoading={isSeatPlanLoading}
         isSeatPlanError={!!isSeatPlanError}
         onClose={() => setChangeSeatRecapMember(null)}
+      />
+
+      <PokeMemberSpendLimitModal
+        isOpen={!!spendLimitRecapMember}
+        member={spendLimitRecapMember}
+        groups={groups}
+        onClose={() => setSpendLimitRecapMember(null)}
       />
     </main>
   );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -987,9 +987,6 @@ interface MembersUsageTableProps {
   // off-pace column's "Unblock" panel. No-op default for the customer-facing
   // ("legacy") variant, which never renders that column.
   onOpenChangeSeatRecap?: (member: MemberUsageType) => void;
-  // Poke-only: opens the read-only spend-limit recap modal from the
-  // off-pace column's "Unblock" panel. No-op default for the customer-facing
-  // ("legacy") variant, which never renders that column.
   onOpenSpendLimitRecap?: (member: MemberUsageType) => void;
   onSetUserModelTier?: (
     member: MemberUsageType,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -110,6 +110,7 @@ type RowData = {
   overallUsageTarget: CreditUsageTarget | null;
   creditState: UserCreditState;
   onOpenChangeSeatRecap: () => void;
+  onOpenSpendLimitRecap: () => void;
   modelTiersSummary: string;
   hasUserLevelModelTiersOverride: boolean;
   menuItems: MenuItem[];
@@ -750,8 +751,12 @@ const offPaceColumn: ColumnDef<RowData, string> = {
   enableSorting: false,
   accessorFn: (row) => row.overallUsageTarget ?? "",
   cell: (info: Info) => {
-    const { overallUsageTarget, creditState, onOpenChangeSeatRecap } =
-      info.row.original;
+    const {
+      overallUsageTarget,
+      creditState,
+      onOpenChangeSeatRecap,
+      onOpenSpendLimitRecap,
+    } = info.row.original;
 
     if (creditState === "capped") {
       return (
@@ -776,8 +781,7 @@ const offPaceColumn: ColumnDef<RowData, string> = {
                 />
                 <DropdownMenuItem
                   label="Edit spend limit"
-                  disabled
-                  description="Not available from Poke yet"
+                  onClick={onOpenSpendLimitRecap}
                 />
               </DropdownMenuContent>
             </DropdownMenu>
@@ -983,6 +987,10 @@ interface MembersUsageTableProps {
   // off-pace column's "Unblock" panel. No-op default for the customer-facing
   // ("legacy") variant, which never renders that column.
   onOpenChangeSeatRecap?: (member: MemberUsageType) => void;
+  // Poke-only: opens the read-only spend-limit recap modal from the
+  // off-pace column's "Unblock" panel. No-op default for the customer-facing
+  // ("legacy") variant, which never renders that column.
+  onOpenSpendLimitRecap?: (member: MemberUsageType) => void;
   onSetUserModelTier?: (
     member: MemberUsageType,
     selection: UserModelTierSelection
@@ -1025,6 +1033,7 @@ export function MembersUsageTable({
   onRemoveSeat,
   onEditSpendLimit,
   onOpenChangeSeatRecap = NOOP_ON_MEMBER,
+  onOpenSpendLimitRecap = NOOP_ON_MEMBER,
   onSetUserModelTier,
   showModelTiersColumn = false,
   variant = "legacy",
@@ -1085,6 +1094,7 @@ export function MembersUsageTable({
           overallUsageTarget: m.overallUsageTarget,
           creditState: m.creditState,
           onOpenChangeSeatRecap: () => onOpenChangeSeatRecap(m),
+          onOpenSpendLimitRecap: () => onOpenSpendLimitRecap(m),
           modelTiersSummary: (() => {
             const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
             switch (variant) {
@@ -1192,6 +1202,7 @@ export function MembersUsageTable({
       onRemoveSeat,
       onEditSpendLimit,
       onOpenChangeSeatRecap,
+      onOpenSpendLimitRecap,
       onSetUserModelTier,
     ]
   );


### PR DESCRIPTION
Wires "Edit spend limit" to a new PokeMemberSpendLimitModal matching the
Figma design; Validate is a notice too, since no write route exists yet.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
