### PR TITLE
Fix marketing auth context cross-region redirect

### DIFF
--- a/marketing/lib/api/authContext.ts
+++ b/marketing/lib/api/authContext.ts
@@ -35,6 +35,88 @@ const AuthContextResponseSchema = z.object({
   defaultWorkspaceId: z.string().nullable().optional(),
 });
 
+const RegionRedirectResponseSchema = z.object({
+  error: z.object({
+    type: z.literal("workspace_in_different_region"),
+    message: z.string(),
+    redirect: z.object({
+      region: z.string(),
+      url: z.string().url(),
+    }),
+  }),
+});
+
+export type MarketingRegionRedirect = z.infer<
+  typeof RegionRedirectResponseSchema
+>["error"]["redirect"];
+
+type AuthContextResponse =
+  | { type: "success"; authContext: MarketingAuthContext }
+  | { type: "region_redirect"; redirect: MarketingRegionRedirect }
+  | null;
+
+/**
+ * Parse the auth-context response while preserving the cross-region routing
+ * signal. This is shared by the server-side and browser-side marketing flows.
+ */
+export async function parseAuthContextResponse(
+  response: Response
+): Promise<AuthContextResponse> {
+  const body: unknown = await response.json().catch(() => null);
+
+  if (response.ok) {
+    const parsed = AuthContextResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      return null;
+    }
+    return {
+      type: "success",
+      authContext: {
+        user: parsed.data.user,
+        defaultWorkspaceId: parsed.data.defaultWorkspaceId ?? null,
+      },
+    };
+  }
+
+  const regionRedirect = RegionRedirectResponseSchema.safeParse(body);
+  if (regionRedirect.success) {
+    return {
+      type: "region_redirect",
+      redirect: regionRedirect.data.error.redirect,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build the regional auth-context URL returned by front-api, while refusing
+ * unexpected hosts before forwarding the session cookie or browser credentials.
+ */
+export function getRegionalAuthContextUrl(
+  redirect: MarketingRegionRedirect
+): string | null {
+  try {
+    const url = new URL("/api/auth-context", redirect.url);
+    const isDustHost =
+      url.hostname === "dust.tt" || url.hostname.endsWith(".dust.tt");
+    const isLocalHost =
+      url.hostname === "localhost" || url.hostname === "127.0.0.1";
+    if (
+      url.protocol !== "https:" &&
+      !(url.protocol === "http:" && isLocalHost)
+    ) {
+      return null;
+    }
+    if (!isDustHost && !isLocalHost) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
 export function hasWorkosSessionCookie(cookieHeader: string): boolean {
   return cookieHeader.includes("workos_session=");
 }
@@ -53,21 +135,37 @@ export async function fetchAuthContext(
   }: { failureLogMessage?: string } = {}
 ): Promise<MarketingAuthContext | null> {
   try {
-    const res = await fetch(AUTH_CONTEXT_URL, {
-      headers: { cookie: cookieHeader },
-      signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      return null;
-    }
-    const parsed = AuthContextResponseSchema.safeParse(await res.json());
-    if (!parsed.success) {
-      return null;
-    }
-    return {
-      user: parsed.data.user,
-      defaultWorkspaceId: parsed.data.defaultWorkspaceId ?? null,
+    const deadline = Date.now() + AUTH_CONTEXT_TIMEOUT_MS;
+    const fetchAt = async (url: string): Promise<AuthContextResponse> => {
+      const remainingMs = Math.max(deadline - Date.now(), 1);
+      const response = await fetch(url, {
+        headers: { cookie: cookieHeader },
+        signal: AbortSignal.timeout(remainingMs),
+      });
+      return parseAuthContextResponse(response);
     };
+
+    const initialResponse = await fetchAt(AUTH_CONTEXT_URL);
+    if (initialResponse?.type === "region_redirect") {
+      const regionalUrl = getRegionalAuthContextUrl(initialResponse.redirect);
+      if (!regionalUrl || regionalUrl === AUTH_CONTEXT_URL) {
+        return null;
+      }
+
+      const regionalResponse = await fetchAt(regionalUrl);
+      if (regionalResponse?.type !== "success") {
+        logger.warn(
+          { region: initialResponse.redirect.region },
+          `${failureLogMessage}: regional retry failed`
+        );
+        return null;
+      }
+      return regionalResponse.authContext;
+    }
+
+    return initialResponse?.type === "success"
+      ? initialResponse.authContext
+      : null;
   } catch (err) {
     logger.warn({ err: normalizeError(err) }, failureLogMessage);
     return null;

--- a/marketing/lib/api/authContext.ts
+++ b/marketing/lib/api/authContext.ts
@@ -1,5 +1,6 @@
 import config from "@marketing/lib/api/config";
 import logger from "@marketing/logger/logger";
+import { assertNever } from "@marketing/types/shared/utils/assert_never";
 import { normalizeError } from "@marketing/types/shared/utils/error_utils";
 import type { UserType } from "@marketing/types/user";
 import { z } from "zod";
@@ -146,26 +147,32 @@ export async function fetchAuthContext(
     };
 
     const initialResponse = await fetchAt(AUTH_CONTEXT_URL);
-    if (initialResponse?.type === "region_redirect") {
-      const regionalUrl = getRegionalAuthContextUrl(initialResponse.redirect);
-      if (!regionalUrl || regionalUrl === AUTH_CONTEXT_URL) {
-        return null;
-      }
-
-      const regionalResponse = await fetchAt(regionalUrl);
-      if (regionalResponse?.type !== "success") {
-        logger.warn(
-          { region: initialResponse.redirect.region },
-          `${failureLogMessage}: regional retry failed`
-        );
-        return null;
-      }
-      return regionalResponse.authContext;
+    if (!initialResponse) {
+      return null;
     }
 
-    return initialResponse?.type === "success"
-      ? initialResponse.authContext
-      : null;
+    switch (initialResponse.type) {
+      case "region_redirect": {
+        const regionalUrl = getRegionalAuthContextUrl(initialResponse.redirect);
+        if (!regionalUrl || regionalUrl === AUTH_CONTEXT_URL) {
+          return null;
+        }
+
+        const regionalResponse = await fetchAt(regionalUrl);
+        if (regionalResponse?.type !== "success") {
+          logger.warn(
+            { region: initialResponse.redirect.region },
+            `${failureLogMessage}: regional retry failed`
+          );
+          return null;
+        }
+        return regionalResponse.authContext;
+      }
+      case "success":
+        return initialResponse.authContext;
+      default:
+        assertNever(initialResponse);
+    }
   } catch (err) {
     logger.warn({ err: normalizeError(err) }, failureLogMessage);
     return null;

--- a/marketing/lib/api/authContext.ts
+++ b/marketing/lib/api/authContext.ts
@@ -2,13 +2,18 @@ import config from "@marketing/lib/api/config";
 import logger from "@marketing/logger/logger";
 import { assertNever } from "@marketing/types/shared/utils/assert_never";
 import { normalizeError } from "@marketing/types/shared/utils/error_utils";
+import { safeParseJSON } from "@marketing/types/shared/utils/json_utils";
 import type { UserType } from "@marketing/types/user";
 import { z } from "zod";
 
-export const AUTH_CONTEXT_URL = `${config.getApiBaseUrl()}/api/auth-context`;
+const AUTH_CONTEXT_PATH = "/api/auth-context";
 
-// Cap SSR auth-context lookups so a slow/unavailable front API never hangs pages.
-export const AUTH_CONTEXT_TIMEOUT_MS = 1500;
+export const AUTH_CONTEXT_URL = `${config.getApiBaseUrl()}${AUTH_CONTEXT_PATH}`;
+
+// Cap each SSR auth-context request so a slow/unavailable front API never hangs
+// pages. A session from another region costs two requests (home region, then
+// regional host), so the worst case is twice this value.
+export const AUTH_CONTEXT_TIMEOUT_MS = 1_500;
 
 export type MarketingAuthContext = {
   user: UserType;
@@ -36,39 +41,37 @@ const AuthContextResponseSchema = z.object({
   defaultWorkspaceId: z.string().nullable().optional(),
 });
 
+// front-api answers 400 with this body when the session's workspace lives in
+// the other region. Mirrors `RegionRedirectError` in front/types/error.ts.
+const RegionRedirectSchema = z.object({
+  region: z.string(),
+  url: z.string().url(),
+});
+
 const RegionRedirectResponseSchema = z.object({
   error: z.object({
     type: z.literal("workspace_in_different_region"),
-    message: z.string(),
-    redirect: z.object({
-      region: z.string(),
-      url: z.string().url(),
-    }),
+    redirect: RegionRedirectSchema,
   }),
 });
 
-export type MarketingRegionRedirect = z.infer<
-  typeof RegionRedirectResponseSchema
->["error"]["redirect"];
-
-type AuthContextResponse =
+type ParsedAuthContextResponse =
   | { type: "success"; authContext: MarketingAuthContext }
-  | { type: "region_redirect"; redirect: MarketingRegionRedirect }
-  | null;
+  | { type: "region_redirect"; redirect: z.infer<typeof RegionRedirectSchema> }
+  | { type: "failure" };
 
-/**
- * Parse the auth-context response while preserving the cross-region routing
- * signal. This is shared by the server-side and browser-side marketing flows.
- */
-export async function parseAuthContextResponse(
+async function parseAuthContextResponse(
   response: Response
-): Promise<AuthContextResponse> {
-  const body: unknown = await response.json().catch(() => null);
+): Promise<ParsedAuthContextResponse> {
+  const body = safeParseJSON(await response.text());
+  if (body.isErr()) {
+    return { type: "failure" };
+  }
 
   if (response.ok) {
-    const parsed = AuthContextResponseSchema.safeParse(body);
+    const parsed = AuthContextResponseSchema.safeParse(body.value);
     if (!parsed.success) {
-      return null;
+      return { type: "failure" };
     }
     return {
       type: "success",
@@ -79,42 +82,56 @@ export async function parseAuthContextResponse(
     };
   }
 
-  const regionRedirect = RegionRedirectResponseSchema.safeParse(body);
-  if (regionRedirect.success) {
-    return {
-      type: "region_redirect",
-      redirect: regionRedirect.data.error.redirect,
-    };
+  const redirect = RegionRedirectResponseSchema.safeParse(body.value);
+  if (redirect.success) {
+    return { type: "region_redirect", redirect: redirect.data.error.redirect };
   }
 
-  return null;
+  return { type: "failure" };
 }
 
+export type AuthContextResolution =
+  | { type: "success"; authContext: MarketingAuthContext }
+  | { type: "failure"; status: number }
+  | { type: "regional_failure"; region: string; status: number };
+
 /**
- * Build the regional auth-context URL returned by front-api, while refusing
- * unexpected hosts before forwarding the session cookie or browser credentials.
+ * Fetch the auth context from `url`, following a region redirect once.
+ *
+ * `fetchUrl` supplies the transport (cookie forwarding on the server, browser
+ * credentials on the client). `redirect.url` is trusted as-is: front-api builds
+ * it from its own region config. A second redirect is treated as a failure, so
+ * at most two requests are ever made.
  */
-export function getRegionalAuthContextUrl(
-  redirect: MarketingRegionRedirect
-): string | null {
-  try {
-    const url = new URL("/api/auth-context", redirect.url);
-    const isDustHost =
-      url.hostname === "dust.tt" || url.hostname.endsWith(".dust.tt");
-    const isLocalHost =
-      url.hostname === "localhost" || url.hostname === "127.0.0.1";
-    if (
-      url.protocol !== "https:" &&
-      !(url.protocol === "http:" && isLocalHost)
-    ) {
-      return null;
+export async function resolveAuthContext(
+  url: string,
+  fetchUrl: (url: string) => Promise<Response>
+): Promise<AuthContextResolution> {
+  const initialResponse = await fetchUrl(url);
+  const initial = await parseAuthContextResponse(initialResponse);
+
+  switch (initial.type) {
+    case "success":
+      return initial;
+    case "failure":
+      return { type: "failure", status: initialResponse.status };
+    case "region_redirect": {
+      const { region } = initial.redirect;
+      const regionalResponse = await fetchUrl(
+        new URL(AUTH_CONTEXT_PATH, initial.redirect.url).toString()
+      );
+      const regional = await parseAuthContextResponse(regionalResponse);
+      if (regional.type !== "success") {
+        return {
+          type: "regional_failure",
+          region,
+          status: regionalResponse.status,
+        };
+      }
+      return regional;
     }
-    if (!isDustHost && !isLocalHost) {
-      return null;
-    }
-    return url.toString();
-  } catch {
-    return null;
+    default:
+      assertNever(initial);
   }
 }
 
@@ -136,42 +153,38 @@ export async function fetchAuthContext(
   }: { failureLogMessage?: string } = {}
 ): Promise<MarketingAuthContext | null> {
   try {
-    const deadline = Date.now() + AUTH_CONTEXT_TIMEOUT_MS;
-    const fetchAt = async (url: string): Promise<AuthContextResponse> => {
-      const remainingMs = Math.max(deadline - Date.now(), 1);
-      const response = await fetch(url, {
+    const resolution = await resolveAuthContext(AUTH_CONTEXT_URL, (url) =>
+      fetch(url, {
         headers: { cookie: cookieHeader },
-        signal: AbortSignal.timeout(remainingMs),
-      });
-      return parseAuthContextResponse(response);
-    };
+        signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
+      })
+    );
 
-    const initialResponse = await fetchAt(AUTH_CONTEXT_URL);
-    if (!initialResponse) {
-      return null;
-    }
-
-    switch (initialResponse.type) {
-      case "region_redirect": {
-        const regionalUrl = getRegionalAuthContextUrl(initialResponse.redirect);
-        if (!regionalUrl || regionalUrl === AUTH_CONTEXT_URL) {
-          return null;
-        }
-
-        const regionalResponse = await fetchAt(regionalUrl);
-        if (regionalResponse?.type !== "success") {
-          logger.warn(
-            { region: initialResponse.redirect.region },
-            `${failureLogMessage}: regional retry failed`
-          );
-          return null;
-        }
-        return regionalResponse.authContext;
-      }
+    switch (resolution.type) {
       case "success":
-        return initialResponse.authContext;
+        return resolution.authContext;
+      case "failure":
+        // 401/403 is the normal anonymous path. Anything 5xx means front-api is
+        // degraded and would otherwise be indistinguishable from anonymous.
+        if (resolution.status >= 500) {
+          logger.warn(
+            { statusCode: resolution.status, context: failureLogMessage },
+            "auth-context lookup failed upstream"
+          );
+        }
+        return null;
+      case "regional_failure":
+        logger.warn(
+          {
+            region: resolution.region,
+            statusCode: resolution.status,
+            context: failureLogMessage,
+          },
+          "auth-context regional retry failed"
+        );
+        return null;
       default:
-        assertNever(initialResponse);
+        assertNever(resolution);
     }
   } catch (err) {
     logger.warn({ err: normalizeError(err) }, failureLogMessage);

--- a/marketing/lib/swr/website.ts
+++ b/marketing/lib/swr/website.ts
@@ -1,8 +1,7 @@
 import {
   AUTH_CONTEXT_URL,
-  getRegionalAuthContextUrl,
-  parseAuthContextResponse,
   type MarketingAuthContext,
+  resolveAuthContext,
 } from "@marketing/lib/api/authContext";
 import { useSWRWithDefaults } from "@marketing/lib/swr/swr";
 import { assertNever } from "@marketing/types/shared/utils/assert_never";
@@ -17,32 +16,21 @@ type GetNoWorkspaceAuthContextResponseType = MarketingAuthContext;
 async function landingFetcher(
   url: string
 ): Promise<GetNoWorkspaceAuthContextResponseType> {
-  // eslint-disable-next-line no-restricted-globals
-  const response = await fetch(url, { credentials: "include" });
-  const parsed = await parseAuthContextResponse(response);
+  const resolution = await resolveAuthContext(url, (target) =>
+    fetch(target, { credentials: "include" })
+  );
 
-  if (!parsed) {
-    throw new Error(`Failed to fetch ${url}: ${response.status}`);
-  }
-
-  switch (parsed.type) {
-    case "region_redirect": {
-      const regionalUrl = getRegionalAuthContextUrl(parsed.redirect);
-      if (regionalUrl && regionalUrl !== url) {
-        const regionalResponse = await fetch(regionalUrl, {
-          credentials: "include",
-        });
-        const regionalParsed = await parseAuthContextResponse(regionalResponse);
-        if (regionalParsed?.type === "success") {
-          return regionalParsed.authContext;
-        }
-      }
-      throw new Error(`Failed to fetch ${url}: ${response.status}`);
-    }
+  switch (resolution.type) {
     case "success":
-      return parsed.authContext;
+      return resolution.authContext;
+    case "failure":
+      throw new Error(`Failed to fetch ${url}: ${resolution.status}`);
+    case "regional_failure":
+      throw new Error(
+        `Failed to fetch auth context from region ${resolution.region}: ${resolution.status}`
+      );
     default:
-      assertNever(parsed);
+      assertNever(resolution);
   }
 }
 

--- a/marketing/lib/swr/website.ts
+++ b/marketing/lib/swr/website.ts
@@ -5,6 +5,7 @@ import {
   type MarketingAuthContext,
 } from "@marketing/lib/api/authContext";
 import { useSWRWithDefaults } from "@marketing/lib/swr/swr";
+import { assertNever } from "@marketing/types/shared/utils/assert_never";
 
 type GetNoWorkspaceAuthContextResponseType = MarketingAuthContext;
 
@@ -20,24 +21,29 @@ async function landingFetcher(
   const response = await fetch(url, { credentials: "include" });
   const parsed = await parseAuthContextResponse(response);
 
-  if (parsed?.type === "region_redirect") {
-    const regionalUrl = getRegionalAuthContextUrl(parsed.redirect);
-    if (regionalUrl && regionalUrl !== url) {
-      const regionalResponse = await fetch(regionalUrl, {
-        credentials: "include",
-      });
-      const regionalParsed = await parseAuthContextResponse(regionalResponse);
-      if (regionalParsed?.type === "success") {
-        return regionalParsed.authContext;
+  if (!parsed) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+
+  switch (parsed.type) {
+    case "region_redirect": {
+      const regionalUrl = getRegionalAuthContextUrl(parsed.redirect);
+      if (regionalUrl && regionalUrl !== url) {
+        const regionalResponse = await fetch(regionalUrl, {
+          credentials: "include",
+        });
+        const regionalParsed = await parseAuthContextResponse(regionalResponse);
+        if (regionalParsed?.type === "success") {
+          return regionalParsed.authContext;
+        }
       }
+      throw new Error(`Failed to fetch ${url}: ${response.status}`);
     }
+    case "success":
+      return parsed.authContext;
+    default:
+      assertNever(parsed);
   }
-
-  if (parsed?.type === "success") {
-    return parsed.authContext;
-  }
-
-  throw new Error(`Failed to fetch ${url}: ${response.status}`);
 }
 
 export function useLandingAuthContext({

--- a/marketing/lib/swr/website.ts
+++ b/marketing/lib/swr/website.ts
@@ -1,5 +1,7 @@
 import {
   AUTH_CONTEXT_URL,
+  getRegionalAuthContextUrl,
+  parseAuthContextResponse,
   type MarketingAuthContext,
 } from "@marketing/lib/api/authContext";
 import { useSWRWithDefaults } from "@marketing/lib/swr/swr";
@@ -15,11 +17,27 @@ async function landingFetcher(
   url: string
 ): Promise<GetNoWorkspaceAuthContextResponseType> {
   // eslint-disable-next-line no-restricted-globals
-  const res = await fetch(url, { credentials: "include" });
-  if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  const response = await fetch(url, { credentials: "include" });
+  const parsed = await parseAuthContextResponse(response);
+
+  if (parsed?.type === "region_redirect") {
+    const regionalUrl = getRegionalAuthContextUrl(parsed.redirect);
+    if (regionalUrl && regionalUrl !== url) {
+      const regionalResponse = await fetch(regionalUrl, {
+        credentials: "include",
+      });
+      const regionalParsed = await parseAuthContextResponse(regionalResponse);
+      if (regionalParsed?.type === "success") {
+        return regionalParsed.authContext;
+      }
+    }
   }
-  return res.json();
+
+  if (parsed?.type === "success") {
+    return parsed.authContext;
+  }
+
+  throw new Error(`Failed to fetch ${url}: ${response.status}`);
 }
 
 export function useLandingAuthContext({


### PR DESCRIPTION
## Description

A user whose session cookie points at a workspace in the other region was shown the logged-out landing page on the marketing site. Typically a user with accounts in both regions who logs into one, then visits the other's marketing site. Follow up of `27268` / `27389`.

**Root cause:** marketing calls `/api/auth-context` on its own region's front-api. When the sealed `workspaceId` in the shared `workos_session` cookie lives in the other region, front-api answers `400 workspace_in_different_region` with `redirect.url`. Marketing treated any non-2xx as anonymous.

**Fix:** `resolveAuthContext`, shared by SSR and the landing SWR fetcher, follows that redirect exactly once. Direction-agnostic: US marketing → EU and EU marketing → US use the same path, since both front-apis run the same lookup and the resolver follows whatever URL comes back. `redirect.url` is trusted as-is since front-api builds it from its own region config. SSR now also warns on 5xx so a degraded front-api is distinguishable from an anonymous visitor.

## Tests

- `Lint & Build (marketing)` (tsgo + next build).
- Manual: US and EU sessions on both `dust.tt` and `eu.dust.tt`, anonymous, expired.

## Risk

Worst case, the regional retry fails or times out and we fall back to today's behavior (landing page). SSR worst case is 2 × 1.5s. Safe to rollback.

## Deploy Plan

- [ ] Deploy marketing (both regions)
- [ ] Verify cross-region session on each marketing site: `400` then `200` from the other region, header shows logged-in state
