### PR TITLE
Add customer-facing AWU pool current-cycle / cycle-history app routes

### DIFF
--- a/front-api/lib/api/awu_pool_summary_errors.ts
+++ b/front-api/lib/api/awu_pool_summary_errors.ts
@@ -1,0 +1,38 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+export function awuPoolSummaryErrorToApi(
+  ctx: Context,
+  err: AwuPoolSummaryError
+) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}

--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,43 +1,9 @@
-import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { awuPoolSummaryErrorToApi } from "@front-api/lib/api/awu_pool_summary_errors";
 import { pokeApp } from "@front-api/middlewares/ctx";
-import { apiError } from "@front-api/middlewares/utils";
-import type { Context } from "hono";
 
 export type { AwuPoolCurrentCycleResponseBody };
-
-function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
-  switch (err.type) {
-    case "not_configured":
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
-      });
-    case "balances_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
-        },
-      });
-    case "invoices_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
-        },
-      });
-    default:
-      assertNever(err.type);
-  }
-}
 
 // Mounted at /api/poke/workspaces/:wId/credits/awu-pool-current-cycle.
 const app = pokeApp();
@@ -48,7 +14,7 @@ app.get("/", async (ctx) => {
 
   const result = await getAwuPoolCurrentCycle(auth);
   if (result.isErr()) {
-    return currentCycleErrorToApi(ctx, result.error);
+    return awuPoolSummaryErrorToApi(ctx, result.error);
   }
 
   return ctx.json(result.value);

--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,47 +1,13 @@
-import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import {
   AwuPoolSummaryQuerySchema,
   getAwuPoolCycleHistory,
 } from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { awuPoolSummaryErrorToApi } from "@front-api/lib/api/awu_pool_summary_errors";
 import { pokeApp } from "@front-api/middlewares/ctx";
-import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import type { Context } from "hono";
 
 export type { AwuPoolCycleHistoryResponseBody };
-
-function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
-  switch (err.type) {
-    case "not_configured":
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
-      });
-    case "balances_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
-        },
-      });
-    case "invoices_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
-        },
-      });
-    default:
-      assertNever(err.type);
-  }
-}
 
 // Mounted at /api/poke/workspaces/:wId/credits/awu-pool-cycle-history.
 const app = pokeApp();
@@ -53,7 +19,7 @@ app.get("/", validate("query", AwuPoolSummaryQuerySchema), async (ctx) => {
 
   const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
   if (result.isErr()) {
-    return cycleHistoryErrorToApi(ctx, result.error);
+    return awuPoolSummaryErrorToApi(ctx, result.error);
   }
 
   return ctx.json(result.value);

--- a/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.test.ts
@@ -1,0 +1,82 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeBalances: vi.fn(),
+    listMetronomeDraftInvoices: vi.fn(),
+    listMetronomeFinalizedInvoices: vi.fn(),
+  };
+});
+
+function awuPoolCurrentCycleUrl(wId: string) {
+  return `/api/w/${wId}/credits/awu-pool-current-cycle`;
+}
+
+const EMPTY_CURRENT_CYCLE = {
+  totalRemainingCredits: 0,
+  totalActiveCredits: 0,
+  overageCredits: null,
+  overageAmountCents: null,
+  overageCurrency: null,
+  currentCycleStartMs: null,
+  currentCycleEndMs: null,
+  currentCycleConsumedCredits: null,
+  excessConsumedCredits: null,
+  programmaticConsumedCredits: null,
+  otherConsumedCredits: null,
+};
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeDraftInvoices).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/credits/awu-pool-current-cycle", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      awuPoolCurrentCycleUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(metronomeClient.listMetronomeBalances).not.toHaveBeenCalled();
+  });
+
+  it("allows a manager to read the AWU pool current cycle", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "manager",
+      workspace,
+    });
+
+    const response = await honoApp.request(
+      awuPoolCurrentCycleUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(EMPTY_CURRENT_CYCLE);
+    expect(metronomeClient.listMetronomeBalances).toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,0 +1,61 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/awu-pool-current-cycle.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  async (ctx): HandlerResult<AwuPoolCurrentCycleResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await getAwuPoolCurrentCycle(auth);
+    if (result.isErr()) {
+      return currentCycleErrorToApi(ctx, result.error);
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-current-cycle.ts
@@ -1,43 +1,9 @@
-import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import { getAwuPoolCurrentCycle } from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolCurrentCycleResponseBody } from "@app/types/api/credits/awu_pool_summary";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { awuPoolSummaryErrorToApi } from "@front-api/lib/api/awu_pool_summary_errors";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { apiError } from "@front-api/middlewares/utils";
-import type { Context } from "hono";
-
-function currentCycleErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
-  switch (err.type) {
-    case "not_configured":
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
-      });
-    case "balances_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
-        },
-      });
-    case "invoices_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
-        },
-      });
-    default:
-      assertNever(err.type);
-  }
-}
 
 // Mounted at /api/w/:wId/credits/awu-pool-current-cycle.
 const app = workspaceApp();
