### PR TITLE
refactor(AdminLayout): remove style from AdminLayout

### DIFF
--- a/front/components/layouts/AdminLayout.tsx
+++ b/front/components/layouts/AdminLayout.tsx
@@ -7,7 +7,6 @@ import {
 } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { cn } from "@dust-tt/sparkle";
 import type { ReactElement } from "react";
 import { useMemo } from "react";
 
@@ -38,13 +37,5 @@ export function AdminLayout({ children }: AdminLayoutProps) {
 
   useSetSubNavigation(subNavigation);
 
-  return (
-    <div
-      className={cn("flex h-full w-full flex-col items-center pt-4 sm:pt-8")}
-    >
-      <div className="flex w-full max-w-6xl grow flex-col px-4 sm:px-10 pb-4 sm:pb-8">
-        {children}
-      </div>
-    </div>
-  );
+  return children;
 }

--- a/front/components/layouts/AdminPageContainer.tsx
+++ b/front/components/layouts/AdminPageContainer.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+interface AdminPageContainerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function AdminPageContainer({
+  children,
+  className,
+}: AdminPageContainerProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto flex min-h-full w-full max-w-6xl flex-col px-4 py-4 sm:px-10 sm:py-8",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
@@ -30,33 +31,35 @@ export function AnalyticsAutomationsPage() {
   }, [owner.sId]);
 
   return (
-    <Page.Vertical align="stretch" gap="xl">
-      <Page.Header
-        title={
-          <div className="flex w-full flex-row justify-between">
-            <div className="flex flex-col gap-1">
-              <Page.H variant="h3">Automations</Page.H>
-              <Page.P variant="secondary">
-                Everything that runs on its own: who set it up, how often it
-                runs, what it costs.
-              </Page.P>
+    <AdminPageContainer>
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Header
+          title={
+            <div className="flex w-full flex-row justify-between">
+              <div className="flex flex-col gap-1">
+                <Page.H variant="h3">Automations</Page.H>
+                <Page.P variant="secondary">
+                  Everything that runs on its own: who set it up, how often it
+                  runs, what it costs.
+                </Page.P>
+              </div>
+              <ConsumptionPeriodSelector
+                period={period}
+                onPeriodChange={setPeriod}
+              />
             </div>
-            <ConsumptionPeriodSelector
-              period={period}
-              onPeriodChange={setPeriod}
-            />
-          </div>
-        }
-      />
+          }
+        />
 
-      <AutomationsOverview owner={owner} period={period} />
+        <AutomationsOverview owner={owner} period={period} />
 
-      <AutomationsTriggersTable
-        owner={owner}
-        period={period}
-        filter={filter}
-        onFilterChange={setFilter}
-      />
-    </Page.Vertical>
+        <AutomationsTriggersTable
+          owner={owner}
+          period={period}
+          filter={filter}
+          onFilterChange={setFilter}
+        />
+      </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,6 +1,7 @@
 import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { CHART_HEIGHT } from "@app/components/charts/constants";
 import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { AnalyticsExportPanel } from "@app/components/workspace/analytics/AnalyticsExportPanel";
 import type { ConsumptionAttributionTableProps } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
@@ -186,12 +187,14 @@ export function AnalyticsConsumptionPage() {
         skillId={skillDetailsId}
         onClose={() => setSkillDetailsId(null)}
       />
-      <AnalyticsConsumptionContent
-        owner={owner}
-        state={{ ...state, filter }}
-        onAgentClick={setAgentDetailsId}
-        onSkillClick={setSkillDetailsId}
-      />
+      <AdminPageContainer>
+        <AnalyticsConsumptionContent
+          owner={owner}
+          state={{ ...state, filter }}
+          onAgentClick={setAgentDetailsId}
+          onSkillClick={setSkillDetailsId}
+        />
+      </AdminPageContainer>
     </>
   );
 }

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -1,4 +1,5 @@
 import { WorkspaceGroupsList } from "@app/components/groups/WorkspaceGroupsList";
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { WorkspaceMembersSection } from "@app/components/members/WorkspaceMembersSection";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -45,9 +46,11 @@ export function MembersPage() {
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
+      <AdminPageContainer>
+        <div className="flex h-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      </AdminPageContainer>
     );
   }
 
@@ -64,25 +67,30 @@ export function MembersPage() {
   );
 
   return (
-    <div className="mb-4">
-      <div className="flex flex-col gap-6">
-        <Page.Header
-          title="People"
-          description="Manage team members and their roles."
-        />
-        <Tabs value={activeTab} onValueChange={(value) => tab.setParam(value)}>
-          <TabsList className="mb-6">
-            <TabsTrigger value="members" label="Members" />
-            <TabsTrigger value="groups" label="Groups" />
-          </TabsList>
-          <TabsContent value="members" className="flex flex-col gap-4">
-            {membersContent}
-          </TabsContent>
-          <TabsContent value="groups" className="flex flex-col gap-4">
-            <WorkspaceGroupsList owner={owner} />
-          </TabsContent>
-        </Tabs>
+    <AdminPageContainer>
+      <div className="mb-4">
+        <div className="flex flex-col gap-6">
+          <Page.Header
+            title="People"
+            description="Manage team members and their roles."
+          />
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => tab.setParam(value)}
+          >
+            <TabsList className="mb-6">
+              <TabsTrigger value="members" label="Members" />
+              <TabsTrigger value="groups" label="Groups" />
+            </TabsList>
+            <TabsContent value="members" className="flex flex-col gap-4">
+              {membersContent}
+            </TabsContent>
+            <TabsContent value="groups" className="flex flex-col gap-4">
+              <WorkspaceGroupsList owner={owner} />
+            </TabsContent>
+          </Tabs>
+        </div>
       </div>
-    </div>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1,6 +1,7 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { ConfirmContext } from "@app/components/Confirm";
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
 import { BulkChangeSeatModal } from "@app/components/workspace/BulkChangeSeatModal";
 import { BulkEditSpendLimitModal } from "@app/components/workspace/BulkEditSpendLimitModal";
