### PR TITLE
dust-hive: print clickable URLs in forward output

### DIFF
--- a/x/henry/dust-hive/src/commands/forward.ts
+++ b/x/henry/dust-hive/src/commands/forward.ts
@@ -1,5 +1,10 @@
 import { detectEnvironmentFromCwd, getEnvironment } from "../lib/environment";
-import { getForwarderStatus, startForwarder, stopForwarder } from "../lib/forward";
+import {
+  formatForwarderMapping,
+  getForwarderStatus,
+  startForwarder,
+  stopForwarder,
+} from "../lib/forward";
 import { FORWARDER_MAPPINGS } from "../lib/forwarderConfig";
 import { logger } from "../lib/logger";
 import { FORWARDER_LOG_PATH } from "../lib/paths";
@@ -22,9 +27,7 @@ export async function forwardStatusCommand(): Promise<Result<void>> {
     console.log(`Updated:    ${status.state.updatedAt}`);
     console.log("Listening:");
     for (const m of FORWARDER_MAPPINGS) {
-      console.log(
-        `            ${m.name.padEnd(16)} ${String(m.listenPort).padStart(4)} → ${status.state.basePort + m.targetOffset}`
-      );
+      console.log(`            ${formatForwarderMapping(m, status.state.basePort)}`);
     }
 
     // Check if target is still warm

--- a/x/henry/dust-hive/src/lib/forward.ts
+++ b/x/henry/dust-hive/src/lib/forward.ts
@@ -252,6 +252,8 @@ function mappingUrl(m: ForwarderMapping, port: number): string {
   return `http://localhost:${port}${FORWARDER_URL_PATHS[m.name] ?? ""}`;
 }
 
+const NAME_COLUMN_WIDTH = 16;
+
 // Width of the longest listen URL, so the arrows line up across rows.
 const LISTEN_URL_WIDTH = Math.max(
   ...FORWARDER_MAPPINGS.map((m) => mappingUrl(m, m.listenPort).length)
@@ -261,7 +263,7 @@ export function formatForwarderMapping(m: ForwarderMapping, basePort: number): s
   const listenUrl = mappingUrl(m, m.listenPort);
   const targetUrl = mappingUrl(m, basePort + m.targetOffset);
   const padding = " ".repeat(LISTEN_URL_WIDTH - listenUrl.length);
-  return `${m.name.padEnd(16)} ${hyperlink(listenUrl)}${padding} → ${hyperlink(targetUrl)}`;
+  return `${m.name.padEnd(NAME_COLUMN_WIDTH)} ${hyperlink(listenUrl)}${padding} → ${hyperlink(targetUrl)}`;
 }
 
 // Get forwarder status info

--- a/x/henry/dust-hive/src/lib/forward.ts
+++ b/x/henry/dust-hive/src/lib/forward.ts
@@ -11,6 +11,7 @@ import { logger } from "./logger";
 import { FORWARDER_LOG_PATH, FORWARDER_PID_PATH, FORWARDER_STATE_PATH } from "./paths";
 import { getPortProcessInfo, isPortInUse } from "./ports";
 import { isProcessRunning, killProcess } from "./process";
+import { WORKSPACE_ID } from "./seed";
 
 const ForwarderStateFields = z.object({
   targetEnv: z.string(),
@@ -230,10 +231,37 @@ export async function startForwarder(basePort: number, envName: string): Promise
 
   logger.success(`Forwarding ports → ${envName} (base ${basePort})`);
   for (const m of FORWARDER_MAPPINGS) {
-    console.log(
-      `  ${m.name.padEnd(16)} ${String(m.listenPort).padStart(4)} → ${basePort + m.targetOffset}`
-    );
+    console.log(`  ${formatForwarderMapping(m, basePort)}`);
   }
+}
+
+type ForwarderMapping = (typeof FORWARDER_MAPPINGS)[number];
+
+// Deep links for the SPAs, pointing at the seeded dev workspace.
+const FORWARDER_URL_PATHS: Partial<Record<ForwarderMapping["name"], string>> = {
+  "front-spa-app": `/w/${WORKSPACE_ID}`,
+  "front-spa-poke": `/${WORKSPACE_ID}`,
+};
+
+// OSC 8 hyperlink: clickable in most terminals, plain text elsewhere.
+function hyperlink(url: string): string {
+  return `\x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\`;
+}
+
+function mappingUrl(m: ForwarderMapping, port: number): string {
+  return `http://localhost:${port}${FORWARDER_URL_PATHS[m.name] ?? ""}`;
+}
+
+// Width of the longest listen URL, so the arrows line up across rows.
+const LISTEN_URL_WIDTH = Math.max(
+  ...FORWARDER_MAPPINGS.map((m) => mappingUrl(m, m.listenPort).length)
+);
+
+export function formatForwarderMapping(m: ForwarderMapping, basePort: number): string {
+  const listenUrl = mappingUrl(m, m.listenPort);
+  const targetUrl = mappingUrl(m, basePort + m.targetOffset);
+  const padding = " ".repeat(LISTEN_URL_WIDTH - listenUrl.length);
+  return `${m.name.padEnd(16)} ${hyperlink(listenUrl)}${padding} → ${hyperlink(targetUrl)}`;
 }
 
 // Get forwarder status info

--- a/x/henry/dust-hive/tests/lib/forward.test.ts
+++ b/x/henry/dust-hive/tests/lib/forward.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { formatForwarderMapping } from "../../src/lib/forward";
+import { FORWARDER_MAPPINGS } from "../../src/lib/forwarderConfig";
+import { WORKSPACE_ID } from "../../src/lib/seed";
+
+const BASE_PORT = 12000;
+const ESC = "\x1b";
+
+// Strip OSC 8 hyperlink escapes, keeping the visible text.
+const HYPERLINK_ESCAPES = new RegExp(`${ESC}\\]8;;.*?${ESC}\\\\`, "g");
+
+function stripHyperlinks(line: string): string {
+  return line.replace(HYPERLINK_ESCAPES, "");
+}
+
+function mappingNamed(name: string) {
+  const mapping = FORWARDER_MAPPINGS.find((m) => m.name === name);
+  if (!mapping) throw new Error(`No mapping named ${name}`);
+  return mapping;
+}
+
+describe("formatForwarderMapping", () => {
+  it("prints listen and target URLs", () => {
+    const line = stripHyperlinks(formatForwarderMapping(mappingNamed("proxy"), BASE_PORT));
+    expect(line).toMatch(/^proxy\s+http:\/\/localhost:3000\s+→ http:\/\/localhost:12000$/);
+  });
+
+  it("deep-links SPA rows into the seeded workspace", () => {
+    const app = stripHyperlinks(formatForwarderMapping(mappingNamed("front-spa-app"), BASE_PORT));
+    expect(app).toContain(`http://localhost:3011/w/${WORKSPACE_ID}`);
+    expect(app).toContain(`http://localhost:12011/w/${WORKSPACE_ID}`);
+
+    const poke = stripHyperlinks(formatForwarderMapping(mappingNamed("front-spa-poke"), BASE_PORT));
+    expect(poke).toContain(`http://localhost:3010/${WORKSPACE_ID}`);
+    expect(poke).toContain(`http://localhost:12010/${WORKSPACE_ID}`);
+  });
+
+  it("aligns arrows across all rows", () => {
+    const arrowColumns = FORWARDER_MAPPINGS.map((m) =>
+      stripHyperlinks(formatForwarderMapping(m, BASE_PORT)).indexOf("→")
+    );
+    expect(new Set(arrowColumns).size).toBe(1);
+  });
+
+  it("wraps both URLs in OSC 8 hyperlinks", () => {
+    const line = formatForwarderMapping(mappingNamed("proxy"), BASE_PORT);
+    expect(line).toContain(
+      `${ESC}]8;;http://localhost:3000${ESC}\\http://localhost:3000${ESC}]8;;${ESC}\\`
+    );
+    expect(line).toContain(
+      `${ESC}]8;;http://localhost:12000${ESC}\\http://localhost:12000${ESC}]8;;${ESC}\\`
+    );
+  });
+});


### PR DESCRIPTION
## Description

`dust-hive forward` and `forward status` listed bare ports (`proxy 3000 → 12000`). They now print URLs on both sides, wrapped in OSC 8 hyperlinks so they are clickable in terminals that support them:

```
proxy            http://localhost:3000              → http://localhost:12000
front-spa-poke   http://localhost:3010/DevWkSpace   → http://localhost:12010/DevWkSpace
front-spa-app    http://localhost:3011/w/DevWkSpace → http://localhost:12011/w/DevWkSpace
```

The SPA rows deep-link into the seeded workspace, using the existing `WORKSPACE_ID` constant from `seed.ts`. The same helper formats both the start-time table (also shown by `warm`) and `forward status`.

Why do I bother? Because for some reason when I typed localhost 12011 for some reason workOS is redirecting me to my non dust hive workspace http://localhost:12011/w/XfGEztL6cC/conversation/new which is a 404 and it's very annoying. 

## Tests

`bun run check` passes. Ran `forward status` from the worktree against a running forwarder.

## Risk

None, dev tooling only.

## Deploy Plan

None.