### PR TITLE
Poke: tidy the Frame details page

### DIFF
--- a/front/components/poke/frames/publication.tsx
+++ b/front/components/poke/frames/publication.tsx
@@ -6,7 +6,7 @@ import {
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
 import type { PokeFrameDetails } from "@app/lib/api/poke/frames";
-import { CodeBlock } from "@dust-tt/sparkle";
+import { CodeBlock, File02, Folder, Tree } from "@dust-tt/sparkle";
 
 interface FramePublicationSectionProps {
   publication: PokeFrameDetails["publication"];
@@ -56,18 +56,13 @@ export function FramePublicationSection({
           <h3 className="pt-6 pb-2 font-medium">
             Source files ({publication.sourceFiles.length})
           </h3>
-          <PokeTable>
-            <PokeTableBody>
-              {publication.sourceFiles.map((sourceFile) => (
-                <PokeTableRow key={sourceFile.path}>
-                  <PokeTableHead>{sourceFile.path}</PokeTableHead>
-                  <PokeTableCell className="font-mono text-xs">
-                    {sourceFile.contentSha256}
-                  </PokeTableCell>
-                </PokeTableRow>
-              ))}
-            </PokeTableBody>
-          </PokeTable>
+          <Tree isBoxed>
+            {renderSourceFileTree(
+              buildSourceFileTree(
+                publication.sourceFiles.map((sourceFile) => sourceFile.path)
+              )
+            )}
+          </Tree>
 
           {publication.databases.length > 0 && (
             <>
@@ -98,5 +93,64 @@ export function FramePublicationSection({
         </>
       )}
     </div>
+  );
+}
+
+interface SourceFileTreeNode {
+  name: string;
+  path: string;
+  children: SourceFileTreeNode[];
+}
+
+function buildSourceFileTree(paths: string[]): SourceFileTreeNode[] {
+  const root: SourceFileTreeNode = { name: "", path: "", children: [] };
+  const nodesByPath = new Map<string, SourceFileTreeNode>([["", root]]);
+
+  for (const path of paths) {
+    let parent = root;
+    let currentPath = "";
+    for (const segment of path.split("/")) {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      let node = nodesByPath.get(currentPath);
+      if (!node) {
+        node = { name: segment, path: currentPath, children: [] };
+        nodesByPath.set(currentPath, node);
+        parent.children.push(node);
+      }
+      parent = node;
+    }
+  }
+
+  return sortSourceFileTree(root.children);
+}
+
+// Directories first, then files, each alphabetically.
+function sortSourceFileTree(nodes: SourceFileTreeNode[]): SourceFileTreeNode[] {
+  return [...nodes]
+    .sort((a, b) => {
+      const aIsDir = a.children.length > 0;
+      const bIsDir = b.children.length > 0;
+      if (aIsDir !== bIsDir) {
+        return aIsDir ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    })
+    .map((node) => ({ ...node, children: sortSourceFileTree(node.children) }));
+}
+
+function renderSourceFileTree(nodes: SourceFileTreeNode[]): React.ReactNode {
+  return nodes.map((node) =>
+    node.children.length > 0 ? (
+      <Tree.Item key={node.path} label={node.name} visual={Folder} type="node">
+        {renderSourceFileTree(node.children)}
+      </Tree.Item>
+    ) : (
+      <Tree.Item
+        key={node.path}
+        label={node.name}
+        visual={File02}
+        type="leaf"
+      />
+    )
   );
 }

--- a/front/components/poke/frames/publication.tsx
+++ b/front/components/poke/frames/publication.tsx
@@ -58,9 +58,7 @@ export function FramePublicationSection({
           </h3>
           <Tree isBoxed>
             {renderSourceFileTree(
-              buildSourceFileTree(
-                publication.sourceFiles.map((sourceFile) => sourceFile.path)
-              )
+              publication.sourceFiles.map((sourceFile) => sourceFile.path)
             )}
           </Tree>
 
@@ -96,61 +94,33 @@ export function FramePublicationSection({
   );
 }
 
-interface SourceFileTreeNode {
-  name: string;
-  path: string;
-  children: SourceFileTreeNode[];
-}
-
-function buildSourceFileTree(paths: string[]): SourceFileTreeNode[] {
-  const root: SourceFileTreeNode = { name: "", path: "", children: [] };
-  const nodesByPath = new Map<string, SourceFileTreeNode>([["", root]]);
-
+// Directories first, then files, each alphabetically.
+function renderSourceFileTree(paths: string[]): React.ReactNode {
+  const directories = new Map<string, string[]>();
+  const files: string[] = [];
   for (const path of paths) {
-    let parent = root;
-    let currentPath = "";
-    for (const segment of path.split("/")) {
-      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
-      let node = nodesByPath.get(currentPath);
-      if (!node) {
-        node = { name: segment, path: currentPath, children: [] };
-        nodesByPath.set(currentPath, node);
-        parent.children.push(node);
-      }
-      parent = node;
+    const slashIndex = path.indexOf("/");
+    if (slashIndex === -1) {
+      files.push(path);
+    } else {
+      const directory = path.slice(0, slashIndex);
+      const rest = path.slice(slashIndex + 1);
+      directories.set(directory, [...(directories.get(directory) ?? []), rest]);
     }
   }
 
-  return sortSourceFileTree(root.children);
-}
-
-// Directories first, then files, each alphabetically.
-function sortSourceFileTree(nodes: SourceFileTreeNode[]): SourceFileTreeNode[] {
-  return [...nodes]
-    .sort((a, b) => {
-      const aIsDir = a.children.length > 0;
-      const bIsDir = b.children.length > 0;
-      if (aIsDir !== bIsDir) {
-        return aIsDir ? -1 : 1;
-      }
-      return a.name.localeCompare(b.name);
-    })
-    .map((node) => ({ ...node, children: sortSourceFileTree(node.children) }));
-}
-
-function renderSourceFileTree(nodes: SourceFileTreeNode[]): React.ReactNode {
-  return nodes.map((node) =>
-    node.children.length > 0 ? (
-      <Tree.Item key={node.path} label={node.name} visual={Folder} type="node">
-        {renderSourceFileTree(node.children)}
-      </Tree.Item>
-    ) : (
-      <Tree.Item
-        key={node.path}
-        label={node.name}
-        visual={File02}
-        type="leaf"
-      />
-    )
-  );
+  return [
+    ...[...directories]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, children]) => (
+        <Tree.Item key={name} label={name} visual={Folder} type="node">
+          {renderSourceFileTree(children)}
+        </Tree.Item>
+      )),
+    ...files
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => (
+        <Tree.Item key={name} label={name} visual={File02} type="leaf" />
+      )),
+  ];
 }

--- a/front/components/poke/frames/view.tsx
+++ b/front/components/poke/frames/view.tsx
@@ -42,20 +42,6 @@ export function ViewFrameTable({ details, owner }: ViewFrameTableProps) {
             <PokeTableCell>{frame.status}</PokeTableCell>
           </PokeTableRow>
           <PokeTableRow>
-            <PokeTableHead>Mount path</PokeTableHead>
-            {frame.mountFilePath ? (
-              <PokeTableCellWithCopy label={frame.mountFilePath} />
-            ) : (
-              <PokeTableCell>—</PokeTableCell>
-            )}
-          </PokeTableRow>
-          <PokeTableRow>
-            <PokeTableHead>Active publication</PokeTableHead>
-            <PokeTableCell>
-              {frame.activePublicationId ?? "unpublished"}
-            </PokeTableCell>
-          </PokeTableRow>
-          <PokeTableRow>
             <PokeTableHead>Origin</PokeTableHead>
             <PokeTableCell>
               {frame.conversationId ? (

--- a/front/components/poke/pages/FrameV2Page.tsx
+++ b/front/components/poke/pages/FrameV2Page.tsx
@@ -40,14 +40,11 @@ export function FrameV2Page({ frameId }: FrameV2PageProps) {
   return (
     <div className="mx-auto max-w-6xl">
       <h3 className="text-xl font-bold">
-        Frame {details.frame.fileName} within workspace{" "}
+        Frame {details.frame.name ?? details.frame.fileName} within workspace{" "}
         <LinkWrapper href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </LinkWrapper>
       </h3>
-      <div className="text-sm text-muted-foreground">
-        Frame ID: <code className="text-xs">{details.frame.sId}</code>
-      </div>
 
       <ViewFrameTable details={details} owner={owner} />
       <FrameSharingSection

--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -16,11 +16,7 @@ import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { UserResource } from "@app/lib/resources/user_resource";
-import {
-  getFrameBasePath,
-  getFrameDatabaseReplicasBasePath,
-  getFramePublicationsBasePath,
-} from "@app/types/api/frame_storage";
+import { getFrameBasePath } from "@app/types/api/frame_storage";
 import type {
   SandboxFunctionExecutionMode,
   SandboxFunctionStake,
@@ -197,20 +193,6 @@ function makeStorageLocations(
     {
       label: "Frame root",
       prefix: getFrameBasePath({ workspaceId, frameId: frame.sId }),
-    },
-    {
-      label: "Publications",
-      prefix: getFramePublicationsBasePath({
-        workspaceId,
-        frameId: frame.sId,
-      }),
-    },
-    {
-      label: "Database replicas",
-      prefix: getFrameDatabaseReplicasBasePath({
-        workspaceId,
-        frameId: frame.sId,
-      }),
     },
   ];
 


### PR DESCRIPTION
## Description

A few cleanups to the Poke Frame details page:

- The title now uses the Frame name when it has one, falling back to the file name (previously it always said `manifest.json`).
- Source files in the active publication are rendered as a collapsible tree (directories first, then files) instead of a flat table, and the per-file content SHA is no longer shown.
- Removed redundant rows and storage locations: the Frame ID line under the title, the "Mount path" and "Active publication" rows (both already shown elsewhere on the page), and the "Publications" / "Database replicas" storage locations (both under "Frame root").

## Tests

Type-checked and linted. Not verified in the browser.

## Risk

Low, Poke-only.

## Deploy Plan

Deploy front-spa.