### PR TITLE
feat: remove permissions on regular_auto groups

### DIFF
--- a/front-api/routes/w/[wId]/governance-permissions.test.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.test.ts
@@ -192,18 +192,15 @@ describe("PATCH /api/w/:wId/governance-permissions", () => {
   });
 
   it("rejects a groups configuration referencing a non-manageable group", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace, globalGroup } = await createPrivateApiMockRequest({
       method: "PATCH",
       role: "admin",
     });
 
-    // `regular_auto` groups back spaces and are not user-managed, so they cannot be granted here.
-    const autoGroup = await GroupFactory.regularAuto(workspace, "auto");
-
     const response = await patchGovernancePermission(workspace, {
       grantType: "publish",
       resourceType: "agent",
-      configuration: { scope: "groups", groupIds: [autoGroup.sId] },
+      configuration: { scope: "groups", groupIds: [globalGroup.sId] },
     });
 
     expect(response.status).toBe(400);

--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -405,14 +405,13 @@ describe("GET /api/w/:wId/groups/:groupId", () => {
     expect((await response.json()).error.type).toBe("workspace_auth_error");
   });
 
-  it("returns 404 for a non-regular_manual group", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+  it("returns 404 for a non-manageable group", async () => {
+    const { workspace, globalGroup } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
-    const group = await GroupFactory.regularAuto(workspace, "Automatic");
 
-    const response = await getGroup(workspace, group.sId);
+    const response = await getGroup(workspace, globalGroup.sId);
 
     expect(response.status).toBe(404);
     expect((await response.json()).error.type).toBe("group_not_found");
@@ -570,7 +569,7 @@ describe("PATCH /api/w/:wId/groups/:groupId", () => {
       method: "PATCH",
       role: "admin",
     });
-    const group = await GroupFactory.regularAuto(workspace, "Automatic");
+    const group = await GroupFactory.provisioned(workspace, "Automatic");
 
     const response = await patchGroup(workspace, group.sId, {
       name: "New name",
@@ -685,7 +684,7 @@ describe("DELETE /api/w/:wId/groups/:groupId", () => {
       method: "DELETE",
       role: "admin",
     });
-    const group = await GroupFactory.regularAuto(workspace, "Automatic");
+    const group = await GroupFactory.provisioned(workspace, "Automatic");
 
     const response = await deleteGroup(workspace, group.sId);
 

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.test.ts
@@ -71,11 +71,12 @@ describe("GET /api/w/:wId/groups/:groupId", () => {
     expect(body.members).toEqual([expect.objectContaining({ sId: bob.sId })]);
   });
 
-  it("returns 404 on a group that is not surfaced in admin UIs", async () => {
-    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
-    const spaceGroup = await GroupFactory.regularAuto(workspace, "Space group");
+  it("returns 404 on a non-manageable group", async () => {
+    const { workspace, globalGroup } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
 
-    const response = await getGroupRequest(workspace.sId, spaceGroup.sId);
+    const response = await getGroupRequest(workspace.sId, globalGroup.sId);
 
     expect(response.status).toBe(404);
     expect((await response.json()).error.type).toBe("group_not_found");

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -118,18 +118,13 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
 
     it("returns 400 on a non-provisioned group", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
-      const regularGroup = await GroupResource.makeNew({
-        name: "Space group",
-        workspaceId: workspace.id,
-        kind: "regular_auto",
-      });
-      await createPrivateApiMockRequest({
+      const { globalGroup } = await createPrivateApiMockRequest({
         method: "PUT",
         role: "admin",
         workspace,
       });
 
-      const response = await putLimit(workspace.sId, regularGroup.sId, {
+      const response = await putLimit(workspace.sId, globalGroup.sId, {
         kind: "limited",
         awuCredits: 1500,
       });

--- a/front/lib/model_tiers/allowed_tiers.test.ts
+++ b/front/lib/model_tiers/allowed_tiers.test.ts
@@ -120,7 +120,9 @@ describe("allowed model tiers permissions", () => {
     });
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.code).toBe("invalid_request_error");
+      // A regular auto group cannot be read without its resource,
+      // so the fetch turns it away before the kind check.
+      expect(result.error.code).toBe("unauthorized");
     }
     expect(await listGroupAllowedTierNames(auth)).toEqual([]);
   });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -61,20 +61,6 @@ import { col, fn, Op, QueryTypes } from "sequelize";
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const MANAGER_GROUP_NAME = "dust-managers";
 
-/**
- * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
- * ┃                                                                         ┃
- * ┃  IMPORTANT: GroupResource DOES NOT and SHOULD NOT have permissions      ┃
- * ┃  management of its own.                                                 ┃
- * ┃                                                                         ┃
- * ┃  Groups are designed to be used within the context of other resources   ┃
- * ┃  (e.g., SpaceResource, AgentConfigurationResource). The permissions     ┃
- * ┃  should be managed at the junction with parent resource level,          ┃
- * ┃  not at the group level.                                                ┃
- * ┃                                                                         ┃
- * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
- */
-
 type CachedGroup = {
   id: ModelId;
   name: string;
@@ -2568,18 +2554,15 @@ export class GroupResource extends BaseResource<GroupModel> {
   // Permissions
 
   /**
-   * Returns the requested permissions for this resource.
-   *
-   * Configures two types of access:
-   * 1. Group-based: The group's members get read access
-   * 2. Role-based: Workspace admins get read and write access
-   *
-   * For agent_editors groups, the permissions are:
-   * 1. Group-based: The group's members get full access
-   * 2. Role-based: Workspace admins get read and admin access. All users can
-   *    read "agent_editors" groups.
-   *    Admin do not have write access, they can however add themselves to
-   *    groups to gain it.
+   * The ACLs a caller has to satisfy to hold a verb on this group, by kind:
+   * - regular_manual: read, write and admin for admins and managers, read for everyone else.
+   * - global, provisioned: read for every workspace member, and nothing else — their
+   *   membership is not editable in app. Global membership is implicit, and provisioned
+   *   membership comes from directory sync.
+   * - regular_auto: nothing. These groups only carry the membership of the resource
+   *   they are linked to, so the permission is checked on that resource and never on the
+   *   group itself.
+   * - system: nothing, it is internal to the workspace.
    *
    * CAUTION: if / when editing, note that for role permissions, permissions are
    * NOT inherited, i.e., if you set a permission for role "user", an "admin"
@@ -2589,35 +2572,6 @@ export class GroupResource extends BaseResource<GroupModel> {
    * configuration
    */
   getAccessControlLists(auth: Authenticator): AccessControlList[] {
-    // TODO(2026-09-03 regular-auto-acl): temporary probe, remove once regular_auto stops
-    // granting permissions. These groups are only reachable through the resource that owns
-    // them, so no caller should be permission-checking one; the stack tells us where to look
-    // if any does.
-    if (this.isRegularAuto()) {
-      logger.warn(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          groupId: this.sId,
-          authRole: auth.role(),
-          isKey: auth.isKey(),
-          stack_trace: new Error().stack,
-        },
-        "[GroupResource.getAccessControlLists] Permission checked on a regular_auto group"
-      );
-
-      return [
-        {
-          roles: [
-            { role: "admin", permissions: ["read"] },
-            { role: "manager", permissions: ["read"] },
-            { role: "user", permissions: ["read"] },
-            { role: "builder", permissions: ["read"] },
-          ],
-          workspaceId: this.workspaceId,
-        },
-      ];
-    }
-
     // regular_manual: admins and managers manage the group; everyone can read.
     if (this.isRegularManual()) {
       return [
@@ -2647,8 +2601,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       ];
     }
 
-    // system: internal group — no one can read or write. The single empty grant
-    // denies every verb (an empty ACL array would instead vacuously allow).
+    // system, regular_auto: no permission for anyone. Access to a regular_auto group is
+    // decided on the resource it is linked to, and its owner fetches it without an ACL check.
     return [
       {
         roles: [],

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2724,11 +2724,17 @@ describe("SpaceResource group_permissions enforcement", () => {
     }
 
     const space = await SpaceFactory.regular(workspace);
-    // The space's own auto-created member group is readable by an admin, so only a kind check keeps
-    // it — and the workspace global group — out of a group-managed selection.
     const [autoGroup] = await space.fetchRegularAutoGroups(adminAuth);
 
-    for (const group of [globalGroupRes.value, autoGroup]) {
+    // The global group is readable by everyone, so only a kind check keeps it out of a
+    // group-managed selection. The space's own auto-created member group is readable by no one,
+    // so it is turned away by `fetchByIds` before the kind check runs.
+    const cases = [
+      { group: globalGroupRes.value, expectedCode: "invalid_group_kind" },
+      { group: autoGroup, expectedCode: "unauthorized" },
+    ];
+
+    for (const { group, expectedCode } of cases) {
       const res = await space.updatePermissions(adminAuth, {
         isRestricted: true,
         managementMode: "group",
@@ -2737,7 +2743,7 @@ describe("SpaceResource group_permissions enforcement", () => {
       });
       expect(res.isErr()).toBe(true);
       if (res.isErr()) {
-        expect(res.error.code).toBe("invalid_group_kind");
+        expect(res.error.code).toBe(expectedCode);
       }
     }
   });


### PR DESCRIPTION
## Description

This PR removes direct permissions from `regular_auto` groups so access is enforced through the resource they belong to rather than the group itself.

## Tests
Manually

## Risks
Callers that directly fetch or permission-check `regular_auto` groups will now receive `unauthorized`; they must access these groups through their owning resource. Wait for https://github.com/dust-tt/dust/pull/31774 to be deployed first and check that no warn logs appear.

## Deploy Plan
Deploy only after having verified that https://github.com/dust-tt/dust/pull/31774 produced to warning logs.