### PR TITLE
Poke: skip the seat-upgrade option when a member has no upgrade path

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -214,6 +214,18 @@ export function PoolUsagePage() {
   const { seatPlans, isSeatPlanLoading, isSeatPlanError } = usePokeSeatPlan({
     owner,
   });
+  // Mirrors the customer-facing `isSeatBased` check (UsagePage.tsx): more
+  // than one seat type on offer means the workspace actually sells seat
+  // upgrades, not just a single non-selectable plan.
+  const isSeatBased = Object.keys(seatPlans).length > 1;
+  const canUpgradeSeat = useCallback(
+    (member: MemberUsageType) =>
+      isSeatBased &&
+      !!member.seatType &&
+      member.seatType !== "none" &&
+      toBaseSeatType(member.seatType) !== "workspace",
+    [isSeatBased]
+  );
 
   const { data: allGroups } = usePokeGroups({ owner });
   const groups = useMemo(
@@ -398,6 +410,7 @@ export function PoolUsagePage() {
                   onChangeSeat={noopOnMember}
                   onOpenChangeSeatRecap={setChangeSeatRecapMember}
                   onOpenSpendLimitRecap={setSpendLimitRecapMember}
+                  canUpgradeSeat={canUpgradeSeat}
                   onRemoveSeat={noopOnMember}
                   onEditSpendLimit={noopOnMember}
                   pagination={pagination}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -214,9 +214,6 @@ export function PoolUsagePage() {
   const { seatPlans, isSeatPlanLoading, isSeatPlanError } = usePokeSeatPlan({
     owner,
   });
-  // Mirrors the customer-facing `isSeatBased` check (UsagePage.tsx): more
-  // than one seat type on offer means the workspace actually sells seat
-  // upgrades, not just a single non-selectable plan.
   const isSeatBased = Object.keys(seatPlans).length > 1;
   const canUpgradeSeat = useCallback(
     (member: MemberUsageType) =>

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -762,9 +762,6 @@ const offPaceColumn: ColumnDef<RowData, string> = {
     } = info.row.original;
 
     if (creditState === "capped") {
-      // A member with no seat upgrade path (already on the top seat tier, or
-      // the workspace isn't seat-based at all) has only one unblock action —
-      // skip the dropdown and go straight to the spend-limit modal.
       if (!canUpgradeSeat) {
         return (
           <DataTable.CellContent className="justify-center">
@@ -1011,11 +1008,6 @@ interface MembersUsageTableProps {
   // ("legacy") variant, which never renders that column.
   onOpenChangeSeatRecap?: (member: MemberUsageType) => void;
   onOpenSpendLimitRecap?: (member: MemberUsageType) => void;
-  // Poke-only: whether the off-pace column's "Unblock" panel offers a seat
-  // upgrade for this member. When false, "Unblock" skips the dropdown and
-  // opens the spend-limit modal directly. Defaults to true (always offer
-  // both actions) since the customer-facing ("legacy") variant never renders
-  // that column.
   canUpgradeSeat?: (member: MemberUsageType) => boolean;
   onSetUserModelTier?: (
     member: MemberUsageType,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -87,6 +87,7 @@ const EMPTY_MODEL_TIER_DEFINITION_BY_NAME = new Map<
   ModelsTierDefinition
 >();
 const NOOP_ON_MEMBER = (_member: MemberUsageType) => {};
+const ALWAYS_CAN_UPGRADE_SEAT = (_member: MemberUsageType) => true;
 
 type RowData = {
   sId: string;
@@ -109,6 +110,7 @@ type RowData = {
   isSeatChangePending: boolean;
   overallUsageTarget: CreditUsageTarget | null;
   creditState: UserCreditState;
+  canUpgradeSeat: boolean;
   onOpenChangeSeatRecap: () => void;
   onOpenSpendLimitRecap: () => void;
   modelTiersSummary: string;
@@ -754,11 +756,32 @@ const offPaceColumn: ColumnDef<RowData, string> = {
     const {
       overallUsageTarget,
       creditState,
+      canUpgradeSeat,
       onOpenChangeSeatRecap,
       onOpenSpendLimitRecap,
     } = info.row.original;
 
     if (creditState === "capped") {
+      // A member with no seat upgrade path (already on the top seat tier, or
+      // the workspace isn't seat-based at all) has only one unblock action —
+      // skip the dropdown and go straight to the spend-limit modal.
+      if (!canUpgradeSeat) {
+        return (
+          <DataTable.CellContent className="justify-center">
+            <div
+              onClick={(event) => event.stopPropagation()}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <Button
+                variant="highlight"
+                size="xs"
+                label="Unblock"
+                onClick={onOpenSpendLimitRecap}
+              />
+            </div>
+          </DataTable.CellContent>
+        );
+      }
       return (
         <DataTable.CellContent className="justify-center">
           <div
@@ -988,6 +1011,12 @@ interface MembersUsageTableProps {
   // ("legacy") variant, which never renders that column.
   onOpenChangeSeatRecap?: (member: MemberUsageType) => void;
   onOpenSpendLimitRecap?: (member: MemberUsageType) => void;
+  // Poke-only: whether the off-pace column's "Unblock" panel offers a seat
+  // upgrade for this member. When false, "Unblock" skips the dropdown and
+  // opens the spend-limit modal directly. Defaults to true (always offer
+  // both actions) since the customer-facing ("legacy") variant never renders
+  // that column.
+  canUpgradeSeat?: (member: MemberUsageType) => boolean;
   onSetUserModelTier?: (
     member: MemberUsageType,
     selection: UserModelTierSelection
@@ -1031,6 +1060,7 @@ export function MembersUsageTable({
   onEditSpendLimit,
   onOpenChangeSeatRecap = NOOP_ON_MEMBER,
   onOpenSpendLimitRecap = NOOP_ON_MEMBER,
+  canUpgradeSeat = ALWAYS_CAN_UPGRADE_SEAT,
   onSetUserModelTier,
   showModelTiersColumn = false,
   variant = "legacy",
@@ -1090,6 +1120,7 @@ export function MembersUsageTable({
           isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
           overallUsageTarget: m.overallUsageTarget,
           creditState: m.creditState,
+          canUpgradeSeat: canUpgradeSeat(m),
           onOpenChangeSeatRecap: () => onOpenChangeSeatRecap(m),
           onOpenSpendLimitRecap: () => onOpenSpendLimitRecap(m),
           modelTiersSummary: (() => {
@@ -1200,6 +1231,7 @@ export function MembersUsageTable({
       onEditSpendLimit,
       onOpenChangeSeatRecap,
       onOpenSpendLimitRecap,
+      canUpgradeSeat,
       onSetUserModelTier,
     ]
   );


### PR DESCRIPTION


## Description

When a capped member is already on the top seat tier, or the workspace isn't seat-based, Unblock skips the dropdown and opens spend limit directly.

## Tests

Tested localy

## Risk

Low additve only on poke

## Deploy Plan

- Deploy front
