### PR TITLE
Poke: add a filter to only show Frames that have a sandbox

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/frames/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/index.ts
@@ -32,11 +32,13 @@ app.get("/", async (ctx): HandlerResult<PokeListFrames> => {
   }
 
   const { limit, lastValue, orderDirection } = paginationRes.value;
+  const { hasSandbox } = ctx.req.query();
 
   const frames = await listWorkspaceFrames(auth, {
     limit,
     lastValue,
     orderDirection,
+    hasSandbox: hasSandbox === "true",
   });
 
   return ctx.json(frames);

--- a/front/components/poke/frames/table.tsx
+++ b/front/components/poke/frames/table.tsx
@@ -4,7 +4,7 @@ import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { usePokeFrames } from "@app/poke/swr/frames";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button } from "@dust-tt/sparkle";
+import { Button, CheckboxWithText } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const PAGE_SIZE = 20;
@@ -16,8 +16,9 @@ interface FramesDataTableProps {
 
 export function FramesDataTable({ loadOnInit, owner }: FramesDataTableProps) {
   const [limit, setLimit] = useState(PAGE_SIZE);
+  const [hasSandbox, setHasSandbox] = useState(false);
   const useFramesWithLimit = (props: PokeConditionalFetchProps) =>
-    usePokeFrames({ ...props, limit });
+    usePokeFrames({ ...props, limit, hasSandbox });
 
   return (
     <PokeDataTableConditionalFetch
@@ -25,6 +26,16 @@ export function FramesDataTable({ loadOnInit, owner }: FramesDataTableProps) {
       loadOnInit={loadOnInit}
       owner={owner}
       useSWRHook={useFramesWithLimit}
+      globalActions={
+        <CheckboxWithText
+          text="Only with a sandbox"
+          checked={hasSandbox}
+          onCheckedChange={(checked) => {
+            setHasSandbox(checked === true);
+            setLimit(PAGE_SIZE);
+          }}
+        />
+      }
     >
       {({ items, hasMore, isLoadingMore }) => (
         <div className="flex flex-col gap-3">

--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -96,14 +96,21 @@ function toPokeFrameListItem(
 
 export async function listWorkspaceFrames(
   auth: Authenticator,
-  pagination: {
+  {
+    hasSandbox,
+    ...pagination
+  }: {
     limit: number;
     lastValue?: string;
     orderDirection: "asc" | "desc";
+    hasSandbox: boolean;
   }
 ): Promise<PokeListFrames> {
   const { frames, hasMore, lastValue } =
-    await FileResource.listFrameV2ForWorkspacePaginated(auth, pagination);
+    await FileResource.listFrameV2ForWorkspacePaginated(auth, {
+      ...pagination,
+      hasSandbox,
+    });
 
   if (frames.length === 0) {
     return { items: [], hasMore, lastValue };

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -124,7 +124,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op, UniqueConstraintError } from "sequelize";
+import { Op, Sequelize, UniqueConstraintError } from "sequelize";
 import type { Readable, Writable } from "stream";
 import { validate } from "uuid";
 import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
@@ -246,20 +246,33 @@ export class FileResource extends BaseResource<FileModel> {
       // pagination.
       lastValue,
       orderDirection,
+      hasSandbox = false,
     }: {
       limit: number;
       lastValue?: string;
       orderDirection: "asc" | "desc";
+      hasSandbox?: boolean;
     }
   ): Promise<{
     frames: FileResource[];
     hasMore: boolean;
     lastValue: string | null;
   }> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
     const where: WhereOptions<InferAttributes<FileModel>> = {
-      workspaceId: auth.getNonNullableWorkspace().id,
+      workspaceId: workspaceModelId,
       contentType: frameV2ContentType,
     };
+
+    if (hasSandbox) {
+      assert(typeof workspaceModelId === "number");
+      where.id = {
+        [Op.in]: Sequelize.literal(
+          // `workspaceModelId` cannot be user provided + assert above.
+          `(SELECT "frameFileModelId" FROM sandbox_owners WHERE "workspaceId" = '${workspaceModelId}' AND "frameFileModelId" IS NOT NULL)`
+        ),
+      };
+    }
 
     if (lastValue) {
       const timestampMs = parseInt(lastValue, 10);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -53,6 +53,7 @@ import {
   ShareableFileModel,
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
+import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -124,7 +125,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op, Sequelize, UniqueConstraintError } from "sequelize";
+import { Op, UniqueConstraintError } from "sequelize";
 import type { Readable, Writable } from "stream";
 import { validate } from "uuid";
 import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
@@ -258,21 +259,10 @@ export class FileResource extends BaseResource<FileModel> {
     hasMore: boolean;
     lastValue: string | null;
   }> {
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
     const where: WhereOptions<InferAttributes<FileModel>> = {
-      workspaceId: workspaceModelId,
+      workspaceId: auth.getNonNullableWorkspace().id,
       contentType: frameV2ContentType,
     };
-
-    if (hasSandbox) {
-      assert(typeof workspaceModelId === "number");
-      where.id = {
-        [Op.in]: Sequelize.literal(
-          // `workspaceModelId` cannot be user provided + assert above.
-          `(SELECT "frameFileModelId" FROM sandbox_owners WHERE "workspaceId" = '${workspaceModelId}' AND "frameFileModelId" IS NOT NULL)`
-        ),
-      };
-    }
 
     if (lastValue) {
       const timestampMs = parseInt(lastValue, 10);
@@ -285,6 +275,19 @@ export class FileResource extends BaseResource<FileModel> {
 
     const rows = await this.model.findAll({
       where,
+      // A Frame has at most one sandbox owner link (unique index), so the inner join never
+      // duplicates rows. `subQuery: false` keeps the join out of the LIMIT subquery.
+      include: hasSandbox
+        ? [
+            {
+              model: SandboxOwnerModel,
+              as: "sandboxOwnerLinks",
+              required: true,
+              attributes: [],
+            },
+          ]
+        : [],
+      subQuery: false,
       order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
       limit: limit + 1,
     });

--- a/front/poke/swr/frames.ts
+++ b/front/poke/swr/frames.ts
@@ -13,6 +13,7 @@ import type { Fetcher } from "swr";
 
 interface UsePokeFramesProps {
   disabled?: boolean;
+  hasSandbox: boolean;
   limit: number;
   owner: LightWorkspaceType;
 }
@@ -23,11 +24,16 @@ export interface PokeFramesData {
   isLoadingMore: boolean;
 }
 
-export function usePokeFrames({ disabled, limit, owner }: UsePokeFramesProps) {
+export function usePokeFrames({
+  disabled,
+  hasSandbox,
+  limit,
+  owner,
+}: UsePokeFramesProps) {
   const { fetcher } = useFetcher();
   const framesFetcher: Fetcher<PokeListFrames> = fetcher;
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/frames?limit=${limit}`,
+    `/api/poke/workspaces/${owner.sId}/frames?limit=${limit}&hasSandbox=${hasSandbox}`,
     framesFetcher,
     { disabled, keepPreviousData: true }
   );


### PR DESCRIPTION
## Description

Adds an "Only with a sandbox" checkbox to the Frames table on the Poke workspace page.

The list is server-paginated with "Load more", so a client-side filter would hide matching frames behind later pages. The filter is applied in the database instead: a new `hasSandbox` query param on the Poke frames endpoint adds an `IN (subquery)` clause on the `sandbox_owners` link table (same literal-subquery pattern as `run_resource.ts`, workspace id asserted numeric). Toggling the checkbox resets the page limit and refetches.

## Tests

Type-checked front and front-api, verified the generated SQL runs against the local database. Not verified in the browser.

## Risk

Low, Poke-only.

## Deploy Plan

Deploy front-api then front-spa.