### PR TITLE
Poke: introduce the fair-use credits column for premium message plans

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -859,7 +859,7 @@ function buildFairUseCreditsColumn(
       <div className="flex flex-col">
         <span className="flex items-center gap-1">
           <Icon visual={CoinsStacked03} size="xs" />
-          Credits
+          Fair Usage Credits
         </span>
         <span className="text-xs font-normal text-muted-foreground">
           Resets on a rolling {windowDays}-day basis
@@ -930,7 +930,7 @@ function buildFairUseCreditsColumn(
     // local-only, which would misbehave across pages, so it's disabled here.
     enableSorting: false,
     meta: {
-      className: "w-40",
+      className: "w-56",
     },
   };
 }

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -14,8 +14,14 @@ import {
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { PremiumModelMessageUsage } from "@app/lib/api/assistant/rate_limits";
-import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import { formatCredits } from "@app/lib/client/credits";
+import type {
+  MemberFairUseUsage,
+  MemberUsageType,
+} from "@app/lib/api/credits/members_usage";
+import {
+  formatCreditResetCountdown,
+  formatCredits,
+} from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import {
   getUserModelTierMenuItemsWithSelection,
@@ -117,6 +123,7 @@ type RowData = {
   onOpenChangeSeatRecap: () => void;
   onOpenSpendLimitRecap: () => void;
   premiumMessageUsage: PremiumModelMessageUsage | null;
+  fairUse: MemberFairUseUsage | null;
   modelTiersSummary: string;
   hasUserLevelModelTiersOverride: boolean;
   menuItems: MenuItem[];
@@ -843,6 +850,91 @@ function buildPremiumMessageUsageColumn(
   };
 }
 
+function buildFairUseCreditsColumn(
+  windowDays: number
+): ColumnDef<RowData, string> {
+  return {
+    id: "fairUse" as const,
+    header: () => (
+      <div className="flex flex-col">
+        <span className="flex items-center gap-1">
+          <Icon visual={CoinsStacked03} size="xs" />
+          Credits
+        </span>
+        <span className="text-xs font-normal text-muted-foreground">
+          Resets on a rolling {windowDays}-day basis
+        </span>
+      </div>
+    ),
+    accessorFn: (row) => (row.fairUse?.usedCredits ?? 0).toString(),
+    cell: (info: Info) => {
+      const fairUse = info.row.original.fairUse;
+      if (!fairUse) {
+        return (
+          <DataTable.CellContent className="justify-center">
+            <span className="text-sm text-muted-foreground">--</span>
+          </DataTable.CellContent>
+        );
+      }
+      const { usedCredits, limitCredits, nextResetAt } = fairUse;
+      const percentage =
+        limitCredits > 0
+          ? Math.min(100, (usedCredits / limitCredits) * 100)
+          : usedCredits > 0
+            ? 100
+            : 0;
+      const isAtLimit = limitCredits > 0 && usedCredits >= limitCredits;
+      const resetLabel = nextResetAt
+        ? formatCreditResetCountdown(nextResetAt)
+        : null;
+      const bar = (
+        <ProgressBar
+          aria-label="Fair-use credits usage"
+          aria-valuenow={percentage}
+          aria-valuetext={`${formatCredits(usedCredits)} of ${formatCredits(limitCredits)} credits used`}
+          className="h-1 w-full gap-px bg-transparent"
+          values={[
+            {
+              value: percentage,
+              className: isAtLimit
+                ? AT_POOL_LIMIT_BAR_CLASSES.fill
+                : MUTED_BAR_CLASSES.fill,
+            },
+            { value: 100 - percentage, className: MUTED_BAR_CLASSES.track },
+          ]}
+        />
+      );
+      return (
+        <div className="flex w-full flex-col gap-1 pr-3">
+          <div className="flex justify-between text-xs tabular-nums text-foreground">
+            <span>{formatCredits(usedCredits)}</span>
+            <span>{formatCredits(limitCredits)}</span>
+          </div>
+          {resetLabel ? (
+            <Tooltip
+              tooltipTriggerAsChild
+              trigger={
+                <div className="flex h-3 w-full cursor-help items-center">
+                  {bar}
+                </div>
+              }
+              label={resetLabel}
+            />
+          ) : (
+            <div className="flex h-3 w-full items-center">{bar}</div>
+          )}
+        </div>
+      );
+    },
+    // Not part of the backend `orderColumn` union yet: sorting stays
+    // local-only, which would misbehave across pages, so it's disabled here.
+    enableSorting: false,
+    meta: {
+      className: "w-40",
+    },
+  };
+}
+
 const offPaceColumn: ColumnDef<RowData, string> = {
   id: "overallUsageTarget" as const,
   header: "",
@@ -1009,12 +1101,14 @@ function buildCreditPlanColumns({
   hasPool,
   showPremiumMessageUsage,
   premiumMessageWindowDays,
+  fairUseWindowDays,
 }: {
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
   hasPool: boolean;
   showPremiumMessageUsage: boolean;
   premiumMessageWindowDays: number;
+  fairUseWindowDays: number | null;
 }): ColumnDef<RowData, string>[] {
   return [
     // Premium message plans have no seats: every member is billed per
@@ -1038,6 +1132,11 @@ function buildCreditPlanColumns({
         : buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool)),
       meta: { className: "w-56" },
     },
+    // Premium message plans also carry a fixed AWU credit allowance for
+    // usage on non-premium models, alongside the rolling message limit.
+    ...(showPremiumMessageUsage && fairUseWindowDays !== null
+      ? [buildFairUseCreditsColumn(fairUseWindowDays)]
+      : []),
     ...(variant === "compact" && !showPremiumMessageUsage
       ? [offPaceColumn]
       : []),
@@ -1054,6 +1153,7 @@ function buildColumns({
   hasPool,
   showPremiumMessageUsage,
   premiumMessageWindowDays,
+  fairUseWindowDays,
 }: {
   enableSelection: boolean;
   showGroupsColumn: boolean;
@@ -1064,6 +1164,7 @@ function buildColumns({
   hasPool: boolean;
   showPremiumMessageUsage: boolean;
   premiumMessageWindowDays: number;
+  fairUseWindowDays: number | null;
 }): ColumnDef<RowData, string>[] {
   return [
     ...(enableSelection ? [createSelectionColumn<RowData>()] : []),
@@ -1077,6 +1178,7 @@ function buildColumns({
           hasPool,
           showPremiumMessageUsage,
           premiumMessageWindowDays,
+          fairUseWindowDays,
         })
       : []),
     // Every row action belongs to one of these two groups.
@@ -1236,6 +1338,7 @@ export function MembersUsageTable({
           onOpenChangeSeatRecap: () => onOpenChangeSeatRecap(m),
           onOpenSpendLimitRecap: () => onOpenSpendLimitRecap(m),
           premiumMessageUsage: m.premiumMessageUsage ?? null,
+          fairUse: m.fairUse ?? null,
           modelTiersSummary: (() => {
             const maxTierName = getMaxTierName(resolvedModelTiers?.tiers ?? []);
             switch (variant) {
@@ -1350,11 +1453,13 @@ export function MembersUsageTable({
     ]
   );
 
-  // All members share the same rolling-window configuration, so the first
-  // loaded usage payload's `windowDays` is representative of the whole table.
+  // All members share the same rolling-window/plan configuration, so the
+  // first loaded usage payload is representative of the whole table.
   const premiumMessageWindowDays =
     members.find((m) => m.premiumMessageUsage)?.premiumMessageUsage
       ?.windowDays ?? DEFAULT_PREMIUM_MESSAGE_WINDOW_DAYS;
+  const fairUseWindowDays =
+    members.find((m) => m.fairUse)?.fairUse?.windowDays ?? null;
 
   const columns = useMemo(
     () =>
@@ -1368,6 +1473,7 @@ export function MembersUsageTable({
         hasPool,
         showPremiumMessageUsage,
         premiumMessageWindowDays,
+        fairUseWindowDays,
       }),
     [
       enableSelection,
@@ -1379,6 +1485,7 @@ export function MembersUsageTable({
       hasPool,
       premiumMessageWindowDays,
       showPremiumMessageUsage,
+      fairUseWindowDays,
     ]
   );
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -21,6 +21,7 @@ import type {
 import {
   formatCreditResetCountdown,
   formatCredits,
+  formatCreditValue,
 } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import {
@@ -891,8 +892,8 @@ function buildFairUseCreditsColumn(
         <ProgressBar
           aria-label="Fair-use credits usage"
           aria-valuenow={percentage}
-          aria-valuetext={`${formatCredits(usedCredits)} of ${formatCredits(limitCredits)} credits used`}
-          className="h-1 w-full gap-px bg-transparent"
+          aria-valuetext={`${formatCredits(usedCredits)} of ${formatCreditValue(limitCredits)} used`}
+          className="w-full bg-transparent"
           values={[
             {
               value: percentage,
@@ -905,7 +906,7 @@ function buildFairUseCreditsColumn(
         />
       );
       return (
-        <div className="flex w-full flex-col gap-1 pr-3">
+        <div className="flex w-full flex-col gap-1">
           <div className="flex justify-between text-xs tabular-nums text-foreground">
             <span>{formatCredits(usedCredits)}</span>
             <span>{formatCredits(limitCredits)}</span>

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -193,9 +193,6 @@ export type MemberFairUseUsage = {
   usedCredits: number;
   limitCredits: number;
   timeframe: MaxAwuCreditsTimeframeType;
-  // Same rolling-window mechanism as premium messages: each credit-consuming
-  // event frees up its slot `windowDays` after it was recorded, not all at
-  // once. Derived from `timeframe`, in days, for display.
   windowDays: number;
   nextResetAt: string | null;
 };

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -93,6 +93,7 @@ import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
@@ -2382,7 +2383,7 @@ export async function getMembersUsage({
               timeframe: status.timeframe,
               windowDays:
                 getTimeframeSecondsFromLiteral(status.timeframe) /
-                (24 * 60 * 60),
+                (ONE_DAY_MS / 1000),
               nextResetAt: status.nextResetAt ?? null,
             }
       );

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -66,6 +66,7 @@ import {
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   getFixedWindowCount,
+  getTimeframeSecondsFromLiteral,
   setFixedWindowCount,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
@@ -192,6 +193,11 @@ export type MemberFairUseUsage = {
   usedCredits: number;
   limitCredits: number;
   timeframe: MaxAwuCreditsTimeframeType;
+  // Same rolling-window mechanism as premium messages: each credit-consuming
+  // event frees up its slot `windowDays` after it was recorded, not all at
+  // once. Derived from `timeframe`, in days, for display.
+  windowDays: number;
+  nextResetAt: string | null;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -2377,6 +2383,10 @@ export async function getMembersUsage({
               usedCredits: status.count,
               limitCredits: status.limit,
               timeframe: status.timeframe,
+              windowDays:
+                getTimeframeSecondsFromLiteral(status.timeframe) /
+                (24 * 60 * 60),
+              nextResetAt: status.nextResetAt ?? null,
             }
       );
     }


### PR DESCRIPTION
## Description

Premium message plan members also carry a fixed AWU credit allowance (separate from the rolling premium-message limit) for usage on non-premium models, fetched the same way as the personal analytics cards fair-use credits block. Surfaces it as its own column, with a progress bar and per-row reset countdown on hover. Sorting comes in the next PR in this stack. Stacked on #31866.

## Tests

Tested on front-edge

## Risk

- Poke only for now

## Deploy Plan

- Deploy front

