### PR TITLE
feat: add parent_message_id to consumption index

### DIFF
--- a/front/lib/analytics/agent_message_consumption/document_common.ts
+++ b/front/lib/analytics/agent_message_consumption/document_common.ts
@@ -26,6 +26,7 @@ type AgentMessageConsumptionAnalyticsDocumentMetadata = Pick<
   | "conversation_id"
   | "message_version"
   | "normalized_origin"
+  | "parent_message_id"
   | "run_usage_id"
   | "space_id"
   | "step_index"
@@ -77,6 +78,7 @@ export function makeBaseDocument(
     conversation_id: metadata.conversationId,
     message_version: metadata.messageVersion.toString(),
     normalized_origin: normalizeOrigin(metadata.contextOrigin),
+    parent_message_id: metadata.parentMessageId,
     run_usage_id: runUsageModelId.toString(),
     space_id: metadata.spaceId,
     step_index: stepIndex,

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -58,6 +58,7 @@ export type ConsumptionAnalyticsMessageMetadata = {
   messageStatus: AgentMessageStatus;
   messageVersion: number;
   model: AgentMessageAnalyticsModel | null;
+  parentMessageId: string | null;
   spaceId: string | null;
   triggerId: string | null;
   user: AgentMessageConsumptionAnalyticsUser | null;
@@ -312,6 +313,7 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
           resolution_method: agentMessage.modelResolutionMethod,
         }
       : null,
+    parentMessageId: triggeringUserMessage.agenticOriginMessageId ?? null,
     runs,
     skills,
     spaceId:

--- a/front/lib/analytics/agent_message_consumption/store.test.ts
+++ b/front/lib/analytics/agent_message_consumption/store.test.ts
@@ -43,6 +43,7 @@ function makeDocument(): AgentMessageConsumptionAnalyticsData {
     conversation_id: "conversation_1",
     credit_micro: 1_000_000,
     execution_time_ms: null,
+    parent_message_id: null,
     gross_credit_micro: {
       system: 0,
       input: 600_000,

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -15,6 +15,9 @@
     "agent_message_id": {
       "type": "keyword"
     },
+    "parent_message_id": {
+      "type": "keyword"
+    },
     "message_version": {
       "type": "keyword"
     },

--- a/front/lib/analytics/migrations/20260903_add_parent_message_id_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260903_add_parent_message_id_to_agent_message_consumption_analytics_1.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_consumption_analytics_1/_mapping
+{
+  "properties": {
+    "parent_message_id": {
+      "type": "keyword"
+    }
+  }
+}

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -146,6 +146,7 @@ interface ConsumptionMessageBucket {
   agent_id: TermsAgg;
   agent_tag_ids: TermsAgg;
   conversation_id: TermsAgg;
+  parent_message_id: TermsAgg;
   user_id: TermsAgg;
   context_origin: TermsAgg;
   total_credit_micro: estypes.AggregationsSumAggregate;
@@ -192,7 +193,13 @@ function buildConsumptionAggregations(
             size: 100, // keep at most 100 unique tag IDs per message.
           },
         },
-
+        parent_message_id: {
+          // parent_message_id is denormalized on every tool/llm calls: keep a single value per message.
+          terms: {
+            field: "parent_message_id",
+            size: 1,
+          },
+        },
         conversation_id: {
           // conversation_id is denormalized on every tool/llm calls: keep a single value per message.
           terms: {
@@ -308,7 +315,9 @@ function consumptionBucketToDocument(
       (b) => b.key
     ),
     conversation_id: firstBucketKey(bucket.conversation_id),
-    ancestor_message_ids: [],
+    ancestor_message_ids: firstBucketKey(bucket.parent_message_id)
+      ? [firstBucketKey(bucket.parent_message_id)]
+      : [],
     user_id: firstBucketKey(bucket.user_id),
     context_origin: firstBucketKey(bucket.context_origin),
     status: "", // not used by csv export and not fetched by the es aggregation

--- a/front/lib/api/analytics/messages_export_consumption.test.ts
+++ b/front/lib/api/analytics/messages_export_consumption.test.ts
@@ -135,7 +135,7 @@ describe("fetchMessageExportRows (consumption index)", () => {
     expect(row.assistantId).toBe("agent_abc");
     expect(row.assistantTags).toBe("Alpha,Zeta");
     expect(row.conversationId).toBe("conv_xyz");
-    expect(row.parentMessageId).toBe(""); // not yet implemented
+    expect(row.parentMessageId).toBe("msg_parent");
     expect(row.userId).toBe("user_99");
     expect(row.source).toBe("slack");
     expect(row.toolsUsed).toContain("tool_search");

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -140,6 +140,7 @@ export type AgentMessageConsumptionAnalyticsContext = {
     triggerModelId: ModelId | null;
   };
   triggeringUserMessage: {
+    agenticOriginMessageId: string | null;
     apiKeyModelId: ModelId | null;
     origin: UserMessageOrigin;
     userId: string | null;
@@ -894,6 +895,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         triggerModelId: conversation.triggerId,
       },
       triggeringUserMessage: {
+        agenticOriginMessageId:
+          triggeringUserMessage.agenticOriginMessageId ?? null,
         apiKeyModelId: triggeringUserMessage.userContextApiKeyId,
         origin: triggeringUserMessage.userContextOrigin,
         userId: triggeringUserMessage.user?.sId ?? null,

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -305,6 +305,7 @@ type SeedConsumptionBaseFields = Pick<
   | "message_version"
   | "model"
   | "normalized_origin"
+  | "parent_message_id"
   | "run_usage_id"
   | "space_id"
   | "status"
@@ -344,6 +345,7 @@ function makeBaseFields(
       resolution_method: "agent",
     },
     normalized_origin: normalizeOrigin(message.origin),
+    parent_message_id: null,
     run_usage_id: consumptionKey,
     space_id: null,
     status: "succeeded",

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -78,6 +78,7 @@ const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
     reasoning_effort: "medium",
     resolution_method: "auto",
   },
+  parent_message_id: null,
   run_usage_id: "123",
   space_id: "space1",
   status: "succeeded",

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -254,6 +254,7 @@ interface AgentMessageConsumptionAnalyticsBaseData
   credit_micro: number;
   execution_time_ms: number | null;
   message_version: string;
+  parent_message_id: string | null;
   model: AgentMessageAnalyticsModel | null;
   run_usage_id: string;
   space_id: string | null;


### PR DESCRIPTION
## Description

Add `parent_message_id` to `front.agent_message_consumption_analytics` index, with the goal of making it iso with the `front.agent_message_analytics` index.

## Tests

- sent a message that triggered a sub agent conversation
- curl'ed the export endpoint (with the feature flag enable) and see the `parent_message_id` populated:

```
curl {{baseUrl}}/api/v1/w/{{wId}}/analytics/export?table=messages&startDate=2026-09-01&endDate=2026-09-04
messageId,createdAt,assistantId,assistantName,assistantSettings,assistantTags,conversationId,parentMessageId,userId,userEmail,source,toolsUsed,skillsUsed,modelId,modelProviderId,modelResolutionMethod,credits
IGOpFOCxYm,2026-09-03 10:12:51,dust,dust,unknown,,Z7tTfTHuD4,,ZWmML49W5v,sylvain@dust.tt,web,"Run agent__run_dust-task,Skill management__enable_skill",go-deep,gpt-5.6-luna,openai,auto,4
nEXT11C4cj,2026-09-03 10:12:49,dust-task,dust-task,unknown,,TLzBkZhdmO,IGOpFOCxYm,ZWmML49W5v,sylvain@dust.tt,web,,,gpt-5.6-luna,openai,agent,1
```

## Risk

Low. Safe to rollback.

## Deploy Plan

1. apply ES migration first to register the new field with the correct type
2. then deploy