@@ -1044,413 +1045,417 @@ export function UsagePage() {
   );
 
   return (
-    <>
-      <BuyAwuCreditsDialog
-        isOpen={showBuyCreditDialog}
-        onClose={() => setShowBuyCreditDialog(false)}
-        onPurchaseSuccess={() => {
-          void mutateAwuPoolSummary();
-        }}
-        workspaceId={owner.sId}
-        awuPurchaseInfo={awuPurchaseInfo}
-        isAwuPurchaseInfoLoading={isAwuPurchaseInfoLoading}
-        isAwuPurchaseInfoError={!!isAwuPurchaseInfoError}
-        currentTotalPoolCredits={totalActiveCredits}
-      />
+    <AdminPageContainer>
+      <>
+        <BuyAwuCreditsDialog
+          isOpen={showBuyCreditDialog}
+          onClose={() => setShowBuyCreditDialog(false)}
+          onPurchaseSuccess={() => {
+            void mutateAwuPoolSummary();
+          }}
+          workspaceId={owner.sId}
+          awuPurchaseInfo={awuPurchaseInfo}
+          isAwuPurchaseInfoLoading={isAwuPurchaseInfoLoading}
+          isAwuPurchaseInfoError={!!isAwuPurchaseInfoError}
+          currentTotalPoolCredits={totalActiveCredits}
+        />
 
-      <div
-        className={
-          showConsumptionAnalytics
-            ? "flex flex-col items-stretch gap-8 pb-20"
-            : "flex flex-col items-stretch gap-10 pb-20"
-        }
-      >
-        {showConsumptionAnalytics ? (
-          <Page.Header
-            title={
-              <div className="flex w-full items-center justify-between gap-4">
-                <Page.H variant="h3">Usage</Page.H>
-                <Button
-                  label="Breakdown in analytics"
-                  iconRight={LinkExternal01}
-                  size="xs"
-                  variant="highlight-ghost"
-                  href={`/w/${owner.sId}/analytics/consumption`}
-                />
-              </div>
-            }
-            description="Control credit consumption across your workspace."
-          />
-        ) : (
-          <div className="flex items-center justify-between">
-            <Page.Header title="Usage" />
-            {isCreditPriced &&
-              usageSettings.topUpEnabled &&
-              isWorkspaceAdmin && (
-                <Button
-                  label="Top up"
-                  icon={ArrowUp}
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setShowBuyCreditDialog(true)}
-                />
-              )}
-          </div>
-        )}
-
-        {isCreditPricedFreePlan(subscription.plan.code) && (
-          <FreePlanUpgradeSection
-            action={
-              <Button
-                label="Change my seat"
-                variant="highlight"
-                size="sm"
-                onClick={() => setChangeSeatMember(myUsage)}
-              />
-            }
-          />
-        )}
-
-        {isCreditPriced && showConsumptionAnalytics ? (
-          <Page.Vertical gap="none" align="stretch">
-            <h2 className="heading-sm text-foreground">Credit Pool</h2>
-            <div className="flex flex-col gap-2 pt-4">
-              {isOverviewLoading ? (
-                <div
-                  aria-label="Loading Credit Pool"
-                  className="flex flex-col gap-2"
-                  role="status"
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="flex items-center gap-1">
-                      <LoadingBlock className="h-7.5 w-32" />
-                      <LoadingBlock className="h-4 w-36" />
-                    </div>
-                    <LoadingBlock className="h-5 w-16 rounded-full" />
-                  </div>
-                  <LoadingBlock className="h-2 w-full rounded-xs" />
-                  <div className="flex items-center justify-between gap-4">
-                    <LoadingBlock className="h-5 w-12" />
-                    <LoadingBlock className="h-5 w-20" />
-                  </div>
-                </div>
-              ) : isOverviewError ? (
-                <ContentMessage
-                  title="Failed to load Workspace Credit Pool"
-                  icon={AlertCircle}
-                  variant="warning"
-                >
-                  An error occurred while loading your Workspace Credit Pool
-                  data. Please refresh the page or contact support if the issue
-                  persists.
-                </ContentMessage>
-              ) : consumptionOverview !== null &&
-                (creditUsage !== null || hasPool) ? (
-                <>
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="flex items-baseline gap-1">
-                      <span className="heading-2xl text-foreground">
-                        {formatCredits(totalConsumedCredits)}
-                      </span>
-                      <span className="copy-sm text-muted-foreground">
-                        /{formatCredits(initialTotalCredits)} credits
-                      </span>
-                    </div>
-                    {creditUsage && (
-                      <Chip
-                        size="mini"
-                        color={
-                          creditUsageDisplayTarget === "on_target"
-                            ? "highlight"
-                            : "warning"
-                        }
-                        label={
-                          creditUsageDisplayTarget === "on_target"
-                            ? "On target"
-                            : "Off target"
-                        }
-                      />
-                    )}
-                  </div>
-                  <CreditPoolProgressBar
-                    projectedPercentage={projectedPercentage}
-                    target={creditUsageDisplayTarget}
-                    usedPercentage={usedPercentage}
-                  />
-                  <div className="flex items-center justify-between gap-4 text-sm text-muted-foreground">
-                    <span>{usedPercentage}% used</span>
-                    {resetAt && (
-                      <span>Resets {formatConsumptionDate(resetAt)}</span>
-                    )}
-                  </div>
-                </>
-              ) : null}
-              <div className="mt-2 flex flex-col justify-between gap-4 border-t border-border pt-4 sm:flex-row sm:items-center">
-                <div className="flex min-w-0 flex-1 flex-col gap-1 text-sm text-foreground">
-                  {!isOverviewError &&
-                    consumptionOverview !== null &&
-                    (creditUsage !== null || hasPool) && (
-                      <>
-                        {creditUsageDisplayTarget === "on_target" ? (
-                          <span>
-                            At your current rate, you have enough credits to
-                            finish the cycle.
-                          </span>
-                        ) : resetAt ? (
-                          <span>
-                            At this rate, you&apos;re expected to consume your
-                            full credits by{" "}
-                            <span className="font-semibold">
-                              {formatConsumptionDate(resetAt)}
-                            </span>
-                            .
-                          </span>
-                        ) : null}
-                        {overageCredits !== null && overageCredits > 0 && (
-                          <span className="text-muted-foreground">
-                            {formatCredits(overageCredits)} overage credits
-                          </span>
-                        )}
-                      </>
-                    )}
-                </div>
-                {topUpButton}
-              </div>
-            </div>
-          </Page.Vertical>
-        ) : null}
-
-        {isCreditPriced &&
-        !showConsumptionAnalytics &&
-        !isAwuPoolSummaryLoading &&
-        (isAwuPoolSummaryError || hasPool) ? (
-          <Page.Vertical gap="xs" align="stretch">
-            <Page.H variant="h4">Workspace credit pool</Page.H>
-
-            {isAwuPoolSummaryError ? (
-              <ContentMessage
-                title="Failed to load Workspace Credits Pool"
-                icon={AlertCircle}
-                variant="warning"
-              >
-                An error occurred while loading your Workspace Credits Pool
-                data. Please refresh the page or contact support if the issue
-                persists.
-              </ContentMessage>
-            ) : isAwuPoolSummaryLoading ? (
-              <div className="flex justify-center py-8">
-                <Spinner />
-              </div>
-            ) : (
-              <>
-                <div className="flex items-baseline gap-1">
-                  <span className="heading-mono-4xl text-foreground">
-                    {formatCredits(totalConsumedCredits)}
-                  </span>
-                  <span className="copy-sm text-muted-foreground">
-                    /{formatCredits(initialTotalCredits)}
-                  </span>
-                </div>
-                {hasPool && (
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/20">
-                    <div
-                      className="h-full rounded-full bg-foreground/80 transition-all"
-                      style={{
-                        width: `${Math.min(100, initialTotalCredits > 0 ? (totalConsumedCredits / initialTotalCredits) * 100 : 0)}%`,
-                      }}
-                    />
-                  </div>
-                )}
-                <div className="flex items-center gap-2">
-                  {overageCredits !== null && overageCredits > 0 && (
-                    <span className="copy-sm text-muted-foreground">
-                      {formatCredits(overageCredits)} overage credits
-                    </span>
-                  )}
-                  {isEnterprise && (
-                    <span className="copy-sm text-muted-foreground">
-                      Contact your Dust sales representative to buy credits
-                    </span>
-                  )}
-                </div>
-              </>
-            )}
-          </Page.Vertical>
-        ) : null}
-
-        <Tabs
-          value={usageTab}
-          onValueChange={(v) =>
-            setUsageTab(
-              v === "groups" || v === "top-ups" || v === "settings"
-                ? v
-                : "members"
-            )
+        <div
+          className={
+            showConsumptionAnalytics
+              ? "flex flex-col items-stretch gap-8 pb-20"
+              : "flex flex-col items-stretch gap-10 pb-20"
           }
         >
-          <TabsList className="mb-4">
-            <TabsTrigger value="members" label="Members" />
-            <TabsTrigger value="groups" label="Groups" />
-            {isWorkspaceAdmin && isCreditPriced && (
-              <TabsTrigger value="top-ups" label="Top-ups history" />
-            )}
-            {isWorkspaceAdmin && (
-              <TabsTrigger value="settings" label="Settings" />
-            )}
-          </TabsList>
+          {showConsumptionAnalytics ? (
+            <Page.Header
+              title={
+                <div className="flex w-full items-center justify-between gap-4">
+                  <Page.H variant="h3">Usage</Page.H>
+                  <Button
+                    label="Breakdown in analytics"
+                    iconRight={LinkExternal01}
+                    size="xs"
+                    variant="highlight-ghost"
+                    href={`/w/${owner.sId}/analytics/consumption`}
+                  />
+                </div>
+              }
+              description="Control credit consumption across your workspace."
+            />
+          ) : (
+            <div className="flex items-center justify-between">
+              <Page.Header title="Usage" />
+              {isCreditPriced &&
+                usageSettings.topUpEnabled &&
+                isWorkspaceAdmin && (
+                  <Button
+                    label="Top up"
+                    icon={ArrowUp}
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setShowBuyCreditDialog(true)}
+                  />
+                )}
+            </div>
+          )}
 
