### PR TITLE
connectors: cell-00002 is a supported cell

### DIFF
--- a/connectors/src/connectors/shared/config.ts
+++ b/connectors/src/connectors/shared/config.ts
@@ -1,6 +1,10 @@
 import { EnvironmentConfig } from "@connectors/types";
 
-export const SUPPORTED_CELLS = ["cell-00000", "cell-00001"] as const;
+export const SUPPORTED_CELLS = [
+  "cell-00000",
+  "cell-00001",
+  "cell-00002",
+] as const;
 export type CellType = (typeof SUPPORTED_CELLS)[number];
 
 export const connectorsConfig = {


### PR DESCRIPTION
## Description

connectors accepts `cell-00002` as a supported cell. The list drives the `CELL` env var type and the webhook router config schema, both rejected the new cell. cell-00002 is the first cell cluster in europe-west1, connectors is being deployed there from dust-infra #1049.

## Tests

Type-level change only, one entry in a const array. Typecheck covers it.

## Risk

None for the two existing cells. The webhook router config gains a possible key.

## Deploy Plan

Merge, deploy connectors. The cell release waits for it.
