### PR TITLE
Poke: replace credit usage with premium message usage for legacy no-pool workspaces

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -198,12 +198,6 @@ export function PoolUsagePage() {
 
   const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
   const activeSubscription = workspaceInfo?.activeSubscription;
-  // Many legacy (non credit-priced) workspaces still carry a Metronome
-  // contract used only for usage diagnostics (Stripe stays the billing
-  // source of truth), so a raw `metronomeContractId !== null` check matches
-  // almost every legacy workspace. `isSubscriptionMetronomeBilled` excludes
-  // those Stripe-billed shadow contracts and only reports a real,
-  // billing-active Metronome contract.
   const hasMetronomeContract =
     !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
   const isLegacyPremiumMessagePlan =
@@ -213,9 +207,6 @@ export function PoolUsagePage() {
   // cards and previous-cycles table would just render empty for them.
   const isLegacyWithoutPoolOrMetronome =
     isLegacyPremiumMessagePlan && !hasMetronomeContract;
-  // Default to hidden until the subscription loads, so the pool-cycle
-  // endpoints (which 400 for workspaces with no real Metronome contract)
-  // aren't fetched before we know whether this workspace has one.
   const showPoolSection =
     !!activeSubscription && !isLegacyWithoutPoolOrMetronome;
 
@@ -225,9 +216,6 @@ export function PoolUsagePage() {
   });
   const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
 
-  // Apply the "premium message usage" default sort once, the first time we
-  // learn this workspace is legacy-without-pool — without clobbering a sort
-  // the user picks afterwards.
   const hasAppliedDefaultSortRef = useRef(false);
   useEffect(() => {
     if (hasAppliedDefaultSortRef.current || !activeSubscription) {

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -155,9 +155,6 @@ export function PoolUsagePage() {
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
-  // Empty until the user picks a column: the default depends on
-  // `isLegacyWithoutPoolOrMetronome`, which is derived below once workspace
-  // info has loaded.
   const [sorting, setSorting] = useState<SortingState>([]);
 
   // Debounce the search input, and reset to the first page on a new query.

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -33,7 +33,10 @@ import {
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
-import { isCreditPricedPlan } from "@app/types/plan";
+import {
+  isCreditPricedPlan,
+  isSubscriptionMetronomeBilled,
+} from "@app/types/plan";
 import {
   AlertCircle,
   Button,
@@ -193,20 +196,34 @@ export function PoolUsagePage() {
       : "name";
   const orderDirection = sort?.desc ? "desc" : "asc";
 
-  const { awuPoolCurrentCycle } = usePokeAwuPoolCurrentCycle({ owner });
-  const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
-
   const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
   const activeSubscription = workspaceInfo?.activeSubscription;
-  const hasMetronomeContract = activeSubscription?.metronomeContractId != null;
+  // Many legacy (non credit-priced) workspaces still carry a Metronome
+  // contract used only for usage diagnostics (Stripe stays the billing
+  // source of truth), so a raw `metronomeContractId !== null` check matches
+  // almost every legacy workspace. `isSubscriptionMetronomeBilled` excludes
+  // those Stripe-billed shadow contracts and only reports a real,
+  // billing-active Metronome contract.
+  const hasMetronomeContract =
+    !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
   const isLegacyPremiumMessagePlan =
     !!activeSubscription && !isCreditPricedPlan(activeSubscription.plan);
   // Users with no pool and no Metronome contract on a legacy plan only have
   // a premium-message rate limit — no pool/Metronome usage to show. The pool
   // cards and previous-cycles table would just render empty for them.
   const isLegacyWithoutPoolOrMetronome =
-    isLegacyPremiumMessagePlan && !hasPool && !hasMetronomeContract;
-  const showPoolSection = !isLegacyWithoutPoolOrMetronome;
+    isLegacyPremiumMessagePlan && !hasMetronomeContract;
+  // Default to hidden until the subscription loads, so the pool-cycle
+  // endpoints (which 400 for workspaces with no real Metronome contract)
+  // aren't fetched before we know whether this workspace has one.
+  const showPoolSection =
+    !!activeSubscription && !isLegacyWithoutPoolOrMetronome;
+
+  const { awuPoolCurrentCycle } = usePokeAwuPoolCurrentCycle({
+    owner,
+    disabled: !showPoolSection,
+  });
+  const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
 
   // Apply the "premium message usage" default sort once, the first time we
   // learn this workspace is legacy-without-pool — without clobbering a sort

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -53,7 +53,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -187,7 +187,8 @@ export function PoolUsagePage() {
   const orderColumn =
     sort?.id === "email" ||
     sort?.id === "consumedFromPoolAwuCredits" ||
-    sort?.id === "seatUsage"
+    sort?.id === "seatUsage" ||
+    sort?.id === "premiumMessageUsage"
       ? sort.id
       : "name";
   const orderDirection = sort?.desc ? "desc" : "asc";
@@ -206,6 +207,20 @@ export function PoolUsagePage() {
   const isLegacyWithoutPoolOrMetronome =
     isLegacyPremiumMessagePlan && !hasPool && !hasMetronomeContract;
   const showPoolSection = !isLegacyWithoutPoolOrMetronome;
+
+  // Apply the "premium message usage" default sort once, the first time we
+  // learn this workspace is legacy-without-pool — without clobbering a sort
+  // the user picks afterwards.
+  const hasAppliedDefaultSortRef = useRef(false);
+  useEffect(() => {
+    if (hasAppliedDefaultSortRef.current || !activeSubscription) {
+      return;
+    }
+    hasAppliedDefaultSortRef.current = true;
+    if (isLegacyWithoutPoolOrMetronome) {
+      setSorting([{ id: "premiumMessageUsage", desc: true }]);
+    }
+  }, [activeSubscription, isLegacyWithoutPoolOrMetronome]);
 
   const {
     members,
@@ -417,6 +432,7 @@ export function PoolUsagePage() {
                   isSeatBased
                   showSpendLimit
                   hasPool={hasPool}
+                  showPremiumMessageUsage={isLegacyWithoutPoolOrMetronome}
                   readOnly
                   onChangeSeat={noopOnMember}
                   onOpenChangeSeatRecap={setChangeSeatRecapMember}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -190,9 +190,6 @@ export function PoolUsagePage() {
     !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
   const isLegacyPremiumMessagePlan =
     !!activeSubscription && !isCreditPricedPlan(activeSubscription.plan);
-  // Users with no pool and no Metronome contract on a legacy plan only have
-  // a premium-message rate limit — no pool/Metronome usage to show. The pool
-  // cards and previous-cycles table would just render empty for them.
   const isLegacyWithoutPoolOrMetronome =
     isLegacyPremiumMessagePlan && !hasMetronomeContract;
   const showPoolSection =

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -56,7 +56,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -155,9 +155,10 @@ export function PoolUsagePage() {
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: "consumedFromPoolAwuCredits", desc: true },
-  ]);
+  // Empty until the user picks a column: the default depends on
+  // `isLegacyWithoutPoolOrMetronome`, which is derived below once workspace
+  // info has loaded.
+  const [sorting, setSorting] = useState<SortingState>([]);
 
   // Debounce the search input, and reset to the first page on a new query.
   useEffect(() => {
@@ -186,16 +187,6 @@ export function PoolUsagePage() {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
-  const sort = sorting[0];
-  const orderColumn =
-    sort?.id === "email" ||
-    sort?.id === "consumedFromPoolAwuCredits" ||
-    sort?.id === "seatUsage" ||
-    sort?.id === "premiumMessageUsage"
-      ? sort.id
-      : "name";
-  const orderDirection = sort?.desc ? "desc" : "asc";
-
   const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
   const activeSubscription = workspaceInfo?.activeSubscription;
   const hasMetronomeContract =
@@ -216,16 +207,22 @@ export function PoolUsagePage() {
   });
   const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
 
-  const hasAppliedDefaultSortRef = useRef(false);
-  useEffect(() => {
-    if (hasAppliedDefaultSortRef.current || !activeSubscription) {
-      return;
-    }
-    hasAppliedDefaultSortRef.current = true;
-    if (isLegacyWithoutPoolOrMetronome) {
-      setSorting([{ id: "premiumMessageUsage", desc: true }]);
-    }
-  }, [activeSubscription, isLegacyWithoutPoolOrMetronome]);
+  // Sort by premium message usage for legacy no-pool workspaces, by pool
+  // credits otherwise, until the user picks a column explicitly.
+  const defaultSortId = isLegacyWithoutPoolOrMetronome
+    ? "premiumMessageUsage"
+    : "consumedFromPoolAwuCredits";
+  const effectiveSorting: SortingState =
+    sorting.length > 0 ? sorting : [{ id: defaultSortId, desc: true }];
+  const sort = effectiveSorting[0];
+  const orderColumn =
+    sort?.id === "email" ||
+    sort?.id === "consumedFromPoolAwuCredits" ||
+    sort?.id === "seatUsage" ||
+    sort?.id === "premiumMessageUsage"
+      ? sort.id
+      : "name";
+  const orderDirection = sort?.desc ? "desc" : "asc";
 
   const {
     members,
@@ -448,7 +445,7 @@ export function PoolUsagePage() {
                   pagination={pagination}
                   setPagination={setPagination}
                   totalRowCount={totalMembers}
-                  sorting={sorting}
+                  sorting={effectiveSorting}
                   setSorting={handleSetSorting}
                   variant="compact"
                   showGroupsColumn={false}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -13,6 +13,7 @@ import {
   OVER_POOL_LIMIT_BAR_CLASSES,
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
+import type { PremiumModelMessageUsage } from "@app/lib/api/assistant/rate_limits";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
@@ -113,6 +114,7 @@ type RowData = {
   canUpgradeSeat: boolean;
   onOpenChangeSeatRecap: () => void;
   onOpenSpendLimitRecap: () => void;
+  premiumMessageUsage: PremiumModelMessageUsage | null;
   modelTiersSummary: string;
   hasUserLevelModelTiersOverride: boolean;
   menuItems: MenuItem[];
@@ -747,6 +749,48 @@ function buildPoolCreditUsageColumn(
   };
 }
 
+// Legacy (non credit-priced) plans have no AWU credit pool — they enforce a
+// weekly rate limit on premium-tier-model messages instead. This replaces
+// `buildPoolCreditUsageColumn` for those workspaces.
+const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
+  id: "premiumMessageUsage" as const,
+  header: () => (
+    <span className="flex items-center gap-1">
+      <Icon visual={CoinsStacked03} size="xs" />
+      Premium messages
+    </span>
+  ),
+  accessorFn: (row) => (row.premiumMessageUsage?.usedMessages ?? 0).toString(),
+  cell: (info: Info) => {
+    const usage = info.row.original.premiumMessageUsage;
+    if (!usage) {
+      return (
+        <DataTable.CellContent className="justify-center">
+          <span className="text-sm text-muted-foreground">--</span>
+        </DataTable.CellContent>
+      );
+    }
+    return (
+      <DataTable.CellContent className="justify-center">
+        <Tooltip
+          tooltipTriggerAsChild
+          label={`${usage.usedMessages} / ${usage.limitMessages} premium messages used this week`}
+          trigger={
+            <span className="text-xs font-medium text-muted-foreground">
+              {usage.usedMessages} / {usage.limitMessages}
+            </span>
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  enableSorting: true,
+  meta: {
+    className: "w-32",
+    headerAlign: "center",
+  },
+};
+
 const offPaceColumn: ColumnDef<RowData, string> = {
   id: "overallUsageTarget" as const,
   header: "",
@@ -911,10 +955,12 @@ function buildCreditPlanColumns({
   creditsResetAt,
   variant,
   hasPool,
+  showPremiumMessageUsage,
 }: {
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
   hasPool: boolean;
+  showPremiumMessageUsage: boolean;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(() => {
@@ -929,10 +975,16 @@ function buildCreditPlanColumns({
       }
     })(),
     {
-      ...buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool),
+      ...(showPremiumMessageUsage
+        ? premiumMessageUsageColumn
+        : buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool)),
       meta: { className: "w-56" },
     },
-    ...(variant === "compact" ? [offPaceColumn] : []),
+    // The pace-warning/unblock column reads the credit-pool pacing, which
+    // doesn't exist for premium-message-only legacy workspaces.
+    ...(variant === "compact" && !showPremiumMessageUsage
+      ? [offPaceColumn]
+      : []),
   ];
 }
 
@@ -944,6 +996,7 @@ function buildColumns({
   creditsResetAt,
   variant,
   hasPool,
+  showPremiumMessageUsage,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
@@ -952,6 +1005,7 @@ function buildColumns({
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
   hasPool: boolean;
+  showPremiumMessageUsage: boolean;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
@@ -959,7 +1013,12 @@ function buildColumns({
     ...(showGroupsColumn ? [groupsColumn] : []),
     ...(showModelTiersColumn ? [buildModelTiersColumn(variant)] : []),
     ...(showSeatAndCredits
-      ? buildCreditPlanColumns({ creditsResetAt, variant, hasPool })
+      ? buildCreditPlanColumns({
+          creditsResetAt,
+          variant,
+          hasPool,
+          showPremiumMessageUsage,
+        })
       : []),
     // Every row action belongs to one of these two groups.
     ...(showSeatAndCredits || showModelTiersColumn ? [actionsColumn] : []),
@@ -1018,6 +1077,10 @@ interface MembersUsageTableProps {
   // Whether the workspace has an active credit pool. Only affects the
   // "compact" (poke) variant's credit column header.
   hasPool?: boolean;
+  // Legacy (non credit-priced) workspaces with no pool or Metronome
+  // contract: swaps the credit-pool column for a premium-message-usage
+  // column, and hides the credit-pace warning column.
+  showPremiumMessageUsage?: boolean;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
   userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
   groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
@@ -1057,6 +1120,7 @@ export function MembersUsageTable({
   showModelTiersColumn = false,
   variant = "legacy",
   hasPool = true,
+  showPremiumMessageUsage = false,
   userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
   userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
   groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
@@ -1115,6 +1179,7 @@ export function MembersUsageTable({
           canUpgradeSeat: canUpgradeSeat(m),
           onOpenChangeSeatRecap: () => onOpenChangeSeatRecap(m),
           onOpenSpendLimitRecap: () => onOpenSpendLimitRecap(m),
+          premiumMessageUsage: m.premiumMessageUsage ?? null,
           modelTiersSummary: (() => {
             const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
             switch (variant) {
@@ -1238,6 +1303,7 @@ export function MembersUsageTable({
         creditsResetAt,
         variant,
         hasPool,
+        showPremiumMessageUsage,
       }),
     [
       enableSelection,
@@ -1247,6 +1313,7 @@ export function MembersUsageTable({
       creditsResetAt,
       variant,
       hasPool,
+      showPremiumMessageUsage,
     ]
   );
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -57,6 +57,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Icon,
+  InfoCircle,
   LoadingBlock,
   ProgressBar,
   Spinner,
@@ -755,6 +756,10 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
     <span className="flex items-center gap-1">
       <Icon visual={CoinsStacked03} size="xs" />
       Premium messages
+      <Tooltip
+        trigger={<Icon visual={InfoCircle} size="xs" />}
+        label="Usage is capped over a rolling 7-day window: each message frees up its slot 7 days after it was sent, not all at once."
+      />
     </span>
   ),
   accessorFn: (row) => (row.premiumMessageUsage?.usedMessages ?? 0).toString(),
@@ -767,7 +772,7 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         </DataTable.CellContent>
       );
     }
-    const { usedMessages, limitMessages, nextRefill } = usage;
+    const { usedMessages, limitMessages, nextRefill, refillSchedule } = usage;
     const percentage =
       limitMessages > 0
         ? Math.min(100, (usedMessages / limitMessages) * 100)
@@ -802,14 +807,33 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
           />
         </div>
         {nextRefill && (
-          <span className="text-xs font-normal text-muted-foreground">
-            +{nextRefill.messages} on{" "}
-            {new Date(nextRefill.availableAt).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              timeZone: "UTC",
-            })}
-          </span>
+          <Tooltip
+            tooltipTriggerAsChild
+            trigger={
+              <span className="w-fit cursor-help text-xs font-normal text-muted-foreground">
+                +{nextRefill.messages} on{" "}
+                {new Date(nextRefill.availableAt).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  timeZone: "UTC",
+                })}
+              </span>
+            }
+            label={
+              <div className="flex flex-col gap-0.5">
+                {(refillSchedule ?? []).map(({ date, messages }) => (
+                  <span key={date}>
+                    {new Date(date).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      timeZone: "UTC",
+                    })}
+                    : +{messages}
+                  </span>
+                ))}
+              </div>
+            }
+          />
         )}
       </div>
     );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -772,7 +772,7 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         </DataTable.CellContent>
       );
     }
-    const { usedMessages, limitMessages, nextRefill, refillSchedule } = usage;
+    const { usedMessages, limitMessages, refillSchedule } = usage;
     const percentage =
       limitMessages > 0
         ? Math.min(100, (usedMessages / limitMessages) * 100)
@@ -781,47 +781,43 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
           : 0;
     const isOverLimit = usedMessages > limitMessages;
     const isAtLimit = limitMessages > 0 && usedMessages === limitMessages;
+    const bar = (
+      <ProgressBar
+        aria-label="Premium message usage"
+        aria-valuenow={percentage}
+        aria-valuetext={`${usedMessages} of ${limitMessages} premium messages used this week`}
+        className="h-1 w-full gap-px bg-transparent"
+        values={[
+          {
+            value: percentage,
+            className: isOverLimit
+              ? OVER_POOL_LIMIT_BAR_CLASSES.fill
+              : isAtLimit
+                ? AT_POOL_LIMIT_BAR_CLASSES.fill
+                : MUTED_BAR_CLASSES.fill,
+          },
+          { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
+        ]}
+      />
+    );
     return (
       <div className="flex w-full flex-col gap-1 pr-3">
         <div className="flex justify-between text-xs tabular-nums text-foreground">
           <span>{usedMessages}</span>
           <span>{limitMessages}</span>
         </div>
-        <div className="flex h-3 w-full items-center">
-          <ProgressBar
-            aria-label="Premium message usage"
-            aria-valuenow={percentage}
-            aria-valuetext={`${usedMessages} of ${limitMessages} premium messages used this week`}
-            className="h-1 w-full gap-px bg-transparent"
-            values={[
-              {
-                value: percentage,
-                className: isOverLimit
-                  ? OVER_POOL_LIMIT_BAR_CLASSES.fill
-                  : isAtLimit
-                    ? AT_POOL_LIMIT_BAR_CLASSES.fill
-                    : MUTED_BAR_CLASSES.fill,
-              },
-              { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
-            ]}
-          />
-        </div>
-        {nextRefill && (
+        {refillSchedule && refillSchedule.length > 0 ? (
           <Tooltip
             tooltipTriggerAsChild
             trigger={
-              <span className="w-fit cursor-help text-xs font-normal text-muted-foreground">
-                +{nextRefill.messages} on{" "}
-                {new Date(nextRefill.availableAt).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  timeZone: "UTC",
-                })}
-              </span>
+              <div className="flex h-3 w-full cursor-help items-center">
+                {bar}
+              </div>
             }
             label={
               <div className="flex flex-col gap-0.5">
-                {(refillSchedule ?? []).map(({ date, messages }) => (
+                <span className="font-medium">Reset schedule:</span>
+                {refillSchedule.map(({ date, messages }) => (
                   <span key={date}>
                     {new Date(date).toLocaleDateString("en-US", {
                       month: "short",
@@ -834,6 +830,8 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
               </div>
             }
           />
+        ) : (
+          <div className="flex h-3 w-full items-center">{bar}</div>
         )}
       </div>
     );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -752,15 +752,10 @@ function buildPoolCreditUsageColumn(
 const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
   id: "premiumMessageUsage" as const,
   header: () => (
-    <div className="flex flex-col">
-      <span className="flex items-center gap-1">
-        <Icon visual={CoinsStacked03} size="xs" />
-        Premium messages
-      </span>
-      <span className="text-xs font-normal text-muted-foreground">
-        Resets weekly
-      </span>
-    </div>
+    <span className="flex items-center gap-1">
+      <Icon visual={CoinsStacked03} size="xs" />
+      Premium messages
+    </span>
   ),
   accessorFn: (row) => (row.premiumMessageUsage?.usedMessages ?? 0).toString(),
   cell: (info: Info) => {
@@ -772,7 +767,7 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         </DataTable.CellContent>
       );
     }
-    const { usedMessages, limitMessages } = usage;
+    const { usedMessages, limitMessages, nextRefill } = usage;
     const percentage =
       limitMessages > 0
         ? Math.min(100, (usedMessages / limitMessages) * 100)
@@ -806,6 +801,16 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
             ]}
           />
         </div>
+        {nextRefill && (
+          <span className="text-xs font-normal text-muted-foreground">
+            +{nextRefill.messages} on{" "}
+            {new Date(nextRefill.availableAt).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              timeZone: "UTC",
+            })}
+          </span>
+        )}
       </div>
     );
   },

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -91,6 +91,8 @@ const EMPTY_MODEL_TIER_DEFINITION_BY_NAME = new Map<
 const NOOP_ON_MEMBER = (_member: MemberUsageType) => {};
 const ALWAYS_CAN_UPGRADE_SEAT = (_member: MemberUsageType) => true;
 
+const DEFAULT_PREMIUM_MESSAGE_WINDOW_DAYS = 7;
+
 type RowData = {
   sId: string;
   name: string;
@@ -750,91 +752,96 @@ function buildPoolCreditUsageColumn(
   };
 }
 
-const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
-  id: "premiumMessageUsage" as const,
-  header: () => (
-    <span className="flex items-center gap-1">
-      <Icon visual={CoinsStacked03} size="xs" />
-      Premium messages
-      <Tooltip
-        trigger={<Icon visual={InfoCircle} size="xs" />}
-        label="Usage is capped over a rolling 7-day window: each message frees up its slot 7 days after it was sent, not all at once."
-      />
-    </span>
-  ),
-  accessorFn: (row) => (row.premiumMessageUsage?.usedMessages ?? 0).toString(),
-  cell: (info: Info) => {
-    const usage = info.row.original.premiumMessageUsage;
-    if (!usage) {
-      return (
-        <DataTable.CellContent className="justify-center">
-          <span className="text-sm text-muted-foreground">--</span>
-        </DataTable.CellContent>
+function buildPremiumMessageUsageColumn(
+  windowDays: number
+): ColumnDef<RowData, string> {
+  return {
+    id: "premiumMessageUsage" as const,
+    header: () => (
+      <span className="flex items-center gap-1">
+        <Icon visual={CoinsStacked03} size="xs" />
+        Premium messages
+        <Tooltip
+          trigger={<Icon visual={InfoCircle} size="xs" />}
+          label={`Usage is capped over a rolling ${windowDays}-day window: each message frees up its slot ${windowDays} days after it was sent, not all at once.`}
+        />
+      </span>
+    ),
+    accessorFn: (row) =>
+      (row.premiumMessageUsage?.usedMessages ?? 0).toString(),
+    cell: (info: Info) => {
+      const usage = info.row.original.premiumMessageUsage;
+      if (!usage) {
+        return (
+          <DataTable.CellContent className="justify-center">
+            <span className="text-sm text-muted-foreground">--</span>
+          </DataTable.CellContent>
+        );
+      }
+      const { usedMessages, limitMessages, windowDays, refillSchedule } = usage;
+      const percentage =
+        limitMessages > 0
+          ? Math.min(100, (usedMessages / limitMessages) * 100)
+          : usedMessages > 0
+            ? 100
+            : 0;
+      const isAtLimit = limitMessages > 0 && usedMessages === limitMessages;
+      const bar = (
+        <ProgressBar
+          aria-label="Premium message usage"
+          aria-valuenow={percentage}
+          aria-valuetext={`${usedMessages} of ${limitMessages} premium messages used over the last ${windowDays} days`}
+          className="h-1 w-full gap-px bg-transparent"
+          values={[
+            {
+              value: percentage,
+              className: isAtLimit
+                ? AT_POOL_LIMIT_BAR_CLASSES.fill
+                : MUTED_BAR_CLASSES.fill,
+            },
+            { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
+          ]}
+        />
       );
-    }
-    const { usedMessages, limitMessages, refillSchedule } = usage;
-    const percentage =
-      limitMessages > 0
-        ? Math.min(100, (usedMessages / limitMessages) * 100)
-        : usedMessages > 0
-          ? 100
-          : 0;
-    const isAtLimit = limitMessages > 0 && usedMessages === limitMessages;
-    const bar = (
-      <ProgressBar
-        aria-label="Premium message usage"
-        aria-valuenow={percentage}
-        aria-valuetext={`${usedMessages} of ${limitMessages} premium messages used this week`}
-        className="h-1 w-full gap-px bg-transparent"
-        values={[
-          {
-            value: percentage,
-            className: isAtLimit
-              ? AT_POOL_LIMIT_BAR_CLASSES.fill
-              : MUTED_BAR_CLASSES.fill,
-          },
-          { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
-        ]}
-      />
-    );
-    return (
-      <div className="flex w-full flex-col gap-1 pr-3">
-        <div className="flex justify-between text-xs tabular-nums text-foreground">
-          <span>{usedMessages}</span>
-          <span>{limitMessages}</span>
+      return (
+        <div className="flex w-full flex-col gap-1 pr-3">
+          <div className="flex justify-between text-xs tabular-nums text-foreground">
+            <span>{usedMessages}</span>
+            <span>{limitMessages}</span>
+          </div>
+          {refillSchedule && refillSchedule.length > 0 ? (
+            <Tooltip
+              tooltipTriggerAsChild
+              trigger={
+                <div className="flex h-3 w-full cursor-help items-center">
+                  {bar}
+                </div>
+              }
+              label={
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-medium">Reset schedule:</span>
+                  {refillSchedule.map(({ date, messages }) => (
+                    <span key={date}>
+                      {new Date(date).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        timeZone: "UTC",
+                      })}
+                      : +{messages}
+                    </span>
+                  ))}
+                </div>
+              }
+            />
+          ) : (
+            <div className="flex h-3 w-full items-center">{bar}</div>
+          )}
         </div>
-        {refillSchedule && refillSchedule.length > 0 ? (
-          <Tooltip
-            tooltipTriggerAsChild
-            trigger={
-              <div className="flex h-3 w-full cursor-help items-center">
-                {bar}
-              </div>
-            }
-            label={
-              <div className="flex flex-col gap-0.5">
-                <span className="font-medium">Reset schedule:</span>
-                {refillSchedule.map(({ date, messages }) => (
-                  <span key={date}>
-                    {new Date(date).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      timeZone: "UTC",
-                    })}
-                    : +{messages}
-                  </span>
-                ))}
-              </div>
-            }
-          />
-        ) : (
-          <div className="flex h-3 w-full items-center">{bar}</div>
-        )}
-      </div>
-    );
-  },
-  enableSorting: true,
-};
+      );
+    },
+    enableSorting: true,
+  };
+}
 
 const offPaceColumn: ColumnDef<RowData, string> = {
   id: "overallUsageTarget" as const,
@@ -1001,11 +1008,13 @@ function buildCreditPlanColumns({
   variant,
   hasPool,
   showPremiumMessageUsage,
+  premiumMessageWindowDays,
 }: {
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
   hasPool: boolean;
   showPremiumMessageUsage: boolean;
+  premiumMessageWindowDays: number;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(() => {
@@ -1021,7 +1030,7 @@ function buildCreditPlanColumns({
     })(),
     {
       ...(showPremiumMessageUsage
-        ? premiumMessageUsageColumn
+        ? buildPremiumMessageUsageColumn(premiumMessageWindowDays)
         : buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool)),
       meta: { className: "w-56" },
     },
@@ -1040,6 +1049,7 @@ function buildColumns({
   variant,
   hasPool,
   showPremiumMessageUsage,
+  premiumMessageWindowDays,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
@@ -1049,6 +1059,7 @@ function buildColumns({
   variant: MembersUsageTableVariant;
   hasPool: boolean;
   showPremiumMessageUsage: boolean;
+  premiumMessageWindowDays: number;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
@@ -1061,6 +1072,7 @@ function buildColumns({
           variant,
           hasPool,
           showPremiumMessageUsage,
+          premiumMessageWindowDays,
         })
       : []),
     // Every row action belongs to one of these two groups.
@@ -1333,6 +1345,12 @@ export function MembersUsageTable({
     ]
   );
 
+  // All members share the same rolling-window configuration, so the first
+  // loaded usage payload's `windowDays` is representative of the whole table.
+  const premiumMessageWindowDays =
+    members.find((m) => m.premiumMessageUsage)?.premiumMessageUsage
+      ?.windowDays ?? DEFAULT_PREMIUM_MESSAGE_WINDOW_DAYS;
+
   const columns = useMemo(
     () =>
       buildColumns({
@@ -1344,6 +1362,7 @@ export function MembersUsageTable({
         variant,
         hasPool,
         showPremiumMessageUsage,
+        premiumMessageWindowDays,
       }),
     [
       enableSelection,
@@ -1353,6 +1372,7 @@ export function MembersUsageTable({
       creditsResetAt,
       variant,
       hasPool,
+      premiumMessageWindowDays,
       showPremiumMessageUsage,
     ]
   );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -749,9 +749,6 @@ function buildPoolCreditUsageColumn(
   };
 }
 
-// Legacy (non credit-priced) plans have no AWU credit pool — they enforce a
-// weekly rate limit on premium-tier-model messages instead. This replaces
-// `buildPoolCreditUsageColumn` for those workspaces.
 const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
   id: "premiumMessageUsage" as const,
   header: () => (
@@ -1101,9 +1098,6 @@ interface MembersUsageTableProps {
   // Whether the workspace has an active credit pool. Only affects the
   // "compact" (poke) variant's credit column header.
   hasPool?: boolean;
-  // Legacy (non credit-priced) workspaces with no pool or Metronome
-  // contract: swaps the credit-pool column for a premium-message-usage
-  // column, and hides the credit-pace warning column.
   showPremiumMessageUsage?: boolean;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
   userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -779,7 +779,9 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         : usedMessages > 0
           ? 100
           : 0;
-    const isOverLimit = usedMessages > limitMessages;
+    // `usedMessages` can never exceed `limitMessages`: both derive from the
+    // same rate-limit constant, and the backend caps the counted timestamps
+    // at that limit. No "over limit" state to render, only "at limit".
     const isAtLimit = limitMessages > 0 && usedMessages === limitMessages;
     const bar = (
       <ProgressBar
@@ -790,11 +792,9 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         values={[
           {
             value: percentage,
-            className: isOverLimit
-              ? OVER_POOL_LIMIT_BAR_CLASSES.fill
-              : isAtLimit
-                ? AT_POOL_LIMIT_BAR_CLASSES.fill
-                : MUTED_BAR_CLASSES.fill,
+            className: isAtLimit
+              ? AT_POOL_LIMIT_BAR_CLASSES.fill
+              : MUTED_BAR_CLASSES.fill,
           },
           { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
         ]}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -779,9 +779,6 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         : usedMessages > 0
           ? 100
           : 0;
-    // `usedMessages` can never exceed `limitMessages`: both derive from the
-    // same rate-limit constant, and the backend caps the counted timestamps
-    // at that limit. No "over limit" state to render, only "at limit".
     const isAtLimit = limitMessages > 0 && usedMessages === limitMessages;
     const bar = (
       <ProgressBar
@@ -1028,8 +1025,6 @@ function buildCreditPlanColumns({
         : buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool)),
       meta: { className: "w-56" },
     },
-    // The pace-warning/unblock column reads the credit-pool pacing, which
-    // doesn't exist for premium-message-only legacy workspaces.
     ...(variant === "compact" && !showPremiumMessageUsage
       ? [offPaceColumn]
       : []),

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -755,10 +755,15 @@ function buildPoolCreditUsageColumn(
 const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
   id: "premiumMessageUsage" as const,
   header: () => (
-    <span className="flex items-center gap-1">
-      <Icon visual={CoinsStacked03} size="xs" />
-      Premium messages
-    </span>
+    <div className="flex flex-col">
+      <span className="flex items-center gap-1">
+        <Icon visual={CoinsStacked03} size="xs" />
+        Premium messages
+      </span>
+      <span className="text-xs font-normal text-muted-foreground">
+        Resets weekly
+      </span>
+    </div>
   ),
   accessorFn: (row) => (row.premiumMessageUsage?.usedMessages ?? 0).toString(),
   cell: (info: Info) => {
@@ -770,25 +775,44 @@ const premiumMessageUsageColumn: ColumnDef<RowData, string> = {
         </DataTable.CellContent>
       );
     }
+    const { usedMessages, limitMessages } = usage;
+    const percentage =
+      limitMessages > 0
+        ? Math.min(100, (usedMessages / limitMessages) * 100)
+        : usedMessages > 0
+          ? 100
+          : 0;
+    const isOverLimit = usedMessages > limitMessages;
+    const isAtLimit = limitMessages > 0 && usedMessages === limitMessages;
     return (
-      <DataTable.CellContent className="justify-center">
-        <Tooltip
-          tooltipTriggerAsChild
-          label={`${usage.usedMessages} / ${usage.limitMessages} premium messages used this week`}
-          trigger={
-            <span className="text-xs font-medium text-muted-foreground">
-              {usage.usedMessages} / {usage.limitMessages}
-            </span>
-          }
-        />
-      </DataTable.CellContent>
+      <div className="flex w-full flex-col gap-1 pr-3">
+        <div className="flex justify-between text-xs tabular-nums text-foreground">
+          <span>{usedMessages}</span>
+          <span>{limitMessages}</span>
+        </div>
+        <div className="flex h-3 w-full items-center">
+          <ProgressBar
+            aria-label="Premium message usage"
+            aria-valuenow={percentage}
+            aria-valuetext={`${usedMessages} of ${limitMessages} premium messages used this week`}
+            className="h-1 w-full gap-px bg-transparent"
+            values={[
+              {
+                value: percentage,
+                className: isOverLimit
+                  ? OVER_POOL_LIMIT_BAR_CLASSES.fill
+                  : isAtLimit
+                    ? AT_POOL_LIMIT_BAR_CLASSES.fill
+                    : MUTED_BAR_CLASSES.fill,
+              },
+              { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
+            ]}
+          />
+        </div>
+      </div>
     );
   },
   enableSorting: true,
-  meta: {
-    className: "w-32",
-    headerAlign: "center",
-  },
 };
 
 const offPaceColumn: ColumnDef<RowData, string> = {

--- a/front/lib/api/assistant/rate_limits.test.ts
+++ b/front/lib/api/assistant/rate_limits.test.ts
@@ -63,6 +63,11 @@ describe("getPremiumModelMessageUsage", () => {
         { date: "2026-08-25", usedMessages: 0 },
         { date: "2026-08-26", usedMessages: 1 },
       ],
+      refillSchedule: [
+        { date: "2026-08-26", messages: 1 },
+        { date: "2026-08-27", messages: 2 },
+        { date: "2026-09-02", messages: 1 },
+      ],
     });
   });
 
@@ -115,6 +120,7 @@ describe("getPremiumModelMessageUsage", () => {
         { date: "2026-08-25", usedMessages: 0 },
         { date: "2026-08-26", usedMessages: 0 },
       ],
+      refillSchedule: [],
     });
   });
 });

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -5,6 +5,7 @@ import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   expireRateLimiterKey,
   getRateLimiterCount,
+  getRateLimiterCounts,
   getRateLimiterTimestamps,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
@@ -227,6 +228,35 @@ export async function getPremiumModelMessageUsage({
     }),
     refillSchedule: getPremiumModelRefillSchedule({ timestampsMs, windowMs }),
   };
+}
+
+// Lean count-only counterpart to `getPremiumModelMessageUsage`, for ranking a
+// whole workspace by premium message usage (e.g. the poke sort column)
+// without paying for the refill schedule/timestamps of every member. Pipelines
+// every user's `ZCOUNT` into a single Redis round-trip.
+export async function getPremiumModelMessageUsedCountsByUser({
+  workspace,
+  users,
+}: {
+  workspace: Pick<LightWorkspaceType, "id">;
+  users: Pick<UserType, "id" | "sId">[];
+}): Promise<Map<string, number>> {
+  const keyByUserId = new Map(
+    users.map((user) => [
+      user.sId,
+      makePremiumModelMessageRateLimitKeyForUser(workspace, user),
+    ])
+  );
+
+  const result = await getRateLimiterCounts({
+    keys: Array.from(keyByUserId.values()),
+    timeframeSeconds: PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
+  });
+  const countByKey = result.isOk() ? result.value : new Map<string, number>();
+
+  return new Map(
+    Array.from(keyByUserId, ([sId, key]) => [sId, countByKey.get(key) ?? 0])
+  );
 }
 
 // Fixed-window counter backing the admin-configured per-user spend cap. Always

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -110,6 +110,10 @@ export type PremiumModelMessageUsage = {
   nextRefill?: { availableAt: string; messages: number } | null;
   // Optional for compatibility with clients deployed before the daily breakdown was added.
   dailyUsage?: { date: string; usedMessages: number }[];
+  // Upcoming refills grouped by the day each message ages out of the rolling
+  // window, chronologically ordered. Optional for compatibility with clients
+  // deployed before this was added.
+  refillSchedule?: { date: string; messages: number }[];
 };
 
 function getNextPremiumModelRefill({
@@ -134,6 +138,24 @@ function getNextPremiumModelRefill({
     availableAt: new Date(oldestTimestampMs + windowMs).toISOString(),
     messages,
   };
+}
+
+function getPremiumModelRefillSchedule({
+  timestampsMs,
+  windowMs,
+}: {
+  timestampsMs: number[];
+  windowMs: number;
+}): { date: string; messages: number }[] {
+  const messagesByRefillDay = new Map<string, number>();
+  for (const timestampMs of timestampsMs) {
+    const date = new Date(timestampMs + windowMs).toISOString().slice(0, 10);
+    messagesByRefillDay.set(date, (messagesByRefillDay.get(date) ?? 0) + 1);
+  }
+
+  return Array.from(messagesByRefillDay.entries())
+    .map(([date, messages]) => ({ date, messages }))
+    .sort((a, b) => a.date.localeCompare(b.date));
 }
 
 function getUtcDayStartMs(timestampMs: number): number {
@@ -203,6 +225,7 @@ export async function getPremiumModelMessageUsage({
       windowStartMs,
       windowEndMs,
     }),
+    refillSchedule: getPremiumModelRefillSchedule({ timestampsMs, windowMs }),
   };
 }
 

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -111,9 +111,6 @@ export type PremiumModelMessageUsage = {
   nextRefill?: { availableAt: string; messages: number } | null;
   // Optional for compatibility with clients deployed before the daily breakdown was added.
   dailyUsage?: { date: string; usedMessages: number }[];
-  // Upcoming refills grouped by the day each message ages out of the rolling
-  // window, chronologically ordered. Optional for compatibility with clients
-  // deployed before this was added.
   refillSchedule?: { date: string; messages: number }[];
 };
 
@@ -230,10 +227,6 @@ export async function getPremiumModelMessageUsage({
   };
 }
 
-// Lean count-only counterpart to `getPremiumModelMessageUsage`, for ranking a
-// whole workspace by premium message usage (e.g. the poke sort column)
-// without paying for the refill schedule/timestamps of every member. Pipelines
-// every user's `ZCOUNT` into a single Redis round-trip.
 export async function getPremiumModelMessageUsedCountsByUser({
   workspace,
   users,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2052,7 +2052,7 @@ async function resolveMembersUsagePageUsers({
       // Count-only and pipelined into a single Redis round-trip
       const usedCountByUserId = await getPremiumModelMessageUsedCountsByUser({
         workspace,
-        users: allUsers.map((u) => u.toJSON()),
+        users: allUsers.map((u) => ({ id: u.id, sId: u.sId })),
       });
       for (const u of allUsers) {
         sortKeyByUserId.set(u.sId, usedCountByUserId.get(u.sId) ?? 0);

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2390,6 +2390,15 @@ export async function getMembersUsage({
   >();
   if (includeAlertLinks) {
     const plan = auth.plan();
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        planCode: plan?.code ?? null,
+        isCreditPriced: plan ? isCreditPricedPlan(plan) : null,
+        userCount: users.length,
+      },
+      "[PoolUsage] Resolving bulk premium message usage"
+    );
     if (plan && !isCreditPricedPlan(plan)) {
       const entries = await concurrentExecutor(
         users,
@@ -2403,6 +2412,14 @@ export async function getMembersUsage({
       for (const [sId, usage] of entries) {
         premiumMessageUsageByUserId.set(sId, usage);
       }
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          populatedCount: premiumMessageUsageByUserId.size,
+          sampleUsage: entries[0]?.[1] ?? null,
+        },
+        "[PoolUsage] Bulk premium message usage populated"
+      );
     }
   }
 

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,6 +1,7 @@
 import type { PremiumModelMessageUsage } from "@app/lib/api/assistant/rate_limits";
 import {
   getPremiumModelMessageUsage,
+  getPremiumModelMessageUsedCountsByUser,
   makeApiKeySpendLimitAwuCreditsRateLimitKey,
   makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace,
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
@@ -1827,7 +1828,6 @@ async function resolveMembersUsagePageUsers({
     {
       users: UserResource[];
       total: number;
-      premiumMessageUsageByUserId?: Map<string, PremiumModelMessageUsage>;
     },
     Error
   >
@@ -1867,10 +1867,6 @@ async function resolveMembersUsagePageUsers({
 
   const sortKeyByUserId = new Map<string, number | string>();
   const overageLimitByUserId = new Map<string, number>();
-  const premiumMessageUsageByUserId = new Map<
-    string,
-    PremiumModelMessageUsage
-  >();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -2056,18 +2052,16 @@ async function resolveMembersUsagePageUsers({
       break;
     }
     case "premiumMessageUsage": {
-      const entries = await concurrentExecutor(
-        allUsers,
-        async (u) =>
-          [
-            u.sId,
-            await getPremiumModelMessageUsage({ workspace, user: u.toJSON() }),
-          ] as const,
-        { concurrency: 8 }
-      );
-      for (const [sId, usage] of entries) {
-        sortKeyByUserId.set(sId, usage.usedMessages);
-        premiumMessageUsageByUserId.set(sId, usage);
+      // Count-only and pipelined into a single Redis round-trip: sorting can
+      // run over every matching user in the workspace, so per-user reads here
+      // would turn into an N+1 over Redis. The full usage (refill schedule
+      // included) is fetched separately, only for the returned page.
+      const usedCountByUserId = await getPremiumModelMessageUsedCountsByUser({
+        workspace,
+        users: allUsers.map((u) => u.toJSON()),
+      });
+      for (const u of allUsers) {
+        sortKeyByUserId.set(u.sId, usedCountByUserId.get(u.sId) ?? 0);
       }
       break;
     }
@@ -2104,10 +2098,6 @@ async function resolveMembersUsagePageUsers({
   return new Ok({
     users: sortedUsers.slice(offset, offset + limit),
     total,
-    premiumMessageUsageByUserId:
-      orderColumn === "premiumMessageUsage"
-        ? premiumMessageUsageByUserId
-        : undefined,
   });
 }
 
@@ -2159,11 +2149,7 @@ export async function getMembersUsage({
     return { members: [], total: 0, creditsResetAt };
   }
 
-  const {
-    users,
-    total,
-    premiumMessageUsageByUserId: precomputedPremiumMessageUsageByUserId,
-  } = usersResult.value;
+  const { users, total } = usersResult.value;
 
   if (users.length === 0) {
     return { members: [], total, creditsResetAt };
@@ -2409,31 +2395,23 @@ export async function getMembersUsage({
   if (includeAlertLinks) {
     const plan = auth.plan();
     if (plan && !isCreditPricedPlan(plan)) {
-      if (precomputedPremiumMessageUsageByUserId) {
-        // Already read from Redis while sorting the full matching set by
-        // this same column; avoid reading it again for the page.
-        for (const u of users) {
-          premiumMessageUsageByUserId.set(
+      // Bounded to the current page (≤ page size), regardless of whether the
+      // page is sorted by this column — the sort itself only reads a
+      // count per user (see `getPremiumModelMessageUsedCountsByUser`).
+      const entries = await concurrentExecutor(
+        users,
+        async (u) =>
+          [
             u.sId,
-            precomputedPremiumMessageUsageByUserId.get(u.sId) ?? null
-          );
-        }
-      } else {
-        const entries = await concurrentExecutor(
-          users,
-          async (u) =>
-            [
-              u.sId,
-              await getPremiumModelMessageUsage({
-                workspace,
-                user: u.toJSON(),
-              }),
-            ] as const,
-          { concurrency: 8 }
-        );
-        for (const [sId, usage] of entries) {
-          premiumMessageUsageByUserId.set(sId, usage);
-        }
+            await getPremiumModelMessageUsage({
+              workspace,
+              user: u.toJSON(),
+            }),
+          ] as const,
+        { concurrency: 8 }
+      );
+      for (const [sId, usage] of entries) {
+        premiumMessageUsageByUserId.set(sId, usage);
       }
     }
   }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -249,9 +249,6 @@ export const MembersUsagePaginationSchema = z.object({
       "seatType",
       "creditState",
       "seatUsage",
-      // Legacy (non credit-priced) plans only: sorts by weekly premium-model
-      // message usage, the replacement for the credit-pool column on those
-      // workspaces.
       "premiumMessageUsage",
     ])
     .catch("name"),
@@ -2052,10 +2049,7 @@ async function resolveMembersUsagePageUsers({
       break;
     }
     case "premiumMessageUsage": {
-      // Count-only and pipelined into a single Redis round-trip: sorting can
-      // run over every matching user in the workspace, so per-user reads here
-      // would turn into an N+1 over Redis. The full usage (refill schedule
-      // included) is fetched separately, only for the returned page.
+      // Count-only and pipelined into a single Redis round-trip
       const usedCountByUserId = await getPremiumModelMessageUsedCountsByUser({
         workspace,
         users: allUsers.map((u) => u.toJSON()),
@@ -2395,9 +2389,7 @@ export async function getMembersUsage({
   if (includeAlertLinks) {
     const plan = auth.plan();
     if (plan && !isCreditPricedPlan(plan)) {
-      // Bounded to the current page (≤ page size), regardless of whether the
-      // page is sorted by this column — the sort itself only reads a
-      // count per user (see `getPremiumModelMessageUsedCountsByUser`).
+      // Bounded to the current page size
       const entries = await concurrentExecutor(
         users,
         async (u) =>

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -184,6 +184,11 @@ export type MemberUsageType = {
   // (free/trial) where a fair-use limit is set. Null when the plan carries no
   // fair-use limit (limit === -1) or when not requested. Poke-only.
   fairUse?: MemberFairUseUsage | null;
+  // Per-user weekly premium-model message usage. Applies to legacy (non
+  // credit-priced) plans, which enforce a rate limit on premium-tier-model
+  // messages instead of an AWU credit pool. Null when the plan is
+  // credit-priced or when not requested. Poke-only.
+  premiumMessageUsage?: PremiumModelMessageUsage | null;
 };
 
 export type MemberFairUseUsage = {
@@ -247,6 +252,10 @@ export const MembersUsagePaginationSchema = z.object({
       "seatType",
       "creditState",
       "seatUsage",
+      // Legacy (non credit-priced) plans only: sorts by weekly premium-model
+      // message usage, the replacement for the credit-pool column on those
+      // workspaces.
+      "premiumMessageUsage",
     ])
     .catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
@@ -2037,6 +2046,21 @@ async function resolveMembersUsagePageUsers({
       }
       break;
     }
+    case "premiumMessageUsage": {
+      const entries = await concurrentExecutor(
+        allUsers,
+        async (u) =>
+          [
+            u.sId,
+            await getPremiumModelMessageUsage({ workspace, user: u.toJSON() }),
+          ] as const,
+        { concurrency: 8 }
+      );
+      for (const [sId, usage] of entries) {
+        sortKeyByUserId.set(sId, usage.usedMessages);
+      }
+      break;
+    }
     default:
       assertNever(orderColumn);
   }
@@ -2357,6 +2381,31 @@ export async function getMembersUsage({
     }
   }
 
+  // Bulk-fetch each user's weekly premium-model message usage (poke-only).
+  // Only legacy (non credit-priced) plans enforce this rate limit, so it's
+  // skipped entirely for credit-priced workspaces.
+  const premiumMessageUsageByUserId = new Map<
+    string,
+    PremiumModelMessageUsage | null
+  >();
+  if (includeAlertLinks) {
+    const plan = auth.plan();
+    if (plan && !isCreditPricedPlan(plan)) {
+      const entries = await concurrentExecutor(
+        users,
+        async (u) =>
+          [
+            u.sId,
+            await getPremiumModelMessageUsage({ workspace, user: u.toJSON() }),
+          ] as const,
+        { concurrency: 8 }
+      );
+      for (const [sId, usage] of entries) {
+        premiumMessageUsageByUserId.set(sId, usage);
+      }
+    }
+  }
+
   const membersUsage: MemberUsageType[] = users.flatMap((u) => {
     const membership = membershipByUserId.get(u.id);
     if (!membership) {
@@ -2570,6 +2619,7 @@ export async function getMembersUsage({
         creditState: membership.creditState,
         nearLimit,
         fairUse: fairUseByUserId.get(userId) ?? null,
+        premiumMessageUsage: premiumMessageUsageByUserId.get(userId) ?? null,
         seatUsageTarget,
         overallUsageTarget,
       },

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2390,15 +2390,6 @@ export async function getMembersUsage({
   >();
   if (includeAlertLinks) {
     const plan = auth.plan();
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        planCode: plan?.code ?? null,
-        isCreditPriced: plan ? isCreditPricedPlan(plan) : null,
-        userCount: users.length,
-      },
-      "[PoolUsage] Resolving bulk premium message usage"
-    );
     if (plan && !isCreditPricedPlan(plan)) {
       const entries = await concurrentExecutor(
         users,
@@ -2412,14 +2403,6 @@ export async function getMembersUsage({
       for (const [sId, usage] of entries) {
         premiumMessageUsageByUserId.set(sId, usage);
       }
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          populatedCount: premiumMessageUsageByUserId.size,
-          sampleUsage: entries[0]?.[1] ?? null,
-        },
-        "[PoolUsage] Bulk premium message usage populated"
-      );
     }
   }
 

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1822,7 +1822,16 @@ async function resolveMembersUsagePageUsers({
   workspace: LightWorkspaceType;
   paginationParams: MembersUsagePaginationInput;
   restrictToUserIds: string[] | undefined;
-}): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
+}): Promise<
+  Result<
+    {
+      users: UserResource[];
+      total: number;
+      premiumMessageUsageByUserId?: Map<string, PremiumModelMessageUsage>;
+    },
+    Error
+  >
+> {
   const { orderColumn, orderDirection, offset, limit } = paginationParams;
   const searchTerm = paginationParams.search ?? "";
 
@@ -1858,6 +1867,10 @@ async function resolveMembersUsagePageUsers({
 
   const sortKeyByUserId = new Map<string, number | string>();
   const overageLimitByUserId = new Map<string, number>();
+  const premiumMessageUsageByUserId = new Map<
+    string,
+    PremiumModelMessageUsage
+  >();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -2054,6 +2067,7 @@ async function resolveMembersUsagePageUsers({
       );
       for (const [sId, usage] of entries) {
         sortKeyByUserId.set(sId, usage.usedMessages);
+        premiumMessageUsageByUserId.set(sId, usage);
       }
       break;
     }
@@ -2087,7 +2101,14 @@ async function resolveMembersUsagePageUsers({
     return a.sId < b.sId ? -1 : a.sId > b.sId ? 1 : 0;
   });
 
-  return new Ok({ users: sortedUsers.slice(offset, offset + limit), total });
+  return new Ok({
+    users: sortedUsers.slice(offset, offset + limit),
+    total,
+    premiumMessageUsageByUserId:
+      orderColumn === "premiumMessageUsage"
+        ? premiumMessageUsageByUserId
+        : undefined,
+  });
 }
 
 export async function getMembersUsage({
@@ -2138,7 +2159,11 @@ export async function getMembersUsage({
     return { members: [], total: 0, creditsResetAt };
   }
 
-  const { users, total } = usersResult.value;
+  const {
+    users,
+    total,
+    premiumMessageUsageByUserId: precomputedPremiumMessageUsageByUserId,
+  } = usersResult.value;
 
   if (users.length === 0) {
     return { members: [], total, creditsResetAt };
@@ -2384,17 +2409,31 @@ export async function getMembersUsage({
   if (includeAlertLinks) {
     const plan = auth.plan();
     if (plan && !isCreditPricedPlan(plan)) {
-      const entries = await concurrentExecutor(
-        users,
-        async (u) =>
-          [
+      if (precomputedPremiumMessageUsageByUserId) {
+        // Already read from Redis while sorting the full matching set by
+        // this same column; avoid reading it again for the page.
+        for (const u of users) {
+          premiumMessageUsageByUserId.set(
             u.sId,
-            await getPremiumModelMessageUsage({ workspace, user: u.toJSON() }),
-          ] as const,
-        { concurrency: 8 }
-      );
-      for (const [sId, usage] of entries) {
-        premiumMessageUsageByUserId.set(sId, usage);
+            precomputedPremiumMessageUsageByUserId.get(u.sId) ?? null
+          );
+        }
+      } else {
+        const entries = await concurrentExecutor(
+          users,
+          async (u) =>
+            [
+              u.sId,
+              await getPremiumModelMessageUsage({
+                workspace,
+                user: u.toJSON(),
+              }),
+            ] as const,
+          { concurrency: 8 }
+        );
+        for (const [sId, usage] of entries) {
+          premiumMessageUsageByUserId.set(sId, usage);
+        }
       }
     }
   }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -184,10 +184,6 @@ export type MemberUsageType = {
   // (free/trial) where a fair-use limit is set. Null when the plan carries no
   // fair-use limit (limit === -1) or when not requested. Poke-only.
   fairUse?: MemberFairUseUsage | null;
-  // Per-user weekly premium-model message usage. Applies to legacy (non
-  // credit-priced) plans, which enforce a rate limit on premium-tier-model
-  // messages instead of an AWU credit pool. Null when the plan is
-  // credit-priced or when not requested. Poke-only.
   premiumMessageUsage?: PremiumModelMessageUsage | null;
 };
 
@@ -2381,9 +2377,6 @@ export async function getMembersUsage({
     }
   }
 
-  // Bulk-fetch each user's weekly premium-model message usage (poke-only).
-  // Only legacy (non credit-priced) plans enforce this rate limit, so it's
-  // skipped entirely for credit-priced workspaces.
   const premiumMessageUsageByUserId = new Map<
     string,
     PremiumModelMessageUsage | null

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -249,6 +249,44 @@ export async function getRateLimiterCount({
   }
 }
 
+// Same as `getRateLimiterCount`, but for many keys sharing the same
+// timeframe. Pipelines every `ZCOUNT` into a single Redis round-trip instead
+// of one round-trip per key, so callers sorting/ranking a whole workspace by
+// a rate-limited counter don't turn into an N+1 over Redis.
+export async function getRateLimiterCounts({
+  keys,
+  timeframeSeconds,
+}: {
+  keys: string[];
+  timeframeSeconds: number;
+}): Promise<Result<Map<string, number>, Error>> {
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    return new Err(new Error("timeframeSeconds must be a positive integer."));
+  }
+  if (keys.length === 0) {
+    return new Ok(new Map());
+  }
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const windowMs = timeframeSeconds * 1000;
+    const trimBeforeMs = Date.now() - windowMs;
+
+    const uniqueKeys = Array.from(new Set(keys));
+    const pipeline = redis.multi();
+    for (const key of uniqueKeys) {
+      pipeline.zCount(makeRateLimiterKey(key), trimBeforeMs, "+inf");
+    }
+    const counts = (await pipeline.exec()) as number[];
+
+    return new Ok(
+      new Map(uniqueKeys.map((key, index) => [key, counts[index]]))
+    );
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 // TODO: @jd 20260825 - Remove this once all legacy plans are gone
 // (or if we get rid of the premium limit)
 export async function getRateLimiterTimestamps({

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -249,10 +249,6 @@ export async function getRateLimiterCount({
   }
 }
 
-// Same as `getRateLimiterCount`, but for many keys sharing the same
-// timeframe. Pipelines every `ZCOUNT` into a single Redis round-trip instead
-// of one round-trip per key, so callers sorting/ranking a whole workspace by
-// a rate-limited counter don't turn into an N+1 over Redis.
 export async function getRateLimiterCounts({
   keys,
   timeframeSeconds,

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -10,6 +10,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import chunk from "lodash/chunk";
 import { v4 as uuidv4 } from "uuid";
 
 export class RateLimitError extends Error {}
@@ -20,6 +21,8 @@ export const RATE_LIMITER_PREFIX = "rate_limiter";
 // a read straddling the boundary still sees a just-closed window rather than a
 // premature miss.
 const FIXED_WINDOW_EXPIRE_GRACE_MS = 60_000;
+
+const RATE_LIMITER_COUNTS_BATCH_SIZE = 300;
 
 // A resolved fixed window: a stable label identifying the current window and
 // the absolute UTC end of that window. The label is appended to the Redis key
@@ -269,15 +272,25 @@ export async function getRateLimiterCounts({
     const trimBeforeMs = Date.now() - windowMs;
 
     const uniqueKeys = Array.from(new Set(keys));
-    const pipeline = redis.multi();
-    for (const key of uniqueKeys) {
-      pipeline.zCount(makeRateLimiterKey(key), trimBeforeMs, "+inf");
+    const countByKey = new Map<string, number>();
+    for (const batchKeys of chunk(uniqueKeys, RATE_LIMITER_COUNTS_BATCH_SIZE)) {
+      const pipeline = redis.multi();
+      for (const key of batchKeys) {
+        pipeline.zCount(makeRateLimiterKey(key), trimBeforeMs, "+inf");
+      }
+      const replies = await pipeline.exec();
+      for (const [index, key] of batchKeys.entries()) {
+        const reply = replies[index];
+        if (typeof reply !== "number") {
+          return new Err(
+            new Error(`Non-numeric rate-limiter count reply for key ${key}.`)
+          );
+        }
+        countByKey.set(key, reply);
+      }
     }
-    const counts = (await pipeline.exec()) as number[];
 
-    return new Ok(
-      new Map(uniqueKeys.map((key, index) => [key, counts[index]]))
-    );
+    return new Ok(countByKey);
   } catch (err) {
     return new Err(normalizeError(err));
   }

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -263,7 +263,8 @@ export function usePokeMembersUsage({
     | "consumedFromPoolAwuCredits"
     | "seatType"
     | "creditState"
-    | "seatUsage";
+    | "seatUsage"
+    | "premiumMessageUsage";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType;
   creditState?: UserCreditState;


### PR DESCRIPTION
## Description

For workspaces with no pool, no Metronome contract, and a legacy plan, the members table showed a credit-usage column and a pace-warning column that have no meaning without a credit pool. Swap the credit column for a new
premium message usage column.

**Visual:**
<img width="1067" height="531" alt="Capture d’écran 2026-09-04 à 10 18 24" src="https://github.com/user-attachments/assets/f1c11757-e224-49c2-8d2c-27507fff4b70" />

## Tests

Tested on front-edge

## Risk

low additons only scoped to poke

## Deploy Plan

- Deploy front
