### PR TITLE
fix(connectors): redact credentials from request logs

### DIFF
--- a/connectors/src/api/webhooks/webhook_discord_app.ts
+++ b/connectors/src/api/webhooks/webhook_discord_app.ts
@@ -138,10 +138,7 @@ function validateDiscordSignature(
     );
     return isVerified;
   } catch (error) {
-    logger.error(
-      { error, signature, timestamp, publicKey },
-      "Error validating Discord signature"
-    );
+    logger.error({ error }, "Error validating Discord signature");
     return false;
   }
 }

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -48,13 +48,14 @@ import { getWebhookRouterEntryHandler } from "./api/get_webhook_router_config";
 import { profilerAPIHandler } from "./api/profiler";
 import { syncWebhookRouterEntryHandler } from "./api/sync_webhook_router_config";
 import { webhookFirecrawlAPIHandler } from "./api/webhooks/webhook_firecrawl";
+import { safeMorganFormat, sanitizeRequestUrl } from "./logger/request_logging";
 
 export function startServer(port: number) {
   setupGlobalErrorHandler(logger);
   const app = express();
 
   // Initialize logger.
-  app.use(morgan("tiny"));
+  app.use(morgan<Request, Response>(safeMorganFormat));
 
   // Indicates that the app is behind a proxy / LB. req.ip will be the left-most entry in the X-Forwarded-* header.
   app.set("trust proxy", true);
@@ -94,7 +95,7 @@ export function startServer(port: number) {
           next();
         } else {
           logger.info(
-            { clientIp, url: req.originalUrl },
+            { clientIp, url: sanitizeRequestUrl(req.originalUrl) },
             "Connector query rate limited."
           );
           res.status(429).send("Too many requests");

--- a/connectors/src/logger/request_logging.test.ts
+++ b/connectors/src/logger/request_logging.test.ts
@@ -1,0 +1,87 @@
+import type { Request } from "express";
+import { describe, expect, it } from "vitest";
+import {
+  formatMorganRequestLog,
+  getSafeRequestHeaders,
+  getSafeRequestLogContext,
+  sanitizeRequestUrl,
+} from "./request_logging";
+
+const SECRET_SENTINEL = "must-never-appear-in-logs";
+
+describe("sanitizeRequestUrl", () => {
+  it.each([
+    {
+      url: `/webhooks/${SECRET_SENTINEL}/slack?token=${SECRET_SENTINEL}`,
+      expected: "/webhooks/[REDACTED]/slack",
+    },
+    {
+      url: `/webhooks_router_entries/${SECRET_SENTINEL}/notion/workspace?secret=${SECRET_SENTINEL}`,
+      expected: "/webhooks_router_entries/[REDACTED]/notion/workspace",
+    },
+    {
+      url: `/profiler?secret=${SECRET_SENTINEL}`,
+      expected: "/profiler",
+    },
+    {
+      url: `/webhooks/${SECRET_SENTINEL}`,
+      expected: "/webhooks/[REDACTED]",
+    },
+  ])("removes credentials from $url", ({ url, expected }) => {
+    const sanitized = sanitizeRequestUrl(url);
+
+    expect(sanitized).toBe(expected);
+    expect(sanitized).not.toContain(SECRET_SENTINEL);
+  });
+});
+
+describe("getSafeRequestHeaders", () => {
+  it("keeps operational headers without logging credentials", () => {
+    const safeHeaders = getSafeRequestHeaders({
+      authorization: `Bearer ${SECRET_SENTINEL}`,
+      cookie: `session=${SECRET_SENTINEL}`,
+      "content-type": "application/json",
+      "user-agent": "test-agent",
+      "x-dust-clientid": "webhook-router",
+      "x-hub-signature-256": `sha256=${SECRET_SENTINEL}`,
+      "x-signature-ed25519": SECRET_SENTINEL,
+    });
+
+    expect(safeHeaders).toEqual({
+      "content-type": "application/json",
+      "user-agent": "test-agent",
+      "x-dust-clientid": "webhook-router",
+    });
+    expect(JSON.stringify(safeHeaders)).not.toContain(SECRET_SENTINEL);
+  });
+});
+
+describe("request log output", () => {
+  it("does not expose credentials to structured or HTTP logs", () => {
+    const url = `/webhooks/${SECRET_SENTINEL}/slack?secret=${SECRET_SENTINEL}`;
+    const request = {
+      method: "POST",
+      originalUrl: url,
+      url,
+      headers: {
+        authorization: `Bearer ${SECRET_SENTINEL}`,
+        cookie: `session=${SECRET_SENTINEL}`,
+        "content-type": "application/json",
+        "x-hub-signature-256": `sha256=${SECRET_SENTINEL}`,
+      },
+    } as unknown as Request;
+
+    const structuredLogContext = getSafeRequestLogContext(request);
+    const httpLogLine = formatMorganRequestLog({
+      method: request.method,
+      url: request.url,
+      status: "200",
+      contentLength: "0",
+      responseTime: "1.5",
+    });
+
+    expect(JSON.stringify(structuredLogContext)).not.toContain(SECRET_SENTINEL);
+    expect(httpLogLine).not.toContain(SECRET_SENTINEL);
+    expect(httpLogLine).toContain("/webhooks/[REDACTED]/slack");
+  });
+});

--- a/connectors/src/logger/request_logging.ts
+++ b/connectors/src/logger/request_logging.ts
@@ -1,0 +1,98 @@
+import type { Request, Response } from "express";
+import type morgan from "morgan";
+
+const REDACTED_PATH_SEGMENT = "[REDACTED]";
+
+const SAFE_REQUEST_HEADER_NAMES = [
+  "content-length",
+  "content-type",
+  "user-agent",
+  "x-dust-clientid",
+] as const;
+
+type SafeRequestHeaderName = (typeof SAFE_REQUEST_HEADER_NAMES)[number];
+type SafeRequestHeaders = Partial<
+  Record<SafeRequestHeaderName, string | string[]>
+>;
+
+/**
+ * Returns a URL suitable for logging.
+ *
+ * Query strings are omitted because they can contain credentials or user data.
+ * Legacy webhook routes contain a shared secret in their first path segment,
+ * which is redacted until those routes can be migrated to header-based auth.
+ */
+export function sanitizeRequestUrl(url: string | undefined): string {
+  if (!url) {
+    return "-";
+  }
+
+  const queryOrFragmentIndex = url.search(/[?#]/);
+  const path =
+    queryOrFragmentIndex === -1 ? url : url.slice(0, queryOrFragmentIndex);
+
+  return path
+    .replace(/(\/webhooks\/)[^/]+/g, `$1${REDACTED_PATH_SEGMENT}`)
+    .replace(
+      /(\/webhooks_router_entries\/)[^/]+/g,
+      `$1${REDACTED_PATH_SEGMENT}`
+    );
+}
+
+export function getSafeRequestHeaders(
+  headers: Request["headers"]
+): SafeRequestHeaders {
+  const safeHeaders: SafeRequestHeaders = {};
+
+  for (const name of SAFE_REQUEST_HEADER_NAMES) {
+    const value = headers[name];
+    if (value !== undefined) {
+      safeHeaders[name] = value;
+    }
+  }
+
+  return safeHeaders;
+}
+
+export function getSafeRequestLogContext(req: Request) {
+  return {
+    method: req.method,
+    url: sanitizeRequestUrl(req.originalUrl || req.url),
+    headers: getSafeRequestHeaders(req.headers),
+  };
+}
+
+function tokenValue(value: string | undefined | null): string {
+  return value ?? "-";
+}
+
+export function formatMorganRequestLog({
+  method,
+  url,
+  status,
+  contentLength,
+  responseTime,
+}: {
+  method: string | undefined | null;
+  url: string | undefined | null;
+  status: string | undefined | null;
+  contentLength: string | undefined | null;
+  responseTime: string | undefined | null;
+}): string {
+  return `${tokenValue(method)} ${sanitizeRequestUrl(url ?? undefined)} ${tokenValue(
+    status
+  )} ${tokenValue(contentLength)} - ${tokenValue(responseTime)} ms`;
+}
+
+export const safeMorganFormat: morgan.FormatFn<Request, Response> = (
+  tokens,
+  req,
+  res
+) =>
+  formatMorganRequestLog({
+    method: tokens.method?.(req, res),
+    url: tokens.url?.(req, res),
+    status: tokens.status?.(req, res),
+    contentLength: tokens.res?.(req, res, "content-length"),
+    responseTime: tokens["response-time"]?.(req, res),
+  });

--- a/connectors/src/logger/withlogging.ts
+++ b/connectors/src/logger/withlogging.ts
@@ -1,4 +1,8 @@
 import logger from "@connectors/logger/logger";
+import {
+  getSafeRequestLogContext,
+  sanitizeRequestUrl,
+} from "@connectors/logger/request_logging";
 import type {
   ConnectorsAPIErrorWithStatusCode,
   WithConnectorsAPIErrorReponse,
@@ -18,13 +22,11 @@ export const withLogging = (handler: any) => {
       const elapsed = new Date().getTime() - now.getTime();
       logger.error(
         {
-          method: req.method,
-          url: req.url,
+          ...getSafeRequestLogContext(req),
           durationMs: elapsed,
           error: err,
           // @ts-expect-error we can't really know what the error is
           error_stack: err?.stack,
-          headers: req.headers,
         },
         "Unhandled API Error"
       );
@@ -67,11 +69,9 @@ export const withLogging = (handler: any) => {
 
     logger.info(
       {
-        method: req.method,
-        url: req.url,
+        ...getSafeRequestLogContext(req),
         statusCode: res.statusCode,
         durationMs: elapsed,
-        headers: req.headers,
       },
       "Processed request"
     );
@@ -87,7 +87,7 @@ export function apiError<T>(
   logger.error(
     {
       method: req.method,
-      url: req.url,
+      url: sanitizeRequestUrl(req.originalUrl || req.url),
       statusCode: apiError.status_code,
       apiError: apiError,
       error: error,

--- a/connectors/src/middleware/auth.ts
+++ b/connectors/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import logger from "@connectors/logger/logger";
+import { sanitizeRequestUrl } from "@connectors/logger/request_logging";
 import { apiError } from "@connectors/logger/withlogging";
 import type { ConnectorsAPIErrorResponse } from "@connectors/types";
 import crypto from "crypto";
@@ -121,7 +122,10 @@ const _authMiddlewareWebhooksGithub = (
   next: NextFunction
 ) => {
   if (!req.path.split("/").includes(DUST_CONNECTORS_WEBHOOKS_SECRET)) {
-    logger.error({ path: req.path }, `Invalid webhook secret`);
+    logger.error(
+      { path: sanitizeRequestUrl(req.path) },
+      `Invalid webhook secret`
+    );
     return apiError(req, res, {
       api_error: {
         type: "not_found",
@@ -165,10 +169,7 @@ const _authMiddlewareWebhooksGithub = (
     .digest("hex")}`;
 
   if (Array.isArray(signatureHeader)) {
-    logger.error(
-      { signatureHeader },
-      `Unexpected x-hub-signature-256 header format`
-    );
+    logger.error(`Unexpected x-hub-signature-256 header format`);
     return apiError(req, res, {
       api_error: {
         type: "connector_not_found",
@@ -185,7 +186,6 @@ const _authMiddlewareWebhooksGithub = (
     )
   ) {
     logger.error(
-      { signatureHeader, computedSignature },
       `x-hub-signature-256 header does not match computed signature`
     );
     return apiError(req, res, {
@@ -206,7 +206,10 @@ const _authMiddlewareWebhooksIntercom = (
   next: NextFunction
 ) => {
   if (!req.path.split("/").includes(DUST_CONNECTORS_WEBHOOKS_SECRET)) {
-    logger.error({ path: req.path }, `Invalid webhook secret`);
+    logger.error(
+      { path: sanitizeRequestUrl(req.path) },
+      `Invalid webhook secret`
+    );
     return apiError(req, res, {
       api_error: {
         type: "not_found",
@@ -258,10 +261,7 @@ const _authMiddlewareWebhooksIntercom = (
       .digest("hex")}`;
 
     if (Array.isArray(signatureHeader)) {
-      logger.error(
-        { signatureHeader },
-        `Unexpected x-hub-signature header format`
-      );
+      logger.error(`Unexpected x-hub-signature header format`);
       return apiError(req, res, {
         api_error: {
           type: "connector_not_found",
@@ -277,10 +277,7 @@ const _authMiddlewareWebhooksIntercom = (
         Buffer.from(computedSignature)
       )
     ) {
-      logger.error(
-        { signatureHeader, computedSignature },
-        `x-hub-signature header does not match computed signature`
-      );
+      logger.error(`x-hub-signature header does not match computed signature`);
       return apiError(req, res, {
         api_error: {
           type: "not_found",


### PR DESCRIPTION
## Description

- Sanitize request URLs before Morgan and structured logging.
- Remove query strings and redact credentials in legacy webhook path segments.
- Replace full request-header logging with an allowlist of operational headers.
- Stop logging GitHub, Intercom, and Discord signature material.
- Add sentinel-based regression coverage for HTTP and structured log output.

No endpoint, authentication, schema, or response behavior changes.

## Tests

- `npm run tsgo -- --noEmit`
- Focused Vitest suite: 6 tests passed in isolation from the database-only global setup.
- `npm run build`
- Biome checks and `git diff --check`

The normal connector Vitest setup could not run locally because the PostgreSQL test service is stopped; the focused tests themselves pass with the unrelated database setup disabled.

## Risk

Low. This intentionally removes query parameters and most request headers from logs, which reduces debugging detail. Core method, sanitized path, status, response size, duration, content metadata, user agent, and Dust client ID remain available. The change is safe to roll back and does not affect request handling.

## Deploy Plan

Deploy connectors normally. Verify webhook and profiler logs contain redacted paths and no query strings. Coordinate historical-log review and `DUST_CONNECTORS_WEBHOOKS_SECRET` rotation separately because existing provider callback URLs still use the legacy path-based credential.