### PR TITLE
skills: permission filtering modes on the skill fetchers, with a redacted mode for admins

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -15202,6 +15202,10 @@
               }
             }
           },
+          "canRead": {
+            "type": "boolean",
+            "description": "Whether the authenticated actor can read the skill's instructions, tools and files. False when they were redacted for a workspace admin who is not a member of every space the skill requires."
+          },
           "canWrite": {
             "type": "boolean",
             "description": "Whether the authenticated actor can edit the skill"

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -746,6 +746,9 @@
  *               fileName:
  *                 type: string
  *                 description: Name of the attached file
+ *         canRead:
+ *           type: boolean
+ *           description: Whether the authenticated actor can read the skill's instructions, tools and files. False when they were redacted for a workspace admin who is not a member of every space the skill requires.
  *         canWrite:
  *           type: boolean
  *           description: Whether the authenticated actor can edit the skill

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
@@ -119,7 +119,7 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", (
     const updatedSkills = await SkillResource.listByAgentConfiguration(
       auth,
       updatedAgent,
-      { dangerouslySkipPermissionFiltering: true }
+      { permissionFiltering: "dangerously_skip" }
     );
     expect(updatedSkills.map((s) => s.sId)).toEqual([skill.sId]);
   });

--- a/front/lib/api/assistant/configuration/context.ts
+++ b/front/lib/api/assistant/configuration/context.ts
@@ -107,7 +107,11 @@ export async function getAgentConfigurationContext(
   const skills = await SkillResource.listByAgentConfiguration(
     auth,
     agentConfiguration,
-    { dangerouslySkipPermissionFiltering }
+    {
+      permissionFiltering: dangerouslySkipPermissionFiltering
+        ? "dangerously_skip"
+        : "strict",
+    }
   );
   const editorsResult = await GroupResource.findEditorGroupForAgent(
     auth,

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -107,7 +107,11 @@ export async function createOrUpgradeAgentConfiguration({
     skills = await SkillResource.fetchByIds(
       auth,
       assistant.skills.map((s) => s.sId),
-      { dangerouslySkipPermissionFiltering }
+      {
+        permissionFiltering: dangerouslySkipPermissionFiltering
+          ? "dangerously_skip"
+          : "strict",
+      }
     );
   }
 

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -26,6 +26,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],
+    canRead: true,
     canAdministrate: true,
     canWrite: true,
     isDefault: false,

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -25,6 +25,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],
+    canRead: true,
     canAdministrate: true,
     canWrite: true,
     isDefault: false,

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2211,8 +2211,8 @@ describe("SkillResource", () => {
 
       expect(fetched).not.toBeNull();
       expect(fetched!.canRead(testContext.authenticator)).toBe(false);
-      expect(fetched!.canWrite(testContext.authenticator)).toBe(false);
-      expect(fetched!.canAdministrate(testContext.authenticator)).toBe(false);
+      // Administration is a role matter, unrelated to reading the spaces.
+      expect(fetched!.canAdministrate(testContext.authenticator)).toBe(true);
       const json = fetched!.toJSON(testContext.authenticator);
       expect(json.name).toBe("Restricted Space Skill");
       expect(json.canRead).toBe(false);

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2154,6 +2154,130 @@ describe("SkillResource", () => {
     });
   });
 
+  describe("permission filtering modes", () => {
+    // A skill owned by another member and built on a restricted space the test admin is not a
+    // member of.
+    async function createRestrictedSkill() {
+      const owner = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, owner, {
+        role: "user",
+      });
+      const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        owner.sId,
+        testContext.workspace.sId
+      );
+      const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
+      await restrictedSpace.addMembers(testContext.authenticator, {
+        userIds: [owner.sId],
+      });
+      const skill = await SkillFactory.create(ownerAuth, {
+        name: "Restricted Space Skill",
+        instructions: "Secret guidelines",
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+      return { skill, ownerAuth };
+    }
+
+    it("returns a readable skill as is", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Readable Skill",
+        instructions: "Public guidelines",
+      });
+
+      const fetched = await SkillResource.fetchById(
+        testContext.authenticator,
+        skill.sId,
+        { permissionFiltering: "redact_unreadable" }
+      );
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.canRead(testContext.authenticator)).toBe(true);
+      expect(fetched!.toJSON(testContext.authenticator).instructions).toBe(
+        "Public guidelines"
+      );
+    });
+
+    it("returns a redacted skill to an admin who cannot read it", async () => {
+      const { skill } = await createRestrictedSkill();
+      expect(
+        await SkillResource.fetchById(testContext.authenticator, skill.sId)
+      ).toBeNull();
+
+      const fetched = await SkillResource.fetchById(
+        testContext.authenticator,
+        skill.sId,
+        { permissionFiltering: "redact_unreadable" }
+      );
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.canRead(testContext.authenticator)).toBe(false);
+      expect(fetched!.canWrite(testContext.authenticator)).toBe(false);
+      expect(fetched!.canAdministrate(testContext.authenticator)).toBe(false);
+      const json = fetched!.toJSON(testContext.authenticator);
+      expect(json.name).toBe("Restricted Space Skill");
+      expect(json.canRead).toBe(false);
+      expect(json.instructions).toBeNull();
+      expect(json.instructionsHtml).toBeNull();
+      expect(json.tools).toEqual([]);
+      expect(json.fileAttachments).toEqual([]);
+    });
+
+    it("refuses the option to a non-admin, who gets null without it", async () => {
+      const { skill } = await createRestrictedSkill();
+      const builder = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, builder, {
+        role: "builder",
+      });
+      const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        builder.sId,
+        testContext.workspace.sId
+      );
+
+      await expect(
+        SkillResource.fetchById(builderAuth, skill.sId, {
+          permissionFiltering: "redact_unreadable",
+        })
+      ).rejects.toThrow("Only admins");
+      await expect(
+        SkillResource.listByWorkspace(builderAuth, {
+          permissionFiltering: "redact_unreadable",
+        })
+      ).rejects.toThrow("Only admins");
+      expect(await SkillResource.fetchById(builderAuth, skill.sId)).toBeNull();
+    });
+
+    it("returns null for an unknown skill", async () => {
+      expect(
+        await SkillResource.fetchById(
+          testContext.authenticator,
+          "skl_does_not_exist",
+          { permissionFiltering: "redact_unreadable" }
+        )
+      ).toBeNull();
+    });
+
+    it("listByWorkspace with redact_unreadable only redacts the skills the caller cannot read", async () => {
+      const { skill: restrictedSkill } = await createRestrictedSkill();
+      const readableSkill = await SkillFactory.create(
+        testContext.authenticator,
+        { name: "Readable Skill" }
+      );
+
+      const skills = await SkillResource.listByWorkspace(
+        testContext.authenticator,
+        { onlyCustom: true, permissionFiltering: "redact_unreadable" }
+      );
+
+      const bySId = new Map(skills.map((s) => [s.sId, s]));
+      expect(
+        bySId.get(restrictedSkill.sId)!.canRead(testContext.authenticator)
+      ).toBe(false);
+      expect(
+        bySId.get(readableSkill.sId)!.canRead(testContext.authenticator)
+      ).toBe(true);
+    });
+  });
+
   describe("fetchByIds", () => {
     it("skips heavy hydration when it is not requested", async () => {
       const server = await RemoteMCPServerFactory.create(testContext.workspace);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -654,17 +654,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    * referencing one are dropped too. This is what the fetch path applies (see
    * `SkillPermissionFilteringMode`).
    */
-  static async filterReadable<
-    T extends {
-      id: ModelId;
-      workspaceId: ModelId;
-      requestedSpaceIds: ModelId[];
-    },
-  >(
+  private static async filterReadable(
     auth: Authenticator,
-    skills: T[],
+    skills: SkillConfigurationModel[],
     { transaction }: { transaction?: Transaction } = {}
-  ): Promise<T[]> {
+  ): Promise<SkillConfigurationModel[]> {
     const uniqueRequestedSpaceIds = uniq(
       skills.flatMap((skill) => skill.requestedSpaceIds)
     );
@@ -674,12 +668,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             transaction,
           })
         : [];
-    const spaceById = new Map(spaces.map((s) => [s.id, s]));
+    const spaceByModelId = new Map(spaces.map((s) => [s.id, s]));
 
     return skills.filter(
       (skill) =>
         this.canReadRow(auth, skill) &&
-        canReadRequestedSpaces(auth, spaceById, skill.requestedSpaceIds)
+        canReadRequestedSpaces(auth, spaceByModelId, skill.requestedSpaceIds)
     );
   }
 
@@ -2330,7 +2324,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   // skill the caller cannot read is never hydrated.
   private static canReadRow(
     auth: Authenticator,
-    skill: { id: ModelId; workspaceId: ModelId }
+    skill: SkillConfigurationModel
   ): boolean {
     // See canWrite: API keys hold no skill grant, so any key reads any skill.
     if (auth.isKey()) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -300,8 +300,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   // serialized to the front-end. Custom skills always expose their own.
   private readonly exposeInstructions: boolean;
   // Set on the skills an admin fetched without being able to read them (built on spaces they are
-  // not a member of): the permission methods answer false and `toJSON` drops the private fields.
-  // See the "redact_unreadable" permission filtering mode of the fetchers.
+  // not a member of): `canRead` answers false and `toJSON` drops the private fields. The other
+  // permissions are left as they are, so an admin can still administrate such a skill (archive,
+  // availability). See the "redact_unreadable" permission filtering mode of the fetchers.
   private redactedForCaller = false;
 
   private _mcpServerConfigurations: SkillMCPServerConfiguration[];
@@ -2267,10 +2268,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canWrite(auth: Authenticator): boolean {
-    if (this.redactedForCaller) {
-      return false;
-    }
-
     // TODO(governance): cleanup once we'll be able to grant API keys editorship on a skill.
     // TODO(@jd): Revisit this shortcircuit with our current ACLs stack.
     // API keys cannot hold a skill's `editor` grant (no such assignment mechanism exists),
@@ -2284,10 +2281,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canAdministrate(auth: Authenticator): boolean {
-    if (this.redactedForCaller) {
-      return false;
-    }
-
     // See canWrite: API keys have no editor-group assignment mechanism, so any key can
     // administrate any skill.
     if (auth.isKey()) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -96,6 +96,7 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   isNumber,
@@ -135,11 +136,20 @@ type ReplaceSkillReferenceTagsOptions = {
   html?: boolean;
 };
 
+// How the fetch path treats the custom skills the caller cannot read (row ACL, or a requested
+// space they are not a member of):
+// - "strict" (default): drop them.
+// - "redact_unreadable": keep them, redacted (see `redactedForCaller`). Admins only.
+// - "dangerously_skip": keep them as is. Only for callers that must operate on a skill without
+//   gaining access to what its spaces protect, e.g. an admin re-saving an agent they do not edit:
+//   dropping the skill would silently strip it from the new version.
+export type SkillPermissionFilteringMode =
+  | "strict"
+  | "redact_unreadable"
+  | "dangerously_skip";
+
 type SkillFetchContext = {
-  // Returns skills requesting spaces the caller cannot read. Only for callers that must operate
-  // on a skill without gaining access to what its spaces protect, e.g. an admin re-saving an
-  // agent they do not edit: dropping the skill would silently strip it from the new version.
-  dangerouslySkipPermissionFiltering?: boolean;
+  permissionFiltering?: SkillPermissionFilteringMode;
 } & (
   | {
       agentLoopData?: AgentLoopExecutionData;
@@ -289,6 +299,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   // Only meaningful for global skills: whether their instructions may be
   // serialized to the front-end. Custom skills always expose their own.
   private readonly exposeInstructions: boolean;
+  // Set on the skills an admin fetched without being able to read them (built on spaces they are
+  // not a member of): the permission methods answer false and `toJSON` drops the private fields.
+  // See the "redact_unreadable" permission filtering mode of the fetchers.
+  private redactedForCaller = false;
 
   private _mcpServerConfigurations: SkillMCPServerConfiguration[];
 
@@ -632,13 +646,49 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
   }
 
+  /**
+   * The skills of `skills` the caller can read. Two checks, both required: the caller must be able
+   * to read the skill itself (see `canRead`) and every space it requests. A missing/deleted
+   * requested space is treated as not readable (see `canReadRequestedSpaces`), so skills
+   * referencing one are dropped too. This is what the fetch path applies (see
+   * `SkillPermissionFilteringMode`).
+   */
+  static async filterReadable<
+    T extends {
+      id: ModelId;
+      workspaceId: ModelId;
+      requestedSpaceIds: ModelId[];
+    },
+  >(
+    auth: Authenticator,
+    skills: T[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<T[]> {
+    const uniqueRequestedSpaceIds = uniq(
+      skills.flatMap((skill) => skill.requestedSpaceIds)
+    );
+    const spaces =
+      uniqueRequestedSpaceIds.length > 0
+        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
+            transaction,
+          })
+        : [];
+    const spaceById = new Map(spaces.map((s) => [s.id, s]));
+
+    return skills.filter(
+      (skill) =>
+        this.canReadRow(auth, skill) &&
+        canReadRequestedSpaces(auth, spaceById, skill.requestedSpaceIds)
+    );
+  }
+
   private static async baseFetch(
     auth: Authenticator,
     options: SkillConfigurationFindOptions = {},
     context: {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
-      dangerouslySkipPermissionFiltering?: boolean;
+      permissionFiltering?: SkillPermissionFilteringMode;
       transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
@@ -646,7 +696,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const {
       agentLoopData,
       effectiveSpaceIds: providedEffectiveSpaceIds,
-      dangerouslySkipPermissionFiltering,
+      permissionFiltering = "strict",
       transaction,
     } = context;
 
@@ -676,28 +726,37 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     });
 
-    // Check if the user has access to skill requested spaces.
-    const uniqueRequestedSpaceIds = uniq(
-      customSkills.flatMap((c) => c.requestedSpaceIds)
-    );
-    const spaces =
-      uniqueRequestedSpaceIds.length > 0
-        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
-            transaction,
-          })
-        : [];
-    const spaceById = new Map(spaces.map((s) => [s.id, s]));
-
-    // Two checks, both required: the caller must be able to read the skill itself (see `canRead`)
-    // and every space it requests. A missing/deleted requested space is treated as not readable
-    // (see `canReadRequestedSpaces`), so skills referencing one are dropped here too.
-    const allowedCustomSkills = dangerouslySkipPermissionFiltering
-      ? customSkills
-      : customSkills.filter(
-          (skill) =>
-            this.canReadRow(auth, skill) &&
-            canReadRequestedSpaces(auth, spaceById, skill.requestedSpaceIds)
+    let allowedCustomSkills: SkillConfigurationModel[];
+    const redactedCustomSkillIds = new Set<ModelId>();
+    switch (permissionFiltering) {
+      case "strict":
+        allowedCustomSkills = await this.filterReadable(auth, customSkills, {
+          transaction,
+        });
+        break;
+      case "redact_unreadable": {
+        if (!auth.isAdmin()) {
+          throw new Error("Only admins can fetch the skills they cannot read.");
+        }
+        const readableIds = new Set(
+          (await this.filterReadable(auth, customSkills, { transaction })).map(
+            (skill) => skill.id
+          )
         );
+        for (const skill of customSkills) {
+          if (!readableIds.has(skill.id)) {
+            redactedCustomSkillIds.add(skill.id);
+          }
+        }
+        allowedCustomSkills = customSkills;
+        break;
+      }
+      case "dangerously_skip":
+        allowedCustomSkills = customSkills;
+        break;
+      default:
+        assertNever(permissionFiltering);
+    }
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
 
     let allowedCustomSkillsRes: SkillResource[] = [];
@@ -804,7 +863,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           )
         );
 
-        return new this(this.model, customSkillAttributes, {
+        const resource = new this(this.model, customSkillAttributes, {
           mcpServerConfigurations: skillMCPServerViews.map((view) => ({
             view,
           })),
@@ -815,6 +874,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             )
           ),
         });
+        if (redactedCustomSkillIds.has(customSkill.id)) {
+          resource.redactedForCaller = true;
+        }
+        return resource;
       });
     }
 
@@ -915,11 +978,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     ids: ModelId[],
     {
-      dangerouslySkipPermissionFiltering,
+      permissionFiltering,
       status,
       withTools = true,
     }: {
-      dangerouslySkipPermissionFiltering?: boolean;
+      permissionFiltering?: SkillPermissionFilteringMode;
       // `baseFetch` returns active skills only unless a status is given.
       status?: SkillStatus | SkillStatus[];
       withTools?: boolean;
@@ -937,7 +1000,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         onlyCustom: true,
         withTools,
       },
-      { dangerouslySkipPermissionFiltering }
+      { permissionFiltering }
     );
   }
 
