### PR TITLE
[front] enh: overlay active users on consumption chart

### DIFF
--- a/front/components/charts/ChartContainer.tsx
+++ b/front/components/charts/ChartContainer.tsx
@@ -20,7 +20,7 @@ import { useState } from "react";
 import { ResponsiveContainer } from "recharts";
 
 interface ChartContainerProps {
-  title: ReactNode;
+  title?: ReactNode;
   isLoading: boolean;
   errorMessage?: string;
   emptyMessage?: string;
@@ -64,7 +64,9 @@ export function ChartContainer({
           )}
         >
           <div className="flex shrink-0 items-center justify-between gap-2">
-            <h3 className="text-base font-medium text-foreground">{title}</h3>
+            {title && (
+              <h3 className="text-base font-medium text-foreground">{title}</h3>
+            )}
             {statusChip}
           </div>
           <div className="flex items-center gap-3">

--- a/front/components/charts/ChartLegend.tsx
+++ b/front/components/charts/ChartLegend.tsx
@@ -35,6 +35,7 @@ export interface LegendItem {
   colorClassName: string;
   onClick?: () => void;
   isActive?: boolean;
+  isTrailing?: boolean;
 }
 
 export type ChartLegendAlignment = "left" | "center" | "right";
@@ -50,7 +51,50 @@ interface ChartLegendProps {
   alignment?: ChartLegendAlignment;
 }
 
+function ChartLegendItem({ item }: { item: LegendItem }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2",
+        item.onClick && "cursor-pointer transition-opacity hover:opacity-80",
+        item.isActive === false && "opacity-20"
+      )}
+      onClick={item.onClick}
+    >
+      <LegendDot
+        className={item.colorClassName}
+        rounded={item.key === "versionMarkers" ? "full" : "sm"}
+      />
+      <span className="text-sm text-muted-foreground">{item.label}</span>
+    </div>
+  );
+}
+
 export function ChartLegend({ items, alignment = "left" }: ChartLegendProps) {
+  const trailingItems = items.filter((item) => item.isTrailing);
+
+  if (trailingItems.length > 0) {
+    const mainItems = items.filter((item) => !item.isTrailing);
+
+    return (
+      <div className="mt-3 flex items-center">
+        <span aria-hidden className="min-w-0 flex-1" />
+        <div className="flex min-w-0 flex-wrap items-center justify-center gap-x-6 gap-y-2">
+          {mainItems.map((item) => (
+            <ChartLegendItem key={item.key} item={item} />
+          ))}
+        </div>
+        <span aria-hidden className="min-w-0 flex-1" />
+        <div className="flex shrink-0 items-center gap-x-6 gap-y-2">
+          {trailingItems.map((item) => (
+            <ChartLegendItem key={item.key} item={item} />
+          ))}
+        </div>
+        <span aria-hidden className="min-w-0 flex-1" />
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -59,21 +103,7 @@ export function ChartLegend({ items, alignment = "left" }: ChartLegendProps) {
       )}
     >
       {items.map((item) => (
-        <div
-          key={item.key}
-          className={`flex items-center gap-2 ${
-            item.onClick
-              ? "cursor-pointer transition-opacity hover:opacity-80"
-              : ""
-          } ${item.isActive === false ? "opacity-20" : ""}`}
-          onClick={item.onClick}
-        >
-          <LegendDot
-            className={item.colorClassName}
-            rounded={item.key === "versionMarkers" ? "full" : "sm"}
-          />
-          <span className="text-sm text-muted-foreground">{item.label}</span>
-        </div>
+        <ChartLegendItem key={item.key} item={item} />
       ))}
     </div>
   );

--- a/front/components/charts/ChartTooltip.test.tsx
+++ b/front/components/charts/ChartTooltip.test.tsx
@@ -1,0 +1,32 @@
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("ChartTooltipCard", () => {
+  it("renders the same light separator between rows and before the footer", () => {
+    render(
+      <ChartTooltipCard
+        rows={[
+          { key: "active-users", label: "Active users", value: 3 },
+          { key: "credits", label: "Credits", value: 10 },
+        ]}
+        footer="10 credits total"
+        separatorAfterKey="active-users"
+      />
+    );
+
+    const creditsRow = screen.getByText("Credits").closest("li");
+    const footer = screen.getByText("10 credits total");
+    const activeUsersValue = screen.getByText("3");
+
+    expect(activeUsersValue).toHaveClass("tabular-nums");
+    expect(activeUsersValue).not.toHaveClass("font-mono");
+    expect(creditsRow).toHaveClass(
+      "mt-1",
+      "border-t",
+      "border-border/50",
+      "pt-1"
+    );
+    expect(footer).toHaveClass("mt-1", "border-t", "border-border/50", "pt-1");
+  });
+});

--- a/front/components/charts/ChartTooltip.test.tsx
+++ b/front/components/charts/ChartTooltip.test.tsx
@@ -21,12 +21,8 @@ describe("ChartTooltipCard", () => {
 
     expect(activeUsersValue).toHaveClass("tabular-nums");
     expect(activeUsersValue).not.toHaveClass("font-mono");
-    expect(creditsRow).toHaveClass(
-      "mt-1",
-      "border-t",
-      "border-border/50",
-      "pt-1"
-    );
+    expect(creditsRow?.parentElement).toHaveClass("space-y-1.5");
+    expect(creditsRow).toHaveClass("border-t", "border-border/50", "pt-1");
     expect(footer).toHaveClass("mt-1", "border-t", "border-border/50", "pt-1");
   });
 });

