### PR TITLE
feat(model_picker): knock the degraded badge out of its surface

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -718,8 +718,8 @@ export const InputBar = React.memo(function InputBar({
             : classNames(
                 "rounded-squircle-40 w-full overflow-hidden",
                 "border",
-                "has-[.tiptap:focus]:bg-stone-25 bg-[oklch(0.988_0_89.876)]",
-                "dark:has-[.tiptap:focus]:bg-[oklch(0.310_0.007_75)] dark:bg-[oklch(0.294_0.008_84.593)]",
+                "bg-input-bar-background",
+                "has-[.tiptap:focus]:bg-stone-25 dark:has-[.tiptap:focus]:bg-[oklch(0.310_0.007_75)]",
                 isFloating
                   ? "max-md:border-border max-md:has-[.tiptap:focus]:border-border-dark max-md:dark:has-[.tiptap:focus]:border-stone-750"
                   : "border-border has-[.tiptap:focus]:border-border-dark dark:has-[.tiptap:focus]:border-stone-750",

--- a/front/components/model_picker/DegradedModelIcon.tsx
+++ b/front/components/model_picker/DegradedModelIcon.tsx
@@ -1,27 +1,54 @@
+import type { DoubleIconProps } from "@dust-tt/sparkle";
 import { DoubleIcon, Icon, InfoCircle } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
+// Surfaces the degradation badge is rendered on. Its glyph — and the halo the
+// glyph draws around itself — is knocked out in the surface color, so the badge
+// reads as punched out of that surface in both themes.
+type DegradationSurface = "composer" | "menu";
+
+const SURFACE_KNOCKOUT: Record<
+  DegradationSurface,
+  Pick<DoubleIconProps, "surface" | "className">
+> = {
+  // The input bar paints its own background instead of a surface token.
+  composer: { surface: "current", className: "text-input-bar-background" },
+  menu: { surface: "overlay-background" },
+};
+
 interface DegradedModelIconProps {
   icon: ComponentType;
+  surface: DegradationSurface;
 }
 
-export function DegradedModelIcon({ icon }: DegradedModelIconProps) {
+export function DegradedModelIcon({ icon, surface }: DegradedModelIconProps) {
   return (
     <DoubleIcon
       size="xs"
       mainIcon={icon}
       secondaryIcon={InfoCircle}
+      // The badge carries the whole degradation signal on a 16px trigger, so it
+      // stays close to the provider icon's size rather than scaling down.
       position="top-right"
       secondaryColor="info"
+      secondarySize="badge"
+      {...SURFACE_KNOCKOUT[surface]}
     />
   );
 }
 
+// The row-level counterpart, always inside the picker menu. Nothing sits behind
+// it, so knocking the glyph out in the menu background drops the halo and
+// leaves a plain filled disc.
 export function DegradedInfoIcon() {
   return (
     <span className="relative flex h-5 w-5">
       <span className="absolute inset-px rounded-full bg-info-500" />
-      <Icon visual={InfoCircle} size="sm" className="relative text-white" />
+      <Icon
+        visual={InfoCircle}
+        size="sm"
+        className="relative text-overlay-background"
+      />
     </span>
   );
 }

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -320,7 +320,7 @@ export function ModelPicker({
           size={buttonSize}
           icon={
             degradedModelTooltip !== null ? (
-              <DegradedModelIcon icon={buttonIcon} />
+              <DegradedModelIcon icon={buttonIcon} surface="composer" />
             ) : (
               buttonIcon
             )

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -64,7 +64,7 @@ export function ModelPickerMakersView({
               label={getModelMakerDisplayName(maker.makerId)}
               icon={
                 hasDegradedModel ? (
-                  <DegradedModelIcon icon={makerLogo} />
+                  <DegradedModelIcon icon={makerLogo} surface="menu" />
                 ) : (
                   makerLogo
                 )

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -15,9 +15,23 @@
   height: var(--panel-height); /* defined in global.css */
 }
 
-/* Map the border-darker token (defined in global.css :root/.dark). */
+/* The expanded input bar paints its own surface color rather than one of the
+   shared background tokens (see InputBar.tsx). Defined here, in the one entry
+   every app's Tailwind pass imports, so the value lives in a single place and
+   anything that has to match the input bar — a glyph knocked out of it, say —
+   can reach it as `bg-`/`text-input-bar-background`. */
+:root {
+  --color-input-bar-background: oklch(98.8% 0 89.876);
+}
+.dark {
+  --color-input-bar-background: oklch(29.4% 0.008 84.593);
+}
+
+/* Map the border-darker token (defined in global.css :root/.dark) and the
+   input bar surface above. */
 @theme inline {
   --color-border-darker: var(--color-border-darker);
+  --color-input-bar-background: var(--color-input-bar-background);
 }
 
 @theme {

--- a/sparkle/src/components/Icon.tsx
+++ b/sparkle/src/components/Icon.tsx
@@ -5,14 +5,17 @@ import React, { type ComponentType } from "react";
 export interface IconProps {
   /** The SVG icon component to render; nothing is rendered when omitted. */
   visual?: ComponentType<{ className?: string }>;
-  size?: "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+  size?: "2xs" | "badge" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
   /** Color is inherited from text color, so set it with a `text-*` class here. */
   className?: string;
 }
 
 const IconSizes = {
   // Badge scale: too small for a standalone glyph, use it inside DoubleIcon.
+  // `badge` (14px) sits between the two steps, for a status disc that has to
+  // read on a 16px main icon without matching it.
   "2xs": "h-3 w-3",
+  badge: "h-3.5 w-3.5",
   xs: "h-4 w-4",
   sm: "h-5 w-5",
   md: "h-6 w-6",
@@ -80,7 +83,34 @@ const fillVariants = cva("absolute inset-px rounded-full", {
   },
 });
 
+// A filled badge knocks its glyph out in the color of the surface behind the
+// icon: the status glyphs draw their own ring, which then reads as a halo
+// separating the badge from the main icon. Plain white only works on a light
+// surface, hence a token per surface.
+const knockoutVariants = cva("relative", {
+  variants: {
+    surface: {
+      background: "text-background",
+      "app-background": "text-app-background",
+      "panel-background": "text-panel-background",
+      "overlay-background": "text-overlay-background",
+      "modal-background": "text-modal-background",
+      "muted-background": "text-muted-background",
+      // For surfaces that paint their own color instead of a token: the caller
+      // sets that color as a `text-*` class on the DoubleIcon itself.
+      current: "text-current",
+    },
+  },
+  defaultVariants: {
+    surface: "background",
+  },
+});
+
 type DoubleIconSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+type DoubleIconSurface = NonNullable<
+  VariantProps<typeof knockoutVariants>["surface"]
+>;
 
 const MAIN_ICON_SIZE: Record<DoubleIconSize, IconProps["size"]> = {
   xs: "xs",
@@ -100,7 +130,8 @@ const SECONDARY_ICON_SIZE: Record<DoubleIconSize, IconProps["size"]> = {
 
 export interface DoubleIconProps
   extends VariantProps<typeof sizeVariants>,
-    VariantProps<typeof positionVariants> {
+    VariantProps<typeof positionVariants>,
+    VariantProps<typeof knockoutVariants> {
   /** The primary icon, rendered at the full size. */
   mainIcon: React.ComponentType;
   /** The smaller badge icon, overlaid on a corner of the main icon. */
@@ -108,8 +139,14 @@ export interface DoubleIconProps
   size?: DoubleIconSize;
   /** Corner the badge sits in; defaults to the bottom-right. */
   position?: "bottom-right" | "top-right";
-  /** Fills the badge with a semantic color and knocks the glyph out in white. */
+  /** Fills the badge with a semantic color and knocks the glyph out. */
   secondaryColor?: "info" | "warning" | "success" | "highlight";
+  /** Badge size, when the badge needs more presence than `size` gives it. */
+  secondarySize?: IconProps["size"];
+  /** Surface behind the icon; a filled badge is knocked out in its color so it
+   * reads the same in both themes. Defaults to the page background; pass
+   * `current` to knock it out in this icon's own text color instead. */
+  surface?: DoubleIconSurface;
   className?: string;
 }
 
@@ -117,7 +154,8 @@ export interface DoubleIconProps
  * Renders a main icon with a smaller secondary icon overlaid on one of its
  * corners, e.g. a tool icon badged with its provider logo, or a model icon
  * badged with an `info` status. Pass `secondaryColor` to turn the badge into a
- * filled status disc. For a plain glyph use Icon.
+ * filled status disc, along with the `surface` it sits on so its glyph is
+ * knocked out in that surface's color. For a plain glyph use Icon.
  *
  * @summary Icon with an overlaid badge icon.
  */
@@ -128,7 +166,11 @@ export const DoubleIcon = ({
   size = "lg",
   position = "bottom-right",
   secondaryColor,
+  secondarySize,
+  surface = "background",
 }: DoubleIconProps) => {
+  const badgeSize = secondarySize ?? SECONDARY_ICON_SIZE[size];
+
   return (
     <div className={cn(sizeVariants({ size }), className)}>
       <Icon
@@ -140,14 +182,14 @@ export const DoubleIcon = ({
         <span className={cn(positionVariants({ position }), "flex")}>
           <span className={fillVariants({ color: secondaryColor })} />
           <Icon
-            size={SECONDARY_ICON_SIZE[size]}
+            size={badgeSize}
             visual={secondaryIcon}
-            className="relative text-white"
+            className={knockoutVariants({ surface })}
           />
         </span>
       ) : (
         <Icon
-          size={SECONDARY_ICON_SIZE[size]}
+          size={badgeSize}
           visual={secondaryIcon}
           className={positionVariants({ position })}
         />

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -154,6 +154,7 @@ export { FilterChips } from "./FilterChips";
 export { Div3D, Hover3D } from "./Hover3D";
 export { Hoverable } from "./Hoverable";
 export { HoveringBar } from "./HoveringBar";
+export type { DoubleIconProps } from "./Icon";
 export { DoubleIcon, Icon } from "./Icon";
 export { IconButton } from "./IconButton";
 export type { ImageGenerationPlaceholderProps } from "./ImageGenerationPlaceholder";

--- a/sparkle/src/stories/DoubleIcon.stories.tsx
+++ b/sparkle/src/stories/DoubleIcon.stories.tsx
@@ -35,11 +35,12 @@ const meta = {
 
 **When to use**
 - To show a piece of content alongside its origin (e.g. a document with its connector logo).
-- To flag an icon with a status: pass **secondaryColor** to fill the badge and knock the glyph out in white.
+- To flag an icon with a status: pass **secondaryColor** to fill the badge, and **surface** to knock its glyph out in the color of the surface behind the icon.
 
 **Guidelines**
 - Keep the **mainIcon** as the subject and the **secondaryIcon** as a small qualifier such as a provider logo or a status glyph.
 - Use **secondaryColor** only with the semantic intent it names (\`info\`, \`warning\`, \`success\`, \`highlight\`); leave it unset for provider logos, which carry their own colors.
+- Always name the **surface** alongside **secondaryColor** (e.g. \`overlay-background\` inside a menu, or \`current\` plus a \`text-*\` class for a surface that paints its own color): a knockout that misses the surface behind the icon leaves a mismatched halo around the badge.
 - \`xs\` badges a 16px glyph — the scale of an icon inside a button; reach for a larger size wherever there is room.
 - For a single glyph use **Icon**; for an entity image use **Avatar**.`,
       },
@@ -63,8 +64,26 @@ const meta = {
     },
     secondaryColor: {
       description:
-        "Fills the badge with a semantic color and knocks the glyph out in white",
+        "Fills the badge with a semantic color and knocks the glyph out",
       options: [undefined, "info", "warning", "success", "highlight"],
+      control: { type: "select" },
+    },
+    surface: {
+      description: "Surface a filled badge is knocked out against",
+      options: [
+        "background",
+        "app-background",
+        "panel-background",
+        "overlay-background",
+        "modal-background",
+        "muted-background",
+        "current",
+      ],
+      control: { type: "select" },
+    },
+    secondarySize: {
+      description: "Badge size, overriding the one `size` implies",
+      options: [undefined, "2xs", "badge", "xs", "sm"],
       control: { type: "select" },
     },
     mainIcon: {
@@ -130,10 +149,11 @@ export const Sizes: Story = {
 };
 
 /**
- * A status badge: `secondaryColor` fills the corner disc and knocks the glyph
- * out in white, so the flag reads at a glance over a busy main icon. Used for
- * flagging a model as degraded in the model picker, where the whole control is
- * a 16px button icon (`size="xs"`, badged top-right).
+ * A status badge: `secondaryColor` fills the corner disc and `surface` knocks
+ * the glyph out in the color behind the icon, leaving a halo that separates the
+ * badge from a busy main icon. Used for flagging a model as degraded in the
+ * model picker, where the whole control is a 16px button icon (`size="xs"`,
+ * badged top-right with a 14px `secondarySize="badge"` disc).
  * @summary Glyph flagged with a filled status badge.
  */
 export const StatusBadge: Story = {
@@ -149,6 +169,8 @@ export const StatusBadge: Story = {
 /**
  * Visual reference: each semantic `secondaryColor` in both corners, at the
  * `xs` scale used inside buttons and at `lg` for a closer look at the disc.
+ * The last row is the model picker's degraded badge — an oversized badge
+ * (`secondarySize="badge"`) knocked out against the composer surface.
  * Kept for design review.
  * @summary Status badge colors and corners.
  */
@@ -188,6 +210,26 @@ export const StatusBadges: Story = {
           />
         </div>
       ))}
+      <div className="flex items-center gap-8 rounded-2xl bg-muted-background p-4">
+        <DoubleIcon
+          size="xs"
+          mainIcon={Folder}
+          secondaryIcon={InfoCircle}
+          secondarySize="badge"
+          position="top-right"
+          secondaryColor="info"
+          surface="muted-background"
+        />
+        <DoubleIcon
+          size="lg"
+          mainIcon={Folder}
+          secondaryIcon={InfoCircle}
+          secondarySize="sm"
+          position="top-right"
+          secondaryColor="info"
+          surface="muted-background"
+        />
+      </div>
     </div>
   ),
 };


### PR DESCRIPTION
## Description
<img width="1027" height="658" alt="Screenshot 2026-09-03 at 18 08 43" src="https://github.com/user-attachments/assets/745547ba-df71-4f0e-a7a6-c466313bab74" />
<img width="1063" height="732" alt="Screenshot 2026-09-03 at 18 12 26" src="https://github.com/user-attachments/assets/7f1ae4fc-98ed-4c43-af13-bae2852622c6" />

The degraded-model badge (`InfoCircle` filled with `info`) knocked its glyph out in
plain white. That only holds on a light surface: in dark mode the white ring the
glyph draws around itself read as a bright halo pasted onto the icon, and the badge
sat visually on top of the provider logo rather than beside it.

`DoubleIcon` now takes the `surface` it is rendered on and knocks a filled badge's
glyph out in that surface's color, so the halo matches whatever is behind the icon in
both themes. Surfaces are the existing background tokens (`overlay-background`,
`panel-background`, …) plus `current`, for callers whose surface paints its own color
— they set it as a `text-*` class on the `DoubleIcon`.

The expanded input bar is one such caller: it painted a raw `oklch(...)` pair inline.
That value moves to a `--color-input-bar-background` token in `theme-extras.css`
(the one entry every app's Tailwind pass imports), so the composer and the glyph
knocked out of it read the same value.

Also on the badge: `secondarySize` lets the badge keep its full size instead of
scaling down from `size`. On the 16px composer trigger the badge carries the entire
degradation signal, so it now matches the provider icon rather than shrinking below it.

- `DegradedModelIcon` takes a `surface` prop (`composer` | `menu`) and maps it to the
  right knockout.
- `DegradedInfoIcon` (the picker row) knocks out in `overlay-background` instead of
  white — nothing sits behind it, so the halo correctly disappears and it reads as a
  plain filled disc.
- Storybook: `surface` / `secondarySize` controls, updated guidance, and a
  `StatusBadges` row showing the composer badge over a non-default surface.

## Tests

Visual — check the degraded badge in the model picker button and in the makers list,
in both light and dark mode, and confirm the badge halo matches the surface behind it
(input bar surface for the composer trigger, menu background inside the picker).
