### PR TITLE
prodbox image gets cmake and screen

### DIFF
--- a/dockerfiles/prodbox.Dockerfile
+++ b/dockerfiles/prodbox.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24.16.0 AS base
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop curl libpq-dev build-essential tmux
+RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop curl libpq-dev build-essential cmake tmux screen
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
## Description

The prodbox image gets `cmake` and `screen`. `cmake` because building core on a prodbox fails without it: the sentencepiece crate compiles its C++ library through cmake, the core image installs it in its builder stage, the prodbox image never did. Running `cargo run --bin init_db` on the new cell-00002 prodbox stopped at that error and needed a manual `apt-get install cmake` in the pod. `screen` alongside the existing `tmux`, for long-running sessions.

## Tests

Same install line, two more packages. The manual install of `cmake` on the cell-00002 prodbox let `init_db` build and run, which is what this bakes in.

## Risk

None to the running services, the image is only the ops box. A larger image by a few tens of megabytes.

## Deploy Plan

Merge, the next prodbox build picks it up. Nothing to do on legacy regions, the current pods keep running.
