### PR TITLE
[front] fix: make the user Tools/Automations dialogs scroll when the list is long

### DIFF
--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -23,7 +23,7 @@ export function UserAutomationsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" height="xl" grow>
+      <DialogContent size="2xl" height="xl">
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>

--- a/front/components/me/UserToolsDialog.tsx
+++ b/front/components/me/UserToolsDialog.tsx
@@ -23,7 +23,7 @@ export function UserToolsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
        * closes. The table's SWR hooks need no `disabled` gating. */}
-      <DialogContent size="2xl" height="xl" grow>
+      <DialogContent size="2xl" height="xl">
         <DialogHeader>
           <DialogTitle>Tools</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Description

Tools and Automations dialogs uses `DialogContent height="xl" grow`. The `grow` prop drops the fixed height and keeps only a `min-height` floor + `max-h-[90vh]`, so `DialogContent` has no definite height. The `DialogContainer` `ScrollArea` viewport uses `height: 100%`, which resolves against that indefinite parent and expands to the full content height instead of being bounded — the overflowing rows are then clipped by `DialogContent`'s `overflow-hidden` with no scrollbar.

Dropping `grow` restores the definite `sm:h-xl` (768px) height, which bounds the `ScrollArea` and lets it scroll, matching every other scrollable list dialog (e.g. `DegradedModelsDialog`).

Fixes https://github.com/dust-tt/tasks/issues/10297

## Tests

- `npx tsgo --noEmit` passes.
- Verified the layout fix in a browser against a minimal reproduction of the exact `DialogContent` → `ScrollArea` flexbox structure: with `grow` the viewport `clientHeight == scrollHeight` (unbounded, clipped); without `grow` the viewport is bounded (~703px) and scrolls while `scrollHeight` stays at full content height.

## Risk

Low. CSS-only change on two user-menu dialogs. The dialog height goes from "at least 768px, growing up to 90vh (and clipping)" to "fixed 768px that scrolls" — same as other list dialogs.

## Deploy Plan

Ship normally.