@@ -51,7 +17,7 @@ app.get(
 
     const result = await getAwuPoolCurrentCycle(auth);
     if (result.isErr()) {
-      return currentCycleErrorToApi(ctx, result.error);
+      return awuPoolSummaryErrorToApi(ctx, result.error);
     }
 
     return ctx.json(result.value);

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -1,0 +1,73 @@
+import * as metronomeClient from "@app/lib/metronome/client";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<typeof metronomeClient>(
+    "@app/lib/metronome/client"
+  );
+  return {
+    ...actual,
+    listMetronomeBalances: vi.fn(),
+    listMetronomeDraftInvoices: vi.fn(),
+    listMetronomeFinalizedInvoices: vi.fn(),
+  };
+});
+
+function awuPoolCycleHistoryUrl(wId: string) {
+  return `/api/w/${wId}/credits/awu-pool-cycle-history`;
+}
+
+beforeEach(() => {
+  vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeDraftInvoices).mockResolvedValue(
+    new Ok([])
+  );
+  vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+    new Ok([])
+  );
+});
+
+describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
+  it("returns 403 when the caller is a user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      awuPoolCycleHistoryUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+    expect(
+      metronomeClient.listMetronomeFinalizedInvoices
+    ).not.toHaveBeenCalled();
+  });
+
+  it("allows a manager to read the AWU pool cycle history", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "manager",
+      workspace,
+    });
+
+    const response = await honoApp.request(
+      awuPoolCycleHistoryUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      cycleBreakdown: [],
+      excessCycleBreakdown: [],
+    });
+    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,0 +1,67 @@
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
+import {
+  AwuPoolSummaryQuerySchema,
+  getAwuPoolCycleHistory,
+} from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { Context } from "hono";
+
+function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/awu-pool-cycle-history.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  validate("query", AwuPoolSummaryQuerySchema),
+  async (ctx): HandlerResult<AwuPoolCycleHistoryResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cycleHistoryLimit } = ctx.req.valid("query");
+
+    const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
+    if (result.isErr()) {
+      return cycleHistoryErrorToApi(ctx, result.error);
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.ts
@@ -1,47 +1,13 @@
-import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import {
   AwuPoolSummaryQuerySchema,
   getAwuPoolCycleHistory,
 } from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolCycleHistoryResponseBody } from "@app/types/api/credits/awu_pool_summary";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { awuPoolSummaryErrorToApi } from "@front-api/lib/api/awu_pool_summary_errors";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import type { Context } from "hono";
-
-function cycleHistoryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
-  switch (err.type) {
-    case "not_configured":
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
-      });
-    case "balances_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
-        },
-      });
-    case "invoices_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
-        },
-      });
-    default:
-      assertNever(err.type);
-  }
-}
 
 // Mounted at /api/w/:wId/credits/awu-pool-cycle-history.
 const app = workspaceApp();
