### PR TITLE
webhook-router: forward to cell-00002

### DIFF
--- a/firebase-functions/webhook-router/README.md
+++ b/firebase-functions/webhook-router/README.md
@@ -37,6 +37,7 @@ verification.
    - `GCP_GLOBAL_PROJECT_ID`
    - `GCP_US_PROJECT_ID`
    - `GCP_EU_PROJECT_ID`
+   - `GCP_CELL_00002_PROJECT_ID`
    - `GCP_WEBHOOK_ROUTER_CONFIG_BUCKET`
 
 ### Project Configuration
@@ -82,6 +83,7 @@ NOTION_SIGNING_SECRET="your-notion-signing-secret"
 OAUTH_SHOPIFY_CLIENT_SECRET="your-shopify-client-secret"
 US_CONNECTOR_URL=http://localhost:3002
 EU_CONNECTOR_URL=http://localhost:3002
+CELL_00002_CONNECTOR_URL=http://localhost:3002
 ```
 
 Note: `GCP_WEBHOOK_ROUTER_CONFIG_BUCKET` must be set to `dust-infra.firebasestorage.app` for the config sync function to work properly with the emulator.

--- a/firebase-functions/webhook-router/deploy.sh
+++ b/firebase-functions/webhook-router/deploy.sh
@@ -3,9 +3,9 @@
 set -e
 
 # Check required environment variables.
-if [[ -z "$GCP_US_PROJECT_ID" || -z "$GCP_EU_PROJECT_ID" || -z "$GCP_GLOBAL_PROJECT_ID" ]]; then
+if [[ -z "$GCP_US_PROJECT_ID" || -z "$GCP_EU_PROJECT_ID" || -z "$GCP_CELL_00002_PROJECT_ID" || -z "$GCP_GLOBAL_PROJECT_ID" ]]; then
   echo "❌ Error: Missing required environment variables"
-  echo "   Please set: GCP_US_PROJECT_ID, GCP_EU_PROJECT_ID, and GCP_GLOBAL_PROJECT_ID"
+  echo "   Please set: GCP_US_PROJECT_ID, GCP_EU_PROJECT_ID, GCP_CELL_00002_PROJECT_ID, and GCP_GLOBAL_PROJECT_ID"
   exit 1
 fi
 
@@ -13,12 +13,14 @@ echo "🔧 Project Configuration:"
 echo "  Global Project: $GCP_GLOBAL_PROJECT_ID (webhook secrets)"
 echo "  US Project: $GCP_US_PROJECT_ID (connector secrets)"
 echo "  EU Project: $GCP_EU_PROJECT_ID (connector secrets)"
+echo "  cell-00002 Project: $GCP_CELL_00002_PROJECT_ID (connector secrets)"
 
 echo "🔧 Creating .env file for Firebase deployment..."
 cat > .env << EOF
 GCP_GLOBAL_PROJECT_ID=$GCP_GLOBAL_PROJECT_ID
 GCP_US_PROJECT_ID=$GCP_US_PROJECT_ID
 GCP_EU_PROJECT_ID=$GCP_EU_PROJECT_ID
+GCP_CELL_00002_PROJECT_ID=$GCP_CELL_00002_PROJECT_ID
 SERVICE_ACCOUNT=webhook-router-sa@$GCP_GLOBAL_PROJECT_ID.iam.gserviceaccount.com
 GCP_WEBHOOK_ROUTER_CONFIG_BUCKET=bkt-$GCP_GLOBAL_PROJECT_ID-webhook-router-config
 EOF

--- a/firebase-functions/webhook-router/src/config.ts
+++ b/firebase-functions/webhook-router/src/config.ts
@@ -4,6 +4,7 @@ import { defineString } from "firebase-functions/params";
 const gcpGlobalProjectId = defineString("GCP_GLOBAL_PROJECT_ID");
 const gcpUsProjectId = defineString("GCP_US_PROJECT_ID");
 const gcpEuProjectId = defineString("GCP_EU_PROJECT_ID");
+const gcpCell00002ProjectId = defineString("GCP_CELL_00002_PROJECT_ID");
 
 export const CONFIG = {
   FETCH_TIMEOUT_MS: 20_000,
@@ -28,6 +29,9 @@ export const CONFIG = {
     process.env.US_CONNECTOR_URL ?? "https://connectors.dust.tt",
   EU_CONNECTOR_URL:
     process.env.EU_CONNECTOR_URL ?? "https://eu.connectors.dust.tt",
+  CELL_00002_CONNECTOR_URL:
+    process.env.CELL_00002_CONNECTOR_URL ??
+    "https://cell-00002.cells.dust.tt/connectors",
 
   // Secret names.
   SECRET_NAME: "connectors-DUST_CONNECTORS_WEBHOOKS_SECRET",
@@ -52,4 +56,5 @@ export const getProjectIds = () => ({
   GCP_GLOBAL_PROJECT_ID: gcpGlobalProjectId.value(),
   GCP_US_PROJECT_ID: gcpUsProjectId.value(),
   GCP_EU_PROJECT_ID: gcpEuProjectId.value(),
+  GCP_CELL_00002_PROJECT_ID: gcpCell00002ProjectId.value(),
 });

--- a/firebase-functions/webhook-router/src/forwarder.ts
+++ b/firebase-functions/webhook-router/src/forwarder.ts
@@ -38,6 +38,11 @@ export class WebhookForwarder {
         url: CONFIG.EU_CONNECTOR_URL,
         secret: this.secrets.euSecret,
       },
+      {
+        cell: "cell-00002",
+        url: CONFIG.CELL_00002_CONNECTOR_URL,
+        secret: this.secrets.cell00002Secret,
+      },
     ];
 
     const requests = targets

--- a/firebase-functions/webhook-router/src/secrets.ts
+++ b/firebase-functions/webhook-router/src/secrets.ts
@@ -4,6 +4,7 @@ import { error, log } from "firebase-functions/logger";
 import { CONFIG, getProjectIds } from "./config.js";
 
 export interface Secrets {
+  cell00002Secret: string;
   euSecret: string;
   slackSigningSecret: string;
   usSecret: string;
@@ -44,6 +45,7 @@ export class SecretManager {
         source: "environment",
       });
       return {
+        cell00002Secret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
         euSecret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
         microsoftBotId: CONFIG.MICROSOFT_BOT_ID_SECRET,
         slackSigningSecret: CONFIG.SLACK_SIGNING_SECRET ?? "",
@@ -63,10 +65,19 @@ export class SecretManager {
   }
 
   private async loadFromSecretManager(): Promise<Secrets> {
-    const { GCP_GLOBAL_PROJECT_ID, GCP_US_PROJECT_ID, GCP_EU_PROJECT_ID } =
-      getProjectIds();
+    const {
+      GCP_GLOBAL_PROJECT_ID,
+      GCP_US_PROJECT_ID,
+      GCP_EU_PROJECT_ID,
+      GCP_CELL_00002_PROJECT_ID,
+    } = getProjectIds();
 
-    if (!GCP_GLOBAL_PROJECT_ID || !GCP_US_PROJECT_ID || !GCP_EU_PROJECT_ID) {
+    if (
+      !GCP_GLOBAL_PROJECT_ID ||
+      !GCP_US_PROJECT_ID ||
+      !GCP_EU_PROJECT_ID ||
+      !GCP_CELL_00002_PROJECT_ID
+    ) {
       throw new Error("Missing required project environment variables");
     }
 
@@ -75,6 +86,7 @@ export class SecretManager {
         webhookSecretResponse,
         usSecretResponse,
         euSecretResponse,
+        cell00002SecretResponse,
         slackSigningSecretResponse,
         microsoftBotIdResponse,
         notionSigningSecretResponse,
@@ -88,6 +100,9 @@ export class SecretManager {
         }),
         this.client.accessSecretVersion({
           name: `projects/${GCP_EU_PROJECT_ID}/secrets/${CONFIG.SECRET_NAME}/versions/latest`,
+        }),
+        this.client.accessSecretVersion({
+          name: `projects/${GCP_CELL_00002_PROJECT_ID}/secrets/${CONFIG.SECRET_NAME}/versions/latest`,
         }),
         this.client.accessSecretVersion({
           name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.SLACK_SIGNING_SECRET_NAME}/versions/latest`,
