### PR TITLE
spaces: add POST members endpoint to add members without replacing the list

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.test.ts
@@ -1,4 +1,7 @@
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -15,6 +18,132 @@ function patchMembers(
     body: JSON.stringify(body),
   });
 }
+
+function postMembers(
+  workspace: { sId: string },
+  spaceId: string,
+  body: unknown
+) {
+  return honoApp.request(`/api/w/${workspace.sId}/spaces/${spaceId}/members`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/spaces/:spaceId/members", () => {
+  it("lets a non-member admin add themselves to a restricted space", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+    expect(space.isMember(auth)).toBe(false);
+
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: [user.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.space.sId).toBe(space.sId);
+
+    const refreshedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const refreshedSpace = await SpaceResource.fetchById(
+      refreshedAuth,
+      space.sId
+    );
+    expect(refreshedSpace?.isMember(refreshedAuth)).toBe(true);
+  });
+
+  it("keeps the existing members", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+    const { agentOwner: existingMember } = await setupAgentOwner(
+      workspace,
+      "user"
+    );
+    await space.addMembers(auth, { userIds: [existingMember.sId] });
+
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: [user.sId],
+    });
+    expect(response.status).toBe(200);
+
+    const members = await space.fetchDistinctActiveManualGroupMembers(auth);
+    expect(new Set(members.map((m) => m.sId))).toEqual(
+      new Set([existingMember.sId, user.sId])
+    );
+  });
+
+  it("rejects non-admins", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "builder",
+    });
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(internalAdminAuth);
+    const space = await SpaceFactory.regular(workspace);
+    await space.addMembers(internalAdminAuth, { userIds: [user.sId] });
+    expect(space.isMember(auth)).toBe(false);
+
+    const { agentOwner: otherUser } = await setupAgentOwner(workspace, "user");
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: [otherUser.sId],
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 for an unknown user", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: ["usr_does_not_exist"],
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects more than 100 members at once", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: Array.from({ length: 101 }, (_, i) => `usr_${i}`),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects an empty member list", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: [],
+    });
+
+    expect(response.status).toBe(400);
+  });
+});
 
 describe("PATCH /api/w/:wId/spaces/:spaceId/members", () => {
   it("blocks making a restricted project open when open projects are disabled", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -3,8 +3,14 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { PatchSpaceMembersRequestBodySchema } from "@app/lib/api/spaces/members";
+import {
+  PatchSpaceMembersRequestBodySchema,
+  PostSpaceMembersRequestBodySchema,
+} from "@app/lib/api/spaces/members";
+import type { Authenticator } from "@app/lib/auth";
 import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
 import { auditLog } from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -12,11 +18,176 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import type { Context } from "hono";
 
-export type { PatchSpaceMembersRequestBodyType } from "@app/lib/api/spaces/members";
+export type {
+  PatchSpaceMembersRequestBodyType,
+  PostSpaceMembersRequestBodyType,
+} from "@app/lib/api/spaces/members";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/members.
 const app = workspaceApp();
+
+// Members can only be administrated on regular spaces and projects, by their administrators.
+function membersAdministrationError(
+  ctx: Context,
+  auth: Authenticator,
+  space: SpaceResource
+) {
+  if (!space.isRegular() && !space.isProject()) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Only projects and regular spaces can have members.",
+      },
+    });
+  }
+
+  if (!auth.can("admin", space)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only users that are `admins` can administrate space members.",
+      },
+    });
+  }
+
+  return null;
+}
+
+type MembersMutationErrorCode =
+  | "unauthorized"
+  | "user_not_found"
+  | "user_not_member"
+  | "group_not_found"
+  | "user_already_member"
+  | "invalid_id"
+  | "group_requirements_not_met"
+  | "invalid_group_kind"
+  | "system_or_global_group";
+
+// Maps the error codes of the space membership mutations to API errors. POST only produces a
+// subset of PATCH's codes; both go through the same mapping.
+function membersMutationError(ctx: Context, code: MembersMutationErrorCode) {
+  switch (code) {
+    case "unauthorized":
+      return apiError(ctx, {
+        status_code: 401,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` can administrate space members.",
+        },
+      });
+    case "user_not_found":
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "user_not_found",
+          message: "The user was not found in the workspace.",
+        },
+      });
+    case "user_not_member":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The user is not a member of the workspace.",
+        },
+      });
+    case "group_not_found":
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: "The group was not found in the workspace.",
+        },
+      });
+    case "user_already_member":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The user is already a member of the space.",
+        },
+      });
+    case "invalid_id":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Some of the passed ids are invalid.",
+        },
+      });
+    case "group_requirements_not_met":
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Some users have insufficient role privilege to be added to the space.",
+        },
+      });
+    case "invalid_group_kind":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Only provisioned and manual groups can be given access to a space.",
+        },
+      });
+    case "system_or_global_group":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Users cannot be added to or removed from system or global groups.",
+        },
+      });
+    default:
+      assertNever(code);
+  }
+}
+
+// Shared by every members mutation: a security log entry when the acting admin is not a member of
+// the space, plus the WorkOS audit event with the mutation-specific metadata.
+function emitSpacePermissionsUpdatedAuditLogs(
+  auth: Authenticator,
+  space: SpaceResource,
+  metadata: Record<string, string>
+) {
+  if (!auth.can("read", space)) {
+    const user = auth.user();
+    auditLog(
+      {
+        author: user ? user.toJSON() : "no-author",
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        spaceId: space.sId,
+        spaceName: space.name,
+        action: "space_permissions_updated_by_non_member",
+      },
+      "[Security] Admin updated space permissions without being a member"
+    );
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "space.permissions_updated",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("space", space),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      space_name: space.name,
+      ...metadata,
+    },
+  });
+}
 
 /** @ignoreswagger */
 app.patch(
@@ -27,25 +198,9 @@ app.patch(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    if (!space.isRegular() && !space.isProject()) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Only projects and regular spaces can have members.",
-        },
-      });
-    }
-
-    if (!auth.can("admin", space)) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` can administrate space members.",
-        },
-      });
+    const guardError = membersAdministrationError(ctx, auth, space);
+    if (guardError) {
+      return guardError;
     }
 
     const body = ctx.req.valid("json");
@@ -77,124 +232,21 @@ app.patch(
 
     const updateRes = await space.updatePermissions(auth, body);
     if (updateRes.isErr()) {
-      switch (updateRes.error.code) {
-        case "unauthorized":
-          return apiError(ctx, {
-            status_code: 401,
-            api_error: {
-              type: "workspace_auth_error",
-              message:
-                "Only users that are `admins` can administrate space members.",
-            },
-          });
-        case "user_not_found":
-          return apiError(ctx, {
-            status_code: 404,
-            api_error: {
-              type: "user_not_found",
-              message: "The user was not found in the workspace.",
-            },
-          });
-        case "user_not_member":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "The user is not a member of the workspace.",
-            },
-          });
-        case "group_not_found":
-          return apiError(ctx, {
-            status_code: 404,
-            api_error: {
-              type: "group_not_found",
-              message: "The group was not found in the workspace.",
-            },
-          });
-        case "user_already_member":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "The user is already a member of the space.",
-            },
-          });
-        case "invalid_id":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Some of the passed ids are invalid.",
-            },
-          });
-        case "group_requirements_not_met":
-          return apiError(ctx, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
-              message:
-                "Some users have insufficient role privilege to be added to the space.",
-            },
-          });
-        case "invalid_group_kind":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Only provisioned and manual groups can be given access to a space.",
-            },
-          });
-        case "system_or_global_group":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Users cannot be removed from system or global groups.",
-            },
-          });
-        default:
-          assertNever(updateRes.error.code);
-      }
+      return membersMutationError(ctx, updateRes.error.code);
     }
 
