### PR TITLE
Admin access: list skills built on spaces the admin cannot read, with guidelines redacted

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -282,4 +282,33 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     expect(data.editors).toHaveLength(1); // Creator is editor
     expect(data.editors[0].sId).toBe(user.sId);
   });
+
+  it("GET endpoint lists the editors of a skill built on a space the admin cannot read", async () => {
+    const { workspace } = await setup();
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, { role: "user" });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(internalAdminAuth, {
+      userIds: [skillOwner.sId],
+    });
+    const skill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.editors.map((e: { sId: string }) => e.sId)).toEqual([
+      skillOwner.sId,
+    ]);
+  });
 });

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -52,9 +52,20 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { sId } = ctx.req.valid("param");
 
-  const skill = await loadSkill(ctx, sId);
-  if (skill instanceof Response) {
-    return skill;
+  // Editors are not private: admins can list them for the skills they cannot read too, e.g. to
+  // know whom to ask for access.
+  const skill = await SkillResource.fetchById(auth, sId, {
+    // biome-ignore lint/plugin/noDirectRoleCheck: the mode is admin-only, everyone else gets the regular fetch
+    permissionFiltering: auth.isAdmin() ? "redact_unreadable" : "strict",
+  });
+  if (!skill) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The skill was not found.",
+      },
+    });
   }
 
   const members = (await skill.listEditors(auth)) ?? [];

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -26,11 +26,21 @@ const ParamsSchema = z.object({
 // describing the failure — keeps the validation prelude in one place per [API10].
 async function loadSkill(
   ctx: Context,
-  sId: string
+  sId: string,
+  {
+    redactUnreadableForAdmin = false,
+  }: {
+    redactUnreadableForAdmin?: boolean;
+  } = {}
 ): Promise<SkillResource | Response> {
   const auth = ctx.get("auth");
 
-  const skill = await SkillResource.fetchById(auth, sId);
+  const skill = await SkillResource.fetchById(auth, sId, {
+    permissionFiltering:
+      redactUnreadableForAdmin && auth.isAdmin()
+        ? "redact_unreadable"
+        : "strict",
+  });
   if (!skill) {
     return apiError(ctx, {
       status_code: 404,
@@ -54,18 +64,9 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
 
   // Editors are not private: admins can list them for the skills they cannot read too, e.g. to
   // know whom to ask for access.
-  const skill = await SkillResource.fetchById(auth, sId, {
-    // biome-ignore lint/plugin/noDirectRoleCheck: the mode is admin-only, everyone else gets the regular fetch
-    permissionFiltering: auth.isAdmin() ? "redact_unreadable" : "strict",
-  });
-  if (!skill) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "The skill was not found.",
-      },
-    });
+  const skill = await loadSkill(ctx, sId, { redactUnreadableForAdmin: true });
+  if (skill instanceof Response) {
+    return skill;
   }
 
   const members = (await skill.listEditors(auth)) ?? [];

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -301,8 +301,9 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.sId).toBe(restrictedSkill.sId);
     expect(data.skill.name).toBe("Restricted Space Skill");
     expect(data.skill.canRead).toBe(false);
+    // Not an editor, but an admin: archiving and availability changes stay possible.
     expect(data.skill.canWrite).toBe(false);
-    expect(data.skill.canAdministrate).toBe(false);
+    expect(data.skill.canAdministrate).toBe(true);
     expect(data.skill.instructions).toBeNull();
     expect(data.skill.instructionsHtml).toBeNull();
     expect(data.skill.tools).toEqual([]);
@@ -1568,6 +1569,34 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
 });
 
 describe("DELETE /api/w/:wId/skills/:sId", () => {
+  it("lets an admin archive a skill built on a space they cannot read", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "user",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [skillOwner.sId] });
+    const restrictedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const response = await deleteSkill(workspace, restrictedSkill.sId);
+
+    expect(response.status).toBe(200);
+    const [archived] = await SkillResource.fetchByIds(skillOwnerAuth, [
+      restrictedSkill.sId,
+    ]);
+    expect(archived.status).toBe("archived");
+  });
+
   it("should return 403 for non-editor user", async () => {
     const { workspace, skill } = await setupTest({
       skillOwnerRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -238,6 +238,119 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.isFavorite).toBe(true);
   });
 
+  it("redacts the private fields of a skill built on a space the admin cannot read", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "user",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [skillOwner.sId] });
+    const restrictedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      instructions: "Secret guidelines",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+    // Give the skill a tool and a file, so the redaction is tested on real data.
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Restricted Server",
+    });
+    const serverView = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      restrictedSpace
+    );
+    const file = await FileFactory.create(skillOwnerAuth, skillOwner, {
+      contentType: "text/plain",
+      fileName: "secret.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+    await restrictedSkill.updateSkill(skillOwnerAuth, {
+      name: restrictedSkill.name,
+      agentFacingDescription: restrictedSkill.agentFacingDescription,
+      userFacingDescription: restrictedSkill.userFacingDescription,
+      instructions: "Secret guidelines",
+      icon: null,
+      attachedKnowledge: [],
+      mcpServerViews: [serverView],
+      fileAttachments: [file],
+      requestedSpaceIds: [restrictedSpace.id],
+      manuallyRequestedSpaceIds: [],
+    });
+    const ownerView = await getSkill(workspace, restrictedSkill.sId);
+    // Sanity check on the fixture through the owner's own resource: the private data is there.
+    const ownerSkill = (
+      await SkillResource.fetchByIds(skillOwnerAuth, [restrictedSkill.sId])
+    )[0];
+    expect(ownerSkill.toJSON(skillOwnerAuth).tools).toHaveLength(1);
+    expect(ownerSkill.toJSON(skillOwnerAuth).fileAttachments).toHaveLength(1);
+    expect(ownerView.status).toBe(200);
+
+    const response = await getSkill(workspace, restrictedSkill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill.sId).toBe(restrictedSkill.sId);
+    expect(data.skill.name).toBe("Restricted Space Skill");
+    expect(data.skill.canRead).toBe(false);
+    expect(data.skill.canWrite).toBe(false);
+    expect(data.skill.canAdministrate).toBe(false);
+    expect(data.skill.instructions).toBeNull();
+    expect(data.skill.instructionsHtml).toBeNull();
+    expect(data.skill.tools).toEqual([]);
+    expect(data.skill.fileAttachments).toEqual([]);
+
+    // The details sheet also asks for the relations (editors, usage): they stay available.
+    const withRelationsResponse = await getSkillWithRelations(
+      workspace,
+      restrictedSkill.sId
+    );
+    expect(withRelationsResponse.status).toBe(200);
+    const withRelations = await withRelationsResponse.json();
+    expect(withRelations.skill.canRead).toBe(false);
+    expect(withRelations.skill.instructions).toBeNull();
+    expect(
+      withRelations.skill.relations.editors.map((e: { sId: string }) => e.sId)
+    ).toEqual([skillOwner.sId]);
+  });
+
+  it("returns 404 for a skill built on a space a non-admin cannot read", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "builder",
+    });
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "user",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(internalAdminAuth, {
+      userIds: [skillOwner.sId],
+    });
+    const restrictedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const response = await getSkill(workspace, restrictedSkill.sId);
+
+    expect(response.status).toBe(404);
+  });
+
   it("should return 404 for non-existent skill", async () => {
     const { workspace } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -73,14 +73,24 @@ const PatchSkillRequestBodySchema = z.object({
 // failure Response. See [API10].
 async function loadSkill(
   ctx: Context,
-  sId: string
+  sId: string,
+  {
+    redactUnreadableForAdmin = false,
+  }: {
+    redactUnreadableForAdmin?: boolean;
+  } = {}
 ): Promise<
   | { skill: SkillResource; sId: string }
   | (Response & TypedResponse<APIErrorResponse>)
 > {
   const auth = ctx.get("auth");
 
-  const skill = await SkillResource.fetchById(auth, sId);
+  const skill = await SkillResource.fetchById(auth, sId, {
+    permissionFiltering:
+      redactUnreadableForAdmin && auth.isAdmin()
+        ? "redact_unreadable"
+        : "strict",
+  });
   if (!skill) {
     return apiError(ctx, {
       status_code: 404,
@@ -117,21 +127,14 @@ app.get(
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
 
-    // Admins get the skills built on spaces they are not a member of too, redacted (`canRead`
-    // false); see `SkillResource.fetchById`.
-    const skill = await SkillResource.fetchById(auth, sId, {
-      // biome-ignore lint/plugin/noDirectRoleCheck: the mode is admin-only, everyone else gets the regular fetch
-      permissionFiltering: auth.isAdmin() ? "redact_unreadable" : "strict",
+    const loaded = await loadSkill(ctx, sId, {
+      redactUnreadableForAdmin: true,
     });
-    if (!skill) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "skill_not_found",
-          message: "The skill you're trying to access was not found.",
-        },
-      });
+    if (loaded instanceof Response) {
+      return loaded;
     }
+    const { skill } = loaded;
+
     const withRelations = ctx.req.query("withRelations");
 
     const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
@@ -505,7 +508,11 @@ app.delete(
     const owner = auth.getNonNullableWorkspace();
     const { sId } = ctx.req.valid("param");
 
-    const loaded = await loadSkill(ctx, sId);
+    // Admins can archive the skills built on spaces they are not a member of (shown to them
+    // redacted).
+    const loaded = await loadSkill(ctx, sId, {
+      redactUnreadableForAdmin: true,
+    });
     if (loaded instanceof Response) {
       return loaded;
     }

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -117,12 +117,21 @@ app.get(
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
 
-    const loaded = await loadSkill(ctx, sId);
-    if (loaded instanceof Response) {
-      return loaded;
+    // Admins get the skills built on spaces they are not a member of too, redacted (`canRead`
+    // false); see `SkillResource.fetchById`.
+    const skill = await SkillResource.fetchById(auth, sId, {
+      // biome-ignore lint/plugin/noDirectRoleCheck: the mode is admin-only, everyone else gets the regular fetch
+      permissionFiltering: auth.isAdmin() ? "redact_unreadable" : "strict",
+    });
+    if (!skill) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The skill you're trying to access was not found.",
+        },
+      });
     }
-    const { skill } = loaded;
-
     const withRelations = ctx.req.query("withRelations");
 
     const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");

--- a/front-api/routes/w/[wId]/skills/archive.test.ts
+++ b/front-api/routes/w/[wId]/skills/archive.test.ts
@@ -3,6 +3,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
@@ -26,7 +27,7 @@ async function setupTest(role: MembershipRoleType = "admin") {
     workspace.sId
   );
 
-  return { workspace, requestUserAuth, skillOwnerAuth };
+  return { workspace, requestUserAuth, skillOwner, skillOwnerAuth };
 }
 
 function archiveSkills(workspace: { sId: string }, skillIds: string[]) {
@@ -62,6 +63,33 @@ describe("POST /api/w/:wId/skills/archive", () => {
       "archived",
       "archived",
     ]);
+  });
+
+  it("lets an admin archive a skill built on a space they cannot read", async () => {
+    const { workspace, requestUserAuth, skillOwner, skillOwnerAuth } =
+      await setupTest();
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(requestUserAuth, {
+      userIds: [skillOwner.sId],
+    });
+    const restrictedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      availability: "editors",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+    // The admin cannot read the skill through the regular fetch.
+    expect(
+      await SkillResource.fetchByIds(requestUserAuth, [restrictedSkill.sId])
+    ).toEqual([]);
+
+    const response = await archiveSkills(workspace, [restrictedSkill.sId]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ archived: 1 });
+    const [archived] = await SkillResource.fetchByIds(skillOwnerAuth, [
+      restrictedSkill.sId,
+    ]);
+    expect(archived.status).toBe("archived");
   });
 
   it("denies a caller who cannot administrate every skill", async () => {

--- a/front-api/routes/w/[wId]/skills/archive.ts
+++ b/front-api/routes/w/[wId]/skills/archive.ts
@@ -42,8 +42,11 @@ app.post(
       });
     }
 
+    // Admins can archive the skills built on spaces they are not a member of (listed to them
+    // redacted), so those are fetched too.
     const skills = await SkillResource.fetchByIds(auth, skillIds, {
       onlyActive: true,
+      permissionFiltering: auth.isAdmin() ? "redact_unreadable" : "strict",
     });
     const foundSkillIds = new Set(skills.map((skill) => skill.sId));
     const missingSkillIds = skillIds.filter(

--- a/front-api/routes/w/[wId]/skills/availability.test.ts
+++ b/front-api/routes/w/[wId]/skills/availability.test.ts
@@ -4,6 +4,7 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
@@ -96,6 +97,39 @@ describe("PATCH /api/w/:wId/skills/availability", () => {
     );
     expect(untouchedSkill?.availability).toBe("workspace_users");
     expect(untouchedSkill?.editedBy).toBe(skillOwner.id);
+  });
+
+  it("lets an admin change the availability of a skill built on a space they cannot read", async () => {
+    const { workspace, requestUserAuth, skillOwner, skillOwnerAuth } =
+      await setupTest();
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(requestUserAuth, {
+      userIds: [skillOwner.sId],
+    });
+    const restrictedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      availability: "editors",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+    // The admin cannot read the skill through the regular fetch.
+    expect(
+      await SkillResource.fetchByIds(requestUserAuth, [restrictedSkill.sId])
+    ).toEqual([]);
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [restrictedSkill.sId],
+      availability: "workspace_users",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skills[0].availability).toBe("workspace_users");
+    expect(data.skills[0].canRead).toBe(false);
+    expect(data.skills[0].instructions).toBeNull();
+    const [updated] = await SkillResource.fetchByIds(skillOwnerAuth, [
+      restrictedSkill.sId,
+    ]);
+    expect(updated.availability).toBe("workspace_users");
   });
 
   it("refuses the batch when one of the skills is archived", async () => {

--- a/front-api/routes/w/[wId]/skills/availability.ts
+++ b/front-api/routes/w/[wId]/skills/availability.ts
@@ -74,7 +74,12 @@ app.patch(
       });
     }
 
-    const skills = await SkillResource.fetchByIds(auth, skillIds);
+    // Admins can change the availability of the skills built on spaces they are not a member of
+    // (listed to them redacted), so those are fetched too.
+    const permissionFiltering = auth.isAdmin() ? "redact_unreadable" : "strict";
+    const skills = await SkillResource.fetchByIds(auth, skillIds, {
+      permissionFiltering,
+    });
 
     const foundSkillIds = new Set(skills.map((skill) => skill.sId));
     const missingSkillIds = skillIds.filter(
@@ -115,7 +120,9 @@ app.patch(
     await SkillResource.updateAvailabilities(auth, skills, availability);
 
     // Re-fetch: the bulk update does not refresh the in-memory resources.
-    const updatedSkills = await SkillResource.fetchByIds(auth, skillIds);
+    const updatedSkills = await SkillResource.fetchByIds(auth, skillIds, {
+      permissionFiltering,
+    });
 
     return ctx.json({
       skills: updatedSkills.map((skill) => skill.toJSON(auth)),

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -319,6 +319,52 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).toContain("Someone Else's Unpublished Skill");
   });
 
+  it("lists skills built on spaces the admin cannot read with bypassEditorVisibility, redacted", async () => {
+    const { workspace, auth } = await setupTest("admin");
+
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "user",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [skillOwner.sId] });
+    await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      availability: "workspace_users",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    // Without the bypass the skill is filtered out by the space.
+    const withoutParamResponse = await getSkills(workspace);
+    expect(withoutParamResponse.status).toBe(200);
+    const withoutParamNames = (await withoutParamResponse.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(withoutParamNames).not.toContain("Restricted Space Skill");
+
+    const response = await getSkills(workspace, {
+      bypassEditorVisibility: "true",
+    });
+    expect(response.status).toBe(200);
+    const skills: SkillWithoutInstructionsAndToolsType[] = (
+      await response.json()
+    ).skills;
+    const restrictedSkill = skills.find(
+      (s) => s.name === "Restricted Space Skill"
+    );
+    expect(restrictedSkill).toBeDefined();
+    expect(restrictedSkill!.canRead).toBe(false);
+    expect(restrictedSkill!.fileAttachments).toEqual([]);
+    expect(restrictedSkill!.requestedSpaceIds).toEqual([restrictedSpace.sId]);
+
+    // Readable skills keep `canRead` true.
+    expect(skills.filter((s) => s.canRead)).not.toHaveLength(0);
+  });
+
   it("rejects bypassEditorVisibility for non-admins", async () => {
     const { workspace } = await setupTest("user");
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -191,6 +191,9 @@ app.get(
       withInstructions: false,
       withTools: false,
       withFileAttachments: false,
+      permissionFiltering: bypassEditorVisibility
+        ? "redact_unreadable"
+        : "strict",
     });
     const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
     let favoriteSkillIds = new Set<string>();

--- a/front/components/skills/RedactedSkillMessage.tsx
+++ b/front/components/skills/RedactedSkillMessage.tsx
@@ -1,0 +1,134 @@
+import { ConfirmContext } from "@app/components/Confirm";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  useSkill,
+  useSkillsWithRelations,
+} from "@app/lib/swr/skill_configurations";
+import {
+  useAddSpaceMembers,
+  useSpaces,
+  useSpacesAsAdmin,
+} from "@app/lib/swr/spaces";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, ContentMessage, Lock01, UsersPlus } from "@dust-tt/sparkle";
+import { useContext, useState } from "react";
+
+// Explains to an admin why the private fields of a skill were redacted: it requires spaces they
+// are not a member of. Offers to join them, which is the only way to read the skill.
+export function RedactedSkillMessage({
+  skill,
+  owner,
+}: {
+  skill: SkillType;
+  owner: LightWorkspaceType;
+}) {
+  // Spaces the caller is a member of, and every space of the workspace to name the missing ones.
+  const { spaces: memberSpaces } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: "all",
+  });
+  const { spaces: allSpaces } = useSpacesAsAdmin({ workspaceId: owner.sId });
+  const { user } = useAuth();
+  const addSpaceMembers = useAddSpaceMembers({ owner });
+  const { mutateSkill } = useSkill({
+    workspaceId: owner.sId,
+    skillId: skill.sId,
+    disabled: true, // We only use the hook to mutate the cache
+  });
+  const {
+    mutateSkillsWithRelationsRegardlessOfQueryParams: mutateSkillsWithRelations,
+  } = useSkillsWithRelations({
+    owner,
+    status: "active",
+    disabled: true, // We only use the hook to mutate the cache
+  });
+  const [isJoiningSpaces, setIsJoiningSpaces] = useState(false);
+  const confirm = useContext(ConfirmContext);
+
+  const memberSpaceIds = new Set(memberSpaces.map((s) => s.sId));
+  const spaceById = new Map(allSpaces.map((s) => [s.sId, s]));
+  const missingSpaceIds = skill.requestedSpaceIds.filter(
+    (sId) => !memberSpaceIds.has(sId)
+  );
+  const missingSpaceNames = missingSpaceIds.map(
+    (sId) => spaceById.get(sId)?.name ?? sId
+  );
+
+  // Adds the admin to every requested space they are not a member of, with the same security
+  // notice as the space settings modal.
+  const handleJoinSpaces = async () => {
+    if (isJoiningSpaces) {
+      return;
+    }
+    const confirmed = await confirm({
+      title: "Security notice",
+      message:
+        `You are about to join ${missingSpaceIds.length === 1 ? "this space" : "these spaces"}. ` +
+        "This action will be logged for security purposes. Do you want to proceed?",
+      validateLabel: "Proceed",
+      validateVariant: "warning",
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    setIsJoiningSpaces(true);
+    try {
+      // The spaces are independent, so they are joined concurrently.
+      await concurrentExecutor(
+        missingSpaceIds,
+        async (spaceId) => {
+          const space = spaceById.get(spaceId);
+          if (!space) {
+            return;
+          }
+          await addSpaceMembers(space, [user.sId], {
+            title: `Joined ${space.name}`,
+            description: `You are now a member of ${space.name}.`,
+          });
+        },
+        { concurrency: 4 }
+      );
+      void mutateSkill();
+      void mutateSkillsWithRelations();
+    } finally {
+      setIsJoiningSpaces(false);
+    }
+  };
+
+  return (
+    <ContentMessage title="Restricted access" icon={Lock01} size="md">
+      <div className="flex flex-col gap-2">
+        <span>You cannot see the guidelines of this skill.</span>
+        {missingSpaceNames.length > 0 && (
+          <>
+            <span>
+              The skill uses restricted spaces you are not a member of:{" "}
+              {missingSpaceNames.join(", ")}.
+            </span>
+            <div>
+              <Button
+                variant="outline"
+                size="sm"
+                icon={UsersPlus}
+                label={
+                  missingSpaceNames.length === 1
+                    ? `Join space ${missingSpaceNames[0]}`
+                    : "Join all required spaces"
+                }
+                isLoading={isJoiningSpaces}
+                disabled={isJoiningSpaces}
+                onClick={() => {
+                  void handleJoinSpaces();
+                }}
+                type="button"
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </ContentMessage>
+  );
+}

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -45,6 +45,12 @@ export function SkillDetailsButtonBar({
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
   const [isSkillLinkCopied, copySkillLink] = useCopyToClipboard();
 
+  // The API redacts the private fields of the skills an admin cannot read (built on spaces they
+  // are not a member of) and flags it with `canRead: false`; only admins ever get such a skill.
+  // Trying or favoriting it would fail, so those entry points are hidden (the edit and archive
+  // ones already are, since the redaction drops `canAdministrate`).
+  const isRedactedForAdmin = !skill.canRead;
+
   return (
     <>
       <ArchiveSkillDialog
@@ -57,7 +63,7 @@ export function SkillDetailsButtonBar({
         }}
       />
       <div className="flex flex-row items-center gap-2 px-1.5">
-        {onFavoriteChange && (
+        {onFavoriteChange && !isRedactedForAdmin && (
           <SkillFavoriteButton
             isFavorite={skill.isFavorite ?? false}
             variant="outline"
@@ -66,13 +72,15 @@ export function SkillDetailsButtonBar({
             }
           />
         )}
-        <Button
-          size="sm"
-          tooltip="Try skill"
-          href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
-          variant="outline"
-          icon={MessagePlusCircle}
-        />
+        {!isRedactedForAdmin && (
+          <Button
+            size="sm"
+            tooltip="Try skill"
+            href={getConversationRoute(owner.sId, "new", `skill=${skill.sId}`)}
+            variant="outline"
+            icon={MessagePlusCircle}
+          />
+        )}
         {skill.canAdministrate && (
           <Button
             size="sm"

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -47,8 +47,8 @@ export function SkillDetailsButtonBar({
 
   // The API redacts the private fields of the skills an admin cannot read (built on spaces they
   // are not a member of) and flags it with `canRead: false`; only admins ever get such a skill.
-  // Trying or favoriting it would fail, so those entry points are hidden (the edit and archive
-  // ones already are, since the redaction drops `canAdministrate`).
+  // Trying, favoriting or editing it would fail or work on an empty skill, so those entry points
+  // are hidden. Archiving stays: it only needs the admin role.
   const isRedactedForAdmin = !skill.canRead;
 
   return (
@@ -81,7 +81,7 @@ export function SkillDetailsButtonBar({
             icon={MessagePlusCircle}
           />
         )}
-        {skill.canAdministrate && (
+        {skill.canAdministrate && !isRedactedForAdmin && (
           <Button
             size="sm"
             tooltip="Edit skill"

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -2,6 +2,7 @@ import { KnowledgeChip } from "@app/components/editor/extensions/skill_builder/K
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { isFullKnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { SkillDescriptionReadOnlyEditor } from "@app/components/editor/SkillDescriptionEditor";
+import { RedactedSkillMessage } from "@app/components/skills/RedactedSkillMessage";
 import { SkillInstructionsReadOnlyEditor } from "@app/components/skills/SkillInstructionsReadOnlyEditor";
 import {
   getMcpServerViewDescription,
@@ -13,13 +14,14 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { SKILL_INVOCATION_LABEL } from "@app/lib/skills/labels";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
-import { useSpaces } from "@app/lib/swr/spaces";
+import { useSpaces, useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import type {
   SkillRelations,
   SkillType,
 } from "@app/types/assistant/skill_configuration";
 import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   AttachmentChip,
   Chip,
@@ -62,8 +64,23 @@ export function SkillInfoTab({
     kinds: ["global", "regular", "project"],
     disabled: !shouldLoadSpaces || !!spaces,
   });
+  // A redacted skill (admin, see `canRead`) requests spaces the caller is not a member of, which
+  // the member listing above does not return: resolve them through the admin listing.
+  const { spaces: spacesAsAdmin } = useSpacesAsAdmin({
+    workspaceId: owner.sId,
+    disabled: !isAdmin(owner) || skill.canRead || !shouldLoadSpaces || !!spaces,
+  });
 
-  const resolvedSpaces = spaces ?? spacesFromHook;
+  const resolvedSpaces = useMemo(
+    () =>
+      spaces ??
+      Array.from(
+        new Map(
+          [...spacesFromHook, ...spacesAsAdmin].map((s) => [s.sId, s])
+        ).values()
+      ),
+    [spaces, spacesFromHook, spacesAsAdmin]
+  );
 
   const sortedMCPServerViews = useMemo(
     () => sortBy(skill.tools.map(renderMCPServerView), "title"),
@@ -114,6 +131,10 @@ export function SkillInfoTab({
           {skill.userFacingDescription}
         </div>
       ) : null}
+
+      {/* The API redacts the private fields of the skills an admin cannot read and flags it with
+          `canRead: false`; only admins ever get such a skill. */}
+      {!skill.canRead && <RedactedSkillMessage skill={skill} owner={owner} />}
 
       {showSeparator ? <Separator /> : null}
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -537,7 +537,8 @@ export function SkillsTable({
                 {
                   label: "Edit",
                   icon: Edit04,
-                  disabled: !skill.canAdministrate,
+                  // `canRead` is false for skills redacted for an admin (see the details sheet).
+                  disabled: !skill.canAdministrate || !skill.canRead,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     void router.push(


### PR DESCRIPTION
## Description

Uses the `redact_unreadable` permission filtering mode added to the skill fetchers in #31863 (merged).

Unlike agents, a skill's availability does not restrict reading it: editors-only skills can be read by anyone since an agent may expose them. The only thing that hides a skill is a restricted space the caller is not a member of. Today "Show hidden skills" on the manage skills page only lifts the editors-only filter, so those skills stay invisible to admins, and opening one gives a 404.

- `GET /skills?bypassEditorVisibility=true` (admin only) lists the skills built on spaces the admin is not a member of, redacted: instructions, tools and files removed, `canRead` false. Name, icon, description, availability and editors stay.
- `GET /skills/:sId` and `GET /skills/:sId/editors` return the same redacted skill to admins instead of a 404, so the details sheet and its Editors tab work. Non-admins keep the 404.
- Batch edit and archive: admins can change the availability of redacted skills and archive them (batch endpoints and the single DELETE fetch them in the redacted mode). Only the actions that need the guidelines are hidden: Try, favorite and Edit.
- Details sheet: a "Restricted access" message listing the missing spaces with a "Join space" button behind the same security notice as the space settings.

<img width="1578" height="923" alt="Screenshot 2026-09-04 at 14 23 04" src="https://github.com/user-attachments/assets/f8200186-0ddc-49f5-b260-e942f36856c8" />

<img width="1240" height="688" alt="image" src="https://github.com/user-attachments/assets/599983a1-5c1b-4c7b-b309-19e6ac61983d" />


## Tests

 - manual tests for the UI
 - new endpoint unit tests

## Risk

Low.

## Deploy Plan

- Deploy front


