### PR TITLE
[sparkle] Markdown: add step variant for task lists

### DIFF
--- a/sparkle/src/components/markdown/InputBlock.tsx
+++ b/sparkle/src/components/markdown/InputBlock.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from "@sparkle/components/Checkbox";
 import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { sameNodePosition } from "@sparkle/components/markdown/utils";
+import { assertNever } from "@sparkle/lib/utils";
 import React, { memo } from "react";
 import type { ReactMarkdownProps } from "react-markdown/lib/ast-to-react";
 
@@ -11,7 +12,7 @@ type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
 
 /**
  * Renders `<input>` elements inside Markdown output; checkboxes (as produced
- * by GFM task lists) are swapped for the Sparkle Checkbox component, or
+ * by GitHub Flavored Markdown task lists) are swapped for the Sparkle Checkbox component, or
  * dropped when the "step" task-list variant draws its own badge; other input
  * types pass through unchanged.
  * @summary Input renderer for Markdown task-list checkboxes.
@@ -34,8 +35,13 @@ export const InputBlock = memo(
       );
     }
 
-    if (taskListVariant === "step") {
-      return null;
+    switch (taskListVariant) {
+      case "step":
+        return null;
+      case "checkbox":
+        break;
+      default:
+        assertNever(taskListVariant);
     }
 
     const handleCheckedChange = (isChecked: boolean) => {

--- a/sparkle/src/components/markdown/InputBlock.tsx
+++ b/sparkle/src/components/markdown/InputBlock.tsx
@@ -1,4 +1,5 @@
 import { Checkbox } from "@sparkle/components/Checkbox";
+import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { sameNodePosition } from "@sparkle/components/markdown/utils";
 import React, { memo } from "react";
 import type { ReactMarkdownProps } from "react-markdown/lib/ast-to-react";
@@ -10,14 +11,16 @@ type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
 
 /**
  * Renders `<input>` elements inside Markdown output; checkboxes (as produced
- * by GFM task lists) are swapped for the Sparkle Checkbox component, other
- * input types pass through unchanged.
+ * by GFM task lists) are swapped for the Sparkle Checkbox component, or
+ * dropped when the "step" task-list variant draws its own badge; other input
+ * types pass through unchanged.
  * @summary Input renderer for Markdown task-list checkboxes.
  */
 export const InputBlock = memo(
   ({ type, checked, className, onChange, ref, ...props }: InputProps) => {
     const inputRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => inputRef.current!);
+    const { taskListVariant } = useMarkdownStyle();
 
     if (type !== "checkbox") {
       return (
@@ -29,6 +32,10 @@ export const InputBlock = memo(
           {...props}
         />
       );
+    }
+
+    if (taskListVariant === "step") {
+      return null;
     }
 
     const handleCheckedChange = (isChecked: boolean) => {

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -113,6 +113,7 @@ export const OlBlock = memo(
 );
 OlBlock.displayName = "OlBlock";
 
+// mt-[3px] centers the 20px badge on the 26px leading-relaxed text line.
 const taskStepBadgeVariants = cva(
   "mt-[3px] flex size-5 shrink-0 items-center justify-center rounded-full",
   {
@@ -130,9 +131,20 @@ interface TaskStepBadgeProps {
   number?: number;
 }
 
+function taskStepLabel({ checked, number }: TaskStepBadgeProps) {
+  if (checked) {
+    return "Done";
+  }
+  return number !== undefined ? `Step ${number}` : "To do";
+}
+
 function TaskStepBadge({ checked, number }: TaskStepBadgeProps) {
   return (
-    <div className={taskStepBadgeVariants({ checked })}>
+    <div
+      role="img"
+      aria-label={taskStepLabel({ checked, number })}
+      className={taskStepBadgeVariants({ checked })}
+    >
       {checked ? (
         <Icon visual={Check} size="2xs" />
       ) : (
@@ -182,12 +194,13 @@ export const LiBlock = memo(
         >
           <TaskStepBadge
             checked={isChecked}
-            number={
-              ordered && index !== undefined ? start + index : undefined
-            }
+            number={ordered && index !== undefined ? start + index : undefined}
           />
           <div
-            className={cn("min-w-0 flex-1", isChecked && "text-faint line-through")}
+            className={cn(
+              "min-w-0 flex-1",
+              isChecked && "text-faint line-through"
+            )}
           >
             {children}
           </div>

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -1,12 +1,17 @@
+import { Icon } from "@sparkle/components/Icon";
 import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { markdownParagraphSize } from "@sparkle/components/markdown/markdownSizes";
 import {
   type MarkdownNode,
   sameNodePosition,
 } from "@sparkle/components/markdown/utils";
+import { Check } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib";
 import { cva } from "class-variance-authority";
-import React, { memo } from "react";
+import React, { createContext, memo, useContext } from "react";
+
+// Ordered lists share their `start` so step badges can number task items.
+const OlStartContext = createContext(1);
 
 export const ulBlockVariants = cva("pb-2 flex flex-col gap-1", {
   variants: {
@@ -54,54 +59,142 @@ export const UlBlock = memo(
 );
 UlBlock.displayName = "UlBlock";
 
-export const olBlockVariants = cva([
-  "list-decimal pb-2 pl-6 flex flex-col gap-1",
-]);
+export const olBlockVariants = cva("pb-2 flex flex-col gap-1", {
+  variants: {
+    taskSteps: {
+      false: "list-decimal pl-6",
+      true: "",
+    },
+  },
+  defaultVariants: {
+    taskSteps: false,
+  },
+});
 
 interface OlBlockProps {
   children: React.ReactNode;
+  className?: string;
   start?: number;
   node?: MarkdownNode;
 }
 
 /**
  * Renders ordered lists inside Markdown output, honoring the `start` number
- * from the source Markdown.
+ * from the source Markdown. Task lists in the "step" variant drop the decimal
+ * markers since the badges carry the numbers.
  * @summary Ordered-list renderer for Markdown.
  */
 export const OlBlock = memo(
-  ({ children, start }: OlBlockProps) => {
-    const { textColor, forcedTextSize } = useMarkdownStyle();
+  ({ children, className, start }: OlBlockProps) => {
+    const { textColor, forcedTextSize, taskListVariant } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
+    const isTaskSteps =
+      taskListVariant === "step" && className?.includes("contains-task-list");
     return (
-      <ol start={start} className={cn(olBlockVariants(), textColor, textSize)}>
-        {children}
-      </ol>
+      <OlStartContext.Provider value={start ?? 1}>
+        <ol
+          start={start}
+          className={cn(
+            olBlockVariants({ taskSteps: isTaskSteps }),
+            textColor,
+            textSize,
+            className
+          )}
+        >
+          {children}
+        </ol>
+      </OlStartContext.Provider>
     );
   },
   (prev, next) =>
-    sameNodePosition(prev.node, next.node) && prev.start === next.start
+    sameNodePosition(prev.node, next.node) &&
+    prev.start === next.start &&
+    prev.className === next.className
 );
 OlBlock.displayName = "OlBlock";
+
+const taskStepBadgeVariants = cva(
+  "mt-[3px] flex size-5 shrink-0 items-center justify-center rounded-full",
+  {
+    variants: {
+      checked: {
+        true: "bg-highlight-50 text-highlight-500",
+        false: "border border-faint text-faint",
+      },
+    },
+  }
+);
+
+interface TaskStepBadgeProps {
+  checked: boolean;
+  number?: number;
+}
+
+function TaskStepBadge({ checked, number }: TaskStepBadgeProps) {
+  return (
+    <div className={taskStepBadgeVariants({ checked })}>
+      {checked ? (
+        <Icon visual={Check} size="2xs" />
+      ) : (
+        number !== undefined && (
+          <span className="text-xs font-medium leading-none">{number}</span>
+        )
+      )}
+    </div>
+  );
+}
 
 export const liBlockVariants = cva(["break-words"]);
 
 interface LiBlockProps {
   children: React.ReactNode;
   className?: string;
+  checked?: boolean | null;
+  index?: number;
+  ordered?: boolean;
   node?: MarkdownNode;
 }
 
 /**
  * Renders list items inside Markdown output; task-list items (detected via the
- * `task-list-item` class) suppress their list marker.
+ * `task-list-item` class) suppress their list marker. In the "step" task-list
+ * variant they get a read-only circle badge instead of a checkbox.
  * @summary List-item renderer for Markdown.
  */
 export const LiBlock = memo(
-  ({ children, className }: LiBlockProps) => {
-    const { textColor, forcedTextSize } = useMarkdownStyle();
+  ({ children, className, checked, index, ordered }: LiBlockProps) => {
+    const { textColor, forcedTextSize, taskListVariant } = useMarkdownStyle();
+    const start = useContext(OlStartContext);
     const textSize = forcedTextSize ?? markdownParagraphSize;
     const isTaskListItem = className?.includes("task-list-item");
+
+    if (isTaskListItem && taskListVariant === "step") {
+      const isChecked = checked === true;
+      return (
+        <li
+          className={cn(
+            liBlockVariants(),
+            "flex list-none items-start gap-2",
+            textColor,
+            textSize,
+            className
+          )}
+        >
+          <TaskStepBadge
+            checked={isChecked}
+            number={
+              ordered && index !== undefined ? start + index : undefined
+            }
+          />
+          <div
+            className={cn("min-w-0 flex-1", isChecked && "text-faint line-through")}
+          >
+            {children}
+          </div>
+        </li>
+      );
+    }
+
     return (
       <li
         className={cn(
@@ -117,6 +210,10 @@ export const LiBlock = memo(
     );
   },
   (prev, next) =>
-    sameNodePosition(prev.node, next.node) && prev.className === next.className
+    sameNodePosition(prev.node, next.node) &&
+    prev.className === next.className &&
+    prev.checked === next.checked &&
+    prev.index === next.index &&
+    prev.ordered === next.ordered
 );
 LiBlock.displayName = "LiBlock";

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -7,6 +7,7 @@ import {
 } from "@sparkle/components/markdown/utils";
 import { Check } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib";
+import { assertNever } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import React, { createContext, memo, useContext } from "react";
 
@@ -31,20 +32,25 @@ interface UlBlockProps {
   node?: MarkdownNode;
 }
 
+// remark-gfm marks lists holding task items with the `contains-task-list` class. react-markdown
+// gives list items a `checked` prop, but the list element itself only carries this class.
+function isTaskList(className?: string) {
+  return className?.includes("contains-task-list") ?? false;
+}
+
 /**
- * Renders unordered lists inside Markdown output; GFM task lists (detected via
- * the `contains-task-list` class) drop the disc bullets.
+ * Renders unordered lists inside Markdown output; GitHub Flavored Markdown
+ * task lists drop the disc bullets.
  * @summary Unordered-list renderer for Markdown.
  */
 export const UlBlock = memo(
   ({ children, className }: UlBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
-    const isTaskList = className?.includes("contains-task-list");
     return (
       <ul
         className={cn(
-          ulBlockVariants({ taskList: isTaskList }),
+          ulBlockVariants({ taskList: isTaskList(className) }),
           textColor,
           textSize,
           className
@@ -80,21 +86,20 @@ interface OlBlockProps {
 
 /**
  * Renders ordered lists inside Markdown output, honoring the `start` number
- * from the source Markdown; GFM task lists (detected via the `contains-task-list`
- * class) drop the decimal markers and indent, like UlBlock does for bullets.
+ * from the source Markdown; task lists drop the decimal markers and indent,
+ * like UlBlock does for bullets.
  * @summary Ordered-list renderer for Markdown.
  */
 export const OlBlock = memo(
   ({ children, className, start }: OlBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
-    const isTaskList = className?.includes("contains-task-list");
     return (
       <OlStartContext.Provider value={start ?? 1}>
         <ol
           start={start}
           className={cn(
-            olBlockVariants({ taskList: isTaskList }),
+            olBlockVariants({ taskList: isTaskList(className) }),
             textColor,
             textSize,
             className
@@ -175,9 +180,9 @@ interface LiBlockProps {
 }
 
 /**
- * Renders list items inside Markdown output; task-list items (detected via the
- * `task-list-item` class) suppress their list marker. In the "step" task-list
- * variant they get a read-only circle badge instead of a checkbox.
+ * Renders list items inside Markdown output; task-list items (react-markdown
+ * passes them a boolean `checked`) suppress their list marker. In the "step"
+ * task-list variant they get a read-only circle badge instead of a checkbox.
  * @summary List-item renderer for Markdown.
  */
 export const LiBlock = memo(
@@ -185,34 +190,42 @@ export const LiBlock = memo(
     const { textColor, forcedTextSize, taskListVariant } = useMarkdownStyle();
     const start = useContext(OlStartContext);
     const textSize = forcedTextSize ?? markdownParagraphSize;
-    const isTaskListItem = className?.includes("task-list-item");
+    const isTaskListItem = typeof checked === "boolean";
 
-    if (isTaskListItem && taskListVariant === "step") {
-      const isChecked = checked === true;
-      return (
-        <li
-          className={cn(
-            liBlockVariants(),
-            "flex list-none items-start gap-2",
-            textColor,
-            textSize,
-            className
-          )}
-        >
-          <TaskStepBadge
-            checked={isChecked}
-            number={ordered && index !== undefined ? start + index : undefined}
-          />
-          <div
-            className={cn(
-              "min-w-0 flex-1 transition-colors duration-300 motion-reduce:transition-none",
-              isChecked && "text-faint line-through"
-            )}
-          >
-            {children}
-          </div>
-        </li>
-      );
+    if (isTaskListItem) {
+      switch (taskListVariant) {
+        case "step":
+          return (
+            <li
+              className={cn(
+                liBlockVariants(),
+                "flex list-none items-start gap-2",
+                textColor,
+                textSize,
+                className
+              )}
+            >
+              <TaskStepBadge
+                checked={checked}
+                number={
+                  ordered && index !== undefined ? start + index : undefined
+                }
+              />
+              <div
+                className={cn(
+                  "min-w-0 flex-1 transition-colors duration-300 motion-reduce:transition-none",
+                  checked && "text-faint line-through"
+                )}
+              >
+                {children}
+              </div>
+            </li>
+          );
+        case "checkbox":
+          break;
+        default:
+          assertNever(taskListVariant);
+      }
     }
 
     return (

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -113,14 +113,18 @@ export const OlBlock = memo(
 );
 OlBlock.displayName = "OlBlock";
 
-// mt-[3px] centers the 20px badge on the 26px leading-relaxed text line.
+// mt-[3px] centers the 20px badge on the 26px leading-relaxed text line. The border stays on
+// both states so ticking a task only transitions colors.
 const taskStepBadgeVariants = cva(
-  "mt-[3px] flex size-5 shrink-0 items-center justify-center rounded-full",
+  cn(
+    "mt-[3px] flex size-5 shrink-0 items-center justify-center rounded-full border",
+    "transition-colors duration-300 motion-reduce:transition-none"
+  ),
   {
     variants: {
       checked: {
-        true: "bg-highlight-50 text-highlight-500",
-        false: "border border-faint text-faint",
+        true: "border-highlight-50 bg-highlight-50 text-highlight-500",
+        false: "border-faint text-faint",
       },
     },
   }
@@ -146,7 +150,11 @@ function TaskStepBadge({ checked, number }: TaskStepBadgeProps) {
       className={taskStepBadgeVariants({ checked })}
     >
       {checked ? (
-        <Icon visual={Check} size="2xs" />
+        <Icon
+          visual={Check}
+          size="2xs"
+          className="animate-in fade-in zoom-in-50 duration-300 motion-reduce:animate-none"
+        />
       ) : (
         number !== undefined && (
           <span className="text-xs font-medium leading-none">{number}</span>
@@ -198,7 +206,7 @@ export const LiBlock = memo(
           />
           <div
             className={cn(
-              "min-w-0 flex-1",
+              "min-w-0 flex-1 transition-colors duration-300 motion-reduce:transition-none",
               isChecked && "text-faint line-through"
             )}
           >

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -61,13 +61,13 @@ UlBlock.displayName = "UlBlock";
 
 export const olBlockVariants = cva("pb-2 flex flex-col gap-1", {
   variants: {
-    taskSteps: {
+    taskList: {
       false: "list-decimal pl-6",
       true: "",
     },
   },
   defaultVariants: {
-    taskSteps: false,
+    taskList: false,
   },
 });
 
@@ -80,22 +80,21 @@ interface OlBlockProps {
 
 /**
  * Renders ordered lists inside Markdown output, honoring the `start` number
- * from the source Markdown. Task lists in the "step" variant drop the decimal
- * markers since the badges carry the numbers.
+ * from the source Markdown; GFM task lists (detected via the `contains-task-list`
+ * class) drop the decimal markers and indent, like UlBlock does for bullets.
  * @summary Ordered-list renderer for Markdown.
  */
 export const OlBlock = memo(
   ({ children, className, start }: OlBlockProps) => {
-    const { textColor, forcedTextSize, taskListVariant } = useMarkdownStyle();
+    const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
-    const isTaskSteps =
-      taskListVariant === "step" && className?.includes("contains-task-list");
+    const isTaskList = className?.includes("contains-task-list");
     return (
       <OlStartContext.Provider value={start ?? 1}>
         <ol
           start={start}
           className={cn(
-            olBlockVariants({ taskSteps: isTaskSteps }),
+            olBlockVariants({ taskList: isTaskList }),
             textColor,
             textSize,
             className

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -1,7 +1,10 @@
 import { Chip } from "@sparkle/components/Chip";
 import { createBaseMarkdownComponents } from "@sparkle/components/markdown/createBaseMarkdownComponents";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
-import { MarkdownStyleContext } from "@sparkle/components/markdown/MarkdownStyleContext";
+import {
+  MarkdownStyleContext,
+  type TaskListVariant,
+} from "@sparkle/components/markdown/MarkdownStyleContext";
 import { safeRehypeKatex } from "@sparkle/components/markdown/safeRehypeKatex";
 import {
   type StreamingState,
@@ -57,6 +60,8 @@ export interface MarkdownProps {
   additionalMarkdownPlugins?: PluggableList;
   /** When true (default), blockquotes show a copy button. */
   canCopyQuotes?: boolean;
+  /** "checkbox" (default) renders GFM task items with checkboxes; "step" renders read-only circles, numbered inside ordered lists. */
+  taskListVariant?: TaskListVariant;
   /** When true, streamed text is revealed with a smooth animation (see useAnimatedText). */
   enableAnimation?: boolean;
   /** Duration of each streaming reveal animation. */
@@ -86,6 +91,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   canCopyQuotes = true,
+  taskListVariant = "checkbox",
   enableAnimation = false,
   animationDurationSeconds = DEFAULT_ANIMATION_DURATION_SECONDS,
   delimiter = DEFAULT_DELIMITER,
@@ -118,8 +124,9 @@ export const Markdown: React.FC<MarkdownProps> = ({
       forcedTextSize,
       compactSpacing,
       canCopyQuotes,
+      taskListVariant,
     }),
-    [textColor, forcedTextSize, compactSpacing, canCopyQuotes]
+    [textColor, forcedTextSize, compactSpacing, canCopyQuotes, taskListVariant]
   );
 
   // Note on re-renderings. A lot of effort has been put into preventing rerendering across markdown

--- a/sparkle/src/components/markdown/MarkdownStyleContext.tsx
+++ b/sparkle/src/components/markdown/MarkdownStyleContext.tsx
@@ -1,22 +1,28 @@
 import { createContext, useContext } from "react";
 
+/** How GFM task-list items render: interactive-looking checkboxes, or read-only step circles. */
+export type TaskListVariant = "checkbox" | "step";
+
 interface MarkdownStyleContextType {
   textColor: string;
   forcedTextSize?: string;
   compactSpacing: boolean;
   canCopyQuotes: boolean;
+  taskListVariant: TaskListVariant;
 }
 
 /**
  * Provides shared typography and behavior options (`textColor`,
- * `forcedTextSize`, `compactSpacing`, `canCopyQuotes`) to every renderer block,
- * so style changes bypass the blocks' position-based memoization.
+ * `forcedTextSize`, `compactSpacing`, `canCopyQuotes`, `taskListVariant`) to
+ * every renderer block, so style changes bypass the blocks' position-based
+ * memoization.
  * @summary Context providing Markdown typography options.
  */
 export const MarkdownStyleContext = createContext<MarkdownStyleContextType>({
   textColor: "text-foreground",
   compactSpacing: false,
   canCopyQuotes: true,
+  taskListVariant: "checkbox",
 });
 
 /**

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -92,6 +92,63 @@ export const TextFormatting: Story = {
   },
 };
 
+const taskListContent = `
+### Bulleted tasks
+
+- [x] Pull the Q3 deals
+- [x] Read the account notes
+- [ ] Review the support history
+- [ ] Write the briefs
+
+### Numbered tasks
+
+1. [x] Pull the Q3 deals
+2. [x] Read the account notes
+3. [ ] Review the support history
+4. [ ] Write the briefs
+`;
+
+/**
+ * GFM task lists in both variants: the default checkboxes, meant for content
+ * the user can edit, and the read-only "step" circles, numbered inside
+ * ordered lists, meant for progress the agent reports (e.g. a plan).
+ * @summary Checkbox vs step task lists.
+ */
+export const TaskLists: Story = {
+  args: {
+    content: taskListContent,
+  },
+  render: (args) => (
+    <div className="grid grid-cols-2 gap-8">
+      <div>
+        <p className="heading-sm pb-2 text-muted-foreground">
+          taskListVariant="checkbox" (default)
+        </p>
+        <Markdown {...args} taskListVariant="checkbox" />
+      </div>
+      <div>
+        <p className="heading-sm pb-2 text-muted-foreground">
+          taskListVariant="step"
+        </p>
+        <Markdown {...args} taskListVariant="step" />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      // The checkbox variant renders 8 checkboxes, the step variant none.
+      expect(canvasElement.querySelectorAll('[role="checkbox"]')).toHaveLength(
+        8
+      );
+      // Step badges: done ones show an icon, numbered pending ones their number.
+      const badges = Array.from(
+        canvasElement.querySelectorAll(".rounded-full")
+      ).map((badge) => badge.textContent);
+      expect(badges).toEqual(["", "", "", "", "", "", "3", "4"]);
+    });
+  },
+};
+
 const tablesContent = `
 ### Short Table
 

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -140,11 +140,20 @@ export const TaskLists: Story = {
       expect(canvasElement.querySelectorAll('[role="checkbox"]')).toHaveLength(
         8
       );
-      // Step badges: done ones show an icon, numbered pending ones their number.
+      // Step badges expose their state, numbered only inside ordered lists.
       const badges = Array.from(
-        canvasElement.querySelectorAll(".rounded-full")
-      ).map((badge) => badge.textContent);
-      expect(badges).toEqual(["", "", "", "", "", "", "3", "4"]);
+        canvasElement.querySelectorAll('[role="img"]')
+      ).map((badge) => badge.getAttribute("aria-label"));
+      expect(badges).toEqual([
+        "Done",
+        "Done",
+        "To do",
+        "To do",
+        "Done",
+        "Done",
+        "Step 3",
+        "Step 4",
+      ]);
     });
   },
 };


### PR DESCRIPTION
Adds a `taskListVariant` prop to `Markdown` (`"checkbox"` by default, `"step"`).

In step mode, GFM task items render read-only circles instead of checkboxes: numbered inside ordered lists, empty in bulleted ones, highlight check when done. Intended for the plan mode panel, where the agent ticks progress and the user cannot.

New `TaskLists` story shows both variants.

Small thing about the animation: when a task gets ticked the circle changes color and the check pops in. Since the pop-in fires when the icon mounts, already done tasks also pop once when the plan first shows up. I'm fine with it, it looks like a reveal. Only animating real changes would mean knowing what the plan looked like before, and Markdown doesn't, only the caller does.

<kbd>
<img width="1041" height="424" alt="Screenshot 2026-09-04 at 14 54 23" src="https://github.com/user-attachments/assets/d970d3a4-0dad-432c-a49e-8964caf4d224" />
</kbd>



