### PR TITLE
feat(llm): close the model health loop with breach detection

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -66,6 +66,16 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
       "Disable Firecrawl for web browsing and use Spider.cloud instead.",
     icon: Fire,
   },
+  pause_model_health_detection: {
+    title: "Model Health Detection",
+    description:
+      "Stop recording model attempts into the health counters, and stop the breach detection they feed.",
+    note:
+      "Sheds the per-attempt Redis write and the recovery workflow starts. Recovery workflows already " +
+      "running are left alone. Takes up to 60s to apply on each pod, as the write path reads the switch " +
+      "from an in-process cache.",
+    icon: AlertCircle,
+  },
   pause_upsert_queue: {
     title: "Upsert Queue",
     description:

--- a/front/lib/api/kill_switch_cache.ts
+++ b/front/lib/api/kill_switch_cache.ts
@@ -1,0 +1,50 @@
+import type { KillSwitchType } from "@app/lib/poke/types";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * A kill switch read as a plain synchronous boolean, kept in process.
+ *
+ * `KillSwitchResource` reads Redis, and falls back to the database when that
+ * fails: far too much for a switch consulted on every call of a hot path. This
+ * keeps the last known value in process and refreshes it in the background at
+ * most once per `refreshIntervalMs`.
+ *
+ * Consequences: toggling the switch in Poke takes effect within that window on
+ * each pod, a pod reads `false` until its first refresh resolves (a few ms
+ * after boot), and a Redis or database blip leaves the last known value in
+ * place rather than flipping behaviour.
+ */
+export function makeCachedKillSwitch(
+  type: KillSwitchType,
+  { refreshIntervalMs }: { refreshIntervalMs: number }
+): () => boolean {
+  let cachedValue = false;
+  let lastRefreshStartedAtMs = 0;
+  let refreshing = false;
+
+  return function isEnabled(): boolean {
+    const nowMs = Date.now();
+    if (!refreshing && nowMs - lastRefreshStartedAtMs > refreshIntervalMs) {
+      refreshing = true;
+      lastRefreshStartedAtMs = nowMs;
+
+      void KillSwitchResource.isKillSwitchEnabled(type)
+        .then((enabled) => {
+          cachedValue = enabled;
+        })
+        .catch((err) => {
+          logger.error(
+            { err: normalizeError(err), killSwitch: type },
+            "Failed to refresh a kill switch"
+          );
+        })
+        .finally(() => {
+          refreshing = false;
+        });
+    }
+
+    return cachedValue;
+  };
+}

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -5,14 +5,29 @@
  * without a workflow environment.
  */
 
+// Share of provider-attributed errors over attempts, within the window, at
+// which an endpoint is declared degraded. A real outage is routinely 60%.
+export const ERROR_RATIO_THRESHOLD = 0.2;
+
 // Length of the sliding window, in whole UTC minutes.
 export const WINDOW_MINUTES = 5;
+
+// Volume floor. Below this the ratio is noise, and it is low enough that we
+// fail back quickly after reopening an endpoint to 100% of traffic.
+export const MIN_ATTEMPTS_IN_WINDOW = 200;
 
 // How long an endpoint stays degraded before the first recovery probe.
 export const MIN_DEGRADED_DURATION_MS = 10 * 60 * 1000;
 
 // Consecutive synthetic probes that must all succeed to declare a recovery.
 export const PROBES_PER_RECOVERY = 3;
+
+// How often one endpoint may be evaluated, per pod. A breach can only begin
+// with an error write, and during an outage those land hundreds of times a
+// second on the same endpoint: evaluating every one would re-read the same
+// window, and hand Temporal a rejected duplicate start, hundreds of times to
+// learn the same thing.
+export const MIN_EVALUATION_INTERVAL_MS = 5_000;
 
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -5,15 +5,11 @@
  * without a workflow environment.
  */
 
-// Share of provider-attributed errors over attempts, within the window, at
-// which an endpoint is declared degraded. A real outage is routinely 60%.
 export const ERROR_RATIO_THRESHOLD = 0.2;
 
 // Length of the sliding window, in whole UTC minutes.
 export const WINDOW_MINUTES = 5;
 
-// Volume floor. Below this the ratio is noise, and it is low enough that we
-// fail back quickly after reopening an endpoint to 100% of traffic.
 export const MIN_ATTEMPTS_IN_WINDOW = 200;
 
 // How long an endpoint stays degraded before the first recovery probe.

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -10,7 +10,7 @@ export const ERROR_RATIO_THRESHOLD = 0.2;
 // Length of the sliding window, in whole UTC minutes.
 export const WINDOW_MINUTES = 5;
 
-export const MIN_ATTEMPTS_IN_WINDOW = 200;
+export const MIN_ATTEMPTS_IN_WINDOW = 100;
 
 // How long an endpoint stays degraded before the first recovery probe.
 export const MIN_DEGRADED_DURATION_MS = 10 * 60 * 1000;

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -18,21 +18,12 @@ export const MIN_DEGRADED_DURATION_MS = 10 * 60 * 1000;
 // Consecutive synthetic probes that must all succeed to declare a recovery.
 export const PROBES_PER_RECOVERY = 3;
 
-// How often one endpoint may be evaluated, per pod. A breach can only begin
-// with an error write, and during an outage those land hundreds of times a
-// second on the same endpoint: evaluating every one would re-read the same
-// window, and hand Temporal a rejected duplicate start, hundreds of times to
-// learn the same thing.
+// How often one endpoint may be evaluated, per pod: during an outage error
+// writes land hundreds of times a second on the same endpoint.
 export const MIN_EVALUATION_INTERVAL_MS = 5_000;
 
-/**
- * The next instant the recovery workflow will probe, given when it started.
- *
- * Mirrors that workflow's loop -- sleep `MIN_DEGRADED_DURATION_MS`, probe,
- * repeat -- so probes land on this grid from its start time. Those are the only
- * moments an endpoint can stop being degraded, which makes the next one the
- * exact point for a detector to look again rather than guess an interval.
- */
+// The next instant the recovery workflow will probe, mirroring its
+// sleep-`MIN_DEGRADED_DURATION_MS`-then-probe loop from its start time.
 export function nextProbeAtMs(degradedSinceMs: number, nowMs: number): number {
   const elapsedRounds = Math.floor(
     (nowMs - degradedSinceMs) / MIN_DEGRADED_DURATION_MS

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -25,6 +25,20 @@ export const PROBES_PER_RECOVERY = 3;
 // learn the same thing.
 export const MIN_EVALUATION_INTERVAL_MS = 5_000;
 
+// How long a pod holds off re-evaluating an endpoint it declared degraded
+// itself. Recovery will hold it for at least `MIN_DEGRADED_DURATION_MS` counted
+// from that launch, so nothing this pod could learn before then can change
+// anything: the window still breaches and the workflow id is still taken.
+export const RECOVERY_STARTED_EVALUATION_INTERVAL_MS = MIN_DEGRADED_DURATION_MS;
+
+// How long a pod holds off re-evaluating an endpoint it found already degraded.
+// The workflow's start time is not knowable from a rejected start, so this hold
+// cannot be anchored the way the launcher's can -- recovery may have ten minutes
+// left or ten seconds. Kept short for that reason: it still drops the duplicate
+// starts by an order of magnitude, and it bounds how long this pod stays blind
+// to a fresh breach once recovery completes.
+export const ALREADY_DEGRADED_EVALUATION_INTERVAL_MS = 60_000;
+
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.
 export const COUNTER_KEY_TTL_SECONDS = WINDOW_MINUTES * 60 * 3;

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -22,16 +22,6 @@ export const PROBES_PER_RECOVERY = 3;
 // writes land hundreds of times a second on the same endpoint.
 export const MIN_EVALUATION_INTERVAL_MS = 5_000;
 
-// The next instant the recovery workflow will probe, mirroring its
-// sleep-`MIN_DEGRADED_DURATION_MS`-then-probe loop from its start time.
-export function nextProbeAtMs(degradedSinceMs: number, nowMs: number): number {
-  const elapsedRounds = Math.floor(
-    (nowMs - degradedSinceMs) / MIN_DEGRADED_DURATION_MS
-  );
-
-  return degradedSinceMs + MIN_DEGRADED_DURATION_MS * (elapsedRounds + 1);
-}
-
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.
 export const COUNTER_KEY_TTL_SECONDS = WINDOW_MINUTES * 60 * 3;

--- a/front/lib/api/llm/health/config.ts
+++ b/front/lib/api/llm/health/config.ts
@@ -25,19 +25,21 @@ export const PROBES_PER_RECOVERY = 3;
 // learn the same thing.
 export const MIN_EVALUATION_INTERVAL_MS = 5_000;
 
-// How long a pod holds off re-evaluating an endpoint it declared degraded
-// itself. Recovery will hold it for at least `MIN_DEGRADED_DURATION_MS` counted
-// from that launch, so nothing this pod could learn before then can change
-// anything: the window still breaches and the workflow id is still taken.
-export const RECOVERY_STARTED_EVALUATION_INTERVAL_MS = MIN_DEGRADED_DURATION_MS;
+/**
+ * The next instant the recovery workflow will probe, given when it started.
+ *
+ * Mirrors that workflow's loop -- sleep `MIN_DEGRADED_DURATION_MS`, probe,
+ * repeat -- so probes land on this grid from its start time. Those are the only
+ * moments an endpoint can stop being degraded, which makes the next one the
+ * exact point for a detector to look again rather than guess an interval.
+ */
+export function nextProbeAtMs(degradedSinceMs: number, nowMs: number): number {
+  const elapsedRounds = Math.floor(
+    (nowMs - degradedSinceMs) / MIN_DEGRADED_DURATION_MS
+  );
 
-// How long a pod holds off re-evaluating an endpoint it found already degraded.
-// The workflow's start time is not knowable from a rejected start, so this hold
-// cannot be anchored the way the launcher's can -- recovery may have ten minutes
-// left or ten seconds. Kept short for that reason: it still drops the duplicate
-// starts by an order of magnitude, and it bounds how long this pod stays blind
-// to a fresh breach once recovery completes.
-export const ALREADY_DEGRADED_EVALUATION_INTERVAL_MS = 60_000;
+  return degradedSinceMs + MIN_DEGRADED_DURATION_MS * (elapsedRounds + 1);
+}
 
 // Counter keys are only ever read across `WINDOW_MINUTES`; the extra headroom
 // covers clock skew between pods.

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -1,10 +1,18 @@
+import { MIN_EVALUATION_INTERVAL_MS } from "@app/lib/api/llm/health/config";
 import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
+import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import { modelHealthKey } from "@app/lib/api/llm/health/keys";
 import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import { runOnRedisCache } from "@app/lib/api/redis";
 import { redisMock } from "@app/tests/utils/mocks/redis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Detection is exercised on its own; here we only care about when it is asked
+// for, so it never reaches Redis.
+vi.mock("@app/lib/api/llm/health/detect", () => ({
+  evaluateEndpoint: vi.fn().mockResolvedValue(undefined),
+}));
 
 const ENDPOINT = {
   modelId: "claude-sonnet-5",
@@ -121,5 +129,63 @@ describe("model health counters", () => {
     await record(SUCCESS);
 
     expect((await redisMock.cacheClient.hGetAll(KEY)).attempts).toBe("1");
+  });
+
+  it("evaluates the endpoint it just wrote, and only on a provider error", async () => {
+    // The throttle is module state keyed by endpoint, so each of these tests
+    // takes a model of its own.
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-5" } as const;
+
+    await recordLLMAttempt({ endpoint, outcome: SUCCESS, now: NOW });
+    expect(evaluateEndpoint).not.toHaveBeenCalled();
+
+    await recordLLMAttempt({
+      endpoint,
+      outcome: providerError("overloaded_error"),
+      now: NOW,
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledWith(endpoint, NOW);
+  });
+
+  it("evaluates one endpoint at most once per interval", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-8" } as const;
+    const error = providerError("overloaded_error");
+
+    // An outage puts hundreds of these a second on the same endpoint; they must
+    // not each read the window and hand Temporal a duplicate start.
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + 1_000),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    const laterMs = NOW.getTime() + MIN_EVALUATION_INTERVAL_MS;
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(laterMs),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not evaluate when the write failed", async () => {
+    const endpoint = {
+      ...ENDPOINT,
+      modelId: "claude-haiku-4-5-20251001",
+    } as const;
+    vi.mocked(runOnRedisCache).mockRejectedValueOnce(
+      new Error("redis is down")
+    );
+
+    await recordLLMAttempt({
+      endpoint,
+      outcome: providerError("server_error"),
+      now: NOW,
+    });
+
+    expect(evaluateEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -1,4 +1,8 @@
-import { MIN_EVALUATION_INTERVAL_MS } from "@app/lib/api/llm/health/config";
+import {
+  ALREADY_DEGRADED_EVALUATION_INTERVAL_MS,
+  MIN_EVALUATION_INTERVAL_MS,
+  RECOVERY_STARTED_EVALUATION_INTERVAL_MS,
+} from "@app/lib/api/llm/health/config";
 import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
 import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import { modelHealthKey } from "@app/lib/api/llm/health/keys";
@@ -11,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Detection is exercised on its own; here we only care about when it is asked
 // for, so it never reaches Redis.
 vi.mock("@app/lib/api/llm/health/detect", () => ({
-  evaluateEndpoint: vi.fn().mockResolvedValue(undefined),
+  evaluateEndpoint: vi.fn().mockResolvedValue("not_breaching"),
 }));
 
 const ENDPOINT = {
@@ -168,6 +172,68 @@ describe("model health counters", () => {
       outcome: error,
       now: new Date(laterMs),
     });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds an endpoint it declared degraded for the whole degradation", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-sonnet-4-6" } as const;
+    const error = providerError("overloaded_error");
+    vi.mocked(evaluateEndpoint).mockResolvedValue("recovery_started");
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    // Past the plain throttle, but this pod launched the workflow, so it knows
+    // the endpoint is held from here: re-reading the window would only earn a
+    // rejected start, from every pod, for the whole outage.
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + MIN_EVALUATION_INTERVAL_MS * 10),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    // The hold only ever delays: once it lapses the endpoint is evaluated
+    // again, whatever became of the workflow in the meantime.
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + RECOVERY_STARTED_EVALUATION_INTERVAL_MS),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds an endpoint another pod declared degraded for much less", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-6" } as const;
+    const error = providerError("overloaded_error");
+    vi.mocked(evaluateEndpoint).mockResolvedValue("already_degraded");
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    // The workflow may have started nine minutes ago, so this pod cannot hold
+    // for a full degradation without going blind to whatever follows recovery.
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + ALREADY_DEGRADED_EVALUATION_INTERVAL_MS),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps evaluating when the workflow could not be started", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-7" } as const;
+    const error = providerError("overloaded_error");
+    vi.mocked(evaluateEndpoint).mockResolvedValue("launch_failed");
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + MIN_EVALUATION_INTERVAL_MS),
+    });
+
+    // Nothing holds the endpoint, so the next window is still worth a look.
     expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
   });
 

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -1,7 +1,6 @@
 import {
-  ALREADY_DEGRADED_EVALUATION_INTERVAL_MS,
+  MIN_DEGRADED_DURATION_MS,
   MIN_EVALUATION_INTERVAL_MS,
-  RECOVERY_STARTED_EVALUATION_INTERVAL_MS,
 } from "@app/lib/api/llm/health/config";
 import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
 import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