-          <TabsContent value="members">
-            <Page.Vertical gap="sm" align="stretch">
-              {searchAndInviteRow}
-              <div className="flex flex-col gap-2">
-                <div className="flex flex-row items-center justify-between gap-2">
-                  {isCreditPriced && (
-                    <ButtonsSwitchList
-                      size="xs"
-                      defaultValue="members"
-                      onValueChange={(v: string) =>
-                        setMembersTab(v === "requests" ? "requests" : "members")
-                      }
-                    >
-                      <ButtonsSwitch value="members" label="Members" />
-                      <ButtonsSwitch
-                        value="requests"
-                        label="Requests"
-                        isCounter
-                        counterValue={
-                          filteredUpgradeRequests.length > 0
-                            ? String(filteredUpgradeRequests.length)
-                            : undefined
-                        }
-                      />
-                    </ButtonsSwitchList>
-                  )}
-                  {membersTab === "members" && (
-                    <div className="flex flex-row items-center gap-2">
-                      {groupsFilterDropdown}
-                      {isWorkspaceAdmin && groupFilter && (
-                        <GroupModelTierPickerDropdown
-                          owner={owner}
-                          groupId={groupFilter}
+          {isCreditPricedFreePlan(subscription.plan.code) && (
+            <FreePlanUpgradeSection
+              action={
+                <Button
+                  label="Change my seat"
+                  variant="highlight"
+                  size="sm"
+                  onClick={() => setChangeSeatMember(myUsage)}
+                />
+              }
+            />
+          )}
+
+          {isCreditPriced && showConsumptionAnalytics ? (
+            <Page.Vertical gap="none" align="stretch">
+              <h2 className="heading-sm text-foreground">Credit Pool</h2>
+              <div className="flex flex-col gap-2 pt-4">
+                {isOverviewLoading ? (
+                  <div
+                    aria-label="Loading Credit Pool"
+                    className="flex flex-col gap-2"
+                    role="status"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-center gap-1">
+                        <LoadingBlock className="h-7.5 w-32" />
+                        <LoadingBlock className="h-4 w-36" />
+                      </div>
+                      <LoadingBlock className="h-5 w-16 rounded-full" />
+                    </div>
+                    <LoadingBlock className="h-2 w-full rounded-xs" />
+                    <div className="flex items-center justify-between gap-4">
+                      <LoadingBlock className="h-5 w-12" />
+                      <LoadingBlock className="h-5 w-20" />
+                    </div>
+                  </div>
+                ) : isOverviewError ? (
+                  <ContentMessage
+                    title="Failed to load Workspace Credit Pool"
+                    icon={AlertCircle}
+                    variant="warning"
+                  >
+                    An error occurred while loading your Workspace Credit Pool
+                    data. Please refresh the page or contact support if the
+                    issue persists.
+                  </ContentMessage>
+                ) : consumptionOverview !== null &&
+                  (creditUsage !== null || hasPool) ? (
+                  <>
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-baseline gap-1">
+                        <span className="heading-2xl text-foreground">
+                          {formatCredits(totalConsumedCredits)}
+                        </span>
+                        <span className="copy-sm text-muted-foreground">
+                          /{formatCredits(initialTotalCredits)} credits
+                        </span>
+                      </div>
+                      {creditUsage && (
+                        <Chip
+                          size="mini"
+                          color={
+                            creditUsageDisplayTarget === "on_target"
+                              ? "highlight"
+                              : "warning"
+                          }
+                          label={
+                            creditUsageDisplayTarget === "on_target"
+                              ? "On target"
+                              : "Off target"
+                          }
                         />
                       )}
-                      {isCreditPriced && seatFilterDropdown}
                     </div>
-                  )}
-                </div>
-                <div className="flex flex-col gap-2 pt-2">
-                  {membersTab === "members" ? (
-                    <>
-                      {membersTable}
-                      {selectionBanner}
-                    </>
-                  ) : (
-                    <UpgradeRequestsTable
-                      requests={filteredUpgradeRequests}
-                      isLoading={isUpgradeRequestsLoading}
-                      seatPlans={seatPlans}
-                      pendingRequestIds={resolvingRequestIds}
-                      onUpgradePlan={handleUpgradePlanRequest}
-                      onEditLimit={handleEditLimitRequest}
-                      onDeny={handleDenyRequest}
+                    <CreditPoolProgressBar
+                      projectedPercentage={projectedPercentage}
+                      target={creditUsageDisplayTarget}
+                      usedPercentage={usedPercentage}
                     />
-                  )}
+                    <div className="flex items-center justify-between gap-4 text-sm text-muted-foreground">
+                      <span>{usedPercentage}% used</span>
+                      {resetAt && (
+                        <span>Resets {formatConsumptionDate(resetAt)}</span>
+                      )}
+                    </div>
+                  </>
+                ) : null}
+                <div className="mt-2 flex flex-col justify-between gap-4 border-t border-border pt-4 sm:flex-row sm:items-center">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1 text-sm text-foreground">
+                    {!isOverviewError &&
+                      consumptionOverview !== null &&
+                      (creditUsage !== null || hasPool) && (
+                        <>
+                          {creditUsageDisplayTarget === "on_target" ? (
+                            <span>
+                              At your current rate, you have enough credits to
+                              finish the cycle.
+                            </span>
+                          ) : resetAt ? (
+                            <span>
+                              At this rate, you&apos;re expected to consume your
+                              full credits by{" "}
+                              <span className="font-semibold">
+                                {formatConsumptionDate(resetAt)}
+                              </span>
+                              .
+                            </span>
+                          ) : null}
+                          {overageCredits !== null && overageCredits > 0 && (
+                            <span className="text-muted-foreground">
+                              {formatCredits(overageCredits)} overage credits
+                            </span>
+                          )}
+                        </>
+                      )}
+                  </div>
+                  {topUpButton}
                 </div>
               </div>
             </Page.Vertical>
-          </TabsContent>
-          <TabsContent value="groups">
-            <GroupsUsageTable
-              owner={owner}
-              showSpendLimitColumn={isCreditPriced}
-              showModelTiersColumn={isWorkspaceAdmin}
-            />
-          </TabsContent>
+          ) : null}
 
-          {isWorkspaceAdmin && isCreditPriced && (
-            <TabsContent value="top-ups">
-              <TopUpsHistoryTable owner={owner} />
+          {isCreditPriced &&
+          !showConsumptionAnalytics &&
+          !isAwuPoolSummaryLoading &&
+          (isAwuPoolSummaryError || hasPool) ? (
+            <Page.Vertical gap="xs" align="stretch">
+              <Page.H variant="h4">Workspace credit pool</Page.H>
+
+              {isAwuPoolSummaryError ? (
+                <ContentMessage
+                  title="Failed to load Workspace Credits Pool"
+                  icon={AlertCircle}
+                  variant="warning"
+                >
+                  An error occurred while loading your Workspace Credits Pool
+                  data. Please refresh the page or contact support if the issue
+                  persists.
+                </ContentMessage>
+              ) : isAwuPoolSummaryLoading ? (
+                <div className="flex justify-center py-8">
+                  <Spinner />
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-baseline gap-1">
+                    <span className="heading-mono-4xl text-foreground">
+                      {formatCredits(totalConsumedCredits)}
+                    </span>
+                    <span className="copy-sm text-muted-foreground">
+                      /{formatCredits(initialTotalCredits)}
+                    </span>
+                  </div>
+                  {hasPool && (
+                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/20">
+                      <div
+                        className="h-full rounded-full bg-foreground/80 transition-all"
+                        style={{
+                          width: `${Math.min(100, initialTotalCredits > 0 ? (totalConsumedCredits / initialTotalCredits) * 100 : 0)}%`,
+                        }}
+                      />
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2">
+                    {overageCredits !== null && overageCredits > 0 && (
+                      <span className="copy-sm text-muted-foreground">
+                        {formatCredits(overageCredits)} overage credits
+                      </span>
+                    )}
+                    {isEnterprise && (
+                      <span className="copy-sm text-muted-foreground">
+                        Contact your Dust sales representative to buy credits
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </Page.Vertical>
+          ) : null}
+
+          <Tabs
+            value={usageTab}
+            onValueChange={(v) =>
+              setUsageTab(
+                v === "groups" || v === "top-ups" || v === "settings"
+                  ? v
+                  : "members"
+              )
+            }
+          >
+            <TabsList className="mb-4">
+              <TabsTrigger value="members" label="Members" />
+              <TabsTrigger value="groups" label="Groups" />
+              {isWorkspaceAdmin && isCreditPriced && (
+                <TabsTrigger value="top-ups" label="Top-ups history" />
+              )}
+              {isWorkspaceAdmin && (
+                <TabsTrigger value="settings" label="Settings" />
+              )}
+            </TabsList>
+
+            <TabsContent value="members">
+              <Page.Vertical gap="sm" align="stretch">
+                {searchAndInviteRow}
+                <div className="flex flex-col gap-2">
+                  <div className="flex flex-row items-center justify-between gap-2">
+                    {isCreditPriced && (
+                      <ButtonsSwitchList
+                        size="xs"
+                        defaultValue="members"
+                        onValueChange={(v: string) =>
+                          setMembersTab(
+                            v === "requests" ? "requests" : "members"
+                          )
+                        }
+                      >
+                        <ButtonsSwitch value="members" label="Members" />
+                        <ButtonsSwitch
+                          value="requests"
+                          label="Requests"
+                          isCounter
+                          counterValue={
+                            filteredUpgradeRequests.length > 0
+                              ? String(filteredUpgradeRequests.length)
+                              : undefined
+                          }
+                        />
+                      </ButtonsSwitchList>
+                    )}
+                    {membersTab === "members" && (
+                      <div className="flex flex-row items-center gap-2">
+                        {groupsFilterDropdown}
+                        {isWorkspaceAdmin && groupFilter && (
+                          <GroupModelTierPickerDropdown
+                            owner={owner}
+                            groupId={groupFilter}
+                          />
+                        )}
+                        {isCreditPriced && seatFilterDropdown}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-2 pt-2">
+                    {membersTab === "members" ? (
+                      <>
+                        {membersTable}
+                        {selectionBanner}
+                      </>
+                    ) : (
+                      <UpgradeRequestsTable
+                        requests={filteredUpgradeRequests}
+                        isLoading={isUpgradeRequestsLoading}
+                        seatPlans={seatPlans}
+                        pendingRequestIds={resolvingRequestIds}
+                        onUpgradePlan={handleUpgradePlanRequest}
+                        onEditLimit={handleEditLimitRequest}
+                        onDeny={handleDenyRequest}
+                      />
+                    )}
+                  </div>
+                </div>
+              </Page.Vertical>
             </TabsContent>
-          )}
-
-          {isWorkspaceAdmin && (
-            <TabsContent value="settings">
-              <div className="flex flex-col gap-10">
-                {isCreditPriced && (
-                  <UsageSettingsCard
-                    workspaceId={owner.sId}
-                    hasPool={hasPool}
-                  />
-                )}
-                <ModelTiersSettingsCard owner={owner} />
-                {isCreditPriced && (
-                  <LockedSection
-                    locked={!isAwuPoolSummaryLoading && !hasPool}
-                    className="flex flex-col gap-10"
-                  >
-                    <UsageProgrammaticLimitCard workspaceId={owner.sId} />
-                    <UsageNotificationsCard workspaceId={owner.sId} />
-                  </LockedSection>
-                )}
-              </div>
+            <TabsContent value="groups">
+              <GroupsUsageTable
+                owner={owner}
+                showSpendLimitColumn={isCreditPriced}
+                showModelTiersColumn={isWorkspaceAdmin}
+              />
             </TabsContent>
-          )}
-        </Tabs>
-      </div>
 
-      {inviteBlockedPopupReason && (
-        <ReachedLimitPopup
-          isAdmin={isAdmin(owner)}
-          isOpened={!!inviteBlockedPopupReason}
-          onClose={() => setInviteBlockedPopupReason(null)}
-          subscription={subscription}
+            {isWorkspaceAdmin && isCreditPriced && (
+              <TabsContent value="top-ups">
+                <TopUpsHistoryTable owner={owner} />
+              </TabsContent>
+            )}
+
+            {isWorkspaceAdmin && (
+              <TabsContent value="settings">
+                <div className="flex flex-col gap-10">
+                  {isCreditPriced && (
+                    <UsageSettingsCard
+                      workspaceId={owner.sId}
+                      hasPool={hasPool}
+                    />
+                  )}
+                  <ModelTiersSettingsCard owner={owner} />
+                  {isCreditPriced && (
+                    <LockedSection
+                      locked={!isAwuPoolSummaryLoading && !hasPool}
+                      className="flex flex-col gap-10"
+                    >
+                      <UsageProgrammaticLimitCard workspaceId={owner.sId} />
+                      <UsageNotificationsCard workspaceId={owner.sId} />
+                    </LockedSection>
+                  )}
+                </div>
+              </TabsContent>
+            )}
+          </Tabs>
+        </div>
+
+        {inviteBlockedPopupReason && (
+          <ReachedLimitPopup
+            isAdmin={isAdmin(owner)}
+            isOpened={!!inviteBlockedPopupReason}
+            onClose={() => setInviteBlockedPopupReason(null)}
+            subscription={subscription}
+            owner={owner}
+            code={inviteBlockedPopupReason}
+          />
+        )}
+
+        <ChangeSeatModal
+          isOpen={changeSeatMember !== null}
+          onClose={() => {
+            setChangeSeatMember(null);
+            setPendingApproveRequestId(null);
+          }}
+          member={changeSeatMember}
           owner={owner}
-          code={inviteBlockedPopupReason}
+          seatPlans={seatPlans}
+          isSeatPlanLoading={isSeatPlanLoading}
+          isSeatPlanError={!!isSeatPlanError}
+          onSavingChange={handleSeatChangePendingChange}
+          onSaved={handleSeatMutationSaved}
         />
-      )}
 
-      <ChangeSeatModal
-        isOpen={changeSeatMember !== null}
-        onClose={() => {
-          setChangeSeatMember(null);
-          setPendingApproveRequestId(null);
-        }}
-        member={changeSeatMember}
-        owner={owner}
-        seatPlans={seatPlans}
-        isSeatPlanLoading={isSeatPlanLoading}
-        isSeatPlanError={!!isSeatPlanError}
-        onSavingChange={handleSeatChangePendingChange}
-        onSaved={handleSeatMutationSaved}
-      />
+        <EditSpendLimitModal
+          isOpen={editSpendLimitMember !== null}
+          onClose={() => {
+            setEditSpendLimitMember(null);
+            setPendingApproveRequestId(null);
+          }}
+          member={editSpendLimitMember}
+          owner={owner}
+          onSavingChange={handleUsagePendingChange}
+          onSaved={handleApproveOnModalSaved}
+        />
 
-      <EditSpendLimitModal
-        isOpen={editSpendLimitMember !== null}
-        onClose={() => {
-          setEditSpendLimitMember(null);
-          setPendingApproveRequestId(null);
-        }}
-        member={editSpendLimitMember}
-        owner={owner}
-        onSavingChange={handleUsagePendingChange}
-        onSaved={handleApproveOnModalSaved}
-      />
-
-      <BulkEditSpendLimitModal
-        isOpen={isBulkSpendLimitOpen}
-        onClose={() => setIsBulkSpendLimitOpen(false)}
-        memberCount={selection.selectedCount}
-        onValidate={handleBulkSpendLimitValidate}
-      />
-      <BulkChangeSeatModal
-        isOpen={isBulkChangeSeatOpen}
-        onClose={() => setIsBulkChangeSeatOpen(false)}
-        memberCount={selection.selectedCount}
-        selectedMembers={selectedVisibleMembers}
-        seatPlans={seatPlans}
-        onFetchPreview={handleBulkSeatChangePreview}
-        onValidate={handleBulkChangeSeatValidate}
-      />
-    </>
+        <BulkEditSpendLimitModal
+          isOpen={isBulkSpendLimitOpen}
+          onClose={() => setIsBulkSpendLimitOpen(false)}
+          memberCount={selection.selectedCount}
+          onValidate={handleBulkSpendLimitValidate}
+        />
+        <BulkChangeSeatModal
+          isOpen={isBulkChangeSeatOpen}
+          onClose={() => setIsBulkChangeSeatOpen(false)}
+          memberCount={selection.selectedCount}
+          selectedMembers={selectedVisibleMembers}
+          seatPlans={seatPlans}
+          onFetchPreview={handleBulkSeatChangePreview}
+          onValidate={handleBulkChangeSeatValidate}
+        />
+      </>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/WorkspaceBrandingPage.tsx
+++ b/front/components/pages/workspace/WorkspaceBrandingPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { BrandingSection } from "@app/components/workspace/settings/BrandingSection";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { cn, Page } from "@dust-tt/sparkle";
@@ -8,24 +9,26 @@ export function WorkspaceBrandingPage() {
   const isWhitelabelFramesAllowed = hasFeature("whitelabel_frames");
 
   return (
-    <Page.Vertical align="stretch" gap="xl">
-      <Page.Header title="Branding" />
-      {isWhitelabelFramesAllowed ? (
-        <BrandingSection owner={owner} />
-      ) : (
-        <div
-          className={cn(
-            "flex flex-col gap-2 rounded-xl border p-6",
-            "border-border bg-muted"
-          )}
-        >
-          <p className="heading-lg text-foreground">Workspace branding</p>
-          <p className="text-sm text-muted-foreground">
-            Workspace branding is not available for this workspace. Whitelabel
-            frames must be enabled to customize your workspace logo.
-          </p>
-        </div>
-      )}
-    </Page.Vertical>
+    <AdminPageContainer>
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Header title="Branding" />
+        {isWhitelabelFramesAllowed ? (
+          <BrandingSection owner={owner} />
+        ) : (
+          <div
+            className={cn(
+              "flex flex-col gap-2 rounded-xl border p-6",
+              "border-border bg-muted"
+            )}
+          >
+            <p className="heading-lg text-foreground">Workspace branding</p>
+            <p className="text-sm text-muted-foreground">
+              Workspace branding is not available for this workspace. Whitelabel
+              frames must be enabled to customize your workspace logo.
+            </p>
+          </div>
+        )}
+      </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
+++ b/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import WorkspaceAccessPanel from "@app/components/workspace/WorkspaceAccessPanel";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useWorkspaceVerifiedDomains } from "@app/lib/swr/workspaces";
@@ -13,25 +14,29 @@ export function WorkspaceIdentityProvisioningPage() {
 
   if (isVerifiedDomainsLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
+      <AdminPageContainer>
+        <div className="flex h-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      </AdminPageContainer>
     );
   }
 
   return (
-    <div className="mb-4">
-      <Page.Vertical gap="lg" align="stretch">
-        <Page.Header
-          title="IT & Security"
-          description="Verify your domain, manage team members and their permissions."
-        />
-        <WorkspaceAccessPanel
-          workspaceVerifiedDomains={verifiedDomains}
-          owner={owner}
-          plan={plan}
-        />
-      </Page.Vertical>
-    </div>
+    <AdminPageContainer>
+      <div className="mb-4">
+        <Page.Vertical gap="lg" align="stretch">
+          <Page.Header
+            title="IT & Security"
+            description="Verify your domain, manage team members and their permissions."
+          />
+          <WorkspaceAccessPanel
+            workspaceVerifiedDomains={verifiedDomains}
+            owner={owner}
+            plan={plan}
+          />
+        </Page.Vertical>
+      </div>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { BillingInformation } from "@app/components/workspace/billing/BillingInformation";
 import { BillingOverview } from "@app/components/workspace/billing/BillingOverview";
 import { BillingSeatsOverview } from "@app/components/workspace/billing/BillingSeatsOverview";
@@ -47,51 +48,53 @@ export function BillingPage() {
   }
 
   return (
-    <Page.Vertical gap="xl" align="stretch">
-      <Page.Header
-        title="Billing"
-        description="Change your subscription and edit your billing information."
-      />
-      <SubscriptionProvider owner={owner} subscription={subscription}>
-        {freePlan ? (
-          <FreePlanBilling owner={owner} subscription={subscription} />
-        ) : (
-          <Tabs defaultValue="billing-information">
-            <TabsList>
-              <TabsTrigger
-                value="billing-information"
-                label="Billing information"
-              />
-              <TabsTrigger value="invoices" label="Invoices" />
-              {hasCoupons && <TabsTrigger value="coupons" label="Coupons" />}
-            </TabsList>
-            <TabsContent value="billing-information">
-              <div className="flex flex-col mt-8 gap-8">
-                <div className="flex flex-col gap-4">
-                  <BillingOverview />
-                  <BillingSeatsOverview owner={owner} />
-                </div>
-                <BillingUpgrade />
-                <BillingInformation />
-              </div>
-            </TabsContent>
-            <TabsContent value="invoices">
-              <div className="flex flex-col mt-8 gap-8">
-                <NextInvoiceOverview />
-                <NextInvoicePreview />
-                <RecentInvoices />
-              </div>
-            </TabsContent>
-            {hasCoupons && (
-              <TabsContent value="coupons">
+    <AdminPageContainer>
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="Billing"
+          description="Change your subscription and edit your billing information."
+        />
+        <SubscriptionProvider owner={owner} subscription={subscription}>
+          {freePlan ? (
+            <FreePlanBilling owner={owner} subscription={subscription} />
+          ) : (
+            <Tabs defaultValue="billing-information">
+              <TabsList>
+                <TabsTrigger
+                  value="billing-information"
+                  label="Billing information"
+                />
+                <TabsTrigger value="invoices" label="Invoices" />
+                {hasCoupons && <TabsTrigger value="coupons" label="Coupons" />}
+              </TabsList>
+              <TabsContent value="billing-information">
                 <div className="flex flex-col mt-8 gap-8">
-                  <CouponsList />
+                  <div className="flex flex-col gap-4">
+                    <BillingOverview />
+                    <BillingSeatsOverview owner={owner} />
+                  </div>
+                  <BillingUpgrade />
+                  <BillingInformation />
                 </div>
               </TabsContent>
-            )}
-          </Tabs>
-        )}
-      </SubscriptionProvider>
-    </Page.Vertical>
+              <TabsContent value="invoices">
+                <div className="flex flex-col mt-8 gap-8">
+                  <NextInvoiceOverview />
+                  <NextInvoicePreview />
+                  <RecentInvoices />
+                </div>
+              </TabsContent>
+              {hasCoupons && (
+                <TabsContent value="coupons">
+                  <div className="flex flex-col mt-8 gap-8">
+                    <CouponsList />
+                  </div>
+                </TabsContent>
+              )}
+            </Tabs>
+          )}
+        </SubscriptionProvider>
+      </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { APIKeyCreationSheet } from "@app/components/workspace/api-keys/APIKeyCreationSheet";
@@ -338,25 +339,27 @@ export function APIKeysPage() {
   );
 
   return (
-    <Page.Vertical gap="xl" align="stretch">
-      <Page.Header
-        title={
-          <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-start">
-            <div className="flex max-w-2xl flex-col gap-1">
-              <Page.H variant="h3">API Keys</Page.H>
-              <Page.P variant="secondary">
-                Create and manage API keys, track what they consume, and control
-                their monthly spend.
-              </Page.P>
+    <AdminPageContainer>
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title={
+            <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-start">
+              <div className="flex max-w-2xl flex-col gap-1">
+                <Page.H variant="h3">API Keys</Page.H>
+                <Page.P variant="secondary">
+                  Create and manage API keys, track what they consume, and
+                  control their monthly spend.
+                </Page.P>
+              </div>
+              <ConsumptionPeriodSelector
+                period={period}
+                onPeriodChange={setPeriod}
+              />
             </div>
-            <ConsumptionPeriodSelector
-              period={period}
-              onPeriodChange={setPeriod}
-            />
-          </div>
-        }
-      />
-      <APIKeysPageContent owner={owner} period={period} />
-    </Page.Vertical>
+          }
+        />
+        <APIKeysPageContent owner={owner} period={period} />
+      </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import {
   ConsumptionProgressBar,
   ConsumptionProgressBarWithNumbers,
@@ -305,163 +306,165 @@ export function CreditsUsagePage() {
   }, [credits]);
 
   return (
-    <>
-      <BuyCreditDialog
-        isOpen={showBuyCreditDialog}
-        onClose={() => setShowBuyCreditDialog(false)}
-        workspaceId={owner.sId}
-        isEnterprise={isEnterprise}
-        currency={currency}
-        discountPercent={discountPercent}
-        creditPricing={creditPricing}
-        creditPurchaseLimits={creditPurchaseLimits}
-        paygUsage={
-          isEnterprise
-            ? {
-                consumed: creditsByType.payg.consumed,
-                total: creditsByType.payg.total,
-              }
-            : null
-        }
-      />
-
-      <Page.Vertical gap="xl" align="stretch">
-        <Page.Header
-          title={"Programmatic Usage"}
-          description={
-            <div>
-              <p>
-                Monitor usage and credits for programmatic usage (API keys,
-                automated workflows, etc.). Learn more in the{" "}
-                <Hoverable
-                  href="https://docs.dust.tt/docs/programmatic-usage"
-                  target="_blank"
-                  variant="primary"
-                >
-                  usage documentation
-                </Hoverable>
-                .
-              </p>
-            </div>
+    <AdminPageContainer>
+      <>
+        <BuyCreditDialog
+          isOpen={showBuyCreditDialog}
+          onClose={() => setShowBuyCreditDialog(false)}
+          workspaceId={owner.sId}
+          isEnterprise={isEnterprise}
+          currency={currency}
+          discountPercent={discountPercent}
+          creditPricing={creditPricing}
+          creditPurchaseLimits={creditPurchaseLimits}
+          paygUsage={
+            isEnterprise
+              ? {
+                  consumed: creditsByType.payg.consumed,
+                  total: creditsByType.payg.total,
+                }
+              : null
           }
         />
 
-        {shouldShowLowCreditsWarning && (
-          <ContentMessage
-            title={`You're ${totalConsumed < totalCredits ? "almost" : ""} out of credits.`}
-            variant="warning"
-            size="lg"
-            icon={AlertCircle}
-          >
-            <div className="flex items-end justify-between">
-              <p>Add credits to ensure uninterrupted usage.</p>
-              <Button
-                label="Buy credits"
-                variant="primary"
-                onClick={() => setShowBuyCreditDialog(true)}
-              />
-            </div>
-          </ContentMessage>
-        )}
-
-        {/* Purposefully not giving email since we want to test determination here and limit support requests, it's a very edgy case and most likely fraudulent. */}
-        {creditPurchaseLimits &&
-          !creditPurchaseLimits.canPurchase &&
-          creditPurchaseLimits.reason === "trialing" && (
-            <ContentMessage title="Available after trial" variant="info">
-              Credit purchases are available once you upgrade to a paid plan. If
-              you would like to purchase credits before upgrading, please
-              contact support.
-            </ContentMessage>
-          )}
-
-        {creditPurchaseLimits &&
-          !creditPurchaseLimits.canPurchase &&
-          creditPurchaseLimits.reason === "payment_issue" && (
-            <ContentMessage title="Subscription issue" variant="warning">
-              Credit purchases require an active subscription. Please ensure
-              your payment method is up to date.
-            </ContentMessage>
-          )}
-
-        {pendingCredits.length > 0 &&
-          (() => {
-            const totalPendingMicroUsd = pendingCredits.reduce(
-              (sum, c) => sum + c.initialAmountMicroUsd,
-              0
-            );
-            const isSingle = pendingCredits.length === 1;
-            const title = isSingle
-              ? `You have a pending ${getPriceAsString({ currency: "usd", priceInMicroUsd: totalPendingMicroUsd })} credit purchase awaiting payment.`
-              : `You have ${pendingCredits.length} pending credit purchases totaling ${getPriceAsString({ currency: "usd", priceInMicroUsd: totalPendingMicroUsd })} awaiting payment.`;
-
-            return (
-              <ContentMessage
-                title={title}
-                variant="info"
-                size="lg"
-                icon={AlertCircle}
-              >
-                <div className="flex items-end justify-between">
-                  <p>Complete your payment to activate your credits.</p>
-                  <Button
-                    label={isSingle ? "Complete payment" : "Manage invoices"}
+        <Page.Vertical gap="xl" align="stretch">
+          <Page.Header
+            title={"Programmatic Usage"}
+            description={
+              <div>
+                <p>
+                  Monitor usage and credits for programmatic usage (API keys,
+                  automated workflows, etc.). Learn more in the{" "}
+                  <Hoverable
+                    href="https://docs.dust.tt/docs/programmatic-usage"
+                    target="_blank"
                     variant="primary"
-                    onClick={() => {
-                      window.open(
-                        `/w/${owner.sId}/subscription/manage`,
-                        "_blank"
-                      );
-                    }}
-                  />
-                </div>
-              </ContentMessage>
-            );
-          })()}
+                  >
+                    usage documentation
+                  </Hoverable>
+                  .
+                </p>
+              </div>
+            }
+          />
 
-        {/* Usage Section */}
-        <UsageSection
-          subscription={subscription}
-          isEnterprise={isEnterprise}
-          creditsByType={creditsByType}
-          totalConsumed={totalConsumed}
-          totalCredits={totalCredits}
-          freeCreditRenewalDateMs={freeCreditRenewalDateMs}
-          isLoading={isCreditsLoading || isCreditPurchaseInfoLoading}
-          setShowBuyCreditDialog={setShowBuyCreditDialog}
-        />
-
-        {/* Current Credits Section */}
-        <Page.Vertical sizing="grow">
-          <div className="flex w-full items-start justify-between">
-            <Page.Vertical gap="sm" sizing="grow">
-              <div className="flex w-full items-center justify-between">
-                <Page.H variant="h5">Current credits</Page.H>
-                <CreditHistorySheet
-                  credits={expiredCredits}
-                  isLoading={isCreditsLoading}
+          {shouldShowLowCreditsWarning && (
+            <ContentMessage
+              title={`You're ${totalConsumed < totalCredits ? "almost" : ""} out of credits.`}
+              variant="warning"
+              size="lg"
+              icon={AlertCircle}
+            >
+              <div className="flex items-end justify-between">
+                <p>Add credits to ensure uninterrupted usage.</p>
+                <Button
+                  label="Buy credits"
+                  variant="primary"
+                  onClick={() => setShowBuyCreditDialog(true)}
                 />
               </div>
-              <Page.P variant="secondary">
-                Active credits for programmatic usage. Credits invoices are sent
-                by email at time of purchase.
-              </Page.P>
-            </Page.Vertical>
-          </div>
-          <CreditsList credits={activeCredits} isLoading={isCreditsLoading} />
-        </Page.Vertical>
+            </ContentMessage>
+          )}
 
-        {/* Usage Graph */}
-        {isCreditPurchaseInfoLoading ? (
-          <LoadingBlock className="h-64" />
-        ) : (
-          <ProgrammaticCostChart
-            workspaceId={owner.sId}
-            billingCycleStartDay={billingCycleStartDay ?? 1}
+          {/* Purposefully not giving email since we want to test determination here and limit support requests, it's a very edgy case and most likely fraudulent. */}
+          {creditPurchaseLimits &&
+            !creditPurchaseLimits.canPurchase &&
+            creditPurchaseLimits.reason === "trialing" && (
+              <ContentMessage title="Available after trial" variant="info">
+                Credit purchases are available once you upgrade to a paid plan.
+                If you would like to purchase credits before upgrading, please
+                contact support.
+              </ContentMessage>
+            )}
+
+          {creditPurchaseLimits &&
+            !creditPurchaseLimits.canPurchase &&
+            creditPurchaseLimits.reason === "payment_issue" && (
+              <ContentMessage title="Subscription issue" variant="warning">
+                Credit purchases require an active subscription. Please ensure
+                your payment method is up to date.
+              </ContentMessage>
+            )}
+
+          {pendingCredits.length > 0 &&
+            (() => {
+              const totalPendingMicroUsd = pendingCredits.reduce(
+                (sum, c) => sum + c.initialAmountMicroUsd,
+                0
+              );
+              const isSingle = pendingCredits.length === 1;
+              const title = isSingle
+                ? `You have a pending ${getPriceAsString({ currency: "usd", priceInMicroUsd: totalPendingMicroUsd })} credit purchase awaiting payment.`
+                : `You have ${pendingCredits.length} pending credit purchases totaling ${getPriceAsString({ currency: "usd", priceInMicroUsd: totalPendingMicroUsd })} awaiting payment.`;
+
+              return (
+                <ContentMessage
+                  title={title}
+                  variant="info"
+                  size="lg"
+                  icon={AlertCircle}
+                >
+                  <div className="flex items-end justify-between">
+                    <p>Complete your payment to activate your credits.</p>
+                    <Button
+                      label={isSingle ? "Complete payment" : "Manage invoices"}
+                      variant="primary"
+                      onClick={() => {
+                        window.open(
+                          `/w/${owner.sId}/subscription/manage`,
+                          "_blank"
+                        );
+                      }}
+                    />
+                  </div>
+                </ContentMessage>
+              );
+            })()}
+
+          {/* Usage Section */}
+          <UsageSection
+            subscription={subscription}
+            isEnterprise={isEnterprise}
+            creditsByType={creditsByType}
+            totalConsumed={totalConsumed}
+            totalCredits={totalCredits}
+            freeCreditRenewalDateMs={freeCreditRenewalDateMs}
+            isLoading={isCreditsLoading || isCreditPurchaseInfoLoading}
+            setShowBuyCreditDialog={setShowBuyCreditDialog}
           />
-        )}
-      </Page.Vertical>
-      <div className="h-12" />
-    </>
+
+          {/* Current Credits Section */}
+          <Page.Vertical sizing="grow">
+            <div className="flex w-full items-start justify-between">
+              <Page.Vertical gap="sm" sizing="grow">
+                <div className="flex w-full items-center justify-between">
+                  <Page.H variant="h5">Current credits</Page.H>
+                  <CreditHistorySheet
+                    credits={expiredCredits}
+                    isLoading={isCreditsLoading}
+                  />
+                </div>
+                <Page.P variant="secondary">
+                  Active credits for programmatic usage. Credits invoices are
+                  sent by email at time of purchase.
+                </Page.P>
+              </Page.Vertical>
+            </div>
+            <CreditsList credits={activeCredits} isLoading={isCreditsLoading} />
+          </Page.Vertical>
+
+          {/* Usage Graph */}
+          {isCreditPurchaseInfoLoading ? (
+            <LoadingBlock className="h-64" />
+          ) : (
+            <ProgrammaticCostChart
+              workspaceId={owner.sId}
+              billingCycleStartDay={billingCycleStartDay ?? 1}
+            />
+          )}
+        </Page.Vertical>
+        <div className="h-12" />
+      </>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/developers/ProvidersPage.tsx
+++ b/front/components/pages/workspace/developers/ProvidersPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import {
   MODEL_PROVIDER_CONFIGS,
   ProviderSetup,
@@ -194,14 +195,16 @@ export function ProvidersPage() {
   const owner = useWorkspace();
 
   return (
-    <Page.Vertical gap="xl" align="stretch">
-      <Page.Header
-        title="App Credentials"
-        description="Configure model and service providers to enable advanced capabilities in your Apps. Note: These providers are not used by Dust agents at all, but are required for running your own custom Dust Apps."
-      />
-      <Page.Vertical align="stretch" gap="md">
-        <Providers owner={owner} />
+    <AdminPageContainer>
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="App Credentials"
+          description="Configure model and service providers to enable advanced capabilities in your Apps. Note: These providers are not used by Dust agents at all, but are required for running your own custom Dust Apps."
+        />
+        <Page.Vertical align="stretch" gap="md">
+          <Providers owner={owner} />
+        </Page.Vertical>
       </Page.Vertical>
-    </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
 import { AgentRequestedDomainsSetting } from "@app/components/sandbox/AgentRequestedDomainsSetting";
@@ -101,12 +102,14 @@ export function SandboxPage() {
   };
 
   return (
-    <Page.Vertical gap="xl" align="stretch">
-      <Page.Header
-        title="Computer"
-        description="Configure workspace and Pod network access and environment variables for the Computer."
-      />
-      {renderBody()}
-    </Page.Vertical>
+    <AdminPageContainer>
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="Computer"
+          description="Configure workspace and Pod network access and environment variables for the Computer."
+        />
+        {renderBody()}
+      </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/developers/SecretsPage.tsx
+++ b/front/components/pages/workspace/developers/SecretsPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -183,147 +184,149 @@ export function SecretsPage() {
     }));
 
   return (
-    <>
-      {secretToRevoke ? (
+    <AdminPageContainer>
+      <>
+        {secretToRevoke ? (
+          <Dialog
+            open={true}
+            onOpenChange={(open) => {
+              if (!open) {
+                setSecretToRevoke(null);
+              }
+            }}
+          >
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Delete {secretToRevoke?.name}</DialogTitle>
+              </DialogHeader>
+              <DialogContainer>
+                Are you sure you want to delete the secret{" "}
+                <strong>{secretToRevoke?.name}</strong>?
+              </DialogContainer>
+              <DialogFooter
+                leftButtonProps={{
+                  label: "Cancel",
+                  variant: "outline",
+                  onClick: () => setSecretToRevoke(null),
+                }}
+                rightButtonProps={{
+                  label: "Delete",
+                  variant: "warning",
+                  onClick: () => handleRevoke(secretToRevoke),
+                }}
+              />
+            </DialogContent>
+          </Dialog>
+        ) : null}
         <Dialog
-          open={true}
+          open={isNewSecretPromptOpen}
           onOpenChange={(open) => {
             if (!open) {
-              setSecretToRevoke(null);
+              setIsNewSecretPromptOpen(false);
             }
           }}
         >
-          <DialogContent>
+          <DialogContent size="lg">
             <DialogHeader>
-              <DialogTitle>Delete {secretToRevoke?.name}</DialogTitle>
+              <DialogTitle>
+                {isInputNameDisabled ? "Update" : "New"} Developer Secret
+              </DialogTitle>
             </DialogHeader>
             <DialogContainer>
-              Are you sure you want to delete the secret{" "}
-              <strong>{secretToRevoke?.name}</strong>?
+              <Input
+                message="Secret names must be alphanumeric and underscore characters only."
+                name="Secret Name"
+                placeholder="SECRET_NAME"
+                value={newDustAppSecret.name}
+                disabled={isInputNameDisabled}
+                onChange={(e) =>
+                  setNewDustAppSecret({
+                    ...newDustAppSecret,
+                    name: cleanSecretName(e.target.value),
+                  })
+                }
+              />
+              <Input
+                // prevent autocompletion of secrets
+                autoComplete="off"
+                message="Secret values are encrypted and stored securely in our database."
+                name="Secret value"
+                placeholder="Type the secret value"
+                value={newDustAppSecret.value}
+                onChange={(e) =>
+                  setNewDustAppSecret({
+                    ...newDustAppSecret,
+                    value: e.target.value,
+                  })
+                }
+              />
             </DialogContainer>
             <DialogFooter
               leftButtonProps={{
                 label: "Cancel",
                 variant: "outline",
-                onClick: () => setSecretToRevoke(null),
+                onClick: () => setIsNewSecretPromptOpen(false),
               }}
               rightButtonProps={{
-                label: "Delete",
-                variant: "warning",
-                onClick: () => handleRevoke(secretToRevoke),
+                label: isInputNameDisabled ? "Update" : "Create",
+                variant: "primary",
+                onClick: () => handleGenerate(newDustAppSecret),
               }}
             />
           </DialogContent>
         </Dialog>
-      ) : null}
-      <Dialog
-        open={isNewSecretPromptOpen}
-        onOpenChange={(open) => {
-          if (!open) {
-            setIsNewSecretPromptOpen(false);
-          }
-        }}
-      >
-        <DialogContent size="lg">
-          <DialogHeader>
-            <DialogTitle>
-              {isInputNameDisabled ? "Update" : "New"} Developer Secret
-            </DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <Input
-              message="Secret names must be alphanumeric and underscore characters only."
-              name="Secret Name"
-              placeholder="SECRET_NAME"
-              value={newDustAppSecret.name}
-              disabled={isInputNameDisabled}
-              onChange={(e) =>
-                setNewDustAppSecret({
-                  ...newDustAppSecret,
-                  name: cleanSecretName(e.target.value),
-                })
-              }
-            />
-            <Input
-              // prevent autocompletion of secrets
-              autoComplete="off"
-              message="Secret values are encrypted and stored securely in our database."
-              name="Secret value"
-              placeholder="Type the secret value"
-              value={newDustAppSecret.value}
-              onChange={(e) =>
-                setNewDustAppSecret({
-                  ...newDustAppSecret,
-                  value: e.target.value,
-                })
-              }
-            />
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => setIsNewSecretPromptOpen(false),
-            }}
-            rightButtonProps={{
-              label: isInputNameDisabled ? "Update" : "Create",
-              variant: "primary",
-              onClick: () => handleGenerate(newDustAppSecret),
-            }}
-          />
-        </DialogContent>
-      </Dialog>
 
-      <Page.Vertical gap="xl" align="stretch">
-        <Page.Header
-          title="Developer Secrets"
-          description="Secrets usable in Dust apps or MCP servers to safely store sensitive data."
-        />
-        <Page.Vertical align="stretch" gap="md">
-          <div className="flex items-center gap-2">
-            <SearchInput
-              className="flex-grow"
-              name="secrets-search"
-              placeholder="Search secrets"
-              value={searchQuery}
-              onChange={setSearchQuery}
-            />
-            <Button
-              label="Read the API reference"
-              size="sm"
-              variant="outline"
-              icon={BookOpen01}
-              onClick={() => {
-                window.open(
-                  "https://docs.dust.tt/reference/developer-platform-overview#developer-secrets",
-                  "_blank"
-                );
-              }}
-            />
-            {isAdmin && (
-              <Button
-                label="Create Secret"
-                variant="primary"
-                onClick={() => {
-                  setNewDustAppSecret(defaultSecret);
-                  setIsInputNameDisabled(false);
-                  setIsNewSecretPromptOpen(true);
-                }}
-                icon={Plus}
-                disabled={isGenerating || isRevoking}
-              />
-            )}
-          </div>
-          <SecretsTable
-            isLoading={isSecretsLoading}
-            isError={!!isSecretsError}
-            rows={rows}
-            searchQuery={searchQuery}
+        <Page.Vertical gap="xl" align="stretch">
+          <Page.Header
+            title="Developer Secrets"
+            description="Secrets usable in Dust apps or MCP servers to safely store sensitive data."
           />
+          <Page.Vertical align="stretch" gap="md">
+            <div className="flex items-center gap-2">
+              <SearchInput
+                className="flex-grow"
+                name="secrets-search"
+                placeholder="Search secrets"
+                value={searchQuery}
+                onChange={setSearchQuery}
+              />
+              <Button
+                label="Read the API reference"
+                size="sm"
+                variant="outline"
+                icon={BookOpen01}
+                onClick={() => {
+                  window.open(
+                    "https://docs.dust.tt/reference/developer-platform-overview#developer-secrets",
+                    "_blank"
+                  );
+                }}
+              />
+              {isAdmin && (
+                <Button
+                  label="Create Secret"
+                  variant="primary"
+                  onClick={() => {
+                    setNewDustAppSecret(defaultSecret);
+                    setIsInputNameDisabled(false);
+                    setIsNewSecretPromptOpen(true);
+                  }}
+                  icon={Plus}
+                  disabled={isGenerating || isRevoking}
+                />
+              )}
+            </div>
+            <SecretsTable
+              isLoading={isSecretsLoading}
+              isError={!!isSecretsError}
+              rows={rows}
+              searchQuery={searchQuery}
+            />
+          </Page.Vertical>
         </Page.Vertical>
-      </Page.Vertical>
-      <div className="h-12" />
-    </>
+        <div className="h-12" />
+      </>
+    </AdminPageContainer>
   );
 }
 

--- a/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { SelfImprovingSkillsConsumptionSection } from "@app/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection";
 import { SelfImprovingSkillsListSection } from "@app/components/workspace/settings/SelfImprovingSkillsListSection";
 import { SelfImprovingSkillsSettingsSection } from "@app/components/workspace/settings/SelfImprovingSkillsSettingsSection";
@@ -66,27 +67,29 @@ export function SelfImprovingSkillsPage() {
   };
 
   return (
-    <div className="mb-4">
-      <Page.Vertical gap="xl" align="stretch">
-        <Page.Header
-          title="Self-Improving Skills"
-          description={
-            <span>
-              Configure self-improving skills settings for this workspace.{" "}
-              <a
-                href="https://docs.dust.tt/docs/self-improving-skills"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-highlight underline"
-              >
-                Learn more
-              </a>
-              .
-            </span>
-          }
-        />
-        {renderBody()}
-      </Page.Vertical>
-    </div>
+    <AdminPageContainer>
+      <div className="mb-4">
+        <Page.Vertical gap="xl" align="stretch">
+          <Page.Header
+            title="Self-Improving Skills"
+            description={
+              <span>
+                Configure self-improving skills settings for this workspace.{" "}
+                <a
+                  href="https://docs.dust.tt/docs/self-improving-skills"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-highlight underline"
+                >
+                  Learn more
+                </a>
+                .
+              </span>
+            }
+          />
+          {renderBody()}
+        </Page.Vertical>
+      </div>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/governance/GovernancePageLayout.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageLayout.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { Page } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
@@ -7,12 +8,14 @@ interface GovernancePageLayoutProps {
 
 export function GovernancePageLayout({ children }: GovernancePageLayoutProps) {
   return (
-    <div className="flex flex-col gap-6">
-      <Page.Header
-        title="Settings & Governance"
-        description="Manage what members can do in your workspace"
-      />
-      {children}
-    </div>
+    <AdminPageContainer>
+      <div className="flex flex-col gap-6">
+        <Page.Header
+          title="Settings & Governance"
+          description="Manage what members can do in your workspace"
+        />
+        {children}
+      </div>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { ModelProvidersPageContent } from "@app/components/pages/workspace/model_providers/ModelProvidersPageContent";
 import { useProvidersSelection } from "@app/hooks/useProvidersSelection";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -13,27 +14,31 @@ export function ModelProvidersPage() {
 
   if (!workspace) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
+      <AdminPageContainer>
+        <div className="flex h-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      </AdminPageContainer>
     );
   }
 
   return (
-    <Page.Vertical align="stretch" gap="xl">
-      <Page.Header
-        title="Model Providers"
-        description="Choose which AI providers and models are available to your workspace."
-      />
-      <Page.Vertical align="stretch" gap="md">
-        <ModelProvidersPageContent
-          workspace={workspace}
-          providersSelection={providersSelection}
-          isWorkspaceValidating={isWorkspaceValidating}
-          onToggleProvider={toggleProvider}
-          onSelectAllProviders={selectAllProviders}
+    <AdminPageContainer>
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Header
+          title="Model Providers"
+          description="Choose which AI providers and models are available to your workspace."
         />
+        <Page.Vertical align="stretch" gap="md">
+          <ModelProvidersPageContent
+            workspace={workspace}
+            providersSelection={providersSelection}
+            isWorkspaceValidating={isWorkspaceValidating}
+            onToggleProvider={toggleProvider}
+            onSelectAllProviders={selectAllProviders}
+          />
+        </Page.Vertical>
       </Page.Vertical>
-    </Page.Vertical>
+    </AdminPageContainer>
   );
 }

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -1,3 +1,4 @@
+import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import type { PaidPlanTier } from "@app/components/pages/onboarding/SubscriptionPlans";
 import {
   BillingPeriodSwitch,
@@ -612,301 +613,309 @@ export function SubscriptionPage() {
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
+      <AdminPageContainer>
+        <div className="flex h-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      </AdminPageContainer>
     );
   }
 
   return (
-    <>
-      {(isCancellingMigration || isResumingMigration) && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/60 dark:bg-black/60">
-          <Spinner size="lg" />
-        </div>
-      )}
-      {perSeatPricing && (
-        <>
-          <CancelFreeTrialDialog
-            show={showCancelFreeTrialDialog}
-            onClose={() => setShowCancelFreeTrialDialog(false)}
-            onValidate={cancelFreeTrial}
-            isSaving={cancelFreeTrialSubmitting}
-          />
-
-          <CancelMigrationDialog
-            show={showCancelMigrationDialog}
-            onClose={() => setShowCancelMigrationDialog(false)}
-            onValidate={handleCancelMigration}
-            isSaving={isCancellingMigration}
-            billingPeriod={perSeatPricing.billingPeriod}
-          />
-
-          <SkipFreeTrialDialog
-            plan={subscription.plan}
-            show={showSkipFreeTrialDialog}
-            onClose={() => {
-              setShowSkipFreeTrialDialog(false);
-            }}
-            onValidate={skipFreeTrial}
-            workspaceSeats={workspaceSeats}
-            perSeatPricing={perSeatPricing}
-            isSaving={skipFreeTrialIsSubmitting}
-          />
-        </>
-      )}
-
-      <Page.Vertical gap="xl" align="stretch">
-        <Page.Header title="Subscription" description="Manage your plan." />
-        <Page.Vertical align="stretch" gap="md">
-          <Page.H variant="h5">Your plan </Page.H>
-
-          {isCancelledNotMigrating && endDate && (
-            <ContentMessage
-              title={`Your subscription ends on ${endDate}.`}
-              variant="warning"
-            >
-              {isEnterprisePlanPrefix(plan.code) ? (
-                <>
-                  Please reach out to your account manager to ensure continuity.
-                </>
-              ) : (
-                <>
-                  Connections will be deleted and members will be revoked.
-                  Details{" "}
-                  <LinkWrapper
-                    href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
-                    target="_blank"
-                    className="underline"
-                  >
-                    here
-                  </LinkWrapper>
-                  .
-                  {willBeRefundedOnEnd && (
-                    <>
-                      {" "}
-                      You'll be refunded for the remaining days of your current
-                      period.
-                    </>
-                  )}
-                </>
-              )}
-            </ContentMessage>
-          )}
-          {scheduledMigrationLabel ||
-          (migrationDate && !isCancelledNotMigrating) ? (
-            <ContentMessage
-              title="Your plan is scheduled to migrate to the new credit-based pricing."
-              variant="blue"
-            >
-              On{" "}
-              <span className="font-semibold">
-                {scheduledMigrationLabel ?? migrationDate}
-              </span>{" "}
-              your plan will move to the new credit-based pricing.
-              {perSeatPricing?.billingPeriod === "yearly" ? (
-                <>
-                  {" "}
-                  You'll be refunded for the remaining days of your current
-                  annual period. To opt out, cancel your subscription below — it
-                  will then end on that date without moving to the new pricing.
-                </>
-              ) : (
-                <>
-                  {" "}
-                  To opt out, cancel your subscription below — it will then end
-                  at the end of your current billing period instead.
-                </>
-              )}
-            </ContentMessage>
-          ) : null}
+    <AdminPageContainer>
+      <>
+        {(isCancellingMigration || isResumingMigration) && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/60 dark:bg-black/60">
+            <Spinner size="lg" />
+          </div>
+        )}
+        {perSeatPricing && (
           <>
-            <div>
-              {isWebhookProcessing ? (
-                <Spinner />
-              ) : (
-                <>
-                  <Page.Horizontal gap="sm">
-                    <Chip size="sm" color={chipColor} label={planLabel} />
-                    {canCancelSubscription && (
-                      <Button
-                        label="Cancel subscription"
-                        variant="outline"
-                        disabled={isCancellingMigration}
-                        onClick={() => {
-                          setShowCancelMigrationDialog(true);
-                        }}
-                      />
-                    )}
-                    {canResumeMigration && (
-                      <Button
-                        label="Resume subscription"
-                        variant="primary"
-                        disabled={isResumingMigration}
-                        onClick={() => {
-                          void handleResumeMigration();
-                        }}
-                      />
-                    )}
-                  </Page.Horizontal>
-                </>
-              )}
-            </div>
-            {perSeatPricing && subscription.trialing && (
-              <Page.Vertical>
-                <Page.Horizontal gap="sm">
-                  <Button
-                    onClick={withTracking(
-                      TRACKING_AREAS.AUTH,
-                      "subscription_skip_trial",
-                      () => {
-                        setShowSkipFreeTrialDialog(true);
-                      }
-                    )}
-                    label="End trial & get full access"
-                  />
-                  <Button
-                    label="Cancel subscription"
-                    variant="ghost"
-                    onClick={withTracking(
-                      TRACKING_AREAS.AUTH,
-                      "subscription_cancel_trial",
-                      () => {
-                        setShowCancelFreeTrialDialog(true);
-                      }
-                    )}
-                  />
-                </Page.Horizontal>
-              </Page.Vertical>
-            )}
-            {subscription.stripeSubscriptionId && (
-              <Page.Vertical gap="sm">
-                <Page.H variant="h5">Billing</Page.H>
-                {perSeatPricing !== null && (
+            <CancelFreeTrialDialog
+              show={showCancelFreeTrialDialog}
+              onClose={() => setShowCancelFreeTrialDialog(false)}
+              onValidate={cancelFreeTrial}
+              isSaving={cancelFreeTrialSubmitting}
+            />
+
+            <CancelMigrationDialog
+              show={showCancelMigrationDialog}
+              onClose={() => setShowCancelMigrationDialog(false)}
+              onValidate={handleCancelMigration}
+              isSaving={isCancellingMigration}
+              billingPeriod={perSeatPricing.billingPeriod}
+            />
+
+            <SkipFreeTrialDialog
+              plan={subscription.plan}
+              show={showSkipFreeTrialDialog}
+              onClose={() => {
+                setShowSkipFreeTrialDialog(false);
+              }}
+              onValidate={skipFreeTrial}
+              workspaceSeats={workspaceSeats}
+              perSeatPricing={perSeatPricing}
+              isSaving={skipFreeTrialIsSubmitting}
+            />
+          </>
+        )}
+
+        <Page.Vertical gap="xl" align="stretch">
+          <Page.Header title="Subscription" description="Manage your plan." />
+          <Page.Vertical align="stretch" gap="md">
+            <Page.H variant="h5">Your plan </Page.H>
+
+            {isCancelledNotMigrating && endDate && (
+              <ContentMessage
+                title={`Your subscription ends on ${endDate}.`}
+                variant="warning"
+              >
+                {isEnterprisePlanPrefix(plan.code) ? (
                   <>
-                    <Page.P>
-                      Estimated {perSeatPricing.billingPeriod} billing:{" "}
-                      <span className="font-bold">
-                        {getPriceAsString({
-                          currency: perSeatPricing.seatCurrency,
-                          priceInCents:
-                            perSeatPricing.seatPrice * workspaceSeats,
-                        })}
-                      </span>{" "}
-                      (excluding taxes).
-                    </Page.P>
-                    <Page.P>
-                      {workspaceSeats === 1 ? (
-                        <>
-                          {workspaceSeats} member,{" "}
-                          {getPriceAsString({
-                            currency: perSeatPricing.seatCurrency,
-                            priceInCents: perSeatPricing.seatPrice,
-                          })}{" "}
-                          per member.
-                        </>
-                      ) : (
-                        <>
-                          {workspaceSeats} members,{" "}
-                          {getPriceAsString({
-                            currency: perSeatPricing.seatCurrency,
-                            priceInCents: perSeatPricing.seatPrice,
-                          })}{" "}
-                          per member.
-                        </>
-                      )}
-                    </Page.P>
-                  </>
-                )}
-                <div className="my-5">
-                  <Button
-                    icon={CreditCard01}
-                    label="Your billing dashboard on Stripe"
-                    variant="ghost"
-                    onClick={withTracking(
-                      TRACKING_AREAS.AUTH,
-                      "subscription_stripe_portal",
-                      () => {
-                        void handleGoToStripePortal();
-                      }
-                    )}
-                  />
-                </div>
-              </Page.Vertical>
-            )}
-            {canUpsellToBusinessPlan && (
-              <Page.Vertical gap="sm">
-                <Page.H variant="h5">Upgrade your plan</Page.H>
-                <Page.P>
-                  You are eligible to upgrade to the Enteprise seat-based plan
-                  with additional features.
-                </Page.P>
-                <div>
-                  <Button
-                    label="Upgrade to Enterprise seat-based plan"
-                    variant="primary"
-                    disabled={isProcessing}
-                    onClick={withTracking(
-                      TRACKING_AREAS.AUTH,
-                      "subscription_upgrade_to_business",
-                      () => {
-                        void handleUpgradeToBusiness();
-                      }
-                    )}
-                  />
-                </div>
-              </Page.Vertical>
-            )}
-            {displayPricingTable && (
-              <div className="pt-2">
-                {isMetronomeCheckout ? (
-                  <>
-                    <div className="flex items-start justify-between gap-4">
-                      <Page.H variant="h5">Choose a plan</Page.H>
-                      <BillingPeriodSwitch
-                        defaultValue={billingPeriod}
-                        onValueChange={setBillingPeriod}
-                      />
-                    </div>
-                    <div className="flex w-full flex-col gap-4 pt-4 sm:flex-row">
-                      <PaidPlanCards
-                        billingPeriod={billingPeriod}
-                        onSubscribe={(seatType) =>
-                          void handleSubscribeMetronome(seatType)
-                        }
-                      />
-                    </div>
+                    Please reach out to your account manager to ensure
+                    continuity.
                   </>
                 ) : (
                   <>
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
+                    Connections will be deleted and members will be revoked.
+                    Details{" "}
+                    <LinkWrapper
+                      href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+                      target="_blank"
+                      className="underline"
+                    >
+                      here
+                    </LinkWrapper>
+                    .
+                    {willBeRefundedOnEnd && (
+                      <>
+                        {" "}
+                        You'll be refunded for the remaining days of your
+                        current period.
+                      </>
+                    )}
+                  </>
+                )}
+              </ContentMessage>
+            )}
+            {scheduledMigrationLabel ||
+            (migrationDate && !isCancelledNotMigrating) ? (
+              <ContentMessage
+                title="Your plan is scheduled to migrate to the new credit-based pricing."
+                variant="blue"
+              >
+                On{" "}
+                <span className="font-semibold">
+                  {scheduledMigrationLabel ?? migrationDate}
+                </span>{" "}
+                your plan will move to the new credit-based pricing.
+                {perSeatPricing?.billingPeriod === "yearly" ? (
+                  <>
+                    {" "}
+                    You'll be refunded for the remaining days of your current
+                    annual period. To opt out, cancel your subscription below —
+                    it will then end on that date without moving to the new
+                    pricing.
+                  </>
+                ) : (
+                  <>
+                    {" "}
+                    To opt out, cancel your subscription below — it will then
+                    end at the end of your current billing period instead.
+                  </>
+                )}
+              </ContentMessage>
+            ) : null}
+            <>
+              <div>
+                {isWebhookProcessing ? (
+                  <Spinner />
+                ) : (
+                  <>
+                    <Page.Horizontal gap="sm">
+                      <Chip size="sm" color={chipColor} label={planLabel} />
+                      {canCancelSubscription && (
+                        <Button
+                          label="Cancel subscription"
+                          variant="outline"
+                          disabled={isCancellingMigration}
+                          onClick={() => {
+                            setShowCancelMigrationDialog(true);
+                          }}
+                        />
+                      )}
+                      {canResumeMigration && (
+                        <Button
+                          label="Resume subscription"
+                          variant="primary"
+                          disabled={isResumingMigration}
+                          onClick={() => {
+                            void handleResumeMigration();
+                          }}
+                        />
+                      )}
+                    </Page.Horizontal>
+                  </>
+                )}
+              </div>
+              {perSeatPricing && subscription.trialing && (
+                <Page.Vertical>
+                  <Page.Horizontal gap="sm">
+                    <Button
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_skip_trial",
+                        () => {
+                          setShowSkipFreeTrialDialog(true);
+                        }
+                      )}
+                      label="End trial & get full access"
+                    />
+                    <Button
+                      label="Cancel subscription"
+                      variant="ghost"
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_cancel_trial",
+                        () => {
+                          setShowCancelFreeTrialDialog(true);
+                        }
+                      )}
+                    />
+                  </Page.Horizontal>
+                </Page.Vertical>
+              )}
+              {subscription.stripeSubscriptionId && (
+                <Page.Vertical gap="sm">
+                  <Page.H variant="h5">Billing</Page.H>
+                  {perSeatPricing !== null && (
+                    <>
+                      <Page.P>
+                        Estimated {perSeatPricing.billingPeriod} billing:{" "}
+                        <span className="font-bold">
+                          {getPriceAsString({
+                            currency: perSeatPricing.seatCurrency,
+                            priceInCents:
+                              perSeatPricing.seatPrice * workspaceSeats,
+                          })}
+                        </span>{" "}
+                        (excluding taxes).
+                      </Page.P>
+                      <Page.P>
+                        {workspaceSeats === 1 ? (
+                          <>
+                            {workspaceSeats} member,{" "}
+                            {getPriceAsString({
+                              currency: perSeatPricing.seatCurrency,
+                              priceInCents: perSeatPricing.seatPrice,
+                            })}{" "}
+                            per member.
+                          </>
+                        ) : (
+                          <>
+                            {workspaceSeats} members,{" "}
+                            {getPriceAsString({
+                              currency: perSeatPricing.seatCurrency,
+                              priceInCents: perSeatPricing.seatPrice,
+                            })}{" "}
+                            per member.
+                          </>
+                        )}
+                      </Page.P>
+                    </>
+                  )}
+                  <div className="my-5">
+                    <Button
+                      icon={CreditCard01}
+                      label="Your billing dashboard on Stripe"
+                      variant="ghost"
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_stripe_portal",
+                        () => {
+                          void handleGoToStripePortal();
+                        }
+                      )}
+                    />
+                  </div>
+                </Page.Vertical>
+              )}
+              {canUpsellToBusinessPlan && (
+                <Page.Vertical gap="sm">
+                  <Page.H variant="h5">Upgrade your plan</Page.H>
+                  <Page.P>
+                    You are eligible to upgrade to the Enteprise seat-based plan
+                    with additional features.
+                  </Page.P>
+                  <div>
+                    <Button
+                      label="Upgrade to Enterprise seat-based plan"
+                      variant="primary"
+                      disabled={isProcessing}
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_upgrade_to_business",
+                        () => {
+                          void handleUpgradeToBusiness();
+                        }
+                      )}
+                    />
+                  </div>
+                </Page.Vertical>
+              )}
+              {displayPricingTable && (
+                <div className="pt-2">
+                  {isMetronomeCheckout ? (
+                    <>
+                      <div className="flex items-start justify-between gap-4">
                         <Page.H variant="h5">Choose a plan</Page.H>
-                        <Page.P>Pick a plan that best suits your team.</Page.P>
-                      </div>
-                      {!isWorkspaceWhitelistedBusinessPlan && (
                         <BillingPeriodSwitch
                           defaultValue={billingPeriod}
                           onValueChange={setBillingPeriod}
                         />
-                      )}
-                    </div>
-                    <div className="pt-4">
-                      <SubscriptionPlanCards
-                        billingPeriod={billingPeriod}
-                        onSubscribe={handleSubscribePlan}
-                        isProcessing={isProcessing}
-                        owner={owner}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
-          </>
+                      </div>
+                      <div className="flex w-full flex-col gap-4 pt-4 sm:flex-row">
+                        <PaidPlanCards
+                          billingPeriod={billingPeriod}
+                          onSubscribe={(seatType) =>
+                            void handleSubscribeMetronome(seatType)
+                          }
+                        />
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <Page.H variant="h5">Choose a plan</Page.H>
+                          <Page.P>
+                            Pick a plan that best suits your team.
+                          </Page.P>
+                        </div>
+                        {!isWorkspaceWhitelistedBusinessPlan && (
+                          <BillingPeriodSwitch
+                            defaultValue={billingPeriod}
+                            onValueChange={setBillingPeriod}
+                          />
+                        )}
+                      </div>
+                      <div className="pt-4">
+                        <SubscriptionPlanCards
+                          billingPeriod={billingPeriod}
+                          onSubscribe={handleSubscribePlan}
+                          isProcessing={isProcessing}
+                          owner={owner}
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </>
+          </Page.Vertical>
         </Page.Vertical>
-      </Page.Vertical>
-      <div className="h-12" />
-    </>
+        <div className="h-12" />
+      </>
+    </AdminPageContainer>
   );
 }


### PR DESCRIPTION
## Description

Move styling from Admin Layout to a new dedicated container, in order to allow more flexibiliy to the children pages. 
This is done to prepare stack: https://github.com/dust-tt/dust/pull/31237


## Risk

Low, refactor only. 

## Deploy Plan

Standard deploy.
