### PR TITLE
[front] enh: replace group consumption share with member usage metrics in attribution table

### DIFF
--- a/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
+++ b/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
@@ -82,6 +82,7 @@ function PokeConsumptionAttributionRows(
   const {
     rows,
     totalCredits,
+    totalActiveMembers,
     totalCount,
     isTopLoading,
     isTopError,
@@ -103,6 +104,7 @@ function PokeConsumptionAttributionRows(
       data={{
         rows,
         totalCredits,
+        totalActiveMembers,
         totalCount,
         isTopLoading,
         isTopError: Boolean(isTopError),

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -81,6 +81,8 @@ function AttributionSkeletonCell({
       );
     case "credits":
     case "avgCredits":
+    case "activeMembers":
+    case "usageVsAverage":
     case "vsPrev":
       return (
         <div className="flex h-12 items-center justify-end">

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -283,6 +283,60 @@ describe("ConsumptionAttributionTable", () => {
     expect(screen.getByRole("tab", { name: "Groups" })).toBeInTheDocument();
   });
 
+  it("shows active members and per-member usage for groups", () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [
+        {
+          id: "engineering",
+          name: "Engineering",
+          pictureUrl: null,
+          description: null,
+          icon: null,
+          modelId: null,
+          modelDisplayName: null,
+          credits: 500,
+          avgCredits: 100,
+          activeMembers: 2,
+          totalMembers: 5,
+          previousCredits: null,
+        },
+      ],
+      totalCredits: 1_000,
+      totalActiveMembers: 10,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="group"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Active / total members" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Vs workspace avg" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Consumption share" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("2 / 5")).toBeInTheDocument();
+    const usagePercentage = screen.getByText("+150%");
+    expect(usagePercentage.parentElement).toHaveClass("text-highlight-600");
+    expect(usagePercentage.parentElement?.querySelector("svg")).toBeNull();
+  });
+
   it("caps the available pages and fetches the selected fixed-size page", async () => {
     const rows = Array.from({ length: 1_025 }, (_, index) => ({
       id: `agent-${index + 1}`,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -186,16 +186,8 @@ function growthPercent(
     : null;
 }
 
-function VsPrevCell({
-  credits,
-  previousCredits,
-}: {
-  credits: number;
-  previousCredits: number | null;
-}) {
-  const growth = growthPercent(credits, previousCredits);
-
-  if (growth === null) {
+function PercentageChangeCell({ percentage }: { percentage: number | null }) {
+  if (percentage === null) {
     return (
       <DataTable.CellContent className="w-full justify-end text-right">
         <Tooltip
@@ -211,15 +203,84 @@ function VsPrevCell({
     <div
       className={cn(
         "flex w-full items-center justify-end gap-1 text-right text-sm tabular-nums",
-        growth > 100 ? "text-highlight-600" : "text-muted-foreground"
+        percentage > 100 ? "text-highlight-600" : "text-muted-foreground"
       )}
     >
       <Icon
-        visual={growth >= 0 ? ArrowNarrowUpRight : ArrowNarrowDownRight}
+        visual={percentage >= 0 ? ArrowNarrowUpRight : ArrowNarrowDownRight}
         size="xs"
       />
-      <span>{Math.round(Math.abs(growth))}%</span>
+      <span>{Math.round(Math.abs(percentage))}%</span>
     </div>
+  );
+}
+
+function VsPrevCell({
+  credits,
+  previousCredits,
+}: {
+  credits: number;
+  previousCredits: number | null;
+}) {
+  return (
+    <PercentageChangeCell
+      percentage={growthPercent(credits, previousCredits)}
+    />
+  );
+}
+
+function UsageVsAverageCell({ percentage }: { percentage: number | null }) {
+  if (percentage === null) {
+    return (
+      <DataTable.CellContent className="w-full justify-end text-right">
+        <Tooltip
+          label="Not enough data to compute"
+          tooltipTriggerAsChild
+          trigger={<span className="text-sm text-muted-foreground">--</span>}
+        />
+      </DataTable.CellContent>
+    );
+  }
+
+  const roundedPercentage = Math.round(percentage);
+  const sign = roundedPercentage > 0 ? "+" : "";
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center justify-end text-right text-sm tabular-nums",
+        percentage > 100 ? "text-highlight-600" : "text-muted-foreground"
+      )}
+    >
+      <span>
+        {sign}
+        {roundedPercentage}%
+      </span>
+    </div>
+  );
+}
+
+function usageDifferenceFromAveragePercent({
+  credits,
+  activeMembers,
+  totalCredits,
+  totalActiveMembers,
+}: {
+  credits: number;
+  activeMembers: number | undefined;
+  totalCredits: number;
+  totalActiveMembers: number;
+}): number | null {
+  if (!activeMembers || totalCredits <= 0 || totalActiveMembers <= 0) {
+    return null;
+  }
+
+  const groupAverageCredits = credits / activeMembers;
+  const overallAverageCredits = totalCredits / totalActiveMembers;
+
+  return (
+    ((groupAverageCredits - overallAverageCredits) / overallAverageCredits) *
+    100
   );
 }
 
@@ -229,6 +290,7 @@ function buildColumns({
   isAvatarRounded,
   avgLabel,
   totalCredits,
+  totalActiveMembers,
   isDark,
   expandedRowId,
   selectedIdSet,
@@ -238,6 +300,7 @@ function buildColumns({
   isAvatarRounded: boolean;
   avgLabel: string;
   totalCredits: number;
+  totalActiveMembers: number;
   isDark: boolean;
   expandedRowId: string | null;
   selectedIdSet: Set<string>;
@@ -342,24 +405,73 @@ function buildColumns({
         );
       },
     },
-    {
-      id: "costShare",
-      // Same denominator (totalCredits) for every row, so ranking by cost
-      // share is the same order as ranking by credits
-      accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
-      header: "Consumption share",
-      enableSorting: true,
-      meta: { className: "w-36", sizeRatio: 20, headerAlign: "left" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-start">
-          <CostShareCell
-            share={
-              totalCredits > 0 ? info.row.original.credits / totalCredits : 0
-            }
-          />
-        </DataTable.CellContent>
-      ),
-    },
+    ...(dimension === "group"
+      ? ([
+          {
+            id: "activeMembers",
+            header: "Active / total members",
+            enableSorting: false,
+            meta: { sizeRatio: 18, headerAlign: "right" },
+            cell: (info) => (
+              <DataTable.BasicCellContent
+                className="justify-end text-right tabular-nums"
+                label={
+                  info.row.original.activeMembers !== undefined &&
+                  info.row.original.totalMembers !== undefined
+                    ? `${info.row.original.activeMembers.toLocaleString(
+                        "en-US"
+                      )} / ${info.row.original.totalMembers.toLocaleString(
+                        "en-US"
+                      )}`
+                    : "--"
+                }
+              />
+            ),
+          },
+          {
+            id: "usageVsAverage",
+            header: "Vs workspace avg",
+            enableSorting: false,
+            meta: { sizeRatio: 22, headerAlign: "right" },
+            cell: (info) => {
+              const usagePercent = usageDifferenceFromAveragePercent({
+                credits: info.row.original.credits,
+                activeMembers: info.row.original.activeMembers,
+                totalCredits,
+                totalActiveMembers,
+              });
+
+              return <UsageVsAverageCell percentage={usagePercent} />;
+            },
+          },
+        ] satisfies ColumnDef<AttributionRowData>[])
+      : ([
+          {
+            id: "costShare",
+            // Same denominator (totalCredits) for every row, so ranking by cost
+            // share is the same order as ranking by credits
+            accessorFn: (row) =>
+              totalCredits > 0 ? row.credits / totalCredits : 0,
+            header: "Consumption share",
+            enableSorting: true,
+            meta: {
+              className: "w-36",
+              sizeRatio: 20,
+              headerAlign: "left",
+            },
+            cell: (info) => (
+              <DataTable.CellContent className="w-full justify-start">
+                <CostShareCell
+                  share={
+                    totalCredits > 0
+                      ? info.row.original.credits / totalCredits
+                      : 0
+                  }
+                />
+              </DataTable.CellContent>
+            ),
+          },
+        ] satisfies ColumnDef<AttributionRowData>[])),
     {
       id: "credits",
       accessorKey: "credits",
@@ -480,6 +592,7 @@ export interface ConsumptionAttributionRowsProps {
 export interface ConsumptionAttributionRowsData {
   rows: ConsumptionTopRow[];
   totalCredits: number;
+  totalActiveMembers: number;
   totalCount: number;
   isTopLoading: boolean;
   isTopError: boolean;
@@ -556,6 +669,7 @@ export function ConsumptionAttributionRowsView({
   data: {
     rows,
     totalCredits,
+    totalActiveMembers,
     totalCount,
     isTopLoading,
     isTopError,
@@ -582,6 +696,7 @@ export function ConsumptionAttributionRowsView({
         isAvatarRounded: dimension === "user",
         avgLabel,
         totalCredits,
+        totalActiveMembers,
         isDark,
         expandedRowId,
         selectedIdSet,
@@ -591,6 +706,7 @@ export function ConsumptionAttributionRowsView({
       dimension,
       avgLabel,
       totalCredits,
+      totalActiveMembers,
       isDark,
       expandedRowId,
       selectedIdSet,
@@ -737,6 +853,7 @@ function WorkspaceConsumptionAttributionRows(
   const {
     rows,
     totalCredits,
+    totalActiveMembers,
     totalCount,
     isTopLoading,
     isTopError,
@@ -760,6 +877,7 @@ function WorkspaceConsumptionAttributionRows(
       data={{
         rows,
         totalCredits,
+        totalActiveMembers,
         totalCount,
         isTopLoading,
         isTopError: Boolean(isTopError),

--- a/front/hooks/useConsumptionTop.test.ts
+++ b/front/hooks/useConsumptionTop.test.ts
@@ -1,4 +1,5 @@
 import { toConsumptionTopRows } from "@app/hooks/useConsumptionTop";
+import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
 import type { GetConsumptionTopReasoningEffortsResponse } from "@app/lib/api/analytics/consumption/top_reasoning_efforts";
 import { describe, expect, it } from "vitest";
 
@@ -36,6 +37,48 @@ describe("toConsumptionTopRows", () => {
         credits: 60,
         avgCredits: 20,
         previousCredits: 40,
+      },
+    ]);
+  });
+
+  it("keeps group active-member counts for cohort comparisons", () => {
+    const response: GetConsumptionTopGroupsResponse = {
+      period: {
+        startDate: "2026-07-01T00:00:00.000Z",
+        endDate: "2026-08-01T00:00:00.000Z",
+      },
+      totalCredits: 1_000,
+      totalActiveMembers: 10,
+      totalCount: 1,
+      hasMore: false,
+      groups: [
+        {
+          groupId: "engineering",
+          name: "Engineering",
+          credits: 300,
+          activeMembers: 2,
+          totalMembers: 5,
+          previousCredits: 250,
+          messageCount: 3,
+          avgCreditsPerMessage: 100,
+        },
+      ],
+    };
+
+    expect(toConsumptionTopRows(response)).toEqual([
+      {
+        id: "engineering",
+        name: "Engineering",
+        pictureUrl: null,
+        description: null,
+        icon: null,
+        modelId: null,
+        modelDisplayName: null,
+        credits: 300,
+        avgCredits: 100,
+        activeMembers: 2,
+        totalMembers: 5,
+        previousCredits: 250,
       },
     ]);
   });

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -52,6 +52,8 @@ export type ConsumptionTopRow = {
   modelDisplayName: string | null;
   credits: number;
   avgCredits: number;
+  activeMembers?: number;
+  totalMembers?: number;
   previousCredits: number | null;
 };
 
@@ -124,6 +126,8 @@ export function toConsumptionTopRows(
       modelDisplayName: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
+      activeMembers: row.activeMembers,
+      totalMembers: row.totalMembers,
       previousCredits: row.previousCredits,
     }));
   }
@@ -255,9 +259,11 @@ export function useConsumptionTop({
 
   return {
     rows,
-    // Everything in the selected scope consumed over the period, so a row's
-    // share of it is `credits / totalCredits`.
+    // Selected-scope totals back row-relative metrics. Group rows also use the
+    // distinct active-member total to compare per-member usage.
     totalCredits: data?.totalCredits ?? 0,
+    totalActiveMembers:
+      data && "totalActiveMembers" in data ? data.totalActiveMembers : 0,
     totalCount: data?.totalCount ?? 0,
     hasMore: data?.hasMore ?? false,
     isTopLoading: !error && isLoading,

--- a/front/poke/swr/consumption.ts
+++ b/front/poke/swr/consumption.ts
@@ -213,6 +213,8 @@ export function usePokeConsumptionTop({
   return {
     rows,
     totalCredits: data?.totalCredits ?? 0,
+    totalActiveMembers:
+      data && "totalActiveMembers" in data ? data.totalActiveMembers : 0,
     totalCount: data?.totalCount ?? 0,
     hasMore: data?.hasMore ?? false,
     isTopLoading: !error && isLoading,


### PR DESCRIPTION
## Description

Context in [thread](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1788508787255659).

In the attribution table of the new analytics page, the group tab currently shows the consumption share of the group.
Since groups are not MECE, the consumption share is hard to interpret as the user needs to constantly account for group overlap when looking at this one, unlike most other tabs where it's straightforward.

Groups are also hard to identify from here, so the user needs to have in mind precisely which group is which if not named clearly, and the information displayed cannot be normalized by group size so large groups will be advertised with no way to account for it.

This PR removes the consumption share column and adds the active user/total members and a comparison with the workspace's average.

<img width="879" height="272" alt="image" src="https://github.com/user-attachments/assets/79fa8d72-aa95-4d91-bc9f-2f3471afd297" />

## Tests

- Added tests.
- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