-    // Audit log when an admin who is not a member of the space updates its permissions.
-    if (!auth.can("read", space)) {
-      const user = auth.user();
-      auditLog(
-        {
-          author: user ? user.toJSON() : "no-author",
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          spaceId: space.sId,
-          spaceName: space.name,
-          action: "space_permissions_updated_by_non_member",
-        },
-        "[Security] Admin updated space permissions without being a member"
-      );
-    }
-
-    void emitAuditLogEvent({
-      auth,
-      action: "space.permissions_updated",
-      targets: [
-        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-        buildAuditLogTarget("space", space),
-      ],
-      context: getAuditLogContext(auth),
-      metadata: {
-        space_name: space.name,
-        management_mode: body.managementMode,
-        is_restricted: String(body.isRestricted),
-        ...(body.managementMode === "manual"
-          ? {
-              member_ids: body.memberIds.join(","),
-              editor_ids: body.editorIds.join(","),
-            }
-          : {
-              group_ids: body.groupIds.join(","),
-              editor_group_ids: body.editorGroupIds.join(","),
-            }),
-      },
+    emitSpacePermissionsUpdatedAuditLogs(auth, space, {
+      management_mode: body.managementMode,
+      is_restricted: String(body.isRestricted),
+      ...(body.managementMode === "manual"
+        ? {
+            member_ids: body.memberIds.join(","),
+            editor_ids: body.editorIds.join(","),
+          }
+        : {
+            group_ids: body.groupIds.join(","),
+            editor_group_ids: body.editorGroupIds.join(","),
+          }),
     });
 
     // Trigger notifications for newly added members (projects only).
@@ -213,6 +265,68 @@ app.patch(
         });
       }
     }
