### PR TITLE
core: backfill prompts name the cell and region from the pod topology

### DIFF
--- a/core/bin/elasticsearch/backfill_folders_index.rs
+++ b/core/bin/elasticsearch/backfill_folders_index.rs
@@ -34,6 +34,14 @@ struct Args {
  * cargo run --bin elasticsearch_backfill_index -- --index-version <version> [--skip-confirmation] [--start-cursor <cursor>] [--batch-size <batch_size>]
  *
  */
+// The pods carry CELL and REGION from their topology labels, so the prompt names the
+// deployment the operator is about to touch.
+fn deployment_target() -> String {
+    let cell = std::env::var("CELL").expect("CELL must be set");
+    let region = std::env::var("REGION").expect("REGION must be set");
+    format!("{} ({})", cell, region)
+}
+
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
@@ -121,7 +129,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let password =
         std::env::var("ELASTICSEARCH_PASSWORD").expect("ELASTICSEARCH_PASSWORD must be set");
 
-    let region = std::env::var("DUST_REGION").expect("DUST_REGION must be set");
+    let target = deployment_target();
 
     // create ES client
     let search_store = ElasticsearchSearchStore::new(&url, &username, &password).await?;
@@ -142,8 +150,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     if !args.skip_confirmation {
         println!(
-            "Are you sure you want to backfill the index {} in region {}? (y/N)",
-            index_fullname, region
+            "Are you sure you want to backfill the index {} in {}? (y/N)",
+            index_fullname, target
         );
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();

--- a/core/bin/elasticsearch/backfill_index.rs
+++ b/core/bin/elasticsearch/backfill_index.rs
@@ -31,6 +31,14 @@ struct Args {
  * cargo run --bin elasticsearch_backfill_nodes_index -- --index-version <version> [--skip-confirmation] [--start-cursor <cursor>] [--batch-size <batch_size>]
  *
  */
+// The pods carry CELL and REGION from their topology labels, so the prompt names the
+// deployment the operator is about to touch.
+fn deployment_target() -> String {
+    let cell = std::env::var("CELL").expect("CELL must be set");
+    let region = std::env::var("REGION").expect("REGION must be set");
+    format!("{} ({})", cell, region)
+}
+
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
@@ -53,9 +61,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let password =
         std::env::var("ELASTICSEARCH_PASSWORD").expect("ELASTICSEARCH_PASSWORD must be set");
 
-    let region = match std::env::var("NODE_ENV").unwrap_or_default().as_str() {
+    let target = match std::env::var("NODE_ENV").unwrap_or_default().as_str() {
         "development" => "local".to_string(),
-        _ => std::env::var("DUST_REGION").expect("DUST_REGION must be set"),
+        _ => deployment_target(),
     };
 
     // create ES client
@@ -77,8 +85,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     if !args.skip_confirmation {
         println!(
-            "Are you sure you want to backfill the index {} in region {}? (y/N)",
-            index_fullname, region
+            "Are you sure you want to backfill the index {} in {}? (y/N)",
+            index_fullname, target
         );
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();

--- a/core/bin/migrations/20250205_backfill_document_tags_index.rs
+++ b/core/bin/migrations/20250205_backfill_document_tags_index.rs
@@ -42,6 +42,14 @@ struct Args {
  * cargo run --bin elasticsearch_backfill_document_tags_index -- --index-version <version> [--skip-confirmation] [--start-cursor <cursor>] [--batch-size <batch_size>]
  *
  */
+// The pods carry CELL and REGION from their topology labels, so the prompt names the
+// deployment the operator is about to touch.
+fn deployment_target() -> String {
+    let cell = std::env::var("CELL").expect("CELL must be set");
+    let region = std::env::var("REGION").expect("REGION must be set");
+    format!("{} ({})", cell, region)
+}
+
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
@@ -92,7 +100,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let password =
         std::env::var("ELASTICSEARCH_PASSWORD").expect("ELASTICSEARCH_PASSWORD must be set");
 
-    let region = std::env::var("DUST_REGION").expect("DUST_REGION must be set");
+    let target = deployment_target();
 
     // create ES client
     let search_store = ElasticsearchSearchStore::new(&url, &username, &password).await?;
@@ -113,8 +121,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     if !args.skip_confirmation {
         println!(
-            "Are you sure you want to backfill the index {} in region {}? (y/N)",
-            index_fullname, region
+            "Are you sure you want to backfill the index {} in {}? (y/N)",
+            index_fullname, target
         );
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();

--- a/core/bin/migrations/20250226_backfill_elasticsearch_text_size.rs
+++ b/core/bin/migrations/20250226_backfill_elasticsearch_text_size.rs
@@ -33,6 +33,14 @@ struct Args {
  * cargo run --bin backfill_elasticsearch_text_size -- --index-version <version> [--skip-confirmation] [--start-cursor <cursor>] [--batch-size <batch_size>]
  *
  */
+// The pods carry CELL and REGION from their topology labels, so the prompt names the
+// deployment the operator is about to touch.
+fn deployment_target() -> String {
+    let cell = std::env::var("CELL").expect("CELL must be set");
+    let region = std::env::var("REGION").expect("REGION must be set");
+    format!("{} ({})", cell, region)
+}
+
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
@@ -120,7 +128,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let password =
         std::env::var("ELASTICSEARCH_PASSWORD").expect("ELASTICSEARCH_PASSWORD must be set");
 
-    let region = std::env::var("DUST_REGION").expect("DUST_REGION must be set");
+    let target = deployment_target();
 
     // create ES client
     let search_store = ElasticsearchSearchStore::new(&url, &username, &password).await?;
@@ -141,8 +149,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     if !args.skip_confirmation {
         println!(
-            "Are you sure you want to backfill the index {} in region {}? (y/N)",
-            index_fullname, region
+            "Are you sure you want to backfill the index {} in {}? (y/N)",
+            index_fullname, target
         );
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();


### PR DESCRIPTION
## Description

The Elasticsearch backfill binaries in core asked for `DUST_REGION` only to print it in their confirmation prompt. Every core pod already carries `CELL` and `REGION` from its topology labels, so the prompt now reads them and names the deployment precisely: "backfill the index X in cell-00002 (europe-west1)?". The generic backfill keeps its "local" shortcut in development.

Two of the four binaries are commented out of the build. They get the same change so they do not rot. Once this is deployed, `core-DUST_REGION` can leave the legacy bundles, nothing else reads it.

## Tests

No behaviour change.

## Risk

None at runtime, core-api and the sqlite worker never read these variables. An operator running a backfill from a pod without `CELL` set gets a clear panic message instead of a prompt.

## Deploy Plan

Merge, ships with the next core deploy.
