### PR TITLE
[front] enh: change group consumption attribution columns

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -253,6 +253,7 @@ const TOP_GROUPS: GetConsumptionTopGroupsResponse = {
       name: "Engineering",
       credits: 200,
       activeMembers: 3,
+      totalMembers: 5,
       previousCredits: null,
       messageCount: 4,
       avgCreditsPerMessage: 50,

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -244,6 +244,7 @@ const TOP_SOURCES: GetConsumptionTopSourcesResponse = {
 const TOP_GROUPS: GetConsumptionTopGroupsResponse = {
   period: PERIOD,
   totalCredits: 5000,
+  totalActiveMembers: 8,
   totalCount: 1,
   hasMore: false,
   groups: [
@@ -251,6 +252,7 @@ const TOP_GROUPS: GetConsumptionTopGroupsResponse = {
       groupId: "group1",
       name: "Engineering",
       credits: 200,
+      activeMembers: 3,
       previousCredits: null,
       messageCount: 4,
       avgCreditsPerMessage: 50,

--- a/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
+++ b/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
@@ -82,6 +82,7 @@ function PokeConsumptionAttributionRows(
   const {
     rows,
     totalCredits,
+    totalActiveMembers,
     totalCount,
     isTopLoading,
     isTopError,
@@ -103,6 +104,7 @@ function PokeConsumptionAttributionRows(
       data={{
         rows,
         totalCredits,
+        totalActiveMembers,
         totalCount,
         isTopLoading,
         isTopError: Boolean(isTopError),

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -82,7 +82,7 @@ function AttributionSkeletonCell({
     case "credits":
     case "avgCredits":
     case "activeMembers":
-    case "usageVsWorkspaceAverage":
+    case "usageVsAverage":
     case "vsPrev":
       return (
         <div className="flex h-12 items-center justify-end">

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -81,6 +81,8 @@ function AttributionSkeletonCell({
       );
     case "credits":
     case "avgCredits":
+    case "activeMembers":
+    case "usageVsWorkspaceAverage":
     case "vsPrev":
       return (
         <div className="flex h-12 items-center justify-end">

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -297,6 +297,7 @@ describe("ConsumptionAttributionTable", () => {
           credits: 300,
           avgCredits: 100,
           activeMembers: 2,
+          totalMembers: 5,
           previousCredits: null,
         },
       ],
@@ -322,7 +323,7 @@ describe("ConsumptionAttributionTable", () => {
     );
 
     expect(
-      screen.getByRole("columnheader", { name: "Active members" })
+      screen.getByRole("columnheader", { name: "Active / total members" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("columnheader", { name: "Usage vs workspace avg" })
@@ -330,6 +331,7 @@ describe("ConsumptionAttributionTable", () => {
     expect(
       screen.queryByRole("columnheader", { name: "Consumption share" })
     ).not.toBeInTheDocument();
+    expect(screen.getByText("2 / 5")).toBeInTheDocument();
     expect(screen.getByText("1.5×")).toBeInTheDocument();
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -326,15 +326,14 @@ describe("ConsumptionAttributionTable", () => {
       screen.getByRole("columnheader", { name: "Active / total members" })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: "Per-member usage vs avg" })
+      screen.getByRole("columnheader", { name: "Vs workspace avg" })
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("columnheader", { name: "Consumption share" })
     ).not.toBeInTheDocument();
     expect(screen.getByText("2 / 5")).toBeInTheDocument();
-    const usagePercentage = screen.getByText("250%");
+    const usagePercentage = screen.getByText("+150%");
     expect(usagePercentage.parentElement).toHaveClass("text-highlight-600");
-    expect(screen.getByText("Higher")).toBeInTheDocument();
     expect(usagePercentage.parentElement?.querySelector("svg")).toBeNull();
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -332,9 +332,9 @@ describe("ConsumptionAttributionTable", () => {
       screen.queryByRole("columnheader", { name: "Consumption share" })
     ).not.toBeInTheDocument();
     expect(screen.getByText("2 / 5")).toBeInTheDocument();
-    expect(screen.getByText("150%").parentElement).toHaveClass(
-      "text-highlight-600"
-    );
+    const usagePercentage = screen.getByText("250%");
+    expect(usagePercentage.parentElement).toHaveClass("text-highlight-600");
+    expect(usagePercentage.parentElement?.querySelector("svg")).toBeNull();
   });
 
   it("caps the available pages and fetches the selected fixed-size page", async () => {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -334,6 +334,7 @@ describe("ConsumptionAttributionTable", () => {
     expect(screen.getByText("2 / 5")).toBeInTheDocument();
     const usagePercentage = screen.getByText("250%");
     expect(usagePercentage.parentElement).toHaveClass("text-highlight-600");
+    expect(screen.getByText("Higher")).toBeInTheDocument();
     expect(usagePercentage.parentElement?.querySelector("svg")).toBeNull();
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -294,7 +294,7 @@ describe("ConsumptionAttributionTable", () => {
           icon: null,
           modelId: null,
           modelDisplayName: null,
-          credits: 300,
+          credits: 500,
           avgCredits: 100,
           activeMembers: 2,
           totalMembers: 5,
@@ -326,13 +326,15 @@ describe("ConsumptionAttributionTable", () => {
       screen.getByRole("columnheader", { name: "Active / total members" })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: "Usage vs workspace avg" })
+      screen.getByRole("columnheader", { name: "Per-member usage vs avg" })
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("columnheader", { name: "Consumption share" })
     ).not.toBeInTheDocument();
     expect(screen.getByText("2 / 5")).toBeInTheDocument();
-    expect(screen.getByText("1.5×")).toBeInTheDocument();
+    expect(screen.getByText("150%").parentElement).toHaveClass(
+      "text-highlight-600"
+    );
   });
 
   it("caps the available pages and fetches the selected fixed-size page", async () => {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -283,6 +283,56 @@ describe("ConsumptionAttributionTable", () => {
     expect(screen.getByRole("tab", { name: "Groups" })).toBeInTheDocument();
   });
 
+  it("shows active members and per-member usage for groups", () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [
+        {
+          id: "engineering",
+          name: "Engineering",
+          pictureUrl: null,
+          description: null,
+          icon: null,
+          modelId: null,
+          modelDisplayName: null,
+          credits: 300,
+          avgCredits: 100,
+          activeMembers: 2,
+          previousCredits: null,
+        },
+      ],
+      totalCredits: 1_000,
+      totalActiveMembers: 10,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="group"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Active members" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Usage vs workspace avg" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Consumption share" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("1.5×")).toBeInTheDocument();
+  });
+
   it("caps the available pages and fetches the selected fixed-size page", async () => {
     const rows = Array.from({ length: 1_025 }, (_, index) => ({
       id: `agent-${index + 1}`,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -243,28 +243,24 @@ function UsageVsAverageCell({ percentage }: { percentage: number | null }) {
   }
 
   const roundedPercentage = Math.round(percentage);
-  const comparison =
-    roundedPercentage > 100
-      ? "Higher"
-      : roundedPercentage < 100
-        ? "Lower"
-        : "Average";
+  const sign = roundedPercentage > 0 ? "+" : "";
 
   return (
     <div
       className={cn(
-        "flex w-full items-center justify-end gap-1 text-right text-sm tabular-nums",
-        roundedPercentage > 100 ? "text-highlight-600" : "text-muted-foreground"
+        "flex w-full items-center justify-end text-right text-sm tabular-nums",
+        percentage > 100 ? "text-highlight-600" : "text-muted-foreground"
       )}
     >
-      <span>{roundedPercentage}%</span>
-      <span aria-hidden="true">·</span>
-      <span>{comparison}</span>
+      <span>
+        {sign}
+        {roundedPercentage}%
+      </span>
     </div>
   );
 }
 
-function usagePercentOfAverage({
+function usageDifferenceFromAveragePercent({
   credits,
   activeMembers,
   totalCredits,
@@ -282,7 +278,10 @@ function usagePercentOfAverage({
   const groupAverageCredits = credits / activeMembers;
   const overallAverageCredits = totalCredits / totalActiveMembers;
 
-  return (groupAverageCredits / overallAverageCredits) * 100;
+  return (
+    ((groupAverageCredits - overallAverageCredits) / overallAverageCredits) *
+    100
+  );
 }
 
 function buildColumns({
@@ -431,11 +430,11 @@ function buildColumns({
           },
           {
             id: "usageVsAverage",
-            header: "Per-member usage vs avg",
+            header: "Vs workspace avg",
             enableSorting: false,
             meta: { sizeRatio: 22, headerAlign: "right" },
             cell: (info) => {
-              const usagePercent = usagePercentOfAverage({
+              const usagePercent = usageDifferenceFromAveragePercent({
                 credits: info.row.original.credits,
                 activeMembers: info.row.original.activeMembers,
                 totalCredits,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -223,12 +223,34 @@ function VsPrevCell({
   );
 }
 
+function usageVsWorkspaceAverage({
+  credits,
+  activeMembers,
+  totalCredits,
+  totalActiveMembers,
+}: {
+  credits: number;
+  activeMembers: number | undefined;
+  totalCredits: number;
+  totalActiveMembers: number;
+}): number | null {
+  if (!activeMembers || totalCredits <= 0 || totalActiveMembers <= 0) {
+    return null;
+  }
+
+  const groupAverageCredits = credits / activeMembers;
+  const workspaceAverageCredits = totalCredits / totalActiveMembers;
+
+  return groupAverageCredits / workspaceAverageCredits;
+}
+
 function buildColumns({
   dimension,
   hasAvatar,
   isAvatarRounded,
   avgLabel,
   totalCredits,
+  totalActiveMembers,
   isDark,
   expandedRowId,
   selectedIdSet,
@@ -238,6 +260,7 @@ function buildColumns({
   isAvatarRounded: boolean;
   avgLabel: string;
   totalCredits: number;
+  totalActiveMembers: number;
   isDark: boolean;
   expandedRowId: string | null;
   selectedIdSet: Set<string>;
@@ -342,24 +365,78 @@ function buildColumns({
         );
       },
     },
-    {
-      id: "costShare",
-      // Same denominator (totalCredits) for every row, so ranking by cost
-      // share is the same order as ranking by credits
-      accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
-      header: "Consumption share",
-      enableSorting: true,
-      meta: { className: "w-36", sizeRatio: 20, headerAlign: "left" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-start">
-          <CostShareCell
-            share={
-              totalCredits > 0 ? info.row.original.credits / totalCredits : 0
-            }
-          />
-        </DataTable.CellContent>
-      ),
-    },
+    ...(dimension === "group"
+      ? ([
+          {
+            id: "activeMembers",
+            header: "Active members",
+            enableSorting: false,
+            meta: { sizeRatio: 18, headerAlign: "right" },
+            cell: (info) => (
+              <DataTable.BasicCellContent
+                className="justify-end text-right tabular-nums"
+                label={
+                  info.row.original.activeMembers?.toLocaleString("en-US") ??
+                  "--"
+                }
+              />
+            ),
+          },
+          {
+            id: "usageVsWorkspaceAverage",
+            header: "Usage vs workspace avg",
+            enableSorting: false,
+            meta: { sizeRatio: 22, headerAlign: "right" },
+            cell: (info) => {
+              const usageRatio = usageVsWorkspaceAverage({
+                credits: info.row.original.credits,
+                activeMembers: info.row.original.activeMembers,
+                totalCredits,
+                totalActiveMembers,
+              });
+
+              return (
+                <DataTable.BasicCellContent
+                  className="justify-end text-right tabular-nums"
+                  label={
+                    usageRatio === null
+                      ? "--"
+                      : `${usageRatio.toLocaleString("en-US", {
+                          maximumFractionDigits: 1,
+                        })}×`
+                  }
+                />
+              );
+            },
+          },
+        ] satisfies ColumnDef<AttributionRowData>[])
+      : ([
+          {
+            id: "costShare",
+            // Same denominator (totalCredits) for every row, so ranking by cost
+            // share is the same order as ranking by credits
+            accessorFn: (row) =>
+              totalCredits > 0 ? row.credits / totalCredits : 0,
+            header: "Consumption share",
+            enableSorting: true,
+            meta: {
+              className: "w-36",
+              sizeRatio: 20,
+              headerAlign: "left",
+            },
+            cell: (info) => (
+              <DataTable.CellContent className="w-full justify-start">
+                <CostShareCell
+                  share={
+                    totalCredits > 0
+                      ? info.row.original.credits / totalCredits
+                      : 0
+                  }
+                />
+              </DataTable.CellContent>
+            ),
+          },
+        ] satisfies ColumnDef<AttributionRowData>[])),
     {
       id: "credits",
       accessorKey: "credits",
@@ -480,6 +557,7 @@ export interface ConsumptionAttributionRowsProps {
 export interface ConsumptionAttributionRowsData {
   rows: ConsumptionTopRow[];
   totalCredits: number;
+  totalActiveMembers: number;
   totalCount: number;
   isTopLoading: boolean;
   isTopError: boolean;
@@ -556,6 +634,7 @@ export function ConsumptionAttributionRowsView({
   data: {
     rows,
     totalCredits,
+    totalActiveMembers,
     totalCount,
     isTopLoading,
     isTopError,
@@ -582,6 +661,7 @@ export function ConsumptionAttributionRowsView({
         isAvatarRounded: dimension === "user",
         avgLabel,
         totalCredits,
+        totalActiveMembers,
         isDark,
         expandedRowId,
         selectedIdSet,
@@ -591,6 +671,7 @@ export function ConsumptionAttributionRowsView({
       dimension,
       avgLabel,
       totalCredits,
+      totalActiveMembers,
       isDark,
       expandedRowId,
       selectedIdSet,
@@ -737,6 +818,7 @@ function WorkspaceConsumptionAttributionRows(
   const {
     rows,
     totalCredits,
+    totalActiveMembers,
     totalCount,
     isTopLoading,
     isTopError,
@@ -760,6 +842,7 @@ function WorkspaceConsumptionAttributionRows(
       data={{
         rows,
         totalCredits,
+        totalActiveMembers,
         totalCount,
         isTopLoading,
         isTopError: Boolean(isTopError),

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -229,7 +229,32 @@ function VsPrevCell({
   );
 }
 
-function usageVsAveragePercent({
+function UsageVsAverageCell({ percentage }: { percentage: number | null }) {
+  if (percentage === null) {
+    return (
+      <DataTable.CellContent className="w-full justify-end text-right">
+        <Tooltip
+          label="Not enough data to compute"
+          tooltipTriggerAsChild
+          trigger={<span className="text-sm text-muted-foreground">--</span>}
+        />
+      </DataTable.CellContent>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center justify-end text-right text-sm tabular-nums",
+        percentage > 100 ? "text-highlight-600" : "text-muted-foreground"
+      )}
+    >
+      <span>{Math.round(percentage)}%</span>
+    </div>
+  );
+}
+
+function usagePercentOfAverage({
   credits,
   activeMembers,
   totalCredits,
@@ -247,10 +272,7 @@ function usageVsAveragePercent({
   const groupAverageCredits = credits / activeMembers;
   const overallAverageCredits = totalCredits / totalActiveMembers;
 
-  return (
-    ((groupAverageCredits - overallAverageCredits) / overallAverageCredits) *
-    100
-  );
+  return (groupAverageCredits / overallAverageCredits) * 100;
 }
 
 function buildColumns({
@@ -403,14 +425,14 @@ function buildColumns({
             enableSorting: false,
             meta: { sizeRatio: 22, headerAlign: "right" },
             cell: (info) => {
-              const usagePercent = usageVsAveragePercent({
+              const usagePercent = usagePercentOfAverage({
                 credits: info.row.original.credits,
                 activeMembers: info.row.original.activeMembers,
                 totalCredits,
                 totalActiveMembers,
               });
 
-              return <PercentageChangeCell percentage={usagePercent} />;
+              return <UsageVsAverageCell percentage={usagePercent} />;
             },
           },
         ] satisfies ColumnDef<AttributionRowData>[])

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -369,15 +369,21 @@ function buildColumns({
       ? ([
           {
             id: "activeMembers",
-            header: "Active members",
+            header: "Active / total members",
             enableSorting: false,
             meta: { sizeRatio: 18, headerAlign: "right" },
             cell: (info) => (
               <DataTable.BasicCellContent
                 className="justify-end text-right tabular-nums"
                 label={
-                  info.row.original.activeMembers?.toLocaleString("en-US") ??
-                  "--"
+                  info.row.original.activeMembers !== undefined &&
+                  info.row.original.totalMembers !== undefined
+                    ? `${info.row.original.activeMembers.toLocaleString(
+                        "en-US"
+                      )} / ${info.row.original.totalMembers.toLocaleString(
+                        "en-US"
+                      )}`
+                    : "--"
                 }
               />
             ),

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -242,14 +242,24 @@ function UsageVsAverageCell({ percentage }: { percentage: number | null }) {
     );
   }
 
+  const roundedPercentage = Math.round(percentage);
+  const comparison =
+    roundedPercentage > 100
+      ? "Higher"
+      : roundedPercentage < 100
+        ? "Lower"
+        : "Average";
+
   return (
     <div
       className={cn(
-        "flex w-full items-center justify-end text-right text-sm tabular-nums",
-        percentage > 100 ? "text-highlight-600" : "text-muted-foreground"
+        "flex w-full items-center justify-end gap-1 text-right text-sm tabular-nums",
+        roundedPercentage > 100 ? "text-highlight-600" : "text-muted-foreground"
       )}
     >
-      <span>{Math.round(percentage)}%</span>
+      <span>{roundedPercentage}%</span>
+      <span aria-hidden="true">·</span>
+      <span>{comparison}</span>
     </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -186,16 +186,8 @@ function growthPercent(
     : null;
 }
 
-function VsPrevCell({
-  credits,
-  previousCredits,
-}: {
-  credits: number;
-  previousCredits: number | null;
-}) {
-  const growth = growthPercent(credits, previousCredits);
-
-  if (growth === null) {
+function PercentageChangeCell({ percentage }: { percentage: number | null }) {
+  if (percentage === null) {
     return (
       <DataTable.CellContent className="w-full justify-end text-right">
         <Tooltip
@@ -211,19 +203,33 @@ function VsPrevCell({
     <div
       className={cn(
         "flex w-full items-center justify-end gap-1 text-right text-sm tabular-nums",
-        growth > 100 ? "text-highlight-600" : "text-muted-foreground"
+        percentage > 100 ? "text-highlight-600" : "text-muted-foreground"
       )}
     >
       <Icon
-        visual={growth >= 0 ? ArrowNarrowUpRight : ArrowNarrowDownRight}
+        visual={percentage >= 0 ? ArrowNarrowUpRight : ArrowNarrowDownRight}
         size="xs"
       />
-      <span>{Math.round(Math.abs(growth))}%</span>
+      <span>{Math.round(Math.abs(percentage))}%</span>
     </div>
   );
 }
 
-function usageVsWorkspaceAverage({
+function VsPrevCell({
+  credits,
+  previousCredits,
+}: {
+  credits: number;
+  previousCredits: number | null;
+}) {
+  return (
+    <PercentageChangeCell
+      percentage={growthPercent(credits, previousCredits)}
+    />
+  );
+}
+
+function usageVsAveragePercent({
   credits,
   activeMembers,
   totalCredits,
@@ -239,9 +245,12 @@ function usageVsWorkspaceAverage({
   }
 
   const groupAverageCredits = credits / activeMembers;
-  const workspaceAverageCredits = totalCredits / totalActiveMembers;
+  const overallAverageCredits = totalCredits / totalActiveMembers;
 
-  return groupAverageCredits / workspaceAverageCredits;
+  return (
+    ((groupAverageCredits - overallAverageCredits) / overallAverageCredits) *
+    100
+  );
 }
 
 function buildColumns({
@@ -389,30 +398,19 @@ function buildColumns({
             ),
           },
           {
-            id: "usageVsWorkspaceAverage",
-            header: "Usage vs workspace avg",
+            id: "usageVsAverage",
+            header: "Per-member usage vs avg",
             enableSorting: false,
             meta: { sizeRatio: 22, headerAlign: "right" },
             cell: (info) => {
-              const usageRatio = usageVsWorkspaceAverage({
+              const usagePercent = usageVsAveragePercent({
                 credits: info.row.original.credits,
                 activeMembers: info.row.original.activeMembers,
                 totalCredits,
                 totalActiveMembers,
               });
 
-              return (
-                <DataTable.BasicCellContent
-                  className="justify-end text-right tabular-nums"
-                  label={
-                    usageRatio === null
-                      ? "--"
-                      : `${usageRatio.toLocaleString("en-US", {
-                          maximumFractionDigits: 1,
-                        })}×`
-                  }
-                />
-              );
+              return <PercentageChangeCell percentage={usagePercent} />;
             },
           },
         ] satisfies ColumnDef<AttributionRowData>[])

--- a/front/hooks/useConsumptionTop.test.ts
+++ b/front/hooks/useConsumptionTop.test.ts
@@ -1,4 +1,5 @@
 import { toConsumptionTopRows } from "@app/hooks/useConsumptionTop";
+import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
 import type { GetConsumptionTopReasoningEffortsResponse } from "@app/lib/api/analytics/consumption/top_reasoning_efforts";
 import { describe, expect, it } from "vitest";
 
@@ -36,6 +37,46 @@ describe("toConsumptionTopRows", () => {
         credits: 60,
         avgCredits: 20,
         previousCredits: 40,
+      },
+    ]);
+  });
+
+  it("keeps group active-member counts for cohort comparisons", () => {
+    const response: GetConsumptionTopGroupsResponse = {
+      period: {
+        startDate: "2026-07-01T00:00:00.000Z",
+        endDate: "2026-08-01T00:00:00.000Z",
+      },
+      totalCredits: 1_000,
+      totalActiveMembers: 10,
+      totalCount: 1,
+      hasMore: false,
+      groups: [
+        {
+          groupId: "engineering",
+          name: "Engineering",
+          credits: 300,
+          activeMembers: 2,
+          previousCredits: 250,
+          messageCount: 3,
+          avgCreditsPerMessage: 100,
+        },
+      ],
+    };
+
+    expect(toConsumptionTopRows(response)).toEqual([
+      {
+        id: "engineering",
+        name: "Engineering",
+        pictureUrl: null,
+        description: null,
+        icon: null,
+        modelId: null,
+        modelDisplayName: null,
+        credits: 300,
+        avgCredits: 100,
+        activeMembers: 2,
+        previousCredits: 250,
       },
     ]);
   });

--- a/front/hooks/useConsumptionTop.test.ts
+++ b/front/hooks/useConsumptionTop.test.ts
@@ -57,6 +57,7 @@ describe("toConsumptionTopRows", () => {
           name: "Engineering",
           credits: 300,
           activeMembers: 2,
+          totalMembers: 5,
           previousCredits: 250,
           messageCount: 3,
           avgCreditsPerMessage: 100,
@@ -76,6 +77,7 @@ describe("toConsumptionTopRows", () => {
         credits: 300,
         avgCredits: 100,
         activeMembers: 2,
+        totalMembers: 5,
         previousCredits: 250,
       },
     ]);

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -53,6 +53,7 @@ export type ConsumptionTopRow = {
   credits: number;
   avgCredits: number;
   activeMembers?: number;
+  totalMembers?: number;
   previousCredits: number | null;
 };
 
@@ -126,6 +127,7 @@ export function toConsumptionTopRows(
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
       activeMembers: row.activeMembers,
+      totalMembers: row.totalMembers,
       previousCredits: row.previousCredits,
     }));
   }

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -52,6 +52,7 @@ export type ConsumptionTopRow = {
   modelDisplayName: string | null;
   credits: number;
   avgCredits: number;
+  activeMembers?: number;
   previousCredits: number | null;
 };
 
@@ -124,6 +125,7 @@ export function toConsumptionTopRows(
       modelDisplayName: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
+      activeMembers: row.activeMembers,
       previousCredits: row.previousCredits,
     }));
   }
@@ -255,9 +257,11 @@ export function useConsumptionTop({
 
   return {
     rows,
-    // Everything in the selected scope consumed over the period, so a row's
-    // share of it is `credits / totalCredits`.
+    // Selected-scope totals back row-relative metrics. Group rows also use the
+    // distinct active-member total to compare per-member usage.
     totalCredits: data?.totalCredits ?? 0,
+    totalActiveMembers:
+      data && "totalActiveMembers" in data ? data.totalActiveMembers : 0,
     totalCount: data?.totalCount ?? 0,
     hasMore: data?.hasMore ?? false,
     isTopLoading: !error && isLoading,

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -241,11 +241,17 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels groups with their group name", async () => {
-    const { authenticator, workspace } = await createResourceTest({
+  it("labels groups with their name and current member count", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
       role: "admin",
     });
     const group = await GroupFactory.regularManual(workspace, "Engineering");
+    const addMemberResult = await GroupFactory.withMembers(
+      authenticator,
+      group,
+      [user]
+    );
+    expect(addMemberResult.isOk()).toBe(true);
 
     const labels = await resolveDimensionLabels(authenticator, "group", [
       group.sId,
@@ -255,6 +261,7 @@ describe("resolveDimensionLabels", () => {
       name: "Engineering",
       pictureUrl: null,
       description: null,
+      memberCount: 1,
     });
   });
 

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -53,6 +53,8 @@ export type DimensionLabel = {
   scope?: AgentConfigurationScope;
   maker?: ModelMakerIdType;
   tier?: ModelsTierName;
+  // Only groups have one; this is the current active membership count.
+  memberCount?: number;
 };
 
 function labelsFromNames(
@@ -121,9 +123,27 @@ export async function resolveDimensionLabels(
       const groups = await GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
       });
-      const namesById = new Map(groups.map((group) => [group.sId, group.name]));
-      return labelsFromNames(
-        new Map(keys.map((key) => [key, namesById.get(key) ?? key]))
+      const groupsWithMemberCounts = await GroupResource.toJSONWithMemberCounts(
+        auth,
+        groups
+      );
+      const groupsById = new Map(
+        groupsWithMemberCounts.map((group) => [group.sId, group])
+      );
+
+      return new Map(
+        keys.map((key) => {
+          const group = groupsById.get(key);
+          return [
+            key,
+            {
+              name: group?.name ?? key,
+              pictureUrl: null,
+              description: null,
+              memberCount: group?.memberCount ?? 0,
+            },
+          ];
+        })
       );
     }
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -576,7 +576,19 @@ describe("consumption top rankings", () => {
     });
 
     vi.mocked(searchConsumptionAnalytics).mockClear();
-    mockLabels({ key1: "Engineering" });
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        [
+          "key1",
+          {
+            name: "Engineering",
+            pictureUrl: null,
+            description: null,
+            memberCount: 5,
+          },
+        ],
+      ])
+    );
     const groups = await fetchConsumptionTopGroups(auth, {
       period: PERIOD,
       limit: 10,
@@ -590,6 +602,7 @@ describe("consumption top rankings", () => {
       name: "Engineering",
       credits: 2,
       activeMembers: 2,
+      totalMembers: 5,
       previousCredits: 2,
       messageCount: 4,
       avgCreditsPerMessage: 0.5,

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -58,11 +58,13 @@ function mockAggs({
   buckets,
   totalCount = buckets.length,
   totalMicro,
+  totalActiveMembers = 0,
   filtered = false,
 }: {
   buckets: Array<Record<string, unknown> & { key: string }>;
   totalCount?: number;
   totalMicro: number;
+  totalActiveMembers?: number;
   filtered?: boolean;
 }) {
   vi.mocked(searchConsumptionAnalytics).mockImplementation(
@@ -89,6 +91,7 @@ function mockAggs({
       return esResponse({
         ...(filtered ? { ranking } : ranking),
         total_credit_micro: { value: totalMicro },
+        active_members: { value: totalActiveMembers },
       });
     }
   );
@@ -543,9 +546,11 @@ describe("consumption top rankings", () => {
           doc_count: 6,
           credit_micro: { value: 2_000_000 },
           messages: { value: 4 },
+          active_members: { value: 2 },
         },
       ],
       totalMicro: 2_000_000,
+      totalActiveMembers: 3,
     });
 
     mockLabels({ key1: "Jane Doe" });
@@ -570,6 +575,7 @@ describe("consumption top rankings", () => {
       field: "user.id",
     });
 
+    vi.mocked(searchConsumptionAnalytics).mockClear();
     mockLabels({ key1: "Engineering" });
     const groups = await fetchConsumptionTopGroups(auth, {
       period: PERIOD,
@@ -583,13 +589,23 @@ describe("consumption top rankings", () => {
       groupId: "key1",
       name: "Engineering",
       credits: 2,
+      activeMembers: 2,
       previousCredits: 2,
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+    expect(groups.value.totalActiveMembers).toBe(3);
+    const [, groupRankingOptions] = rankingSearchCall();
+    expect(groupRankingOptions?.aggregations?.by_group?.terms).toMatchObject({
       field: "user.group_ids",
     });
+    expect(
+      groupRankingOptions?.aggregations?.by_group?.aggs?.active_members
+        ?.cardinality
+    ).toMatchObject({ field: "user.id" });
+    expect(
+      groupRankingOptions?.aggregations?.active_members?.cardinality
+    ).toMatchObject({ field: "user.id" });
 
     mockLabels({ key1: "Claude 4 Sonnet" });
     const models = await fetchConsumptionTopModels(auth, {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -526,6 +526,7 @@ export type ResolvedConsumptionGroup = {
   count: number;
   avgCredits: number;
   activeMembers?: number;
+  memberCount?: number;
   previousCredits: number | null;
 };
 
@@ -558,6 +559,9 @@ export async function resolveConsumptionGroupLabels(
     avgCredits: avgCreditsPerUnit(group.credits, group.count),
     ...(group.activeMembers !== undefined
       ? { activeMembers: group.activeMembers }
+      : {}),
+    ...(labels.get(group.key)?.memberCount !== undefined
+      ? { memberCount: labels.get(group.key)?.memberCount }
       : {}),
     previousCredits: group.previousCredits,
   }));

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -39,6 +39,8 @@ export type ConsumptionTopGroup = {
   credits: number;
   // Distinct messages, or tool invocations, per the ranking's unit.
   count: number;
+  // Only populated for the group dimension.
+  activeMembers?: number;
   // This key's credits over the equivalent window immediately preceding the
   // period, for period-over-period growth. Null when the key had no
   // consumption at all in that prior window.
@@ -54,12 +56,15 @@ export type ConsumptionTopGroups = {
   // sum of `groups`. The ranking is capped at `limit`, and a dimension that only
   // exists on some documents (a tool, a skill) accounts for part of the total.
   totalCredits: number;
+  // Only populated for the group dimension.
+  totalActiveMembers?: number;
 };
 
 // Sub-aggregation names, kept out of the callers so the ranking order and the
 // bucket reads below cannot drift apart.
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
+const ACTIVE_MEMBERS_AGG = "active_members";
 const TOTAL_COUNT_AGG = "total_count";
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
@@ -70,13 +75,24 @@ type GroupBucket = {
   doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
+  [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
-function subAggs(unit: ConsumptionTopUnit) {
+function subAggs(unit: ConsumptionTopUnit, dimension: ConsumptionTopDimension) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
     ...(unit === "message"
       ? { [MESSAGES_AGG]: uniqueMessagesCardinalityAgg() }
+      : {}),
+    ...(dimension === "group"
+      ? {
+          [ACTIVE_MEMBERS_AGG]: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
       : {}),
   };
 }
@@ -89,6 +105,7 @@ type RankingAggs = {
 type TopAggs = RankingAggs & {
   ranking?: estypes.AggregationsSingleBucketAggregateBase & RankingAggs;
   total_credit_micro?: estypes.AggregationsSumAggregate;
+  [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
 function countFromBucket(
@@ -233,7 +250,7 @@ function buildConsumptionTopAggregations({
         order: rankingOrder(dimension, rankBy, sortOrder),
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
-      aggs: subAggs(unit),
+      aggs: subAggs(unit, dimension),
     },
     ...(includeTotalCount
       ? {
@@ -259,6 +276,16 @@ function buildConsumptionTopAggregations({
   return {
     ...rankingRootAggregations,
     total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+    ...(dimension === "group"
+      ? {
+          [ACTIVE_MEMBERS_AGG]: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
+      : {}),
   };
 }
 
@@ -377,6 +404,7 @@ export async function fetchConsumptionTopGroups(
   let batchSize = 0;
   let totalCount = 0;
   let totalCredits = 0;
+  let totalActiveMembers = 0;
 
   // Terms aggregations do not expose an after_key when ordered by a metric.
   // Continue the ranked result in bounded batches by excluding the keys
@@ -409,19 +437,31 @@ export async function fetchConsumptionTopGroups(
       : result.value.aggregations;
     buckets = bucketsToArray<GroupBucket>(ranking?.by_group?.buckets);
     rankedGroups.push(
-      ...buckets.map((bucket) => ({
-        key: String(bucket.key),
-        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-        count: countFromBucket(
-          bucket,
-          CONSUMPTION_TOP_DIMENSION_UNIT[dimension]
-        ),
-      }))
+      ...buckets.map((bucket) => {
+        const group = {
+          key: String(bucket.key),
+          credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+          count: countFromBucket(
+            bucket,
+            CONSUMPTION_TOP_DIMENSION_UNIT[dimension]
+          ),
+        };
+
+        return dimension === "group"
+          ? {
+              ...group,
+              activeMembers: Math.round(bucket[ACTIVE_MEMBERS_AGG]?.value ?? 0),
+            }
+          : group;
+      })
     );
     totalCredits = microCreditsToCredits(
       result.value.aggregations?.total_credit_micro?.value ?? 0
     );
     totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
+    totalActiveMembers = Math.round(
+      result.value.aggregations?.[ACTIVE_MEMBERS_AGG]?.value ?? 0
+    );
   } while (
     rankedGroups.length < requestedBucketCount &&
     buckets.length === batchSize
@@ -461,6 +501,7 @@ export async function fetchConsumptionTopGroups(
     hasMore: totalCount > offset + limit,
     totalCount,
     totalCredits,
+    ...(dimension === "group" ? { totalActiveMembers } : {}),
   });
 }
 
@@ -484,6 +525,7 @@ export type ResolvedConsumptionGroup = {
   credits: number;
   count: number;
   avgCredits: number;
+  activeMembers?: number;
   previousCredits: number | null;
 };
 
@@ -514,6 +556,9 @@ export async function resolveConsumptionGroupLabels(
     credits: group.credits,
     count: group.count,
     avgCredits: avgCreditsPerUnit(group.credits, group.count),
+    ...(group.activeMembers !== undefined
+      ? { activeMembers: group.activeMembers }
+      : {}),
     previousCredits: group.previousCredits,
   }));
 }

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -24,6 +24,8 @@ export type ConsumptionTopGroupRow = {
   name: string;
   credits: number;
   activeMembers: number;
+  // Current active group membership count.
+  totalMembers: number;
   previousCredits: number | null;
   messageCount: number;
   avgCreditsPerMessage: number;
@@ -92,6 +94,7 @@ export async function fetchConsumptionTopGroups(
       name: row.name,
       credits: row.credits,
       activeMembers: row.activeMembers ?? 0,
+      totalMembers: row.memberCount ?? 0,
       previousCredits: row.previousCredits,
       messageCount: row.count,
       avgCreditsPerMessage: row.avgCredits,

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -13,16 +13,17 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
 /**
- * Groups ranked by the credits consumed by their members over the period,
- * averaged per message. A member can belong to several groups, in which case
- * their consumption is attributed to each group they belonged to when the
- * message completed.
+ * Groups ranked by the credits consumed by their members over the period, with
+ * distinct active-member and message counts. A member can belong to several
+ * groups, in which case their consumption is attributed to each group they
+ * belonged to when the message completed.
  */
 
 export type ConsumptionTopGroupRow = {
   groupId: string;
   name: string;
   credits: number;
+  activeMembers: number;
   previousCredits: number | null;
   messageCount: number;
   avgCreditsPerMessage: number;
@@ -31,6 +32,7 @@ export type ConsumptionTopGroupRow = {
 export type ConsumptionTopGroups = {
   period: ConsumptionPeriod;
   totalCredits: number;
+  totalActiveMembers: number;
   hasMore: boolean;
   totalCount: number;
   // Highest credits first.
@@ -69,19 +71,27 @@ export async function fetchConsumptionTopGroups(
   if (result.isErr()) {
     return result;
   }
-  const { groups, hasMore, totalCount, totalCredits } = result.value;
+  const {
+    groups,
+    hasMore,
+    totalCount,
+    totalCredits,
+    totalActiveMembers = 0,
+  } = result.value;
 
   const rows = await resolveConsumptionGroupLabels(auth, "group", groups);
 
   return new Ok({
     period,
     totalCredits,
+    totalActiveMembers,
     hasMore,
     totalCount,
     groups: rows.map((row) => ({
       groupId: row.key,
       name: row.name,
       credits: row.credits,
+      activeMembers: row.activeMembers ?? 0,
       previousCredits: row.previousCredits,
       messageCount: row.count,
       avgCreditsPerMessage: row.avgCredits,

--- a/front/poke/swr/consumption.ts
+++ b/front/poke/swr/consumption.ts
@@ -213,6 +213,8 @@ export function usePokeConsumptionTop({
   return {
     rows,
     totalCredits: data?.totalCredits ?? 0,
+    totalActiveMembers:
+      data && "totalActiveMembers" in data ? data.totalActiveMembers : 0,
     totalCount: data?.totalCount ?? 0,
     hasMore: data?.hasMore ?? false,
     isTopLoading: !error && isLoading,


### PR DESCRIPTION
## Description

Context in [thread](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1788508787255659).

Groups can overlap, so presenting each group as a share of total consumption implies a partition that does not exist.

For the Groups attribution view, replace consumption share with active members over current total group membership and per-active-member usage as a percentage of the selected scope average. The cell explicitly labels the result as Higher, Lower, or Average so the comparison does not rely on color. Other attribution dimensions keep their existing columns.

## Tests

- Added coverage for group active-member aggregation, current group-size resolution, response mapping, route serialization, and percentage rendering.

## Risk

- Low. Limited to the Groups attribution view and additive private API response fields.

## Deploy Plan

- Deploy front.