### PR TITLE
Poke: drop seat columns and add reset caption for premium message plans

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -57,7 +57,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Icon,
-  InfoCircle,
   LoadingBlock,
   ProgressBar,
   Spinner,
@@ -758,14 +757,15 @@ function buildPremiumMessageUsageColumn(
   return {
     id: "premiumMessageUsage" as const,
     header: () => (
-      <span className="flex items-center gap-1">
-        <Icon visual={CoinsStacked03} size="xs" />
-        Premium messages
-        <Tooltip
-          trigger={<Icon visual={InfoCircle} size="xs" />}
-          label={`Usage is capped over a rolling ${windowDays}-day window: each message frees up its slot ${windowDays} days after it was sent, not all at once.`}
-        />
-      </span>
+      <div className="flex flex-col">
+        <span className="flex items-center gap-1">
+          <Icon visual={CoinsStacked03} size="xs" />
+          Premium messages
+        </span>
+        <span className="text-xs font-normal text-muted-foreground">
+          Resets on a rolling {windowDays}-day basis
+        </span>
+      </div>
     ),
     accessorFn: (row) =>
       (row.premiumMessageUsage?.usedMessages ?? 0).toString(),


### PR DESCRIPTION
## Description

Replace the Premium messages tooltip by a "Resets on a rolling 7-day basis" sub column header

## Tests

Tested on front-edge

## Risk

- Poke only for now

## Deploy Plan

- Deploy front