### PR TITLE
Core GCS access in cell-00002

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "flate2",
  "futures",
  "gcp-bigquery-client",
+ "gcp_auth",
  "http 1.3.1",
  "humantime",
  "hyper 1.6.0",
@@ -1413,6 +1414,7 @@ dependencies = [
  "rayon",
  "redis",
  "regex",
+ "reqwest 0.11.27",
  "reqwest 0.12.20",
  "ring 0.17.14",
  "rsa",
@@ -1783,6 +1785,33 @@ dependencies = [
  "tonic-build",
  "url",
  "yup-oauth2",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d27dbcc645b60b8e7f6e2868a9d7102ece97d1bb49c1288b5321fcc67f7260"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "ring 0.17.14",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
 ]
 
 [[package]]
@@ -5338,6 +5367,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -138,7 +138,7 @@ bstr = "1.9"
 chardetng = "0.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
-cloud-storage = { version = "0.11", features = ["global-client"] }
+cloud-storage = "0.11"
 csv = "1.3.0"
 csv-async = "1.3.0"
 dateparser = "0.2.1"
@@ -151,6 +151,7 @@ eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client
 fancy-regex = "0.13"
 flate2 = "1.0"
 futures = "0.3"
+gcp_auth = "0.12.7"
 gcp-bigquery-client = "0.25.1"
 http = "1.1.0"
 humantime = "2.2.0"
@@ -174,6 +175,8 @@ rand = "0.8"
 rayon = "1.10"
 redis = { version = "0.24.0", features = ["tokio-comp"] }
 regex = "1.10"
+# cloud-storage 0.11 exposes reqwest 0.11 in its TokenCache trait.
+reqwest011 = { package = "reqwest", version = "0.11", default-features = false }
 reqwest = { version = "0.12", features = ["json"] }
 ring = "0.17.14"
 rsa = { version = "0.9.4", features = ["pem"] }

--- a/core/bin/migrations/20241203_fix_created_dsdocs.rs
+++ b/core/bin/migrations/20241203_fix_created_dsdocs.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use cloud_storage::{ListRequest, Object};
+use cloud_storage::ListRequest;
 use dust::data_sources::data_source::make_document_id_hash;
 use dust::data_sources::file_storage_document::FileStorageDocument;
+use dust::gcs_client::gcs_client;
 use dust::stores::{postgres, store};
 use futures::{pin_mut, StreamExt};
 
@@ -217,14 +218,17 @@ async fn list_files_with_prefix(prefix: &str) -> Result<Vec<String>> {
 
     let mut paths = Vec::new();
 
-    let stream = Object::list(
-        &bucket,
-        ListRequest {
-            prefix: Some(prefix.to_string()),
-            ..Default::default()
-        },
-    )
-    .await?;
+    let stream = gcs_client()
+        .await?
+        .object()
+        .list(
+            &bucket,
+            ListRequest {
+                prefix: Some(prefix.to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
 
     pin_mut!(stream);
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Result};
-use cloud_storage::{ErrorList, GoogleErrorResponse, Object};
+use cloud_storage::{ErrorList, GoogleErrorResponse};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 
-use crate::utils;
+use crate::{gcs_client::gcs_client, utils};
 
 use super::data_source::{DataSource, Document, DocumentVersion, Section};
 
@@ -51,7 +51,7 @@ impl FileStorageDocument {
     pub async fn path_exists(path: &str) -> Result<bool> {
         let bucket = FileStorageDocument::get_bucket().await?;
 
-        match Object::read(&bucket, path).await {
+        match gcs_client().await?.object().read(&bucket, path).await {
             Ok(_) => Ok(true),
             Err(_err) => Ok(false),
         }
@@ -60,7 +60,7 @@ impl FileStorageDocument {
     pub async fn delete_if_exists(path: &str) -> Result<bool> {
         let bucket = FileStorageDocument::get_bucket().await?;
 
-        match Object::delete(&bucket, &path).await {
+        match gcs_client().await?.object().delete(&bucket, path).await {
             Ok(_) => Ok(true),
             Err(e) => match e {
                 cloud_storage::Error::Google(GoogleErrorResponse {
@@ -87,7 +87,12 @@ impl FileStorageDocument {
         let bucket = FileStorageDocument::get_bucket().await?;
 
         let now = utils::now();
-        match Object::download(&bucket, &file_path).await {
+        match gcs_client()
+            .await?
+            .object()
+            .download(&bucket, &file_path)
+            .await
+        {
             Ok(bytes) => {
                 info!(
                     data_source_internal_id = data_source.internal_id(),
@@ -153,7 +158,12 @@ impl FileStorageDocument {
         );
 
         let now = utils::now();
-        match Object::delete(&bucket, &document_file_path).await {
+        match gcs_client()
+            .await?
+            .object()
+            .delete(&bucket, &document_file_path)
+            .await
+        {
             Ok(_) => (),
             Err(e) => {
                 match e {
@@ -207,13 +217,16 @@ impl FileStorageDocument {
         let serialized_document = serde_json::to_vec(&file_storage_document)?;
 
         let now = utils::now();
-        let _ = Object::create(
-            &bucket,
-            serialized_document,
-            &document_file_path,
-            "application/json",
-        )
-        .await?;
+        let _ = gcs_client()
+            .await?
+            .object()
+            .create(
+                &bucket,
+                serialized_document,
+                &document_file_path,
+                "application/json",
+            )
+            .await?;
 
         info!(
             data_source_internal_id = data_source_internal_id,

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use cloud_storage::Object;
 use csv_async::AsyncReaderBuilder;
 use futures::stream::StreamExt;
 use lazy_static::lazy_static;
@@ -12,7 +11,7 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::info;
 use unicode_normalization::UnicodeNormalization;
 
-use crate::{databases::table::Row, utils};
+use crate::{databases::table::Row, gcs_client::gcs_client, utils};
 
 pub struct GoogleCloudStorageCSVContent {
     pub bucket: String,
@@ -33,7 +32,7 @@ impl GoogleCloudStorageCSVContent {
         let path = &self.bucket_csv_path;
 
         // Check file size before downloading to prevent OOM issues.
-        let metadata = Object::read(bucket, path).await?;
+        let metadata = gcs_client().await?.object().read(bucket, path).await?;
         if metadata.size > MAX_CSV_FILE_SIZE_BYTES {
             info!(
                 bucket = bucket,
@@ -51,7 +50,7 @@ impl GoogleCloudStorageCSVContent {
 
         // This is not the most efficient as we download the entire file here but we will
         // materialize it in memory as Vec<Row> anyway so that's not a massive difference.
-        let content = Object::download(bucket, path).await?;
+        let content = gcs_client().await?.object().download(bucket, path).await?;
         // csv_async only accepts UTF-8; transcode UTF-16 (BOM-based) and detected single-byte
         // encodings (e.g. Windows-1252 produced by Excel's default "Save as CSV").
         let content = Self::decode_to_utf8(content)?;

--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use cloud_storage::{ErrorList, GoogleErrorResponse, Object};
+use cloud_storage::{ErrorList, GoogleErrorResponse};
 use csv::Writer;
 use tracing::info;
 
@@ -12,6 +12,7 @@ use crate::{
         table::{Row, Table},
         table_schema::TableSchema,
     },
+    gcs_client::gcs_client,
     utils::{self},
 };
 
@@ -51,7 +52,11 @@ pub async fn write_rows_to_bucket(
 
     let csv = wtr.into_inner()?;
 
-    Object::create(bucket, csv, bucket_csv_path, "text/csv").await?;
+    gcs_client()
+        .await?
+        .object()
+        .create(bucket, csv, bucket_csv_path, "text/csv")
+        .await?;
 
     Ok(())
 }
@@ -236,11 +241,14 @@ impl DatabasesStore for GoogleCloudStorageDatabasesStore {
     }
 
     async fn delete_table_data(&self, table: &Table) -> Result<()> {
-        match Object::delete(
-            &Self::get_bucket()?,
-            &Self::get_csv_storage_file_path(table),
-        )
-        .await
+        match gcs_client()
+            .await?
+            .object()
+            .delete(
+                &Self::get_bucket()?,
+                &Self::get_csv_storage_file_path(table),
+            )
+            .await
         {
             Ok(_) => {}
             Err(e) => match e {

--- a/core/src/databases_store/gcs_background.rs
+++ b/core/src/databases_store/gcs_background.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use async_std::stream::StreamExt;
-use cloud_storage::{ListRequest, Object};
+use cloud_storage::ListRequest;
 use futures::future::try_join_all;
 use std::collections::HashMap;
 use tracing::error;
@@ -13,6 +13,7 @@ use crate::{
         table_schema::TableSchema,
     },
     databases_store::gcs::write_rows_to_bucket,
+    gcs_client::gcs_client,
 };
 
 // This Store is used to pass upsert and delete call info from the APIs to the background worker
@@ -79,7 +80,11 @@ impl GoogleCloudStorageBackgroundProcessingStore {
             start_offset: None,
             versions: None,
         };
-        let stream = Object::list(&bucket, list_request).await?;
+        let stream = gcs_client()
+            .await?
+            .object()
+            .list(&bucket, list_request)
+            .await?;
 
         let mut pinned_stream = Box::pin(stream);
         let mut files = Vec::new();
@@ -148,10 +153,11 @@ impl GoogleCloudStorageBackgroundProcessingStore {
     pub async fn delete_files(files: &Vec<String>) -> Result<()> {
         // We delete the files concurrently to speed up the process
         let bucket = Self::get_bucket()?;
+        let client = gcs_client().await?;
         let delete_futures = files.iter().map(|file| {
             let bucket = bucket.clone();
             async move {
-                match Object::delete(&bucket, &file).await {
+                match client.object().delete(&bucket, file).await {
                     Ok(_) => Ok::<(), ()>(()),
                     Err(e) => {
                         error!("Failed to delete file {}: {}", file, e);

--- a/core/src/gcs_client.rs
+++ b/core/src/gcs_client.rs
@@ -1,0 +1,263 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use cloud_storage::{Client, TokenCache};
+use gcp_auth::TokenProvider;
+use std::sync::Arc;
+use tokio::sync::{Mutex, OnceCell, RwLock};
+
+const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.full_control";
+// Keep this aligned with gcp_auth::Token::has_expired().
+const TOKEN_EXPIRY_SKEW_SECONDS: u64 = 20;
+// These are the four credential sources supported by cloud-storage::Client::new().
+// Keep their authentication behavior unchanged in existing deployments.
+const LEGACY_SERVICE_ACCOUNT_ENV_VARIABLES: [&str; 4] = [
+    "SERVICE_ACCOUNT",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "SERVICE_ACCOUNT_JSON",
+    "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+];
+
+static GCS_CLIENT: OnceCell<Client> = OnceCell::const_new();
+
+#[derive(Debug, PartialEq)]
+enum GcsAuthenticationMode {
+    LegacyServiceAccount,
+    ApplicationDefaultCredentials,
+}
+
+/// Returns the shared GCS client used by core.
+///
+/// Existing regions keep using cloud-storage's service-account authentication.
+/// When no legacy Dust credential is configured, the client uses ADC, including
+/// the GKE metadata server exposed by Workload Identity Federation.
+pub async fn gcs_client() -> Result<&'static Client> {
+    GCS_CLIENT
+        .get_or_try_init(|| async { build_gcs_client().await })
+        .await
+}
+
+async fn build_gcs_client() -> Result<Client> {
+    match authentication_mode_from_environment() {
+        GcsAuthenticationMode::LegacyServiceAccount => Ok(Client::new()),
+        GcsAuthenticationMode::ApplicationDefaultCredentials => {
+            let provider = gcp_auth::provider()
+                .await
+                .context("failed to initialize GCP application default credentials for GCS")?;
+            Ok(Client::with_cache(GcpAuthTokenCache::new(provider)))
+        }
+    }
+}
+
+fn authentication_mode_from_environment() -> GcsAuthenticationMode {
+    select_authentication_mode(|name| std::env::var(name).ok())
+}
+
+fn select_authentication_mode(
+    mut read_environment_variable: impl FnMut(&str) -> Option<String>,
+) -> GcsAuthenticationMode {
+    let has_legacy_credentials = LEGACY_SERVICE_ACCOUNT_ENV_VARIABLES.iter().any(|name| {
+        read_environment_variable(name)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+    });
+
+    if has_legacy_credentials {
+        GcsAuthenticationMode::LegacyServiceAccount
+    } else {
+        GcsAuthenticationMode::ApplicationDefaultCredentials
+    }
+}
+
+struct GcpAuthTokenCache {
+    provider: Arc<dyn TokenProvider>,
+    cached: RwLock<Option<(String, u64)>>,
+    refresh: Mutex<()>,
+}
+
+impl GcpAuthTokenCache {
+    fn new(provider: Arc<dyn TokenProvider>) -> Self {
+        Self {
+            provider,
+            cached: RwLock::new(None),
+            refresh: Mutex::new(()),
+        }
+    }
+
+    async fn valid_cached_token(&self) -> Option<String> {
+        self.cached
+            .read()
+            .await
+            .as_ref()
+            .filter(|(_, expires_at_seconds)| {
+                now_unix_seconds().saturating_add(TOKEN_EXPIRY_SKEW_SECONDS) < *expires_at_seconds
+            })
+            .map(|(token, _)| token.clone())
+    }
+}
+
+#[async_trait]
+impl TokenCache for GcpAuthTokenCache {
+    async fn token_and_exp(&self) -> Option<(String, u64)> {
+        self.cached.read().await.clone()
+    }
+
+    async fn set_token(&self, token: String, expires_at_seconds: u64) -> cloud_storage::Result<()> {
+        *self.cached.write().await = Some((token, expires_at_seconds));
+        Ok(())
+    }
+
+    async fn scope(&self) -> String {
+        GCS_SCOPE.to_string()
+    }
+
+    async fn get(&self, client: &reqwest011::Client) -> cloud_storage::Result<String> {
+        if let Some(token) = self.valid_cached_token().await {
+            return Ok(token);
+        }
+
+        let _refresh_guard = self.refresh.lock().await;
+
+        // Another request may have refreshed the token while this one waited.
+        if let Some(token) = self.valid_cached_token().await {
+            return Ok(token);
+        }
+
+        let (token, expires_at_seconds) = self.fetch_token(client).await?;
+        self.set_token(token.clone(), expires_at_seconds).await?;
+        Ok(token)
+    }
+
+    async fn fetch_token(
+        &self,
+        _client: &reqwest011::Client,
+    ) -> cloud_storage::Result<(String, u64)> {
+        let token = self
+            .provider
+            .token(&[GCS_SCOPE])
+            .await
+            .map_err(|error| cloud_storage::Error::Other(error.to_string()))?;
+        let expires_at_seconds =
+            u64::try_from(token.expires_at().timestamp()).map_err(|error| {
+                cloud_storage::Error::Other(format!("invalid GCP token expiry: {error}"))
+            })?;
+
+        Ok((token.as_str().to_string(), expires_at_seconds))
+    }
+}
+
+fn now_unix_seconds() -> u64 {
+    u64::try_from(chrono::Utc::now().timestamp()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use futures::future::join_all;
+    use gcp_auth::Token;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    struct CountingProvider {
+        calls: AtomicUsize,
+        delay: Duration,
+    }
+
+    #[async_trait]
+    impl TokenProvider for CountingProvider {
+        async fn token(&self, _scopes: &[&str]) -> Result<Arc<Token>, gcp_auth::Error> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.delay).await;
+            let token = serde_json::from_value(serde_json::json!({
+                "access_token": "test-access-token",
+                "expires_in": 3600,
+            }))
+            .map_err(|error| gcp_auth::Error::Json("failed to build test token", error))?;
+            Ok(Arc::new(token))
+        }
+
+        async fn project_id(&self) -> Result<Arc<str>, gcp_auth::Error> {
+            Ok(Arc::from("test-project"))
+        }
+    }
+
+    #[test]
+    fn selects_application_default_credentials_without_legacy_configuration() {
+        assert_eq!(
+            select_authentication_mode(|_| None),
+            GcsAuthenticationMode::ApplicationDefaultCredentials
+        );
+    }
+
+    #[test]
+    fn selects_legacy_authentication_for_existing_service_account_variables() {
+        for configured_name in LEGACY_SERVICE_ACCOUNT_ENV_VARIABLES {
+            assert_eq!(
+                select_authentication_mode(|name| {
+                    (name == configured_name).then(|| "configured".to_string())
+                }),
+                GcsAuthenticationMode::LegacyServiceAccount
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_blank_legacy_service_account_variables() {
+        assert_eq!(
+            select_authentication_mode(|_| Some("  ".to_string())),
+            GcsAuthenticationMode::ApplicationDefaultCredentials
+        );
+    }
+
+    #[tokio::test]
+    async fn serializes_concurrent_token_refreshes() -> Result<()> {
+        let provider = Arc::new(CountingProvider {
+            calls: AtomicUsize::new(0),
+            delay: Duration::from_millis(20),
+        });
+        let cache = GcpAuthTokenCache::new(provider.clone());
+        let client = reqwest011::Client::builder().no_proxy().build()?;
+
+        let results = join_all((0..8).map(|_| cache.get(&client))).await;
+        for result in results {
+            assert_eq!(result?, "test-access-token");
+        }
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reuses_a_valid_cached_token() -> Result<()> {
+        let provider = Arc::new(CountingProvider {
+            calls: AtomicUsize::new(0),
+            delay: Duration::ZERO,
+        });
+        let cache = GcpAuthTokenCache::new(provider.clone());
+        let client = reqwest011::Client::builder().no_proxy().build()?;
+
+        assert_eq!(cache.get(&client).await?, "test-access-token");
+        assert_eq!(cache.get(&client).await?, "test-access-token");
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn refreshes_a_token_near_expiry() -> Result<()> {
+        let provider = Arc::new(CountingProvider {
+            calls: AtomicUsize::new(0),
+            delay: Duration::ZERO,
+        });
+        let cache = GcpAuthTokenCache::new(provider.clone());
+        cache
+            .set_token(
+                "nearly-expired-token".to_string(),
+                now_unix_seconds().saturating_add(TOKEN_EXPIRY_SKEW_SECONDS),
+            )
+            .await?;
+        let client = reqwest011::Client::builder().no_proxy().build()?;
+
+        assert_eq!(cache.get(&client).await?, "test-access-token");
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod databases {
     pub mod transient_database;
 }
 pub mod gcp_auth;
+pub mod gcs_client;
 pub mod project;
 pub mod run;
 pub mod search_filter;

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -4,10 +4,10 @@ use crate::{
         transient_database::get_transient_database_unique_table_names,
     },
     databases_store::{gcs::GoogleCloudStorageDatabasesStore, store::DatabasesStore},
+    gcs_client::gcs_client,
     utils,
 };
 use anyhow::{anyhow, Result};
-use cloud_storage::Object;
 use futures::future::try_join_all;
 use parking_lot::Mutex;
 use rayon::prelude::*;
@@ -331,11 +331,14 @@ async fn create_in_memory_sqlite_db_with_csv(
             }
 
             async move {
-                let mut stream = Object::download_streamed(
-                    &GoogleCloudStorageDatabasesStore::get_bucket()?,
-                    &GoogleCloudStorageDatabasesStore::get_csv_storage_file_path(&table.table),
-                )
-                .await?;
+                let mut stream = gcs_client()
+                    .await?
+                    .object()
+                    .download_streamed(
+                        &GoogleCloudStorageDatabasesStore::get_bucket()?,
+                        &GoogleCloudStorageDatabasesStore::get_csv_storage_file_path(&table.table),
+                    )
+                    .await?;
                 let mut temp_file = NamedTempFile::new()?;
 
                 // Buffer bytes to avoid writing one byte at a time


### PR DESCRIPTION
## Description

Core can now access GCS from cell-00002 through Workload Identity, while existing regions continue to use their configured service-account credentials. All GCS operations share one client that keeps the current `cloud-storage` authentication whenever any of its four credential variables is present, and otherwise resolves Application Default Credentials through the GKE metadata server.

This keeps object operations and error behavior on the existing storage crate instead of combining the authentication rollout with a storage client migration. Concurrent ADC token requests share one refresh and use the same 20-second expiry margin as `gcp_auth`.

> [!NOTE]
> BigQuery authentication and removal of legacy service-account secrets are deliberately out of scope. This supersedes #31832.

## Tests

Added six focused tests covering authentication selection, blank legacy variables, token reuse, near-expiry refresh, and concurrent refreshes.

```
cargo check --manifest-path core/Cargo.toml
Finished `dev` profile [unoptimized + debuginfo] target(s)

cargo test --manifest-path core/Cargo.toml --lib gcs_client
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 96 filtered out
```

`cargo fmt --manifest-path core/Cargo.toml --all -- --check` and `cargo clippy --manifest-path core/Cargo.toml --lib` also pass. The full library run passed 96 tests with one ignored; five unrelated MCP tests could not run in the local macOS proxy and socket environment.

## Risk

The main risk is selecting the wrong authentication source. Existing regions take the unchanged `Client::new()` path whenever one of the four credentials supported by the current crate is configured, while cell-00002 uses ADC only when none is present. Rollback is safe because this changes no infrastructure and removes no secrets.

## Deploy Plan

Deploy to a legacy region first and verify GCS reads and writes still use its service account. Then deploy to cell-00002 without the four legacy credential variables, verify a GCS read and write through Workload Identity, and watch authentication errors. Roll back the Core deployment if either check fails; keep all legacy secrets in place.
