### PR TITLE
[Notion] Support app.notion.com URLs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 
 ## Tests
 
-<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
+<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
 
 ## Risk
 

--- a/connectors/src/api/notion_url_status.ts
+++ b/connectors/src/api/notion_url_status.ts
@@ -11,9 +11,9 @@ import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { Request, Response } from "express";
 
-// Notion content can be reached through several domains: the classic notion.so,
-// published sites on notion.site, and the newer notion.com (e.g. app.notion.com).
-const VALID_NOTION_HOSTS = ["notion.so", "notion.site", "notion.com"];
+// Notion content can be reached through the legacy app domain, the current app domain,
+// and published sites.
+const VALID_NOTION_HOSTS = ["notion.so", "notion.site", "app.notion.com"];
 
 function isValidNotionUrl(url: string): boolean {
   if (!URL.canParse(url)) {

--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -74,7 +74,7 @@ export function isRepoTooLarge(
   if (repoInfo.size > REPO_SIZE_LIMIT) {
     // We throw a panic log and skip to keep track of the very large repositories and report to the user.
     // The rest of the sync is not affected. Please check out the runbook:
-    // https://www.notion.so/dust-tt/Panic-Log-Github-repository-too-large-to-sync-1bf28599d9418061a396d2378bdd77de?pvs=4
+    // https://app.notion.com/p/dust-tt/Panic-Log-Github-repository-too-large-to-sync-1bf28599d9418061a396d2378bdd77de?pvs=4
 
     // Some connectors are whitelisted to sync large repositories.
     // This is on a connectorId basis to avoid leaking repository names.

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -69,7 +69,7 @@ export function isValidNodeType(
  * own `internal id`. This is because the Microsoft API does not allow to query a document or
  * list its children using its id alone. We compute an internal id that contains all
  * information. More details
- * [here](https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4)
+ * [here](https://app.notion.com/p/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4)
  */
 export type MicrosoftNode = {
   nodeType: MicrosoftNodeType;

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -22,7 +22,7 @@ import { Sequelize } from "sequelize";
 const logger = parentLogger.child({ provider: "notion" });
 
 /** Compute the parents field for a notion pageOrDb See the [Design
- * Doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)
+ * Doc](https://app.notion.com/p/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)
  * and the field documentation [in
  * core](https://github.com/dust-tt/dust/blob/main/core/src/data_sources/data_source.rs)
  * for relevant details

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -100,6 +100,7 @@ import chunk from "lodash/chunk";
 import { Op } from "sequelize";
 
 const logger = mainLogger.child({ provider: "notion" });
+const NOTION_APP_URL = "https://app.notion.com/p";
 
 // Connector ID hashes for which deletion should be skipped during garbage collection.
 const SKIP_DELETION_CONNECTOR_ID_HASHES = new Set<string>([
@@ -2579,7 +2580,7 @@ export async function renderAndUpsertPageFromCache({
             mimeType: INTERNAL_MIME_TYPES.NOTION.DATABASE,
             sourceUrl:
               parentDb.notionUrl ??
-              `https://www.notion.so/${parentDb.notionDatabaseId.replace(/-/g, "")}`,
+              `${NOTION_APP_URL}/${parentDb.notionDatabaseId.replace(/-/g, "")}`,
             allowEmptySchema: true,
           })
         );
@@ -3166,7 +3167,7 @@ export async function upsertDatabaseStructuredDataFromCache({
       mimeType: INTERNAL_MIME_TYPES.NOTION.DATABASE,
       sourceUrl:
         dbModel.notionUrl ??
-        `https://www.notion.so/${dbModel.notionDatabaseId.replace(/-/g, "")}`,
+        `${NOTION_APP_URL}/${dbModel.notionDatabaseId.replace(/-/g, "")}`,
       allowEmptySchema: true,
     })
   );
@@ -3213,7 +3214,7 @@ export async function upsertDatabaseStructuredDataFromCache({
         },
         documentUrl:
           dbModel.notionUrl ??
-          `https://www.notion.so/${databaseId.replace(/-/g, "")}`,
+          `${NOTION_APP_URL}/${databaseId.replace(/-/g, "")}`,
         // TODO: see if we actually want to use the Notion last edited time of the database
         // we currently don't have it because we don't fetch the DB object from notion.
         timestampMs: upsertAt.getTime(),

--- a/connectors/src/types/api.ts
+++ b/connectors/src/types/api.ts
@@ -130,7 +130,7 @@ export type ProviderVisibility = "public" | "private";
  * own. This is because the Microsoft API does not allow to query a document or
  * list its children using its id alone. We compute an internal id that contains all
  * information. More details here:
- * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
+ * https://app.notion.com/p/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
 export interface ContentNode {
   expandable: boolean;

--- a/core/bin/qdrant/create_collection.rs
+++ b/core/bin/qdrant/create_collection.rs
@@ -129,7 +129,7 @@ async fn create_qdrant_collection(
         println!("QDRANT_USE_SHARDING=false, creating collection without distributed features");
     }
 
-    // See https://www.notion.so/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27.
+    // See https://app.notion.com/p/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27.
 
     // First, we create the collection.
     let mut builder = CreateCollectionBuilder::new(collection_name.clone())

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -113,7 +113,7 @@ pub struct Chunk {
 /// not the case for Microsoft. Therefore, for microsoft, instead of using the
 /// provider id directly, we compute our own document id containing all
 /// information for the querying the document using Microsoft's API. More details
-/// [here](https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4)
+/// [here](https://app.notion.com/p/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4)
 ///
 /// Parents array
 /// -------------

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -24,7 +24,7 @@ pub enum QdrantCluster {
     Cluster0,
 }
 
-// See: https://www.notion.so/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27
+// See: https://app.notion.com/p/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27
 pub const SHARD_KEY_COUNT: u64 = 24;
 
 static QDRANT_CLUSTER_VARIANTS: &[QdrantCluster] = &[QdrantCluster::Cluster0];

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -46,6 +46,7 @@ import capitalize from "lodash/capitalize";
 import { useEffect, useState } from "react";
 
 const maxNotionParentChainDepth = 20;
+const NOTION_APP_URL = "https://app.notion.com/p";
 
 function FolderDisplay({
   owner,
@@ -362,12 +363,13 @@ function NotionUrlCheckOrFind({
 
     try {
       // Extract Notion ID from URL
-      // Handle both full URLs (https://www.notion.so/Block-child-page-28cd1abaf14f80a4bfd4c51ba853d732)
-      // and just IDs (28cd1abaf14f80a4bfd4c51ba853d732)
+      // Handle full URLs such as
+      // https://app.notion.com/p/Block-child-page-28cd1abaf14f80a4bfd4c51ba853d732
+      // and IDs such as 28cd1abaf14f80a4bfd4c51ba853d732.
       let notionId = notionUrl.trim();
 
       // If it's a full URL, extract the last part
-      if (notionId.includes("notion.so/")) {
+      if (URL.canParse(notionId)) {
         const urlParts = notionId.split("/").filter((p) => p);
         notionId = urlParts[urlParts.length - 1];
       }
@@ -582,7 +584,7 @@ function NotionUrlCheckOrFind({
                                 Parent URL:
                               </span>
                               <span className="pl-2">
-                                {` https://www.notion.so/${(
+                                {` ${NOTION_APP_URL}/${(
                                   urlDetails.page.parentId as string
                                 ).replaceAll("-", "")}`}
                               </span>
@@ -594,7 +596,7 @@ function NotionUrlCheckOrFind({
                                 Parent URL:
                               </span>
                               <span className="pl-2">
-                                {` https://www.notion.so/${(
+                                {` ${NOTION_APP_URL}/${(
                                   urlDetails.page.parentId as string
                                 ).replaceAll("-", "")}`}
                               </span>
@@ -618,7 +620,7 @@ function NotionUrlCheckOrFind({
                                 Parent URL:
                               </span>
                               <span className="pl-2">
-                                {`https://www.notion.so/${(
+                                {`${NOTION_APP_URL}/${(
                                   urlDetails.db?.parentId as string
                                 ).replaceAll("-", "")}`}
                               </span>
@@ -630,7 +632,7 @@ function NotionUrlCheckOrFind({
                                 Parent URL:
                               </span>
                               <span className="pl-2">
-                                {` https://www.notion.so/${(
+                                {` ${NOTION_APP_URL}/${(
                                   urlDetails.db?.parentId as string
                                 ).replaceAll("-", "")}`}
                               </span>

--- a/front/components/spaces/AdvancedNotionManagement.tsx
+++ b/front/components/spaces/AdvancedNotionManagement.tsx
@@ -19,9 +19,9 @@ import {
 import type { CellContext } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
 
-// Notion content can be reached through several domains: the classic notion.so,
-// published sites on notion.site, and the newer notion.com (e.g. app.notion.com).
-const VALID_NOTION_HOSTS = ["notion.so", "notion.site", "notion.com"];
+// Notion content can be reached through the legacy app domain, the current app domain,
+// and published sites.
+const VALID_NOTION_HOSTS = ["notion.so", "notion.site", "app.notion.com"];
 
 function isValidNotionUrl(url: string): boolean {
   if (!URL.canParse(url)) {
@@ -320,7 +320,7 @@ export function AdvancedNotionManagement({
 
         <div className="p-1">
           <Input
-            placeholder="https://www.notion.so/..."
+            placeholder="https://app.notion.com/p/..."
             value={statusUrl}
             onChange={(e) => setStatusUrl(e.target.value)}
             className="w-full"
@@ -416,7 +416,7 @@ export function AdvancedNotionManagement({
         Enter up to 10 Notion URLs to sync (one per line)
       </div>
       <TextArea
-        placeholder="https://www.notion.so/..."
+        placeholder="https://app.notion.com/p/..."
         value={urls.join("\n")}
         onChange={(e) => {
           setUrls(e.target.value.split("\n").map((url) => url.trim()));

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -189,7 +189,7 @@ function warnDocumentationAck(documentationAckLabel: string) {
 function checkAppsRegistry() {
   warn(
     `File \`front/lib/registry.ts\` has been modified.
-    Please check [Runbook: Update Assistant dust-apps](https://www.notion.so/dust-tt/Runbook-Update-Assistant-dust-apps-18c28599d94180d78dabe92f445157a8)
+    Please check [Runbook: Update Assistant dust-apps](https://app.notion.com/p/dust-tt/Runbook-Update-Assistant-dust-apps-18c28599d94180d78dabe92f445157a8)
     `
   );
 }

--- a/front/lib/api/actions/servers/pod_tasks/source_utils.test.ts
+++ b/front/lib/api/actions/servers/pod_tasks/source_utils.test.ts
@@ -32,6 +32,14 @@ describe("inferProjectTaskSourceFromUrl", () => {
     expect(source.sourceType).toBe("github");
   });
 
+  it("detects current Notion URLs", () => {
+    const source = inferProjectTaskSourceFromUrl({
+      url: "https://app.notion.com/p/Project-12345678901234567890123456789012",
+      title: "Project",
+    });
+    expect(source.sourceType).toBe("notion");
+  });
+
   it("falls back to project_knowledge for unknown URLs", () => {
     const source = inferProjectTaskSourceFromUrl({
       url: "https://example.com/doc",

--- a/front/lib/api/actions/servers/pod_tasks/source_utils.ts
+++ b/front/lib/api/actions/servers/pod_tasks/source_utils.ts
@@ -4,6 +4,7 @@ import type {
 } from "@app/types/project_task";
 
 const CONVERSATION_PATH_RE = /\/w\/[^/]+\/conversation\/([^/?#]+)/;
+const NOTION_HOSTS = ["notion.so", "notion.site", "app.notion.com"];
 
 function inferSourceTypeFromHostname(hostname: string): PodTaskSourceType {
   if (hostname.includes("slack.com")) {
@@ -12,7 +13,11 @@ function inferSourceTypeFromHostname(hostname: string): PodTaskSourceType {
   if (hostname.includes("github.com")) {
     return "github";
   }
-  if (hostname.includes("notion.so") || hostname.includes("notion.site")) {
+  if (
+    NOTION_HOSTS.some(
+      (host) => hostname === host || hostname.endsWith(`.${host}`)
+    )
+  ) {
     return "notion";
   }
   if (hostname.includes("atlassian.net") || hostname.includes("confluence")) {

--- a/front/lib/connectors.test.ts
+++ b/front/lib/connectors.test.ts
@@ -175,7 +175,7 @@ describe("nodeCandidateFromUrl", () => {
   describe("Notion", () => {
     it("should extract node ID from Notion page URL with 32-char ID", () => {
       const url =
-        "https://www.notion.so/Page-Title-12345678901234567890123456789012";
+        "https://app.notion.com/p/Page-Title-12345678901234567890123456789012";
       const result = nodeCandidateFromUrl(url);
 
       expect(result).not.toBeNull();
@@ -189,7 +189,7 @@ describe("nodeCandidateFromUrl", () => {
     it("should handle Notion URLs with multiple dashes", () => {
       // The last part after splitting by "-" must be exactly 32 characters
       const url =
-        "https://www.notion.so/My-Page-Title-With-Many-Words-abcdef12345678901234567890123456";
+        "https://dust-tt.notion.site/My-Page-Title-With-Many-Words-abcdef12345678901234567890123456";
       const result = nodeCandidateFromUrl(url);
 
       expect(result).not.toBeNull();
@@ -213,7 +213,7 @@ describe("nodeCandidateFromUrl", () => {
     });
 
     it("should return null node when ID is not 32 characters", () => {
-      const url = "https://www.notion.so/Page-12345";
+      const url = "https://app.notion.com/p/Page-12345";
       const result = nodeCandidateFromUrl(url);
 
       expect(result).not.toBeNull();
@@ -222,6 +222,14 @@ describe("nodeCandidateFromUrl", () => {
         expect(result.node).toBeNull();
         expect(result.provider).toBe("notion");
       }
+    });
+
+    it("should not match lookalike Notion domains", () => {
+      const result = nodeCandidateFromUrl(
+        "https://app.notion.com.example.com/p/Page-12345"
+      );
+
+      expect(result).toBeNull();
     });
   });
 

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -244,8 +244,7 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
   notion: {
     matcher: (url: URL): boolean => {
       return NOTION_HOSTS.some(
-        (host) =>
-          url.hostname === host || url.hostname.endsWith(`.${host}`)
+        (host) => url.hostname === host || url.hostname.endsWith(`.${host}`)
       );
     },
     extractor: (url: URL): NodeCandidate => {

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -20,6 +20,8 @@ function getConnectorOrder() {
 
 type ComparableByProvider = { connectorProvider: ConnectorProvider | null };
 
+const NOTION_HOSTS = ["notion.so", "notion.site", "app.notion.com"];
+
 function compareByImportance(
   a: ComparableByProvider,
   b: ComparableByProvider
@@ -241,7 +243,10 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
   },
   notion: {
     matcher: (url: URL): boolean => {
-      return url.hostname.includes("notion.so");
+      return NOTION_HOSTS.some(
+        (host) =>
+          url.hostname === host || url.hostname.endsWith(`.${host}`)
+      );
     },
     extractor: (url: URL): NodeCandidate => {
       // Get the last part of the path, which contains the ID

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -267,7 +267,7 @@ export const createStripeSubscriptionCheckoutSession = async ({
     custom_text: {
       terms_of_service_acceptance: {
         message:
-          "I have read and accept the [Master Services Agreement](https://dust-tt.notion.site/Master-Services-Agreement-2bdcf30156db4a40bcb20d27b0b1bd4e?pvs=4) and [Data Processing Addendum](https://www.notion.so/dust-tt/Data-Processing-Addendum-466528e861e34f08949428e06eecd5f4?pvs=4).",
+          "I have read and accept the [Master Services Agreement](https://dust-tt.notion.site/Master-Services-Agreement-2bdcf30156db4a40bcb20d27b0b1bd4e?pvs=4) and [Data Processing Addendum](https://dust-tt.notion.site/Data-Processing-Addendum-466528e861e34f08949428e06eecd5f4?pvs=4).",
       },
     },
   });
@@ -362,7 +362,7 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
     custom_text: {
       terms_of_service_acceptance: {
         message:
-          "I have read and accept the [Master Services Agreement](https://dust-tt.notion.site/Master-Services-Agreement-2bdcf30156db4a40bcb20d27b0b1bd4e?pvs=4) and [Data Processing Addendum](https://www.notion.so/dust-tt/Data-Processing-Addendum-466528e861e34f08949428e06eecd5f4?pvs=4).",
+          "I have read and accept the [Master Services Agreement](https://dust-tt.notion.site/Master-Services-Agreement-2bdcf30156db4a40bcb20d27b0b1bd4e?pvs=4) and [Data Processing Addendum](https://dust-tt.notion.site/Data-Processing-Addendum-466528e861e34f08949428e06eecd5f4?pvs=4).",
       },
     },
   });

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -118,7 +118,7 @@ function checkWorkspaceIsolation<MS extends ModelStatic<Model>>(
       throw new Error(
         `Query attempted without workspaceId on ${modelName}. All workspace-aware model ` +
           "queries must be scoped to a specific workspaceId for query isolation. " +
-          "See Runbook https://www.notion.so/dust-tt/Runbook-WorkspaceAwareModel-Workspace-Isolation-Enforcement-2d128599d94180dbbbace7cffcd958f6"
+          "See Runbook https://app.notion.com/p/dust-tt/Runbook-WorkspaceAwareModel-Workspace-Isolation-Enforcement-2d128599d94180dbbbace7cffcd958f6"
       );
     }
 

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -664,14 +664,14 @@ When creating or updating pages, follow these formatting rules:
                   "# GitHub & Jira Combined Report\n\n## GitHub Activity\n\n| Project | Title | Type | Status |\n|---|---|---|---|\n| CoreEngine | Fix auth flow | Issue | Open |\n| CoreEngine | Refactor auth module | PR | Merged |\n| FrontendUI | Update dashboard | Issue | Closed |\n| MobileApp | Add push notifications | PR | Open |\n\n## Jira Sprint Status\n\n**Sprint 24** — 75% complete\n\n| Key | Summary | Status |\n|---|---|---|\n| ENG-401 | API rate limiting | In Progress |\n| ENG-402 | DB migration | Done |\n\n*Generated on 2026-04-10*",
               },
               output:
-                '{"pageId": "page_abc123", "url": "https://notion.so/report-abc123"}',
+                '{"pageId": "page_abc123", "url": "https://app.notion.com/p/report-abc123"}',
             },
           ],
         },
         {
           role: "agent",
           content:
-            "I've published the combined report to Notion. Here's a summary:\n\n**GitHub Activity:**\n- CoreEngine: 1 open issue (Fix auth flow), 1 merged PR (Refactor auth module)\n- FrontendUI: 1 closed issue (Update dashboard)\n- MobileApp: 1 open PR (Add push notifications)\n\n**Jira Sprint 24 (75% complete):**\n- ENG-401: API rate limiting (In Progress)\n- ENG-402: DB migration (Done)\n\nFull report: https://notion.so/report-abc123",
+            "I've published the combined report to Notion. Here's a summary:\n\n**GitHub Activity:**\n- CoreEngine: 1 open issue (Fix auth flow), 1 merged PR (Refactor auth module)\n- FrontendUI: 1 closed issue (Update dashboard)\n- MobileApp: 1 open PR (Add push notifications)\n\n**Jira Sprint 24 (75% complete):**\n- ENG-401: API rate limiting (In Progress)\n- ENG-402: DB migration (Done)\n\nFull report: https://app.notion.com/p/report-abc123",
         },
         {
           role: "user",
@@ -712,7 +712,7 @@ When creating or updating pages, follow these formatting rules:
         {
           role: "agent",
           content:
-            "I've updated the Notion report with the DevCode data. Here's what was added:\n\n**DevCode:**\n- 2 open issues (Implement caching layer, Fix race condition in worker), 1 closed issue (Add retry logic for webhooks)\n- 1 open PR (Add caching middleware), 1 merged PR (Fix worker pool exhaustion)\n\nThe report at https://notion.so/report-abc123 now includes all five repositories.",
+            "I've updated the Notion report with the DevCode data. Here's what was added:\n\n**DevCode:**\n- 2 open issues (Implement caching layer, Fix race condition in worker), 1 closed issue (Add retry logic for webhooks)\n- 1 open PR (Add caching middleware), 1 merged PR (Fix worker pool exhaustion)\n\nThe report at https://app.notion.com/p/report-abc123 now includes all five repositories.",
         },
       ],
       workspaceContext: WORKSPACE_CONTEXT,

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -126,7 +126,7 @@ export type ProviderVisibility = "public" | "private";
  * own. This is because the Microsoft API does not allow to query a document or
  * list its children using its id alone. We compute an internal id that contains all
  * information. More details here:
- * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
+ * https://app.notion.com/p/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
 export interface ContentNode {
   childrenCount: number;

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -154,7 +154,7 @@ export const AsLink: Story = {
       secondaryIcon: NotionLogo,
       size: "sm",
     },
-    href: "https://notion.so",
+    href: "https://app.notion.com",
     target: "_blank",
   },
   decorators: [

--- a/sparkle/src/stories/ConversationMessages.stories.tsx
+++ b/sparkle/src/stories/ConversationMessages.stories.tsx
@@ -157,7 +157,7 @@ export const WithAttachments: Story = {
                   secondaryIcon: NotionLogo,
                   size: "sm",
                 }}
-                href="https://notion.so"
+                href="https://app.notion.com"
                 target="_blank"
               />
             </div>

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -169,7 +169,7 @@ procs:
     autostart: false
 
   ngrok:
-    # Doc: https://www.notion.so/dust-tt/Runbook-Local-Setup-Slack-2ad003fc529d4144bb0ee61b7fd797c9?source=copy_link#2a728599d941807fb71dccb4addc0234
+    # Doc: https://app.notion.com/p/dust-tt/Runbook-Local-Setup-Slack-2ad003fc529d4144bb0ee61b7fd797c9?source=copy_link#2a728599d941807fb71dccb4addc0234
     shell: "ngrok start localhost-via-https"
     autostart: false
 
@@ -223,6 +223,6 @@ procs:
     autostart: false
 
   stripe:
-    # Doc: https://www.notion.so/dust-tt/Runbook-Local-Dev-setup-720bffc7d67a447184cb957e9471380c?source=copy_link#5814f227351d4d258422e21e8de39c82/
+    # Doc: https://app.notion.com/p/dust-tt/Runbook-Local-Dev-setup-720bffc7d67a447184cb957e9471380c?source=copy_link#5814f227351d4d258422e21e8de39c82/
     shell: "stripe listen --forward-to localhost:3000/api/stripe/webhook"
     autostart: false

--- a/tools/process-compose.yaml
+++ b/tools/process-compose.yaml
@@ -331,7 +331,7 @@ processes:
     disabled: true
 
   ngrok:
-    # Doc: https://www.notion.so/dust-tt/Runbook-Local-Setup-Slack-2ad003fc529d4144bb0ee61b7fd797c9?source=copy_link#2a728599d941807fb71dccb4addc0234
+    # Doc: https://app.notion.com/p/dust-tt/Runbook-Local-Setup-Slack-2ad003fc529d4144bb0ee61b7fd797c9?source=copy_link#2a728599d941807fb71dccb4addc0234
     command: "ngrok start localhost-via-https"
     namespace: 90-optional
     disabled: true
@@ -377,7 +377,7 @@ processes:
     disabled: true
 
   stripe:
-    # Doc: https://www.notion.so/dust-tt/Runbook-Local-Dev-setup-720bffc7d67a447184cb957e9471380c?source=copy_link#5814f227351d4d258422e21e8de39c82/
+    # Doc: https://app.notion.com/p/dust-tt/Runbook-Local-Dev-setup-720bffc7d67a447184cb957e9471380c?source=copy_link#5814f227351d4d258422e21e8de39c82/
     command: "stripe listen --forward-to localhost:3000/api/stripe/webhook"
     namespace: 90-optional
     disabled: true


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/27055.

Notion finished moving workspace links from `notion.so` to `app.notion.com`, but the shared URL matcher still only recognized the old host. Newly copied Notion links were therefore not detected when pasted into the input bar.

Recognize current app links and published `notion.site` links while keeping legacy `notion.so` support. Also stop generating or showing old-host links in source fallbacks, admin tools, examples, legal copy, and internal documentation. `api.notion.com` and `mcp.notion.com` remain unchanged.

Context: [Notion migration announcement](https://www.linkedin.com/posts/notionhq_for-years-notionso-was-home-today-we-activity-7467656747625873408-EdCh), [Notion Sites URL documentation](https://www.notion.com/en-gb/help/manage-your-notion-sites), [Notion API base URL documentation](https://developers.notion.com/reference/intro).

## Risks

Blast radius: Notion URL detection and links generated or displayed by front and connectors.
Risk: low

## Deploy Plan

- deploy connectors
- deploy front

## Tests

- [x] `NODE_ENV=test npm test -- lib/connectors.test.ts lib/api/actions/servers/pod_tasks/source_utils.test.ts`