### PR TITLE
[front] fix: make analytics filter search accent-insensitive

### DIFF
--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -2,6 +2,7 @@ import { FilterCategoryNav } from "@app/components/workspace/analytics/filterPan
 import { FilterFooter } from "@app/components/workspace/analytics/filterPanel/FilterFooter";
 import { FilterOptionCheckboxList } from "@app/components/workspace/analytics/filterPanel/FilterOptionCheckboxList";
 import { FilterSelectionSummary } from "@app/components/workspace/analytics/filterPanel/FilterSelectionSummary";
+import { filterOptionMatchesSearch } from "@app/components/workspace/analytics/filterPanel/filterState";
 import type {
   ConsumptionFacetOptions,
   UsageFilter,
@@ -230,7 +231,6 @@ export function UsageFilterPanelView({
 
   const activeOptions = categoryOptions[activeCategory];
   const filteredOptions = useMemo(() => {
-    const search = searchText.trim().toLowerCase();
     const selectedGroupMemberIds =
       activeCategory === "member" && selectedGroups.items.length > 0
         ? new Set(selectedGroups.items.flatMap((group) => group.memberIds))
@@ -247,7 +247,7 @@ export function UsageFilterPanelView({
       if (selectedGroupMemberIds && !selectedGroupMemberIds.has(option.id)) {
         return false;
       }
-      return !search || option.name.toLowerCase().includes(search);
+      return filterOptionMatchesSearch(option.name, searchText);
     });
   }, [
     activeOptions,

--- a/front/components/workspace/analytics/filterPanel/filterState.test.ts
+++ b/front/components/workspace/analytics/filterPanel/filterState.test.ts
@@ -1,0 +1,16 @@
+import { filterOptionMatchesSearch } from "@app/components/workspace/analytics/filterPanel/filterState";
+import { describe, expect, it } from "vitest";
+
+describe("filterOptionMatchesSearch", () => {
+  it.each([
+    ["Développeur", "developpeur"],
+    ["Developpeur", "développeur"],
+    ["Développeur", "  DEVELOPPEUR  "],
+  ])("matches %s with %s regardless of accents", (optionName, searchText) => {
+    expect(filterOptionMatchesSearch(optionName, searchText)).toBe(true);
+  });
+
+  it("does not match unrelated names", () => {
+    expect(filterOptionMatchesSearch("Développeur", "designer")).toBe(false);
+  });
+});

--- a/front/components/workspace/analytics/filterPanel/filterState.ts
+++ b/front/components/workspace/analytics/filterPanel/filterState.ts
@@ -3,6 +3,8 @@
 // and option shape; these helpers only assume `{id}`-shaped options keyed by
 // a category.
 
+import { removeDiacritics } from "@app/lib/utils";
+
 export interface FilterOptionBase {
   id: string;
   name: string;
@@ -18,6 +20,18 @@ export interface FilterSummary<Category extends string> {
   category: Category;
   categoryLabel: string;
   options: Array<{ id: string; name: string }>;
+}
+
+export function filterOptionMatchesSearch(
+  optionName: string,
+  searchText: string
+): boolean {
+  const normalizedSearch = removeDiacritics(searchText.trim()).toLowerCase();
+
+  return (
+    !normalizedSearch ||
+    removeDiacritics(optionName).toLowerCase().includes(normalizedSearch)
+  );
 }
 
 export function getFilterSummaries<


### PR DESCRIPTION
## Description

- Make the analytics Filters picker search accent-insensitive.
- Normalize both the search query and option names before matching.
- Add regression coverage for accented, unaccented, case-insensitive, and unrelated searches.

## Tests

- npm run test -- components/workspace/analytics/usageFilter.test.ts components/workspace/analytics/filterPanel/filterState.test.ts (34 passed)
- Biome on the three changed files

## Notes

The repository-wide front type-check is currently blocked by unrelated existing errors outside these changed files.