### PR TITLE
Share the credit-pool card logic between Poke and the compact usage page

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -7,10 +7,7 @@ import {
 import { EditMemberSpendLimitModal } from "@app/components/workspace/EditMemberSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
-import {
-  CreditPoolCardsFromCycleData,
-  toCreditPoolFetchStatus,
-} from "@app/components/workspace/WorkspaceCreditPoolCards";
+import { CreditPoolCardsFromCycleData } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { expandMaxTierName } from "@app/lib/client/model_tiers";
@@ -89,16 +86,12 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
   return (
     <CreditPoolCardsFromCycleData
       awuPoolCurrentCycle={awuPoolCurrentCycle}
-      cardsStatus={toCreditPoolFetchStatus(
-        isAwuPoolCurrentCycleLoading,
-        !!isAwuPoolCurrentCycleError
-      )}
+      isAwuPoolCurrentCycleLoading={isAwuPoolCurrentCycleLoading}
+      isAwuPoolCurrentCycleError={!!isAwuPoolCurrentCycleError}
       poolCycleBreakdown={poolCycleBreakdown}
       excessCycleBreakdown={excessCycleBreakdown}
-      tableStatus={toCreditPoolFetchStatus(
-        isAwuPoolCycleHistoryLoading,
-        !!isAwuPoolCycleHistoryError
-      )}
+      isAwuPoolCycleHistoryLoading={isAwuPoolCycleHistoryLoading}
+      isAwuPoolCycleHistoryError={!!isAwuPoolCycleHistoryError}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -279,17 +279,27 @@ export function WorkspaceCreditPoolSection({
 
 interface CreditPoolCardsFromCycleDataProps {
   awuPoolCurrentCycle: AwuPoolCurrentCycleResponseBody | null;
-  cardsStatus: CreditPoolFetchStatus;
+  isAwuPoolCurrentCycleLoading: boolean;
+  isAwuPoolCurrentCycleError: boolean;
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
-  tableStatus: CreditPoolFetchStatus;
+  isAwuPoolCycleHistoryLoading: boolean;
+  isAwuPoolCycleHistoryError: boolean;
 }
+
+// Turns a fetched current-cycle/cycle-history pair into the credit
+// consumption cards. Shared by Poke's read-only pool view
+// (front/components/poke/pages/PoolUsagePage.tsx) and the customer-facing
+// compact usage page so the "showPoolCard vs. excess" logic below can't
+// drift between the two — only the SWR hooks feeding it differ.
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
-  cardsStatus,
+  isAwuPoolCurrentCycleLoading,
+  isAwuPoolCurrentCycleError,
   poolCycleBreakdown,
   excessCycleBreakdown,
-  tableStatus,
+  isAwuPoolCycleHistoryLoading,
+  isAwuPoolCycleHistoryError,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -317,8 +327,14 @@ export function CreditPoolCardsFromCycleData({
 
   return (
     <WorkspaceCreditPoolSection
-      cardsStatus={cardsStatus}
-      tableStatus={tableStatus}
+      cardsStatus={toCreditPoolFetchStatus(
+        isAwuPoolCurrentCycleLoading,
+        isAwuPoolCurrentCycleError
+      )}
+      tableStatus={toCreditPoolFetchStatus(
+        isAwuPoolCycleHistoryLoading,
+        isAwuPoolCycleHistoryError
+      )}
       showPoolCard={hasPool}
       isVisible={hasPool || hasExcessData}
       totalRemainingCredits={totalRemainingCredits}
@@ -354,16 +370,12 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   return (
     <CreditPoolCardsFromCycleData
       awuPoolCurrentCycle={awuPoolCurrentCycle}
-      cardsStatus={toCreditPoolFetchStatus(
-        isAwuPoolCurrentCycleLoading,
-        !!isAwuPoolCurrentCycleError
-      )}
+      isAwuPoolCurrentCycleLoading={isAwuPoolCurrentCycleLoading}
+      isAwuPoolCurrentCycleError={!!isAwuPoolCurrentCycleError}
       poolCycleBreakdown={poolCycleBreakdown}
       excessCycleBreakdown={excessCycleBreakdown}
-      tableStatus={toCreditPoolFetchStatus(
-        isAwuPoolCycleHistoryLoading,
-        !!isAwuPoolCycleHistoryError
-      )}
+      isAwuPoolCycleHistoryLoading={isAwuPoolCycleHistoryLoading}
+      isAwuPoolCycleHistoryError={!!isAwuPoolCycleHistoryError}
     />
   );
 }


### PR DESCRIPTION
Poke's PoolCreditCard and the customer-facing CompactCreditPoolCards had
grown into near-identical copies of the same showPoolCard/isVisible
derivation. Extract that into CreditPoolCardsFromCycleData so the two
pages can't silently drift apart; only the SWR hooks that fetch the
cycle data still differ between them.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