@@ -57,7 +23,7 @@ app.get(
 
     const result = await getAwuPoolCycleHistory(auth, { cycleHistoryLimit });
     if (result.isErr()) {
-      return cycleHistoryErrorToApi(ctx, result.error);
+      return awuPoolSummaryErrorToApi(ctx, result.error);
     }
 
     return ctx.json(result.value);

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,47 +1,13 @@
-import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import {
   AwuPoolSummaryQuerySchema,
   getAwuPoolSummary,
 } from "@app/lib/api/credits/awu_pool_summary";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { awuPoolSummaryErrorToApi } from "@front-api/lib/api/awu_pool_summary_errors";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import type { Context } from "hono";
-
-function summaryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
-  switch (err.type) {
-    case "not_configured":
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
-      });
-    case "balances_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
-        },
-      });
-    case "invoices_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
-        },
-      });
-    default:
-      assertNever(err.type);
-  }
-}
 
 // Mounted at /api/w/:wId/credits/awu-pool-summary.
 const app = workspaceApp();
@@ -57,7 +23,7 @@ app.get(
 
     const result = await getAwuPoolSummary(auth, { cycleHistoryLimit });
     if (result.isErr()) {
-      return summaryErrorToApi(ctx, result.error);
+      return awuPoolSummaryErrorToApi(ctx, result.error);
     }
     return ctx.json(result.value);
   }

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -10,6 +10,8 @@ import type {
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 
+import awuPoolCurrentCycle from "./awu-pool-current-cycle";
+import awuPoolCycleHistory from "./awu-pool-cycle-history";
 import awuPoolSummary from "./awu-pool-summary";
 import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
@@ -25,6 +27,8 @@ import usageConfiguration from "./usage-configuration";
 const app = workspaceApp();
 
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/awu-pool-current-cycle", awuPoolCurrentCycle);
+app.route("/awu-pool-cycle-history", awuPoolCycleHistory);
 app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/my-top-conversations", myTopConversations);

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -5,7 +5,11 @@ import type { GetAwuPurchaseInfoResponseBody } from "@app/lib/credits/awu_purcha
 import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type {
+  AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleHistoryResponseBody,
+  AwuPoolSummaryResponseBody,
+} from "@app/types/api/credits/awu_pool_summary";
 import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import type { GetMyTopConversationsResponseBody } from "@app/types/api/credits/my_top_conversations";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
@@ -258,6 +262,57 @@ export function useAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function useAwuPoolCurrentCycle({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuFetcher: Fetcher<AwuPoolCurrentCycleResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/awu-pool-current-cycle`,
+    awuFetcher,
+    { disabled }
+  );
+
+  return {
+    awuPoolCurrentCycle: data ?? null,
+    isAwuPoolCurrentCycleLoading: !error && !data && !disabled,
+    isAwuPoolCurrentCycleError: error,
+    isAwuPoolCurrentCycleValidating: isValidating,
+    mutateAwuPoolCurrentCycle: mutate,
+  };
+}
+
+export function useAwuPoolCycleHistory({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuFetcher: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/awu-pool-cycle-history`,
+    awuFetcher,
+    { disabled }
+  );
+
+  return {
+    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
+    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
+    isAwuPoolCycleHistoryError: error,
+    isAwuPoolCycleHistoryValidating: isValidating,
+    mutateAwuPoolCycleHistory: mutate,
   };
 }
 


### PR DESCRIPTION
## Description

Registers the awu-pool-current-cycle and awu-pool-cycle-history endpoints under the customer-facing /api/w/:wId/credits app routes, alongside SWR hooks to consume them from the front.

This is preliminary work toward exposing the new usage page already available in poke to front.

## Tests


## Risk

- Low not consumed anywhere yet mirror existing behavior powering poke

## Deploy Plan

- Deploy front
