### PR TITLE
Poke: hide credit-pool cards and previous-cycles table for legacy no-pool workspaces

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -23,6 +23,7 @@ import {
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeGroups } from "@app/poke/swr/groups";
 import { usePokeAllowedModelTiers } from "@app/poke/swr/model_tiers";
+import { usePokeWorkspaceInfo } from "@app/poke/swr/workspace_info";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { isCapEligibleGroupKind } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -31,6 +32,7 @@ import {
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
+import { isCreditPricedPlan } from "@app/types/plan";
 import {
   AlertCircle,
   Button,
@@ -189,6 +191,18 @@ export function PoolUsagePage() {
 
   const { awuPoolCurrentCycle } = usePokeAwuPoolCurrentCycle({ owner });
   const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
+
+  const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
+  const activeSubscription = workspaceInfo?.activeSubscription;
+  const hasMetronomeContract = activeSubscription?.metronomeContractId != null;
+  const isLegacyPremiumMessagePlan =
+    !!activeSubscription && !isCreditPricedPlan(activeSubscription.plan);
+  // Users with no pool and no Metronome contract on a legacy plan only have
+  // a premium-message rate limit — no pool/Metronome usage to show. The pool
+  // cards and previous-cycles table would just render empty for them.
+  const isLegacyWithoutPoolOrMetronome =
+    isLegacyPremiumMessagePlan && !hasPool && !hasMetronomeContract;
+  const showPoolSection = !isLegacyWithoutPoolOrMetronome;
 
   const {
     members,
@@ -349,7 +363,7 @@ export function PoolUsagePage() {
       />
 
       <div className="flex flex-col items-stretch gap-10 py-6 pb-20">
-        <PoolCreditCard owner={owner} />
+        {showPoolSection && <PoolCreditCard owner={owner} />}
 
         <Tabs defaultValue="members">
           <TabsList className="mb-4">


### PR DESCRIPTION
Workspaces with no active credit pool, no Metronome contract, and a legacy
(non credit-priced) plan only enforce a premium-message rate limit — there's
no pool or Metronome usage to show, so the header cards and previous-cycles
table just rendered empty for them.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
