### PR TITLE
feat(llm): add the model health recovery workflow and its probe

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -66,6 +66,16 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
       "Disable Firecrawl for web browsing and use Spider.cloud instead.",
     icon: Fire,
   },
+  pause_model_health_detection: {
+    title: "Model Health Detection",
+    description:
+      "Stop recording model attempts into the health counters, and stop the breach detection they feed.",
+    note:
+      "Sheds the per-attempt Redis write and the recovery workflow starts. Recovery workflows already " +
+      "running are left alone. Takes up to 60s to apply on each pod, as the write path reads the switch " +
+      "from an in-process cache.",
+    icon: AlertCircle,
+  },
   pause_upsert_queue: {
     title: "Upsert Queue",
     description:

--- a/front/lib/api/kill_switch_cache.ts
+++ b/front/lib/api/kill_switch_cache.ts
@@ -1,0 +1,50 @@
+import type { KillSwitchType } from "@app/lib/poke/types";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * A kill switch read as a plain synchronous boolean, kept in process.
+ *
+ * `KillSwitchResource` reads Redis, and falls back to the database when that
+ * fails: far too much for a switch consulted on every call of a hot path. This
+ * keeps the last known value in process and refreshes it in the background at
+ * most once per `refreshIntervalMs`.
+ *
+ * Consequences: toggling the switch in Poke takes effect within that window on
+ * each pod, a pod reads `false` until its first refresh resolves (a few ms
+ * after boot), and a Redis or database blip leaves the last known value in
+ * place rather than flipping behaviour.
+ */
+export function makeCachedKillSwitch(
+  type: KillSwitchType,
+  { refreshIntervalMs }: { refreshIntervalMs: number }
+): () => boolean {
+  let cachedValue = false;
+  let lastRefreshStartedAtMs = 0;
+  let refreshing = false;
+
+  return function isEnabled(): boolean {
+    const nowMs = Date.now();
+    if (!refreshing && nowMs - lastRefreshStartedAtMs > refreshIntervalMs) {
+      refreshing = true;
+      lastRefreshStartedAtMs = nowMs;
+
+      void KillSwitchResource.isKillSwitchEnabled(type)
+        .then((enabled) => {
+          cachedValue = enabled;
+        })
+        .catch((err) => {
+          logger.error(
+            { err: normalizeError(err), killSwitch: type },
+            "Failed to refresh a kill switch"
+          );
+        })
+        .finally(() => {
+          refreshing = false;
+        });
+    }
+
+    return cachedValue;
+  };
+}

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -8,6 +8,12 @@
 // Length of the sliding window, in whole UTC minutes.
 export const WINDOW_MINUTES = 5;
 
+// How long an endpoint stays degraded before the first recovery probe.
+export const MIN_DEGRADED_DURATION_MS = 10 * 60 * 1000;
+
+// Consecutive synthetic probes that must all succeed to declare a recovery.
+export const PROBES_PER_RECOVERY = 3;
+
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.
 export const COUNTER_KEY_TTL_SECONDS = WINDOW_MINUTES * 60 * 3;

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -17,3 +17,6 @@ export const PROBES_PER_RECOVERY = 3;
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.
 export const COUNTER_KEY_TTL_SECONDS = WINDOW_MINUTES * 60 * 3;
+
+// Wall-clock ceiling for a single probe, from request to first event.
+export const PROBE_TIMEOUT_MS = 30 * 1000;

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -5,14 +5,22 @@
  * without a workflow environment.
  */
 
+export const ERROR_RATIO_THRESHOLD = 0.2;
+
 // Length of the sliding window, in whole UTC minutes.
 export const WINDOW_MINUTES = 5;
+
+export const MIN_ATTEMPTS_IN_WINDOW = 100;
 
 // How long an endpoint stays degraded before the first recovery probe.
 export const MIN_DEGRADED_DURATION_MS = 10 * 60 * 1000;
 
 // Consecutive synthetic probes that must all succeed to declare a recovery.
 export const PROBES_PER_RECOVERY = 3;
+
+// How often one endpoint may be evaluated, per pod: during an outage error
+// writes land hundreds of times a second on the same endpoint.
+export const MIN_EVALUATION_INTERVAL_MS = 5_000;
 
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -1,10 +1,28 @@
+import {
+  MIN_DEGRADED_DURATION_MS,
+  MIN_EVALUATION_INTERVAL_MS,
+} from "@app/lib/api/llm/health/config";
 import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
+import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import { modelHealthKey } from "@app/lib/api/llm/health/keys";
+import { isModelHealthDetectionPaused } from "@app/lib/api/llm/health/kill_switch";
 import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import { runOnRedisCache } from "@app/lib/api/redis";
 import { redisMock } from "@app/tests/utils/mocks/redis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Detection is exercised on its own; here we only care about when it is asked
+// for, so it never reaches Redis.
+vi.mock("@app/lib/api/llm/health/detect", () => ({
+  evaluateEndpoint: vi.fn().mockResolvedValue({ outcome: "not_breaching" }),
+}));
+
+// Reads the kill switch out of an in-process cache in production; here it is
+// simply off unless a test says otherwise.
+vi.mock("@app/lib/api/llm/health/kill_switch", () => ({
+  isModelHealthDetectionPaused: vi.fn().mockReturnValue(false),
+}));
 
 const ENDPOINT = {
   modelId: "claude-sonnet-5",
@@ -121,5 +139,145 @@ describe("model health counters", () => {
     await record(SUCCESS);
 
     expect((await redisMock.cacheClient.hGetAll(KEY)).attempts).toBe("1");
+  });
+
+  it("evaluates the endpoint it just wrote, and only on a provider error", async () => {
+    // The throttle is module state keyed by endpoint, so each of these tests
+    // takes a model of its own.
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-5" } as const;
+
+    await recordLLMAttempt({ endpoint, outcome: SUCCESS, now: NOW });
+    expect(evaluateEndpoint).not.toHaveBeenCalled();
+
+    await recordLLMAttempt({
+      endpoint,
+      outcome: providerError("overloaded_error"),
+      now: NOW,
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledWith(endpoint, NOW);
+  });
+
+  it("evaluates one endpoint at most once per interval", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-8" } as const;
+    const error = providerError("overloaded_error");
+
+    // An outage puts hundreds of these a second on the same endpoint; they must
+    // not each read the window and hand Temporal a duplicate start.
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + 1_000),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    const laterMs = NOW.getTime() + MIN_EVALUATION_INTERVAL_MS;
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(laterMs),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { outcome: "recovery_started", modelId: "claude-sonnet-4-6" },
+    { outcome: "already_degraded", modelId: "claude-opus-4-6" },
+  ] as const)("holds a $outcome endpoint until the workflow's next probe", async ({
+    outcome,
+    modelId,
+  }) => {
+    const endpoint = { ...ENDPOINT, modelId } as const;
+    const error = providerError("overloaded_error");
+    const degradedSinceMs = NOW.getTime() - MIN_DEGRADED_DURATION_MS * 0.9;
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome,
+      degradedSinceMs,
+    });
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    // Nothing can change before that probe, so re-reading the window until
+    // then would only earn a rejected start, from every pod.
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(degradedSinceMs + MIN_DEGRADED_DURATION_MS - 1),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(degradedSinceMs + MIN_DEGRADED_DURATION_MS),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the usual cadence when the workflow start time is unknown", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-fable-5" } as const;
+    const error = providerError("overloaded_error");
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome: "already_degraded",
+      degradedSinceMs: null,
+    });
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + MIN_EVALUATION_INTERVAL_MS),
+    });
+
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps evaluating when the workflow could not be started", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-7" } as const;
+    const error = providerError("overloaded_error");
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome: "launch_failed",
+    });
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + MIN_EVALUATION_INTERVAL_MS),
+    });
+
+    // Nothing holds the endpoint, so the next window is still worth a look.
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not evaluate when the write failed", async () => {
+    const endpoint = {
+      ...ENDPOINT,
+      modelId: "claude-haiku-4-5-20251001",
+    } as const;
+    vi.mocked(runOnRedisCache).mockRejectedValueOnce(
+      new Error("redis is down")
+    );
+
+    await recordLLMAttempt({
+      endpoint,
+      outcome: providerError("server_error"),
+      now: NOW,
+    });
+
+    expect(evaluateEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all while the kill switch is on", async () => {
+    vi.mocked(isModelHealthDetectionPaused).mockReturnValueOnce(true);
+
+    await record(providerError("server_error"));
+
+    // The point of the switch is to take the whole path out during an incident,
+    // so neither the write nor the detection it triggers may run.
+    expect(runOnRedisCache).not.toHaveBeenCalled();
+    expect(evaluateEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -1,15 +1,81 @@
-import { COUNTER_KEY_TTL_SECONDS } from "@app/lib/api/llm/health/config";
+import {
+  COUNTER_KEY_TTL_SECONDS,
+  MIN_DEGRADED_DURATION_MS,
+  MIN_EVALUATION_INTERVAL_MS,
+} from "@app/lib/api/llm/health/config";
+import type { EndpointEvaluationType } from "@app/lib/api/llm/health/detect";
+import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import {
   ATTEMPTS_FIELD,
   minuteBucket,
   modelHealthKey,
   PROVIDER_ERRORS_FIELD,
 } from "@app/lib/api/llm/health/keys";
+import { isModelHealthDetectionPaused } from "@app/lib/api/llm/health/kill_switch";
 import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
 import { runOnRedisCache } from "@app/lib/api/redis";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import { degradedModelEndpointKey } from "@app/lib/model_constructors/types/degradations";
 import { NOOP_HOST } from "@app/lib/model_constructors/types/hosts";
 import { statsDMetrics } from "@app/lib/utils/statsd";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+// The soonest each endpoint may be evaluated again, per pod.
+const nextEvaluationAtMs = new Map<string, number>();
+
+// A running recovery workflow only releases the endpoint at one of its probes,
+// so wait for the next one; anything else keeps the usual cadence.
+function evaluationDueAtMs(
+  evaluation: EndpointEvaluationType,
+  nowMs: number
+): number {
+  const cadenceAtMs = nowMs + MIN_EVALUATION_INTERVAL_MS;
+
+  switch (evaluation.outcome) {
+    case "recovery_started":
+    case "already_degraded": {
+      const { degradedSinceMs } = evaluation;
+      if (degradedSinceMs === null) {
+        return cadenceAtMs;
+      }
+
+      const probesSoFar = Math.floor(
+        (nowMs - degradedSinceMs) / MIN_DEGRADED_DURATION_MS
+      );
+
+      return Math.max(
+        cadenceAtMs,
+        degradedSinceMs + MIN_DEGRADED_DURATION_MS * (probesSoFar + 1)
+      );
+    }
+
+    case "not_breaching":
+    case "launch_failed":
+      return cadenceAtMs;
+
+    default:
+      assertNever(evaluation);
+  }
+}
+
+function isEvaluationDue(
+  endpoint: DegradedModelEndpointType,
+  nowMs: number
+): boolean {
+  const key = degradedModelEndpointKey(endpoint);
+  const dueAtMs = nextEvaluationAtMs.get(key);
+
+  if (dueAtMs !== undefined && nowMs < dueAtMs) {
+    return false;
+  }
+
+  // Held before the evaluation runs, not after: two attempts on this pod can
+  // interleave across the await otherwise, and both would evaluate. The outcome
+  // overwrites this with its own hold.
+  nextEvaluationAtMs.set(key, nowMs + MIN_EVALUATION_INTERVAL_MS);
+
+  return true;
+}
 
 /**
  * Records one model call attempt at its terminal outcome.
@@ -21,6 +87,9 @@ import { statsDMetrics } from "@app/lib/utils/statsd";
  * Dropping writes is acceptable by design. The threshold is a share of hundreds
  * of attempts over five minutes, so a handful of lost increments cannot change
  * the verdict -- which is why nothing here retries, batches or blocks.
+ *
+ * An error write is also what triggers detection for that endpoint, throttled by
+ * `evaluationDueAtMs` on what the last evaluation established.
  *
  * Only provider-attributed errors count towards the numerator. That is exactly
  * the `error_source:provider` filter the existing Datadog monitor applies at
@@ -40,6 +109,13 @@ export async function recordLLMAttempt({
     return;
   }
 
+  // The operator switch, so this whole path can be taken out during an incident
+  // without shipping a revert.
+  if (isModelHealthDetectionPaused()) {
+    return;
+  }
+
+  const nowMs = now.getTime();
   const key = modelHealthKey(endpoint, minuteBucket(now));
   const isProviderError =
     outcome.outcome === "error" && outcome.errorSource === "provider";
@@ -58,6 +134,20 @@ export async function recordLLMAttempt({
 
       await multi.exec();
     });
+
+    // Only an error can push the ratio over the threshold, so a successful
+    // attempt has nothing to detect. This reads back the window for this one
+    // endpoint -- the one we just served -- and never for any other.
+    if (isProviderError && isEvaluationDue(endpoint, nowMs)) {
+      // While recovery holds the endpoint, evaluating again buys nothing: the
+      // window still breaches and the start still comes back rejected. How long
+      // that stays true depends on the outcome, so the hold does too.
+      const evaluation = await evaluateEndpoint(endpoint, now);
+      nextEvaluationAtMs.set(
+        degradedModelEndpointKey(endpoint),
+        evaluationDueAtMs(evaluation, nowMs)
+      );
+    }
   } catch {
     // Counted rather than logged: this runs once per attempt, so a Redis outage
     // would put one line per attempt in the logs. The connection error itself is

--- a/front/lib/api/llm/health/detect.test.ts
+++ b/front/lib/api/llm/health/detect.test.ts
@@ -1,0 +1,148 @@
+import {
+  ERROR_RATIO_THRESHOLD,
+  MIN_ATTEMPTS_IN_WINDOW,
+} from "@app/lib/api/llm/health/config";
+import { evaluateEndpoint, isBreaching } from "@app/lib/api/llm/health/detect";
+import {
+  ATTEMPTS_FIELD,
+  modelHealthKey,
+  PROVIDER_ERRORS_FIELD,
+} from "@app/lib/api/llm/health/keys";
+import { logModelHealthTransition } from "@app/lib/api/llm/health/transitions";
+import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
+import { redisMock } from "@app/tests/utils/mocks/redis";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/model_health/client", () => ({
+  launchModelHealthRecovery: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/llm/health/transitions", () => ({
+  logModelHealthTransition: vi.fn(),
+}));
+
+const ENDPOINT = {
+  modelId: "claude-sonnet-5",
+  providerId: "anthropic",
+  host: "anthropic",
+} as const;
+
+// Just enough attempts to clear the volume floor, so only the ratio decides,
+// and the fewest errors that breach on them.
+const ATTEMPTS = MIN_ATTEMPTS_IN_WINDOW;
+const BREACHING_ERRORS = Math.ceil(ATTEMPTS * ERROR_RATIO_THRESHOLD);
+
+const NOW = new Date("2026-09-03T14:32:10Z");
+const DEGRADED_SINCE_MS = NOW.getTime();
+
+async function seedWindow({
+  attempts,
+  providerErrors,
+}: {
+  attempts: number;
+  providerErrors: number;
+}): Promise<void> {
+  const key = modelHealthKey(ENDPOINT, "202609031432");
+  await redisMock.cacheClient.hIncrBy(key, ATTEMPTS_FIELD, attempts);
+  await redisMock.cacheClient.hIncrBy(
+    key,
+    PROVIDER_ERRORS_FIELD,
+    providerErrors
+  );
+}
+
+describe("isBreaching", () => {
+  it("ignores an endpoint below the volume floor, however bad the ratio", () => {
+    // 100% errors, but one attempt short of the floor the ratio is noise.
+    const attempts = MIN_ATTEMPTS_IN_WINDOW - 1;
+    expect(isBreaching({ attempts, providerErrors: attempts })).toBe(false);
+  });
+
+  it("breaches at the threshold", () => {
+    expect(
+      isBreaching({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS })
+    ).toBe(true);
+  });
+
+  it("does not breach just below it", () => {
+    expect(
+      isBreaching({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS - 1 })
+    ).toBe(false);
+  });
+
+  it("treats an idle endpoint as healthy", () => {
+    expect(isBreaching({ attempts: 0, providerErrors: 0 })).toBe(false);
+  });
+});
+
+describe("evaluateEndpoint", () => {
+  beforeEach(() => {
+    redisMock.reset();
+    vi.clearAllMocks();
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(
+      new Ok({ outcome: "started", degradedSinceMs: DEGRADED_SINCE_MS })
+    );
+  });
+
+  it("declares a breaching endpoint degraded", async () => {
+    await seedWindow({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS });
+
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "recovery_started",
+      degradedSinceMs: DEGRADED_SINCE_MS,
+    });
+
+    expect(launchModelHealthRecovery).toHaveBeenCalledWith(ENDPOINT);
+    expect(logModelHealthTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: ENDPOINT, transition: "degraded" })
+    );
+  });
+
+  it("leaves a healthy endpoint alone", async () => {
+    await seedWindow({
+      attempts: ATTEMPTS,
+      providerErrors: BREACHING_ERRORS - 1,
+    });
+
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "not_breaching",
+    });
+
+    expect(launchModelHealthRecovery).not.toHaveBeenCalled();
+    expect(logModelHealthTransition).not.toHaveBeenCalled();
+  });
+
+  it("does not log a transition when the endpoint was already degraded", async () => {
+    // Another pod won the race: the workflow already exists, so this is not a
+    // state change and must not show up as a second incident.
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(
+      new Ok({
+        outcome: "already_degraded",
+        degradedSinceMs: DEGRADED_SINCE_MS,
+      })
+    );
+    await seedWindow({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS });
+
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "already_degraded",
+      degradedSinceMs: DEGRADED_SINCE_MS,
+    });
+
+    expect(launchModelHealthRecovery).toHaveBeenCalledTimes(1);
+    expect(logModelHealthTransition).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a transition when the workflow could not be started", async () => {
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(
+      new Err(new Error("temporal is unreachable"))
+    );
+    await seedWindow({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS });
+
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "launch_failed",
+    });
+
+    expect(logModelHealthTransition).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/llm/health/detect.ts
+++ b/front/lib/api/llm/health/detect.ts
@@ -1,0 +1,74 @@
+import {
+  ERROR_RATIO_THRESHOLD,
+  MIN_ATTEMPTS_IN_WINDOW,
+} from "@app/lib/api/llm/health/config";
+import { logModelHealthTransition } from "@app/lib/api/llm/health/transitions";
+import type { ModelHealthWindowType } from "@app/lib/api/llm/health/types";
+import { readEndpointWindow } from "@app/lib/api/llm/health/window";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import logger from "@app/logger/logger";
+import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export function isBreaching(window: ModelHealthWindowType): boolean {
+  if (window.attempts < MIN_ATTEMPTS_IN_WINDOW) {
+    return false;
+  }
+
+  return window.providerErrors / window.attempts >= ERROR_RATIO_THRESHOLD;
+}
+
+/**
+ * What one evaluation established.
+ *
+ * The two degraded outcomes carry `degradedSinceMs`, the recovery workflow's
+ * start time, because that alone pins when the endpoint could next change
+ * state. It is null only when the workflow is running but its start time could
+ * not be read.
+ */
+export type EndpointEvaluationType =
+  | { outcome: "not_breaching" }
+  | { outcome: "recovery_started"; degradedSinceMs: number }
+  | { outcome: "already_degraded"; degradedSinceMs: number | null }
+  | { outcome: "launch_failed" };
+
+export async function evaluateEndpoint(
+  endpoint: DegradedModelEndpointType,
+  now: Date = new Date()
+): Promise<EndpointEvaluationType> {
+  const window = await readEndpointWindow(endpoint, now);
+  if (!isBreaching(window)) {
+    return { outcome: "not_breaching" };
+  }
+
+  const launchRes = await launchModelHealthRecovery(endpoint);
+  if (launchRes.isErr()) {
+    logger.error(
+      {
+        err: normalizeError(launchRes.error),
+        modelId: endpoint.modelId,
+        providerId: endpoint.providerId,
+        modelHost: endpoint.host,
+      },
+      "Failed to start the model health recovery workflow"
+    );
+    return { outcome: "launch_failed" };
+  }
+
+  switch (launchRes.value.outcome) {
+    case "started":
+      logModelHealthTransition({ endpoint, transition: "degraded", window });
+      return {
+        outcome: "recovery_started",
+        degradedSinceMs: launchRes.value.degradedSinceMs,
+      };
+
+    case "already_degraded":
+      // Not a state change: another pod already logged the transition.
+      return launchRes.value;
+
+    default:
+      assertNever(launchRes.value);
+  }
+}

--- a/front/lib/api/llm/health/kill_switch.ts
+++ b/front/lib/api/llm/health/kill_switch.ts
@@ -1,0 +1,24 @@
+import { makeCachedKillSwitch } from "@app/lib/api/kill_switch_cache";
+
+// How long a pod may serve a stale value of the kill switch.
+const REFRESH_INTERVAL_MS = 60 * 1000;
+
+const isDetectionPaused = makeCachedKillSwitch("pause_model_health_detection", {
+  refreshIntervalMs: REFRESH_INTERVAL_MS,
+});
+
+/**
+ * Whether to stop recording attempts and detecting breaches, toggled from Poke.
+ *
+ * The whole point of an operator switch here is that it works during an
+ * incident, when shipping a revert is exactly what we cannot afford. It is read
+ * on every attempt, so it comes from an in-process cache rather than Redis --
+ * consulting Redis to decide whether to write to Redis would be self-defeating
+ * on the one failure this path most needs to survive.
+ *
+ * Recovery workflows already running are not affected: they only probe and log,
+ * and they end on their own.
+ */
+export function isModelHealthDetectionPaused(): boolean {
+  return isDetectionPaused();
+}

--- a/front/lib/api/llm/health/probe.ts
+++ b/front/lib/api/llm/health/probe.ts
@@ -1,4 +1,7 @@
-import { PROBES_PER_RECOVERY } from "@app/lib/api/llm/health/config";
+import {
+  PROBE_TIMEOUT_MS,
+  PROBES_PER_RECOVERY,
+} from "@app/lib/api/llm/health/config";
 import { dangerouslyGetDustManagedLlmCredentials } from "@app/lib/api/provider_credentials";
 import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
@@ -6,10 +9,9 @@ import type { DegradedModelEndpointType } from "@app/lib/model_constructors/type
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import type { Payload } from "@app/lib/model_constructors/types/input/messages";
 import logger from "@app/logger/logger";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-// Short enough that the provider has nothing to think about, and phrased so the
-// first token arrives immediately.
 const PROBE_PROMPT = "Reply with the single character: 1";
 
 export function findStreamEndpoint({
@@ -31,15 +33,9 @@ export function findStreamEndpoint({
 }
 
 /**
- * The cheapest config an endpoint will accept.
- *
- * Reasoning off is the goal, but each endpoint's schema mirrors what its
- * provider actually supports, and they disagree: some expose `none`, some reject
- * it and rely on a `configParsers` entry to map it onto their own floor. The
- * parsers therefore run before `parse`, exactly as `buildConfig` does in
- * transitionLLM. Where even that is refused, fall back to the empty config so
- * the schema applies its own defaults -- a probe that thinks for a moment is
- * still a probe, and we abort at the first token either way.
+ * The cheapest config an endpoint will accept. Reasoning off where possible,
+ * running `configParsers` before `parse` as `buildConfig` does in transitionLLM,
+ * and falling back to the schema defaults when `none` is refused.
  */
 function buildProbeConfig(
   endpoint: DustStreamEndpointConstructor
@@ -61,14 +57,10 @@ function buildProbeConfig(
 }
 
 /**
- * One synthetic inference against a live endpoint.
- *
- * Deliberately bypasses `LLM`: no `Run` row, no usage row, no Langfuse trace and
- * no counter write, so a probe can never feed the very signal it is measuring.
- *
- * Resolves as soon as the endpoint emits its first token. That is all we need --
- * one inferred token proves it is serving -- and returning early from the
- * generator stops the generation instead of paying for a full response.
+ * One synthetic inference against a live endpoint. Bypasses `LLM` so a probe
+ * writes no `Run`, usage, trace or counter, and never feeds the signal it
+ * measures. Resolves on the first event -- reasoning included -- then stops the
+ * generation, with `PROBE_TIMEOUT_MS` bounding an endpoint that streams nothing.
  */
 async function runSingleProbe(
   endpoint: DustStreamEndpointConstructor
@@ -90,34 +82,78 @@ async function runSingleProbe(
   const input = await instance.buildRequestPayload(payload, config);
   const events = instance.rawStreamOutputToEvents(instance.streamRaw(input));
 
-  try {
-    for await (const event of events) {
-      switch (event.type) {
-        case "text_delta":
-        case "reasoning_delta":
-        case "text":
-        case "reasoning":
-        case "success":
-          return true;
-        case "error":
-          return false;
-        default:
-          continue;
+  const firstEvent = (async (): Promise<boolean> => {
+    try {
+      for await (const event of events) {
+        switch (event.type) {
+          case "text_delta":
+          case "reasoning_delta":
+          case "text":
+          case "reasoning":
+          case "success":
+            return true;
+          case "error":
+            return false;
+          case "response_id":
+          case "tool_call_started":
+          case "tool_call_delta":
+          case "tool_call":
+          case "provider_passthrough":
+          case "token_usage":
+            // Not evidence the endpoint can generate: keep waiting.
+            continue;
+          default:
+            assertNeverAndIgnore(event);
+            continue;
+        }
       }
+    } finally {
+      // Stops the provider stream when we returned before it ended.
+      await events.return(undefined);
     }
+
+    // Closed without a terminal event: not healthy.
+    return false;
+  })();
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeoutHandle = setTimeout(() => resolve("timeout"), PROBE_TIMEOUT_MS);
+  });
+
+  let raced;
+  try {
+    raced = await Promise.race([firstEvent, timeoutPromise]);
   } finally {
-    // Stops the provider stream when we returned before it ended.
-    await events.return(undefined);
+    clearTimeout(timeoutHandle);
   }
 
-  // The stream closed without a terminal event: not a healthy endpoint.
+  if (raced !== "timeout") {
+    return raced;
+  }
+
+  logger.info(
+    {
+      modelId: endpoint.modelConfig.modelId,
+      providerId: endpoint.modelConfig.providerId,
+      modelHost: endpoint.host,
+      timeoutMs: PROBE_TIMEOUT_MS,
+    },
+    "Model health probe timed out"
+  );
+
+  // Queued behind the in-flight `next()`, so awaiting it would reintroduce the
+  // hang the deadline bounds.
+  void events.return(undefined);
+  // Swallow a late rejection from the abandoned generator.
+  firstEvent.catch(() => {});
+
   return false;
 }
 
 /**
- * A recovery round: `PROBES_PER_RECOVERY` sequential probes, all of which must
- * succeed. Sequential rather than parallel so a provider that is only
- * intermittently serving cannot pass on a lucky burst.
+ * A recovery round: `PROBES_PER_RECOVERY` probes that must all succeed. Run
+ * sequentially so an intermittent provider cannot pass on a lucky burst.
  */
 export async function probeEndpoint(
   endpoint: DegradedModelEndpointType
@@ -128,7 +164,7 @@ export async function probeEndpoint(
       {
         modelId: endpoint.modelId,
         providerId: endpoint.providerId,
-        host: endpoint.host,
+        modelHost: endpoint.host,
       },
       "No stream endpoint matches the endpoint to probe"
     );
@@ -140,14 +176,13 @@ export async function probeEndpoint(
     try {
       healthy = await runSingleProbe(constructor);
     } catch (err) {
-      // The provider SDKs are external, so a throw here is expected shape, not
-      // a bug on our side: treat it as a failed probe.
+      // Provider SDKs are external: a throw is a failed probe, not a bug.
       logger.info(
         {
           err: normalizeError(err),
           modelId: endpoint.modelId,
           providerId: endpoint.providerId,
-          host: endpoint.host,
+          modelHost: endpoint.host,
           attempt,
         },
         "Model health probe threw"

--- a/front/lib/api/llm/health/probe.ts
+++ b/front/lib/api/llm/health/probe.ts
@@ -1,0 +1,164 @@
+import { PROBES_PER_RECOVERY } from "@app/lib/api/llm/health/config";
+import { dangerouslyGetDustManagedLlmCredentials } from "@app/lib/api/provider_credentials";
+import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
+import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Short enough that the provider has nothing to think about, and phrased so the
+// first token arrives immediately.
+const PROBE_PROMPT = "Reply with the single character: 1";
+
+export function findStreamEndpoint({
+  modelId,
+  providerId,
+  host,
+}: DegradedModelEndpointType): DustStreamEndpointConstructor | null {
+  for (const endpoint of Object.values(DUST_STREAM_ENDPOINTS)) {
+    if (
+      endpoint.modelConfig.modelId === modelId &&
+      endpoint.modelConfig.providerId === providerId &&
+      endpoint.host === host
+    ) {
+      return endpoint;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The cheapest config an endpoint will accept.
+ *
+ * Reasoning off is the goal, but each endpoint's schema mirrors what its
+ * provider actually supports, and they disagree: some expose `none`, some reject
+ * it and rely on a `configParsers` entry to map it onto their own floor. The
+ * parsers therefore run before `parse`, exactly as `buildConfig` does in
+ * transitionLLM. Where even that is refused, fall back to the empty config so
+ * the schema applies its own defaults -- a probe that thinks for a moment is
+ * still a probe, and we abort at the first token either way.
+ */
+function buildProbeConfig(
+  endpoint: DustStreamEndpointConstructor
+): InputConfig {
+  const parsers = endpoint.configParsers ?? [];
+  const withReasoningOff = parsers.reduce<InputConfig>(
+    (acc, parser) => parser(acc),
+    { reasoning: { effort: "none" } }
+  );
+
+  const parsed = endpoint.configSchema.safeParse(withReasoningOff);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  return endpoint.configSchema.parse(
+    parsers.reduce<InputConfig>((acc, parser) => parser(acc), {})
+  );
+}
+
+/**
+ * One synthetic inference against a live endpoint.
+ *
+ * Deliberately bypasses `LLM`: no `Run` row, no usage row, no Langfuse trace and
+ * no counter write, so a probe can never feed the very signal it is measuring.
+ *
+ * Resolves as soon as the endpoint emits its first token. That is all we need --
+ * one inferred token proves it is serving -- and returning early from the
+ * generator stops the generation instead of paying for a full response.
+ */
+async function runSingleProbe(
+  endpoint: DustStreamEndpointConstructor
+): Promise<boolean> {
+  const credentials = dangerouslyGetDustManagedLlmCredentials();
+  const instance = new endpoint(credentials);
+
+  const config = buildProbeConfig(endpoint);
+
+  const payload: Payload = {
+    conversation: {
+      system: [],
+      messages: [
+        { role: "user", type: "text", content: { value: PROBE_PROMPT } },
+      ],
+    },
+  };
+
+  const input = await instance.buildRequestPayload(payload, config);
+  const events = instance.rawStreamOutputToEvents(instance.streamRaw(input));
+
+  try {
+    for await (const event of events) {
+      switch (event.type) {
+        case "text_delta":
+        case "reasoning_delta":
+        case "text":
+        case "reasoning":
+        case "success":
+          return true;
+        case "error":
+          return false;
+        default:
+          continue;
+      }
+    }
+  } finally {
+    // Stops the provider stream when we returned before it ended.
+    await events.return(undefined);
+  }
+
+  // The stream closed without a terminal event: not a healthy endpoint.
+  return false;
+}
+
+/**
+ * A recovery round: `PROBES_PER_RECOVERY` sequential probes, all of which must
+ * succeed. Sequential rather than parallel so a provider that is only
+ * intermittently serving cannot pass on a lucky burst.
+ */
+export async function probeEndpoint(
+  endpoint: DegradedModelEndpointType
+): Promise<boolean> {
+  const constructor = findStreamEndpoint(endpoint);
+  if (!constructor) {
+    logger.error(
+      {
+        modelId: endpoint.modelId,
+        providerId: endpoint.providerId,
+        host: endpoint.host,
+      },
+      "No stream endpoint matches the endpoint to probe"
+    );
+    return false;
+  }
+
+  for (let attempt = 0; attempt < PROBES_PER_RECOVERY; attempt++) {
+    let healthy: boolean;
+    try {
+      healthy = await runSingleProbe(constructor);
+    } catch (err) {
+      // The provider SDKs are external, so a throw here is expected shape, not
+      // a bug on our side: treat it as a failed probe.
+      logger.info(
+        {
+          err: normalizeError(err),
+          modelId: endpoint.modelId,
+          providerId: endpoint.providerId,
+          host: endpoint.host,
+          attempt,
+        },
+        "Model health probe threw"
+      );
+      return false;
+    }
+
+    if (!healthy) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/front/lib/api/llm/health/transitions.ts
+++ b/front/lib/api/llm/health/transitions.ts
@@ -1,0 +1,58 @@
+import type { ModelHealthWindowType } from "@app/lib/api/llm/health/types";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import { statsDMetrics } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+
+export type ModelHealthTransitionType =
+  | "degraded"
+  | "recovered"
+  | "probe_failed";
+
+/**
+ * The only output of the shadow phase. Nothing is persisted, so these logs and
+ * the matching Datadog series are the whole record of what the breaker would
+ * have done.
+ */
+export function logModelHealthTransition({
+  endpoint,
+  transition,
+  window,
+  degradedForMs,
+}: {
+  endpoint: DegradedModelEndpointType;
+  transition: ModelHealthTransitionType;
+  window?: ModelHealthWindowType;
+  degradedForMs?: number;
+}): void {
+  const { modelId, providerId, host } = endpoint;
+
+  logger.info(
+    {
+      modelId,
+      providerId,
+      // `host` is reserved by our log infrastructure, so the endpoint's host
+      // goes out under a name of our own.
+      modelHost: host,
+      transition,
+      ...(window
+        ? {
+            attempts: window.attempts,
+            providerErrors: window.providerErrors,
+            errorRatio:
+              window.attempts > 0
+                ? window.providerErrors / window.attempts
+                : null,
+          }
+        : {}),
+      ...(degradedForMs !== undefined ? { degradedForMs } : {}),
+    },
+    "Model health transition"
+  );
+
+  statsDMetrics.increment("model_health.transition.count", 1, [
+    `transition:${transition}`,
+    `model_id:${modelId}`,
+    `provider_id:${providerId}`,
+    `model_host:${host}`,
+  ]);
+}

--- a/front/lib/api/permissions/legacy_acls.ts
+++ b/front/lib/api/permissions/legacy_acls.ts
@@ -1,47 +1,23 @@
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { makeCachedKillSwitch } from "@app/lib/api/kill_switch_cache";
 
 // How long a pod may serve a stale value of the kill switch.
 const REFRESH_INTERVAL_MS = 60 * 1000;
 
-let cachedValue = false;
-let lastRefreshStartedAt = 0;
-let refreshing = false;
+const isLegacyAclsKillSwitchEnabled = makeCachedKillSwitch("use_legacy_acls", {
+  refreshIntervalMs: REFRESH_INTERVAL_MS,
+});
 
 /**
  * Whether to serve permission decisions from the legacy inline-group ACLs instead of the
  * `group_permissions` table — the revert path for the governance migration, toggled from Poke.
  *
  * Read synchronously because permission checks are: `canWrite` runs inside `toJSON` and inside
- * array predicates. The kill switch itself lives in Redis, so this keeps the last known value in
- * process and refreshes it in the background at most every REFRESH_INTERVAL_MS. Consequences:
- * enabling it in Poke takes effect within that window on each pod, and a pod serves the new path
- * until its first refresh resolves (a few ms after boot).
+ * array predicates. The kill switch itself lives in Redis, so `makeCachedKillSwitch` keeps the
+ * last known value in process and refreshes it in the background at most every
+ * REFRESH_INTERVAL_MS.
  *
  * Temporary — delete along with the legacy path once the table is trusted.
  */
 export function isLegacyAclsEnabled(): boolean {
-  const now = Date.now();
-  if (!refreshing && now - lastRefreshStartedAt > REFRESH_INTERVAL_MS) {
-    refreshing = true;
-    lastRefreshStartedAt = now;
-
-    void KillSwitchResource.isKillSwitchEnabled("use_legacy_acls")
-      .then((enabled) => {
-        cachedValue = enabled;
-      })
-      .catch((err) => {
-        // Keep the last known value: a Redis blip must not flip permission behaviour.
-        logger.error(
-          { err: normalizeError(err) },
-          "Failed to refresh the use_legacy_acls kill switch"
-        );
-      })
-      .finally(() => {
-        refreshing = false;
-      });
-  }
-
-  return cachedValue;
+  return isLegacyAclsKillSwitchEnabled();
 }

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -4,6 +4,7 @@ export const KILL_SWITCH_TYPES = [
   "global_blacklist_anthropic",
   "global_blacklist_openai",
   "global_disable_firecrawl",
+  "pause_model_health_detection",
   "pause_upsert_queue",
   "use_legacy_acls",
 ] as const;

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -72,6 +72,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/mentions_count_queue");
     case "mentions_queue":
       return path.join(baseDir, "temporal/mentions_queue");
+    case "model_health":
+      return path.join(baseDir, "temporal/model_health");
     case "notifications_queue":
       return path.join(baseDir, "temporal/notifications_queue");
     case "poke":

--- a/front/temporal/model_health/activities.ts
+++ b/front/temporal/model_health/activities.ts
@@ -1,0 +1,37 @@
+import { probeEndpoint } from "@app/lib/api/llm/health/probe";
+import { logModelHealthTransition } from "@app/lib/api/llm/health/transitions";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+
+export async function probeEndpointActivity(
+  endpoint: DegradedModelEndpointType
+): Promise<boolean> {
+  return probeEndpoint(endpoint);
+}
+
+export async function logModelHealthRecoveryActivity({
+  endpoint,
+  degradedForMs,
+}: {
+  endpoint: DegradedModelEndpointType;
+  degradedForMs: number;
+}): Promise<void> {
+  logModelHealthTransition({
+    endpoint,
+    transition: "recovered",
+    degradedForMs,
+  });
+}
+
+export async function logModelHealthProbeFailedActivity({
+  endpoint,
+  degradedForMs,
+}: {
+  endpoint: DegradedModelEndpointType;
+  degradedForMs: number;
+}): Promise<void> {
+  logModelHealthTransition({
+    endpoint,
+    transition: "probe_failed",
+    degradedForMs,
+  });
+}

--- a/front/temporal/model_health/client.ts
+++ b/front/temporal/model_health/client.ts
@@ -1,0 +1,45 @@
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import {
+  QUEUE_NAME,
+  recoveryWorkflowId,
+} from "@app/temporal/model_health/config";
+import { modelHealthRecoveryWorkflow } from "@app/temporal/model_health/workflows";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+export type LaunchRecoveryOutcome = "started" | "already_degraded";
+
+/**
+ * Declares an endpoint degraded by starting its recovery workflow.
+ *
+ * Idempotent by construction: the workflow id is derived from the endpoint, so
+ * every pod that detects the same breach in the same instant lands on the same
+ * id and all but one get `WorkflowExecutionAlreadyStartedError` back. That
+ * rejection is not a failure -- it is how we learn the endpoint was already
+ * degraded -- so it comes back as an outcome rather than an error.
+ */
+export async function launchModelHealthRecovery(
+  endpoint: DegradedModelEndpointType
+): Promise<Result<LaunchRecoveryOutcome, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = recoveryWorkflowId(endpoint);
+
+  try {
+    await client.workflow.start(modelHealthRecoveryWorkflow, {
+      args: [endpoint],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+    });
+  } catch (err) {
+    if (err instanceof WorkflowExecutionAlreadyStartedError) {
+      return new Ok("already_degraded");
+    }
+
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok("started");
+}

--- a/front/temporal/model_health/client.ts
+++ b/front/temporal/model_health/client.ts
@@ -1,5 +1,6 @@
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
 import {
   QUEUE_NAME,
   recoveryWorkflowId,
@@ -10,7 +11,50 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 
-export type LaunchRecoveryOutcome = "started" | "already_degraded";
+/**
+ * How the endpoint came to be degraded, and since when.
+ *
+ * `degradedSinceMs` is the recovery workflow's start time, which is what pins
+ * the whole schedule: the workflow probes at that instant plus every multiple of
+ * `MIN_DEGRADED_DURATION_MS`, so it is the only thing a caller needs to know
+ * when the endpoint could next change state. It is null only when the workflow
+ * is running but its start time could not be read.
+ */
+export type LaunchRecoveryOutcome =
+  | { outcome: "started"; degradedSinceMs: number }
+  | { outcome: "already_degraded"; degradedSinceMs: number | null };
+
+/**
+ * Reads back the start time of the run that rejected our own start.
+ *
+ * There is exactly one run per degradation -- the workflow never continues as
+ * new -- so this run's start time is the moment the endpoint became degraded,
+ * with no chain to walk back.
+ */
+async function describeDegradedSinceMs(
+  client: Awaited<ReturnType<typeof getTemporalClientForFrontNamespace>>,
+  workflowId: string
+): Promise<number | null> {
+  try {
+    const description = await client.workflow.getHandle(workflowId).describe();
+
+    // It can have finished in the moment between the rejected start and this
+    // call, in which case the endpoint is no longer degraded and the caller
+    // should come back rather than wait on a schedule that has ended.
+    if (description.status.name !== "RUNNING") {
+      return null;
+    }
+
+    return description.startTime.getTime();
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), workflowId },
+      "Failed to read the model health recovery workflow start time"
+    );
+
+    return null;
+  }
+}
 
 /**
  * Declares an endpoint degraded by starting its recovery workflow.
@@ -19,7 +63,9 @@ export type LaunchRecoveryOutcome = "started" | "already_degraded";
  * every pod that detects the same breach in the same instant lands on the same
  * id and all but one get `WorkflowExecutionAlreadyStartedError` back. That
  * rejection is not a failure -- it is how we learn the endpoint was already
- * degraded -- so it comes back as an outcome rather than an error.
+ * degraded -- so it comes back as an outcome rather than an error. The error
+ * carries only the workflow id, so the start time costs one `describe()`, on
+ * that path alone.
  */
 export async function launchModelHealthRecovery(
   endpoint: DegradedModelEndpointType
@@ -35,11 +81,15 @@ export async function launchModelHealthRecovery(
     });
   } catch (err) {
     if (err instanceof WorkflowExecutionAlreadyStartedError) {
-      return new Ok("already_degraded");
+      return new Ok({
+        outcome: "already_degraded",
+        degradedSinceMs: await describeDegradedSinceMs(client, workflowId),
+      });
     }
 
     return new Err(normalizeError(err));
   }
 
-  return new Ok("started");
+  // Our own start, so the schedule is anchored here without asking the server.
+  return new Ok({ outcome: "started", degradedSinceMs: Date.now() });
 }

--- a/front/temporal/model_health/config.ts
+++ b/front/temporal/model_health/config.ts
@@ -1,0 +1,28 @@
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+
+const QUEUE_VERSION = 1;
+export const QUEUE_NAME = `model-health-queue-v${QUEUE_VERSION}`;
+
+// Probe rounds before the workflow continues as new, to keep history bounded on
+// an outage that drags on.
+export const MAX_PROBE_ROUNDS_PER_RUN = 100;
+
+/**
+ * The workflow id *is* the state in this phase: while a recovery workflow with
+ * this id is running, the endpoint is degraded. Temporal's workflow-id
+ * uniqueness therefore doubles as the cross-pod dedup, and the default
+ * `ALLOW_DUPLICATE` reuse policy frees the id once recovery completes so a later
+ * breach can open a fresh one.
+ */
+export function recoveryWorkflowId({
+  modelId,
+  providerId,
+  host,
+}: DegradedModelEndpointType): string {
+  const slug = `${providerId}-${modelId}-${host}`.replace(
+    /[^a-zA-Z0-9._-]/g,
+    "_"
+  );
+
+  return `model-health-${slug}`;
+}

--- a/front/temporal/model_health/config.ts
+++ b/front/temporal/model_health/config.ts
@@ -3,9 +3,12 @@ import type { DegradedModelEndpointType } from "@app/lib/model_constructors/type
 const QUEUE_VERSION = 1;
 export const QUEUE_NAME = `model-health-queue-v${QUEUE_VERSION}`;
 
-// Probe rounds before the workflow continues as new, to keep history bounded on
-// an outage that drags on.
-export const MAX_PROBE_ROUNDS_PER_RUN = 100;
+// Probe rounds before the run gives up and ends. At one round per
+// `MIN_DEGRADED_DURATION_MS` that is a shade under 17 hours, past which an
+// endpoint is a human problem rather than something to keep probing on the same
+// history. Ending is safe: nothing pins the endpoint healthy, so a breach that
+// is still live opens a fresh run.
+export const MAX_PROBE_ROUNDS = 100;
 
 /**
  * The workflow id *is* the state in this phase: while a recovery workflow with

--- a/front/temporal/model_health/worker.ts
+++ b/front/temporal/model_health/worker.ts
@@ -1,0 +1,46 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import {
+  createTemporalWorker,
+  getWorkflowConfig,
+} from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/model_health/activities";
+import type { Context } from "@temporalio/activity";
+
+import { QUEUE_NAME } from "./config";
+
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
+export async function runModelHealthWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await createTemporalWorker({
+    ...getWorkflowConfig({
+      workerName: "model_health",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    connection,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  // No schedule: recovery workflows are started on demand by the pod that
+  // detects the breach.
+  await worker.run();
+}

--- a/front/temporal/model_health/workflows.ts
+++ b/front/temporal/model_health/workflows.ts
@@ -1,0 +1,64 @@
+import { MIN_DEGRADED_DURATION_MS } from "@app/lib/api/llm/health/config";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import type * as activities from "@app/temporal/model_health/activities";
+import { MAX_PROBE_ROUNDS_PER_RUN } from "@app/temporal/model_health/config";
+import { continueAsNew, proxyActivities, sleep } from "@temporalio/workflow";
+
+const {
+  probeEndpointActivity,
+  logModelHealthProbeFailedActivity,
+  logModelHealthRecoveryActivity,
+} = proxyActivities<typeof activities>({
+  // A round is `PROBES_PER_RECOVERY` sequential provider calls, so give it room
+  // for slow-but-alive providers. This is the probe's only timeout: it runs
+  // outside the agent loop, so the stream watchdog never sees it.
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    // The probes inside the activity are the retry. Retrying the activity on top
+    // would multiply the calls and blur what "3 probes passed" means.
+    maximumAttempts: 1,
+  },
+});
+
+/**
+ * Recovery for one degraded endpoint.
+ *
+ * Started by whichever pod detected the breach; the deterministic workflow id
+ * makes concurrent starts collapse into this single run, and its existence is
+ * what "degraded" means while it lasts.
+ *
+ * Holds for `MIN_DEGRADED_DURATION_MS` on a durable Temporal timer -- a worker
+ * restart mid-hold costs nothing -- then probes until the endpoint answers.
+ *
+ * There is no sleep between failed rounds. A round is three sequential provider
+ * calls, so the loop paces itself on real provider latency rather than spinning.
+ */
+export async function modelHealthRecoveryWorkflow(
+  endpoint: DegradedModelEndpointType,
+  degradedAtMs?: number
+): Promise<void> {
+  // Preserved across `continueAsNew` so the recovery log reports the full
+  // outage, not just the last run.
+  const startedAtMs = degradedAtMs ?? Date.now();
+
+  if (degradedAtMs === undefined) {
+    await sleep(MIN_DEGRADED_DURATION_MS);
+  }
+
+  for (let round = 0; round < MAX_PROBE_ROUNDS_PER_RUN; round++) {
+    const healthy = await probeEndpointActivity(endpoint);
+    const degradedForMs = Date.now() - startedAtMs;
+
+    if (healthy) {
+      await logModelHealthRecoveryActivity({ endpoint, degradedForMs });
+      return;
+    }
+
+    await logModelHealthProbeFailedActivity({ endpoint, degradedForMs });
+  }
+
+  await continueAsNew<typeof modelHealthRecoveryWorkflow>(
+    endpoint,
+    startedAtMs
+  );
+}

--- a/front/temporal/model_health/workflows.ts
+++ b/front/temporal/model_health/workflows.ts
@@ -1,8 +1,8 @@
 import { MIN_DEGRADED_DURATION_MS } from "@app/lib/api/llm/health/config";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
 import type * as activities from "@app/temporal/model_health/activities";
-import { MAX_PROBE_ROUNDS_PER_RUN } from "@app/temporal/model_health/config";
-import { continueAsNew, proxyActivities, sleep } from "@temporalio/workflow";
+import { MAX_PROBE_ROUNDS } from "@app/temporal/model_health/config";
+import { proxyActivities, sleep } from "@temporalio/workflow";
 
 const {
   probeEndpointActivity,
@@ -25,27 +25,28 @@ const {
  *
  * Started by whichever pod detected the breach; the deterministic workflow id
  * makes concurrent starts collapse into this single run, and its existence is
- * what "degraded" means while it lasts.
+ * what "degraded" means while it lasts. Because that is the only state, this
+ * run's start time is also the moment the endpoint became degraded, which is
+ * what the detection guard reads back off `describe()`.
  *
- * Holds for `MIN_DEGRADED_DURATION_MS` on a durable Temporal timer -- a worker
- * restart mid-hold costs nothing -- then probes until the endpoint answers.
+ * Every round waits `MIN_DEGRADED_DURATION_MS` on a durable Temporal timer --
+ * a worker restart mid-wait costs nothing -- and then probes once. The timer
+ * comes first, so it serves as both the initial hold and the backoff between
+ * failed rounds: a dead endpoint sees one round every ten minutes rather than
+ * as fast as it can refuse them.
  *
- * There is no sleep between failed rounds. A round is three sequential provider
- * calls, so the loop paces itself on real provider latency rather than spinning.
+ * After `MAX_PROBE_ROUNDS` the run simply ends, logging no transition. The
+ * endpoint stops being degraded because the workflow id frees up, so an outage
+ * still in progress is re-detected from the counters and opens a fresh run.
  */
 export async function modelHealthRecoveryWorkflow(
-  endpoint: DegradedModelEndpointType,
-  degradedAtMs?: number
+  endpoint: DegradedModelEndpointType
 ): Promise<void> {
-  // Preserved across `continueAsNew` so the recovery log reports the full
-  // outage, not just the last run.
-  const startedAtMs = degradedAtMs ?? Date.now();
+  const startedAtMs = Date.now();
 
-  if (degradedAtMs === undefined) {
+  for (let round = 0; round < MAX_PROBE_ROUNDS; round++) {
     await sleep(MIN_DEGRADED_DURATION_MS);
-  }
 
-  for (let round = 0; round < MAX_PROBE_ROUNDS_PER_RUN; round++) {
     const healthy = await probeEndpointActivity(endpoint);
     const degradedForMs = Date.now() - startedAtMs;
 
@@ -56,9 +57,4 @@ export async function modelHealthRecoveryWorkflow(
 
     await logModelHealthProbeFailedActivity({ endpoint, degradedForMs });
   }
-
-  await continueAsNew<typeof modelHealthRecoveryWorkflow>(
-    endpoint,
-    startedAtMs
-  );
 }

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -18,6 +18,7 @@ import { runLabsTranscriptsWorker } from "@app/temporal/labs/transcripts/worker"
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
 import { runMentionsQueueWorker } from "@app/temporal/mentions_queue/worker";
 import { runMetronomeEventsWorker } from "@app/temporal/metronome_events_queue/worker";
+import { runModelHealthWorker } from "@app/temporal/model_health/worker";
 import { runNotificationsQueueWorker } from "@app/temporal/notifications_queue/worker";
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runReinforcementWorker } from "@app/temporal/reinforcement/worker";
@@ -53,6 +54,7 @@ export type WorkerName =
   | "mentions_count"
   | "mentions_queue"
   | "metronome_events_queue"
+  | "model_health"
   | "notifications_queue"
   | "poke"
   | "production_checks"
@@ -86,6 +88,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   mentions_count: runMentionsCountWorker,
   mentions_queue: runMentionsQueueWorker,
   metronome_events_queue: runMetronomeEventsWorker,
+  model_health: runModelHealthWorker,
   notifications_queue: runNotificationsQueueWorker,
   poke: runPokeWorker,
   production_checks: runProductionChecksWorker,


### PR DESCRIPTION
## Description

Second half of the breaker, and inert on its own: nothing starts these workflows until
#31881, so the worker sits idle once deployed.

A recovery workflow *is* the degraded state in this phase. Its id is derived from the
endpoint, so Temporal's workflow-id uniqueness doubles as cross-pod dedup and concurrent
starts collapse into one run. It holds for `MIN_DEGRADED_DURATION_MS` on a durable timer
(a worker restart mid-hold costs nothing), then probes until the endpoint answers,
continuing as new after 100 rounds to keep history bounded on an outage that drags on.

A probe is one synthetic inference that bypasses `LLM` entirely — no `Run` row, no usage
row, no Langfuse trace, no counter write — so it can never feed the signal it measures.
It resolves on the first token and returns early to stop the generation rather than
paying for a full response. Three sequential probes must all pass before a recovery is
declared, so a provider that is only intermittently serving cannot pass on a lucky burst.

Transitions are logged and counted, nothing is persisted: in this shadow phase the logs
and the matching Datadog series are the whole record of what the breaker would have done.
The endpoint's host goes out as `modelHost` — `host` is reserved by our log infrastructure.

PR 4 of 5: #31877 → #31878 → #31879 → this → #31881.

## Tests

Typecheck and the existing suites; the probe itself is exercised against live providers
rather than mocked. Before merging #31881, I plan to deploy this worker and start one
recovery workflow by hand against a healthy endpoint, to confirm the probe path, the
early return on first token, and the transition logs.

## Risk

Probes spend real provider credits under the Dust-managed keys, but the prompt is a
single character with reasoning off and we abort at the first token, so a round is three
near-minimal calls. The activity is capped at 5 minutes with `maximumAttempts: 1` — the
probes inside it are the retry, and retrying the activity on top would multiply the calls
and blur what "3 probes passed" means.

Inert until #31881, so this is safe to land and observe on its own.

## Deploy Plan

Adds a new `model_health` Temporal worker. It needs its deployment before #31881 merges,
otherwise breaches would start workflows with no worker to pick them up. The
`shutdownGraceTime` is set to 70s and must stay at the deployment's
`terminationGracePeriodSeconds` minus a 10s buffer.

Nothing to do for this PR itself — no schedule is registered, and no workflow is started
until the next one.