+
+    return ctx.json({ space: space.toJSON() });
+  }
+);
+
+// Adds members to a manually managed space without touching the rest of its membership, unlike
+// PATCH which replaces the whole member list.
+/** @ignoreswagger */
+app.post(
+  "/",
+  withSpace({ requireCanReadOrAdministrate: true }),
+  validate("json", PostSpaceMembersRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    const guardError = membersAdministrationError(ctx, auth, space);
+    if (guardError) {
+      return guardError;
+    }
+
+    if (space.managementMode !== "manual") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The members of this space are managed by groups. Add users to one of its groups instead.",
+        },
+      });
+    }
+
+    const { memberIds } = ctx.req.valid("json");
+
+    const addRes = await space.addMembers(auth, { userIds: memberIds });
+    if (addRes.isErr()) {
+      return membersMutationError(ctx, addRes.error.code);
+    }
+
+    emitSpacePermissionsUpdatedAuditLogs(auth, space, {
+      management_mode: "manual",
+      is_restricted: String(await space.isRestricted(auth)),
+      member_ids: addRes.value.map((user) => user.sId).join(","),
+    });
+
+    // Trigger notifications for newly added members (projects only).
+    if (space.isProject() && addRes.value.length > 0) {
+      notifyPodMembersAdded(auth, {
+        pod: space.toJSON(),
+        addedUserIds: addRes.value.map((user) => user.sId),
+      });
+    }
+
+    // The group membership cache is invalidated asynchronously by the add. Callers (an admin
+    // joining a space to read an agent) refetch right after the response, so wait for it here, as
+    // the join route does.
+    const workspace = auth.getNonNullableWorkspace();
+    await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+      addRes.value.map((user) => [
+        { user: { id: user.id }, workspace: { id: workspace.id } },
+      ])
+    );
 
     return ctx.json({ space: space.toJSON() });
   }

--- a/front/lib/api/spaces/members.ts
+++ b/front/lib/api/spaces/members.ts
@@ -22,3 +22,14 @@ export const PatchSpaceMembersRequestBodySchema = z.intersection(
 export type PatchSpaceMembersRequestBodyType = z.infer<
   typeof PatchSpaceMembersRequestBodySchema
 >;
+
+// Unlike PATCH, which has to carry the full member list, POST only adds users and is bounded.
+export const MAX_SPACE_MEMBERS_PER_ADD = 100;
+
+export const PostSpaceMembersRequestBodySchema = z.object({
+  memberIds: z.array(z.string()).min(1).max(MAX_SPACE_MEMBERS_PER_ADD),
+});
+
+export type PostSpaceMembersRequestBodyType = z.infer<
+  typeof PostSpaceMembersRequestBodySchema
+>;

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -3,7 +3,10 @@ import type {
   CursorPaginationParams,
   SortingParams,
 } from "@app/lib/api/pagination";
-import type { PatchSpaceMembersRequestBodyType } from "@app/lib/api/spaces/members";
+import type {
+  PatchSpaceMembersRequestBodyType,
+  PostSpaceMembersRequestBodyType,
+} from "@app/lib/api/spaces/members";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import { getSpaceName } from "@app/lib/spaces";
@@ -751,6 +754,62 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
     return spaceResponse.space;
   };
   return doUpdate;
+}
+
+// Adds members to a manually managed space without replacing its member list.
+export function useAddSpaceMembers({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+  const { mutate: mutateSpaces } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: "all",
+    disabled: true, // Needed just to mutate
+  });
+  const { mutate: mutateSpacesAsAdmin } = useSpacesAsAdmin({
+    workspaceId: owner.sId,
+    disabled: true, // Needed just to mutate
+  });
+
+  const doAdd = async (
+    space: SpaceType,
+    memberIds: string[],
+    notification?: { title: string; description: string }
+  ): Promise<boolean> => {
+    const res = await clientFetch(
+      `/api/w/${owner.sId}/spaces/${space.sId}/members`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          memberIds,
+        } satisfies PostSpaceMembersRequestBodyType),
+      }
+    );
+
+    if (!res.ok) {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: `Failed to add members to ${getSpaceName(space)}`,
+        description: `Error: ${errorData.message}`,
+      });
+      return false;
+    }
+
+    void mutateSpaces();
+    void mutateSpacesAsAdmin();
+
+    sendNotification({
+      type: "success",
+      title: notification?.title ?? "Successfully added members",
+      description:
+        notification?.description ??
+        `Members were added to ${getSpaceName(space)}.`,
+    });
+    return true;
+  };
+  return doAdd;
 }
 
 export function useDeleteSpace({


### PR DESCRIPTION
## Description

Joining a space from the redacted agent details panel (#31770) currently reads the space members and sends the whole list back through `PATCH /spaces/:spaceId/members`. That replaces the membership from a client snapshot, so concurrent changes could be overwritten.

- New `POST /api/w/:wId/spaces/:spaceId/members` with `{ memberIds }`, which only adds the given users. Admin only, manually managed regular spaces and projects only, capped at 100 users per request. It reuses `SpaceResource.addMembers`, shares the guards, error mapping and audit logging with PATCH, notifies added project members, and waits for the groups cache invalidation before responding so an immediate refetch sees the new membership.
- New `useAddSpaceMembers` hook for the client. #31770 will switch the agent details panel to it once this is merged.

## Tests

Added route tests for the new endpoint: a non-member admin adding themselves, existing members preserved, non-admin rejected, unknown user, empty list, more than 100 users. `SpaceResource.addMembers` already existed and is covered by the resource tests.

## Risk

Low. New admin-only endpoint that adds members without removing any. No UI change in this PR.

## Deploy Plan

- Deploy front-api
- Deploy front
