### PR TITLE
[Admin Governance] Mirror agent editor removals to grants

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -319,6 +319,32 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/editors", () => 
     const data = await response.json();
     expect(data.editors).toHaveLength(1);
     expect(data.editors[0].sId).toBe(editorToRemove.sId);
+
+    const agentGrant = (
+      await GroupPermissionResource.listForWorkspace(agentOwnerAuth)
+    ).find(
+      (grant) => grant.grantType === "editor" && grant.resourceType === "agent"
+    );
+    if (!agentGrant) {
+      throw new Error("Agent editor grant was not created");
+    }
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(
+        agentOwnerAuth,
+        {
+          grantType: "editor",
+          resourceType: "agent",
+          resourceId: agentGrant.resourceId,
+        }
+      );
+    if (!grantGroup) {
+      throw new Error("Agent editor group was not created");
+    }
+    expect(
+      (await grantGroup.getActiveMembers(agentOwnerAuth)).map(
+        (editor) => editor.sId
+      )
+    ).toEqual([editorToRemove.sId]);
   });
 
   it("editor should successfully add another editor and get light response", async () => {

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -8,7 +8,6 @@ import {
   restoreAgentConfiguration,
   unsafeHardDeleteAgentConfiguration,
   updateAgentConfigurationsScope,
-  updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration/agent";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
@@ -160,72 +159,6 @@ describe("stable agent identities", () => {
   });
 });
 
-describe("agent editor grants", () => {
-  it("mirrors removals from incremental and full editor updates", async () => {
-    const { authenticator, workspace, user } = await createResourceTest({
-      role: "admin",
-    });
-    const agent =
-      await AgentConfigurationFactory.createTestAgent(authenticator);
-    const incrementalEditor = await UserFactory.basic();
-    const fullUpdateEditor = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, incrementalEditor, {
-      role: "user",
-    });
-    await MembershipFactory.associate(workspace, fullUpdateEditor, {
-      role: "user",
-    });
-
-    const addResult = await updateAgentPermissions(authenticator, {
-      agent,
-      usersToAdd: [incrementalEditor.toJSON(), fullUpdateEditor.toJSON()],
-      usersToRemove: [],
-    });
-    expect(addResult.isOk()).toBe(true);
-
-    const agentResource = await AgentResource.fetchByAgentConfiguration(
-      authenticator,
-      agent
-    );
-    if (agentResource.id === null) {
-      throw new Error("Agent identity was not created");
-    }
-    const grantGroup =
-      await GroupPermissionResource.findRegularAutoGroupForGrant(
-        authenticator,
-        {
-          grantType: "editor",
-          resourceType: "agent",
-          resourceId: agentResource.id,
-        }
-      );
-    if (!grantGroup) {
-      throw new Error("Agent editor grant was not created");
-    }
-
-    const removeResult = await updateAgentPermissions(authenticator, {
-      agent,
-      usersToAdd: [],
-      usersToRemove: [incrementalEditor.toJSON()],
-    });
-    expect(removeResult.isOk()).toBe(true);
-    expect(
-      new Set(
-        (await grantGroup.getActiveMembers(authenticator)).map(
-          (editor) => editor.id
-        )
-      )
-    ).toEqual(new Set([user.id, fullUpdateEditor.id]));
-
-    await AgentConfigurationFactory.updateTestAgent(authenticator, agent.sId);
-    expect(
-      (await grantGroup.getActiveMembers(authenticator)).map(
-        (editor) => editor.id
-      )
-    ).toEqual([user.id]);
-  });
-});
-
 describe("createAgentConfiguration with pending agent", () => {
   it("converts pending agent to active when agentConfigurationId points to a pending agent", async () => {
     const { authenticator, workspace, user } = await createResourceTest({
@@ -320,6 +253,13 @@ describe("createAgentConfiguration with pending agent", () => {
         )
       )
     ).toEqual(new Set([user.sId, newEditor.sId]));
+
+    await AgentConfigurationFactory.updateTestAgent(authenticator, pendingId);
+    expect(
+      (await pendingGrantGroup.getActiveMembers(authenticator)).map(
+        (editor) => editor.sId
+      )
+    ).toEqual([user.sId]);
   });
 
   it("creates new agent if agentConfigurationId does not exist", async () => {

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -8,6 +8,7 @@ import {
   restoreAgentConfiguration,
   unsafeHardDeleteAgentConfiguration,
   updateAgentConfigurationsScope,
+  updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration/agent";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
@@ -103,7 +104,7 @@ describe("stable agent identities", () => {
     expect([...agentModelIds][0]).not.toBeNull();
   });
 
-  it("deletes the identity only after its last version is deleted", async () => {
+  it("deletes the identity and grants only after its last version is deleted", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -113,6 +114,25 @@ describe("stable agent identities", () => {
       authenticator,
       firstVersion.sId
     );
+    const agentResource = await AgentResource.fetchByAgentConfiguration(
+      authenticator,
+      firstVersion
+    );
+    if (agentResource.id === null) {
+      throw new Error("Agent identity was not created");
+    }
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(
+        authenticator,
+        {
+          grantType: "editor",
+          resourceType: "agent",
+          resourceId: agentResource.id,
+        }
+      );
+    if (!grantGroup) {
+      throw new Error("Agent editor grant was not created");
+    }
 
     await unsafeHardDeleteAgentConfiguration(authenticator, secondVersion);
     expect(
@@ -120,6 +140,11 @@ describe("stable agent identities", () => {
         where: { sId: firstVersion.sId, workspaceId: workspace.id },
       })
     ).not.toBeNull();
+    expect(
+      await GroupResource.dangerouslyFetchByModelIds(authenticator, [
+        grantGroup.id,
+      ])
+    ).toHaveLength(1);
 
     await unsafeHardDeleteAgentConfiguration(authenticator, firstVersion);
     expect(
@@ -127,6 +152,77 @@ describe("stable agent identities", () => {
         where: { sId: firstVersion.sId, workspaceId: workspace.id },
       })
     ).toBeNull();
+    expect(
+      await GroupResource.dangerouslyFetchByModelIds(authenticator, [
+        grantGroup.id,
+      ])
+    ).toHaveLength(0);
+  });
+});
+
+describe("agent editor grants", () => {
+  it("mirrors removals from incremental and full editor updates", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const incrementalEditor = await UserFactory.basic();
+    const fullUpdateEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, incrementalEditor, {
+      role: "user",
+    });
+    await MembershipFactory.associate(workspace, fullUpdateEditor, {
+      role: "user",
+    });
+
+    const addResult = await updateAgentPermissions(authenticator, {
+      agent,
+      usersToAdd: [incrementalEditor.toJSON(), fullUpdateEditor.toJSON()],
+      usersToRemove: [],
+    });
+    expect(addResult.isOk()).toBe(true);
+
+    const agentResource = await AgentResource.fetchByAgentConfiguration(
+      authenticator,
+      agent
+    );
+    if (agentResource.id === null) {
+      throw new Error("Agent identity was not created");
+    }
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(
+        authenticator,
+        {
+          grantType: "editor",
+          resourceType: "agent",
+          resourceId: agentResource.id,
+        }
+      );
+    if (!grantGroup) {
+      throw new Error("Agent editor grant was not created");
+    }
+
+    const removeResult = await updateAgentPermissions(authenticator, {
+      agent,
+      usersToAdd: [],
+      usersToRemove: [incrementalEditor.toJSON()],
+    });
+    expect(removeResult.isOk()).toBe(true);
+    expect(
+      new Set(
+        (await grantGroup.getActiveMembers(authenticator)).map(
+          (editor) => editor.id
+        )
+      )
+    ).toEqual(new Set([user.id, fullUpdateEditor.id]));
+
+    await AgentConfigurationFactory.updateTestAgent(authenticator, agent.sId);
+    expect(
+      (await grantGroup.getActiveMembers(authenticator)).map(
+        (editor) => editor.id
+      )
+    ).toEqual([user.id]);
   });
 });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -31,6 +31,7 @@ import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { canReadRequestedSpaces } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -934,15 +935,6 @@ export async function createAgentConfiguration(
               "Unexpected: agent should have exactly one editor group."
             );
           }
-          const newEditorIds = new Set(editors.map((editor) => editor.id));
-          removedEditors = (
-            await group.getActiveMembers(auth, {
-              transaction: t,
-            })
-          )
-            .filter((editor) => !newEditorIds.has(editor.id))
-            .map((editor) => editor.toJSON());
-
           // For pending agents updated in place, the group is already linked to the same agent ID
           // For regular updates, we need to link the group to the new agent configuration
           if (existingAgent.id !== agentConfigurationInstance.id) {
@@ -979,6 +971,7 @@ export async function createAgentConfiguration(
             );
             throw setMembersRes.error;
           }
+          removedEditors = setMembersRes.value.removedUsers;
         }
 
         const agentResource = AgentResource.fromAgentConfigurationModel(
@@ -1529,41 +1522,59 @@ export async function batchHardDeletePendingAgentConfigurations(
   agents: AgentConfigurationModel[]
 ) {
   const workspaceId = auth.getNonNullableWorkspace().id;
-  const agentIds = agents.map((a) => a.id);
-  const agentResources = new Map(
-    agents.map((agent) => [
-      agent.sId,
-      AgentResource.fromAgentConfigurationModel(agent),
-    ])
-  );
+  const agentConfigurationModelIds = agents.map((agent) => agent.id);
+  const agentModelIds = [...new Set(agents.map((agent) => agent.agentId))];
 
   // Find all editor group IDs for this batch.
   const groupAgents = await GroupAgentModel.findAll({
-    where: { agentConfigurationId: agentIds, workspaceId },
+    where: {
+      agentConfigurationId: agentConfigurationModelIds,
+      workspaceId,
+    },
   });
-  const groupIds = groupAgents.map((ga) => ga.groupId);
+  const editorGroupModelIds = groupAgents.map(
+    (groupAgent) => groupAgent.groupId
+  );
 
   await withTransaction(async (t) => {
-    if (groupIds.length > 0) {
+    const grantGroups =
+      await GroupPermissionResource.listRegularAutoGroupsForResources(auth, {
+        resourceType: "agent",
+        resourceIds: agentModelIds,
+        transaction: t,
+      });
+    await GroupPermissionResource.deleteAllForResources(auth, {
+      resourceType: "agent",
+      resourceIds: agentModelIds,
+      transaction: t,
+    });
+
+    const groupModelIds = [
+      ...new Set([
+        ...editorGroupModelIds,
+        ...grantGroups.map((group) => group.id),
+      ]),
+    ];
+    if (groupModelIds.length > 0) {
       await GroupMembershipModel.destroy({
-        where: { groupId: groupIds, workspaceId },
+        where: { groupId: groupModelIds, workspaceId },
         transaction: t,
       });
 
       await GroupAgentModel.destroy({
-        where: { groupId: groupIds, workspaceId },
+        where: { groupId: groupModelIds, workspaceId },
         transaction: t,
       });
 
       await GroupModel.destroy({
-        where: { id: groupIds, workspaceId },
+        where: { id: groupModelIds, workspaceId },
         transaction: t,
       });
     }
 
     // Delete agent suggestions before agents (FK constraint)
     await AgentSuggestionModel.destroy({
-      where: { agentConfigurationId: agentIds, workspaceId },
+      where: { agentConfigurationId: agentConfigurationModelIds, workspaceId },
       transaction: t,
     });
 
@@ -1573,13 +1584,16 @@ export async function batchHardDeletePendingAgentConfigurations(
     );
 
     await AgentConfigurationModel.destroy({
-      where: { id: agentIds, workspaceId },
+      where: { id: agentConfigurationModelIds, workspaceId },
       transaction: t,
     });
 
-    for (const agentResource of agentResources.values()) {
-      await deleteAgentIdentityIfUnused(auth, agentResource, t);
-    }
+    // Pending configurations are the only version of their logical agent. The FK protects this
+    // invariant by rolling the transaction back if another configuration still uses an identity.
+    await AgentModel.destroy({
+      where: { id: agentModelIds, workspaceId },
+      transaction: t,
+    });
   });
 }
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -627,8 +627,7 @@ export async function createAgentConfiguration(
 
   let userFavorite = false;
 
-  // For hidden agents, track previous editors to disable triggers when editors are removed.
-  let previousEditorIds: Set<ModelId> = new Set();
+  let removedEditors: UserType[] = [];
   // The scope the agent has before this write. A new agent starts hidden, so saving it
   // visible counts as publishing.
   let currentScope: AgentConfigurationScope = "hidden";
@@ -639,16 +638,6 @@ export async function createAgentConfiguration(
     });
     if (existingAgent) {
       currentScope = existingAgent.scope;
-      if (scope === "hidden") {
-        const editorGroupRes = await GroupResource.findEditorGroupForAgent(
-          auth,
-          existingAgent
-        );
-        if (editorGroupRes.isOk()) {
-          const members = await editorGroupRes.value.getActiveMembers(auth);
-          previousEditorIds = new Set(members.map((m) => m.id));
-        }
-      }
     }
   }
 
@@ -945,6 +934,15 @@ export async function createAgentConfiguration(
               "Unexpected: agent should have exactly one editor group."
             );
           }
+          const newEditorIds = new Set(editors.map((editor) => editor.id));
+          removedEditors = (
+            await group.getActiveMembers(auth, {
+              transaction: t,
+            })
+          )
+            .filter((editor) => !newEditorIds.has(editor.id))
+            .map((editor) => editor.toJSON());
+
           // For pending agents updated in place, the group is already linked to the same agent ID
           // For regular updates, we need to link the group to the new agent configuration
           if (existingAgent.id !== agentConfigurationInstance.id) {
@@ -983,9 +981,14 @@ export async function createAgentConfiguration(
           }
         }
 
-        await AgentResource.fromAgentConfigurationModel(
+        const agentResource = AgentResource.fromAgentConfigurationModel(
           agentConfigurationInstance
-        ).grantEditors(auth, { editors, transaction: t });
+        );
+        await agentResource.grantEditors(auth, { editors, transaction: t });
+        await agentResource.revokeEditors(auth, {
+          editors: removedEditors,
+          transaction: t,
+        });
       }
 
       return agentConfigurationInstance;
@@ -1033,32 +1036,25 @@ export async function createAgentConfiguration(
     });
 
     // Disable triggers for editors who were removed from a hidden agent.
