### PR TITLE
[front] enh: add group member consumption metrics to top group endpoint

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -244,6 +244,7 @@ const TOP_SOURCES: GetConsumptionTopSourcesResponse = {
 const TOP_GROUPS: GetConsumptionTopGroupsResponse = {
   period: PERIOD,
   totalCredits: 5000,
+  totalActiveMembers: 8,
   totalCount: 1,
   hasMore: false,
   groups: [
@@ -251,6 +252,8 @@ const TOP_GROUPS: GetConsumptionTopGroupsResponse = {
       groupId: "group1",
       name: "Engineering",
       credits: 200,
+      activeMembers: 3,
+      totalMembers: 5,
       previousCredits: null,
       messageCount: 4,
       avgCreditsPerMessage: 50,

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -241,11 +241,17 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels groups with their group name", async () => {
-    const { authenticator, workspace } = await createResourceTest({
+  it("labels groups with their name and current member count", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
       role: "admin",
     });
     const group = await GroupFactory.regularManual(workspace, "Engineering");
+    const addMemberResult = await GroupFactory.withMembers(
+      authenticator,
+      group,
+      [user]
+    );
+    expect(addMemberResult.isOk()).toBe(true);
 
     const labels = await resolveDimensionLabels(authenticator, "group", [
       group.sId,
@@ -255,6 +261,7 @@ describe("resolveDimensionLabels", () => {
       name: "Engineering",
       pictureUrl: null,
       description: null,
+      memberCount: 1,
     });
   });
 

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -53,6 +53,8 @@ export type DimensionLabel = {
   scope?: AgentConfigurationScope;
   maker?: ModelMakerIdType;
   tier?: ModelsTierName;
+  // Only groups have one; this is the current active membership count.
+  memberCount?: number;
 };
 
 function labelsFromNames(
@@ -121,9 +123,27 @@ export async function resolveDimensionLabels(
       const groups = await GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
       });
-      const namesById = new Map(groups.map((group) => [group.sId, group.name]));
-      return labelsFromNames(
-        new Map(keys.map((key) => [key, namesById.get(key) ?? key]))
+      const groupsWithMemberCounts = await GroupResource.toJSONWithMemberCounts(
+        auth,
+        groups
+      );
+      const groupsById = new Map(
+        groupsWithMemberCounts.map((group) => [group.sId, group])
+      );
+
+      return new Map(
+        keys.map((key) => {
+          const group = groupsById.get(key);
+          return [
+            key,
+            {
+              name: group?.name ?? key,
+              pictureUrl: null,
+              description: null,
+              memberCount: group?.memberCount ?? 0,
+            },
+          ];
+        })
       );
     }
 

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -123,9 +123,11 @@ export async function resolveDimensionLabels(
       const groups = await GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
       });
+      const keySet = new Set(keys);
+      const groupsToResolve = groups.filter((group) => keySet.has(group.sId));
       const groupsWithMemberCounts = await GroupResource.toJSONWithMemberCounts(
         auth,
-        groups
+        groupsToResolve
       );
       const groupsById = new Map(
         groupsWithMemberCounts.map((group) => [group.sId, group])

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -58,11 +58,13 @@ function mockAggs({
   buckets,
   totalCount = buckets.length,
   totalMicro,
+  totalActiveMembers = 0,
   filtered = false,
 }: {
   buckets: Array<Record<string, unknown> & { key: string }>;
   totalCount?: number;
   totalMicro: number;
+  totalActiveMembers?: number;
   filtered?: boolean;
 }) {
   vi.mocked(searchConsumptionAnalytics).mockImplementation(
@@ -89,6 +91,7 @@ function mockAggs({
       return esResponse({
         ...(filtered ? { ranking } : ranking),
         total_credit_micro: { value: totalMicro },
+        active_members: { value: totalActiveMembers },
       });
     }
   );
@@ -543,9 +546,11 @@ describe("consumption top rankings", () => {
           doc_count: 6,
           credit_micro: { value: 2_000_000 },
           messages: { value: 4 },
+          active_members: { value: 2 },
         },
       ],
       totalMicro: 2_000_000,
+      totalActiveMembers: 3,
     });
 
     mockLabels({ key1: "Jane Doe" });
@@ -570,7 +575,20 @@ describe("consumption top rankings", () => {
       field: "user.id",
     });
 
-    mockLabels({ key1: "Engineering" });
+    vi.mocked(searchConsumptionAnalytics).mockClear();
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        [
+          "key1",
+          {
+            name: "Engineering",
+            pictureUrl: null,
+            description: null,
+            memberCount: 5,
+          },
+        ],
+      ])
+    );
     const groups = await fetchConsumptionTopGroups(auth, {
       period: PERIOD,
       limit: 10,
@@ -583,13 +601,24 @@ describe("consumption top rankings", () => {
       groupId: "key1",
       name: "Engineering",
       credits: 2,
+      activeMembers: 2,
+      totalMembers: 5,
       previousCredits: 2,
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+    expect(groups.value.totalActiveMembers).toBe(3);
+    const [, groupRankingOptions] = rankingSearchCall();
+    expect(groupRankingOptions?.aggregations?.by_group?.terms).toMatchObject({
       field: "user.group_ids",
     });
+    expect(
+      groupRankingOptions?.aggregations?.by_group?.aggs?.active_members
+        ?.cardinality
+    ).toMatchObject({ field: "user.id" });
+    expect(
+      groupRankingOptions?.aggregations?.active_members?.cardinality
+    ).toMatchObject({ field: "user.id" });
 
     mockLabels({ key1: "Claude 4 Sonnet" });
     const models = await fetchConsumptionTopModels(auth, {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -39,6 +39,8 @@ export type ConsumptionTopGroup = {
   credits: number;
   // Distinct messages, or tool invocations, per the ranking's unit.
   count: number;
+  // Only populated for the group dimension.
+  activeMembers?: number;
   // This key's credits over the equivalent window immediately preceding the
   // period, for period-over-period growth. Null when the key had no
   // consumption at all in that prior window.
@@ -54,12 +56,15 @@ export type ConsumptionTopGroups = {
   // sum of `groups`. The ranking is capped at `limit`, and a dimension that only
   // exists on some documents (a tool, a skill) accounts for part of the total.
   totalCredits: number;
+  // Only populated for the group dimension.
+  totalActiveMembers?: number;
 };
 
 // Sub-aggregation names, kept out of the callers so the ranking order and the
 // bucket reads below cannot drift apart.
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
+const ACTIVE_MEMBERS_AGG = "active_members";
 const TOTAL_COUNT_AGG = "total_count";
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
@@ -70,13 +75,24 @@ type GroupBucket = {
   doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
+  [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
-function subAggs(unit: ConsumptionTopUnit) {
+function subAggs(unit: ConsumptionTopUnit, dimension: ConsumptionTopDimension) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
     ...(unit === "message"
       ? { [MESSAGES_AGG]: uniqueMessagesCardinalityAgg() }
+      : {}),
+    ...(dimension === "group"
+      ? {
+          [ACTIVE_MEMBERS_AGG]: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
       : {}),
   };
 }
@@ -89,6 +105,7 @@ type RankingAggs = {
 type TopAggs = RankingAggs & {
   ranking?: estypes.AggregationsSingleBucketAggregateBase & RankingAggs;
   total_credit_micro?: estypes.AggregationsSumAggregate;
+  [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
 function countFromBucket(
@@ -233,7 +250,7 @@ function buildConsumptionTopAggregations({
         order: rankingOrder(dimension, rankBy, sortOrder),
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
-      aggs: subAggs(unit),
+      aggs: subAggs(unit, dimension),
     },
     ...(includeTotalCount
       ? {
@@ -259,6 +276,16 @@ function buildConsumptionTopAggregations({
   return {
     ...rankingRootAggregations,
     total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+    ...(dimension === "group"
+      ? {
+          [ACTIVE_MEMBERS_AGG]: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
+      : {}),
   };
 }
 
@@ -377,6 +404,7 @@ export async function fetchConsumptionTopGroups(
   let batchSize = 0;
   let totalCount = 0;
   let totalCredits = 0;
+  let totalActiveMembers = 0;
 
   // Terms aggregations do not expose an after_key when ordered by a metric.
   // Continue the ranked result in bounded batches by excluding the keys
@@ -409,19 +437,31 @@ export async function fetchConsumptionTopGroups(
       : result.value.aggregations;
     buckets = bucketsToArray<GroupBucket>(ranking?.by_group?.buckets);
     rankedGroups.push(
-      ...buckets.map((bucket) => ({
-        key: String(bucket.key),
-        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-        count: countFromBucket(
-          bucket,
-          CONSUMPTION_TOP_DIMENSION_UNIT[dimension]
-        ),
-      }))
+      ...buckets.map((bucket) => {
+        const group = {
+          key: String(bucket.key),
+          credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+          count: countFromBucket(
+            bucket,
+            CONSUMPTION_TOP_DIMENSION_UNIT[dimension]
+          ),
+        };
+
+        return dimension === "group"
+          ? {
+              ...group,
+              activeMembers: Math.round(bucket[ACTIVE_MEMBERS_AGG]?.value ?? 0),
+            }
+          : group;
+      })
     );
     totalCredits = microCreditsToCredits(
       result.value.aggregations?.total_credit_micro?.value ?? 0
     );
     totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
+    totalActiveMembers = Math.round(
+      result.value.aggregations?.[ACTIVE_MEMBERS_AGG]?.value ?? 0
+    );
   } while (
     rankedGroups.length < requestedBucketCount &&
     buckets.length === batchSize
@@ -461,6 +501,7 @@ export async function fetchConsumptionTopGroups(
     hasMore: totalCount > offset + limit,
     totalCount,
     totalCredits,
+    ...(dimension === "group" ? { totalActiveMembers } : {}),
   });
 }
 
@@ -484,6 +525,8 @@ export type ResolvedConsumptionGroup = {
   credits: number;
   count: number;
   avgCredits: number;
+  activeMembers?: number;
+  memberCount?: number;
   previousCredits: number | null;
 };
 
@@ -514,6 +557,12 @@ export async function resolveConsumptionGroupLabels(
     credits: group.credits,
     count: group.count,
     avgCredits: avgCreditsPerUnit(group.credits, group.count),
+    ...(group.activeMembers !== undefined
+      ? { activeMembers: group.activeMembers }
+      : {}),
+    ...(labels.get(group.key)?.memberCount !== undefined
+      ? { memberCount: labels.get(group.key)?.memberCount }
+      : {}),
     previousCredits: group.previousCredits,
   }));
 }

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -13,16 +13,19 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
 /**
- * Groups ranked by the credits consumed by their members over the period,
- * averaged per message. A member can belong to several groups, in which case
- * their consumption is attributed to each group they belonged to when the
- * message completed.
+ * Groups ranked by the credits consumed by their members over the period, with
+ * distinct active-member and message counts. A member can belong to several
+ * groups, in which case their consumption is attributed to each group they
+ * belonged to when the message completed.
  */
 
 export type ConsumptionTopGroupRow = {
   groupId: string;
   name: string;
   credits: number;
+  activeMembers: number;
+  // Current active group membership count.
+  totalMembers: number;
   previousCredits: number | null;
   messageCount: number;
   avgCreditsPerMessage: number;
@@ -31,6 +34,7 @@ export type ConsumptionTopGroupRow = {
 export type ConsumptionTopGroups = {
   period: ConsumptionPeriod;
   totalCredits: number;
+  totalActiveMembers: number;
   hasMore: boolean;
   totalCount: number;
   // Highest credits first.
@@ -69,19 +73,28 @@ export async function fetchConsumptionTopGroups(
   if (result.isErr()) {
     return result;
   }
-  const { groups, hasMore, totalCount, totalCredits } = result.value;
+  const {
+    groups,
+    hasMore,
+    totalCount,
+    totalCredits,
+    totalActiveMembers = 0,
+  } = result.value;
 
   const rows = await resolveConsumptionGroupLabels(auth, "group", groups);
 
   return new Ok({
     period,
     totalCredits,
+    totalActiveMembers,
     hasMore,
     totalCount,
     groups: rows.map((row) => ({
       groupId: row.key,
       name: row.name,
       credits: row.credits,
+      activeMembers: row.activeMembers ?? 0,
+      totalMembers: row.memberCount ?? 0,
       previousCredits: row.previousCredits,
       messageCount: row.count,
       avgCreditsPerMessage: row.avgCredits,


### PR DESCRIPTION
## Description

Context in [thread](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1788508787255659).

The goal is to replace the "Consumption share" column in the attribution table with metrics that are more helpful in guiding decision making: number of active users / total group size and difference in usage with the workspace average.

This PR adds the active-member count to group consumption aggregations and surfaces it in the top-groups endpoint.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low. Mostly additive.

## Deploy Plan

- Deploy front.
