### PR TITLE
chore(workspace_analytics): revamp tools and skills metadata

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -100,7 +100,10 @@ import {
   WEB_SEARCH_BROWSE_SERVER,
   WEB_SEARCH_BROWSE_SERVER_NAME,
 } from "@app/lib/api/actions/servers/web_search_browse/metadata";
-import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
+import {
+  WORKSPACE_ANALYTICS_SERVER,
+  WORKSPACE_ANALYTICS_SERVER_NAME,
+} from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { WORKSPACE_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/workspace_management/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import type {
@@ -241,7 +244,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "ask_user_question",
   "wakeups",
   "plan_mode",
-  "workspace_analytics",
+  WORKSPACE_ANALYTICS_SERVER_NAME,
   "workspace_management",
   "activation_recommendations",
 ] as const;

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1071,76 +1071,6 @@ const QUERIES: LabeledQuery[] = [
     query: "what are the current risks in Vanta",
     expected: "vanta.list_risks",
   },
-
-  // --- workspace_analytics ---
-  {
-    query: "which agents are used most in the workspace",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-    maxRank: 2,
-  },
-  {
-    query: "who are the most active users this month",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-  },
-  {
-    query: "where do workspace messages come from - slack, api, or browser",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-    maxRank: 10,
-  },
-  {
-    query: "which models did the workspace use most this month",
-    expected: "workspace_analytics.get_top_entities_by_message_count",
-    maxRank: 5,
-  },
-  {
-    query:
-      "what does the support agent actually do - show its configuration and prompt",
-    expected: "workspace_analytics.get_agent_details",
-  },
-  {
-    query: "inspect an agent's full system prompt and tools",
-    expected: "workspace_analytics.get_agent_details",
-  },
-  {
-    query: "break down credit spending by agent",
-    expected: "workspace_analytics.get_top_entities_by_credits",
-  },
-  {
-    query: "which skills are executed most in the workspace",
-    expected: "workspace_analytics.get_top_entities_by_execution_count",
-  },
-  {
-    query: "what are the top MCP tools used by agents",
-    expected: "workspace_analytics.get_top_entities_by_execution_count",
-  },
-  {
-    query: "how many times did each integration run",
-    expected: "workspace_analytics.get_top_entities_by_execution_count",
-  },
-  {
-    query: "which agents cost the most credits this month",
-    expected: "workspace_analytics.get_top_entities_by_credits",
-  },
-  {
-    query: "which conversations were the most expensive",
-    expected: "workspace_analytics.get_top_entities_by_credits",
-  },
-  {
-    query: "attribute credit spend to our API keys",
-    expected: "workspace_analytics.get_top_entities_by_credits",
-  },
-  {
-    query: "rank credit spend by tool",
-    expected: "workspace_analytics.get_top_entities_by_credits",
-  },
-  {
-    query: "how many credits did the workspace consume this month",
-    expected: "workspace_analytics.get_consumption_overview",
-  },
-  {
-    query: "show the credit spending trend over the last 30 days",
-    expected: "workspace_analytics.get_credit_timeseries",
-  },
   // --- ashby ---
   {
     query: "find a candidate in ashby by email",
@@ -1637,6 +1567,7 @@ const QUERIES: LabeledQuery[] = [
     query:
       "semantically search company data sources for knowledge about a topic",
     expected: "data_sources_file_system.semantic_search",
+    maxRank: 2, // collides with conversation_files.semantic_search
   },
   {
     query: "find a wiki page in a data source by part of its title",

--- a/front/lib/api/actions/servers/workspace_analytics/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/index.ts
@@ -1,6 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
+import { WORKSPACE_ANALYTICS_SERVER_NAME } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/workspace_analytics/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -9,11 +10,11 @@ function createServer(
   auth: Authenticator,
   toolContext?: ToolContext
 ): McpServer {
-  const server = makeInternalMCPServer("workspace_analytics");
+  const server = makeInternalMCPServer(WORKSPACE_ANALYTICS_SERVER_NAME);
 
   for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
-      monitoringName: "workspace_analytics",
+      monitoringName: WORKSPACE_ANALYTICS_SERVER_NAME,
     });
   }
 

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -19,22 +19,22 @@ import { z } from "zod";
 export const GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME =
   "get_top_entities_by_credits" as const;
 
+export const WORKSPACE_ANALYTICS_SERVER_NAME = "workspace_analytics" as const;
+
 const getAgentDetailsSchema = {
   agentId: z
     .string()
-    .describe(
-      "The agent's id (sId), as returned by get_top_agents or other tools."
-    ),
+    .describe("The agent's id (sId), as returned by the ranking tools."),
 };
 
 const consumptionPeriodSchemaShape = {
   period: ConsumptionPeriodSchema.shape.period.describe(
     "Time window: 'cycle' (default) covers the workspace's current billing " +
-      "cycle, 'days' covers the last N days."
+      "cycle, 'days' covers the last N days.",
   ),
   days: ConsumptionPeriodSchema.shape.days.describe(
     "Number of days the window spans when period is 'days' (default 30). " +
-      "Ignored for 'cycle'."
+      "Ignored for 'cycle'.",
   ),
 };
 
@@ -47,7 +47,7 @@ const getCreditTimeseriesSchema = {
   ...consumptionPeriodSchemaShape,
   ...consumptionFilterSchema,
   timezone: timezoneSchema.describe(
-    "IANA timezone used to align the buckets. Defaults to UTC."
+    "IANA timezone used to align the buckets. Defaults to UTC.",
   ),
   granularity: z
     .enum(["day", "week", "month"])
@@ -59,7 +59,7 @@ const getCreditTimeseriesSchema = {
     .optional()
     .describe(
       "Split each bucket by this dimension — its top groups plus an 'others' " +
-        "series for the rest. Omit for a single total-credits trend."
+        "series for the rest. Omit for a single total-credits trend.",
     ),
   breakdownLimit: z
     .number()
@@ -70,7 +70,7 @@ const getCreditTimeseriesSchema = {
     .describe(
       `Number of top groups to break out when breakdownBy is set ` +
         `(default ${DEFAULT_CREDIT_GROUPS}, max ${MAX_CREDIT_GROUPS}); the ` +
-        `remainder is folded into 'others'.`
+        `remainder is folded into 'others'.`,
     ),
 };
 
@@ -80,6 +80,7 @@ export const GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME =
   "get_top_entities_by_execution_count" as const;
 export const GET_CONSUMPTION_OVERVIEW_TOOL_NAME =
   "get_consumption_overview" as const;
+export const GET_CREDIT_TIMESERIES_TOOL_NAME = "get_credit_timeseries" as const;
 
 const rankingLimitSchema = z
   .number()
@@ -89,7 +90,7 @@ const rankingLimitSchema = z
   .optional()
   .describe(
     `Maximum number of rows to return ` +
-      `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
+      `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`,
   );
 
 const GROUP_BY_DESCRIPTION = "What to group results by.";
@@ -123,14 +124,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME,
     description:
-      "Rank the workspace's entities by message volume over the current " +
-      "billing cycle or the last N days. Use this to " +
-      "answer 'which user is most active this month', 'which agent is " +
-      "used most', 'where do our messages come from, by source', or " +
-      "'list the agent tags, most-used tags first'. Every value it " +
-      "returns, including tag ids, can be fed back in as a filter on " +
-      `any of these tools. Use ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} ` +
-      "to rank by cost.",
+      "Rank the workspace's entities by message count over a time period.",
     schema: getTopEntitiesByMessageCountSchema,
     stake: "never_ask",
     eager: true,
@@ -144,14 +138,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME,
     description:
-      "Rank the workspace's skills, or its MCP tools and integrations, by how " +
-      "many times they were executed over the current billing cycle " +
-      "or the last N days. Use this to answer 'which are the top " +
-      "tools agents used most' or 'which skill runs most often'. One " +
-      "run attributed to several skills counts for each, so skill rows " +
-      "overlap. Use " +
-      `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to rank the same ` +
-      "entities by cost instead.",
+      "Rank the workspace's skills, MCP tools and integrations by execution " +
+      "count over a time period.",
     schema: getTopEntitiesByExecutionCountSchema,
     stake: "never_ask",
     eager: true,
@@ -165,10 +153,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_agent_details",
     description:
-      "Return an agent's full configuration: name, description, scope, model, " +
-      "equipped skills and capabilities, and its complete system prompt and " +
-      "instructions. Use this to inspect what a heavily-used agent actually " +
-      "does. Admin-only.",
+      "Return an agent's full configuration, equipped skills and tools, " +
+      "and its complete instructions.",
     schema: getAgentDetailsSchema,
     stake: "never_ask",
     eager: true,
@@ -182,11 +168,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
     description:
-      "Summarize the workspace's headline figures for the current billing " +
-      "cycle, or the last N days: total credits consumed, messages, active " +
-      "and total members, and the top agent. Use this to answer 'how are we " +
-      "doing this cycle' or 'how many credits did we consume' in one call, " +
-      `and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} to attribute that total.`,
+      "Summarize the workspace's headline figures over a time period.",
     schema: getConsumptionOverviewSchema,
     stake: "never_ask",
     eager: true,
@@ -198,15 +180,9 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     freeUsage: true,
   },
   {
-    name: "get_credit_timeseries",
+    name: GET_CREDIT_TIMESERIES_TOOL_NAME,
     description:
-      "Return credit consumption as a time series over the current billing " +
-      "cycle or the last N days, bucketed by day, week or month. " +
-      "Use this to answer " +
-      "'is credit spend trending up or down' or 'which week had the highest " +
-      `spend'. For a single window use ${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} ` +
-      `for the total and ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} for the ` +
-      "breakdown. Chart the result.",
+      "Return credit consumption as a time series over a time period.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
     eager: true,
@@ -220,13 +196,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME,
     description:
-      "Rank the workspace's credit consumption by entity " +
-      "over the current billing cycle or the last N days. Use " +
-      "this to break credit spending down by agent, or to answer 'which " +
-      "agent costs the most' or 'which conversation was most expensive', " +
-      "or to attribute credit spend by API key, tag, or model. Figures " +
-      "are billed credits. Rows may overlap, so don't sum them for a " +
-      "workspace total.",
+      "Rank the workspace's entities by credits spent over a time period.",
     schema: getTopEntitiesByCreditsSchema,
     stake: "never_ask",
     eager: true,
@@ -241,11 +211,12 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
 
 export const WORKSPACE_ANALYTICS_SERVER = {
   serverInfo: {
-    name: "workspace_analytics",
+    name: WORKSPACE_ANALYTICS_SERVER_NAME,
     version: "1.0.0",
     description:
-      "Answer workspace usage questions for admins and managers (top agents, " +
-      "and more to come).",
+      "Workspace usage analytics for admins and managers: credit consumption, " +
+      "message and execution volume by entity, headline figures, and trends " +
+      "over time.",
     icon: "ActionPieChartIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -1,8 +1,10 @@
 import {
   GET_CONSUMPTION_OVERVIEW_TOOL_NAME,
+  GET_CREDIT_TIMESERIES_TOOL_NAME,
   GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME,
   GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME,
   GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME,
+  WORKSPACE_ANALYTICS_SERVER_NAME,
 } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import {
   GET_AGENT_DETAILS_TOOL_NAME,
@@ -16,62 +18,50 @@ import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_define
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
 
+const WORKSPACE_ANALYTICS_INSTRUCTIONS = `
+You help workspace admins and managers understand how their Dust workspace is used.
+Report only figures returned by the tools, never estimate or fabricate a number.
+
+# What the data covers
+Every analytics tool reads the same consumption record: one entry per model step and per tool call,
+carrying the agent, the user, the model, the source (the channel or integration the message came from), the API key,
+the user's groups, the agent's tags, the skills and tools involved, and the billed credits.
+Credits combine model compute and tool usage and are the same billed credits the workspace Analytics page shows.
+
+# Choosing a tool
+- Headline figures for a time period: ${GET_CONSUMPTION_OVERVIEW_TOOL_NAME}, in one call.
+- Who or what costs the most: ${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} with the dimension asked about.
+- Who or what is most active, by volume rather than cost: ${GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME} with the dimension asked about, or ${GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME} for how often tools and skills ran.
+- Anything over time (trend, evolution, per day, per week): a single ${GET_CREDIT_TIMESERIES_TOOL_NAME} call. Set breakdownBy to split the trend along a dimension into its top groups plus an 'others' series. Never rebuild a trend by calling a ranking tool once per period, and never make one filtered call per entity when a breakdown does it in one call.
+- What an agent does: ${GET_AGENT_DETAILS_TOOL_NAME} with the agent's id.
+- What exists rather than what is used (which agents or skills the workspace has, whether they are published, which ones nobody uses): ${LIST_AGENTS_TOOL_NAME} or ${LIST_SKILLS_TOOL_NAME}, then ${GET_AGENT_DETAILS_TOOL_NAME} or ${GET_SKILL_DETAILS_TOOL_NAME} to inspect a single one. Listing the agents other members have not published is admin-only, so fall back to the default view on an authorization error.
+
+# Filters
+Filters take ids, not names. Every ranking row carries the entity's id: feed those back as filters to narrow any other call, and never guess an id from a display name.
+
+# Reporting
+- Lead with the answer, as a ranked list or a single figure. Chart timeseries results so the trend is visible.
+- Rankings report the credit total over the whole time period separately from the rows. Rows can overlap (an agent can carry several tags, a member can belong to several groups, a tool call can be attributed to several skills), so never sum rows to get a total: use that figure or ${GET_CONSUMPTION_OVERVIEW_TOOL_NAME}.
+- Credits are billed credits, not estimates.`.trim();
+
 export const workspaceAnalyticsSkill = {
   sId: "workspace-analytics",
   kind: "global",
   name: "Workspace Analytics",
   userFacingDescription:
-    "Analyze how your workspace is being used — for example, which agents " +
-    "are used most — and inventory its agents and skills. Available to " +
-    "workspace admins and managers only.",
+    "Analyze how your workspace is used: who and what consumes credits and " +
+    "drives activity, headline figures, and trends over time. Also " +
+    "inventories the workspace's agents and skills.",
   agentFacingDescription:
-    "Enable when a workspace admin or manager asks about workspace usage " +
-    "analytics, such as which agents are used most, or wants to inventory the " +
-    "workspace's agents and skills. Restricted to admins and managers.",
-  instructions:
-    "You help workspace admins and managers analyze how their Dust workspace " +
-    "is being used. Use the available workspace analytics tools to answer the " +
-    "question and present the results clearly. Only report figures returned " +
-    "by the tools — never fabricate numbers. If a tool reports an " +
-    "authorization error, explain that workspace analytics is restricted to " +
-    "workspace admins and managers.\n\n" +
-    "Choosing a tool:\n" +
-    "- For trends over time — anything spanning multiple days or phrased as " +
-    "'over time', 'per day', 'evolution', 'trend' — make a single timeseries " +
-    "call: get_credit_timeseries for credit/spend trends. It returns the " +
-    "whole series bucketed by day/week/month in one call.\n" +
-    "- Never build a trend by calling a snapshot tool once per day or in " +
-    "parallel per period — it is slower and unnecessary, the timeseries " +
-    "tools already bucket over time.\n" +
-    "- To attribute spend (which agents, users, models, tools, skills, " +
-    "sources, API keys, groups, tags or conversations cost the most), call " +
-    `${GET_TOP_ENTITIES_BY_CREDITS_TOOL_NAME} with that dimension. Use ` +
-    `${GET_CONSUMPTION_OVERVIEW_TOOL_NAME} for a window's totals: credits, messages, ` +
-    "active members and the top agent in one call.\n" +
-    "- For a credit trend split by agent, user or model (e.g. 'how did each " +
-    "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
-    "call returns the top groups plus an 'other' series. Do not make one " +
-    "filtered call per agent, user or model.\n" +
-    "- For volume rather than spend: who is most active, which agents or " +
-    "models get used most, where messages come from. Call " +
-    `${GET_TOP_ENTITIES_BY_MESSAGE_COUNT_TOOL_NAME} with that dimension, and ` +
-    `${GET_TOP_ENTITIES_BY_EXECUTION_COUNT_TOOL_NAME} for how often tools and skills ran.\n` +
-    "- The rankings return each row's id. Feed those ids back in as filters " +
-    "(agentIds, userIds, modelIds, agentTagIds, sources, ...) to narrow any " +
-    "other call — never guess an id from a display name.\n" +
-    `- To inventory what EXISTS rather than what is used — which agents or ` +
-    `skills the workspace has, whether they are published or discoverable, ` +
-    `which ones nobody uses — call ${LIST_AGENTS_TOOL_NAME} or ` +
-    `${LIST_SKILLS_TOOL_NAME}, then ${GET_AGENT_DETAILS_TOOL_NAME} or ` +
-    `${GET_SKILL_DETAILS_TOOL_NAME} to inspect a single one.\n` +
-    `- Listing the agents other members have not published is admin-only, so ` +
-    `fall back to the default view if it reports an authorization error.\n` +
-    "- Chart timeseries results so the admin can see the trend.",
+    "Enable when the user asks how their Dust workspace is used: credit " +
+    "consumption or spend, who or what is most active, headline figures, " +
+    "trends over time, or an inventory of the workspace's agents and skills.",
+  instructions: WORKSPACE_ANALYTICS_INSTRUCTIONS,
   mcpServers: [
-    { name: "workspace_analytics" },
+    { name: WORKSPACE_ANALYTICS_SERVER_NAME },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 8,
+  version: 9,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {


### PR DESCRIPTION
## Description

Dry the `workspace_analytics` tool descriptions and clean the `workspace-analytics` skill so it matches the current consumption index.
Removed the lists that leaked dimensions and filters into the prompt: they added maintenance effort and would drift as new ones get added.

Keeping the tool names in the skill's routing section for now, since the tool description were pruned.

Also in this PR:
- `workspace_analytics` becomes a shared constant across the metadata, the server and the registry.
- BM25 tool-search cases for `workspace_analytics` are removed: its tools are all eager, so they never go through tool search. One unrelated near-tie (`data_sources_file_system.semantic_search`) gets `maxRank: 2`.

## Tests

Tested locally.

## Risk

Low. Weaker descriptions could make the model pick the wrong tool. The tools are eager, so they always load and cannot be hidden by their metadata.

## Deploy Plan

Standard deploy. Skill version bumps to 9.
