### PR TITLE
Surface Frames v2 in conversations

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -5,7 +5,7 @@ import { makeInitialMessageStreamState } from "@app/components/assistant/convers
 import { useAutoOpenSidePanel } from "@app/components/assistant/conversation/useAutoOpenSidePanel";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import type { LightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -273,6 +273,26 @@ describe("AgentMessage compact UI view", () => {
         screen.queryByRole("button", { name: "Frames" })
       ).not.toBeInTheDocument();
       expect(screen.getByText("My Frame")).toBeVisible();
+    });
+
+    it("renders a Frames v2 generated file once with the Frame card", () => {
+      const frameV2File = {
+        title: "My Frames v2 app",
+        contentType: frameV2ContentType,
+        fileId: "fil_frame_v2",
+        filePath: undefined,
+      };
+      vi.mocked(useAutoOpenSidePanel).mockReturnValue({
+        interactiveFiles: [frameV2File],
+      });
+
+      renderAgentMessage({
+        uiView: "standard",
+        agentMessageOverrides: { generatedFiles: [frameV2File] },
+      });
+
+      expect(screen.getAllByText("My Frames v2 app")).toHaveLength(1);
+      expect(screen.getByText("Frames")).toBeVisible();
     });
   });
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -89,7 +89,7 @@ import {
 } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
-  isInteractiveContentType,
+  isFrameContentType,
   isSupportedImageContentType,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
