### PR TITLE
agent permissions: require read access on skills, suggestions and YAML export

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.test.ts
@@ -1,0 +1,50 @@
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function exportYaml(workspace: { sId: string }, aId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/export/yaml`
+  );
+}
+
+describe("GET /api/w/:wId/assistant/agent_configurations/:aId/export/yaml", () => {
+  it("does not export an unpublished agent to a non-editor admin", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+
+    const response = await exportYaml(workspace, agent.sId);
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.type).toBe("agent_configuration_not_found");
+  });
+
+  it("exports an agent to one of its editors", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      scope: "hidden",
+    });
+
+    const response = await exportYaml(workspace, agent.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.yamlContent).toContain(agent.instructions);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -14,6 +15,21 @@ function getSkills(workspace: { sId: string }, aId: string) {
 }
 
 describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
+  it("should return 404 for an unpublished agent the caller cannot read", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+
+    const response = await getSkills(workspace, agent.sId);
+
+    expect(response.status).toBe(404);
+  });
+
   it("should return 200 with empty array when agent has no skills", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -26,7 +26,7 @@ app.get(
       agentId: aId,
       variant: "full",
     });
-    if (!agent) {
+    if (!agent || !agent.canRead) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -260,6 +261,22 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/suggestions", ()
     expect((await response.json()).suggestions[0].state).toBe("approved");
   });
 
+  it("returns 403 for a non-editor admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+
+    const response = await patchSuggestions(workspace, agent.sId, {
+      suggestionIds: ["sug_does_not_matter"],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
   it("returns 403 for non-editor of the agent", async () => {
     const { workspace } = await setupTest();
 
@@ -336,6 +353,19 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/suggestions", ()
 });
 
 describe("GET /api/w/:wId/assistant/agent_configurations/:aId/suggestions", () => {
+  it("returns 403 for a non-editor admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+
+    const response = await getSuggestions(workspace, agent.sId);
+
+    expect(response.status).toBe(403);
+  });
+
   it("returns agent's suggestions", async () => {
     const { workspace, auth, agent } = await setupTest();
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -57,13 +57,13 @@ app.get(
         },
       });
     }
-    if (!agent.canEdit && !auth.isAdmin()) {
+    // Suggestions carry instruction replacements, so admins get no bypass: they must be editors.
+    if (!agent.canEdit) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "agent_group_permission_error",
-          message:
-            "Only editors of the agent or workspace admins can view suggestions.",
+          message: "Only editors of the agent can view suggestions.",
         },
       });
     }
@@ -113,13 +113,13 @@ app.patch(
         },
       });
     }
-    if (!agent.canEdit && !auth.isAdmin()) {
+    // Suggestions carry instruction replacements, so admins get no bypass: they must be editors.
+    if (!agent.canEdit) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "agent_group_permission_error",
-          message:
-            "Only editors of the agent or workspace admins can view suggestions.",
+          message: "Only editors of the agent can view suggestions.",
         },
       });
     }

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -33,6 +33,16 @@ export async function getAgentConfigurationAsYAMLConfig(
 
   const { agentConfiguration, editorUsers, skills } = contextResult.value;
 
+  if (!agentConfiguration.canRead) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration you requested was not found.",
+      },
+    });
+  }
+
   const { dataSourceViews, mcpServerViews } =
     await getAccessibleSourcesAndAppsForActions(auth);
   const spaceResources = await SpaceResource.fetchByIds(


### PR DESCRIPTION
## Description

Three agent endpoints returned private data of agents the caller cannot read:

- `GET .../agent_configurations/[aId]/skills` had no read check: any workspace member knowing an unpublished agent's ID could list its skills, instructions included.
- `GET` and `PATCH .../agent_configurations/[aId]/suggestions` let non-editor admins read and apply suggestions, which carry instruction replacements.
- `GET .../agent_configurations/[aId]/export/yaml` let non-editor admins export the full agent (prompt, tools, knowledge, skills).

They now behave like the agent details endpoint: 404 when the agent is not readable, 403 for suggestions unless the caller is an editor. The shared agent context keeps its admin bypass because the batch model update relies on it.

Extracted from #31770, which makes the admin experience on such agents explicit.

## Tests

Added route tests for each endpoint: non-editor admin on an unpublished agent is rejected, editors still get their data.

## Risk

Medium. Permission tightening on shared endpoints. Admins lose access to the skills, suggestions and YAML export of agents they do not edit until they become editors.

## Deploy Plan

- Deploy front
