### PR TITLE
workspace_management MCP: redact private agent fields for admins in get_agent_details

### DIFF
--- a/front/lib/api/actions/servers/workspace_management/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_management/metadata.ts
@@ -196,7 +196,11 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
     description:
       "Return an agent's full configuration: name, description, scope, model, " +
       "equipped skills and capabilities, and its complete system prompt and " +
-      "instructions. Use this to inspect what an agent actually does.",
+      "instructions. Use this to inspect what an agent actually does. Admins " +
+      "get every agent of the workspace, but for the ones they cannot read " +
+      "(unpublished agents they do not edit, agents built on spaces they are " +
+      "not a member of) the instructions, skills, tools and knowledge are " +
+      "withheld; only name, description, scope and model are returned.",
     schema: getAgentDetailsSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_management/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_management/metadata.ts
@@ -198,9 +198,7 @@ export const WORKSPACE_MANAGEMENT_TOOLS_METADATA = [
       "equipped skills and capabilities, and its complete system prompt and " +
       "instructions. Use this to inspect what an agent actually does. Admins " +
       "get every agent of the workspace, but for the ones they cannot read " +
-      "(unpublished agents they do not edit, agents built on spaces they are " +
-      "not a member of) the instructions, skills, tools and knowledge are " +
-      "withheld; only name, description, scope and model are returned.",
+      "the instructions, skills, tools and knowledge are withheld.",
     schema: getAgentDetailsSchema,
     stake: "never_ask",
     eager: true,

--- a/front/lib/api/actions/servers/workspace_management/tools/get_agent_details.ts
+++ b/front/lib/api/actions/servers/workspace_management/tools/get_agent_details.ts
@@ -2,18 +2,16 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationForDetails } from "@app/lib/api/assistant/configuration/agent";
 import { Ok } from "@app/types/shared/result";
 
 export async function getAgentDetails(
   { agentId }: { agentId: string },
   { auth }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const agents = await getAgentConfigurations(auth, {
-    agentIds: [agentId],
-    variant: "full",
-  });
-  const agent = agents[0];
+  // Admins get every agent of the workspace, with the private fields redacted (`canRead` false)
+  // for the ones they cannot read. Everyone else only gets the agents they can read.
+  const agent = await getAgentConfigurationForDetails(auth, { agentId });
 
   if (!agent) {
     return new Ok([
@@ -26,17 +24,21 @@ export async function getAgentDetails(
     ]);
   }
 
+  const header =
+    `Agent ${agent.name} [${agent.sId}]\n` +
+    `- Description: ${agent.description}\n` +
+    `- Scope: ${agent.scope}\n` +
+    `- Model: ${agent.model.providerId}/${agent.model.modelId}\n`;
+
   if (!agent.canRead) {
     return new Ok([
       {
         type: "text" as const,
         text:
-          `Agent ${agent.name} [${agent.sId}]\n` +
-          `- Description: (private agent - not available)\n` +
-          `- Scope: ${agent.scope}\n` +
-          `- Model: ${agent.model.providerId}/${agent.model.modelId}\n\n` +
-          "Instructions, skills, and tools are not available for private " +
-          "agents you do not have access to.",
+          header +
+          "\nInstructions, skills, tools and knowledge are private: you are " +
+          "not an editor of this agent, or not a member of every space it " +
+          "requires. This cannot be overridden from this tool.",
       },
     ]);
   }
@@ -48,10 +50,7 @@ export async function getAgentDetails(
     {
       type: "text" as const,
       text:
-        `Agent ${agent.name} [${agent.sId}]\n` +
-        `- Description: ${agent.description}\n` +
-        `- Scope: ${agent.scope}\n` +
-        `- Model: ${agent.model.providerId}/${agent.model.modelId}\n` +
+        header +
         `- Skills: ${skillNames || "none"}\n` +
         `- Tools: ${toolNames || "none"}\n\n` +
         "Instructions (full system prompt):\n" +

--- a/front/lib/api/actions/servers/workspace_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_management/tools/index.test.ts
@@ -89,15 +89,17 @@ async function callToolLines(
   return (await callTool(name, params, auth)).split("\n");
 }
 
+// An authenticator for a freshly created regular member of the workspace.
+async function createOtherMemberAuth(workspace: LightWorkspaceType) {
+  const agentOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, agentOwner, { role: "user" });
+  return Authenticator.fromUserIdAndWorkspaceId(agentOwner.sId, workspace.sId);
+}
+
 // Creates, as another workspace member, one published agent, one unpublished agent the caller
 // does not edit, and one published agent requesting a space the caller cannot read.
 async function setupOtherMembersAgents(workspace: LightWorkspaceType) {
-  const agentOwner = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, agentOwner, { role: "user" });
-  const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    agentOwner.sId,
-    workspace.sId
-  );
+  const agentOwnerAuth = await createOtherMemberAuth(workspace);
 
   const restrictedSpace = await SpaceFactory.regular(
     agentOwnerAuth.getNonNullableWorkspace()
@@ -309,6 +311,74 @@ describe("workspace_management tools", () => {
       );
 
       expect(text).toContain("No agent found");
+    });
+
+    it("redacts the private fields of an unpublished agent for a non-editor admin", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      const agentOwnerAuth = await createOtherMemberAuth(workspace);
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        agentOwnerAuth,
+        { name: "Unpublished Agent", scope: "hidden" }
+      );
+
+      const text = await callTool(
+        "get_agent_details",
+        { agentId: agent.sId },
+        authenticator
+      );
+
+      expect(text).toContain("Unpublished Agent");
+      expect(text).toContain(`Description: ${agent.description}`);
+      expect(text).toContain("private");
+      expect(text).not.toContain("Test Instructions");
+    });
+
+    it("redacts the private fields of an agent built on a space the admin cannot read", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      const agentOwnerAuth = await createOtherMemberAuth(workspace);
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        agentOwnerAuth,
+        {
+          name: "Restricted Space Agent",
+          scope: "visible",
+          requestedSpaceIds: [restrictedSpace.id],
+        }
+      );
+
+      const text = await callTool(
+        "get_agent_details",
+        { agentId: agent.sId },
+        authenticator
+      );
+
+      expect(text).toContain("Restricted Space Agent");
+      expect(text).toContain("private");
+      expect(text).not.toContain("Test Instructions");
+    });
+
+    it("does not reveal an unpublished agent to a non-editor member", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "user",
+      });
+      const agentOwnerAuth = await createOtherMemberAuth(workspace);
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        agentOwnerAuth,
+        { name: "Unpublished Agent", scope: "hidden" }
+      );
+
+      const text = await callTool(
+        "get_agent_details",
+        { agentId: agent.sId },
+        authenticator
+      );
+
+      expect(text).toContain("No agent found");
+      expect(text).not.toContain("Unpublished Agent");
     });
   });
 


### PR DESCRIPTION
## Description

In the `workspace_management` MCP, `list_agents` with `all_unrestricted` already lists every agent for admins, but `get_agent_details` was inconsistent with it:

- agents built on a space the admin is not a member of came back as "no agent found";
- unpublished agents the admin does not edit came back with a hand-written partial view that hid the description, which admins may see.

`get_agent_details` now uses `getAgentConfigurationForDetails`, the same fetcher as the agent details endpoint (#31770, merged). Admins get name, description, scope and model for agents they cannot read, with instructions, skills, tools and knowledge withheld and a line explaining why. There is no way to override this from the tool, and the tool description says so. Non-admins keep the not-found answer.

## Tests

 - Added three tool tests

## Risk

Low. Admin-only behavior change in one MCP tool, reusing the redaction already reviewed in #31770.

## Deploy Plan

- Deploy front

