### PR TITLE
chore(ConversationSidePanel): refactoring conversations to use new sparkle component

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -21,14 +21,12 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
 import { useAppRouter } from "@app/lib/platform";
-import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type {
   ConversationError,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
 import type React from "react";
 import { useMemo } from "react";
 
@@ -151,8 +149,6 @@ function ConversationInnerLayout({
   conversationError,
   activeConversationId,
 }: ConversationInnerLayoutProps) {
-  const isMobile = useIsMobile();
-
   const conversationMain = (
     <>
       {activeConversationId && !conversationError && (
@@ -170,32 +166,9 @@ function ConversationInnerLayout({
 
   return (
     <ErrorBoundary fallback={<UncaughtConversationErrorFallback />}>
-      {isMobile ? (
-        <div className="relative flex w-full flex-col">
-          {conversationMain}
-          <ConversationSidePanelContainer
-            owner={owner}
-            conversation={conversation}
-          />
-        </div>
-      ) : (
-        <div className="flex h-full w-full flex-col">
-          <ResizablePanelGroup
-            animateLayoutChanges
-            direction="horizontal"
-            className="flex h-full w-full flex-1 @container"
-          >
-            <ResizablePanel defaultSize={100}>
-              <div className="flex h-panel flex-col">{conversationMain}</div>
-            </ResizablePanel>
-
-            <ConversationSidePanelContainer
-              owner={owner}
-              conversation={conversation}
-            />
-          </ResizablePanelGroup>
-        </div>
-      )}
+      <ConversationSidePanelContainer owner={owner} conversation={conversation}>
+        {conversationMain}
+      </ConversationSidePanelContainer>
     </ErrorBoundary>
   );
 }

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -10,28 +10,25 @@ import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
 import type { LightWorkspaceType } from "@app/types/user";
-import { cn, ResizableHandle, ResizablePanel } from "@dust-tt/sparkle";
-import { memo, useEffect, useRef, useState } from "react";
+import { ResizableSidePanel } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
-// Resize events fire on every drag move; avoid re-rendering panel content.
-const MemoizedConversationSidePanelContent = memo(ConversationSidePanelContent);
-
 interface ConversationSidePanelContainerProps {
+  children: ReactNode;
   conversation?: ConversationWithoutContentType;
   owner: LightWorkspaceType;
 }
 
 export default function ConversationSidePanelContainer({
+  children,
   conversation,
   owner,
 }: ConversationSidePanelContainerProps) {
   const { currentPanel, setPanelRef, onPanelClosed } =
     useConversationSidePanelContext();
   const panelRef = useRef<ImperativePanelHandle | null>(null);
-  const [panelContentSizePercent, setPanelContentSizePercent] = useState(
-    DEFAULT_RIGHT_PANEL_SIZE
-  );
   const [fullScreenHash] = useHashParam(FULL_SCREEN_HASH_PARAM);
   const isFullScreen = fullScreenHash === "true";
 
@@ -49,97 +46,49 @@ export default function ConversationSidePanelContainer({
     setPanelRef(panelRef.current);
   }, [isMobile, setPanelRef]);
 
-  useEffect(() => {
-    if (isMobile || !currentPanel || !panelRef.current) {
-      return;
-    }
-
-    const defaultSize = getDefaultRightPanelSize(currentPanel);
-    if (panelRef.current.isCollapsed()) {
-      panelRef.current.expand(defaultSize);
-    } else {
-      panelRef.current.resize(defaultSize);
-    }
-  }, [currentPanel, isMobile]);
-
   if (isMobile) {
-    if (!currentPanel || !conversation) {
-      return null;
-    }
-
     return (
-      <div className="fixed inset-0 z-50 flex flex-col overflow-hidden overscroll-none bg-panel-background">
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
-          <ConversationSidePanelContent
-            conversation={conversation}
-            owner={owner}
-            currentPanel={currentPanel}
-          />
-        </div>
+      <div className="relative flex w-full flex-col">
+        {children}
+        {currentPanel && conversation && (
+          <div className="fixed inset-0 z-50 flex flex-col overflow-hidden overscroll-none bg-panel-background">
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
+              <ConversationSidePanelContent
+                conversation={conversation}
+                owner={owner}
+                currentPanel={currentPanel}
+              />
+            </div>
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <>
-      {!!conversation && (
-        <ResizableHandle
-          withHandle={currentPanel && !isFullScreen}
-          disabled={!currentPanel || isFullScreen}
-          className="z-50"
-          onDragging={(isDragging) => {
-            // Pointer resizing skips transitions, so release completes a drag collapse.
-            if (!isDragging && panelRef.current?.isCollapsed()) {
-              onPanelClosed();
-            }
-          }}
-        />
-      )}
-      {/* Panel Container - either Interactive Content or Actions */}
-      <ResizablePanel
-        ref={panelRef}
-        minSize={20}
-        defaultSize={0}
-        onResize={(size) => {
-          if (size > 0) {
-            setPanelContentSizePercent(size);
-          }
-        }}
-        onTransitionEnd={(event) => {
-          // Programmatic and keyboard collapses keep content until motion completes.
-          if (
-            event.target === event.currentTarget &&
-            event.propertyName === "flex-grow" &&
-            panelRef.current?.isCollapsed()
-          ) {
-            onPanelClosed();
-          }
-        }}
-        collapsible
-        collapsedSize={0}
-        className={cn(
-          "flex-0 overflow-hidden",
-          !currentPanel && "hidden w-0 md:block",
-          // On mobile: overlay full screen with absolute positioning.
-          "md:relative",
-          currentPanel &&
-            "absolute inset-0 bg-panel-background md:relative md:inset-auto"
-        )}
-      >
-        {currentPanel && conversation && (
-          <div
-            className="h-full @container"
-            // Keep content width and container queries stable during animation.
-            style={{ width: `${panelContentSizePercent}cqw` }}
-          >
-            <MemoizedConversationSidePanelContent
-              conversation={conversation}
-              owner={owner}
-              currentPanel={currentPanel}
-            />
-          </div>
-        )}
-      </ResizablePanel>
-    </>
+    <ResizableSidePanel
+      ref={panelRef}
+      isOpen={!!currentPanel}
+      defaultSize={
+        currentPanel
+          ? getDefaultRightPanelSize(currentPanel)
+          : DEFAULT_RIGHT_PANEL_SIZE
+      }
+      minContentSize={0}
+      isResizable={!isFullScreen}
+      onCollapse={onPanelClosed}
+      panel={
+        currentPanel &&
+        conversation && (
+          <ConversationSidePanelContent
+            conversation={conversation}
+            owner={owner}
+            currentPanel={currentPanel}
+          />
+        )
+      }
+    >
+      <div className="flex h-panel flex-col">{children}</div>
+    </ResizableSidePanel>
   );
 }

--- a/sparkle/src/components/ResizableSidePanel.tsx
+++ b/sparkle/src/components/ResizableSidePanel.tsx
@@ -10,13 +10,17 @@ import type { ImperativePanelHandle } from "react-resizable-panels";
 export interface ResizableSidePanelProps {
   /** The main page content the panel docks beside. */
   children: ReactNode;
-  /** Panel content. When omitted, children render on their own with no resize machinery. */
-  panel?: ReactNode;
+  /** Panel content. Keep the panel mounted and drive isOpen so it keeps its state. */
+  panel: ReactNode;
   isOpen?: boolean;
   /** Panel width as a percentage of the available row, used when it opens. */
   defaultSize?: number;
   /** Smallest width the panel can be dragged to, as a percentage. */
   minSize?: number;
+  /** Smallest width the main content can be squeezed to, as a percentage. */
+  minContentSize?: number;
+  /** Locks the divider, for instance while the panel is shown full screen. */
+  isResizable?: boolean;
   /**
    * Called once a collapse settles: on release of a drag that closed the
    * panel, or when the closing animation finishes.
@@ -39,7 +43,8 @@ export interface ResizableSidePanelProps {
 /**
  * Docks a resizable, collapsible panel to the right of the main content,
  * outside of whatever container the content itself uses. The divider is
- * draggable and the panel animates open and shut.
+ * draggable and the panel animates open and shut. The forwarded ref exposes
+ * the panel's imperative handle for hosts that resize it programmatically.
  *
  * @example
  * ```tsx
@@ -48,116 +53,130 @@ export interface ResizableSidePanelProps {
  * </ResizableSidePanel>
  * ```
  */
-export function ResizableSidePanel({
-  children,
-  panel,
-  isOpen = false,
-  defaultSize = 30,
-  minSize = 20,
-  onCollapse,
-  minContentWidthPx,
-  onContentSqueezed,
-  className,
-}: ResizableSidePanelProps) {
-  const panelRef = React.useRef<ImperativePanelHandle>(null);
-  const rowRef = React.useRef<HTMLDivElement>(null);
-  const [panelContentSizePercent, setPanelContentSizePercent] =
-    React.useState(defaultSize);
+export const ResizableSidePanel = React.forwardRef<
+  ImperativePanelHandle,
+  ResizableSidePanelProps
+>(
+  (
+    {
+      children,
+      panel,
+      isOpen = false,
+      defaultSize = 30,
+      minSize = 20,
+      minContentSize = 30,
+      isResizable = true,
+      onCollapse,
+      minContentWidthPx,
+      onContentSqueezed,
+      className,
+    },
+    ref
+  ) => {
+    const panelRef = React.useRef<ImperativePanelHandle>(null);
+    const rowRef = React.useRef<HTMLDivElement>(null);
+    const [panelContentSizePercent, setPanelContentSizePercent] =
+      React.useState(defaultSize);
 
-  React.useEffect(() => {
-    if (!panelRef.current) {
-      return;
-    }
-    if (isOpen) {
-      panelRef.current.expand(defaultSize);
-    } else {
-      panelRef.current.collapse();
-    }
-  }, [isOpen, defaultSize]);
+    React.useImperativeHandle<
+      ImperativePanelHandle | null,
+      ImperativePanelHandle | null
+    >(ref, () => panelRef.current);
 
-  const handlePanelResize = React.useCallback(
-    (panelSizePercent: number) => {
-      if (panelSizePercent > 0) {
-        setPanelContentSizePercent(panelSizePercent);
-      }
-      if (!onContentSqueezed || !minContentWidthPx || !rowRef.current) {
+    React.useEffect(() => {
+      if (!panelRef.current) {
         return;
       }
-      const rowWidthPx = rowRef.current.getBoundingClientRect().width;
-      const contentWidthPx = (rowWidthPx * (100 - panelSizePercent)) / 100;
-      if (contentWidthPx < minContentWidthPx) {
-        onContentSqueezed();
+      if (!isOpen) {
+        panelRef.current.collapse();
+      } else if (panelRef.current.isCollapsed()) {
+        panelRef.current.expand(defaultSize);
+      } else {
+        panelRef.current.resize(defaultSize);
       }
-    },
-    [onContentSqueezed, minContentWidthPx]
-  );
+    }, [isOpen, defaultSize]);
 
-  if (!panel) {
-    return <>{children}</>;
-  }
+    const handlePanelResize = React.useCallback(
+      (panelSizePercent: number) => {
+        if (panelSizePercent > 0) {
+          setPanelContentSizePercent(panelSizePercent);
+        }
+        if (!onContentSqueezed || !minContentWidthPx || !rowRef.current) {
+          return;
+        }
+        const rowWidthPx = rowRef.current.getBoundingClientRect().width;
+        const contentWidthPx = (rowWidthPx * (100 - panelSizePercent)) / 100;
+        if (contentWidthPx < minContentWidthPx) {
+          onContentSqueezed();
+        }
+      },
+      [onContentSqueezed, minContentWidthPx]
+    );
 
-  return (
-    <div
-      ref={rowRef}
-      className={cn("relative flex h-full w-full flex-1 @container", className)}
-    >
-      <ResizablePanelGroup
-        animateLayoutChanges
-        direction="horizontal"
-        className="flex h-full w-full flex-1"
+    return (
+      <div
+        ref={rowRef}
+        className={cn(
+          "relative flex h-full w-full flex-1 @container",
+          className
+        )}
       >
-        <ResizablePanel defaultSize={100} minSize={30}>
-          {children}
-        </ResizablePanel>
-
-        <ResizableHandle
-          withHandle={isOpen}
-          disabled={!isOpen}
-          className="hidden md:flex"
-          onDragging={(isDragging) => {
-            // Pointer resizing skips transitions, so release completes a drag collapse.
-            if (!isDragging && panelRef.current?.isCollapsed()) {
-              onCollapse?.();
-            }
-          }}
-        />
-
-        <ResizablePanel
-          ref={panelRef}
-          defaultSize={isOpen ? defaultSize : 0}
-          minSize={isOpen ? minSize : 0}
-          collapsedSize={0}
-          collapsible
-          onResize={handlePanelResize}
-          onTransitionEnd={(event) => {
-            // Programmatic and keyboard collapses settle when the motion completes.
-            if (
-              event.target === event.currentTarget &&
-              event.propertyName === "flex-grow" &&
-              panelRef.current?.isCollapsed()
-            ) {
-              onCollapse?.();
-            }
-          }}
-          className={cn(
-            "overflow-hidden",
-            isOpen
-              ? "absolute inset-0 z-50 md:relative md:inset-auto md:z-auto"
-              : "hidden md:block"
-          )}
+        <ResizablePanelGroup
+          animateLayoutChanges
+          direction="horizontal"
+          className="flex h-full w-full flex-1"
         >
-          <div
+          <ResizablePanel defaultSize={100} minSize={minContentSize}>
+            {children}
+          </ResizablePanel>
+
+          <ResizableHandle
+            withHandle={isOpen && isResizable}
+            disabled={!isOpen || !isResizable}
+            className="hidden md:flex"
+            onDragging={(isDragging) => {
+              // Pointer resizing skips transitions, so release completes a drag collapse.
+              if (!isDragging && panelRef.current?.isCollapsed()) {
+                onCollapse?.();
+              }
+            }}
+          />
+
+          <ResizablePanel
+            ref={panelRef}
+            defaultSize={isOpen ? defaultSize : 0}
+            minSize={isOpen ? minSize : 0}
+            collapsedSize={0}
+            collapsible
+            onResize={handlePanelResize}
+            onTransitionEnd={(event) => {
+              // Programmatic and keyboard collapses settle when the motion completes.
+              if (
+                event.target === event.currentTarget &&
+                event.propertyName === "flex-grow" &&
+                panelRef.current?.isCollapsed()
+              ) {
+                onCollapse?.();
+              }
+            }}
             className={cn(
-              "h-full min-w-full overflow-hidden bg-panel-background @container md:min-w-0",
-              isOpen && "border-l border-border"
+              "overflow-hidden",
+              isOpen
+                ? "absolute inset-0 z-50 md:relative md:inset-auto md:z-auto"
+                : "hidden md:block"
             )}
-            // Keep content width and container queries stable during animation.
-            style={{ width: `${panelContentSizePercent}cqw` }}
           >
-            {panel}
-          </div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
-    </div>
-  );
-}
+            <div
+              className="h-full min-w-full overflow-hidden bg-panel-background @container md:min-w-0"
+              // Keep content width and container queries stable during animation.
+              style={{ width: `${panelContentSizePercent}cqw` }}
+            >
+              {panel}
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    );
+  }
+);
+ResizableSidePanel.displayName = "ResizableSidePanel";

--- a/sparkle/src/components/ResizableSidePanel.tsx
+++ b/sparkle/src/components/ResizableSidePanel.tsx
@@ -133,7 +133,7 @@ export const ResizableSidePanel = React.forwardRef<
           <ResizableHandle
             withHandle={isOpen && isResizable}
             disabled={!isOpen || !isResizable}
-            className="hidden md:flex"
+            className="z-50 hidden md:flex"
             onDragging={(isDragging) => {
               // Pointer resizing skips transitions, so release completes a drag collapse.
               if (!isDragging && panelRef.current?.isCollapsed()) {


### PR DESCRIPTION
## Description

PR https://github.com/dust-tt/dust/pull/31237 introduced new `ResizableSidePanel` component. Refactoring the `ConversationSidePanelContainer` to use it too.

## Tests

Tested Locally. 

## Risk

Low. Refactor only.

## Deploy Plan

Standard deploy.