@@ -15,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Detection is exercised on its own; here we only care about when it is asked
 // for, so it never reaches Redis.
 vi.mock("@app/lib/api/llm/health/detect", () => ({
-  evaluateEndpoint: vi.fn().mockResolvedValue("not_breaching"),
+  evaluateEndpoint: vi.fn().mockResolvedValue({ outcome: "not_breaching" }),
 }));
 
 const ENDPOINT = {
@@ -175,56 +174,87 @@ describe("model health counters", () => {
     expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
   });
 
-  it("holds an endpoint it declared degraded for the whole degradation", async () => {
+  it("holds an endpoint it declared degraded until the first probe", async () => {
     const endpoint = { ...ENDPOINT, modelId: "claude-sonnet-4-6" } as const;
     const error = providerError("overloaded_error");
-    vi.mocked(evaluateEndpoint).mockResolvedValue("recovery_started");
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome: "recovery_started",
+      degradedSinceMs: NOW.getTime(),
+    });
 
     await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
     expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
 
-    // Past the plain throttle, but this pod launched the workflow, so it knows
-    // the endpoint is held from here: re-reading the window would only earn a
-    // rejected start, from every pod, for the whole outage.
+    // Nothing can change before the workflow's first probe, so re-reading the
+    // window until then would only earn a rejected start, from every pod.
     await recordLLMAttempt({
       endpoint,
       outcome: error,
-      now: new Date(NOW.getTime() + MIN_EVALUATION_INTERVAL_MS * 10),
+      now: new Date(NOW.getTime() + MIN_DEGRADED_DURATION_MS - 1),
     });
     expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
 
-    // The hold only ever delays: once it lapses the endpoint is evaluated
-    // again, whatever became of the workflow in the meantime.
     await recordLLMAttempt({
       endpoint,
       outcome: error,
-      now: new Date(NOW.getTime() + RECOVERY_STARTED_EVALUATION_INTERVAL_MS),
+      now: new Date(NOW.getTime() + MIN_DEGRADED_DURATION_MS),
     });
     expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
   });
 
-  it("holds an endpoint another pod declared degraded for much less", async () => {
+  it("waits only for the next probe of a workflow another pod started", async () => {
     const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-6" } as const;
     const error = providerError("overloaded_error");
-    vi.mocked(evaluateEndpoint).mockResolvedValue("already_degraded");
+    // Nine minutes into someone else's degradation, so its first probe is a
+    // minute out -- not a full `MIN_DEGRADED_DURATION_MS` from here.
+    const degradedSinceMs = NOW.getTime() - 9 * 60 * 1000;
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome: "already_degraded",
+      degradedSinceMs,
+    });
 
     await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
     expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
 
-    // The workflow may have started nine minutes ago, so this pod cannot hold
-    // for a full degradation without going blind to whatever follows recovery.
     await recordLLMAttempt({
       endpoint,
       outcome: error,
-      now: new Date(NOW.getTime() + ALREADY_DEGRADED_EVALUATION_INTERVAL_MS),
+      now: new Date(degradedSinceMs + MIN_DEGRADED_DURATION_MS - 1),
     });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
+
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(degradedSinceMs + MIN_DEGRADED_DURATION_MS),
+    });
+    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the usual cadence when the workflow start time is unknown", async () => {
+    const endpoint = { ...ENDPOINT, modelId: "claude-fable-5" } as const;
+    const error = providerError("overloaded_error");
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome: "already_degraded",
+      degradedSinceMs: null,
+    });
+
+    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
+    await recordLLMAttempt({
+      endpoint,
+      outcome: error,
+      now: new Date(NOW.getTime() + MIN_EVALUATION_INTERVAL_MS),
+    });
+
     expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
   });
 
   it("keeps evaluating when the workflow could not be started", async () => {
     const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-7" } as const;
     const error = providerError("overloaded_error");
-    vi.mocked(evaluateEndpoint).mockResolvedValue("launch_failed");
+    vi.mocked(evaluateEndpoint).mockResolvedValue({
+      outcome: "launch_failed",
+    });
 
     await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
     await recordLLMAttempt({

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -174,48 +174,26 @@ describe("model health counters", () => {
     expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
   });
 
-  it("holds an endpoint it declared degraded until the first probe", async () => {
-    const endpoint = { ...ENDPOINT, modelId: "claude-sonnet-4-6" } as const;
+  it.each([
+    { outcome: "recovery_started", modelId: "claude-sonnet-4-6" },
+    { outcome: "already_degraded", modelId: "claude-opus-4-6" },
+  ] as const)("holds a $outcome endpoint until the workflow's next probe", async ({
+    outcome,
+    modelId,
+  }) => {
+    const endpoint = { ...ENDPOINT, modelId } as const;
     const error = providerError("overloaded_error");
+    const degradedSinceMs = NOW.getTime() - MIN_DEGRADED_DURATION_MS * 0.9;
     vi.mocked(evaluateEndpoint).mockResolvedValue({
-      outcome: "recovery_started",
-      degradedSinceMs: NOW.getTime(),
-    });
-
-    await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
-    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
-
-    // Nothing can change before the workflow's first probe, so re-reading the
-    // window until then would only earn a rejected start, from every pod.
-    await recordLLMAttempt({
-      endpoint,
-      outcome: error,
-      now: new Date(NOW.getTime() + MIN_DEGRADED_DURATION_MS - 1),
-    });
-    expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
-
-    await recordLLMAttempt({
-      endpoint,
-      outcome: error,
-      now: new Date(NOW.getTime() + MIN_DEGRADED_DURATION_MS),
-    });
-    expect(evaluateEndpoint).toHaveBeenCalledTimes(2);
-  });
-
-  it("waits only for the next probe of a workflow another pod started", async () => {
-    const endpoint = { ...ENDPOINT, modelId: "claude-opus-4-6" } as const;
-    const error = providerError("overloaded_error");
-    // Nine minutes into someone else's degradation, so its first probe is a
-    // minute out -- not a full `MIN_DEGRADED_DURATION_MS` from here.
-    const degradedSinceMs = NOW.getTime() - 9 * 60 * 1000;
-    vi.mocked(evaluateEndpoint).mockResolvedValue({
-      outcome: "already_degraded",
+      outcome,
       degradedSinceMs,
     });
 
     await recordLLMAttempt({ endpoint, outcome: error, now: NOW });
     expect(evaluateEndpoint).toHaveBeenCalledTimes(1);
 
+    // Nothing can change before that probe, so re-reading the window until
+    // then would only earn a rejected start, from every pod.
     await recordLLMAttempt({
       endpoint,
       outcome: error,

--- a/front/lib/api/llm/health/counters.test.ts
+++ b/front/lib/api/llm/health/counters.test.ts
@@ -5,6 +5,7 @@ import {
 import { recordLLMAttempt } from "@app/lib/api/llm/health/counters";
 import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import { modelHealthKey } from "@app/lib/api/llm/health/keys";
+import { isModelHealthDetectionPaused } from "@app/lib/api/llm/health/kill_switch";
 import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import { runOnRedisCache } from "@app/lib/api/redis";
@@ -15,6 +16,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // for, so it never reaches Redis.
 vi.mock("@app/lib/api/llm/health/detect", () => ({
   evaluateEndpoint: vi.fn().mockResolvedValue({ outcome: "not_breaching" }),
+}));
+
+// Reads the kill switch out of an in-process cache in production; here it is
+// simply off unless a test says otherwise.
+vi.mock("@app/lib/api/llm/health/kill_switch", () => ({
+  isModelHealthDetectionPaused: vi.fn().mockReturnValue(false),
 }));
 
 const ENDPOINT = {
@@ -260,6 +267,17 @@ describe("model health counters", () => {
       now: NOW,
     });
 
+    expect(evaluateEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all while the kill switch is on", async () => {
+    vi.mocked(isModelHealthDetectionPaused).mockReturnValueOnce(true);
+
+    await record(providerError("server_error"));
+
+    // The point of the switch is to take the whole path out during an incident,
+    // so neither the write nor the detection it triggers may run.
+    expect(runOnRedisCache).not.toHaveBeenCalled();
     expect(evaluateEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -1,4 +1,8 @@
-import { COUNTER_KEY_TTL_SECONDS } from "@app/lib/api/llm/health/config";
+import {
+  COUNTER_KEY_TTL_SECONDS,
+  MIN_EVALUATION_INTERVAL_MS,
+} from "@app/lib/api/llm/health/config";
+import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import {
   ATTEMPTS_FIELD,
   minuteBucket,
@@ -8,8 +12,31 @@ import {
 import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
 import { runOnRedisCache } from "@app/lib/api/redis";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import { degradedModelEndpointKey } from "@app/lib/model_constructors/types/degradations";
 import { NOOP_HOST } from "@app/lib/model_constructors/types/hosts";
 import { statsDMetrics } from "@app/lib/utils/statsd";
+
+// One entry per endpoint, so bounded by the endpoint catalog.
+const lastEvaluatedAtMs = new Map<string, number>();
+
+function isEvaluationDue(
+  endpoint: DegradedModelEndpointType,
+  now: Date
+): boolean {
+  const key = degradedModelEndpointKey(endpoint);
+  const previousMs = lastEvaluatedAtMs.get(key);
+
+  if (
+    previousMs !== undefined &&
+    now.getTime() - previousMs < MIN_EVALUATION_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  lastEvaluatedAtMs.set(key, now.getTime());
+
+  return true;
+}
 
 /**
  * Records one model call attempt at its terminal outcome.
@@ -21,6 +48,9 @@ import { statsDMetrics } from "@app/lib/utils/statsd";
  * Dropping writes is acceptable by design. The threshold is a share of hundreds
  * of attempts over five minutes, so a handful of lost increments cannot change
  * the verdict -- which is why nothing here retries, batches or blocks.
+ *
+ * An error write is also what triggers detection for that endpoint, throttled to
+ * `MIN_EVALUATION_INTERVAL_MS`.
  *
  * Only provider-attributed errors count towards the numerator. That is exactly
  * the `error_source:provider` filter the existing Datadog monitor applies at
@@ -58,6 +88,13 @@ export async function recordLLMAttempt({
 
       await multi.exec();
     });
+
+    // Only an error can push the ratio over the threshold, so a successful
+    // attempt has nothing to detect. This reads back the window for this one
+    // endpoint -- the one we just served -- and never for any other.
+    if (isProviderError && isEvaluationDue(endpoint, now)) {
+      await evaluateEndpoint(endpoint, now);
+    }
   } catch {
     // Counted rather than logged: this runs once per attempt, so a Redis outage
     // would put one line per attempt in the logs. The connection error itself is

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -1,7 +1,10 @@
 import {
+  ALREADY_DEGRADED_EVALUATION_INTERVAL_MS,
   COUNTER_KEY_TTL_SECONDS,
   MIN_EVALUATION_INTERVAL_MS,
+  RECOVERY_STARTED_EVALUATION_INTERVAL_MS,
 } from "@app/lib/api/llm/health/config";
+import type { EndpointEvaluationType } from "@app/lib/api/llm/health/detect";
 import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
 import {
   ATTEMPTS_FIELD,
@@ -16,24 +19,46 @@ import { degradedModelEndpointKey } from "@app/lib/model_constructors/types/degr
 import { NOOP_HOST } from "@app/lib/model_constructors/types/hosts";
 import { statsDMetrics } from "@app/lib/utils/statsd";
 
-// One entry per endpoint, so bounded by the endpoint catalog.
-const lastEvaluatedAtMs = new Map<string, number>();
+// How long to wait before evaluating an endpoint again, by what the last
+// evaluation established. Exhaustive, so a new outcome has to declare its hold.
+const EVALUATION_HOLD_MS: Record<EndpointEvaluationType, number> = {
+  not_breaching: MIN_EVALUATION_INTERVAL_MS,
+  recovery_started: RECOVERY_STARTED_EVALUATION_INTERVAL_MS,
+  already_degraded: ALREADY_DEGRADED_EVALUATION_INTERVAL_MS,
+  // Temporal was unreachable, so nothing is holding this endpoint: keep looking
+  // at the usual cadence.
+  launch_failed: MIN_EVALUATION_INTERVAL_MS,
+};
+
+// The soonest each endpoint may be evaluated again, per pod. One entry per
+// endpoint, so bounded by the endpoint catalog.
+const nextEvaluationAtMs = new Map<string, number>();
+
+function holdEvaluation(
+  endpoint: DegradedModelEndpointType,
+  now: Date,
+  forMs: number
+): void {
+  nextEvaluationAtMs.set(
+    degradedModelEndpointKey(endpoint),
+    now.getTime() + forMs
+  );
+}
 
 function isEvaluationDue(
   endpoint: DegradedModelEndpointType,
   now: Date
 ): boolean {
-  const key = degradedModelEndpointKey(endpoint);
-  const previousMs = lastEvaluatedAtMs.get(key);
+  const dueAtMs = nextEvaluationAtMs.get(degradedModelEndpointKey(endpoint));
 
-  if (
-    previousMs !== undefined &&
-    now.getTime() - previousMs < MIN_EVALUATION_INTERVAL_MS
-  ) {
+  if (dueAtMs !== undefined && now.getTime() < dueAtMs) {
     return false;
   }
 
-  lastEvaluatedAtMs.set(key, now.getTime());
+  // Held before the evaluation runs, not after: two attempts on this pod can
+  // interleave across the await otherwise, and both would evaluate. The outcome
+  // overwrites this with its own hold.
+  holdEvaluation(endpoint, now, MIN_EVALUATION_INTERVAL_MS);
 
   return true;
 }
@@ -49,8 +74,8 @@ function isEvaluationDue(
  * of attempts over five minutes, so a handful of lost increments cannot change
  * the verdict -- which is why nothing here retries, batches or blocks.
  *
- * An error write is also what triggers detection for that endpoint, throttled to
- * `MIN_EVALUATION_INTERVAL_MS`.
+ * An error write is also what triggers detection for that endpoint, throttled by
+ * `EVALUATION_HOLD_MS` on what the last evaluation established.
  *
  * Only provider-attributed errors count towards the numerator. That is exactly
  * the `error_source:provider` filter the existing Datadog monitor applies at
@@ -93,7 +118,11 @@ export async function recordLLMAttempt({
     // attempt has nothing to detect. This reads back the window for this one
     // endpoint -- the one we just served -- and never for any other.
     if (isProviderError && isEvaluationDue(endpoint, now)) {
-      await evaluateEndpoint(endpoint, now);
+      // While recovery holds the endpoint, evaluating again buys nothing: the
+      // window still breaches and the start still comes back rejected. How long
+      // that stays true depends on the outcome, so the hold does too.
+      const evaluation = await evaluateEndpoint(endpoint, now);
+      holdEvaluation(endpoint, now, EVALUATION_HOLD_MS[evaluation]);
     }
   } catch {
     // Counted rather than logged: this runs once per attempt, so a Redis outage

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -1,7 +1,7 @@
 import {
   COUNTER_KEY_TTL_SECONDS,
+  MIN_DEGRADED_DURATION_MS,
   MIN_EVALUATION_INTERVAL_MS,
-  nextProbeAtMs,
 } from "@app/lib/api/llm/health/config";
 import type { EndpointEvaluationType } from "@app/lib/api/llm/health/detect";
 import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
@@ -19,68 +19,59 @@ import { NOOP_HOST } from "@app/lib/model_constructors/types/hosts";
 import { statsDMetrics } from "@app/lib/utils/statsd";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-// How long to wait before evaluating an endpoint again, given what the last
-// evaluation established. Never shorter than `MIN_EVALUATION_INTERVAL_MS`, so
-// clock skew against the Temporal server can only cost a redundant look.
-function holdForEvaluation(
+// The soonest each endpoint may be evaluated again, per pod.
+const nextEvaluationAtMs = new Map<string, number>();
+
+// A running recovery workflow only releases the endpoint at one of its probes,
+// so wait for the next one; anything else keeps the usual cadence.
+function evaluationDueAtMs(
   evaluation: EndpointEvaluationType,
-  now: Date
+  nowMs: number
 ): number {
+  const cadenceAtMs = nowMs + MIN_EVALUATION_INTERVAL_MS;
+
   switch (evaluation.outcome) {
     case "recovery_started":
-    case "already_degraded":
-      // A running workflow can only release the endpoint at one of its probes,
-      // so wait for the next one. A start time we could not read leaves nothing
-      // to wait for.
-      if (evaluation.degradedSinceMs === null) {
-        return MIN_EVALUATION_INTERVAL_MS;
+    case "already_degraded": {
+      const { degradedSinceMs } = evaluation;
+      if (degradedSinceMs === null) {
+        return cadenceAtMs;
       }
 
-      return Math.max(
-        MIN_EVALUATION_INTERVAL_MS,
-        nextProbeAtMs(evaluation.degradedSinceMs, now.getTime()) - now.getTime()
+      const probesSoFar = Math.floor(
+        (nowMs - degradedSinceMs) / MIN_DEGRADED_DURATION_MS
       );
+
+      return Math.max(
+        cadenceAtMs,
+        degradedSinceMs + MIN_DEGRADED_DURATION_MS * (probesSoFar + 1)
+      );
+    }
 
     case "not_breaching":
     case "launch_failed":
-      // Nothing is holding this endpoint -- no breach, or Temporal was
-      // unreachable -- so keep looking at the usual cadence.
-      return MIN_EVALUATION_INTERVAL_MS;
+      return cadenceAtMs;
 
     default:
       assertNever(evaluation);
   }
 }
 
-// The soonest each endpoint may be evaluated again, per pod. One entry per
-// endpoint, so bounded by the endpoint catalog.
-const nextEvaluationAtMs = new Map<string, number>();
-
-function holdEvaluation(
-  endpoint: DegradedModelEndpointType,
-  now: Date,
-  forMs: number
-): void {
-  nextEvaluationAtMs.set(
-    degradedModelEndpointKey(endpoint),
-    now.getTime() + forMs
-  );
-}
-
 function isEvaluationDue(
   endpoint: DegradedModelEndpointType,
-  now: Date
+  nowMs: number
 ): boolean {
-  const dueAtMs = nextEvaluationAtMs.get(degradedModelEndpointKey(endpoint));
+  const key = degradedModelEndpointKey(endpoint);
+  const dueAtMs = nextEvaluationAtMs.get(key);
 
-  if (dueAtMs !== undefined && now.getTime() < dueAtMs) {
+  if (dueAtMs !== undefined && nowMs < dueAtMs) {
     return false;
   }
 
   // Held before the evaluation runs, not after: two attempts on this pod can
   // interleave across the await otherwise, and both would evaluate. The outcome
   // overwrites this with its own hold.
-  holdEvaluation(endpoint, now, MIN_EVALUATION_INTERVAL_MS);
+  nextEvaluationAtMs.set(key, nowMs + MIN_EVALUATION_INTERVAL_MS);
 
   return true;
 }
@@ -97,7 +88,7 @@ function isEvaluationDue(
  * the verdict -- which is why nothing here retries, batches or blocks.
  *
  * An error write is also what triggers detection for that endpoint, throttled by
- * `holdForEvaluation` on what the last evaluation established.
+ * `evaluationDueAtMs` on what the last evaluation established.
  *
  * Only provider-attributed errors count towards the numerator. That is exactly
  * the `error_source:provider` filter the existing Datadog monitor applies at
@@ -117,6 +108,7 @@ export async function recordLLMAttempt({
     return;
   }
 
+  const nowMs = now.getTime();
   const key = modelHealthKey(endpoint, minuteBucket(now));
   const isProviderError =
     outcome.outcome === "error" && outcome.errorSource === "provider";
@@ -139,12 +131,15 @@ export async function recordLLMAttempt({
     // Only an error can push the ratio over the threshold, so a successful
     // attempt has nothing to detect. This reads back the window for this one
     // endpoint -- the one we just served -- and never for any other.
-    if (isProviderError && isEvaluationDue(endpoint, now)) {
+    if (isProviderError && isEvaluationDue(endpoint, nowMs)) {
       // While recovery holds the endpoint, evaluating again buys nothing: the
       // window still breaches and the start still comes back rejected. How long
       // that stays true depends on the outcome, so the hold does too.
       const evaluation = await evaluateEndpoint(endpoint, now);
-      holdEvaluation(endpoint, now, holdForEvaluation(evaluation, now));
+      nextEvaluationAtMs.set(
+        degradedModelEndpointKey(endpoint),
+        evaluationDueAtMs(evaluation, nowMs)
+      );
     }
   } catch {
     // Counted rather than logged: this runs once per attempt, so a Redis outage

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -11,6 +11,7 @@ import {
   modelHealthKey,
   PROVIDER_ERRORS_FIELD,
 } from "@app/lib/api/llm/health/keys";
+import { isModelHealthDetectionPaused } from "@app/lib/api/llm/health/kill_switch";
 import type { LLMAttemptOutcomeTelemetry } from "@app/lib/api/llm/telemetry";
 import { runOnRedisCache } from "@app/lib/api/redis";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
@@ -105,6 +106,12 @@ export async function recordLLMAttempt({
 }): Promise<void> {
   // The noop model is a test fixture, not an endpoint anyone can be degraded on.
   if (endpoint.host === NOOP_HOST) {
+    return;
+  }
+
+  // The operator switch, so this whole path can be taken out during an incident
+  // without shipping a revert.
+  if (isModelHealthDetectionPaused()) {
     return;
   }
 

--- a/front/lib/api/llm/health/counters.ts
+++ b/front/lib/api/llm/health/counters.ts
@@ -1,8 +1,7 @@
 import {
-  ALREADY_DEGRADED_EVALUATION_INTERVAL_MS,
   COUNTER_KEY_TTL_SECONDS,
   MIN_EVALUATION_INTERVAL_MS,
-  RECOVERY_STARTED_EVALUATION_INTERVAL_MS,
+  nextProbeAtMs,
 } from "@app/lib/api/llm/health/config";
 import type { EndpointEvaluationType } from "@app/lib/api/llm/health/detect";
 import { evaluateEndpoint } from "@app/lib/api/llm/health/detect";
@@ -18,17 +17,40 @@ import type { DegradedModelEndpointType } from "@app/lib/model_constructors/type
 import { degradedModelEndpointKey } from "@app/lib/model_constructors/types/degradations";
 import { NOOP_HOST } from "@app/lib/model_constructors/types/hosts";
 import { statsDMetrics } from "@app/lib/utils/statsd";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
-// How long to wait before evaluating an endpoint again, by what the last
-// evaluation established. Exhaustive, so a new outcome has to declare its hold.
-const EVALUATION_HOLD_MS: Record<EndpointEvaluationType, number> = {
-  not_breaching: MIN_EVALUATION_INTERVAL_MS,
-  recovery_started: RECOVERY_STARTED_EVALUATION_INTERVAL_MS,
-  already_degraded: ALREADY_DEGRADED_EVALUATION_INTERVAL_MS,
-  // Temporal was unreachable, so nothing is holding this endpoint: keep looking
-  // at the usual cadence.
-  launch_failed: MIN_EVALUATION_INTERVAL_MS,
-};
+// How long to wait before evaluating an endpoint again, given what the last
+// evaluation established. Never shorter than `MIN_EVALUATION_INTERVAL_MS`, so
+// clock skew against the Temporal server can only cost a redundant look.
+function holdForEvaluation(
+  evaluation: EndpointEvaluationType,
+  now: Date
+): number {
+  switch (evaluation.outcome) {
+    case "recovery_started":
+    case "already_degraded":
+      // A running workflow can only release the endpoint at one of its probes,
+      // so wait for the next one. A start time we could not read leaves nothing
+      // to wait for.
+      if (evaluation.degradedSinceMs === null) {
+        return MIN_EVALUATION_INTERVAL_MS;
+      }
+
+      return Math.max(
+        MIN_EVALUATION_INTERVAL_MS,
+        nextProbeAtMs(evaluation.degradedSinceMs, now.getTime()) - now.getTime()
+      );
+
+    case "not_breaching":
+    case "launch_failed":
+      // Nothing is holding this endpoint -- no breach, or Temporal was
+      // unreachable -- so keep looking at the usual cadence.
+      return MIN_EVALUATION_INTERVAL_MS;
+
+    default:
+      assertNever(evaluation);
+  }
+}
 
 // The soonest each endpoint may be evaluated again, per pod. One entry per
 // endpoint, so bounded by the endpoint catalog.
@@ -75,7 +97,7 @@ function isEvaluationDue(
  * the verdict -- which is why nothing here retries, batches or blocks.
  *
  * An error write is also what triggers detection for that endpoint, throttled by
- * `EVALUATION_HOLD_MS` on what the last evaluation established.
+ * `holdForEvaluation` on what the last evaluation established.
  *
  * Only provider-attributed errors count towards the numerator. That is exactly
  * the `error_source:provider` filter the existing Datadog monitor applies at
@@ -122,7 +144,7 @@ export async function recordLLMAttempt({
       // window still breaches and the start still comes back rejected. How long
       // that stays true depends on the outcome, so the hold does too.
       const evaluation = await evaluateEndpoint(endpoint, now);
-      holdEvaluation(endpoint, now, EVALUATION_HOLD_MS[evaluation]);
+      holdEvaluation(endpoint, now, holdForEvaluation(evaluation, now));
     }
   } catch {
     // Counted rather than logged: this runs once per attempt, so a Redis outage

--- a/front/lib/api/llm/health/detect.test.ts
+++ b/front/lib/api/llm/health/detect.test.ts
@@ -1,0 +1,115 @@
+import { evaluateEndpoint, isBreaching } from "@app/lib/api/llm/health/detect";
+import {
+  ATTEMPTS_FIELD,
+  modelHealthKey,
+  PROVIDER_ERRORS_FIELD,
+} from "@app/lib/api/llm/health/keys";
+import { logModelHealthTransition } from "@app/lib/api/llm/health/transitions";
+import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
+import { redisMock } from "@app/tests/utils/mocks/redis";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/model_health/client", () => ({
+  launchModelHealthRecovery: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/llm/health/transitions", () => ({
+  logModelHealthTransition: vi.fn(),
+}));
+
+const ENDPOINT = {
+  modelId: "claude-sonnet-5",
+  providerId: "anthropic",
+  host: "anthropic",
+} as const;
+
+const NOW = new Date("2026-09-03T14:32:10Z");
+
+async function seedWindow({
+  attempts,
+  providerErrors,
+}: {
+  attempts: number;
+  providerErrors: number;
+}): Promise<void> {
+  const key = modelHealthKey(ENDPOINT, "202609031432");
+  await redisMock.cacheClient.hIncrBy(key, ATTEMPTS_FIELD, attempts);
+  await redisMock.cacheClient.hIncrBy(
+    key,
+    PROVIDER_ERRORS_FIELD,
+    providerErrors
+  );
+}
+
+describe("isBreaching", () => {
+  it("ignores an endpoint below the volume floor, however bad the ratio", () => {
+    // 100% errors, but on 199 attempts the ratio is noise.
+    expect(isBreaching({ attempts: 199, providerErrors: 199 })).toBe(false);
+  });
+
+  it("breaches at the threshold", () => {
+    expect(isBreaching({ attempts: 200, providerErrors: 40 })).toBe(true);
+  });
+
+  it("does not breach just below it", () => {
+    expect(isBreaching({ attempts: 200, providerErrors: 39 })).toBe(false);
+  });
+
+  it("treats an idle endpoint as healthy", () => {
+    expect(isBreaching({ attempts: 0, providerErrors: 0 })).toBe(false);
+  });
+});
+
+describe("evaluateEndpoint", () => {
+  beforeEach(() => {
+    redisMock.reset();
+    vi.clearAllMocks();
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(new Ok("started"));
+  });
+
+  it("declares a breaching endpoint degraded", async () => {
+    await seedWindow({ attempts: 250, providerErrors: 60 });
+
+    await evaluateEndpoint(ENDPOINT, NOW);
+
+    expect(launchModelHealthRecovery).toHaveBeenCalledWith(ENDPOINT);
+    expect(logModelHealthTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: ENDPOINT, transition: "degraded" })
+    );
+  });
+
+  it("leaves a healthy endpoint alone", async () => {
+    await seedWindow({ attempts: 250, providerErrors: 10 });
+
+    await evaluateEndpoint(ENDPOINT, NOW);
+
+    expect(launchModelHealthRecovery).not.toHaveBeenCalled();
+    expect(logModelHealthTransition).not.toHaveBeenCalled();
+  });
+
+  it("does not log a transition when the endpoint was already degraded", async () => {
+    // Another pod won the race: the workflow already exists, so this is not a
+    // state change and must not show up as a second incident.
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(
+      new Ok("already_degraded")
+    );
+    await seedWindow({ attempts: 250, providerErrors: 60 });
+
+    await evaluateEndpoint(ENDPOINT, NOW);
+
+    expect(launchModelHealthRecovery).toHaveBeenCalledTimes(1);
+    expect(logModelHealthTransition).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a transition when the workflow could not be started", async () => {
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(
+      new Err(new Error("temporal is unreachable"))
+    );
+    await seedWindow({ attempts: 250, providerErrors: 60 });
+
+    await evaluateEndpoint(ENDPOINT, NOW);
+
+    expect(logModelHealthTransition).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/llm/health/detect.test.ts
+++ b/front/lib/api/llm/health/detect.test.ts
@@ -25,6 +25,7 @@ const ENDPOINT = {
 } as const;
 
 const NOW = new Date("2026-09-03T14:32:10Z");
+const DEGRADED_SINCE_MS = NOW.getTime();
 
 async function seedWindow({
   attempts,
@@ -65,13 +66,18 @@ describe("evaluateEndpoint", () => {
   beforeEach(() => {
     redisMock.reset();
     vi.clearAllMocks();
-    vi.mocked(launchModelHealthRecovery).mockResolvedValue(new Ok("started"));
+    vi.mocked(launchModelHealthRecovery).mockResolvedValue(
+      new Ok({ outcome: "started", degradedSinceMs: DEGRADED_SINCE_MS })
+    );
   });
 
   it("declares a breaching endpoint degraded", async () => {
     await seedWindow({ attempts: 250, providerErrors: 60 });
 
-    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("recovery_started");
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "recovery_started",
+      degradedSinceMs: DEGRADED_SINCE_MS,
+    });
 
     expect(launchModelHealthRecovery).toHaveBeenCalledWith(ENDPOINT);
     expect(logModelHealthTransition).toHaveBeenCalledWith(
@@ -82,7 +88,9 @@ describe("evaluateEndpoint", () => {
   it("leaves a healthy endpoint alone", async () => {
     await seedWindow({ attempts: 250, providerErrors: 10 });
 
-    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("not_breaching");
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "not_breaching",
+    });
 
     expect(launchModelHealthRecovery).not.toHaveBeenCalled();
     expect(logModelHealthTransition).not.toHaveBeenCalled();
@@ -92,11 +100,17 @@ describe("evaluateEndpoint", () => {
     // Another pod won the race: the workflow already exists, so this is not a
     // state change and must not show up as a second incident.
     vi.mocked(launchModelHealthRecovery).mockResolvedValue(
-      new Ok("already_degraded")
+      new Ok({
+        outcome: "already_degraded",
+        degradedSinceMs: DEGRADED_SINCE_MS,
+      })
     );
     await seedWindow({ attempts: 250, providerErrors: 60 });
 
-    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("already_degraded");
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "already_degraded",
+      degradedSinceMs: DEGRADED_SINCE_MS,
+    });
 
     expect(launchModelHealthRecovery).toHaveBeenCalledTimes(1);
     expect(logModelHealthTransition).not.toHaveBeenCalled();
@@ -108,7 +122,9 @@ describe("evaluateEndpoint", () => {
     );
     await seedWindow({ attempts: 250, providerErrors: 60 });
 
-    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("launch_failed");
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
+      outcome: "launch_failed",
+    });
 
     expect(logModelHealthTransition).not.toHaveBeenCalled();
   });

--- a/front/lib/api/llm/health/detect.test.ts
+++ b/front/lib/api/llm/health/detect.test.ts
@@ -1,3 +1,7 @@
+import {
+  ERROR_RATIO_THRESHOLD,
+  MIN_ATTEMPTS_IN_WINDOW,
+} from "@app/lib/api/llm/health/config";
 import { evaluateEndpoint, isBreaching } from "@app/lib/api/llm/health/detect";
 import {
   ATTEMPTS_FIELD,
@@ -24,6 +28,11 @@ const ENDPOINT = {
   host: "anthropic",
 } as const;
 
+// Just enough attempts to clear the volume floor, so only the ratio decides,
+// and the fewest errors that breach on them.
+const ATTEMPTS = MIN_ATTEMPTS_IN_WINDOW;
+const BREACHING_ERRORS = Math.ceil(ATTEMPTS * ERROR_RATIO_THRESHOLD);
+
 const NOW = new Date("2026-09-03T14:32:10Z");
 const DEGRADED_SINCE_MS = NOW.getTime();
 
@@ -45,16 +54,21 @@ async function seedWindow({
 
 describe("isBreaching", () => {
   it("ignores an endpoint below the volume floor, however bad the ratio", () => {
-    // 100% errors, but on 199 attempts the ratio is noise.
-    expect(isBreaching({ attempts: 199, providerErrors: 199 })).toBe(false);
+    // 100% errors, but one attempt short of the floor the ratio is noise.
+    const attempts = MIN_ATTEMPTS_IN_WINDOW - 1;
+    expect(isBreaching({ attempts, providerErrors: attempts })).toBe(false);
   });
 
   it("breaches at the threshold", () => {
-    expect(isBreaching({ attempts: 200, providerErrors: 40 })).toBe(true);
+    expect(
+      isBreaching({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS })
+    ).toBe(true);
   });
 
   it("does not breach just below it", () => {
-    expect(isBreaching({ attempts: 200, providerErrors: 39 })).toBe(false);
+    expect(
+      isBreaching({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS - 1 })
+    ).toBe(false);
   });
 
   it("treats an idle endpoint as healthy", () => {
@@ -72,7 +86,7 @@ describe("evaluateEndpoint", () => {
   });
 
   it("declares a breaching endpoint degraded", async () => {
-    await seedWindow({ attempts: 250, providerErrors: 60 });
+    await seedWindow({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS });
 
     expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
       outcome: "recovery_started",
@@ -86,7 +100,10 @@ describe("evaluateEndpoint", () => {
   });
 
   it("leaves a healthy endpoint alone", async () => {
-    await seedWindow({ attempts: 250, providerErrors: 10 });
+    await seedWindow({
+      attempts: ATTEMPTS,
+      providerErrors: BREACHING_ERRORS - 1,
+    });
 
     expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
       outcome: "not_breaching",
@@ -105,7 +122,7 @@ describe("evaluateEndpoint", () => {
         degradedSinceMs: DEGRADED_SINCE_MS,
       })
     );
-    await seedWindow({ attempts: 250, providerErrors: 60 });
+    await seedWindow({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS });
 
     expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
       outcome: "already_degraded",
@@ -120,7 +137,7 @@ describe("evaluateEndpoint", () => {
     vi.mocked(launchModelHealthRecovery).mockResolvedValue(
       new Err(new Error("temporal is unreachable"))
     );
-    await seedWindow({ attempts: 250, providerErrors: 60 });
+    await seedWindow({ attempts: ATTEMPTS, providerErrors: BREACHING_ERRORS });
 
     expect(await evaluateEndpoint(ENDPOINT, NOW)).toEqual({
       outcome: "launch_failed",

--- a/front/lib/api/llm/health/detect.test.ts
+++ b/front/lib/api/llm/health/detect.test.ts
@@ -71,7 +71,7 @@ describe("evaluateEndpoint", () => {
   it("declares a breaching endpoint degraded", async () => {
     await seedWindow({ attempts: 250, providerErrors: 60 });
 
-    await evaluateEndpoint(ENDPOINT, NOW);
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("recovery_started");
 
     expect(launchModelHealthRecovery).toHaveBeenCalledWith(ENDPOINT);
     expect(logModelHealthTransition).toHaveBeenCalledWith(
@@ -82,7 +82,7 @@ describe("evaluateEndpoint", () => {
   it("leaves a healthy endpoint alone", async () => {
     await seedWindow({ attempts: 250, providerErrors: 10 });
 
-    await evaluateEndpoint(ENDPOINT, NOW);
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("not_breaching");
 
     expect(launchModelHealthRecovery).not.toHaveBeenCalled();
     expect(logModelHealthTransition).not.toHaveBeenCalled();
@@ -96,7 +96,7 @@ describe("evaluateEndpoint", () => {
     );
     await seedWindow({ attempts: 250, providerErrors: 60 });
 
-    await evaluateEndpoint(ENDPOINT, NOW);
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("already_degraded");
 
     expect(launchModelHealthRecovery).toHaveBeenCalledTimes(1);
     expect(logModelHealthTransition).not.toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe("evaluateEndpoint", () => {
     );
     await seedWindow({ attempts: 250, providerErrors: 60 });
 
-    await evaluateEndpoint(ENDPOINT, NOW);
+    expect(await evaluateEndpoint(ENDPOINT, NOW)).toBe("launch_failed");
 
     expect(logModelHealthTransition).not.toHaveBeenCalled();
   });

--- a/front/lib/api/llm/health/detect.ts
+++ b/front/lib/api/llm/health/detect.ts
@@ -10,11 +10,6 @@ import logger from "@app/logger/logger";
 import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-/**
- * An endpoint is degraded when enough attempts landed in the window and the
- * share attributed to the provider crossed the threshold. The volume floor is
- * what keeps a handful of failures on a low-traffic endpoint from tripping it.
- */
 export function isBreaching(window: ModelHealthWindowType): boolean {
   if (window.attempts < MIN_ATTEMPTS_IN_WINDOW) {
     return false;
@@ -23,19 +18,6 @@ export function isBreaching(window: ModelHealthWindowType): boolean {
   return window.providerErrors / window.attempts >= ERROR_RATIO_THRESHOLD;
 }
 
-/**
- * Reads one endpoint's window and declares it degraded if it is breaching.
- *
- * Runs on the pod that just served the endpoint, right after it wrote its
- * counter, so only the endpoint in hand is ever read -- never a sweep of the
- * catalog. Several pods can reach the same conclusion at the same instant,
- * which is fine: starting the recovery workflow is idempotent, and its
- * deterministic workflow id is what makes it so.
- *
- * There is no state to consult first. In this phase a running recovery workflow
- * *is* the degraded state, so re-declaring an endpoint that is already degraded
- * costs one rejected start and nothing else.
- */
 export async function evaluateEndpoint(
   endpoint: DegradedModelEndpointType,
   now: Date = new Date()
@@ -59,8 +41,6 @@ export async function evaluateEndpoint(
     return;
   }
 
-  // Only a launch that actually created the workflow is a transition: a
-  // rejected duplicate means the endpoint was already degraded.
   if (launchRes.value === "started") {
     logModelHealthTransition({ endpoint, transition: "degraded", window });
   }

--- a/front/lib/api/llm/health/detect.ts
+++ b/front/lib/api/llm/health/detect.ts
@@ -1,0 +1,67 @@
+import {
+  ERROR_RATIO_THRESHOLD,
+  MIN_ATTEMPTS_IN_WINDOW,
+} from "@app/lib/api/llm/health/config";
+import { logModelHealthTransition } from "@app/lib/api/llm/health/transitions";
+import type { ModelHealthWindowType } from "@app/lib/api/llm/health/types";
+import { readEndpointWindow } from "@app/lib/api/llm/health/window";
+import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
+import logger from "@app/logger/logger";
+import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * An endpoint is degraded when enough attempts landed in the window and the
+ * share attributed to the provider crossed the threshold. The volume floor is
+ * what keeps a handful of failures on a low-traffic endpoint from tripping it.
+ */
+export function isBreaching(window: ModelHealthWindowType): boolean {
+  if (window.attempts < MIN_ATTEMPTS_IN_WINDOW) {
+    return false;
+  }
+
+  return window.providerErrors / window.attempts >= ERROR_RATIO_THRESHOLD;
+}
+
+/**
+ * Reads one endpoint's window and declares it degraded if it is breaching.
+ *
+ * Runs on the pod that just served the endpoint, right after it wrote its
+ * counter, so only the endpoint in hand is ever read -- never a sweep of the
+ * catalog. Several pods can reach the same conclusion at the same instant,
+ * which is fine: starting the recovery workflow is idempotent, and its
+ * deterministic workflow id is what makes it so.
+ *
+ * There is no state to consult first. In this phase a running recovery workflow
+ * *is* the degraded state, so re-declaring an endpoint that is already degraded
+ * costs one rejected start and nothing else.
+ */
+export async function evaluateEndpoint(
+  endpoint: DegradedModelEndpointType,
+  now: Date = new Date()
+): Promise<void> {
+  const window = await readEndpointWindow(endpoint, now);
+  if (!isBreaching(window)) {
+    return;
+  }
+
+  const launchRes = await launchModelHealthRecovery(endpoint);
+  if (launchRes.isErr()) {
+    logger.error(
+      {
+        err: normalizeError(launchRes.error),
+        modelId: endpoint.modelId,
+        providerId: endpoint.providerId,
+        modelHost: endpoint.host,
+      },
+      "Failed to start the model health recovery workflow"
+    );
+    return;
+  }
+
+  // Only a launch that actually created the workflow is a transition: a
+  // rejected duplicate means the endpoint was already degraded.
+  if (launchRes.value === "started") {
+    logModelHealthTransition({ endpoint, transition: "degraded", window });
+  }
+}

--- a/front/lib/api/llm/health/detect.ts
+++ b/front/lib/api/llm/health/detect.ts
@@ -20,16 +20,18 @@ export function isBreaching(window: ModelHealthWindowType): boolean {
 }
 
 /**
- * What one evaluation established, mirroring `LaunchRecoveryOutcome` so the
- * caller can tell the two degraded outcomes apart: `recovery_started` anchors
- * the degradation at now, `already_degraded` says only that some other pod
- * anchored it at a time we cannot know.
+ * What one evaluation established.
+ *
+ * The two degraded outcomes carry `degradedSinceMs`, the recovery workflow's
+ * start time, because that alone pins when the endpoint could next change
+ * state. It is null only when the workflow is running but its start time could
+ * not be read.
  */
 export type EndpointEvaluationType =
-  | "not_breaching"
-  | "recovery_started"
-  | "already_degraded"
-  | "launch_failed";
+  | { outcome: "not_breaching" }
+  | { outcome: "recovery_started"; degradedSinceMs: number }
+  | { outcome: "already_degraded"; degradedSinceMs: number | null }
+  | { outcome: "launch_failed" };
 
 export async function evaluateEndpoint(
   endpoint: DegradedModelEndpointType,
@@ -37,7 +39,7 @@ export async function evaluateEndpoint(
 ): Promise<EndpointEvaluationType> {
   const window = await readEndpointWindow(endpoint, now);
   if (!isBreaching(window)) {
-    return "not_breaching";
+    return { outcome: "not_breaching" };
   }
 
   const launchRes = await launchModelHealthRecovery(endpoint);
@@ -51,17 +53,20 @@ export async function evaluateEndpoint(
       },
       "Failed to start the model health recovery workflow"
     );
-    return "launch_failed";
+    return { outcome: "launch_failed" };
   }
 
-  switch (launchRes.value) {
+  switch (launchRes.value.outcome) {
     case "started":
       logModelHealthTransition({ endpoint, transition: "degraded", window });
-      return "recovery_started";
+      return {
+        outcome: "recovery_started",
+        degradedSinceMs: launchRes.value.degradedSinceMs,
+      };
 
     case "already_degraded":
       // Not a state change: another pod already logged the transition.
-      return "already_degraded";
+      return launchRes.value;
 
     default:
       assertNever(launchRes.value);

--- a/front/lib/api/llm/health/detect.ts
+++ b/front/lib/api/llm/health/detect.ts
@@ -8,6 +8,7 @@ import { readEndpointWindow } from "@app/lib/api/llm/health/window";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
 import logger from "@app/logger/logger";
 import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export function isBreaching(window: ModelHealthWindowType): boolean {
@@ -18,13 +19,25 @@ export function isBreaching(window: ModelHealthWindowType): boolean {
   return window.providerErrors / window.attempts >= ERROR_RATIO_THRESHOLD;
 }
 
+/**
+ * What one evaluation established, mirroring `LaunchRecoveryOutcome` so the
+ * caller can tell the two degraded outcomes apart: `recovery_started` anchors
+ * the degradation at now, `already_degraded` says only that some other pod
+ * anchored it at a time we cannot know.
+ */
+export type EndpointEvaluationType =
+  | "not_breaching"
+  | "recovery_started"
+  | "already_degraded"
+  | "launch_failed";
+
 export async function evaluateEndpoint(
   endpoint: DegradedModelEndpointType,
   now: Date = new Date()
-): Promise<void> {
+): Promise<EndpointEvaluationType> {
   const window = await readEndpointWindow(endpoint, now);
   if (!isBreaching(window)) {
-    return;
+    return "not_breaching";
   }
 
   const launchRes = await launchModelHealthRecovery(endpoint);
@@ -38,10 +51,19 @@ export async function evaluateEndpoint(
       },
       "Failed to start the model health recovery workflow"
     );
-    return;
+    return "launch_failed";
   }
 
-  if (launchRes.value === "started") {
-    logModelHealthTransition({ endpoint, transition: "degraded", window });
+  switch (launchRes.value) {
+    case "started":
+      logModelHealthTransition({ endpoint, transition: "degraded", window });
+      return "recovery_started";
+
+    case "already_degraded":
+      // Not a state change: another pod already logged the transition.
+      return "already_degraded";
+
+    default:
+      assertNever(launchRes.value);
   }
 }

--- a/front/lib/api/llm/health/kill_switch.ts
+++ b/front/lib/api/llm/health/kill_switch.ts
@@ -1,0 +1,24 @@
+import { makeCachedKillSwitch } from "@app/lib/api/kill_switch_cache";
+
+// How long a pod may serve a stale value of the kill switch.
+const REFRESH_INTERVAL_MS = 60 * 1000;
+
+const isDetectionPaused = makeCachedKillSwitch("pause_model_health_detection", {
+  refreshIntervalMs: REFRESH_INTERVAL_MS,
+});
+
+/**
+ * Whether to stop recording attempts and detecting breaches, toggled from Poke.
+ *
+ * The whole point of an operator switch here is that it works during an
+ * incident, when shipping a revert is exactly what we cannot afford. It is read
+ * on every attempt, so it comes from an in-process cache rather than Redis --
+ * consulting Redis to decide whether to write to Redis would be self-defeating
+ * on the one failure this path most needs to survive.
+ *
+ * Recovery workflows already running are not affected: they only probe and log,
+ * and they end on their own.
+ */
+export function isModelHealthDetectionPaused(): boolean {
+  return isDetectionPaused();
+}

--- a/front/lib/api/permissions/legacy_acls.ts
+++ b/front/lib/api/permissions/legacy_acls.ts
@@ -1,47 +1,23 @@
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { makeCachedKillSwitch } from "@app/lib/api/kill_switch_cache";
 
 // How long a pod may serve a stale value of the kill switch.
 const REFRESH_INTERVAL_MS = 60 * 1000;
 
-let cachedValue = false;
-let lastRefreshStartedAt = 0;
-let refreshing = false;
+const isLegacyAclsKillSwitchEnabled = makeCachedKillSwitch("use_legacy_acls", {
+  refreshIntervalMs: REFRESH_INTERVAL_MS,
+});
 
 /**
  * Whether to serve permission decisions from the legacy inline-group ACLs instead of the
  * `group_permissions` table — the revert path for the governance migration, toggled from Poke.
  *
  * Read synchronously because permission checks are: `canWrite` runs inside `toJSON` and inside
- * array predicates. The kill switch itself lives in Redis, so this keeps the last known value in
- * process and refreshes it in the background at most every REFRESH_INTERVAL_MS. Consequences:
- * enabling it in Poke takes effect within that window on each pod, and a pod serves the new path
- * until its first refresh resolves (a few ms after boot).
+ * array predicates. The kill switch itself lives in Redis, so `makeCachedKillSwitch` keeps the
+ * last known value in process and refreshes it in the background at most every
+ * REFRESH_INTERVAL_MS.
  *
  * Temporary — delete along with the legacy path once the table is trusted.
  */
 export function isLegacyAclsEnabled(): boolean {
-  const now = Date.now();
-  if (!refreshing && now - lastRefreshStartedAt > REFRESH_INTERVAL_MS) {
-    refreshing = true;
-    lastRefreshStartedAt = now;
-
-    void KillSwitchResource.isKillSwitchEnabled("use_legacy_acls")
-      .then((enabled) => {
-        cachedValue = enabled;
-      })
-      .catch((err) => {
-        // Keep the last known value: a Redis blip must not flip permission behaviour.
-        logger.error(
-          { err: normalizeError(err) },
-          "Failed to refresh the use_legacy_acls kill switch"
-        );
-      })
-      .finally(() => {
-        refreshing = false;
-      });
-  }
-
-  return cachedValue;
+  return isLegacyAclsKillSwitchEnabled();
 }

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -4,6 +4,7 @@ export const KILL_SWITCH_TYPES = [
   "global_blacklist_anthropic",
   "global_blacklist_openai",
   "global_disable_firecrawl",
+  "pause_model_health_detection",
   "pause_upsert_queue",
   "use_legacy_acls",
 ] as const;


### PR DESCRIPTION
## Description

Closes the loop. The only PR in the stack that changes what the system does.

An endpoint is declared degraded when at least `MIN_ATTEMPTS_IN_WINDOW` (100) attempts
landed in the five-minute window and the provider-attributed share crossed
`ERROR_RATIO_THRESHOLD` (20%). The volume floor is what keeps a handful of failures on a
low-traffic endpoint from tripping it, and it is low enough that we fail back quickly
after reopening an endpoint to full traffic; a real outage routinely sits at 60%.

Detection is driven by the write path rather than by a sweep. Only an error can push the
ratio over the threshold, so an error write evaluates the one endpoint it just served —
never a scan of the catalog — throttled to once per `MIN_EVALUATION_INTERVAL_MS` (5s) per
pod. During an outage those writes land hundreds of times a second on the same endpoint,
and evaluating each one would re-read the same window and hand Temporal a rejected
duplicate start hundreds of times to learn the same thing.

Several pods can reach the same conclusion in the same instant, which is fine: the
recovery workflow's deterministic id makes the start idempotent, and only a start that
actually created the workflow is logged as a transition.

Still shadow-only: nothing is persisted and no traffic is steered away from a degraded
endpoint. Declaring one degraded starts its recovery workflow and logs the transition.

The whole path sits behind a `pause_model_health_detection` kill switch, toggled from
Poke. Enabled, `recordLLMAttempt` returns immediately: no counter write, no evaluation, no
workflow start. It exists because the one thing this path must survive is an incident, and
shipping a revert is exactly what we cannot do during one. It is read on every attempt, so
it comes out of an in-process cache refreshed at most every 60s rather than out of Redis --
consulting Redis to decide whether to write to Redis would be self-defeating on the failure
it most needs to cover. That pattern already existed for `use_legacy_acls`, so it moved to
a shared `makeCachedKillSwitch` and both read through it.

PR 5 of 5: #31877 → #31878 → #31879 → #31880 → this.

## Tests

Unit tests for the threshold rails (volume floor, at/just-below the threshold, idle
endpoint) and for `evaluateEndpoint` — that a breaching endpoint is declared degraded,
that a healthy one is left alone, that an already-degraded endpoint is not re-logged as a
transition, and that a failed workflow start does not claim one. Plus the counter-side
tests for the evaluation trigger: only on a provider error, at most once per interval,
and never when the write failed, and that the kill switch takes out both the write and the
detection it triggers. `npm run test -- llm/health`.

## Risk

The thresholds (20% over 200 attempts in 5 minutes, 5s evaluation throttle, 10 minutes
degraded before the first probe) are the tunable part and are calibrated against what the
existing Datadog monitor sees, not against a replay of past incidents. A too-sensitive
setting produces spurious "degraded" logs and one recovery workflow per endpoint; it
cannot affect serving, because nothing consumes the degraded state yet. That is the point
of the shadow phase.

Small and self-contained enough to revert on its own, which leaves the stack in the
write-only state of #31879 -- and the kill switch means we do not have to: enabling
`pause_model_health_detection` in Poke takes the path out within 60s per pod, without a
deploy. Recovery workflows already running are left to finish on their own; they only probe
and log.

## Deploy Plan

Merge after the `model_health` worker from #31880 is actually deployed — this is what
starts recovery workflows, and without a worker they would sit unpicked.

Then watch the `model_health.transition.count` series (tagged by transition, model,
provider and host) for a few days and compare its `degraded` transitions against the
incidents the Datadog `llm_error.count` monitor fires on, before wiring the state into
routing in a follow-up.