@@ -1444,7 +1444,7 @@ function AgentMessageContent({
   const generatedFiles = filesFromMessage.filter(
     (file) =>
       !isSupportedImageContentType(file.contentType) &&
-      !isInteractiveContentType(file.contentType) &&
+      !isFrameContentType(file.contentType) &&
       (file.filePath === undefined || !referencedFilePaths.has(file.filePath))
   );
 

--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -4,7 +4,7 @@ import { formatCalendarDate } from "@app/lib/utils/timestamps";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 import {
   frameSlideshowContentType,
-  isInteractiveContentType,
+  isFrameContentType,
 } from "@app/types/files";
 import { getTime } from "@app/types/shared/utils/date_utils";
 import {
@@ -26,7 +26,7 @@ function getDescriptionForContentType(
     return "Presentation";
   }
 
-  if (isInteractiveContentType(file.contentType)) {
+  if (isFrameContentType(file.contentType)) {
     return "Frames";
   }
 

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -4,7 +4,7 @@ import { PreviewableCitation } from "@app/components/assistant/conversation/atta
 import type { AttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
 import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { isInteractiveContentType, opensInSidePanel } from "@app/types/files";
+import { isFrameContentType, opensInSidePanel } from "@app/types/files";
 import { Icon, useTranscribingProgress } from "@dust-tt/sparkle";
 import { useContext } from "react";
 
@@ -78,7 +78,7 @@ export function AttachmentCitation({
   if (
     fileId &&
     !isLoading &&
-    isInteractiveContentType(contentType) &&
+    isFrameContentType(contentType) &&
     sidePanel != null
   ) {
     return (

--- a/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
+++ b/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
@@ -8,7 +8,7 @@ import { useFilePreviewContext } from "@app/components/assistant/conversation/Fi
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
-  isInteractiveContentType,
+  isFrameContentType,
   isSupportedImageContentType,
 } from "@app/types/files";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -64,7 +64,7 @@ export function PreviewableCitation({
   const sidePanel = useContext(ConversationSidePanelContext);
 
   const handleClick = async () => {
-    if (isInteractiveContentType(contentType) && sidePanel) {
+    if (isFrameContentType(contentType) && sidePanel) {
       try {
         const resolvedFileId =
           fileId ?? (filePath ? await resolveFileIdFromPath(filePath) : null);

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -14,7 +14,7 @@ import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attach
 import { downloadFile } from "@app/lib/swr/files";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isInteractiveContentType, opensInSidePanel } from "@app/types/files";
+import { isFrameContentType, opensInSidePanel } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -69,7 +69,7 @@ export function ConversationFilesPanel({
       title: string;
       contentType: string;
     }) => {
-      if (isInteractiveContentType(contentType)) {
+      if (isFrameContentType(contentType)) {
         openPanel({ type: "interactive_content", fileId });
       } else if (opensInSidePanel(contentType) && filePath) {
         // Some formats (e.g. presentations) open in the resizable right panel

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import {
   frameSlideshowContentType,
-  isInteractiveContentType,
+  isFrameContentType,
 } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
@@ -22,7 +22,7 @@ function getFilePanelCategory(
     return "knowledge";
   }
 
-  if (isInteractiveContentType(item.contentType)) {
+  if (isFrameContentType(item.contentType)) {
     return item.contentType === frameSlideshowContentType
       ? "slideshow"
       : "frame";

--- a/front/components/assistant/conversation/useAutoOpenSidePanel.test.tsx
+++ b/front/components/assistant/conversation/useAutoOpenSidePanel.test.tsx
@@ -1,0 +1,71 @@
+import { makeInitialMessageStreamState } from "@app/components/assistant/conversation/types";
+import { useAutoOpenSidePanel } from "@app/components/assistant/conversation/useAutoOpenSidePanel";
+import { mockAgentMessage } from "@app/tests/utils/conversation_test_factories";
+import { frameV2ContentType } from "@app/types/files";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { closePanel, openPanel } = vi.hoisted(() => ({
+  closePanel: vi.fn(),
+  openPanel: vi.fn(),
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/ConversationSidePanelContext",
+  () => ({
+    useConversationSidePanelContext: () => ({
+      closePanel,
+      currentPanel: null,
+      openPanel,
+    }),
+  })
+);
+
+vi.mock("@app/hooks/conversations", () => ({
+  useConversationMessageAction: () => ({ action: null }),
+}));
+
+vi.mock("@app/hooks/useActiveConversationId", () => ({
+  useActiveConversationId: () => "conversation-1",
+}));
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({ workspace: { sId: "workspace-1" } }),
+}));
+
+vi.mock("@app/lib/swr/useIsMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+describe("useAutoOpenSidePanel", () => {
+  beforeEach(() => {
+    closePanel.mockClear();
+    openPanel.mockClear();
+  });
+
+  it("classifies a completed Frames v2 file as a Frame and opens it", async () => {
+    const frame = {
+      contentType: frameV2ContentType,
+      fileId: "fil_frame_v2",
+      title: "Hello Frame",
+      hidden: false,
+    };
+    const agentMessage = makeInitialMessageStreamState({
+      ...mockAgentMessage({ content: "Done." }),
+      sId: "agent-message-1",
+      generatedFiles: [frame],
+    });
+
+    const { result } = renderHook(() =>
+      useAutoOpenSidePanel({ agentMessage, isLastMessage: true })
+    );
+
+    expect(result.current.interactiveFiles).toEqual([frame]);
+    await waitFor(() => {
+      expect(openPanel).toHaveBeenCalledWith({
+        type: "interactive_content",
+        fileId: frame.fileId,
+      });
+    });
+  });
+});

--- a/front/components/assistant/conversation/useAutoOpenSidePanel.ts
+++ b/front/components/assistant/conversation/useAutoOpenSidePanel.ts
@@ -11,7 +11,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { FILES_SIDE_PANEL_TYPE } from "@app/types/conversation_side_panel";
-import { isInteractiveContentType } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import { removeNulls } from "@app/types/shared/utils/general";
 import React from "react";
 
@@ -123,7 +123,7 @@ export function useAutoOpenSidePanel({
   const completedInteractiveFiles = React.useMemo(
     () =>
       agentMessage.generatedFiles.filter((file) =>
-        isInteractiveContentType(file.contentType)
+        isFrameContentType(file.contentType)
       ),
     [agentMessage.generatedFiles]
   );
@@ -131,7 +131,7 @@ export function useAutoOpenSidePanel({
   const regularGeneratedFiles = React.useMemo(
     () =>
       agentMessage.generatedFiles.filter(
-        (file) => !file.hidden && !isInteractiveContentType(file.contentType)
+        (file) => !file.hidden && !isFrameContentType(file.contentType)
       ),
     [agentMessage.generatedFiles]
   );

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -15,6 +15,7 @@ import {
 import type {
   BrowseResultResourceType,
   DataSourceNodeContentType,
+  ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolContext } from "@app/lib/actions/types";
 import { Authenticator } from "@app/lib/auth";
@@ -25,6 +26,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -34,6 +36,7 @@ import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctio
 import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { frameV2ContentType } from "@app/types/files";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/types/mount_path";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -273,6 +276,46 @@ describe("getAugmentedInputs", () => {
 });
 
 describe("processToolResults", () => {
+  it("preserves the display title of an existing generated file", async () => {
+    const { auth, toolContext } = await setupTest();
+    assert(toolContext.runContext.contextType === "agent_loop");
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: toolContext.runContext.conversation.sId,
+        frameName: "Hello Frame",
+      },
+    });
+
+    const generatedFrame: ToolGeneratedFileType = {
+      contentType: frameV2ContentType,
+      fileId: frame.sId,
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+      snippet: null,
+      text: "Opened Frame.",
+      title: "Hello Frame",
+      uri: "https://dust.tt/frame",
+    };
+
+    const { generatedFiles } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [
+        {
+          type: "resource",
+          resource: generatedFrame,
+        },
+      ],
+    });
+
+    expect(generatedFiles).toHaveLength(1);
+    expect(generatedFiles[0]?.title).toBe("Hello Frame");
+  });
+
   it("should store snippet in DB when text exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES", async () => {
     const { auth, toolContext } = await setupTest();
 

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -40,6 +40,7 @@ import type { Logger } from "@app/logger/logger";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import {
   extensionsForContentType,
+  getFileDisplayName,
   isSupportedFileContentType,
 } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -552,7 +553,7 @@ export async function processToolResults(
           contentType: c.file.contentType,
           fileId: c.file.sId,
           snippet: c.file.snippet,
-          title: c.file.fileName,
+          title: getFileDisplayName(c.file),
           createdAt: c.file.createdAt.getTime(),
           updatedAt: c.file.updatedAt.getTime(),
           isInProjectContext: c.file.useCase === "project_context",

--- a/front/lib/api/actions/servers/conversation_side_panel/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_side_panel/metadata.ts
@@ -11,16 +11,22 @@ export const CONVERSATION_SIDE_PANEL_TOOLS_METADATA = [
   {
     name: OPEN_FRAME_TOOL_NAME,
     description:
-      "Open and show an existing Frame in the conversation side panel without modifying it. " +
-      "Use this when a Frame was already created and you want the user to see it now " +
-      "(for example after referring back to a prior Frame). Creating, editing, reverting, " +
-      "renaming, or publishing a Frame already opens it automatically — call this only to " +
-      "re-open a Frame that is not currently shown.",
+      "Open and show a Frame in the conversation side panel without modifying it. " +
+      "Call this after publishing a Frame so the user sees it and receives a Frame card, " +
+      "or to re-open an existing Frame. Identify it with exactly one of `file_id` or `path`.",
     schema: {
       file_id: z
         .string()
+        .optional()
         .describe(
           "The ID of the Interactive Content file to open (e.g., 'fil_abc123')"
+        ),
+      path: z
+        .string()
+        .optional()
+        .describe(
+          "The canonical Frame source path, with or without the `/files/` prefix " +
+            "(e.g., '/files/pod-abc123/my-frame/manifest.json')"
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/conversation_side_panel/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_side_panel/metadata.ts
@@ -11,9 +11,9 @@ export const CONVERSATION_SIDE_PANEL_TOOLS_METADATA = [
   {
     name: OPEN_FRAME_TOOL_NAME,
     description:
-      "Open and show a Frame in the conversation side panel without modifying it. " +
-      "Call this after publishing a Frame so the user sees it and receives a Frame card, " +
-      "or to re-open an existing Frame. Identify it with exactly one of `file_id` or `path`.",
+      "Open and show an existing Frame in the conversation side panel without modifying it. " +
+      "Use this to show the user a Frame that was already created or just published, " +
+      "and add its Frame card to the answer. Identify it with exactly one of `file_id` or `path`.",
     schema: {
       file_id: z
         .string()
@@ -26,7 +26,7 @@ export const CONVERSATION_SIDE_PANEL_TOOLS_METADATA = [
         .optional()
         .describe(
           "The canonical Frame source path, with or without the `/files/` prefix " +
-            "(e.g., '/files/pod-abc123/my-frame/manifest.json')"
+            "(e.g., '/files/pod-abc123/frame-folder/manifest.json')"
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/conversation_side_panel/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_side_panel/tools/index.test.ts
@@ -1,0 +1,82 @@
+import { OPEN_FRAME_TOOL_NAME } from "@app/lib/api/actions/servers/conversation_side_panel/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/conversation_side_panel/tools";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { getPodFilesBasePath } from "@app/types/mount_path";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
+import { describe, expect, it, vi } from "vitest";
+
+describe("conversation_side_panel.open_frame", () => {
+  it("resolves a Frames v2 manifest path and returns it as a generated file", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const workspace = auth.getNonNullableWorkspace();
+    const scopedPath = `pod-${projectId}/hello-frame/manifest.json`;
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: {
+        spaceId: projectId,
+        frameName: "Hello Frame",
+      },
+      mountFilePath: `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: projectId,
+      })}hello-frame/manifest.json`,
+    });
+    const sendNotification = vi.fn(async () => undefined);
+    const openFrameTool = TOOLS.find(
+      (tool) => tool.name === OPEN_FRAME_TOOL_NAME
+    );
+    assert(openFrameTool, "open_frame tool expected");
+
+    const result = await openFrameTool.handler(
+      { path: `/files/${scopedPath}` },
+      {
+        ...makeExtra(auth, conversation),
+        _meta: { progressToken: "progress-1" },
+        sendNotification,
+      }
+    );
+
+    assert(result.isOk());
+    expect(result.value).toEqual([
+      {
+        type: "resource",
+        resource: {
+          contentType: frameV2ContentType,
+          fileId: frame.sId,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+          snippet: null,
+          text: `Opened Frame '${frame.sId}' (Hello Frame) in the side panel.`,
+          title: "Hello Frame",
+          uri: expect.any(String),
+        },
+      },
+    ]);
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          progressToken: "progress-1",
+          _meta: expect.objectContaining({
+            data: expect.objectContaining({
+              output: expect.objectContaining({
+                fileId: frame.sId,
+                mimeType: frameV2ContentType,
+                title: "Hello Frame",
+                type: "interactive_content_file",
+              }),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+});

--- a/front/lib/api/actions/servers/conversation_side_panel/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_side_panel/tools/index.ts
@@ -9,9 +9,12 @@ import {
   SET_FILES_SIDE_PANEL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/conversation_side_panel/metadata";
 import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { fetchLinkedFileResource } from "@app/lib/api/files/file_system_ops";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { isInteractiveContentType } from "@app/types/files";
+import { getFileDisplayName, isFrameContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 function buildFilesSidePanelControlNotification(
   progressToken: string | number,
@@ -40,7 +43,7 @@ function buildFilesSidePanelControlNotification(
 
 const handlers: ToolHandlers<typeof CONVERSATION_SIDE_PANEL_TOOLS_METADATA> = {
   [OPEN_FRAME_TOOL_NAME]: async (
-    { file_id },
+    { file_id, path },
     { auth, sendNotification, _meta, runContext }
   ) => {
     if (!isAgentLoopRunContext(runContext)) {
@@ -51,17 +54,65 @@ const handlers: ToolHandlers<typeof CONVERSATION_SIDE_PANEL_TOOLS_METADATA> = {
       );
     }
 
-    const fileResource = await FileResource.fetchById(auth, file_id);
-    if (!fileResource) {
+    if ((file_id && path) || (!file_id && !path)) {
       return new Err(
-        new MCPError(`File not found: ${file_id}`, { tracked: false })
+        new MCPError("Provide exactly one of `file_id` or `path`.", {
+          tracked: false,
+        })
       );
     }
 
-    if (!isInteractiveContentType(fileResource.contentType)) {
+    let fileResource: FileResource | undefined;
+    if (file_id) {
+      fileResource = (await FileResource.fetchById(auth, file_id)) ?? undefined;
+    } else if (path) {
+      const pathWithoutMountPrefix = path.startsWith("/files/")
+        ? path.slice("/files/".length)
+        : path;
+      const scopedPath = DustFileSystem.normalizeScopedPath(
+        pathWithoutMountPrefix
+      );
+      if (!scopedPath) {
+        return new Err(
+          new MCPError(`Invalid Frame path: ${path}`, { tracked: false })
+        );
+      }
+
+      const fsResult = await DustFileSystem.forAgentLoop(auth, {
+        conversation: runContext.conversation,
+        scopedPaths: [scopedPath],
+      });
+      if (fsResult.isErr()) {
+        return new Err(
+          new MCPError(fsResult.error.message, { tracked: false })
+        );
+      }
+
+      const sandboxPathResult = fsResult.value.toSandboxPath(scopedPath);
+      if (sandboxPathResult.isErr()) {
+        return new Err(
+          new MCPError(sandboxPathResult.error.message, { tracked: false })
+        );
+      }
+
+      fileResource = await fetchLinkedFileResource(
+        auth,
+        fsResult.value,
+        scopedPath
+      );
+    }
+
+    const fileReference = file_id ?? path;
+    if (!fileResource) {
+      return new Err(
+        new MCPError(`File not found: ${fileReference}`, { tracked: false })
+      );
+    }
+
+    if (!isFrameContentType(fileResource.contentType)) {
       return new Err(
         new MCPError(
-          `File '${file_id}' is not a Frame (content type: ${fileResource.contentType}).`,
+          `File '${fileReference}' is not a Frame (content type: ${fileResource.contentType}).`,
           { tracked: false }
         )
       );
@@ -77,12 +128,19 @@ const handlers: ToolHandlers<typeof CONVERSATION_SIDE_PANEL_TOOLS_METADATA> = {
       );
     }
 
+    const title = getFileDisplayName(fileResource);
     return new Ok([
       {
-        type: "text",
-        text:
-          `Opened Frame '${fileResource.sId}' (${fileResource.fileName}) ` +
-          "in the side panel.",
+        type: "resource",
+        resource: {
+          contentType: fileResource.contentType,
+          fileId: fileResource.sId,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+          snippet: fileResource.snippet,
+          text: `Opened Frame '${fileResource.sId}' (${title}) in the side panel.`,
+          title,
+          uri: fileResource.getPublicUrl(auth),
+        },
       },
     ]);
   },

--- a/front/lib/api/actions/servers/conversation_side_panel/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_side_panel/tools/index.ts
@@ -78,20 +78,10 @@ const handlers: ToolHandlers<typeof CONVERSATION_SIDE_PANEL_TOOLS_METADATA> = {
         );
       }
 
-      const fsResult = await DustFileSystem.forAgentLoop(auth, {
-        conversation: runContext.conversation,
-        scopedPaths: [scopedPath],
-      });
+      const fsResult = await DustFileSystem.fromScopedPath(auth, scopedPath);
       if (fsResult.isErr()) {
         return new Err(
           new MCPError(fsResult.error.message, { tracked: false })
-        );
-      }
-
-      const sandboxPathResult = fsResult.value.toSandboxPath(scopedPath);
-      if (sandboxPathResult.isErr()) {
-        return new Err(
-          new MCPError(sandboxPathResult.error.message, { tracked: false })
         );
       }
 

--- a/front/lib/api/actions/servers/interactive_content/helpers.ts
+++ b/front/lib/api/actions/servers/interactive_content/helpers.ts
@@ -1,5 +1,6 @@
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { getFileDisplayName } from "@app/types/files";
 
 /**
  * Builds a progress notification for interactive content file operations.
@@ -22,7 +23,7 @@ export function buildInteractiveContentFileNotification(
             type: "interactive_content_file",
             fileId: fileResource.sId,
             mimeType: fileResource.contentType,
-            title: fileResource.fileName,
+            title: getFileDisplayName(fileResource),
             updatedAt: fileResource.updatedAtMs.toString(),
           },
         },

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -33,6 +33,7 @@ import type {
   ConversationType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import { frameV2ContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -1328,6 +1329,44 @@ describe("listGeneratedFilesForConversation", () => {
         pictureUrl: agentConfig.pictureUrl,
       },
     });
+  });
+
+  it("uses the Frame name for a Frames v2 generated file", async () => {
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 42,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: conversation.sId,
+        frameName: "Hello Frame",
+      },
+    });
+
+    const { action } = await ConversationFactory.createAgentMessage(auth, {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction: { toolConfiguration },
+    });
+    assert(action);
+
+    const outputRes = await action.createOutputItems(auth, [
+      {
+        content: { type: "text", text: "generated" },
+        fileId: frame.id,
+      },
+    ]);
+    expect(outputRes.isOk()).toBe(true);
+
+    const result =
+      await AgentMCPActionResource.listGeneratedFilesForConversation(auth, {
+        conversationId: conversation.id,
+      });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.title).toBe("Hello Frame");
   });
 
   it("respects upToRank when filtering generated files", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -73,6 +73,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { UNRESUMABLE_AGENT_MESSAGE_STATUSES } from "@app/types/assistant/conversation";
+import { getFileDisplayName } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -932,7 +933,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           workspaceId: file.workspaceId,
         }),
         contentType: file.contentType,
-        title: file.fileName,
+        title: getFileDisplayName(file),
         snippet: file.snippet,
         createdAt: file.createdAt.getTime(),
         updatedAt: file.updatedAt.getTime(),
@@ -1464,7 +1465,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                       workspaceId: file.workspaceId,
                     }),
                     contentType: file.contentType,
-                    title: file.fileName,
+                    title: getFileDisplayName(file),
                     snippet: file.snippet,
                     createdAt: file.createdAt.getTime(),
                     updatedAt: file.updatedAt.getTime(),

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -116,7 +116,10 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(
       "Other interactive-content tools remain available"
     );
-    expect(framesSkill.mcpServers).toEqual([{ name: "interactive_content" }]);
+    expect(framesSkill.mcpServers).toEqual([
+      { name: "interactive_content" },
+      { name: "conversation_side_panel" },
+    ]);
     await expect(
       InternalMCPServerInMemoryResource.isRestrictedForWorkspace(
         auth,

--- a/front/lib/resources/skill/code_defined/global/frames.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.ts
@@ -55,7 +55,10 @@ export const framesSkill = {
       podFunctionsSkillName: POD_FUNCTIONS_SKILL_NAME,
     });
   },
-  mcpServers: [{ name: "interactive_content" }],
-  version: 5,
+  mcpServers: [
+    { name: "interactive_content" },
+    { name: "conversation_side_panel" },
+  ],
+  version: 6,
   icon: "ActionFrameIcon",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -351,6 +351,10 @@ stored, and activated atomically:
 dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
 
+After a successful publish, call \`conversation_side_panel.open_frame\` exactly once with \`path\`
+set to the same canonical \`/files/...\` manifest path. This opens the Frame for the user and adds
+the Frame card to the answer. Do not parse the Frame ID from the CLI output for this step.
+
 If validation, a function build, or database reconciliation fails, no partial publication becomes
 active. Fix the reported error and rerun the command.
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -864,6 +864,21 @@ export function isFrameContentType(
   );
 }
 
+export function getFileDisplayName(file: {
+  contentType: string;
+  fileName: string;
+  useCaseMetadata?: FileUseCaseMetadata | null;
+}): string {
+  if (
+    isFrameV2ContentType(file.contentType) &&
+    file.useCaseMetadata?.frameName
+  ) {
+    return file.useCaseMetadata.frameName;
+  }
+
+  return file.fileName;
+}
+
 export function isAllSupportedFileContentType(
   contentType: string
 ): contentType is AllSupportedFileContentType {


### PR DESCRIPTION
## Description

- Resolve a Frames v2 manifest path through conversation_side_panel.open_frame, so the agent does not parse CLI output for a file ID.
- Return the linked Frame as a generated-file resource and use its Frame name as the card title.
- Treat Frames v1 and v2 consistently for the Frame card, citations, file panel behavior, and automatic side-panel opening.
- Add conversation_side_panel to the Frames skill and instruct the agent to open the published manifest path once.

## Tests

- Focused suite passed: 6 files and 84 tests.
- npx tsgo --noEmit passed before the final branch packaging.
- The full front suite was stopped after it reported 2 failures in 1 file, per request.
- The pre-commit front type-check later failed with broad repository errors, including unresolved @dust-tt/client imports. The commit bypassed the hook per request.

## Risk

The existing file_id input remains supported. The new path input resolves only files linked into the current agent-loop file system. The main risk is a published Frame path that is not linked into that scope; open_frame then returns a file-not-found error.

Rollback by reverting this commit.

## Deploy Plan

No special deployment steps.