-    if (previousEditorIds.size > 0 && scope === "hidden") {
-      const newEditorIds = new Set(editors.map((e) => e.id));
-      const removedEditorIds = Array.from(previousEditorIds).filter(
-        (id) => !newEditorIds.has(id)
-      );
-
-      if (removedEditorIds.length > 0) {
-        const triggersToDisableRes =
-          await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-            agentConfigurationId: agent.sId,
-            editorIds: removedEditorIds,
-          });
-        if (triggersToDisableRes.isOk()) {
-          for (const trigger of triggersToDisableRes.value) {
-            const disableResult = await trigger.disable(auth);
-            if (disableResult.isErr()) {
-              logger.error(
-                {
-                  workspaceId: owner.sId,
-                  agentConfigurationId: agent.sId,
-                  triggerId: trigger.sId,
-                  error: disableResult.error,
-                },
-                `Failed to disable trigger ${trigger.sId} when removing editor from agent ${agent.sId}`
-              );
-            }
+    if (removedEditors.length > 0 && scope === "hidden") {
+      const triggersToDisableRes =
+        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+          agentConfigurationId: agent.sId,
+          editorIds: removedEditors.map((editor) => editor.id),
+        });
+      if (triggersToDisableRes.isOk()) {
+        for (const trigger of triggersToDisableRes.value) {
+          const disableResult = await trigger.disable(auth);
+          if (disableResult.isErr()) {
+            logger.error(
+              {
+                workspaceId: owner.sId,
+                agentConfigurationId: agent.sId,
+                triggerId: trigger.sId,
+                error: disableResult.error,
+              },
+              `Failed to disable trigger ${trigger.sId} when removing editor from agent ${agent.sId}`
+            );
           }
         }
       }
@@ -1408,12 +1404,13 @@ export async function cleanupAgentScopedResourcesForHardDeletion(
 }
 
 async function deleteAgentIdentityIfUnused(
-  workspaceId: number,
-  sId: string,
+  auth: Authenticator,
+  agent: AgentResource,
   transaction: Transaction
 ): Promise<void> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
   const remainingConfiguration = await AgentConfigurationModel.findOne({
-    where: { sId, workspaceId },
+    where: { sId: agent.sId, workspaceId },
     attributes: ["id"],
     transaction,
   });
@@ -1421,8 +1418,9 @@ async function deleteAgentIdentityIfUnused(
     return;
   }
 
+  await agent.deletePermissions(auth, { transaction });
   await AgentModel.destroy({
-    where: { sId, workspaceId },
+    where: { sId: agent.sId, workspaceId },
     transaction,
   });
 }
