### PR TITLE
[sparkle] FilterChips: slots, a secondary variant, controlled selection

### DIFF
--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -1,14 +1,108 @@
-import React, { useCallback, useState } from "react";
+import { cn } from "@sparkle/lib/utils";
+import React, { useCallback, useMemo, useState } from "react";
 
-import { Button } from "./Button";
+import { Button, type ButtonIconType, type ButtonVariantType } from "./Button";
+
+export const FILTER_CHIP_VARIANTS = ["primary", "secondary"] as const;
+export type FilterChipVariantType = (typeof FILTER_CHIP_VARIANTS)[number];
+
+/** An icon (a component or an element), or a run of text. */
+export type FilterChipSlotType = ButtonIconType | string;
+
+export interface FilterChipType<T extends string = string> {
+  /** Identity of the chip, passed back to `onFilterClick`. */
+  value: T;
+  /** Chip text. Defaults to `value`. */
+  label?: string;
+  /** Rendered before the label. */
+  startSlot?: FilterChipSlotType;
+  /** Rendered after the label. */
+  endSlot?: FilterChipSlotType;
+}
+
+// `hover:`/`active:` repeat the overlay so it holds while the pointer is on a
+// selected chip, and the `dark:` pair beats `ghost`'s own lighten-on-hover.
+// `Button` merges this after its variant classes, so twMerge lets each modifier
+// win over the matching one from `ghost`.
+const SECONDARY_SELECTED = cn(
+  "bg-foreground/[0.06]",
+  "hover:bg-foreground/[0.06] active:bg-foreground/[0.06]",
+  "dark:hover:bg-foreground/[0.06] dark:active:bg-foreground/[0.06]"
+);
+
+interface ChipLook {
+  buttonVariant: ButtonVariantType;
+  /** Layered on top of the `Button` variant. */
+  className?: string;
+  /** Colour for a text slot against this look. */
+  slotTextColor: string;
+}
+
+/**
+ * Every look, keyed by variant then selection — so a new variant is a compile
+ * error until both of its states are filled in.
+ *
+ * `secondary`'s selected state is a flat 6% foreground overlay: the
+ * `transparency-selected` token `OptionCard` uses for its selected row.
+ *
+ * Slot text is muted on a ghost chip, but the selected `primary` chip is a dark
+ * surface, so there it tracks the label token at 60% — the same treatment
+ * `Button` gives its own chevron, and it flips correctly in dark mode.
+ */
+const CHIP_LOOKS: Record<
+  FilterChipVariantType,
+  Record<"selected" | "idle", ChipLook>
+> = {
+  primary: {
+    selected: {
+      buttonVariant: "primary",
+      slotTextColor: "text-primary-50/60",
+    },
+    idle: { buttonVariant: "ghost", slotTextColor: "text-muted-foreground" },
+  },
+  secondary: {
+    selected: {
+      buttonVariant: "ghost",
+      className: SECONDARY_SELECTED,
+      slotTextColor: "text-muted-foreground",
+    },
+    idle: { buttonVariant: "ghost", slotTextColor: "text-muted-foreground" },
+  },
+};
+
+function renderSlot(
+  slot: FilterChipSlotType | undefined,
+  slotTextColor: string
+): ButtonIconType | undefined {
+  if (slot === undefined) {
+    return undefined;
+  }
+  if (typeof slot === "string") {
+    return <span className={cn("copy-xs", slotTextColor)}>{slot}</span>;
+  }
+  return slot;
+}
+
+function normalizeFilter<T extends string>(
+  filter: T | FilterChipType<T>
+): FilterChipType<T> {
+  return typeof filter === "string" ? { value: filter } : filter;
+}
 
 interface FilterChipsProps<T extends string> {
-  /** Filter names, each rendered as a chip. */
-  filters: T[];
-  /** Called with the clicked filter's name; only fires when the selection changes. */
-  onFilterClick: (filterName: T) => void;
-  /** Filter preselected on mount (must be one of filters). */
+  /** Plain filter names, or descriptors carrying a label and slots. */
+  filters: readonly (T | FilterChipType<T>)[];
+  /** Called with the clicked filter's name, or `null` when the click cleared it. */
+  onFilterClick: (filterName: T | null) => void;
+  /** Filter preselected on mount (must be one of filters). Ignored when `selectedFilter` is passed. */
   defaultFilter?: T;
+  /** The lit chip. Passing it — including as `null` — makes the row controlled. */
+  selectedFilter?: T | null;
+  /** Whether clicking the lit chip clears the selection. Defaults to true. */
+  allowDeselect?: boolean;
+  /** `primary` fills solid when selected; `secondary` takes a flat overlay. */
+  variant?: FilterChipVariantType;
+  className?: string;
 }
 
 /**
@@ -16,39 +110,79 @@ interface FilterChipsProps<T extends string> {
  * collection to one category at a time, firing onFilterClick on selection.
  * Use it to let users switch between mutually exclusive views or categories
  * (e.g. "Featured", "Research").
+ *
+ * Chips can carry a startSlot and an endSlot — an icon, or a string that
+ * renders in smaller muted type for a readout such as a `3/5` progress count.
+ * Use variant "secondary" where a solid selected chip would read as the
+ * surface's primary action, such as a bar sitting above content.
+ *
+ * Selection is uncontrolled by default; pass selectedFilter to drive it from
+ * state you already own, such as which side panel is open. Clicking the lit
+ * chip clears the selection and reports null, so a row of categories with no
+ * "All" among them can still get back to the unfiltered list — pass
+ * allowDeselect={false} for rows that carry their own neutral chip.
  * @summary Single-select category filter chips.
  */
 export function FilterChips<T extends string>({
   filters,
   onFilterClick,
   defaultFilter,
+  selectedFilter,
+  allowDeselect = true,
+  variant = "primary",
+  className,
 }: FilterChipsProps<T>) {
-  const [selectedFilter, setSelectedFilter] = useState<T | null>(
-    defaultFilter && filters.includes(defaultFilter) ? defaultFilter : null
+  const chips = useMemo(() => filters.map(normalizeFilter), [filters]);
+
+  // `undefined` means the caller is not controlling the row; `null` is a
+  // caller-controlled empty selection, so the two cannot be collapsed.
+  const isControlled = selectedFilter !== undefined;
+
+  const [internalFilter, setInternalFilter] = useState<T | null>(
+    defaultFilter && chips.some((chip) => chip.value === defaultFilter)
+      ? defaultFilter
+      : null
   );
+  const activeFilter = isControlled ? selectedFilter : internalFilter;
 
   const handleFilterClick = useCallback(
     (filterName: T) => {
-      // Avoid unnecessary re-renders by only triggering event if filter has changed.
-      if (filterName !== selectedFilter) {
-        setSelectedFilter(filterName);
-        onFilterClick(filterName);
+      const nextFilter =
+        allowDeselect && filterName === activeFilter ? null : filterName;
+
+      // Re-clicking the lit chip with deselection off changes nothing, so skip
+      // the state write and the callback rather than re-render for no reason.
+      if (nextFilter === activeFilter) {
+        return;
       }
+      if (!isControlled) {
+        setInternalFilter(nextFilter);
+      }
+      onFilterClick(nextFilter);
     },
-    [onFilterClick, selectedFilter]
+    [activeFilter, allowDeselect, isControlled, onFilterClick]
   );
 
   return (
-    <div className="flex flex-row flex-wrap gap-2">
-      {filters.map((filterName) => (
-        <Button
-          label={filterName}
-          variant={selectedFilter === filterName ? "primary" : "ghost"}
-          key={filterName}
-          size="xs"
-          onClick={() => handleFilterClick(filterName)}
-        />
-      ))}
+    <div className={cn("flex flex-row flex-wrap gap-2", className)}>
+      {chips.map(({ value, label, startSlot, endSlot }) => {
+        const isSelected = activeFilter === value;
+        const look = CHIP_LOOKS[variant][isSelected ? "selected" : "idle"];
+
+        return (
+          <Button
+            key={value}
+            size="xs"
+            variant={look.buttonVariant}
+            className={look.className}
+            icon={renderSlot(startSlot, look.slotTextColor)}
+            label={label ?? value}
+            iconRight={renderSlot(endSlot, look.slotTextColor)}
+            aria-pressed={isSelected}
+            onClick={() => handleFilterClick(value)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -150,7 +150,13 @@ export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";
 export { FaviconIcon } from "./FaviconIcon";
-export { FilterChips } from "./FilterChips";
+export {
+  FILTER_CHIP_VARIANTS,
+  type FilterChipSlotType,
+  FilterChips,
+  type FilterChipType,
+  type FilterChipVariantType,
+} from "./FilterChips";
 export { Div3D, Hover3D } from "./Hover3D";
 export { Hoverable } from "./Hoverable";
 export { HoveringBar } from "./HoveringBar";

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
 import { fn } from "storybook/test";
 
-import { FilterChips } from "../index_with_tw_base";
+import {
+  CoinsStacked02,
+  FilterChips,
+  Folder,
+  ListSelect,
+} from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/FilterChips",
@@ -11,12 +17,27 @@ const meta = {
       description: {
         component: `A horizontal row of single-select filter chips for narrowing a list or collection to one category at a time. Takes a list of **filters**, fires **onFilterClick** on selection, and can preselect one via **defaultFilter**.
 
+**Variants**
+- **primary** (default) — the chip fills solid when selected. The stronger of the two; use it when the chips are the main control on the surface.
+- **secondary** — the chip stays ghost and takes a flat 6% overlay when selected, the same \`transparency-selected\` token **OptionCard** uses. Use it where a solid chip would read as the surface's primary action, such as a bar sitting above content.
+
+**Slots**
+- Chips can carry a **startSlot** and an **endSlot**, passed through the object form of **filters**.
+- A slot is either an **icon** (a component or an element) or a **string**, which renders in smaller muted type — for a readout such as a \`3/5\` progress count.
+- Slot text drops to 60% of the label colour on the selected **primary** chip, where the surface is dark.
+
+**Selection**
+- Uncontrolled by default: pass **defaultFilter** for the initial chip and the row tracks the rest itself.
+- Pass **selectedFilter** to control it instead — for when the lit chip is a projection of state you already own, such as which side panel is open. The row then renders what you give it and cannot drift out of sync.
+- Clicking the lit chip clears the selection and reports \`null\`, so a row of categories with no "All" among them can still get back to the unfiltered list.
+- Pass **allowDeselect={false}** for rows that carry their own neutral chip, where "All" *is* the empty state.
+
 **When to use**
 - To let users switch between mutually exclusive views or categories (e.g. \`"Featured"\`, \`"Research"\`).
 
 **Guidelines**
 - Selection is single-choice: only one chip is active at a time, so use it for filtering rather than multi-tagging.
-- Pass a **defaultFilter** that matches an entry in **filters** to highlight the initial category.
+- Keep slot text to a couple of characters — a count or a ratio. Longer text belongs in the label.
 - For a standalone status or metadata label that is not interactive, use **Chip** instead.`,
       },
     },
@@ -29,16 +50,30 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const CATEGORIES = [
+  "Featured",
+  "Writing",
+  "Productivity",
+  "Research",
+  "Knowledge",
+];
+
+/** Panel entry points: an icon before the label, a progress readout after it. */
+const PANELS = [
+  { value: "credits", label: "Credits", startSlot: CoinsStacked02 },
+  { value: "files", label: "Files", startSlot: Folder, endSlot: "4" },
+  { value: "plan", label: "Plan", startSlot: ListSelect, endSlot: "3/5" },
+];
+
 /**
  * A category filter row with an initial selection: **defaultFilter** highlights
  * one chip on mount, and clicking another chip moves the selection and fires
- * **onFilterClick** with the chip's name. Selection state is managed internally
- * (uncontrolled) — the component exposes no prop to drive it from outside.
+ * **onFilterClick** with the chip's name.
  * @summary Single-select filter row with a preselected chip.
  */
 export const Default: Story = {
   args: {
-    filters: ["Featured", "Writing", "Productivity", "Research", "Knowledge"],
+    filters: CATEGORIES,
     defaultFilter: "Featured",
   },
 };
@@ -50,6 +85,101 @@ export const Default: Story = {
  */
 export const NoDefaultSelection: Story = {
   args: {
-    filters: ["Featured", "Writing", "Productivity", "Research", "Knowledge"],
+    filters: CATEGORIES,
+  },
+};
+
+/**
+ * **secondary** keeps the chip ghost and marks selection with a flat 6% overlay
+ * rather than a solid fill, for a row sitting above content where a solid chip
+ * would compete with the page's primary action.
+ * @summary Filter row with the low-emphasis selected state.
+ */
+export const Secondary: Story = {
+  args: {
+    variant: "secondary",
+    filters: CATEGORIES,
+    defaultFilter: "Featured",
+  },
+};
+
+/**
+ * **startSlot** and **endSlot** take an icon or a string. Here each chip leads
+ * with an icon and trails a count, so one row of chips doubles as the entry
+ * points to a set of side panels.
+ * @summary Chips with an icon and a text readout.
+ */
+export const WithSlots: Story = {
+  args: {
+    variant: "secondary",
+    filters: PANELS,
+    defaultFilter: "plan",
+  },
+};
+
+/**
+ * Clicking the lit chip clears it, because none of these chips represents the
+ * unfiltered list. A row that leads with its own **All** chip should pass
+ * **allowDeselect={false}** instead, so the selection cannot be emptied into a
+ * state **All** already expresses.
+ * @summary Deselection, and the row that opts out of it.
+ */
+export const Deselection: Story = {
+  args: {
+    filters: CATEGORIES,
+    defaultFilter: "Featured",
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <span className="label-xs text-muted-foreground">
+          allowDeselect (default) — click the lit chip to clear it
+        </span>
+        <FilterChips {...args} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="label-xs text-muted-foreground">
+          allowDeselect={"{false}"} — &quot;All&quot; is the empty state
+        </span>
+        <FilterChips
+          {...args}
+          allowDeselect={false}
+          filters={["All", ...CATEGORIES]}
+          defaultFilter="All"
+        />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * Passing **selectedFilter** hands the row over to the caller, for when the lit
+ * chip is really a view of state the caller already holds — here which side
+ * panel is open. Re-clicking reports `null`, which closes the panel.
+ * @summary Controlled row driven by the caller's own state.
+ */
+export const Controlled: Story = {
+  args: {
+    variant: "secondary",
+    filters: PANELS,
+  },
+  render: (args) => {
+    const [openPanel, setOpenPanel] = useState<string | null>("plan");
+
+    return (
+      <div className="flex flex-col gap-4">
+        <FilterChips
+          {...args}
+          selectedFilter={openPanel}
+          onFilterClick={(filterName) => {
+            setOpenPanel(filterName);
+            args.onFilterClick(filterName);
+          }}
+        />
+        <div className="copy-sm text-muted-foreground">
+          {openPanel ? `${openPanel} panel open` : "no panel open"}
+        </div>
+      </div>
+    );
   },
 };


### PR DESCRIPTION
## Why

`FilterChips` could only render a bare string label per chip — no icon, no trailing count — and it kept its selection in local state with no prop to drive it from outside. This enriches the chip on all three fronts and shows each one in Storybook.

## Slots

`filters` now also accepts descriptors, so a chip can carry something on either side of its label:

```tsx
<FilterChips
  variant="secondary"
  filters={[
    { value: "credits", label: "Credits", startSlot: CoinsStacked02 },
    { value: "files", label: "Files", startSlot: Folder, endSlot: "4" },
    { value: "plan", label: "Plan", startSlot: ListSelect, endSlot: "3/5" },
  ]}
  onFilterClick={setFilter}
/>
```

A slot is either an **icon** (a component or an element) or a **string**, which renders in `copy-xs` for a readout such as a `3/5` progress count. Both ride on `Button`'s existing `icon` / `iconRight`, which already accept a `ReactElement` — so the chip's geometry is still entirely `Button`'s and nothing is hand-rolled here.

Slot text is muted on a ghost chip, but drops to 60% of the label token on the selected `primary` chip, where the surface is dark — the same treatment `Button` gives its own chevron, and it flips correctly in dark mode. `text-muted-foreground` would be unreadable there.

Plain strings still work, so existing call sites are untouched.

## Two variants

| | idle | selected |
|---|---|---|
| `primary` (default) | `ghost` | `primary` — solid fill |
| `secondary` | `ghost` | `bg-foreground/[0.06]` — flat overlay |

`secondary` marks selection with the 6% `transparency-selected` overlay `OptionCard` already uses for its selected row. It is for rows sitting above content, where a solid chip reads as the page's primary action rather than as a filter.

Looks live in a `Record<variant, Record<selected | idle, …>>`, so adding a third variant is a compile error until both of its states are filled in. The overlay repeats itself across `hover:` / `active:` / `dark:` on purpose: `cn` is `twMerge` and `Button` applies the incoming `className` last, so each modifier has to be restated to win over the matching one from `ghost`.

## Selection

**Controlled mode.** Passing `selectedFilter` hands the row to the caller, for when the lit chip is really a view of state the caller already holds — a filter in the URL, or which side panel is open. Omit it and selection stays internal exactly as before. `undefined` means uncontrolled and `null` means controlled-and-empty, so the two cannot be collapsed; that is called out in the prop doc.

**Deselection, on by default.** Clicking the lit chip clears it and reports `null`. An empty selection was already reachable on mount (omit `defaultFilter`) but was a one-way door — and a row of categories with no "All" among them had no route back to the unfiltered list. Rows that carry their own neutral chip pass `allowDeselect={false}`, where "All" *is* the empty state; that keeps the previous no-op behaviour.

## Breaking change

`onFilterClick` widens to `(T | null) => void`. `FilterChips` has **no render site anywhere in the monorepo**, so nothing here changes behaviour. Out-of-repo consumers of `@dust-tt/sparkle` would need the wider signature.

## Storybook

Four stories join `Default` / `NoDefaultSelection`:

- **Secondary** — the low-emphasis selected state against the same category row.
- **WithSlots** — an icon before the label and a count after it, on both variants.
- **Deselection** — the default beside a row that opts out with `allowDeselect={false}`.
- **Controlled** — `selectedFilter` driven by the caller's own state, with a readout of what is selected.

The `Default` story's doc previously asserted the component *"exposes no prop to drive it from outside"*; that is no longer true, so the sentence is gone.

## Testing

`tsgo --noEmit` clean across sparkle, biome clean, and all six stories render. I checked the emitted CSS carries `copy-xs`, `text-primary-50/60`, and all five `bg-foreground/[0.06]` modifier variants.

Please click through **Deselection** and **Controlled** when reviewing: the selection paths were traced by hand across all six branches rather than covered by a test, since sparkle has no test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)