@@ -982,11 +1045,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchById(
     auth: Authenticator,
-    sId: string
+    sId: string,
+    {
+      permissionFiltering,
+    }: { permissionFiltering?: SkillPermissionFilteringMode } = {}
   ): Promise<SkillResource | null> {
-    const result = await this.fetchByIds(auth, [sId]);
+    const [skill] = await this.fetchByIds(auth, [sId], { permissionFiltering });
 
-    return result.at(0) ?? null;
+    return skill ?? null;
   }
 
   static async fetchByIds(
@@ -995,7 +1061,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       effectiveSpaceIds,
-      dangerouslySkipPermissionFiltering,
+      permissionFiltering,
       onlyActive = false,
       withInstructions = true,
       withTools = true,
@@ -1041,7 +1107,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         withTools,
         withFileAttachments,
       },
-      { agentLoopData, effectiveSpaceIds, dangerouslySkipPermissionFiltering }
+      { agentLoopData, effectiveSpaceIds, permissionFiltering }
     );
   }
 
@@ -1184,7 +1250,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       effectiveSpaceIds,
-      dangerouslySkipPermissionFiltering,
+      permissionFiltering,
       status,
       transaction,
       withInstructions,
@@ -1194,7 +1260,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
-      dangerouslySkipPermissionFiltering?: boolean;
+      permissionFiltering?: SkillPermissionFilteringMode;
       status?: SkillStatus | SkillStatus[];
       transaction?: Transaction;
       withInstructions?: boolean;
