### PR TITLE
[front] fix: hide fair-use usage details when disabled by FF

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -1,5 +1,8 @@
 import type { CreditUsageState } from "@app/components/app/CreditUsage";
-import { CreditUsage } from "@app/components/app/CreditUsage";
+import {
+  CreditUsage,
+  CreditUsageLearnMoreButton,
+} from "@app/components/app/CreditUsage";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { UserAutomationsDialog } from "@app/components/me/UserAutomationsDialog";
@@ -94,6 +97,7 @@ interface UserMenuProps {
   owner: WorkspaceType;
   subscription: SubscriptionType | null;
   creditUsageState?: CreditUsageState | null;
+  showCreditUsageLearnMoreOnly?: boolean;
 }
 
 function trackUserMenuEvent(
@@ -113,6 +117,7 @@ export function UserMenu({
   owner,
   subscription,
   creditUsageState,
+  showCreditUsageLearnMoreOnly = false,
 }: UserMenuProps) {
   const router = useAppRouter();
   const { featureFlags } = useFeatureFlags();
@@ -305,6 +310,12 @@ export function UserMenu({
     return hasMultipleOrgs || hasMultipleLocalWorkspaces;
   }, [user]);
 
+  const handleCreditUsageLearnMore = () => {
+    trackUserMenuEvent("credit_usage_learn_more");
+    setUserMenuOpen(false);
+    setAnalyticsOpen(true);
+  };
+
   return (
     <>
       <UserSettingsPopover
@@ -377,20 +388,25 @@ export function UserMenu({
           sideOffset={8}
           className="w-64"
         >
-          {subscription?.plan.limits.canUseProduct && creditUsageState && (
-            <>
-              <CreditUsage
-                state={creditUsageState}
-                variant="profile_menu"
-                onLearnMore={() => {
-                  trackUserMenuEvent("credit_usage_learn_more");
-                  setUserMenuOpen(false);
-                  setAnalyticsOpen(true);
-                }}
-              />
-              <Separator className="my-1" />
-            </>
-          )}
+          {subscription?.plan.limits.canUseProduct &&
+            (creditUsageState || showCreditUsageLearnMoreOnly) && (
+              <>
+                {showCreditUsageLearnMoreOnly ? (
+                  <div className="p-2">
+                    <CreditUsageLearnMoreButton
+                      onClick={handleCreditUsageLearnMore}
+                    />
+                  </div>
+                ) : creditUsageState ? (
+                  <CreditUsage
+                    state={creditUsageState}
+                    variant="profile_menu"
+                    onLearnMore={handleCreditUsageLearnMore}
+                  />
+                ) : null}
+                <Separator className="my-1" />
+              </>
+            )}
 
           {hasMultipleWorkspaces && (
             <>
@@ -532,8 +548,8 @@ export function UserMenu({
                   setAutomationsOpen(true);
                 }}
               />
-              {/* The credit usage card is the analytics entry point when shown; keep exactly one. */}
-              {!creditUsageState && (
+              {/* The credit usage action is the analytics entry point when shown; keep exactly one. */}
+              {!creditUsageState && !showCreditUsageLearnMoreOnly && (
                 <DropdownMenuItem
                   label="Analytics"
                   icon={BarChart01}

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { CreditUsageState } from "./CreditUsage";
-import { CREDIT_USAGE_LEARN_MORE_LABEL, CreditUsage } from "./CreditUsage";
+import {
+  CREDIT_USAGE_LEARN_MORE_LABEL,
+  CreditUsage,
+  CreditUsageLearnMoreButton,
+} from "./CreditUsage";
 
 const ON_TARGET_STATE = {
   kind: "billing_period",
@@ -37,6 +41,19 @@ describe("CreditUsage", () => {
     fireEvent.click(
       screen.getByRole("button", { name: CREDIT_USAGE_LEARN_MORE_LABEL })
     );
+
+    expect(onLearnMore).toHaveBeenCalledOnce();
+  });
+
+  it("renders the standalone learn more action", () => {
+    const onLearnMore = vi.fn();
+
+    render(<CreditUsageLearnMoreButton onClick={onLearnMore} />);
+
+    const button = screen.getByRole("button", {
+      name: CREDIT_USAGE_LEARN_MORE_LABEL,
+    });
+    fireEvent.click(button);
 
     expect(onLearnMore).toHaveBeenCalledOnce();
   });

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -49,6 +49,22 @@ interface CreditUsageProps {
   onLearnMore?: () => void;
 }
 
+export function CreditUsageLearnMoreButton({
+  onClick,
+}: {
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      label={CREDIT_USAGE_LEARN_MORE_LABEL}
+      variant="outline"
+      size="sm"
+      className="w-full"
+      onClick={onClick}
+    />
+  );
+}
+
 function getUsageDescription(
   state: CreditUsageState,
   variant: CreditUsageCardVariant
@@ -88,13 +104,7 @@ export function CreditUsage({ state, variant, onLearnMore }: CreditUsageProps) {
       {onLearnMore ? (
         <div className="flex flex-col gap-2">
           <span>{usageDescription}</span>
-          <Button
-            label={CREDIT_USAGE_LEARN_MORE_LABEL}
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={onLearnMore}
-          />
+          <CreditUsageLearnMoreButton onClick={onLearnMore} />
         </div>
       ) : (
         usageDescription

--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -30,7 +30,9 @@ export function PersonalUsageCard({
   const { hasFeature } = useFeatureFlags();
   const isCreditBased = isCreditPricedPlan(subscription.plan);
   const showFairUseCredits =
-    !isCreditBased && subscription.plan.limits.assistant.maxAwuCredits > 0;
+    !isCreditBased &&
+    !hasFeature("disable_fair_use_awu_limit") &&
+    subscription.plan.limits.assistant.maxAwuCredits > 0;
   const showPremiumModelUsage =
     !isCreditBased && hasFeature("enforce_premium_model_message_limit");
   const { myUsage, premiumModelUsage, nextCreditResetAt, isMyUsageLoading } =

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -193,6 +193,7 @@ export const NavigationSidebar = React.forwardRef<
           user={user}
           owner={owner}
           subscription={subscription}
+          isFairUseAwuLimitDisabled={hasFeature("disable_fair_use_awu_limit")}
         />
       )}
     </div>

--- a/front/components/navigation/SidebarUserMenu.test.tsx
+++ b/front/components/navigation/SidebarUserMenu.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 interface UserMenuMockProps {
   creditUsageState?: CreditUsageState | null;
+  showCreditUsageLearnMoreOnly: boolean;
 }
 
 vi.mock("@app/components/app/FairUseCreditsUsage", () => ({
@@ -22,12 +23,19 @@ vi.mock("@app/components/app/FairUseCreditsUsage", () => ({
 }));
 
 vi.mock("@app/components/UserMenu", async () => {
-  const { CreditUsage } = await import("@app/components/app/CreditUsage");
+  const { CreditUsage, CreditUsageLearnMoreButton } = await import(
+    "@app/components/app/CreditUsage"
+  );
 
   return {
-    UserMenu: ({ creditUsageState }: UserMenuMockProps) =>
+    UserMenu: ({
+      creditUsageState,
+      showCreditUsageLearnMoreOnly,
+    }: UserMenuMockProps) =>
       creditUsageState ? (
         <CreditUsage state={creditUsageState} variant="profile_menu" />
+      ) : showCreditUsageLearnMoreOnly ? (
+        <CreditUsageLearnMoreButton onClick={() => {}} />
       ) : null,
   };
 });
@@ -61,9 +69,27 @@ const subscription = LightSubscriptionFactory.build({
   metronomeContractId: "contract_1",
   plan: LightPlanFactory.build({ code: CREDIT_PRICED_BUSINESS_PLAN_CODE }),
 });
+const legacyPlan = LightPlanFactory.build();
+const legacySubscription = LightSubscriptionFactory.build({
+  plan: {
+    ...legacyPlan,
+    limits: {
+      ...legacyPlan.limits,
+      assistant: {
+        ...legacyPlan.limits.assistant,
+        maxAwuCredits: 20_000,
+        maxAwuCreditsTimeframe: "week",
+      },
+    },
+  },
+});
 
 describe("SidebarUserMenu", () => {
   beforeEach(() => {
+    mocks.useMyUsage.mockReturnValue({
+      myUsage: null,
+      creditUsageStatus: null,
+    });
     mocks.useFairUseCredits.mockReturnValue({
       fairUseAwuCreditsState: null,
     });
@@ -84,7 +110,12 @@ describe("SidebarUserMenu", () => {
     });
 
     render(
-      <SidebarUserMenu user={user} owner={owner} subscription={subscription} />
+      <SidebarUserMenu
+        user={user}
+        owner={owner}
+        subscription={subscription}
+        isFairUseAwuLimitDisabled={false}
+      />
     );
 
     expect(
@@ -108,10 +139,36 @@ describe("SidebarUserMenu", () => {
     });
 
     render(
-      <SidebarUserMenu user={user} owner={owner} subscription={subscription} />
+      <SidebarUserMenu
+        user={user}
+        owner={owner}
+        subscription={subscription}
+        isFairUseAwuLimitDisabled={false}
+      />
     );
 
     expect(screen.queryByText(/reset/i)).toBeNull();
     expect(screen.queryByText("Credits")).toBeNull();
+  });
+
+  it("shows only the usage action when the fair-use limit is disabled", () => {
+    render(
+      <SidebarUserMenu
+        user={user}
+        owner={owner}
+        subscription={legacySubscription}
+        isFairUseAwuLimitDisabled
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "See your usage" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Credits")).toBeNull();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(mocks.useFairUseCredits).toHaveBeenCalledWith({
+      workspaceId: owner.sId,
+      disabled: true,
+    });
   });
 });

--- a/front/components/navigation/SidebarUserMenu.tsx
+++ b/front/components/navigation/SidebarUserMenu.tsx
@@ -15,17 +15,22 @@ interface SidebarUserMenuProps {
   user: UserTypeWithWorkspaces;
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  isFairUseAwuLimitDisabled: boolean;
 }
 
 export function SidebarUserMenu({
   user,
   owner,
   subscription,
+  isFairUseAwuLimitDisabled,
 }: SidebarUserMenuProps) {
   const isCreditBased = isCreditPricedPlan(subscription.plan);
   const { maxAwuCredits, maxAwuCreditsTimeframe } =
     subscription.plan.limits.assistant;
-  const hasFairUseCreditUsage = !isCreditBased && maxAwuCredits > 0;
+  const showCreditUsageLearnMoreOnly =
+    !isCreditBased && isFairUseAwuLimitDisabled;
+  const hasFairUseCreditUsage =
+    !isCreditBased && !isFairUseAwuLimitDisabled && maxAwuCredits > 0;
   const { myUsage, creditUsageStatus } = useMyUsage({
     workspaceId: owner.sId,
     disabled: !isCreditBased,
@@ -69,7 +74,9 @@ export function SidebarUserMenu({
         }
       : null;
   const rollingCreditUsageState: CreditUsageState | null =
-    fairUseAwuCreditsState && fairUseAwuCreditsState.limit > 0
+    hasFairUseCreditUsage &&
+    fairUseAwuCreditsState &&
+    fairUseAwuCreditsState.limit > 0
       ? {
           kind: "rolling_window",
           usedCredits: fairUseAwuCreditsState.count,
@@ -92,6 +99,7 @@ export function SidebarUserMenu({
   return (
     <>
       {subscription.plan.code !== FREE_TRIAL_PHONE_PLAN_CODE &&
+        !isFairUseAwuLimitDisabled &&
         !isCreditBased &&
         maxAwuCredits !== -1 && <FairUseCreditsUsage workspaceId={owner.sId} />}
       {creditUsageState && !showCreditUsageInProfileMenu && (
@@ -103,6 +111,7 @@ export function SidebarUserMenu({
         user={user}
         owner={owner}
         subscription={subscription}
+        showCreditUsageLearnMoreOnly={showCreditUsageLearnMoreOnly}
         creditUsageState={
           showCreditUsageInProfileMenu ? creditUsageState : null
         }


### PR DESCRIPTION
## Description

Workspaces using `disable_fair_use_awu_limit` should not display a fair-use allowance that is no longer recorded or enforced.

This PR updates the gauge in Personal analytics and in the companion, for the companion we only see the `See your usage` button in the user menu.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
