### PR TITLE
Poke: sort by the fair-use credits column, and default to it

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -201,10 +201,10 @@ export function PoolUsagePage() {
   });
   const hasPool = (awuPoolCurrentCycle?.totalActiveCredits ?? 0) > 0;
 
-  // Sort by premium message usage for legacy no-pool workspaces, by pool
-  // credits otherwise, until the user picks a column explicitly.
+  // Sort by fair-use credits for legacy no-pool workspaces, by pool credits
+  // otherwise, until the user picks a column explicitly.
   const defaultSortId = isLegacyWithoutPoolOrMetronome
-    ? "premiumMessageUsage"
+    ? "fairUse"
     : "consumedFromPoolAwuCredits";
   const effectiveSorting: SortingState =
     sorting.length > 0 ? sorting : [{ id: defaultSortId, desc: true }];
@@ -213,7 +213,8 @@ export function PoolUsagePage() {
     sort?.id === "email" ||
     sort?.id === "consumedFromPoolAwuCredits" ||
     sort?.id === "seatUsage" ||
-    sort?.id === "premiumMessageUsage"
+    sort?.id === "premiumMessageUsage" ||
+    sort?.id === "fairUse"
       ? sort.id
       : "name";
   const orderDirection = sort?.desc ? "desc" : "asc";

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -927,9 +927,8 @@ function buildFairUseCreditsColumn(
         </div>
       );
     },
-    // Not part of the backend `orderColumn` union yet: sorting stays
-    // local-only, which would misbehave across pages, so it's disabled here.
-    enableSorting: false,
+    enableSorting: true,
+    sortDescFirst: true,
     meta: {
       className: "w-56",
     },

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -18,11 +18,7 @@ import type {
   MemberFairUseUsage,
   MemberUsageType,
 } from "@app/lib/api/credits/members_usage";
-import {
-  formatCreditResetCountdown,
-  formatCredits,
-  formatCreditValue,
-} from "@app/lib/client/credits";
+import { formatCredits, formatCreditValue } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import {
   getUserModelTierMenuItemsWithSelection,
@@ -877,7 +873,7 @@ function buildFairUseCreditsColumn(
           </DataTable.CellContent>
         );
       }
-      const { usedCredits, limitCredits, nextResetAt } = fairUse;
+      const { usedCredits, limitCredits, refillSchedule } = fairUse;
       const percentage =
         limitCredits > 0
           ? Math.min(100, (usedCredits / limitCredits) * 100)