@@ -1222,7 +1288,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         agentLoopData,
         effectiveSpaceIds,
-        dangerouslySkipPermissionFiltering,
+        permissionFiltering,
         transaction,
       }
     );
@@ -1346,7 +1412,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       effectiveSpaceIds,
-      dangerouslySkipPermissionFiltering,
+      permissionFiltering,
     }: SkillFetchContext = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
@@ -1361,7 +1427,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.fetchBySkillReferences(auth, refs, {
       agentLoopData,
       effectiveSpaceIds,
-      dangerouslySkipPermissionFiltering,
+      permissionFiltering,
     });
   }
 
@@ -1507,6 +1573,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withInstructions = true,
       withTools = true,
       withFileAttachments = true,
+      permissionFiltering,
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
@@ -1518,21 +1585,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withInstructions?: boolean;
       withTools?: boolean;
       withFileAttachments?: boolean;
+      permissionFiltering?: SkillPermissionFilteringMode;
     } = {}
   ): Promise<SkillResource[]> {
-    const skills = await this.baseFetch(auth, {
-      where: {
-        status,
-        ...(availability !== undefined ? { availability } : {}),
-        ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
-        ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
+    const skills = await this.baseFetch(
+      auth,
+      {
+        where: {
+          status,
+          ...(availability !== undefined ? { availability } : {}),
+          ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
+          ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
+        },
+        ...(limit ? { limit } : {}),
+        onlyCustom,
+        withInstructions,
+        withTools,
+        withFileAttachments,
       },
-      ...(limit ? { limit } : {}),
-      onlyCustom,
-      withInstructions,
-      withTools,
-      withFileAttachments,
-    });
+      { permissionFiltering }
+    );
 
     if (globalSpaceOnly) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
@@ -2179,6 +2251,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canRead(auth: Authenticator): boolean {
+    if (this.redactedForCaller) {
+      return false;
+    }
+
     // See canWrite: API keys hold no skill grant, so any key reads any skill.
     if (auth.isKey()) {
       return true;
@@ -2191,6 +2267,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canWrite(auth: Authenticator): boolean {
+    if (this.redactedForCaller) {
+      return false;
+    }
+
     // TODO(governance): cleanup once we'll be able to grant API keys editorship on a skill.
     // TODO(@jd): Revisit this shortcircuit with our current ACLs stack.
     // API keys cannot hold a skill's `editor` grant (no such assignment mechanism exists),
@@ -2204,6 +2284,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canAdministrate(auth: Authenticator): boolean {
+    if (this.redactedForCaller) {
+      return false;
+    }
+
     // See canWrite: API keys have no editor-group assignment mechanism, so any key can
     // administrate any skill.
     if (auth.isKey()) {
@@ -2253,7 +2337,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   // skill the caller cannot read is never hydrated.
   private static canReadRow(
     auth: Authenticator,
-    skill: SkillConfigurationModel
+    skill: { id: ModelId; workspaceId: ModelId }
   ): boolean {
     // See canWrite: API keys hold no skill grant, so any key reads any skill.
     if (auth.isKey()) {
@@ -4459,7 +4543,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // the public v1 API only returns custom skills, so this only surfaces on the
     // single-skill detail fetch.
     const hideInstructions =
-      this.globalSId !== null && !this.exposeInstructions;
+      (this.globalSId !== null && !this.exposeInstructions) ||
+      this.redactedForCaller;
 
     return {
       id: this.id,
@@ -4484,7 +4569,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       selfImprovementCostsCapAwuCredits: this.selfImprovementCostsCapAwuCredits,
       source: this.source,
       sourceMetadata: this.sourceMetadata,
-      tools: this.mcpServerViews.map((view) => {
+      tools: (this.redactedForCaller ? [] : this.mcpServerViews).map((view) => {
         const serializedView = view.toJSON();
         const server = serializedView.server;
         return {
@@ -4501,10 +4586,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           },
         };
       }),
-      fileAttachments: this.fileAttachments.map((file) => ({
-        fileId: file.sId,
-        fileName: file.fileName,
-      })),
+      fileAttachments: (this.redactedForCaller ? [] : this.fileAttachments).map(
+        (file) => ({
+          fileId: file.sId,
+          fileName: file.fileName,
+        })
+      ),
+      canRead: this.canRead(auth),
       canWrite: this.canWrite(auth),
       canAdministrate: this.canAdministrate(auth),
       isDefault: isDefaultFromAvailability(this.availability),

--- a/front/migrations/20260828_backfill_skill_manually_requested_spaces.ts
+++ b/front/migrations/20260828_backfill_skill_manually_requested_spaces.ts
@@ -233,7 +233,7 @@ async function backfillWorkspaceSkills(
   // which no longer exists: `baseFetch` drops those, and they are precisely the rows whose stale
   // ids need dropping from the manual list rather than being copied into it.
   const skills = await SkillResource.fetchByModelIds(auth, skillModelIds, {
-    dangerouslySkipPermissionFiltering: true,
+    permissionFiltering: "dangerously_skip",
     // `fetchByModelIds` returns active skills only by default. An archived or suggested skill still
     // holds its requested spaces and can be restored and saved, so it needs the provenance too.
     status: ["active", "archived", "suggested"],

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -114,6 +114,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     })),
     fileAttachments: [],
     canWrite: false,
+    canRead: true,
     canAdministrate: false,
     isDefault: false,
     availability: "workspace_users",

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -90,6 +90,9 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
       fileName: z.string(),
     })
   ),
+  // False when the private fields (instructions, tools, files) were redacted: an admin listing a
+  // skill built on a space they are not a member of.
+  canRead: z.boolean(),
   canWrite: z.boolean(),
   canAdministrate: z.boolean(),
   // @deprecated Use availability instead. Kept while old clients still read it.


### PR DESCRIPTION
## Description

Groundwork for listing to admins the skills built on spaces they are not a member of (follow-up PR on top of this one: https://github.com/dust-tt/dust/pull/31830).

- The skill fetchers (`fetchById`, `fetchByIds`, `fetchByModelIds`, `listByWorkspace`, `listByAgentConfiguration`, ...) take a `permissionFiltering` mode instead of the `dangerouslySkipPermissionFiltering` flag:
  - `strict` (default): drop the skills the caller cannot read, as today.
  - `redact_unreadable`: keep them, redacted. The resource flags them, its permission methods answer false and `toJSON` drops instructions, tools and files. Admins only, the resource throws otherwise.
  - `dangerously_skip`: keep them as is, the former flag.
- `baseFetch` centralizes the readability check in `filterReadable` (row ACL plus requested spaces) and applies the mode there, so every fetcher behaves the same.
- New `canRead` field on the skill type and the public Swagger schema, false only for redacted skills.
- Existing callers of the flag switch to `dangerously_skip`. Nothing uses `redact_unreadable` yet.

## Tests

 - new resource tests

## Risk

Low

## Deploy Plan

- Deploy front
