### PR TITLE
Prodbox prompt shows the cell

### DIFF
--- a/prodbox/init.sh
+++ b/prodbox/init.sh
@@ -21,7 +21,7 @@ git remote set-url origin git@github.com:dust-tt/dust.git
 
 git pull origin main
 
-echo "export PS1='\[\e[0;31m\]prodbox(${REGION})\[\e[0m\]:\w\$ '" >> /root/.bashrc
+echo "export PS1='\[\e[0;31m\]prodbox(${REGION}${CELL:+ $CELL})\[\e[0m\]:\w\$ '" >> /root/.bashrc
 
 # This is the script used to start the container, so it needs to stay alive, otherwise the
 # kube pod (container) dies.


### PR DESCRIPTION
## Description

The prodbox prompt shows the cell next to the region, `prodbox(europe-west1 cell-00002):~$`. With cells arriving there will be several prodboxes per region and the prompt is the one thing you look at before typing into the wrong one. The pod already receives `CELL` from its topology label, same as `REGION`, so this is the prompt line only. When the label is absent the prompt stays as it is today, `prodbox(us-central1):~$`.

## Tests

Rendered the prompt line locally with and without `CELL` set. Both legacy prodbox pods carry the cell label (cell-00000, cell-00001), checked on the clusters.

## Risk

A prompt string. Rollback is a revert.

## Deploy Plan

Next prodbox deploy.
