### PR TITLE
Fix tracking extra/properties

### DIFF
--- a/front/lib/api/posthog.ts
+++ b/front/lib/api/posthog.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import type { TrackingExtra } from "@app/lib/tracking";
 import type { UTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import type { UserType } from "@app/types/user";
@@ -26,11 +27,13 @@ export class PostHogServerSideTracking {
   static trackEvent({
     distinctId,
     event,
-    properties,
+    extra,
+    workspaceId,
   }: {
     distinctId: string;
     event: string;
-    properties?: Record<string, string | number | boolean>;
+    extra?: TrackingExtra;
+    workspaceId?: string;
   }): void {
     const client = getClient();
     if (!client) {
@@ -38,7 +41,16 @@ export class PostHogServerSideTracking {
     }
 
     try {
-      client.capture({ distinctId, event, properties });
+      client.capture({
+        distinctId,
+        event,
+        properties: {
+          ...extra, // Spread for PostHog.
+          extra, // As object for Snowflake.
+        },
+        // Resolves the event to a workspace downstream (`properties:$groups:workspace`).
+        ...(workspaceId ? { groups: { workspace: workspaceId } } : {}),
+      });
     } catch (err) {
       logger.error(
         { distinctId, event, err },

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -170,8 +170,8 @@ async function createConversationForAgentConfiguration({
       PostHogServerSideTracking.trackEvent({
         distinctId: auth.getNonNullableUser().sId,
         event: "trigger_blocked",
-        properties: {
-          workspace_id: auth.getNonNullableWorkspace().sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        extra: {
           trigger_id: trigger.sId,
           error_type: errorType,
         },


### PR DESCRIPTION
## Description

Follow-up from https://github.com/dust-tt/dust/pull/31734. The `extra` properties need to be formatted a certain way for Snowflake and PostHog to be able to consume them properly.
Also automatically passes workspace sId when available.

## Tests

Will look at new events post merge

## Risk

Low.

## Deploy Plan

Normal