@@ -885,9 +881,6 @@ function buildFairUseCreditsColumn(
             ? 100
             : 0;
       const isAtLimit = limitCredits > 0 && usedCredits >= limitCredits;
-      const resetLabel = nextResetAt
-        ? formatCreditResetCountdown(nextResetAt)
-        : null;
       const bar = (
         <ProgressBar
           aria-label="Fair-use credits usage"
@@ -911,7 +904,7 @@ function buildFairUseCreditsColumn(
             <span>{formatCredits(usedCredits)}</span>
             <span>{formatCredits(limitCredits)}</span>
           </div>
-          {resetLabel ? (
+          {refillSchedule.length > 0 ? (
             <Tooltip
               tooltipTriggerAsChild
               trigger={
@@ -919,7 +912,21 @@ function buildFairUseCreditsColumn(
                   {bar}
                 </div>
               }
-              label={resetLabel}
+              label={
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-medium">Reset schedule:</span>
+                  {refillSchedule.map(({ date, credits }) => (
+                    <span key={date}>
+                      {new Date(date).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        timeZone: "UTC",
+                      })}
+                      : +{formatCredits(credits)}
+                    </span>
+                  ))}
+                </div>
+              }
             />
           ) : (
             <div className="flex h-3 w-full items-center">{bar}</div>

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -81,8 +81,8 @@ export const makeAgentMentionsRateLimitKeyForWorkspace = (
 };
 
 export const makeFairUseAwuCreditsRateLimitKeyForUser = (
-  owner: LightWorkspaceType,
-  user: UserType,
+  owner: Pick<LightWorkspaceType, "id">,
+  user: Pick<UserType, "id">,
   maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType
 ) => {
   // `:v2_microcredits` marks the switch to weighted amount-carrying entries

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -81,8 +81,8 @@ export const makeAgentMentionsRateLimitKeyForWorkspace = (
 };
 
 export const makeFairUseAwuCreditsRateLimitKeyForUser = (
-  owner: Pick<LightWorkspaceType, "id">,
-  user: Pick<UserType, "id">,
+  owner: LightWorkspaceType,
+  user: UserType,
   maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType
 ) => {
   // `:v2_microcredits` marks the switch to weighted amount-carrying entries

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -197,6 +197,7 @@ export type MemberFairUseUsage = {
   timeframe: MaxAwuCreditsTimeframeType;
   windowDays: number;
   nextResetAt: string | null;
+  refillSchedule: { date: string; credits: number }[];
 };
 
 export type GetMembersUsageResponseBody = {
@@ -2069,7 +2070,7 @@ async function resolveMembersUsagePageUsers({
       // Count-only and pipelined into a single Redis round-trip
       const usedCreditsByUserId = await getFairUseAwuCreditsUsedCountsByUser({
         workspace,
-        users: allUsers.map((u) => ({ id: u.id, sId: u.sId })),
+        users: allUsers.map((u) => u.toJSON()),
         plan: auth.plan(),
       });
       for (const u of allUsers) {
@@ -2399,6 +2400,7 @@ export async function getMembersUsage({
                 getTimeframeSecondsFromLiteral(status.timeframe) /
                 (ONE_DAY_MS / 1000),
               nextResetAt: status.nextResetAt ?? null,
+              refillSchedule: status.refillSchedule ?? [],
             }
       );
     }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -50,6 +50,7 @@ import {
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   getFairUseAwuCreditsStatus,
+  getFairUseAwuCreditsUsedCountsByUser,
   isUserAwuWarnedByMetronome,
 } from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
@@ -254,6 +255,7 @@ export const MembersUsagePaginationSchema = z.object({
       "creditState",
       "seatUsage",
       "premiumMessageUsage",
+      "fairUse",
     ])
     .catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
@@ -2060,6 +2062,18 @@ async function resolveMembersUsagePageUsers({
       });
       for (const u of allUsers) {
         sortKeyByUserId.set(u.sId, usedCountByUserId.get(u.sId) ?? 0);
+      }
+      break;
+    }
+    case "fairUse": {
+      // Count-only and pipelined into a single Redis round-trip
+      const usedCreditsByUserId = await getFairUseAwuCreditsUsedCountsByUser({
+        workspace,
+        users: allUsers.map((u) => ({ id: u.id, sId: u.sId })),
+        plan: auth.plan(),
+      });
+      for (const u of allUsers) {
+        sortKeyByUserId.set(u.sId, usedCreditsByUserId.get(u.sId) ?? 0);
       }
       break;
     }

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -33,8 +33,10 @@ import { microCreditsToCredits } from "@app/lib/credits/units";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { WeightedRateLimiterEntry } from "@app/lib/utils/rate_limiter";
 import {
   getTimeframeSecondsFromLiteral,
+  getWeightedRateLimiterEntries,
   getWeightedRateLimiterUsage,
   getWeightedRateLimiterUsageForKeys,
 } from "@app/lib/utils/rate_limiter";
@@ -68,6 +70,8 @@ export type FairUseAwuCreditsStatus = {
   timeframe: MaxAwuCreditsTimeframeType;
   count: number;
   nextResetAt?: string | null;
+  // Optional for compatibility with clients deployed before the refill schedule was added.
+  refillSchedule?: { date: string; credits: number }[];
 };
 
 const DEFAULT_FAIR_USE_AWU_CREDITS_STATUS: FairUseAwuCreditsStatus = {
@@ -240,6 +244,27 @@ export async function isWorkspaceProgrammaticWarningReachedByMetronome(
   return val === "1";
 }
 
+function getFairUseCreditsRefillSchedule({
+  entries,
+  windowMs,
+}: {
+  entries: WeightedRateLimiterEntry[];
+  windowMs: number;
+}): { date: string; credits: number }[] {
+  const creditsByRefillDay = new Map<string, number>();
+  for (const { timestampMs, microCredits } of entries) {
+    const date = new Date(timestampMs + windowMs).toISOString().slice(0, 10);
+    creditsByRefillDay.set(
+      date,
+      (creditsByRefillDay.get(date) ?? 0) + microCreditsToCredits(microCredits)
+    );
+  }
+
+  return Array.from(creditsByRefillDay.entries())
+    .map(([date, credits]) => ({ date, credits }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
 export async function getFairUseAwuCreditsStatus({
   workspace,
   user,
@@ -266,17 +291,22 @@ export async function getFairUseAwuCreditsStatus({
   }
 
   const timeframeSeconds = getTimeframeSecondsFromLiteral(timeframe);
-  const result = await getWeightedRateLimiterUsage({
-    key: makeFairUseAwuCreditsRateLimitKeyForUser(workspace, user, timeframe),
-    timeframeSeconds,
-  });
+  const key = makeFairUseAwuCreditsRateLimitKeyForUser(
+    workspace,
+    user,
+    timeframe
+  );
+  const [usageResult, entriesResult] = await Promise.all([
+    getWeightedRateLimiterUsage({ key, timeframeSeconds }),
+    getWeightedRateLimiterEntries({ key, timeframeSeconds }),
+  ]);
 
-  if (result.isErr()) {
+  if (usageResult.isErr()) {
     logger.error(
       {
         workspaceId: workspace.sId,
         userId: user.sId,
-        error: result.error,
+        error: usageResult.error,
       },
       "Failed to read fair-use AWU credits usage status."
     );
@@ -289,18 +319,37 @@ export async function getFairUseAwuCreditsStatus({
     };
   }
 
+  if (entriesResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        error: entriesResult.error,
+      },
+      "Failed to read fair-use AWU credits refill schedule."
+    );
+  }
+
+  const windowMs = timeframeSeconds * 1000;
+
   // The counter stores microCredits; the status stays credit-denominated (with
   // decimals), so convert before capping against the credit limit.
   return {
     limit,
     timeframe,
-    count: Math.min(microCreditsToCredits(result.value.count), limit),
+    count: Math.min(microCreditsToCredits(usageResult.value.count), limit),
     nextResetAt:
-      result.value.oldestTimestampMs === null
+      usageResult.value.oldestTimestampMs === null
         ? null
         : new Date(
-            result.value.oldestTimestampMs + timeframeSeconds * 1000
+            usageResult.value.oldestTimestampMs + windowMs
           ).toISOString(),
+    refillSchedule: entriesResult.isOk()
+      ? getFairUseCreditsRefillSchedule({
+          entries: entriesResult.value,
+          windowMs,
+        })
+      : [],
   };
 }
 
@@ -310,8 +359,8 @@ export async function getFairUseAwuCreditsUsedCountsByUser({
   users,
   plan,
 }: {
-  workspace: Pick<LightWorkspaceType, "id">;
-  users: Pick<UserType, "id" | "sId">[];
+  workspace: LightWorkspaceType;
+  users: UserType[];
   plan: PlanType | null;
 }): Promise<Map<string, number>> {
   if (!plan || plan.limits.assistant.maxAwuCredits === -1) {

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -36,6 +36,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   getTimeframeSecondsFromLiteral,
   getWeightedRateLimiterUsage,
+  getWeightedRateLimiterUsageForKeys,
 } from "@app/lib/utils/rate_limiter";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -301,6 +302,47 @@ export async function getFairUseAwuCreditsStatus({
             result.value.oldestTimestampMs + timeframeSeconds * 1000
           ).toISOString(),
   };
+}
+
+// Bulk variant of `getFairUseAwuCreditsStatus`, batched into a single Redis
+// round trip (per chunk). Used to sort the full matching set of members by
+// fair-use credit consumption without one round trip per member.
+export async function getFairUseAwuCreditsUsedCountsByUser({
+  workspace,
+  users,
+  plan,
+}: {
+  workspace: Pick<LightWorkspaceType, "id">;
+  users: Pick<UserType, "id" | "sId">[];
+  plan: PlanType | null;
+}): Promise<Map<string, number>> {
+  if (!plan || plan.limits.assistant.maxAwuCredits === -1) {
+    return new Map();
+  }
+
+  const { maxAwuCredits: limit, maxAwuCreditsTimeframe: timeframe } =
+    plan.limits.assistant;
+  const timeframeSeconds = getTimeframeSecondsFromLiteral(timeframe);
+
+  const keyByUserId = new Map(
+    users.map((user) => [
+      user.sId,
+      makeFairUseAwuCreditsRateLimitKeyForUser(workspace, user, timeframe),
+    ])
+  );
+
+  const result = await getWeightedRateLimiterUsageForKeys({
+    keys: Array.from(keyByUserId.values()),
+    timeframeSeconds,
+  });
+  const usageByKey = result.isOk() ? result.value : new Map();
+
+  return new Map(
+    Array.from(keyByUserId, ([sId, key]) => [
+      sId,
+      Math.min(microCreditsToCredits(usageByKey.get(key)?.count ?? 0), limit),
+    ])
+  );
 }
 
 // Unified read

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -304,9 +304,7 @@ export async function getFairUseAwuCreditsStatus({
   };
 }
 
-// Bulk variant of `getFairUseAwuCreditsStatus`, batched into a single Redis
-// round trip (per chunk). Used to sort the full matching set of members by
-// fair-use credit consumption without one round trip per member.
+// Bulk variant of `getFairUseAwuCreditsStatus`
 export async function getFairUseAwuCreditsUsedCountsByUser({
   workspace,
   users,

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -333,6 +333,52 @@ export type WeightedRateLimiterUsage = {
   oldestTimestampMs: number | null;
 };
 
+export type WeightedRateLimiterEntry = {
+  timestampMs: number;
+  microCredits: number;
+};
+
+export async function getWeightedRateLimiterEntries({
+  key,
+  timeframeSeconds,
+}: {
+  key: string;
+  timeframeSeconds: number;
+}): Promise<Result<WeightedRateLimiterEntry[], Error>> {
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    return new Err(new Error("timeframeSeconds must be a positive integer."));
+  }
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const redisKey = makeRateLimiterKey(key);
+    const trimBeforeMs = Date.now() - timeframeSeconds * 1000;
+    const entries = await redis.zRangeWithScores(
+      redisKey,
+      trimBeforeMs,
+      "+inf",
+      { BY: "SCORE" }
+    );
+
+    const parsedEntries: WeightedRateLimiterEntry[] = [];
+    for (const { value: member, score: timestampMs } of entries) {
+      const sepIndex = member.indexOf(":");
+      if (sepIndex === -1) {
+        continue;
+      }
+      const microCredits = Number(member.slice(0, sepIndex));
+      if (!Number.isFinite(microCredits)) {
+        continue;
+      }
+      parsedEntries.push({ timestampMs, microCredits });
+    }
+
+    return new Ok(parsedEntries);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 /**
  * Reads the weighted total (in microCredits) and oldest timestamp of the
  * amount-carrying entries written by `addRateLimiterCount`. Each entry is
@@ -476,6 +522,13 @@ export async function getWeightedRateLimiterUsageForKeys({
         );
       }
       const replies = parsedReplies.data;
+      if (replies.length !== batchKeys.length) {
+        return new Err(
+          new Error(
+            `Unexpected reply count from getWeightedRateLimiterUsageForKeys: expected ${batchKeys.length}, got ${replies.length}.`
+          )
+        );
+      }
       for (const [index, key] of batchKeys.entries()) {
         const [count, oldestTimestampMs] = replies[index];
         usageByKey.set(key, {

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -407,10 +407,6 @@ const WeightedRateLimiterUsageForKeysReplySchema = z.array(
   z.tuple([z.number(), z.number()])
 );
 
-// Same computation as `getWeightedRateLimiterUsage`, batched over multiple
-// keys in a single round trip (looped server-side in Lua, chunked to a safe
-// KEYS array size), so a full-table sort doesn't issue one round trip per
-// member.
 export async function getWeightedRateLimiterUsageForKeys({
   keys,
   timeframeSeconds,

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -400,6 +400,85 @@ export async function getWeightedRateLimiterUsage({
   }
 }
 
+// Same computation as `getWeightedRateLimiterUsage`, batched over multiple
+// keys in a single round trip (looped server-side in Lua, chunked to a safe
+// KEYS array size), so a full-table sort doesn't issue one round trip per
+// member.
+export async function getWeightedRateLimiterUsageForKeys({
+  keys,
+  timeframeSeconds,
+}: {
+  keys: string[];
+  timeframeSeconds: number;
+}): Promise<Result<Map<string, WeightedRateLimiterUsage>, Error>> {
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    return new Err(new Error("timeframeSeconds must be a positive integer."));
+  }
+  if (keys.length === 0) {
+    return new Ok(new Map());
+  }
+
+  const windowMs = timeframeSeconds * 1000;
+  const luaScript = `
+    local window_ms = tonumber(ARGV[1])
+
+    -- Use Redis server time to avoid client clock skew (matches the writer).
+    local t = redis.call('TIME') -- { seconds, microseconds }
+    local now_ms = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+    local trim_before = now_ms - window_ms
+
+    local results = {}
+    for i, key in ipairs(KEYS) do
+      -- Sum the '<microCredits>:<uuid>' amount prefixes of the entries still
+      -- inside the window, server-side, so only the totals cross the wire.
+      local entries = redis.call('ZRANGEBYSCORE', key, trim_before, '+inf', 'WITHSCORES')
+      local total = 0
+      local oldest_timestamp_ms = -1
+      for j = 1, #entries, 2 do
+        local member = entries[j]
+        local score = tonumber(entries[j + 1])
+        local sep = string.find(member, ':', 1, true)
+        if sep then
+          local amount = tonumber(string.sub(member, 1, sep - 1))
+          if amount then
+            if oldest_timestamp_ms == -1 and score then
+              oldest_timestamp_ms = score
+            end
+            total = total + amount
+          end
+        end
+      end
+      results[i] = { total, oldest_timestamp_ms }
+    end
+    return results
+  `;
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const uniqueKeys = Array.from(new Set(keys));
+    const usageByKey = new Map<string, WeightedRateLimiterUsage>();
+    for (const batchKeys of chunk(uniqueKeys, RATE_LIMITER_COUNTS_BATCH_SIZE)) {
+      const redisKeys = batchKeys.map((key) => makeRateLimiterKey(key));
+      const replies = (await redis.eval(luaScript, {
+        keys: redisKeys,
+        arguments: [windowMs.toString()],
+      })) as [number, number][];
+      for (const [index, key] of batchKeys.entries()) {
+        const [count, oldestTimestampMs] = replies[index];
+        usageByKey.set(key, {
+          count,
+          oldestTimestampMs:
+            oldestTimestampMs === -1 ? null : oldestTimestampMs,
+        });
+      }
+    }
+
+    return new Ok(usageByKey);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 export async function getWeightedRateLimiterCount({
   key,
   timeframeSeconds,

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -12,6 +12,8 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import chunk from "lodash/chunk";
 import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export class RateLimitError extends Error {}
 
@@ -400,6 +402,11 @@ export async function getWeightedRateLimiterUsage({
   }
 }
 
+// One [total, oldestTimestampMs] pair per requested key, in the same order.
+const WeightedRateLimiterUsageForKeysReplySchema = z.array(
+  z.tuple([z.number(), z.number()])
+);
+
 // Same computation as `getWeightedRateLimiterUsage`, batched over multiple
 // keys in a single round trip (looped server-side in Lua, chunked to a safe
 // KEYS array size), so a full-table sort doesn't issue one round trip per
@@ -459,10 +466,20 @@ export async function getWeightedRateLimiterUsageForKeys({
     const usageByKey = new Map<string, WeightedRateLimiterUsage>();
     for (const batchKeys of chunk(uniqueKeys, RATE_LIMITER_COUNTS_BATCH_SIZE)) {
       const redisKeys = batchKeys.map((key) => makeRateLimiterKey(key));
-      const replies = (await redis.eval(luaScript, {
+      const rawReplies = await redis.eval(luaScript, {
         keys: redisKeys,
         arguments: [windowMs.toString()],
-      })) as [number, number][];
+      });
+      const parsedReplies =
+        WeightedRateLimiterUsageForKeysReplySchema.safeParse(rawReplies);
+      if (!parsedReplies.success) {
+        return new Err(
+          new Error(
+            `Unexpected reply shape from getWeightedRateLimiterUsageForKeys: ${fromError(parsedReplies.error).toString()}`
+          )
+        );
+      }
+      const replies = parsedReplies.data;
       for (const [index, key] of batchKeys.entries()) {
         const [count, oldestTimestampMs] = replies[index];
         usageByKey.set(key, {

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -264,7 +264,8 @@ export function usePokeMembersUsage({
     | "seatType"
     | "creditState"
     | "seatUsage"
-    | "premiumMessageUsage";
+    | "premiumMessageUsage"
+    | "fairUse";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType;
   creditState?: UserCreditState;


### PR DESCRIPTION
## Description

Adds server-side sorting on the fair-use credits column, batched into a single pipelined Redis round-trip so a full-table sort does not cost one round-trip per member — same pattern already used for the premium-messages sort. 

Premium message workspaces now default-sort by this column instead of premium message usage. 

Stacked on #31867.

## Tests

Tested on front-edge

## Risk

- Poke only for now

## Deploy Plan

- Deploy front
