### PR TITLE
Add enable_new_usage_page flag and gate the usage page revamp behind it

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -222,7 +222,7 @@ export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
-  const isCompactUsagePage = hasFeature("enable_new_usage_page");
+  const isNewUsagePage = hasFeature("enable_new_usage_page");
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
   // Workspaces off a credit plan see this page without the credit pool, seat
   // and credits columns, spend limits and upgrade requests. Credit actions (top
@@ -1050,7 +1050,7 @@ export function UsagePage() {
       enableSelection={isCreditPriced}
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}
-      variant={isCompactUsagePage ? "compact" : undefined}
+      variant={isNewUsagePage ? "compact" : undefined}
       hasPool={hasPool}
     />
   );
@@ -1114,7 +1114,7 @@ export function UsagePage() {
           ) : (
             <div className="flex items-center justify-between">
               <Page.Header title="Usage" />
-              {!isCompactUsagePage &&
+              {!isNewUsagePage &&
                 isCreditPriced &&
                 usageSettings.topUpEnabled &&
                 isWorkspaceAdmin && (
@@ -1251,7 +1251,7 @@ export function UsagePage() {
             </Page.Vertical>
           ) : null}
 
-          {isCompactUsagePage && isCreditPriced ? (
+          {isNewUsagePage && isCreditPriced ? (
             <div className="flex flex-col items-stretch gap-4">
               <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
               {usageSettings.topUpEnabled && (
@@ -1260,7 +1260,7 @@ export function UsagePage() {
             </div>
           ) : null}
 
-          {!isCompactUsagePage &&
+          {!isNewUsagePage &&
           isCreditPriced &&
           !showConsumptionAnalytics &&
           !isAwuPoolSummaryLoading &&

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -817,10 +817,11 @@ export function UsagePage() {
   const canUpgradeSeat = useCallback(
     (member: MemberUsageType) =>
       isSeatBased &&
+      !isSubscriptionCancelled &&
       !!member.seatType &&
       member.seatType !== "none" &&
       toBaseSeatType(member.seatType) !== "workspace",
-    [isSeatBased]
+    [isSeatBased, isSubscriptionCancelled]
   );
 
   // Seat-type filter options derived from the seats available to this
@@ -1050,6 +1051,7 @@ export function UsagePage() {
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}
       variant={isCompactUsagePage ? "compact" : undefined}
+      hasPool={hasPool}
     />
   );
 
@@ -1255,7 +1257,9 @@ export function UsagePage() {
                 owner={owner}
                 disabled={!isCreditPriced}
               />
-              <div className="flex justify-end">{topUpButton}</div>
+              {usageSettings.topUpEnabled && (
+                <div className="flex justify-end">{topUpButton}</div>
+              )}
             </div>
           ) : null}
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -26,7 +26,7 @@ import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTie
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
-import { CompactCreditPoolCards } from "@app/components/workspace/WorkspaceCreditPoolCards";
+import { CreditPoolCards } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useTableRowsSelection } from "@app/hooks/useTableRowsSelection";
 import {
@@ -1253,10 +1253,7 @@ export function UsagePage() {
 
           {isCompactUsagePage && isCreditPriced ? (
             <div className="flex flex-col items-stretch gap-4">
-              <CompactCreditPoolCards
-                owner={owner}
-                disabled={!isCreditPriced}
-              />
+              <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
               {usageSettings.topUpEnabled && (
                 <div className="flex justify-end">{topUpButton}</div>
               )}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -15,6 +15,7 @@ import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
+import { MemberSpendLimitModal } from "@app/components/workspace/MemberSpendLimitModal";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
@@ -25,6 +26,7 @@ import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTie
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
+import { CompactCreditPoolCards } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useTableRowsSelection } from "@app/hooks/useTableRowsSelection";
 import {
@@ -33,7 +35,11 @@ import {
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import { INHERIT_MODEL_TIER } from "@app/lib/client/model_tier_options";
@@ -215,6 +221,8 @@ const DEFAULT_PAGE_SIZE = 25;
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const isCompactUsagePage = hasFeature("enable_new_usage_page");
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
   // Workspaces off a credit plan see this page without the credit pool, seat
   // and credits columns, spend limits and upgrade requests. Credit actions (top
@@ -308,6 +316,8 @@ export function UsagePage() {
     []
   );
   const [editSpendLimitMember, setEditSpendLimitMember] =
+    useState<MemberUsageType | null>(null);
+  const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
   const [
     totalAllowedUsagePendingMemberIds,
@@ -804,6 +814,15 @@ export function UsagePage() {
 
   const isSeatBased = Object.keys(seatPlans).length > 1;
 
+  const canUpgradeSeat = useCallback(
+    (member: MemberUsageType) =>
+      isSeatBased &&
+      !!member.seatType &&
+      member.seatType !== "none" &&
+      toBaseSeatType(member.seatType) !== "workspace",
+    [isSeatBased]
+  );
+
   // Seat-type filter options derived from the seats available to this
   // workspace, collapsed to base tiers (monthly/yearly share one entry) and
   // ordered by tier.
@@ -1017,6 +1036,9 @@ export function UsagePage() {
       onChangeSeat={handleChangeSeatFromTable}
       onRemoveSeat={onRemoveSeat}
       onEditSpendLimit={handleEditSpendLimitFromTable}
+      onOpenChangeSeatRecap={handleChangeSeatFromTable}
+      onOpenSpendLimitRecap={setSpendLimitRecapMember}
+      canUpgradeSeat={canUpgradeSeat}
       onSetUserModelTier={handleSetUserModelTier}
       pagination={pagination}
       setPagination={setPagination}
@@ -1027,6 +1049,7 @@ export function UsagePage() {
       enableSelection={isCreditPriced}
       rowSelection={selection.rowSelection}
       onRowSelectionChange={selection.onRowSelectionChange}
+      variant={isCompactUsagePage ? "compact" : undefined}
     />
   );
 
@@ -1089,7 +1112,8 @@ export function UsagePage() {
           ) : (
             <div className="flex items-center justify-between">
               <Page.Header title="Usage" />
-              {isCreditPriced &&
+              {!isCompactUsagePage &&
+                isCreditPriced &&
                 usageSettings.topUpEnabled &&
                 isWorkspaceAdmin && (
                   <Button
@@ -1225,7 +1249,18 @@ export function UsagePage() {
             </Page.Vertical>
           ) : null}
 
-          {isCreditPriced &&
+          {isCompactUsagePage && isCreditPriced ? (
+            <div className="flex flex-col items-stretch gap-4">
+              <CompactCreditPoolCards
+                owner={owner}
+                disabled={!isCreditPriced}
+              />
+              <div className="flex justify-end">{topUpButton}</div>
+            </div>
+          ) : null}
+
+          {!isCompactUsagePage &&
+          isCreditPriced &&
           !showConsumptionAnalytics &&
           !isAwuPoolSummaryLoading &&
           (isAwuPoolSummaryError || hasPool) ? (
@@ -1441,6 +1476,15 @@ export function UsagePage() {
           owner={owner}
           onSavingChange={handleUsagePendingChange}
           onSaved={handleApproveOnModalSaved}
+        />
+
+        <MemberSpendLimitModal
+          isOpen={spendLimitRecapMember !== null}
+          onClose={() => setSpendLimitRecapMember(null)}
+          member={spendLimitRecapMember}
+          owner={owner}
+          groups={groups}
+          onSavingChange={handleUsagePendingChange}
         />
 
         <BulkEditSpendLimitModal

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -12,10 +12,10 @@ import {
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
+import { EditMemberSpendLimitModal } from "@app/components/workspace/EditMemberSpendLimitModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
-import { MemberSpendLimitModal } from "@app/components/workspace/MemberSpendLimitModal";
 import { MembersSelectionBanner } from "@app/components/workspace/MembersSelectionBanner";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
@@ -1482,13 +1482,13 @@ export function UsagePage() {
           onSaved={handleApproveOnModalSaved}
         />
 
-        <MemberSpendLimitModal
+        <EditMemberSpendLimitModal
           isOpen={spendLimitRecapMember !== null}
           onClose={() => setSpendLimitRecapMember(null)}
           member={spendLimitRecapMember}
           owner={owner}
           groups={groups}
-          onSavingChange={handleUsagePendingChange}
+          readOnly
         />
 
         <BulkEditSpendLimitModal

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -334,18 +334,11 @@ export function CreditPoolCardsFromCycleData({
   );
 }
 
-interface CompactCreditPoolCardsProps {
+interface CreditPoolCardsProps {
   owner: LightWorkspaceType;
   disabled: boolean;
 }
-
-// Credit consumption cards for the compact usage page, mirroring Poke's
-// read-only pool view (front/components/poke/pages/PoolUsagePage.tsx) but
-// backed by the customer-facing awu-pool-current-cycle/cycle-history routes.
-export function CompactCreditPoolCards({
-  owner,
-  disabled,
-}: CompactCreditPoolCardsProps) {
+export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -2,11 +2,16 @@ import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
 import { formatCredits } from "@app/lib/client/credits";
+import {
+  useAwuPoolCurrentCycle,
+  useAwuPoolCycleHistory,
+} from "@app/lib/swr/credits";
 import type {
   AwuPoolCurrentCycleResponseBody,
   AwuPoolCycleBreakdown,
 } from "@app/types/api/credits/awu_pool_summary";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
   ContentMessage,
@@ -325,6 +330,47 @@ export function CreditPoolCardsFromCycleData({
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
       otherConsumedCredits={otherConsumedCredits}
+    />
+  );
+}
+
+interface CompactCreditPoolCardsProps {
+  owner: LightWorkspaceType;
+  disabled: boolean;
+}
+
+// Credit consumption cards for the compact usage page, mirroring Poke's
+// read-only pool view (front/components/poke/pages/PoolUsagePage.tsx) but
+// backed by the customer-facing awu-pool-current-cycle/cycle-history routes.
+export function CompactCreditPoolCards({
+  owner,
+  disabled,
+}: CompactCreditPoolCardsProps) {
+  const {
+    awuPoolCurrentCycle,
+    isAwuPoolCurrentCycleLoading,
+    isAwuPoolCurrentCycleError,
+  } = useAwuPoolCurrentCycle({ workspaceId: owner.sId, disabled });
+  const {
+    cycleBreakdown: poolCycleBreakdown,
+    excessCycleBreakdown,
+    isAwuPoolCycleHistoryLoading,
+    isAwuPoolCycleHistoryError,
+  } = useAwuPoolCycleHistory({ workspaceId: owner.sId, disabled });
+
+  return (
+    <CreditPoolCardsFromCycleData
+      awuPoolCurrentCycle={awuPoolCurrentCycle}
+      cardsStatus={toCreditPoolFetchStatus(
+        isAwuPoolCurrentCycleLoading,
+        !!isAwuPoolCurrentCycleError
+      )}
+      poolCycleBreakdown={poolCycleBreakdown}
+      excessCycleBreakdown={excessCycleBreakdown}
+      tableStatus={toCreditPoolFetchStatus(
+        isAwuPoolCycleHistoryLoading,
+        !!isAwuPoolCycleHistoryError
+      )}
     />
   );
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -441,6 +441,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "ask_owner",
     owner: "sylvain",
   },
+  enable_new_usage_page: {
+    description:
+      "Show the compact credit-pool usage page (credit pool cards + compact members table) on the front usage page instead of the legacy usage page.",
+    stage: "dust_only",
+    owner: "avervaet",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "ask_owner" | "self_serve";

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -443,8 +443,8 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   enable_new_usage_page: {
     description:
-      "Show the compact credit-pool usage page (credit pool cards + compact members table) on the front usage page instead of the legacy usage page.",
-    stage: "dust_only",
+      "Show the new credit-pool usage page (credit pool cards + compact members table) on the front usage page instead of the legacy usage page.",
+    stage: "ask_owner",
     owner: "avervaet",
   },
 } as const satisfies Record<string, FeatureFlag>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -767,6 +767,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_internal_dangerous_in_cluster_mcp_servers"
   | "dust_internal_global_agents"
   | "dust_pod_goal"
+  | "enable_new_usage_page"
   | "fireworks_new_model_feature"
   | "frames_v2"
   | "google_sheets_tool"


### PR DESCRIPTION
## Description

Introduces the enable_new_usage_page feature flag and, when enabled, swaps the front usage page to display the revamped one.


## Tests

- tested locally

## Risk

- Low flag gated

## Deploy Plan

- Deploy front
