### PR TITLE
feat(llm): record every model attempt into the health counters

### DIFF
--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -10,4 +10,4 @@ export const WINDOW_MINUTES = 5;
 
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.
-export const COUNTER_KEY_TTL_SECONDS = 900;
+export const COUNTER_KEY_TTL_SECONDS = WINDOW_MINUTES * 60 * 3;

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -7,3 +7,7 @@
 
 // Length of the sliding window, in whole UTC minutes.
 export const WINDOW_MINUTES = 5;
+
+// Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
+// covers clock skew between pods.
+export const COUNTER_KEY_TTL_SECONDS = 900;

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -1,0 +1,125 @@
+import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
+import { modelHealthKey } from "@app/lib/api/llm/health/keys";
+import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
+import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
+import { runOnRedisCache } from "@app/lib/api/redis";
+import { redisMock } from "@app/tests/utils/mocks/redis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ENDPOINT = {
+  modelId: "claude-sonnet-5",
+  providerId: "anthropic",
+  host: "anthropic",
+} as const;
+
+const SUCCESS = { outcome: "success" } as const;
+
+function providerError(errorType: LLMErrorType) {
+  return { outcome: "error", errorSource: "provider", errorType } as const;
+}
+
+const NOW = new Date("2026-09-03T14:32:10Z");
+const KEY = modelHealthKey(ENDPOINT, "202609031432");
+
+async function record(outcome: LLMAttemptOutcomeTelemetry): Promise<void> {
+  await recordLLMAttempt({ endpoint: ENDPOINT, outcome, now: NOW });
+}
+
+describe("model health counters", () => {
+  beforeEach(() => {
+    redisMock.reset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aggregates attempts and provider errors into one hash", async () => {
+    await record(SUCCESS);
+    await record(SUCCESS);
+    await record(providerError("overloaded_error"));
+    await record(providerError("overloaded_error"));
+    await record(providerError("server_error"));
+
+    expect(await redisMock.cacheClient.hGetAll(KEY)).toEqual({
+      attempts: "5",
+      error_provider: "3",
+    });
+  });
+
+  it("counts a dust-attributed failure as an attempt but not as an error", async () => {
+    // The numerator is provider-attributed outages only: a 429 we raised or a
+    // malformed request says nothing about the provider's health.
+    await record({
+      outcome: "error",
+      errorSource: "dust",
+      errorType: "rate_limit_error",
+    });
+
+    const hash = await redisMock.cacheClient.hGetAll(KEY);
+    expect(hash.attempts).toBe("1");
+    expect(hash.error_provider).toBeUndefined();
+  });
+
+  it("sets a TTL so counters expire on their own", async () => {
+    await record(SUCCESS);
+
+    expect(redisMock.cacheClient.expire).toHaveBeenCalledWith(
+      KEY,
+      expect.any(Number)
+    );
+  });
+
+  it("adds to what other pods already wrote rather than overwriting it", async () => {
+    await redisMock.cacheClient.hIncrBy(KEY, "attempts", 100);
+
+    await record(SUCCESS);
+
+    expect((await redisMock.cacheClient.hGetAll(KEY)).attempts).toBe("101");
+  });
+
+  it("writes each attempt into the bucket of its own minute", async () => {
+    await record(SUCCESS);
+    await recordLLMAttempt({
+      endpoint: ENDPOINT,
+      outcome: SUCCESS,
+      now: new Date("2026-09-03T14:33:01Z"),
+    });
+
+    expect((await redisMock.cacheClient.hGetAll(KEY)).attempts).toBe("1");
+    expect(
+      (
+        await redisMock.cacheClient.hGetAll(
+          modelHealthKey(ENDPOINT, "202609031433")
+        )
+      ).attempts
+    ).toBe("1");
+  });
+
+  it("ignores the noop endpoint", async () => {
+    await recordLLMAttempt({
+      endpoint: { modelId: "noop", providerId: "noop", host: "noop" },
+      outcome: providerError("server_error"),
+      now: NOW,
+    });
+
+    expect(runOnRedisCache).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failed write rather than surfacing it to the caller", async () => {
+    vi.mocked(runOnRedisCache).mockRejectedValueOnce(
+      new Error("redis is down")
+    );
+
+    // Never rejects: callers `void` this, so a rejection would be an unhandled
+    // one on the request path.
+    await expect(
+      record(providerError("server_error"))
+    ).resolves.toBeUndefined();
+
+    // The lost attempt is not replayed; the next one writes on its own.
+    await record(SUCCESS);
+
+    expect((await redisMock.cacheClient.hGetAll(KEY)).attempts).toBe("1");
+  });
+});

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -1,0 +1,67 @@
+import { COUNTER_KEY_TTL_SECONDS } from "@app/lib/api/llm/health/config";
+import {
+  ATTEMPTS_FIELD,
+  minuteBucket,
+  modelHealthKey,
+  PROVIDER_ERRORS_FIELD,
+} from "@app/lib/api/llm/health/keys";
+import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
+import { runOnRedisCache } from "@app/lib/api/redis";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import { NOOP_HOST } from "@app/lib/model_constructors/types/hosts";
+import { statsDMetrics } from "@app/lib/utils/statsd";
+
+/**
+ * Records one model call attempt at its terminal outcome.
+ *
+ * Fire and forget: callers `void` this, so the request path never waits on
+ * Redis and never fails with it. `HINCRBY` is additive, so N pods need no
+ * coordination and no read-modify-write.
+ *
+ * Dropping writes is acceptable by design. The threshold is a share of hundreds
+ * of attempts over five minutes, so a handful of lost increments cannot change
+ * the verdict -- which is why nothing here retries, batches or blocks.
+ *
+ * Only provider-attributed errors count towards the numerator. That is exactly
+ * the `error_source:provider` filter the existing Datadog monitor applies at
+ * query time to `llm_error.count`.
+ */
+export async function recordLLMAttempt({
+  endpoint,
+  outcome,
+  now = new Date(),
+}: {
+  endpoint: DegradedModelEndpointType;
+  outcome: LLMAttemptOutcomeTelemetry;
+  now?: Date;
+}): Promise<void> {
+  // The noop model is a test fixture, not an endpoint anyone can be degraded on.
+  if (endpoint.host === NOOP_HOST) {
+    return;
+  }
+
+  const key = modelHealthKey(endpoint, minuteBucket(now));
+  const isProviderError =
+    outcome.outcome === "error" && outcome.errorSource === "provider";
+
+  try {
+    await runOnRedisCache({ origin: "model_health" }, async (client) => {
+      const multi = client.multi();
+
+      multi.hIncrBy(key, ATTEMPTS_FIELD, 1);
+      if (isProviderError) {
+        multi.hIncrBy(key, PROVIDER_ERRORS_FIELD, 1);
+      }
+      // Refreshed on every write, so a bucket outlives its last attempt by the
+      // TTL rather than by its own age.
+      multi.expire(key, COUNTER_KEY_TTL_SECONDS);
+
+      await multi.exec();
+    });
+  } catch {
+    // Counted rather than logged: this runs once per attempt, so a Redis outage
+    // would put one line per attempt in the logs. The connection error itself is
+    // already logged once by the client's `error` handler in `lib/api/redis`.
+    statsDMetrics.increment("model_health.write_error.count", 1);
+  }
+}

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -84,8 +84,6 @@ export abstract class LLM<
   protected responseFormat: string | null;
   protected bypassFeatureFlag: boolean;
   protected metadata: LLMClientMetadata;