@@ -1436,6 +1434,12 @@ export async function unsafeHardDeleteAgentConfiguration(
   const workspaceId = auth.getNonNullableWorkspace().id;
 
   await withTransaction(async (t) => {
+    const agentResource = await AgentResource.fetchByAgentConfiguration(
+      auth,
+      agentConfiguration,
+      { transaction: t }
+    );
+
     // Clean up MCP server configurations and their children first
     const mcpConfigs = await AgentMCPServerConfigurationModel.findAll({
       where: {
@@ -1513,7 +1517,7 @@ export async function unsafeHardDeleteAgentConfiguration(
       transaction: t,
     });
 
-    await deleteAgentIdentityIfUnused(workspaceId, agentConfiguration.sId, t);
+    await deleteAgentIdentityIfUnused(auth, agentResource, t);
   });
 }
 
@@ -1521,10 +1525,17 @@ export async function unsafeHardDeleteAgentConfiguration(
  * Batch-deletes pending agent configurations and their editor groups.
  */
 export async function batchHardDeletePendingAgentConfigurations(
-  agents: AgentConfigurationModel[],
-  workspaceId: number
+  auth: Authenticator,
+  agents: AgentConfigurationModel[]
 ) {
+  const workspaceId = auth.getNonNullableWorkspace().id;
   const agentIds = agents.map((a) => a.id);
+  const agentResources = new Map(
+    agents.map((agent) => [
+      agent.sId,
+      AgentResource.fromAgentConfigurationModel(agent),
+    ])
+  );
 
   // Find all editor group IDs for this batch.
   const groupAgents = await GroupAgentModel.findAll({
@@ -1566,8 +1577,8 @@ export async function batchHardDeletePendingAgentConfigurations(
       transaction: t,
     });
 
-    for (const sId of new Set(agents.map((agent) => agent.sId))) {
-      await deleteAgentIdentityIfUnused(workspaceId, sId, t);
+    for (const agentResource of agentResources.values()) {
+      await deleteAgentIdentityIfUnused(auth, agentResource, t);
     }
   });
 }
@@ -1622,6 +1633,12 @@ export async function updateAgentPermissions(
 
   try {
     const transactionResult = await withTransaction(async (t) => {
+      const agentResource = await AgentResource.fetchByAgentConfiguration(
+        auth,
+        agent,
+        { transaction: t }
+      );
+
       if (usersToAdd.length > 0) {
         // TODO(governance) replace by permission check on agent resource
         if (
@@ -1643,11 +1660,6 @@ export async function updateAgentPermissions(
           return addRes;
         }
 
-        const agentResource = await AgentResource.fetchByAgentConfiguration(
-          auth,
-          agent,
-          { transaction: t }
-        );
         await agentResource.grantEditors(auth, {
           editors: usersToAdd,
           transaction: t,
@@ -1677,6 +1689,11 @@ export async function updateAgentPermissions(
         if (removeRes.isErr()) {
           return removeRes;
         }
+
+        await agentResource.revokeEditors(auth, {
+          editors: usersToRemove,
+          transaction: t,
+        });
       }
       return new Ok(undefined);
     });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -628,6 +628,7 @@ export async function createAgentConfiguration(
 
   let userFavorite = false;
 
+  // Track removed editors so their triggers can be disabled if this save leaves the agent hidden.
   let removedEditors: UserType[] = [];
   // The scope the agent has before this write. A new agent starts hidden, so saving it
   // visible counts as publishing.
@@ -1411,7 +1412,7 @@ async function deleteAgentIdentityIfUnused(
     return;
   }
 
-  await agent.deletePermissions(auth, { transaction });
+  await agent.destroyPermissionsAndGroups(auth, { transaction });
   await AgentModel.destroy({
     where: { sId: agent.sId, workspaceId },
     transaction,

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -135,6 +135,54 @@ export class AgentResource implements WithAccessControl {
     }
   }
 
+  async revokeEditors(
+    auth: Authenticator,
+    { editors, transaction }: { editors: UserType[]; transaction: Transaction }
+  ): Promise<void> {
+    assert(this.kind === "custom");
+    assert(this.id !== null);
+    assert(auth.getNonNullableWorkspace().id === this.workspaceId);
+
+    const revokeResult = await GroupPermissionResource.revokeFromUsers(auth, {
+      users: editors,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: this.id,
+      transaction,
+    });
+    if (revokeResult.isErr()) {
+      throw revokeResult.error;
+    }
+  }
+
+  async deletePermissions(
+    auth: Authenticator,
+    { transaction }: { transaction: Transaction }
+  ): Promise<void> {
+    assert(this.kind === "custom");
+    assert(this.id !== null);
+    assert(auth.getNonNullableWorkspace().id === this.workspaceId);
+
+    const grantGroups =
+      await GroupPermissionResource.listRegularAutoGroupsForResource(auth, {
+        resourceType: "agent",
+        resourceId: this.id,
+        transaction,
+      });
+    await GroupPermissionResource.deleteAllForResource(auth, {
+      resourceType: "agent",
+      resourceId: this.id,
+      transaction,
+    });
+
+    for (const grantGroup of grantGroups) {
+      const deleteResult = await grantGroup.delete(auth, { transaction });
+      if (deleteResult.isErr()) {
+        throw deleteResult.error;
+      }
+    }
+  }
+
   getAccessControlLists(auth: Authenticator): AccessControlList[] {
     switch (this.kind) {
       case "global":

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -155,7 +155,11 @@ export class AgentResource implements WithAccessControl {
     }
   }
 
-  async deletePermissions(
+  /**
+   * Deletes the agent's permission rows and their regular_auto groups.
+   * Only call after deleting the last configuration of the logical agent.
+   */
+  async destroyPermissionsAndGroups(
     auth: Authenticator,
     { transaction }: { transaction: Transaction }
   ): Promise<void> {

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -5,6 +5,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
@@ -569,17 +570,39 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         return new Ok(undefined);
       }
 
-      const activeMembers = await group.getActiveMembers(auth, {
+      const now = new Date();
+      const memberships = await GroupMembershipModel.findAll({
+        attributes: ["userId"],
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          groupId: group.id,
+          userId: uniqueUsers.map((user) => user.id),
+          status: "active",
+          startAt: { [Op.lte]: now },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+        },
         transaction: t,
       });
-      const userIds = new Set(uniqueUsers.map((user) => user.id));
-      const usersToRemove = activeMembers
-        .filter((member) => userIds.has(member.id))
-        .map((member) => member.toJSON());
+      const memberIds = new Set(
+        memberships.map((membership) => membership.userId)
+      );
+      const usersToRemove = uniqueUsers.filter((user) =>
+        memberIds.has(user.id)
+      );
       if (usersToRemove.length === 0) {
         return new Ok(undefined);
       }
 
+      const memberCount = await GroupMembershipModel.count({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          groupId: group.id,
+          status: "active",
+          startAt: { [Op.lte]: now },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+        },
+        transaction: t,
+      });
       const removeResult = await group.dangerouslyRemoveMembers(auth, {
         users: usersToRemove,
         transaction: t,
@@ -588,7 +611,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         return removeResult;
       }
 
-      if (usersToRemove.length === activeMembers.length) {
+      if (usersToRemove.length === memberCount) {
         await this.revoke(auth, {
           group,
           grantType,

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -5,7 +5,6 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
@@ -534,6 +533,29 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     auth: Authenticator,
     { user, grantType, resourceType, resourceId, transaction }: UserGrantSpec
   ): Promise<Result<undefined, Error>> {
+    return this.revokeFromUsers(auth, {
+      users: [user],
+      grantType,
+      resourceType,
+      resourceId,
+      transaction,
+    });
+  }
+
+  // Batched counterpart of revokeFromUser: one tuple lookup and one bulk membership write. If the
+  // removed users were the final members, the grant and its backing group are deleted.
+  static async revokeFromUsers(
+    auth: Authenticator,
+    { users, grantType, resourceType, resourceId, transaction }: UsersGrantSpec
+  ): Promise<Result<undefined, Error>> {
+    if (users.length === 0) {
+      return new Ok(undefined);
+    }
+
+    const uniqueUsers = [
+      ...new Map(users.map((user) => [user.id, user])).values(),
+    ];
+
     return withTransaction(async (t) => {
       await this.getGrantLock(auth, { grantType, resourceType, resourceId }, t);
 
@@ -547,31 +569,26 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         return new Ok(undefined);
       }
 
-      const membership = await GroupMembershipModel.findOne({
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          groupId: group.id,
-          userId: user.id,
-          status: "active",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
+      const activeMembers = await group.getActiveMembers(auth, {
         transaction: t,
       });
-      if (!membership) {
+      const userIds = new Set(uniqueUsers.map((user) => user.id));
+      const usersToRemove = activeMembers
+        .filter((member) => userIds.has(member.id))
+        .map((member) => member.toJSON());
+      if (usersToRemove.length === 0) {
         return new Ok(undefined);
       }
 
-      const memberCount = await group.getMemberCount(auth);
-      const removeResult = await group.dangerouslyRemoveMember(auth, {
-        user,
+      const removeResult = await group.dangerouslyRemoveMembers(auth, {
+        users: usersToRemove,
         transaction: t,
       });
       if (removeResult.isErr()) {
         return removeResult;
       }
 
-      if (memberCount === 1) {
+      if (usersToRemove.length === activeMembers.length) {
         await this.revoke(auth, {
           group,
           grantType,

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -885,21 +885,46 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       transaction?: Transaction;
     }
   ): Promise<number> {
+    return this.deleteAllForResources(auth, {
+      resourceType,
+      resourceIds: [resourceId],
+      transaction,
+    });
+  }
+
+  static async deleteAllForResources(
+    auth: Authenticator,
+    {
+      resourceType,
+      resourceIds,
+      transaction,
+    }: {
+      resourceType: GroupPermissionResourceType;
+      resourceIds: number[];
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    const uniqueResourceIds = [...new Set(resourceIds)];
+    if (uniqueResourceIds.length === 0) {
+      return 0;
+    }
     assert(
-      resourceId > 0 && resourceId !== WHOLE_TYPE_RESOURCE_ID,
-      "deleteAllForResource targets a concrete resource; it must not clear type-wide grants."
+      uniqueResourceIds.every(
+        (resourceId) => resourceId > 0 && resourceId !== WHOLE_TYPE_RESOURCE_ID
+      ),
+      "deleteAllForResources targets concrete resources; it must not clear type-wide grants."
     );
 
     const workspaceId = auth.getNonNullableWorkspace().id;
     const groupModelIds = await this.listGroupModelIdsForGrants(
-      { workspaceId, resourceType, resourceId },
+      { workspaceId, resourceType, resourceId: uniqueResourceIds },
       transaction
     );
     const deleted = await GroupPermissionModel.destroy({
       where: {
         workspaceId,
         resourceType,
-        resourceId,
+        resourceId: uniqueResourceIds,
       },
       transaction,
     });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1840,6 +1840,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
+    // Check if all requested users are active members of the group.
     const groupMembershipCount = await GroupMembershipModel.count({
       where: {
         groupId: this.id,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1840,17 +1840,22 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Check if the users are already a member of the group.
-    const activeMembers = await this.getActiveMembers(auth, { transaction });
-    const activeMembersIds = activeMembers.map((m) => m.sId);
-    const notActiveUserIds = userIds.filter(
-      (userId) => !activeMembersIds.includes(userId)
-    );
-    if (notActiveUserIds.length > 0) {
+    const groupMembershipCount = await GroupMembershipModel.count({
+      where: {
+        groupId: this.id,
+        userId: userResources.map((user) => user.id),
+        workspaceId: owner.id,
+        status: "active",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+      transaction,
+    });
+    if (groupMembershipCount !== userIds.length) {
       return new Err(
         new DustError(
           "user_not_member",
-          notActiveUserIds.length === 1
+          userIds.length === 1
             ? "Cannot remove: user is not a member of the group"
             : "Cannot remove: users are not members of the group"
         )

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1826,6 +1826,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const { total } = await MembershipResource.getActiveMemberships({
       users: userResources,
       workspace: owner,
+      transaction,
     });
 
     if (total !== userIds.length) {
@@ -1840,7 +1841,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     // Check if the users are already a member of the group.
-    const activeMembers = await this.getActiveMembers(auth);
+    const activeMembers = await this.getActiveMembers(auth, { transaction });
     const activeMembersIds = activeMembers.map((m) => m.sId);
     const notActiveUserIds = userIds.filter(
       (userId) => !activeMembersIds.includes(userId)

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -2,6 +2,7 @@ import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configur
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import {
@@ -70,7 +71,22 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     const agent = await AgentConfigurationModel.findOne({
       where: { sId, workspaceId: workspace.id },
     });
-    const editorGroupId = await getEditorGroupId(agent!.id, workspace.id);
+    if (!agent) {
+      throw new Error("Pending agent was not created");
+    }
+    const editorGroupId = await getEditorGroupId(agent.id, workspace.id);
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(
+        authenticator,
+        {
+          grantType: "editor",
+          resourceType: "agent",
+          resourceId: agent.agentId,
+        }
+      );
+    if (!grantGroup) {
+      throw new Error("Agent editor grant was not created");
+    }
 
     // Advance time past the retention threshold.
     vi.advanceTimersByTime(PAST_THRESHOLD_MS);
@@ -86,7 +102,7 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     // Editor group should be deleted too.
     const groupsAfter = await GroupResource.dangerouslyFetchByModelIds(
       authenticator,
-      [editorGroupId]
+      [editorGroupId, grantGroup.id]
     );
     expect(groupsAfter).toHaveLength(0);
   });

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
 import { batchHardDeletePendingAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { REINFORCEMENT_EXCLUDED_PLAN_CODES } from "@app/lib/plans/plan_codes";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
@@ -143,6 +144,7 @@ export async function purgeExpiredPendingAgentsActivity(
   const deletedCounts = await concurrentExecutor(
     workspaces,
     async (workspace) => {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       let deleted = 0;
       let hasMore = true;
 
@@ -160,7 +162,7 @@ export async function purgeExpiredPendingAgentsActivity(
         hasMore = batch.length === batchSize;
 
         if (batch.length > 0) {
-          await batchHardDeletePendingAgentConfigurations(batch, workspace.id);
+          await batchHardDeletePendingAgentConfigurations(auth, batch);
           deleted += batch.length;
         }
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: [Admin Governance design doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)

Follows https://github.com/dust-tt/dust/pull/31730, which began writing editor additions to the new grants system.

Agent editor changes still write to the legacy `agent_editors` group while the migration is being verified. This PR mirrors removals to the `agent.editor` grant group in both workflows that can remove an editor: saving the complete editor list and using the dedicated editor update path. Multiple removals use targeted, batched membership queries, and both storage systems remain in the same transaction.

When the final configuration version of a logical agent is hard-deleted, its permission rows and grant-backed group are now deleted with its stable agent identity. Deleting only one version leaves them intact, and archiving continues to preserve editor access. Expired pending-agent cleanup removes permission rows, grant groups, and identities in set-based batches. Permission reads remain on the legacy system.

## Risks

Blast radius: Removing custom-agent editors and hard-deleting custom agents.
Risk: standard. The legacy and grant writes are transactional, and permission reads have not switched to grants yet.

## Deploy Plan

- deploy front

## Tests

- [x] `npm run test --workspace=front -- lib/resources/group_permission_resource.test.ts lib/api/assistant/configuration/agent.test.ts temporal/hard_delete/activities.test.ts` (84 tests)
- [x] `NODE_ENV=test npm run test --workspace=front-api -- editors.test.ts` (18 agent-editor tests passed; the local command later exited on missing AWS region configuration)