### PR TITLE
Front uses Workload Identity for GCS when no key file is set

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -229,8 +229,8 @@ const config = {
   getPersonaApiKey: (): string => {
     return EnvironmentConfig.getEnvVariable("PERSONA_API_KEY");
   },
-  getServiceAccount: (): string => {
-    return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
+  getServiceAccount: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("SERVICE_ACCOUNT");
   },
   getPostHogApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("NEXT_PUBLIC_POSTHOG_KEY");

--- a/front/lib/file_storage/config.ts
+++ b/front/lib/file_storage/config.ts
@@ -1,8 +1,9 @@
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
 const config = {
-  getServiceAccount: (): string => {
-    return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
+  // Key file path. Unset means Application Default Credentials, Workload Identity on GKE.
+  getServiceAccount: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("SERVICE_ACCOUNT");
   },
   getGcsPublicUploadBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_UPLOAD_BUCKET");

--- a/front/temporal/config.ts
+++ b/front/temporal/config.ts
@@ -4,8 +4,8 @@ const config = {
   getUpsertQueueBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_UPSERT_QUEUE_BUCKET");
   },
-  getServiceAccount: (): string => {
-    return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
+  getServiceAccount: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("SERVICE_ACCOUNT");
   },
 };
 

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -51,10 +51,6 @@ export async function upsertDocumentActivity(
   if (!DUST_UPSERT_QUEUE_BUCKET) {
     throw new Error("DUST_UPSERT_QUEUE_BUCKET is not set");
   }
-  if (!SERVICE_ACCOUNT) {
-    throw new Error("SERVICE_ACCOUNT is not set");
-  }
-
   const storage = new Storage({ keyFilename: SERVICE_ACCOUNT });
   const bucket = storage.bucket(DUST_UPSERT_QUEUE_BUCKET);
   // GCS bucket.file().download() returns a `DownloadResponse = [Buffer]` — it's defined as a tuple with exactly one element.


### PR DESCRIPTION
## Description

Front can talk to GCS with Application Default Credentials, which on GKE means the Workload Identity of the pod. Today every GCS client in front is built with `keyFilename` set from the `SERVICE_ACCOUNT` env, and the three accessors behind it throw when the variable is missing. So a pod without a mounted key file cannot start, even though the pod already has a Workload Identity annotation and connectors has used ADC in production for a long time.

The change makes `SERVICE_ACCOUNT` optional. When it is set, nothing changes: the key file is used exactly as before. When it is unset, `keyFilename` is `undefined` and the Google client libraries fall back to ADC on their own. This covers the `FileStorage` class, the sandbox downscoped token minting, the upsert queue and upsert tables activities, and the relocation storage transfer client, all of which read the same accessor. The upsert queue activity also drops its explicit "SERVICE_ACCOUNT is not set" guard.

The consumer is the new cells, where nothing mounts a key: the pod runs as `front-<cell>` and that identity carries the storage roles and `iam.serviceAccountTokenCreator` for signed URLs. Legacy keeps its key until it is deliberately removed there.

## Tests

## Risk

None on the legacy regions, `SERVICE_ACCOUNT` stays set there and the code path with a key is untouched. A cell pod running without the storage roles or without `iam.serviceAccountTokenCreator` fails on the first upload or signed URL with a clear IAM error rather than at boot. Rollback is a revert.

## Deploy Plan

Deploy front normally. Nothing to do on legacy. On a cell, do not set `SERVICE_ACCOUNT` in the front bundle, and grant the front identity the storage roles plus `iam.serviceAccountTokenCreator` on the infra side.
