### PR TITLE
governance seed: add a skill on the private space

### DIFF
--- a/front/scripts/seed/factories/seedSkill.ts
+++ b/front/scripts/seed/factories/seedSkill.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -24,10 +25,22 @@ export async function seedSkill(
 ): Promise<SkillResource | null> {
   const { auth, workspace, execute, logger } = ctx;
 
-  const existingSkills = await SkillResource.listByWorkspace(auth, {
-    status: "active",
+  // Looked up on the model rather than through the context user's view: seeded skills may require
+  // spaces the context user is not a member of, and a re-run must still find them (skill names are
+  // unique among a workspace's active skills).
+  const existingSkillRow = await SkillConfigurationModel.findOne({
+    attributes: ["id"],
+    where: {
+      workspaceId: workspace.id,
+      name: skillAsset.name,
+      status: "active",
+    },
   });
-  const existingSkill = existingSkills.find((s) => s.name === skillAsset.name);
+  const [existingSkill] = existingSkillRow
+    ? await SkillResource.fetchByModelIds(auth, [existingSkillRow.id], {
+        dangerouslySkipPermissionFiltering: true,
+      })
+    : [];
 
   if (existingSkill) {
     logger.info(

--- a/front/scripts/seed/governance/assets/skills.json
+++ b/front/scripts/seed/governance/assets/skills.json
@@ -14,5 +14,13 @@
     "instructions": "# Release Notes\n\nGroup changes under three headings: **New**, **Improved**, **Fixed**.\n\n- One line per change, written from the user's point of view.\n- No internal ticket numbers, no commit hashes.\n- Skip purely internal refactors.",
     "instructionsHtml": "<div data-type=\"instructions-root\" data-block-id=\"instructions-root\"><h1 data-block-id=\"rn01titl\">Release Notes</h1><p data-block-id=\"rn02intr\">Group changes under three headings: <strong>New</strong>, <strong>Improved</strong>, <strong>Fixed</strong>.</p><ul data-block-id=\"rn03rul\"><li>One line per change, written from the user's point of view.</li><li>No internal ticket numbers, no commit hashes.</li><li>Skip purely internal refactors.</li></ul></div>",
     "availability": "workspace_users"
+  },
+  "alfredPrivateSpaceSkill": {
+    "name": "Space Restricted Procedures",
+    "agentFacingDescription": "Guidelines to answer questions about the procedures documented in the restricted space.",
+    "userFacingDescription": "Answer questions about the procedures of the restricted space.",
+    "instructions": "# Space Restricted Procedures\n\nAnswer only from the documents of the restricted space. Cite the document for every statement, and say so when the procedures do not cover the question.",
+    "instructionsHtml": "<div data-type=\"instructions-root\" data-block-id=\"instructions-root\"><h1 data-block-id=\"sp01titl\">Space Restricted Procedures</h1><p data-block-id=\"sp02rule\">Answer only from the documents of the restricted space. Cite the document for every statement, and say so when the procedures do not cover the question.</p></div>",
+    "availability": "workspace_users"
   }
 }

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -86,6 +86,11 @@ describe("governance seed script integration test", () => {
     const alfredSkill = await seedSkill(ctx, assets.skills.alfredSkill, {
       owner: alfred,
     });
+    const alfredPrivateSpaceSkill = await seedSkill(
+      ctx,
+      assets.skills.alfredPrivateSpaceSkill,
+      { owner: alfred, spaces: privateSpace ? [privateSpace] : [] }
+    );
     const currentUserSkill = await seedSkill(
       ctx,
       assets.skills.currentUserSkill,
@@ -152,6 +157,13 @@ describe("governance seed script integration test", () => {
       new Set([user.sId, bob!.sId, alfred!.sId])
     );
     expect(spaceMembers.map((m) => m.sId)).not.toContain(alfred!.sId);
+
+    // Alfred's published skill requires the private space the current user is not a member of.
+    expect(alfredPrivateSpaceSkill).toBeDefined();
+    expect(alfredPrivateSpaceSkill!.requestedSpaceIds).toEqual([
+      privateSpace!.id,
+    ]);
+    expect(alfredPrivateSpaceSkill!.availability).toBe("workspace_users");
 
     // Both skills are created with the availability from the assets.
     expect(alfredSkill).toBeDefined();

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -28,6 +28,7 @@ export interface Assets {
   skills: {
     alfredSkill: SkillAsset;
     currentUserSkill: SkillAsset;
+    alfredPrivateSpaceSkill: SkillAsset;
   };
 }
 
@@ -117,6 +118,13 @@ makeScript({}, async ({ execute }, logger) => {
   await seedSkill(ctx, skills.currentUserSkill, {
     editors: removeNulls([bob, alfred]),
     spaces: restrictedSpace ? [restrictedSpace] : [],
+  });
+  // Alfred's published skill requires the private space the current user is not a member of: the
+  // manage skills page only lists it behind "Show hidden skills", with its guidelines redacted.
+  logger.info("Seeding Alfred's private space skill...");
+  await seedSkill(ctx, skills.alfredPrivateSpaceSkill, {
+    owner: alfred,
+    spaces: privateSpace ? [privateSpace] : [],
   });
 
   // 6. Create an agent edited by the current user that uses Alfred's unpublished skill, plus three


### PR DESCRIPTION
## Description

Test data for #31830 (admins listing skills built on spaces they are not a member of).

- New governance seed skill "Space Restricted Procedures", owned by Alfred and requiring the Governance Private Space the current user is not a member of.
- The skill seeding lookup used the context user's view, so a re-run could not see skills built on spaces the user is not a member of and failed on the unique name. It now looks the row up directly and loads it with permission filtering skipped, like the agent seeding does.

## Tests

Seed test covers the new skill and its requested space.

## Risk

Low. Dev seed only.

## Deploy Plan

- Nothing to deploy
