### PR TITLE
Add tracking when users hit credit limits

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3098,7 +3098,6 @@ async function isMessagesLimitReached(
           limit_credits: maxAwuCredits,
           timeframe: maxAwuCreditsTimeframe,
           used_credits: microCreditsToCredits(result.value),
-          plan_code: plan.code,
           origin: context.origin,
         },
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -73,6 +73,7 @@ import {
 } from "@app/lib/api/credits/access_control";
 import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
+import { PostHogServerSideTracking } from "@app/lib/api/posthog";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import {
   checkProgrammaticUsageLimits,
@@ -84,7 +85,10 @@ import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
+import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import { isFreeOrigin } from "@app/lib/metronome/events";
@@ -3084,6 +3088,21 @@ async function isMessagesLimitReached(
       result.isOk() &&
       result.value >= roundCreditsToMicroCredits(maxAwuCredits)
     ) {
+      // One event per blocked attempt, so we can count the messages a
+      // fair-use-capped user could not send, and over how long.
+      PostHogServerSideTracking.trackEvent({
+        distinctId: user.sId,
+        event: "fair_use_limit_blocked",
+        workspaceId: owner.sId,
+        extra: {
+          limit_credits: maxAwuCredits,
+          timeframe: maxAwuCreditsTimeframe,
+          used_credits: microCreditsToCredits(result.value),
+          plan_code: plan.code,
+          origin: context.origin,
+        },
+      });
+
       return {
         isLimitReached: true,
         limitType: "plan_message_limit_exceeded",

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -4,6 +4,7 @@ import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_l
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { recordProgrammaticSpendLimitUsage } from "@app/lib/api/credits/programmatic_usage_limit";
 import { recordApiKeySpendLimitUsage } from "@app/lib/api/keys/spend_limit";
+import { PostHogServerSideTracking } from "@app/lib/api/posthog";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import { recordUserSpendLimitUsage } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,6 +13,10 @@ import {
   buildAgentMessageBillingPlan,
   computeRunKey,
 } from "@app/lib/credits/agent_message_billing";
+import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
 import { getUsageType } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -21,6 +26,7 @@ import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
 import {
   addRateLimiterCount,
   getTimeframeSecondsFromLiteral,
+  getWeightedRateLimiterUsage,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -186,18 +192,54 @@ export async function computeAndStoreAgentMessageCredits(
     // The limit guard lives in isMessagesLimitReached (pre-message), which reads
     // the count via getRateLimiterCount and blocks the next message once the
     // total reaches maxAwuCredits.
+    const fairUseKey = makeFairUseAwuCreditsRateLimitKeyForUser(
+      auth.getNonNullableWorkspace(),
+      user.toJSON(),
+      assistantLimits.maxAwuCreditsTimeframe
+    );
+    const fairUseTimeframeSeconds = getTimeframeSecondsFromLiteral(
+      assistantLimits.maxAwuCreditsTimeframe
+    );
+
     await addRateLimiterCount({
-      key: makeFairUseAwuCreditsRateLimitKeyForUser(
-        auth.getNonNullableWorkspace(),
-        user.toJSON(),
-        assistantLimits.maxAwuCreditsTimeframe
-      ),
-      timeframeSeconds: getTimeframeSecondsFromLiteral(
-        assistantLimits.maxAwuCreditsTimeframe
-      ),
+      key: fairUseKey,
+      timeframeSeconds: fairUseTimeframeSeconds,
       incrementBy: recordedCostDelta,
       logger,
     });
+
+    // Only the message that crosses the cap emits: from here on the user is
+    // blocked upstream, and each retry emits `fair_use_limit_blocked` instead.
+    const usage = await getWeightedRateLimiterUsage({
+      key: fairUseKey,
+      timeframeSeconds: fairUseTimeframeSeconds,
+    });
+    const limitMicroCredits = roundCreditsToMicroCredits(
+      assistantLimits.maxAwuCredits
+    );
+    if (
+      usage.isOk() &&
+      usage.value.count >= limitMicroCredits &&
+      usage.value.count - roundCreditsToMicroCredits(recordedCostDelta) <
+        limitMicroCredits
+    ) {
+      PostHogServerSideTracking.trackEvent({
+        distinctId: user.sId,
+        event: "fair_use_limit_reached",
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        extra: {
+          limit_credits: assistantLimits.maxAwuCredits,
+          timeframe: assistantLimits.maxAwuCreditsTimeframe,
+          used_credits: microCreditsToCredits(usage.value.count),
+          // How fast the window was burnt: low -> spike, not steady use.
+          burn_duration_hours: usage.value.oldestTimestampMs
+            ? (Date.now() - usage.value.oldestTimestampMs) / (60 * 60 * 1000)
+            : 0,
+          plan_code: plan?.code ?? "unknown",
+          origin: messageOrigin,
+        },
+      });
+    }
   }
 
   // Record against the spend-cap backups (Redis fixed-window counters over the

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -235,7 +235,6 @@ export async function computeAndStoreAgentMessageCredits(
           burn_duration_hours: usage.value.oldestTimestampMs
             ? (Date.now() - usage.value.oldestTimestampMs) / (60 * 60 * 1000)
             : 0,
-          plan_code: plan?.code ?? "unknown",
           origin: messageOrigin,
         },
       });

--- a/front/lib/api/assistant/premium_model_limit.ts
+++ b/front/lib/api/assistant/premium_model_limit.ts
@@ -5,6 +5,7 @@ import {
   PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK,
   PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
 } from "@app/lib/api/assistant/rate_limits";
+import { PostHogServerSideTracking } from "@app/lib/api/posthog";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -137,6 +138,20 @@ export async function applyPremiumModelFairUse(
   }
 
   if (downgradeTarget) {
+    PostHogServerSideTracking.trackEvent({
+      distinctId: user.sId,
+      event: "premium_model_downgraded",
+      workspaceId: workspace.sId,
+      extra: {
+        limit_messages: PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK,
+        requested_model_id: resolvedModel.modelId,
+        requested_reasoning_effort: resolvedModel.reasoningEffort,
+        downgraded_to_model_id: downgradeTarget.modelId,
+        downgraded_to_reasoning_effort: downgradeTarget.reasoningEffort,
+        origin: context.origin,
+      },
+    });
+
     return {
       action: "downgrade",
       requested: resolvedModel,


### PR DESCRIPTION
## Description

Sending PostHog events when users hit limits or have messages unable to send because of such limits.

## Tests

None

## Risk

Low, safe to rollback.

## Deploy Plan
