### PR TITLE
Add customer-facing AWU pool current-cycle / cycle-history endpoints

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.test.ts
@@ -1,0 +1,82 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeBalances: vi.fn(),
+    listMetronomeDraftInvoices: vi.fn(),
+    listMetronomeFinalizedInvoices: vi.fn(),
+  };
+});
+
+function awuPoolCurrentCycleUrl(wId: string) {
+  return `/api/w/${wId}/credits/awu-pool-current-cycle`;
+}
+
+const EMPTY_CURRENT_CYCLE = {
+  totalRemainingCredits: 0,
+  totalActiveCredits: 0,
+  overageCredits: null,
+  overageAmountCents: null,
+  overageCurrency: null,
+  currentCycleStartMs: null,
+  currentCycleEndMs: null,
+  currentCycleConsumedCredits: null,
+  excessConsumedCredits: null,
+  programmaticConsumedCredits: null,
+  otherConsumedCredits: null,
+};
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeDraftInvoices).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/credits/awu-pool-current-cycle", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      awuPoolCurrentCycleUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(metronomeClient.listMetronomeBalances).not.toHaveBeenCalled();
+  });
+
+  it("allows a manager to read the AWU pool current cycle", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "manager",
+      workspace,
+    });
+
+    const response = await honoApp.request(
+      awuPoolCurrentCycleUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(EMPTY_CURRENT_CYCLE);
+    expect(metronomeClient.listMetronomeBalances).toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,0 +1,61 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/awu-pool-current-cycle.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  async (ctx): HandlerResult<AwuPoolCurrentCycleResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await getAwuPoolCurrentCycle(auth);
+    if (result.isErr()) {
+      return currentCycleErrorToApi(ctx, result.error);
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -1,0 +1,73 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeBalances: vi.fn(),
+    listMetronomeDraftInvoices: vi.fn(),
+    listMetronomeFinalizedInvoices: vi.fn(),
+  };
+});
+
+function awuPoolCycleHistoryUrl(wId: string) {
+  return `/api/w/${wId}/credits/awu-pool-cycle-history`;
+}
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeDraftInvoices).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      awuPoolCycleHistoryUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(
+      metronomeClient.listMetronomeFinalizedInvoices
+    ).not.toHaveBeenCalled();
+  });
+
+  it("allows a manager to read the AWU pool cycle history", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "manager",
+      workspace,
+    });
+
+    const response = await honoApp.request(
+      awuPoolCycleHistoryUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      cycleBreakdown: [],
+      excessCycleBreakdown: [],
+    });
+    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,0 +1,67 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import {
+  AwuPoolSummaryQuerySchema,
+  getAwuPoolCycleHistory,
+} from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { Context } from "hono";
+
+function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/awu-pool-cycle-history.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  validate("query", AwuPoolSummaryQuerySchema),
+  async (ctx): HandlerResult<AwuPoolCycleHistoryResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cycleHistoryLimit } = ctx.req.valid("query");
+
+    const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
+    if (result.isErr()) {
+      return cycleHistoryErrorToApi(ctx, result.error);
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -10,6 +10,8 @@ import type {
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 
+import awuPoolCurrentCycle from "./awu-pool-current-cycle";
+import awuPoolCycleHistory from "./awu-pool-cycle-history";
 import awuPoolSummary from "./awu-pool-summary";
 import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
@@ -25,6 +27,8 @@ import usageConfiguration from "./usage-configuration";
 const app = workspaceApp();
 
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
+app.route("/awu-pool-cycle-history", awuPoolCycleHistory);
 app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/my-top-conversations", myTopConversations);

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -24,6 +24,10 @@ import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTie
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
+import {
+  toCreditPoolFetchStatus,
+  WorkspaceCreditPoolSection,
+} from "@app/components/workspace/WorkspaceCreditPoolCards";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useTableRowsSelection } from "@app/hooks/useTableRowsSelection";
 import {
@@ -32,7 +36,11 @@ import {
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import { INHERIT_MODEL_TIER } from "@app/lib/client/model_tier_options";
@@ -49,6 +57,8 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { useSearchParam } from "@app/lib/platform";
 import {
+  useAwuPoolCurrentCycle,
+  useAwuPoolCycleHistory,
   useAwuPoolSummary,
   useAwuPurchaseInfo,
   useMyUsage,
@@ -206,11 +216,86 @@ function CreditPoolProgressBar({
   );
 }
 
+interface CompactCreditPoolCardsProps {
+  owner: ReturnType<typeof useWorkspace>;
+  disabled: boolean;
+}
+
+// Credit consumption cards for the compact usage page, mirroring Poke's
+// read-only pool view (front/components/poke/pages/PoolUsagePage.tsx) but
+// backed by the customer-facing awu-pool-current-cycle/cycle-history routes.
+function CompactCreditPoolCards({
+  owner,
+  disabled,
+}: CompactCreditPoolCardsProps) {
+  const {
+    awuPoolCurrentCycle,
+    isAwuPoolCurrentCycleLoading,
+    isAwuPoolCurrentCycleError,
+  } = useAwuPoolCurrentCycle({ workspaceId: owner.sId, disabled });
+  const {
+    cycleBreakdown: poolCycleBreakdown,
+    excessCycleBreakdown,
+    isAwuPoolCycleHistoryLoading,
+    isAwuPoolCycleHistoryError,
+  } = useAwuPoolCycleHistory({ workspaceId: owner.sId, disabled });
+
+  const {
+    totalRemainingCredits,
+    totalActiveCredits,
+    currentCycleConsumedCredits,
+    currentCycleStartMs,
+    currentCycleEndMs,
+    excessConsumedCredits,
+    programmaticConsumedCredits,
+    otherConsumedCredits,
+  } = awuPoolCurrentCycle ?? {
+    totalRemainingCredits: 0,
+    totalActiveCredits: 0,
+    currentCycleConsumedCredits: null,
+    currentCycleStartMs: null,
+    currentCycleEndMs: null,
+    excessConsumedCredits: null,
+    programmaticConsumedCredits: null,
+    otherConsumedCredits: null,
+  };
+
+  const hasPool = totalActiveCredits > 0;
+  const hasExcessData =
+    excessConsumedCredits !== null || excessCycleBreakdown.length > 0;
+
+  return (
+    <WorkspaceCreditPoolSection
+      cardsStatus={toCreditPoolFetchStatus(
+        isAwuPoolCurrentCycleLoading,
+        !!isAwuPoolCurrentCycleError
+      )}
+      tableStatus={toCreditPoolFetchStatus(
+        isAwuPoolCycleHistoryLoading,
+        !!isAwuPoolCycleHistoryError
+      )}
+      showPoolCard={hasPool}
+      isVisible={hasPool || hasExcessData}
+      totalRemainingCredits={totalRemainingCredits}
+      consumedCredits={
+        hasPool ? currentCycleConsumedCredits : excessConsumedCredits
+      }
+      currentCycleStartMs={currentCycleStartMs}
+      currentCycleEndMs={currentCycleEndMs}
+      cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
+      programmaticConsumedCredits={programmaticConsumedCredits}
+      otherConsumedCredits={otherConsumedCredits}
+    />
+  );
+}
+
 const DEFAULT_PAGE_SIZE = 25;
 
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const isCompactUsagePage = hasFeature("compact_usage_page");
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
   // Workspaces off a credit plan see this page without the credit pool, seat
   // and credits columns, spend limits and upgrade requests. Credit actions (top
@@ -1023,6 +1108,7 @@ export function UsagePage() {
       enableSelection={isCreditPriced}
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}
+      variant={isCompactUsagePage ? "compact" : undefined}
     />
   );
 
@@ -1084,7 +1170,8 @@ export function UsagePage() {
         ) : (
           <div className="flex items-center justify-between">
             <Page.Header title="Usage" />
-            {isCreditPriced &&
+            {!isCompactUsagePage &&
+              isCreditPriced &&
               usageSettings.topUpEnabled &&
               isWorkspaceAdmin && (
                 <Button
@@ -1220,7 +1307,15 @@ export function UsagePage() {
           </Page.Vertical>
         ) : null}
 
-        {isCreditPriced &&
+        {isCompactUsagePage && isCreditPriced ? (
+          <div className="flex flex-col items-stretch gap-4">
+            <CompactCreditPoolCards owner={owner} disabled={!isCreditPriced} />
+            <div className="flex justify-end">{topUpButton}</div>
+          </div>
+        ) : null}
+
+        {!isCompactUsagePage &&
+        isCreditPriced &&
         !showConsumptionAnalytics &&
         !isAwuPoolSummaryLoading &&
         (isAwuPoolSummaryError || hasPool) ? (

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -5,7 +5,11 @@ import type { GetAwuPurchaseInfoResponseBody } from "@app/lib/credits/awu_purcha
 import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type {
+  AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleHistoryResponseBody,
+  AwuPoolSummaryResponseBody,
+} from "@app/types/api/credits/awu_pool_summary";
 import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import type { GetMyTopConversationsResponseBody } from "@app/types/api/credits/my_top_conversations";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
@@ -258,6 +262,57 @@ export function useAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function useAwuPoolCurrentCycle({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuFetcher: Fetcher<AwuPoolCurrentCycleResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/awu-pool-current-cycle`,
+    awuFetcher,
+    { disabled }
+  );
+
+  return {
+    awuPoolCurrentCycle: data ?? null,
+    isAwuPoolCurrentCycleLoading: !error && !data && !disabled,
+    isAwuPoolCurrentCycleError: error,
+    isAwuPoolCurrentCycleValidating: isValidating,
+    mutateAwuPoolCurrentCycle: mutate,
+  };
+}
+
+export function useAwuPoolCycleHistory({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuFetcher: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/awu-pool-cycle-history`,
+    awuFetcher,
+    { disabled }
+  );
+
+  return {
+    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
+    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
+    isAwuPoolCycleHistoryError: error,
+    isAwuPoolCycleHistoryValidating: isValidating,
+    mutateAwuPoolCycleHistory: mutate,
   };
 }
 


### PR DESCRIPTION
## Summary
- Mirror the existing Poke-only `awu-pool-current-cycle` and `awu-pool-cycle-history` routes for the customer-facing app, gated the same way as the existing `awu-pool-summary` route (manager role required).
- Add the matching `useAwuPoolCurrentCycle` / `useAwuPoolCycleHistory` SWR hooks in `front/lib/swr/credits.ts`.
- These back the credit-pool consumption cards added on the compact usage page in the next PR of this stack. The underlying business logic (`getAwuPoolCurrentCycle` / `getAwuPoolCycleHistory`) was already shared and auth-agnostic, so this is purely new routing + hooks.

Part of a stack:
1. Feature flag
2. **This PR** — customer-facing pool endpoints
3. Compact usage page rendering behind the flag

## Test plan
- [x] Added functional tests for both new endpoints (403 for a `user` role, 200 for a `manager` role), mirroring `awu-pool-summary.test.ts`
- [ ] `npm run test -- awu-pool-current-cycle awu-pool-cycle-history`