@@ -109,6 +124,8 @@ export class SecretManager {
           microsoftBotIdResponse[0].payload?.data?.toString() || "",
         usSecret: usSecretResponse[0].payload?.data?.toString() || "",
         euSecret: euSecretResponse[0].payload?.data?.toString() || "",
+        cell00002Secret:
+          cell00002SecretResponse[0].payload?.data?.toString() || "",
         slackSigningSecret:
           slackSigningSecretResponse[0].payload?.data?.toString() || "",
         notionSigningSecret:

--- a/firebase-functions/webhook-router/src/webhook-router-config.ts
+++ b/firebase-functions/webhook-router/src/webhook-router-config.ts
@@ -1,7 +1,7 @@
 import type { Database } from "firebase-admin/database";
 import { z } from "zod";
 
-export const ALL_CELLS = ["cell-00000", "cell-00001"] as const;
+export const ALL_CELLS = ["cell-00000", "cell-00001", "cell-00002"] as const;
 export type Cell = (typeof ALL_CELLS)[number];
 
 type ProviderWithSigningSecret = "slack" | "notion";


### PR DESCRIPTION
## Description

The webhook router forwards to cell-00002. The router is cell-based since #31727 but only knows the two legacy cells. cell-00002 joins the cell list with a third forwarding target: `https://cell-00002.cells.dust.tt/connectors`, where the cell gateway serves the connectors API under a `/connectors` prefix (dust-infra #1049), and the cell's own `connectors-DUST_CONNECTORS_WEBHOOKS_SECRET`, read from project `prj-dust-cell-00002` through a new `GCP_CELL_00002_PROJECT_ID` parameter. The router service account already has read access on that secret from the dust-infra global root.

Once connectors on cell-00002 registers a Slack or Notion workspace, its config entry lists `cell-00002` and the router reaches it. Microsoft forwards to every cell as before, now three.

Pairs with #31862, which lets connectors itself accept `cell-00002`.

## Tests

`tsc` passes with the same pre-existing zod resolution errors as main, nothing new. Same shape as the two existing targets.

## Risk

The router refuses to start if `GCP_CELL_00002_PROJECT_ID` is missing at deploy time, the same guard as the other project ids, and `deploy.sh` checks it up front. A wrong secret only fails forwarding to cell-00002, the legacy cells are untouched.

## Deploy Plan

Merge, then deploy the function with `GCP_CELL_00002_PROJECT_ID=prj-dust-cell-00002` exported next to the existing project ids.