--- a/front/components/charts/ChartTooltip.tsx
+++ b/front/components/charts/ChartTooltip.tsx
@@ -59,7 +59,7 @@ export function ChartTooltipCard({
       className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl"
     >
       {title && <div className="mb-1 font-medium text-foreground">{title}</div>}
-      <ul>
+      <ul className="space-y-1.5">
         {visibleRows.map((r, index) => {
           const rowKey = r.key ?? r.label;
           const isActive = rowKey === activeKey;
@@ -71,10 +71,7 @@ export function ChartTooltipCard({
               key={rowKey}
               className={cn(
                 "flex items-center gap-2 rounded",
-                index > 0 &&
-                  (hasSeparator
-                    ? "mt-1 border-t border-border/50 pt-1"
-                    : "mt-1.5"),
+                hasSeparator && "border-t border-border/50 pt-1",
                 isActive && "-mx-1.5 bg-muted-background/60 px-1.5"
               )}
             >

--- a/front/components/charts/ChartTooltip.tsx
+++ b/front/components/charts/ChartTooltip.tsx
@@ -33,6 +33,7 @@ interface ChartTooltipProps {
   footer?: string;
   activeKey?: string;
   selectedKey?: string;
+  separatorAfterKey?: string;
 }
 
 export function ChartTooltipCard({
@@ -41,6 +42,7 @@ export function ChartTooltipCard({
   footer,
   activeKey,
   selectedKey,
+  separatorAfterKey,
 }: ChartTooltipProps) {
   const visibleRows =
     selectedKey !== undefined
@@ -57,15 +59,22 @@ export function ChartTooltipCard({
       className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl"
     >
       {title && <div className="mb-1 font-medium text-foreground">{title}</div>}
-      <ul className="space-y-1.5">
-        {visibleRows.map((r) => {
+      <ul>
+        {visibleRows.map((r, index) => {
           const rowKey = r.key ?? r.label;
           const isActive = rowKey === activeKey;
+          const previousRow = visibleRows[index - 1];
+          const previousRowKey = previousRow?.key ?? previousRow?.label;
+          const hasSeparator = previousRowKey === separatorAfterKey;
           return (
             <li
               key={rowKey}
               className={cn(
                 "flex items-center gap-2 rounded",
+                index > 0 &&
+                  (hasSeparator
+                    ? "mt-1 border-t border-border/50 pt-1"
+                    : "mt-1.5"),
                 isActive && "-mx-1.5 bg-muted-background/60 px-1.5"
               )}
             >
@@ -79,7 +88,7 @@ export function ChartTooltipCard({
               >
                 {r.label}
               </span>
-              <span className="ml-auto font-mono font-medium tabular-nums text-foreground">
+              <span className="ml-auto font-medium tabular-nums text-foreground">
                 {r.value.toLocaleString()}
               </span>
               {typeof r.percent === "number" && (

--- a/front/components/poke/analytics/PokeConsumptionChart.tsx
+++ b/front/components/poke/analytics/PokeConsumptionChart.tsx
@@ -49,6 +49,7 @@ function PokeConsumptionDailyChart({
           : "No consumption over this period."
       }
       additionalControls={additionalControls}
+      showActiveUsers={filter?.users?.length !== 1}
     />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -7,7 +7,11 @@ import {
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
-import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import {
+  formatCredits,
+  formatCreditsCompact,
+  formatCreditValue,
+} from "@app/lib/client/credits";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
 import {
@@ -84,7 +88,7 @@ function ConsumptionBurnUpTooltip({
       rows={rows}
       footer={
         delta !== null
-          ? `${formatCredits(Math.abs(delta))} ${delta > 0 ? "ahead of" : "behind"} target`
+          ? `${formatCreditValue(Math.abs(delta))} ${delta > 0 ? "ahead of" : "behind"} target`
           : undefined
       }
     />
@@ -147,25 +151,21 @@ export function ConsumptionBurnUpChart({
       : []),
   ];
 
-  const hasConsumption = chartData.some(
+  const hasData = chartData.some(
     (point) => point.actual !== null && point.actual > 0
   );
 
   return (
     <ChartContainer
-      title="Credits over time"
       additionalControls={additionalControls}
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined
       }
-      emptyMessage={
-        !isTimeseriesLoading && !hasConsumption ? emptyMessage : undefined
-      }
+      emptyMessage={!isTimeseriesLoading && !hasData ? emptyMessage : undefined}
       height={CHART_HEIGHT}
       legendItems={legendItems}
       legendAlignment="center"
-      showHeaderDivider
     >
       <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
         <CartesianGrid
@@ -190,6 +190,12 @@ export function ConsumptionBurnUpChart({
           axisLine={false}
           tickMargin={8}
           tickFormatter={formatCreditsCompact}
+          label={{
+            value: "Credits",
+            angle: -90,
+            position: "insideLeft",
+            className: "fill-muted-foreground text-xs",
+          }}
         />
         <Tooltip
           cursor={false}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -1,0 +1,310 @@
+import { ConsumptionBurnUpChart } from "@app/components/workspace/analytics/consumption/ConsumptionBurnUpChart";
+import {
+  ConsumptionChart,
+  ConsumptionDailyChart,
+} from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
+import { fireEvent, render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseConsumptionTimeseries } = vi.hoisted(() => ({
+  mockUseConsumptionTimeseries: vi.fn(),
+}));
+
+vi.mock("@app/hooks/useConsumptionTimeseries", () => ({
+  useConsumptionTimeseries: mockUseConsumptionTimeseries,
+}));
+
+vi.mock("recharts", async (importOriginal) => {
+  const recharts = await importOriginal<typeof import("recharts")>();
+  const { cloneElement } = await import("react");
+
+  return {
+    ...recharts,
+    // ResponsiveContainer cannot measure a jsdom element. Give the real chart
+    // components a stable viewport so this test exercises their rendered SVG.
+    ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+      cloneElement(
+        children as ReactElement<{ height?: number; width?: number }>,
+        { height: 260, width: 800 }
+      ),
+  };
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const START_MS = Date.UTC(2026, 8, 1);
+let getComputedTextLengthDescriptor: PropertyDescriptor | undefined;
+
+function timeseries(
+  mode: GetConsumptionTimeseriesResponse["mode"]
+): GetConsumptionTimeseriesResponse {
+  return {
+    period: {
+      startDate: new Date(START_MS).toISOString(),
+      endDate: new Date(START_MS + 3 * DAY_MS).toISOString(),
+    },
+    granularity: "day",
+    mode,
+    metric: "credit_micro",
+    timezone: "UTC",
+    breakdownBy: null,
+    groups: [{ groupKey: "total", name: "Total" }],
+    points: [
+      {
+        timestamp: START_MS,
+        activeUsers: 2,
+        values: { total: 500_000 },
+      },
+      {
+        timestamp: START_MS + DAY_MS,
+        activeUsers: 8,
+        values: { total: 1_000_000 },
+      },
+      {
+        timestamp: START_MS + 2 * DAY_MS,
+        activeUsers: 0,
+        values: { total: 0 },
+      },
+    ],
+  };
+}
+
+function expectActiveUsersOverlay(container: HTMLElement) {
+  const axes = container.querySelectorAll(".recharts-yAxis");
+  expect(axes).toHaveLength(2);
+  expect(
+    Array.from(container.querySelectorAll("text"))
+      .map((label) => label.textContent)
+      .filter((label) => label === "Credits" || label === "Active users")
+  ).toEqual(["Credits", "Active users"]);
+  const activeUsersLabel = Array.from(container.querySelectorAll("text")).find(
+    (label) => label.textContent === "Active users"
+  );
+  expect(activeUsersLabel).toHaveAttribute("text-anchor", "middle");
+
+  const leftTick = axes[0].querySelector("text");
+  const rightTick = axes[1].querySelector("text");
+  expect(Number(rightTick?.getAttribute("x"))).toBeGreaterThan(
+    Number(leftTick?.getAttribute("x"))
+  );
+  const activeUserTicks = Array.from(
+    axes[1].querySelectorAll(".recharts-cartesian-axis-tick-value")
+  ).map((tick) => Number(tick.textContent));
+  expect(Math.max(...activeUserTicks)).toBe(10);
+  const activeUserTickYs = Array.from(
+    axes[1].querySelectorAll(".recharts-cartesian-axis-tick-value")
+  ).map((tick) => Number(tick.getAttribute("y")));
+  expect(Number(activeUsersLabel?.getAttribute("y"))).toBeCloseTo(
+    (Math.min(...activeUserTickYs) + Math.max(...activeUserTickYs)) / 2
+  );
+
+  const activeUsersSeries = container.querySelector(
+    ".recharts-line.text-golden-500"
+  );
+  expect(activeUsersSeries).not.toBeNull();
+
+  const legendLabels = Array.from(
+    container.querySelectorAll("span.text-sm.text-muted-foreground")
+  );
+  const totalLegendLabel = legendLabels.find(
+    (label) => label.textContent === "Total"
+  );
+  const activeUsersLegendLabel = legendLabels.find(
+    (label) => label.textContent === "Active users"
+  );
+  const totalLegendItem = totalLegendLabel?.parentElement;
+  const activeUsersLegendItem = activeUsersLegendLabel?.parentElement;
+  const mainLegendGroup = totalLegendItem?.parentElement;
+  const activeUsersLegendGroup = activeUsersLegendItem?.parentElement;
+  const legend = mainLegendGroup?.parentElement;
+
+  expect(activeUsersLegendLabel).toBeDefined();
+  expect(activeUsersLegendGroup?.parentElement).toBe(legend);
+  expect(legend?.children).toHaveLength(5);
+  expect(
+    Array.from(legend?.children ?? []).filter((child) =>
+      child.classList.contains("flex-1")
+    )
+  ).toHaveLength(3);
+  expect(mainLegendGroup).toHaveClass("gap-x-6");
+
+  const curvePath = activeUsersSeries?.querySelector(".recharts-line-curve");
+  const path = curvePath?.getAttribute("d") ?? "";
+  expect(path).toContain("L");
+  expect(path).not.toContain("C");
+
+  const dots = Array.from(activeUsersSeries?.querySelectorAll("circle") ?? []);
+  expect(dots).toHaveLength(2);
+  const [firstY, secondY] = dots.map((dot) => Number(dot.getAttribute("cy")));
+  // Credits are several orders of magnitude larger than the user counts. A
+  // meaningful vertical separation proves the line uses its own Y scale.
+  expect(Math.abs(firstY - secondY)).toBeGreaterThan(50);
+}
+
+describe("consumption active users overlay", () => {
+  beforeEach(() => {
+    mockUseConsumptionTimeseries.mockReset().mockReturnValue({
+      timeseries: null,
+      isTimeseriesLoading: true,
+      isTimeseriesError: undefined,
+      isTimeseriesValidating: false,
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(START_MS + DAY_MS + 12 * 60 * 60 * 1000));
+    getComputedTextLengthDescriptor = Object.getOwnPropertyDescriptor(
+      SVGElement.prototype,
+      "getComputedTextLength"
+    );
+    Object.defineProperty(SVGElement.prototype, "getComputedTextLength", {
+      configurable: true,
+      value: () => 24,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (getComputedTextLengthDescriptor) {
+      Object.defineProperty(
+        SVGElement.prototype,
+        "getComputedTextLength",
+        getComputedTextLengthDescriptor
+      );
+    } else {
+      Reflect.deleteProperty(SVGElement.prototype, "getComputedTextLength");
+    }
+  });
+
+  it("renders exact active-user points on a right-side linear scale", () => {
+    const { container } = render(
+      <ConsumptionDailyChart
+        timeseries={timeseries("period")}
+        isTimeseriesLoading={false}
+        isTimeseriesError={false}
+        emptyMessage="No consumption."
+        showActiveUsers
+      />
+    );
+
+    expect(container.querySelector(".recharts-bar")).not.toBeNull();
+    expectActiveUsersOverlay(container);
+
+    const activeUsersDot = container.querySelector(
+      ".recharts-line.text-golden-500 circle"
+    );
+    const chart = container.querySelector<HTMLElement>(".recharts-wrapper");
+    expect(chart).not.toBeNull();
+    Object.defineProperties(chart!, {
+      offsetWidth: { configurable: true, value: 800 },
+      offsetHeight: { configurable: true, value: 260 },
+    });
+    vi.spyOn(chart!, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 800,
+      bottom: 260,
+      left: 0,
+      width: 800,
+      height: 260,
+      toJSON: () => undefined,
+    });
+    fireEvent.mouseMove(chart!, {
+      clientX: Number(activeUsersDot?.getAttribute("cx")),
+      clientY: Number(activeUsersDot?.getAttribute("cy")),
+    });
+
+    const activeDot = container.querySelector(".recharts-active-dot circle");
+    expect(activeDot).toHaveClass("text-golden-500");
+    expect(activeDot).toHaveAttribute("r", "3.75");
+    expect(activeDot).toHaveAttribute("fill", "white");
+    expect(activeDot).toHaveAttribute("stroke", "currentColor");
+    expect(activeDot).toHaveAttribute("stroke-width", "1.5");
+  });
+
+  it("hides the active-user overlay for a single-user filter", () => {
+    mockUseConsumptionTimeseries.mockReturnValue({
+      timeseries: timeseries("period"),
+      isTimeseriesLoading: false,
+      isTimeseriesError: undefined,
+      isTimeseriesValidating: false,
+    });
+
+    const { container } = render(
+      <ConsumptionChart
+        workspaceId="workspace-id"
+        period={{ kind: "days", days: 30 }}
+        dimension="agent"
+        filter={{ users: ["user-id"] }}
+      />
+    );
+
+    expect(container.querySelectorAll(".recharts-yAxis")).toHaveLength(1);
+    expect(
+      container.querySelector(".recharts-line.text-golden-500")
+    ).toBeNull();
+    expect(
+      Array.from(
+        container.querySelectorAll("span.text-sm.text-muted-foreground")
+      ).some((label) => label.textContent === "Active users")
+    ).toBe(false);
+  });
+
+  it("hides the active-user overlay in cumulative mode", () => {
+    const { container } = render(
+      <ConsumptionBurnUpChart
+        timeseries={timeseries("cumulative")}
+        capCredits={null}
+        isTimeseriesLoading={false}
+        isTimeseriesError={false}
+        emptyMessage="No consumption."
+      />
+    );
+
+    expect(container.querySelectorAll(".recharts-yAxis")).toHaveLength(1);
+    expect(
+      container.querySelector(".recharts-line.text-golden-500")
+    ).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("text")).some(
+        (label) => label.textContent === "Active users"
+      )
+    ).toBe(false);
+  });
+
+  it("refreshes the shared timeseries when period and granularity change", () => {
+    const { rerender } = render(
+      <ConsumptionChart
+        workspaceId="workspace-id"
+        period={{ kind: "days", days: 30 }}
+        granularity="day"
+        dimension="agent"
+      />
+    );
+
+    expect(mockUseConsumptionTimeseries).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        period: { kind: "days", days: 30 },
+        granularity: "day",
+        mode: "period",
+      })
+    );
+
+    rerender(
+      <ConsumptionChart
+        workspaceId="workspace-id"
+        period={{ kind: "days", days: 90 }}
+        granularity="month"
+        dimension="agent"
+      />
+    );
+
+    expect(mockUseConsumptionTimeseries).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        period: { kind: "days", days: 90 },
+        granularity: "month",
+        mode: "period",
+      })
+    );
+  });
+});

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -3,6 +3,7 @@ import {
   ConsumptionChart,
   ConsumptionDailyChart,
 } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import { PERSONAL_CONSUMPTION_ANALYTICS_SCOPE } from "@app/lib/analytics/consumption_scope";
 import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
 import { fireEvent, render } from "@testing-library/react";
 import type { ReactElement } from "react";
@@ -240,6 +241,34 @@ describe("consumption active users overlay", () => {
         period={{ kind: "days", days: 30 }}
         dimension="agent"
         filter={{ users: ["user-id"] }}
+      />
+    );
+
+    expect(container.querySelectorAll(".recharts-yAxis")).toHaveLength(1);
+    expect(
+      container.querySelector(".recharts-line.text-golden-500")
+    ).toBeNull();
+    expect(
+      Array.from(
+        container.querySelectorAll("span.text-sm.text-muted-foreground")
+      ).some((label) => label.textContent === "Active users")
+    ).toBe(false);
+  });
+
+  it("hides the active-user overlay for personal analytics", () => {
+    mockUseConsumptionTimeseries.mockReturnValue({
+      timeseries: timeseries("period"),
+      isTimeseriesLoading: false,
+      isTimeseriesError: undefined,
+      isTimeseriesValidating: false,
+    });
+
+    const { container } = render(
+      <ConsumptionChart
+        workspaceId="workspace-id"
+        period={{ kind: "days", days: 30 }}
+        dimension="agent"
+        analyticsScope={PERSONAL_CONSUMPTION_ANALYTICS_SCOPE}
       />
     );
 

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -216,7 +216,10 @@ describe("consumption active users overlay", () => {
 
     const activeDot = container.querySelector(".recharts-active-dot circle");
     expect(activeDot).toHaveClass("text-golden-500");
-    expect(activeDot).toHaveClass("animate-active-users-dot-in");
+    expect(activeDot).toHaveClass("animate-in");
+    expect(activeDot).toHaveClass("zoom-in-90");
+    expect(activeDot).toHaveClass("duration-[50ms]");
+    expect(activeDot).toHaveClass("motion-reduce:animate-none");
     expect(activeDot).toHaveAttribute("r", "3.75");
     expect(activeDot).toHaveAttribute("fill", "white");
     expect(activeDot).toHaveAttribute("stroke", "currentColor");

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -54,8 +54,8 @@ function timeseries(
     points: [
       {
         timestamp: START_MS,
-        activeUsers: 2,
-        values: { total: 500_000 },
+        activeUsers: 0,
+        values: { total: 0 },
       },
       {
         timestamp: START_MS + DAY_MS,
@@ -214,6 +214,11 @@ describe("consumption active users overlay", () => {
       clientX: Number(activeUsersDot?.getAttribute("cx")),
       clientY: Number(activeUsersDot?.getAttribute("cy")),
     });
+
+    const activeUsersRow = Array.from(
+      container.querySelectorAll('[role="tooltip"] li')
+    ).find((row) => row.textContent?.includes("Active users"));
+    expect(activeUsersRow).toHaveTextContent("0");
 
     const activeDot = container.querySelector(".recharts-active-dot circle");
     expect(activeDot).toHaveClass("text-golden-500");

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -218,7 +218,7 @@ describe("consumption active users overlay", () => {
     expect(activeDot).toHaveClass("text-golden-500");
     expect(activeDot).toHaveClass("animate-in");
     expect(activeDot).toHaveClass("zoom-in-90");
-    expect(activeDot).toHaveClass("duration-[50ms]");
+    expect(activeDot).toHaveClass("duration-75");
     expect(activeDot).toHaveClass("motion-reduce:animate-none");
     expect(activeDot).toHaveAttribute("r", "3.75");
     expect(activeDot).toHaveAttribute("fill", "white");

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -216,6 +216,7 @@ describe("consumption active users overlay", () => {
 
     const activeDot = container.querySelector(".recharts-active-dot circle");
     expect(activeDot).toHaveClass("text-golden-500");
+    expect(activeDot).toHaveClass("animate-active-users-dot-in");
     expect(activeDot).toHaveAttribute("r", "3.75");
     expect(activeDot).toHaveAttribute("fill", "white");
     expect(activeDot).toHaveAttribute("stroke", "currentColor");

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -463,7 +463,10 @@ export function ConsumptionDailyChart({
             strokeWidth={2}
             dot={{ r: 3, fill: "currentColor", strokeWidth: 0 }}
             activeDot={{
-              className: cn(ACTIVE_USERS_COLOR, "animate-active-users-dot-in"),
+              className: cn(
+                ACTIVE_USERS_COLOR,
+                "origin-center animate-in zoom-in-90 duration-[50ms] ease-out motion-reduce:animate-none [transform-box:fill-box]"
+              ),
               r: 3.75,
               fill: "white",
               stroke: "currentColor",

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -21,16 +21,21 @@ import type {
   ConsumptionTimeseriesPoint,
   GetConsumptionTimeseriesResponse,
 } from "@app/lib/api/analytics/consumption/timeseries";
-import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import {
+  formatCredits,
+  formatCreditsCompact,
+  formatCreditValue,
+} from "@app/lib/client/credits";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
 import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Bar,
-  BarChart,
   CartesianGrid,
   Cell,
+  ComposedChart,
+  Line,
   ReferenceLine,
   Tooltip,
   XAxis,
@@ -100,6 +105,10 @@ function PartialLabel({ viewBox, value }: RechartsLabelProps) {
 // The bucket in progress is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";
 
+const ACTIVE_USERS_COLOR = "text-golden-500";
+// Leave 20% headroom so the line does not visually sit on top of the bars.
+const ACTIVE_USERS_MAX_HEIGHT_RATIO = 0.8;
+
 const CONSUMPTION_CHART_COLORS = [
   "text-blue-900",
   "text-blue-700",
@@ -113,6 +122,35 @@ const CONSUMPTION_CHART_COLORS = [
 // endpoint adds an aggregate "Others" category.
 export const CONSUMPTION_CHART_BREAKDOWN_COUNT =
   CONSUMPTION_CHART_COLORS.length - 1;
+
+function ActiveUsersAxisLabel({
+  angle = 0,
+  className,
+  offset = 5,
+  value,
+  viewBox,
+}: RechartsLabelProps) {
+  if (!viewBox || !("x" in viewBox)) {
+    return null;
+  }
+
+  const { x = 0, y = 0, width = 0, height = 0 } = viewBox;
+  const labelX = x + width - offset;
+  const labelY = y + height / 2;
+
+  return (
+    <text
+      x={labelX}
+      y={labelY}
+      textAnchor="middle"
+      dominantBaseline="central"
+      transform={`rotate(${angle} ${labelX} ${labelY})`}
+      className={className}
+    >
+      {value}
+    </text>
+  );
+}
 
 function getConsumptionChartColor(index: number): string {
   return CONSUMPTION_CHART_COLORS[
@@ -139,6 +177,7 @@ interface ConsumptionDailyTooltipProps
   colorByGroupKey: Map<string, string>;
   partialTimestamp: number | undefined;
   currentBucketLabel: string;
+  showActiveUsers: boolean;
 }
 
 function ConsumptionDailyTooltip({
@@ -148,6 +187,7 @@ function ConsumptionDailyTooltip({
   colorByGroupKey,
   partialTimestamp,
   currentBucketLabel,
+  showActiveUsers,
 }: ConsumptionDailyTooltipProps) {
   const datum = payload?.[0]?.payload;
   if (!active || !isConsumptionTimeseriesPoint(datum)) {
@@ -175,21 +215,35 @@ function ConsumptionDailyTooltip({
 
   const totalCredits = rows.reduce((sum, row) => sum + row.credits, 0);
   const isPartial = datum.timestamp === partialTimestamp;
+  const { activeUsers } = datum;
 
   return (
     <ChartTooltipCard
       title={formatConsumptionDate(datum.timestamp)}
-      rows={rows.map((row) => ({
-        key: row.key,
-        label: row.label,
-        value: formatCredits(row.credits),
-        colorClassName: row.colorClassName,
-      }))}
+      rows={[
+        ...(showActiveUsers && activeUsers
+          ? [
+              {
+                key: "activeUsers",
+                label: "Active users",
+                value: activeUsers,
+                colorClassName: ACTIVE_USERS_COLOR,
+              },
+            ]
+          : []),
+        ...rows.map((row) => ({
+          key: row.key,
+          label: row.label,
+          value: formatCredits(row.credits),
+          colorClassName: row.colorClassName,
+        })),
+      ]}
       footer={
         isPartial
-          ? `${formatCredits(totalCredits)} so far ${currentBucketLabel.toLowerCase()}`
-          : `${formatCredits(totalCredits)} total`
+          ? `${formatCreditValue(totalCredits)} so far ${currentBucketLabel.toLowerCase()}`
+          : `${formatCreditValue(totalCredits)} total`
       }
+      separatorAfterKey="activeUsers"
     />
   );
 }
@@ -199,6 +253,7 @@ interface ConsumptionDailyChartProps {
   isTimeseriesLoading: boolean;
   isTimeseriesError: boolean;
   emptyMessage: string;
+  showActiveUsers: boolean;
   additionalControls?: ReactNode;
 }
 
@@ -207,6 +262,7 @@ export function ConsumptionDailyChart({
   isTimeseriesLoading,
   isTimeseriesError,
   emptyMessage,
+  showActiveUsers,
   additionalControls,
 }: ConsumptionDailyChartProps) {
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);
@@ -258,37 +314,55 @@ export function ConsumptionDailyChart({
         colorByGroupKey={colorByGroupKey}
         partialTimestamp={partialTimestamp}
         currentBucketLabel={currentBucketLabel}
+        showActiveUsers={showActiveUsers}
       />
     ),
-    [orderedGroups, colorByGroupKey, partialTimestamp, currentBucketLabel]
+    [
+      orderedGroups,
+      colorByGroupKey,
+      partialTimestamp,
+      currentBucketLabel,
+      showActiveUsers,
+    ]
   );
 
-  const legendItems: LegendItem[] = orderedGroups.map((group) => ({
-    key: group.groupKey,
-    label: group.name,
-    colorClassName: colorByGroupKey.get(group.groupKey) ?? "",
-  }));
+  const hasActiveUsers =
+    showActiveUsers && chartData.some(({ activeUsers }) => activeUsers);
+  const legendItems: LegendItem[] = [
+    ...orderedGroups.map((group) => ({
+      key: group.groupKey,
+      label: group.name,
+      colorClassName: colorByGroupKey.get(group.groupKey) ?? "",
+    })),
+    ...(hasActiveUsers
+      ? [
+          {
+            key: "activeUsers",
+            label: "Active users",
+            colorClassName: ACTIVE_USERS_COLOR,
+            isTrailing: true,
+          },
+        ]
+      : []),
+  ];
 
-  const hasConsumption = chartData.some((datum) =>
+  const hasCredits = chartData.some((datum) =>
     Object.values(datum.values).some((credits) => credits > 0)
   );
+  const hasData = hasCredits || hasActiveUsers;
   return (
     <ChartContainer
-      title="Credits over time"
       additionalControls={additionalControls}
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined
       }
-      emptyMessage={
-        !isTimeseriesLoading && !hasConsumption ? emptyMessage : undefined
-      }
+      emptyMessage={!isTimeseriesLoading && !hasData ? emptyMessage : undefined}
       height={CHART_HEIGHT}
       legendItems={legendItems}
       legendAlignment="center"
-      showHeaderDivider
     >
-      <BarChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
+      <ComposedChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
         <CartesianGrid
           vertical={false}
           strokeDasharray="4 4"
@@ -311,7 +385,35 @@ export function ConsumptionDailyChart({
           axisLine={false}
           tickMargin={8}
           tickFormatter={formatCreditsCompact}
+          label={{
+            value: "Credits",
+            angle: -90,
+            position: "insideLeft",
+            className: "fill-muted-foreground text-xs",
+          }}
         />
+        {hasActiveUsers && (
+          <YAxis
+            yAxisId="activeUsers"
+            orientation="right"
+            className="text-xs text-faint"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            allowDecimals={false}
+            domain={[
+              0,
+              (dataMax: number) =>
+                Math.max(1, dataMax / ACTIVE_USERS_MAX_HEIGHT_RATIO),
+            ]}
+            label={{
+              value: "Active users",
+              angle: 90,
+              content: ActiveUsersAxisLabel,
+              className: "fill-muted-foreground text-xs",
+            }}
+          />
+        )}
         <Tooltip
           cursor={false}
           content={renderTooltip}
@@ -345,6 +447,32 @@ export function ConsumptionDailyChart({
             </Bar>
           );
         })}
+        {hasActiveUsers && (
+          <Line
+            yAxisId="activeUsers"
+            type="linear"
+            dataKey={(datum: ConsumptionTimeseriesPoint) =>
+              partialTimestamp !== undefined &&
+              datum.timestamp > partialTimestamp
+                ? null
+                : datum.activeUsers
+            }
+            name="Active users"
+            className={ACTIVE_USERS_COLOR}
+            stroke="currentColor"
+            strokeWidth={2}
+            dot={{ r: 3, fill: "currentColor", strokeWidth: 0 }}
+            activeDot={{
+              className: ACTIVE_USERS_COLOR,
+              r: 3.75,
+              fill: "white",
+              stroke: "currentColor",
+              strokeWidth: 1.5,
+            }}
+            connectNulls={false}
+            isAnimationActive={false}
+          />
+        )}
         {partialTimestamp !== undefined && (
           <ReferenceLine
             x={partialTimestamp}
@@ -358,7 +486,7 @@ export function ConsumptionDailyChart({
             ifOverflow="extendDomain"
           />
         )}
-      </BarChart>
+      </ComposedChart>
     </ChartContainer>
   );
 }
@@ -402,6 +530,7 @@ function WorkspaceConsumptionDailyChart({
       isTimeseriesLoading={isTimeseriesLoading}
       isTimeseriesError={Boolean(isTimeseriesError)}
       emptyMessage="No consumption over this period."
+      showActiveUsers={filter?.users?.length !== 1}
     />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -463,7 +463,7 @@ export function ConsumptionDailyChart({
             strokeWidth={2}
             dot={{ r: 3, fill: "currentColor", strokeWidth: 0 }}
             activeDot={{
-              className: ACTIVE_USERS_COLOR,
+              className: cn(ACTIVE_USERS_COLOR, "animate-active-users-dot-in"),
               r: 3.75,
               fill: "white",
               stroke: "currentColor",

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -221,7 +221,7 @@ function ConsumptionDailyTooltip({
     <ChartTooltipCard
       title={formatConsumptionDate(datum.timestamp)}
       rows={[
-        ...(showActiveUsers && activeUsers
+        ...(showActiveUsers
           ? [
               {
                 key: "activeUsers",

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -533,7 +533,9 @@ function WorkspaceConsumptionDailyChart({
       isTimeseriesLoading={isTimeseriesLoading}
       isTimeseriesError={Boolean(isTimeseriesError)}
       emptyMessage="No consumption over this period."
-      showActiveUsers={filter?.users?.length !== 1}
+      showActiveUsers={
+        analyticsScope?.kind !== "personal" && filter?.users?.length !== 1
+      }
     />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -465,7 +465,7 @@ export function ConsumptionDailyChart({
             activeDot={{
               className: cn(
                 ACTIVE_USERS_COLOR,
-                "origin-center animate-in zoom-in-90 duration-[50ms] ease-out motion-reduce:animate-none [transform-box:fill-box]"
+                "origin-center animate-in zoom-in-90 duration-75 ease-out motion-reduce:animate-none [transform-box:fill-box]"
               ),
               r: 3.75,
               fill: "white",

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -263,6 +263,24 @@ body.document-scroll-mode #root {
   outline: none;
 }
 
+@keyframes active-users-dot-in {
+  from {
+    transform: scale(0.9);
+  }
+}
+
+.animate-active-users-dot-in {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: active-users-dot-in 50ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-active-users-dot-in {
+    animation: none;
+  }
+}
+
 /* Rich text table styles for Contentful blog posts */
 .rich-text-table table tr:last-child td,
 .rich-text-table table tr:last-child th {

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -263,24 +263,6 @@ body.document-scroll-mode #root {
   outline: none;
 }
 
-@keyframes active-users-dot-in {
-  from {
-    transform: scale(0.9);
-  }
-}
-
-.animate-active-users-dot-in {
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: active-users-dot-in 50ms ease-out;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .animate-active-users-dot-in {
-    animation: none;
-  }
-}
-
 /* Rich text table styles for Contentful blog posts */
 .rich-text-table table tr:last-child td,
 .rich-text-table table tr:last-child th {


### PR DESCRIPTION
## Description

This PR adds active users as an overlay of the existing consumption chart.

Example with fake data (data not very authentic past 2d ago):

<img width="982" height="397" alt="image" src="https://github.com/user-attachments/assets/78e9a49b-a8f7-4c89-a2a0-111a26fde09b" />

The line chart is golden, complementary to the credits in blue. It is a straight line on a separate right axis. It has 20% headroom, which keeps it from visually sitting on top of the bars. It is not part of the cumulative view and is hidden when filtering to a single user.

The tooltip puts active users first and separates them from the credit values. The legend keeps the credit labels and active users. Hovering a point shows a white-centered golden marker with a short animation.

Also removes the "Credits over time" title as it is not accurate anymore.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
