### PR TITLE
feat(core): authenticate GCS via ADC/WIF

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "flate2",
  "futures",
  "gcp-bigquery-client",
+ "gcp_auth",
  "http 1.3.1",
  "humantime",
  "hyper 1.6.0",
@@ -1413,6 +1414,7 @@ dependencies = [
  "rayon",
  "redis",
  "regex",
+ "reqwest 0.11.27",
  "reqwest 0.12.20",
  "ring 0.17.14",
  "rsa",
@@ -1783,6 +1785,33 @@ dependencies = [
  "tonic-build",
  "url",
  "yup-oauth2",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d27dbcc645b60b8e7f6e2868a9d7102ece97d1bb49c1288b5321fcc67f7260"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "ring 0.17.14",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
 ]
 
 [[package]]
@@ -5338,6 +5367,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -138,7 +138,7 @@ bstr = "1.9"
 chardetng = "0.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
-cloud-storage = { version = "0.11", features = ["global-client"] }
+cloud-storage = { version = "0.11" }
 csv = "1.3.0"
 csv-async = "1.3.0"
 dateparser = "0.2.1"
@@ -151,6 +151,7 @@ eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client
 fancy-regex = "0.13"
 flate2 = "1.0"
 futures = "0.3"
+gcp_auth = "0.12.7"
 gcp-bigquery-client = "0.25.1"
 http = "1.1.0"
 humantime = "2.2.0"
@@ -158,6 +159,9 @@ hyper = { version = "1.3.1", features = ["full"] }
 init-tracing-opentelemetry =  { version = "0.29.0", features = ["tracing_subscriber_ext"] }
 itertools = "0.10"
 jsonwebtoken = "9.3.0"
+# cloud-storage 0.11 depends on reqwest 0.11; keep a renamed dep so our TokenCache
+# impl can match that crate's TokenCache::fetch_token signature.
+reqwest011 = { package = "reqwest", version = "0.11", default-features = false, features = ["json", "default-tls"] }
 openssl = { version = "0.10", features = ["vendored"] }
 lazy_static = "1.4"
 once_cell = "1.18"

--- a/core/bin/migrations/20241203_fix_created_dsdocs.rs
+++ b/core/bin/migrations/20241203_fix_created_dsdocs.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use cloud_storage::{ListRequest, Object};
+use cloud_storage::ListRequest;
 use dust::data_sources::data_source::make_document_id_hash;
 use dust::data_sources::file_storage_document::FileStorageDocument;
+use dust::gcs_client::gcs_client;
 use dust::stores::{postgres, store};
 use futures::{pin_mut, StreamExt};
 
@@ -217,14 +218,17 @@ async fn list_files_with_prefix(prefix: &str) -> Result<Vec<String>> {
 
     let mut paths = Vec::new();
 
-    let stream = Object::list(
-        &bucket,
-        ListRequest {
-            prefix: Some(prefix.to_string()),
-            ..Default::default()
-        },
-    )
-    .await?;
+    let stream = gcs_client()
+        .await?
+        .object()
+        .list(
+            &bucket,
+            ListRequest {
+                prefix: Some(prefix.to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
 
     pin_mut!(stream);
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -1,8 +1,9 @@
 use anyhow::{anyhow, Result};
-use cloud_storage::{ErrorList, GoogleErrorResponse, Object};
+use cloud_storage::{ErrorList, GoogleErrorResponse};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 
+use crate::gcs_client::gcs_client;
 use crate::utils;
 
 use super::data_source::{DataSource, Document, DocumentVersion, Section};
@@ -51,7 +52,7 @@ impl FileStorageDocument {
     pub async fn path_exists(path: &str) -> Result<bool> {
         let bucket = FileStorageDocument::get_bucket().await?;
 
-        match Object::read(&bucket, path).await {
+        match gcs_client().await?.object().read(&bucket, path).await {
             Ok(_) => Ok(true),
             Err(_err) => Ok(false),
         }
@@ -60,7 +61,7 @@ impl FileStorageDocument {
     pub async fn delete_if_exists(path: &str) -> Result<bool> {
         let bucket = FileStorageDocument::get_bucket().await?;
 
-        match Object::delete(&bucket, &path).await {
+        match gcs_client().await?.object().delete(&bucket, &path).await {
             Ok(_) => Ok(true),
             Err(e) => match e {
                 cloud_storage::Error::Google(GoogleErrorResponse {
@@ -87,7 +88,12 @@ impl FileStorageDocument {
         let bucket = FileStorageDocument::get_bucket().await?;
 
         let now = utils::now();
-        match Object::download(&bucket, &file_path).await {
+        match gcs_client()
+            .await?
+            .object()
+            .download(&bucket, &file_path)
+            .await
+        {
             Ok(bytes) => {
                 info!(
                     data_source_internal_id = data_source.internal_id(),
@@ -153,7 +159,12 @@ impl FileStorageDocument {
         );
 
         let now = utils::now();
-        match Object::delete(&bucket, &document_file_path).await {
+        match gcs_client()
+            .await?
+            .object()
+            .delete(&bucket, &document_file_path)
+            .await
+        {
             Ok(_) => (),
             Err(e) => {
                 match e {
@@ -207,13 +218,16 @@ impl FileStorageDocument {
         let serialized_document = serde_json::to_vec(&file_storage_document)?;
 
         let now = utils::now();
-        let _ = Object::create(
-            &bucket,
-            serialized_document,
-            &document_file_path,
-            "application/json",
-        )
-        .await?;
+        let _ = gcs_client()
+            .await?
+            .object()
+            .create(
+                &bucket,
+                serialized_document,
+                &document_file_path,
+                "application/json",
+            )
+            .await?;
 
         info!(
             data_source_internal_id = data_source_internal_id,

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use cloud_storage::Object;
 use csv_async::AsyncReaderBuilder;
 use futures::stream::StreamExt;
 use lazy_static::lazy_static;
@@ -12,7 +11,7 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::info;
 use unicode_normalization::UnicodeNormalization;
 
-use crate::{databases::table::Row, utils};
+use crate::{databases::table::Row, gcs_client::gcs_client, utils};
 
 pub struct GoogleCloudStorageCSVContent {
     pub bucket: String,
@@ -33,7 +32,7 @@ impl GoogleCloudStorageCSVContent {
         let path = &self.bucket_csv_path;
 
         // Check file size before downloading to prevent OOM issues.
-        let metadata = Object::read(bucket, path).await?;
+        let metadata = gcs_client().await?.object().read(bucket, path).await?;
         if metadata.size > MAX_CSV_FILE_SIZE_BYTES {
             info!(
                 bucket = bucket,
@@ -51,7 +50,7 @@ impl GoogleCloudStorageCSVContent {
 
         // This is not the most efficient as we download the entire file here but we will
         // materialize it in memory as Vec<Row> anyway so that's not a massive difference.
-        let content = Object::download(bucket, path).await?;
+        let content = gcs_client().await?.object().download(bucket, path).await?;
         // csv_async only accepts UTF-8; transcode UTF-16 (BOM-based) and detected single-byte
         // encodings (e.g. Windows-1252 produced by Excel's default "Save as CSV").
         let content = Self::decode_to_utf8(content)?;

--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use cloud_storage::{ErrorList, GoogleErrorResponse, Object};
+use cloud_storage::{ErrorList, GoogleErrorResponse};
 use csv::Writer;
 use tracing::info;
 
@@ -12,6 +12,7 @@ use crate::{
         table::{Row, Table},
         table_schema::TableSchema,
     },
+    gcs_client::gcs_client,
     utils::{self},
 };
 
@@ -51,7 +52,11 @@ pub async fn write_rows_to_bucket(
 
     let csv = wtr.into_inner()?;
 
-    Object::create(bucket, csv, bucket_csv_path, "text/csv").await?;
+    gcs_client()
+        .await?
+        .object()
+        .create(bucket, csv, bucket_csv_path, "text/csv")
+        .await?;
 
     Ok(())
 }
@@ -88,9 +93,9 @@ impl GoogleCloudStorageDatabasesStore {
                 // Treat a non-existing file as an empty table.
                 // Checking for this is trickier than it should be, due to how the cloud_storage crate handles errors,
                 // and depends on which underlying GCS call hits the missing object first:
-                //  - Object::download (the actual file download) returns an 'Other' error containing "No such object".
-                //  - Object::read (the metadata probe parse() does for its file-size check) returns the more
-                //    meaningful Google(GoogleErrorResponse) with a 404, same as Object::delete on a missing object.
+                //  - object().download (the actual file download) returns an 'Other' error containing "No such object".
+                //  - object().read (the metadata probe parse() does for its file-size check) returns the more
+                //    meaningful Google(GoogleErrorResponse) with a 404, same as object().delete on a missing object.
                 // We treat both as an empty table.
                 Some(cloud_storage::Error::Other(s)) if s.contains("No such object") => {
                     info!(
@@ -236,11 +241,14 @@ impl DatabasesStore for GoogleCloudStorageDatabasesStore {
     }
 
     async fn delete_table_data(&self, table: &Table) -> Result<()> {
-        match Object::delete(
-            &Self::get_bucket()?,
-            &Self::get_csv_storage_file_path(table),
-        )
-        .await
+        match gcs_client()
+            .await?
+            .object()
+            .delete(
+                &Self::get_bucket()?,
+                &Self::get_csv_storage_file_path(table),
+            )
+            .await
         {
             Ok(_) => {}
             Err(e) => match e {

--- a/core/src/databases_store/gcs_background.rs
+++ b/core/src/databases_store/gcs_background.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use async_std::stream::StreamExt;
-use cloud_storage::{ListRequest, Object};
+use cloud_storage::ListRequest;
 use futures::future::try_join_all;
 use std::collections::HashMap;
 use tracing::error;
@@ -13,6 +13,7 @@ use crate::{
         table_schema::TableSchema,
     },
     databases_store::gcs::write_rows_to_bucket,
+    gcs_client::gcs_client,
 };
 
 // This Store is used to pass upsert and delete call info from the APIs to the background worker
@@ -79,7 +80,11 @@ impl GoogleCloudStorageBackgroundProcessingStore {
             start_offset: None,
             versions: None,
         };
-        let stream = Object::list(&bucket, list_request).await?;
+        let stream = gcs_client()
+            .await?
+            .object()
+            .list(&bucket, list_request)
+            .await?;
 
         let mut pinned_stream = Box::pin(stream);
         let mut files = Vec::new();
@@ -148,10 +153,11 @@ impl GoogleCloudStorageBackgroundProcessingStore {
     pub async fn delete_files(files: &Vec<String>) -> Result<()> {
         // We delete the files concurrently to speed up the process
         let bucket = Self::get_bucket()?;
+        let client = gcs_client().await?;
         let delete_futures = files.iter().map(|file| {
             let bucket = bucket.clone();
             async move {
-                match Object::delete(&bucket, &file).await {
+                match client.object().delete(&bucket, &file).await {
                     Ok(_) => Ok::<(), ()>(()),
                     Err(e) => {
                         error!("Failed to delete file {}: {}", file, e);

--- a/core/src/gcs_client.rs
+++ b/core/src/gcs_client.rs
@@ -1,0 +1,135 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use cloud_storage::{Client, TokenCache};
+use gcp_auth::TokenProvider;
+use std::sync::Arc;
+use tokio::sync::{OnceCell, RwLock};
+
+const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.full_control";
+
+static GCS_CLIENT: OnceCell<Client> = OnceCell::const_new();
+
+/// Shared GCS client authenticated via Application Default Credentials.
+///
+/// Supports:
+/// - `GOOGLE_CLOUD_ACCESS_TOKEN` (tests / local overrides)
+/// - `GOOGLE_APPLICATION_CREDENTIALS` service-account JSON
+/// - gcloud application-default credentials
+/// - GCE/GKE metadata server (including Workload Identity Federation)
+pub async fn gcs_client() -> Result<&'static Client> {
+    GCS_CLIENT
+        .get_or_try_init(|| async { build_gcs_client().await })
+        .await
+}
+
+async fn build_gcs_client() -> Result<Client> {
+    if let Some(token) = get_static_access_token_from_env() {
+        return Ok(Client::with_cache(StaticAccessTokenCache::new(token)));
+    }
+
+    let provider = gcp_auth::provider()
+        .await
+        .context("failed to initialize GCP authentication for GCS")?;
+
+    Ok(Client::with_cache(GcpAuthTokenCache::new(provider)))
+}
+
+fn get_static_access_token_from_env() -> Option<String> {
+    std::env::var("GOOGLE_CLOUD_ACCESS_TOKEN")
+        .ok()
+        .and_then(|token| {
+            let trimmed = token.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+}
+
+struct StaticAccessTokenCache {
+    token: String,
+}
+
+impl StaticAccessTokenCache {
+    fn new(token: String) -> Self {
+        Self { token }
+    }
+}
+
+#[async_trait]
+impl TokenCache for StaticAccessTokenCache {
+    async fn token_and_exp(&self) -> Option<(String, u64)> {
+        // Static tokens from env have no expiry metadata; treat as long-lived.
+        Some((self.token.clone(), u64::MAX / 2))
+    }
+
+    async fn set_token(&self, _token: String, _exp: u64) -> cloud_storage::Result<()> {
+        Ok(())
+    }
+
+    async fn scope(&self) -> String {
+        GCS_SCOPE.to_string()
+    }
+
+    async fn fetch_token(
+        &self,
+        _client: &reqwest011::Client,
+    ) -> cloud_storage::Result<(String, u64)> {
+        Ok((self.token.clone(), u64::MAX / 2))
+    }
+}
+
+struct GcpAuthTokenCache {
+    provider: Arc<dyn TokenProvider>,
+    cached: RwLock<Option<(String, u64)>>,
+}
+
+impl GcpAuthTokenCache {
+    fn new(provider: Arc<dyn TokenProvider>) -> Self {
+        Self {
+            provider,
+            cached: RwLock::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl TokenCache for GcpAuthTokenCache {
+    async fn token_and_exp(&self) -> Option<(String, u64)> {
+        self.cached.read().await.clone()
+    }
+
+    async fn set_token(&self, token: String, exp: u64) -> cloud_storage::Result<()> {
+        *self.cached.write().await = Some((token, exp));
+        Ok(())
+    }
+
+    async fn scope(&self) -> String {
+        GCS_SCOPE.to_string()
+    }
+
+    async fn fetch_token(
+        &self,
+        _client: &reqwest011::Client,
+    ) -> cloud_storage::Result<(String, u64)> {
+        let token = self
+            .provider
+            .token(&[GCS_SCOPE])
+            .await
+            .map_err(|e| cloud_storage::Error::Other(e.to_string()))?;
+
+        let expires_at = token.expires_at().timestamp();
+        let exp = if expires_at > 0 {
+            expires_at as u64
+        } else {
+            // Fallback if the provider does not expose a usable expiry.
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() + 3600)
+                .unwrap_or(3600)
+        };
+
+        Ok((token.as_str().to_string(), exp))
+    }
+}

--- a/core/src/gcs_client.rs
+++ b/core/src/gcs_client.rs
@@ -1,21 +1,25 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use cloud_storage::{Client, TokenCache};
-use gcp_auth::TokenProvider;
+use gcp_auth::{CustomServiceAccount, TokenProvider};
+use std::path::Path;
 use std::sync::Arc;
-use tokio::sync::{OnceCell, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex, OnceCell, RwLock};
 
 const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.full_control";
+const TOKEN_EXPIRY_SKEW_SECONDS: u64 = 300;
 
 static GCS_CLIENT: OnceCell<Client> = OnceCell::const_new();
 
-/// Shared GCS client authenticated via Application Default Credentials.
+/// Shared GCS client authenticated for Dust's production and local setups.
 ///
-/// Supports:
+/// Supports, in order:
 /// - `GOOGLE_CLOUD_ACCESS_TOKEN` (tests / local overrides)
-/// - `GOOGLE_APPLICATION_CREDENTIALS` service-account JSON
-/// - gcloud application-default credentials
-/// - GCE/GKE metadata server (including Workload Identity Federation)
+/// - `SERVICE_ACCOUNT` path to a service-account JSON file (Dust's existing env)
+/// - `SERVICE_ACCOUNT_JSON` inline service-account JSON
+/// - `gcp_auth::provider()` fallback (GOOGLE_APPLICATION_CREDENTIALS, gcloud ADC,
+///   GCE/GKE metadata / Workload Identity Federation)
 pub async fn gcs_client() -> Result<&'static Client> {
     GCS_CLIENT
         .get_or_try_init(|| async { build_gcs_client().await })
@@ -27,11 +31,44 @@ async fn build_gcs_client() -> Result<Client> {
         return Ok(Client::with_cache(StaticAccessTokenCache::new(token)));
     }
 
-    let provider = gcp_auth::provider()
+    let provider = resolve_token_provider()
         .await
         .context("failed to initialize GCP authentication for GCS")?;
 
     Ok(Client::with_cache(GcpAuthTokenCache::new(provider)))
+}
+
+async fn resolve_token_provider() -> Result<Arc<dyn TokenProvider>> {
+    if let Some(provider) = service_account_provider_from_env()? {
+        return Ok(provider);
+    }
+
+    gcp_auth::provider()
+        .await
+        .map_err(|e| anyhow!("failed to initialize GCP ADC/WIF provider: {e}"))
+}
+
+fn service_account_provider_from_env() -> Result<Option<Arc<dyn TokenProvider>>> {
+    if let Ok(path) = std::env::var("SERVICE_ACCOUNT") {
+        let path = path.trim();
+        if !path.is_empty() {
+            let account = CustomServiceAccount::from_file(Path::new(path)).map_err(|e| {
+                anyhow!("failed to load SERVICE_ACCOUNT credentials from {path}: {e}")
+            })?;
+            return Ok(Some(Arc::new(account)));
+        }
+    }
+
+    if let Ok(json) = std::env::var("SERVICE_ACCOUNT_JSON") {
+        let json = json.trim();
+        if !json.is_empty() {
+            let account = CustomServiceAccount::from_json(json)
+                .map_err(|e| anyhow!("failed to parse SERVICE_ACCOUNT_JSON credentials: {e}"))?;
+            return Ok(Some(Arc::new(account)));
+        }
+    }
+
+    Ok(None)
 }
 
 fn get_static_access_token_from_env() -> Option<String> {
@@ -45,6 +82,13 @@ fn get_static_access_token_from_env() -> Option<String> {
                 Some(trimmed.to_string())
             }
         })
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 struct StaticAccessTokenCache {
@@ -83,6 +127,8 @@ impl TokenCache for StaticAccessTokenCache {
 struct GcpAuthTokenCache {
     provider: Arc<dyn TokenProvider>,
     cached: RwLock<Option<(String, u64)>>,
+    /// Serializes refreshes so concurrent callers share one token fetch.
+    refresh: Mutex<()>,
 }
 
 impl GcpAuthTokenCache {
@@ -90,6 +136,7 @@ impl GcpAuthTokenCache {
         Self {
             provider,
             cached: RwLock::new(None),
+            refresh: Mutex::new(()),
         }
     }
 }
@@ -109,6 +156,27 @@ impl TokenCache for GcpAuthTokenCache {
         GCS_SCOPE.to_string()
     }
 
+    async fn get(&self, client: &reqwest011::Client) -> cloud_storage::Result<String> {
+        if let Some((token, exp)) = self.token_and_exp().await {
+            if now_unix_seconds() + TOKEN_EXPIRY_SKEW_SECONDS < exp {
+                return Ok(token);
+            }
+        }
+
+        let _guard = self.refresh.lock().await;
+
+        // Another waiter may have refreshed while we were queued.
+        if let Some((token, exp)) = self.token_and_exp().await {
+            if now_unix_seconds() + TOKEN_EXPIRY_SKEW_SECONDS < exp {
+                return Ok(token);
+            }
+        }
+
+        let (token, exp) = self.fetch_token(client).await?;
+        self.set_token(token.clone(), exp).await?;
+        Ok(token)
+    }
+
     async fn fetch_token(
         &self,
         _client: &reqwest011::Client,
@@ -123,13 +191,186 @@ impl TokenCache for GcpAuthTokenCache {
         let exp = if expires_at > 0 {
             expires_at as u64
         } else {
-            // Fallback if the provider does not expose a usable expiry.
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs() + 3600)
-                .unwrap_or(3600)
+            now_unix_seconds() + 3600
         };
 
         Ok((token.as_str().to_string(), exp))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gcp_auth::Token;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tempfile::NamedTempFile;
+
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    fn test_service_account_json() -> String {
+        let rsa = openssl::rsa::Rsa::generate(2048).expect("rsa key");
+        let pkey = openssl::pkey::PKey::from_rsa(rsa).expect("pkey");
+        let private_key =
+            String::from_utf8(pkey.private_key_to_pem_pkcs8().expect("pkcs8 pem")).expect("utf8");
+        serde_json::json!({
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "test-key-id",
+            "private_key": private_key,
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+            "client_id": "1234567890",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test"
+        })
+        .to_string()
+    }
+
+    fn test_token(expires_in_seconds: u64) -> Arc<Token> {
+        Arc::new(
+            serde_json::from_value(serde_json::json!({
+                "access_token": "test-access-token",
+                "expires_in": expires_in_seconds,
+            }))
+            .expect("token json"),
+        )
+    }
+
+    struct CountingProvider {
+        calls: AtomicUsize,
+        delay: Duration,
+    }
+
+    #[async_trait]
+    impl TokenProvider for CountingProvider {
+        async fn token(&self, _scopes: &[&str]) -> Result<Arc<Token>, gcp_auth::Error> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.delay).await;
+            Ok(test_token(3600))
+        }
+
+        async fn project_id(&self) -> Result<Arc<str>, gcp_auth::Error> {
+            Ok(Arc::from("test-project"))
+        }
+    }
+
+    #[tokio::test]
+    async fn service_account_env_loads_custom_provider() {
+        let _env_guard = ENV_LOCK.lock().await;
+        let json = test_service_account_json();
+        let mut file = NamedTempFile::new().expect("tempfile");
+        file.write_all(json.as_bytes()).expect("write sa");
+
+        let _sa = EnvGuard::set("SERVICE_ACCOUNT", file.path().to_str().unwrap());
+        let _saj = EnvGuard::remove("SERVICE_ACCOUNT_JSON");
+
+        let provider = service_account_provider_from_env()
+            .expect("resolve SERVICE_ACCOUNT")
+            .expect("provider should be present");
+
+        let project_id = provider.project_id().await.expect("project id");
+        assert_eq!(project_id.as_ref(), "test-project");
+    }
+
+    #[tokio::test]
+    async fn service_account_json_env_loads_custom_provider() {
+        let _env_guard = ENV_LOCK.lock().await;
+        let json = test_service_account_json();
+        let _saj = EnvGuard::set("SERVICE_ACCOUNT_JSON", &json);
+        let _sa = EnvGuard::remove("SERVICE_ACCOUNT");
+
+        let provider = service_account_provider_from_env()
+            .expect("resolve SERVICE_ACCOUNT_JSON")
+            .expect("provider should be present");
+
+        let project_id = provider.project_id().await.expect("project id");
+        assert_eq!(project_id.as_ref(), "test-project");
+    }
+
+    #[tokio::test]
+    async fn token_cache_single_flights_refresh() {
+        let provider = Arc::new(CountingProvider {
+            calls: AtomicUsize::new(0),
+            delay: Duration::from_millis(50),
+        });
+        let cache = Arc::new(GcpAuthTokenCache::new(provider.clone()));
+        let http = reqwest011::Client::new();
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let http = http.clone();
+            handles.push(tokio::spawn(async move {
+                cache.get(&http).await.expect("token")
+            }));
+        }
+
+        let tokens: Vec<String> = futures::future::try_join_all(handles)
+            .await
+            .expect("join")
+            .into_iter()
+            .collect();
+
+        assert!(tokens.iter().all(|t| t == "test-access-token"));
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            1,
+            "concurrent get() calls should share a single refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_cache_reuses_cached_token_without_refresh() {
+        let provider = Arc::new(CountingProvider {
+            calls: AtomicUsize::new(0),
+            delay: Duration::from_millis(0),
+        });
+        let cache = GcpAuthTokenCache::new(provider.clone());
+        let http = reqwest011::Client::new();
+
+        let first = cache.get(&http).await.expect("first token");
+        let second = cache.get(&http).await.expect("second token");
+
+        assert_eq!(first, second);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn static_access_token_ignores_blank_values() {
+        let _env_guard = ENV_LOCK.lock().await;
+        let _guard = EnvGuard::set("GOOGLE_CLOUD_ACCESS_TOKEN", "   ");
+        assert!(get_static_access_token_from_env().is_none());
+    }
+
+    /// RAII env var guard so tests don't leak credentials into other tests.
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod databases {
     pub mod transient_database;
 }
 pub mod gcp_auth;
+pub mod gcs_client;
 pub mod project;
 pub mod run;
 pub mod search_filter;

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -4,10 +4,10 @@ use crate::{
         transient_database::get_transient_database_unique_table_names,
     },
     databases_store::{gcs::GoogleCloudStorageDatabasesStore, store::DatabasesStore},
+    gcs_client::gcs_client,
     utils,
 };
 use anyhow::{anyhow, Result};
-use cloud_storage::Object;
 use futures::future::try_join_all;
 use parking_lot::Mutex;
 use rayon::prelude::*;
@@ -331,11 +331,14 @@ async fn create_in_memory_sqlite_db_with_csv(
             }
 
             async move {
-                let mut stream = Object::download_streamed(
-                    &GoogleCloudStorageDatabasesStore::get_bucket()?,
-                    &GoogleCloudStorageDatabasesStore::get_csv_storage_file_path(&table.table),
-                )
-                .await?;
+                let mut stream = gcs_client()
+                    .await?
+                    .object()
+                    .download_streamed(
+                        &GoogleCloudStorageDatabasesStore::get_bucket()?,
+                        &GoogleCloudStorageDatabasesStore::get_csv_storage_file_path(&table.table),
+                    )
+                    .await?;
                 let mut temp_file = NamedTempFile::new()?;
 
                 // Buffer bytes to avoid writing one byte at a time


### PR DESCRIPTION
## Description

I route all `core` GCS operations through a shared `gcs_client()` backed by `cloud_storage::Client::with_cache(...)` and `gcp_auth` ADC. This supports service-account JSON, gcloud ADC, GCE/GKE metadata, and WIF, while retaining `GOOGLE_CLOUD_ACCESS_TOKEN` for local and test overrides. I replace global `Object::*` calls across table CSV storage, document storage, SQLite streaming, background cleanup, and migration tooling, and remove `cloud-storage`'s `global-client` feature. Related: dust-tt/dust#31822.

## Tests

- Ran `cargo check --manifest-path core/Cargo.toml`.
- Ran `cargo test --manifest-path core/Cargo.toml --lib databases::csv`.

## Risk

Medium: production GCS reads and writes now use the shared ADC-backed client. Existing `GOOGLE_APPLICATION_CREDENTIALS` support remains; a misconfigured ADC or WIF environment can block table or document access. Rollback is a standard `core` deploy.

## Deploy Plan

Deploy `core`. Ensure the runtime identity has GCS access and ADC/WIF is configured for the tables and data-source buckets. Keep the mounted service-account JSON until WIF is verified; remove it afterward if desired. No SQL or infrastructure migration.