-  // Kept alongside modelId/providerId because model health is tracked per
-  // endpoint, see `DegradedModelEndpointType`.
   protected host: Host;
   // Temporary during the router migration; "new" is set by BaseTransition.
   protected readonly router: "legacy" | "new" = "legacy";
@@ -202,10 +200,6 @@ export abstract class LLM<
     const baseTags = this.getTelemetryTags({ surface: "stream" });
     const latencyTags = this.getLatencyTelemetryTags({ surface: "stream" });
 
-    // Feeds the model health circuit breaker. Fired and forgotten: nothing here
-    // waits on Redis or fails with it. The endpoint is always concrete at this
-    // point -- `auto`, `auto_fast` and `auto_complex` are collapsed to a real
-    // model before the LLM is built.
     void recordLLMAttempt({
       endpoint: {
         modelId: this.modelId,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -3,6 +3,7 @@ import {
   contributeFreeUsageCostForUser,
   isFreeUsageContext,
 } from "@app/lib/api/llm/free_usage";
+import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
 import { LLMRunLifecycle } from "@app/lib/api/llm/run_lifecycle";
 import type {
   LLMAttemptOutcome,
@@ -46,6 +47,7 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
 import { getUsageType } from "@app/lib/metronome/events";
 import type { UsageType } from "@app/lib/metronome/types";
+import type { Host } from "@app/lib/model_constructors/types/hosts";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { statsDMetrics } from "@app/lib/utils/statsd";
@@ -82,6 +84,9 @@ export abstract class LLM<
   protected responseFormat: string | null;
   protected bypassFeatureFlag: boolean;
   protected metadata: LLMClientMetadata;
+  // Kept alongside modelId/providerId because model health is tracked per
+  // endpoint, see `DegradedModelEndpointType`.
+  protected host: Host;
   // Temporary during the router migration; "new" is set by BaseTransition.
   protected readonly router: "legacy" | "new" = "legacy";
 
@@ -104,6 +109,7 @@ export abstract class LLM<
   ) {
     const modelConfig = modelInfo.endpoint.modelConfig;
     this.modelId = modelConfig.modelId;
+    this.host = modelInfo.endpoint.host;
     this.modelConfig = modelConfig;
     this.temperature =
       modelInfo.temperature ?? AGENT_CREATIVITY_LEVEL_TEMPERATURES["balanced"];
@@ -195,6 +201,19 @@ export abstract class LLM<
   } & LLMAttemptOutcomeTelemetry): void {
     const baseTags = this.getTelemetryTags({ surface: "stream" });
     const latencyTags = this.getLatencyTelemetryTags({ surface: "stream" });
+
+    // Feeds the model health circuit breaker. Fired and forgotten: nothing here
+    // waits on Redis or fails with it. The endpoint is always concrete at this
+    // point -- `auto`, `auto_fast` and `auto_complex` are collapsed to a real
+    // model before the LLM is built.
+    void recordLLMAttempt({
+      endpoint: {
+        modelId: this.modelId,
+        providerId: this.modelConfig.providerId,
+        host: this.host,
+      },
+      outcome: outcomeTelemetry,
+    });
 
     switch (outcomeTelemetry.outcome) {
       case "error":
@@ -807,6 +826,11 @@ export abstract class LLM<
         statsDMetrics.increment("llm_success.count", 1, metricTags);
       }
       statsDMetrics.increment("llm_interaction.count", 1, metricTags);
+
+      // TODO(detect_outage): batch attempts deliberately do not feed the model
+      // health counters. A batch job is submitted then polled over hours, so its
+      // error surfaces at a timestamp unrelated to when the provider was
+      // unhealthy, and folding that into a five-minute window would smear it.
 
       const { tokenUsage, ...rest } = buffer.currentOutput;
 

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -821,10 +821,10 @@ export abstract class LLM<
       }
       statsDMetrics.increment("llm_interaction.count", 1, metricTags);
 
-      // TODO(detect_outage): batch attempts deliberately do not feed the model
-      // health counters. A batch job is submitted then polled over hours, so its
-      // error surfaces at a timestamp unrelated to when the provider was
-      // unhealthy, and folding that into a five-minute window would smear it.
+      // batch attempts deliberately do not feed the model health counters.
+      // A batch job is submitted then polled over hours, so its error surfaces
+      // at a timestamp unrelated to when the provider was unhealthy, and folding
+      // that into a five-minute window would smear it.
 
       const { tokenUsage, ...rest } = buffer.currentOutput;
 


### PR DESCRIPTION
## Description

Hooks `recordLLMAttempt` into the stream telemetry path, where the terminal outcome of a
run is already known. Write-only for now: the counters accumulate, nothing reads them
back until #31881.

Fire and forget on purpose — the call is `void`ed, wrapped in a try/catch, and reports
failures to statsd rather than the logs (this runs once per attempt, so a Redis outage
would otherwise put one line per attempt in the logs; the connection error itself is
already logged once by the client's `error` handler). `HINCRBY` is additive, so N pods
need no coordination and no read-modify-write, and a dropped increment cannot move a
threshold measured over hundreds of attempts.

Only provider-attributed errors count towards the numerator, matching the
`error_source:provider` filter our Datadog monitor already applies to `llm_error.count`.

Batch attempts are deliberately left out: a batch is submitted then polled over hours,
so its error lands at a timestamp unrelated to when the provider was unhealthy, and
folding that into a five-minute window would smear it.

PR 3 of 5: #31877 → #31878 → this → #31880 → #31881.

## Tests

Unit tests covering the aggregation, that a Dust-attributed failure counts as an attempt
but not as an error, the TTL, additivity against what another pod already wrote,
per-minute bucketing, the noop endpoint being skipped, and that a failed write resolves
rather than rejecting (callers `void` this, so a rejection would be an unhandled one on
the request path). `npm run test -- llm/health`.

## Risk

This is the only PR in the stack that touches the inference request path. The exposure is
one extra `void`ed Redis pipeline per attempt, after the outcome is already settled: it
cannot throw into the caller, cannot delay the stream, and degrades to a statsd counter
if Redis is unavailable. Safe to roll back on its own — nothing depends on the counters yet.

Worth watching after deploy: `model_health.write_error.count` should stay flat, and Redis
memory should rise by roughly (endpoints × 15 live minute-buckets) small hashes, each
expiring on its own via the 900s TTL.
