### PR TITLE
audit log: emit agent.editors_updated when an agent's editors change

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -2,6 +2,8 @@ import {
   archiveAgentConfiguration,
   updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration/agent";
+import type * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { emitAuditLogEvent } from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -18,6 +20,16 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@app/lib/api/assistant/recent_authors", () => ({
   agentConfigurationWasUpdatedBy: vi.fn(),
 }));
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return {
+    ...actual,
+    emitAuditLogEvent: vi.fn(),
+  };
+});
 
 async function setupTest(
   options: {
@@ -72,6 +84,43 @@ function patchEditors(workspace: { sId: string }, aId: string, body: unknown) {
     }
   );
 }
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors - audit log", () => {
+  it("emits an audit event flagging an admin adding themselves as editor", async () => {
+    const { workspace, user: admin } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const agentOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, agentOwner, { role: "user" });
+    const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      agentOwner.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+    vi.mocked(emitAuditLogEvent).mockClear();
+
+    const response = await patchEditors(workspace, agent.sId, {
+      addEditorIds: [admin.sId],
+    });
+    expect(response.status).toBe(200);
+
+    expect(vi.mocked(emitAuditLogEvent)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "agent.editors_updated",
+        metadata: {
+          agent_name: agent.name,
+          scope: "hidden",
+          added_editor_ids: admin.sId,
+          removed_editor_ids: "",
+          actor_added_self: "true",
+        },
+      })
+    );
+  });
+});
 
 describe("GET /api/w/:wId/assistant/agent_configurations/:aId/editors", () => {
   it("should return the editors of an agent built on a space the admin cannot read", async () => {

--- a/front/admin/audit_log_schemas/agent.editors_updated.json
+++ b/front/admin/audit_log_schemas/agent.editors_updated.json
@@ -1,0 +1,19 @@
+{
+  "action": "agent.editors_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "agent"
+    }
+  ],
+  "metadata": {
+    "agent_name": "string",
+    "scope": "string",
+    "added_editor_ids": "string",
+    "removed_editor_ids": "string",
+    "actor_added_self": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/components/assistant/details/tabs/AgentInfoTab/RedactedAgentMessage.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/RedactedAgentMessage.tsx
@@ -152,6 +152,10 @@ export function RedactedAgentMessage({
         )}
         {showBecomeEditor && (
           <>
+            <span>
+              Note that by becoming an editor you will have access to private
+              data and it will trigger an audit log.
+            </span>
             <div>
               <BecomeEditorButton
                 isLoading={isAddingSelfAsEditor}

--- a/front/components/assistant/details/tabs/AgentInfoTab/RedactedAgentMessage.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/RedactedAgentMessage.tsx
@@ -35,11 +35,24 @@ export function RedactedAgentMessage({
     agentConfigurationId: agentConfiguration.sId,
   });
   const [isAddingSelfAsEditor, setIsAddingSelfAsEditor] = useState(false);
+  const confirm = useContext(ConfirmContext);
 
   // Same flow as the agent builder's "Become an editor": the editors update refetches the agent,
   // which comes back unredacted once the caller is an editor.
   const handleAddSelfAsEditor = async () => {
     if (isAddingSelfAsEditor) {
+      return;
+    }
+    const confirmed = await confirm({
+      title: "Security notice",
+      message:
+        "By becoming an editor you will have access to this agent's private data " +
+        "(instructions, skills, knowledge). This action will be logged for security " +
+        "purposes. Do you want to proceed?",
+      validateLabel: "Proceed",
+      validateVariant: "warning",
+    });
+    if (!confirmed) {
       return;
     }
     setIsAddingSelfAsEditor(true);
@@ -59,7 +72,6 @@ export function RedactedAgentMessage({
     (sId) => spaceById.get(sId)?.name ?? sId
   );
 
-  const confirm = useContext(ConfirmContext);
   const addSpaceMembers = useAddSpaceMembers({ owner });
   const { mutateAgentConfiguration } = useAgentConfiguration({
     workspaceId: owner.sId,
@@ -152,10 +164,6 @@ export function RedactedAgentMessage({
         )}
         {showBecomeEditor && (
           <>
-            <span>
-              Note that by becoming an editor you will have access to private
-              data and it will trigger an audit log.
-            </span>
             <div>
               <BecomeEditorButton
                 isLoading={isAddingSelfAsEditor}

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1685,6 +1685,30 @@ export async function updateAgentPermissions(
       return transactionResult;
     }
 
+    // Editors get access to the agent's private data (prompt, skills, knowledge), so editor changes
+    // are audited as soon as they are committed, whatever happens to the triggers below.
+    // `actor_added_self` flags an admin granting themselves that access.
+    const actorUserId = auth.user()?.sId;
+    void emitAuditLogEvent({
+      auth,
+      action: "agent.editors_updated",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("agent", agent),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        agent_name: agent.name,
+        scope: agent.scope,
+        added_editor_ids: usersToAdd.map((u) => u.sId).join(","),
+        removed_editor_ids: usersToRemove.map((u) => u.sId).join(","),
+        actor_added_self: String(
+          actorUserId !== undefined &&
+            usersToAdd.some((u) => u.sId === actorUserId)
+        ),
+      },
+    });
+
     // If the agent is hidden and editors were removed, disable their triggers.
     // Removed editors can no longer access the hidden agent, so their triggers would fail.
     if (usersToRemove.length > 0 && agent.scope === "hidden") {
@@ -1712,29 +1736,6 @@ export async function updateAgentPermissions(
         }
       }
     }
-
-    // Editors get access to the agent's private data (prompt, skills, knowledge), so editor changes
-    // are audited. `actor_added_self` flags an admin granting themselves that access.
-    const actorUserId = auth.user()?.sId;
-    void emitAuditLogEvent({
-      auth,
-      action: "agent.editors_updated",
-      targets: [
-        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-        buildAuditLogTarget("agent", agent),
-      ],
-      context: getAuditLogContext(auth),
-      metadata: {
-        agent_name: agent.name,
-        scope: agent.scope,
-        added_editor_ids: usersToAdd.map((u) => u.sId).join(","),
-        removed_editor_ids: usersToRemove.map((u) => u.sId).join(","),
-        actor_added_self: String(
-          actorUserId !== undefined &&
-            usersToAdd.some((u) => u.sId === actorUserId)
-        ),
-      },
-    });
 
     return new Ok(undefined);
   } catch (error) {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1713,6 +1713,29 @@ export async function updateAgentPermissions(
       }
     }
 
+    // Editors get access to the agent's private data (prompt, skills, knowledge), so editor changes
+    // are audited. `actor_added_self` flags an admin granting themselves that access.
+    const actorUserSId = auth.user()?.sId;
+    void emitAuditLogEvent({
+      auth,
+      action: "agent.editors_updated",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("agent", agent),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        agent_name: agent.name,
+        scope: agent.scope,
+        added_editor_ids: usersToAdd.map((u) => u.sId).join(","),
+        removed_editor_ids: usersToRemove.map((u) => u.sId).join(","),
+        actor_added_self: String(
+          actorUserSId !== undefined &&
+            usersToAdd.some((u) => u.sId === actorUserSId)
+        ),
+      },
+    });
+
     return new Ok(undefined);
   } catch (error) {
     // Catch errors thrown from within the transaction

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1715,7 +1715,7 @@ export async function updateAgentPermissions(
 
     // Editors get access to the agent's private data (prompt, skills, knowledge), so editor changes
     // are audited. `actor_added_self` flags an admin granting themselves that access.
-    const actorUserSId = auth.user()?.sId;
+    const actorUserId = auth.user()?.sId;
     void emitAuditLogEvent({
       auth,
       action: "agent.editors_updated",
@@ -1730,8 +1730,8 @@ export async function updateAgentPermissions(
         added_editor_ids: usersToAdd.map((u) => u.sId).join(","),
         removed_editor_ids: usersToRemove.map((u) => u.sId).join(","),
         actor_added_self: String(
-          actorUserSId !== undefined &&
-            usersToAdd.some((u) => u.sId === actorUserSId)
+          actorUserId !== undefined &&
+            usersToAdd.some((u) => u.sId === actorUserId)
         ),
       },
     });

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -1,6 +1,7 @@
 {
   "agent.archived": 4,
   "agent.created": 3,
+  "agent.editors_updated": 1,
   "agent.executed": 5,
   "agent.restored": 4,
   "agent.scope_changed": 4,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -156,6 +156,7 @@ export const AUDIT_ACTIONS = [
   "agent.archived",
   "agent.restored",
   "agent.scope_changed",
+  "agent.editors_updated",
   // Spaces.
   "space.accessed",
   "space.created",


### PR DESCRIPTION
## Description

Becoming an editor of an agent grants access to its private data (prompt, skills, knowledge), and #31770 (merged) lets admins add themselves as editors of agents they cannot read from the details panel. Editor changes were not audited.

- New `agent.editors_updated` audit event, emitted after every editors update. Metadata: agent name, scope, added and removed editor IDs, and `actor_added_self` to flag an admin granting themselves access.
- The redacted details panel now warns that becoming an editor gives access to private data and is logged.

<img width="2214" height="1240" alt="image" src="https://github.com/user-attachments/assets/0908e5fc-800a-47da-89dd-ef6ad3765921" />


## Tests

 - added unit test for audit log event
 - tested manually the new warning pop up

## Risk

Low.

## Deploy Plan

- Register the audit log schema with WorkOS before merging
- Deploy front

