### PR TITLE
Enable EU routing for Gemini 3.6-3.8

### DIFF
--- a/front/lib/api/llm/index.test.ts
+++ b/front/lib/api/llm/index.test.ts
@@ -47,7 +47,7 @@ describe("getWorkspaceFilter", () => {
     expect(flashEndpoints.every((e) => e.host === AGENT_PLATFORM_HOST)).toBe(
       true
     );
-    expect(flashEndpoints.map((e) => e.region)).toEqual(["global"]);
+    expect(flashEndpoints.map((e) => e.region)).toEqual(["eu", "global"]);
 
     const proEndpoints = getStreamEndpoints(workspaceConfig, {
       ...filter,

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -23,10 +23,13 @@ import { DustGoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream } from "@app
 import { DustGoogleGeminiThreeDotFiveFlashGlobalGoogleAiStudioStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_5_flash_global_google_ai_studio";
 import { DustGoogleGeminiThreeDotFiveFlashLiteGlobalAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_5_flash_lite_global_agent_platform";
 import { DustGoogleGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_5_flash_lite_global_google_ai_studio";
+import { DustGoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_6_flash_eu_agent_platform";
 import { DustGoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_6_flash_global_agent_platform";
 import { DustGoogleGeminiThreeDotSixFlashGlobalGoogleAiStudioStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_6_flash_global_google_ai_studio";
+import { DustGoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_7_flash_eu_agent_platform";
 import { DustGoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_7_flash_global_agent_platform";
 import { DustGoogleGeminiThreeDotSevenFlashGlobalGoogleAiStudioStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_7_flash_global_google_ai_studio";
+import { DustGoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_8_flash_eu_agent_platform";
 import { DustGoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_8_flash_global_agent_platform";
 import { DustGoogleGeminiThreeDotEightFlashGlobalGoogleAiStudioStream } from "@app/lib/llms/stream/endpoints/google_gemini_3_8_flash_global_google_ai_studio";
 import { DustMistralCodestralEuropeMistralStream } from "@app/lib/llms/stream/endpoints/mistral_codestral_eu_mistral";
@@ -90,10 +93,16 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream,
   [DustGoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream.id]:
     DustGoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream,
+  [DustGoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream.id]:
+    DustGoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream,
   [DustGoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream.id]:
     DustGoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream,
+  [DustGoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream.id]:
+    DustGoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream,
   [DustGoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream.id]:
     DustGoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream,
+  [DustGoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream.id]:
+    DustGoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream,
   [DustGoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream.id]:
     DustGoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream,
   [DustGoogleGeminiThreeDotOneFlashLiteGlobalAgentPlatformStream.id]:

--- a/front/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_eu_agent_platform.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_eu_agent_platform.ts
@@ -3,8 +3,6 @@ import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/cl
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { EUROPE } from "@app/lib/model_constructors/types/regions";
 
-// Not registered in STREAM_ENDPOINTS: this model is not available on the EU
-// agent-platform endpoint. Kept defined for when EU support lands.
 export class GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream extends WithGoogleGeminiThreeDotSixFlashConfig(
   GoogleAgentPlatformStream
 ) {

--- a/front/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_eu_agent_platform.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_eu_agent_platform.ts
@@ -3,8 +3,6 @@ import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/cl
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { EUROPE } from "@app/lib/model_constructors/types/regions";
 
-// Not registered in STREAM_ENDPOINTS: this model is not available on the EU
-// agent-platform endpoint. Kept defined for when EU support lands.
 export class GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream extends WithGoogleGeminiThreeDotSevenFlashConfig(
   GoogleAgentPlatformStream
 ) {

--- a/front/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_eu_agent_platform.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_eu_agent_platform.ts
@@ -3,9 +3,6 @@ import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/cl
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { EUROPE } from "@app/lib/model_constructors/types/regions";
 
-// Not registered in STREAM_ENDPOINTS: `@google/genai` maps the `eu` location to
-// `eu-aiplatform.googleapis.com`, which returned "Invalid hostname" in a live
-// test on 2026-09-04. Kept defined for when the native API supports EU.
 export class GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream extends WithGoogleGeminiThreeDotEightFlashConfig(
   GoogleAgentPlatformStream
 ) {

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -23,10 +23,13 @@ import { GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream } from "@app/lib
 import { GoogleGeminiThreeDotFiveFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_5_flash_global_google_ai_studio";
 import { GoogleGeminiThreeDotFiveFlashLiteGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_5_flash_lite_global_agent_platform";
 import { GoogleGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_5_flash_lite_global_google_ai_studio";
+import { GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_eu_agent_platform";
 import { GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_global_agent_platform";
 import { GoogleGeminiThreeDotSixFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_global_google_ai_studio";
+import { GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_eu_agent_platform";
 import { GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_global_agent_platform";
 import { GoogleGeminiThreeDotSevenFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_global_google_ai_studio";
+import { GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_eu_agent_platform";
 import { GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_global_agent_platform";
 import { GoogleGeminiThreeDotEightFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_global_google_ai_studio";
 import { MistralCodestralEuropeMistralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_codestral_eu_mistral";
@@ -83,10 +86,16 @@ export const STREAM_ENDPOINTS = {
     AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream,
   [GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream,
+  [GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream.id]:
+    GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream,
   [GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream,
+  [GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream.id]:
+    GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream,
   [GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream,
+  [GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream.id]:
+    GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream,
   [GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream,
   [GoogleGeminiThreeDotOneFlashLiteGlobalAgentPlatformStream.id]:

--- a/front/lib/model_constructors/test/endpoints/google_gemini_3_6_flash_eu_agent_platform.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_gemini_3_6_flash_eu_agent_platform.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 
 import { GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_eu_agent_platform";
-import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  SUCCESS,
+} from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
@@ -65,7 +68,10 @@ export const GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStreamSetup: StreamS
       "calc/calc/t-default/r-default/force-tool": null,
       "calc/calc/t-default/r-high/force-tool": null,
 
-      "reasoning/no-tools/t-default/r-minimal": null,
+      // Thinking hardly ever occurs at this effort — the model returned 0
+      // thought tokens here, so `HAS_REASONING` would assert a model
+      // decision rather than an API contract; assert success only.
+      "reasoning/no-tools/t-default/r-minimal": [SUCCESS],
       "reasoning/no-tools/t-default/r-low": null,
 
       "output-format/json-schema/t-default/r-high": null,

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -27,10 +27,13 @@ import { GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream } from "@app/lib
 import { GoogleGeminiThreeDotFiveFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_5_flash_global_google_ai_studio";
 import { GoogleGeminiThreeDotFiveFlashLiteGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_5_flash_lite_global_agent_platform";
 import { GoogleGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_5_flash_lite_global_google_ai_studio";
+import { GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_eu_agent_platform";
 import { GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_global_agent_platform";
 import { GoogleGeminiThreeDotSixFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_6_flash_global_google_ai_studio";
+import { GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_eu_agent_platform";
 import { GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_global_agent_platform";
 import { GoogleGeminiThreeDotSevenFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_7_flash_global_google_ai_studio";
+import { GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_eu_agent_platform";
 import { GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_global_agent_platform";
 import { GoogleGeminiThreeDotEightFlashGlobalGoogleAiStudioStream } from "@app/lib/model_constructors/stream/endpoints/google_gemini_3_8_flash_global_google_ai_studio";
 import { MistralCodestralEuropeMistralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_codestral_eu_mistral";
@@ -95,10 +98,13 @@ import { GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStreamSetup } from "@ap
 import { GoogleGeminiThreeDotFiveFlashGlobalGoogleAiStudioStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_5_flash_global_google_ai_studio.test";
 import { GoogleGeminiThreeDotFiveFlashLiteGlobalAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_5_flash_lite_global_agent_platform.test";
 import { GoogleGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_5_flash_lite_global_google_ai_studio.test";
+import { GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_6_flash_eu_agent_platform.test";
 import { GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_6_flash_global_agent_platform.test";
 import { GoogleGeminiThreeDotSixFlashGlobalGoogleAiStudioStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_6_flash_global_google_ai_studio.test";
+import { GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_7_flash_eu_agent_platform.test";
 import { GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_7_flash_global_agent_platform.test";
 import { GoogleGeminiThreeDotSevenFlashGlobalGoogleAiStudioStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_7_flash_global_google_ai_studio.test";
+import { GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_8_flash_eu_agent_platform.test";
 import { GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_8_flash_global_agent_platform.test";
 import { GoogleGeminiThreeDotEightFlashGlobalGoogleAiStudioStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_gemini_3_8_flash_global_google_ai_studio.test";
 import { MistralCodestralEuropeMistralStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_codestral_eu_mistral.test";
@@ -156,10 +162,16 @@ export const STREAM_ENDPOINT_SETUPS = {
     AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStreamSetup,
   [GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotFiveFlashGlobalAgentPlatformStreamSetup,
+  [GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStream.id]:
+    GoogleGeminiThreeDotSixFlashEuropeAgentPlatformStreamSetup,
   [GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotSixFlashGlobalAgentPlatformStreamSetup,
+  [GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStream.id]:
+    GoogleGeminiThreeDotSevenFlashEuropeAgentPlatformStreamSetup,
   [GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotSevenFlashGlobalAgentPlatformStreamSetup,
+  [GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStream.id]:
+    GoogleGeminiThreeDotEightFlashEuropeAgentPlatformStreamSetup,
   [GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStream.id]:
     GoogleGeminiThreeDotEightFlashGlobalAgentPlatformStreamSetup,
   [GoogleGeminiThreeDotOneFlashLiteGlobalAgentPlatformStream.id]:

--- a/front/package.json
+++ b/front/package.json
@@ -52,7 +52,7 @@
     "@emoji-mart/data": "^1.2.1",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
-    "@google/genai": "^1.42.0",
+    "@google/genai": "^1.50.0",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",
     "@hubspot/api-client": "^12.0.1",

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -361,10 +361,10 @@ export const GEMINI_3_6_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   supportsBatchProcessing: true,
   regionalAvailability: {
-    // Day-one Vertex AI availability in us-central1; the EU (europe-west1)
-    // agent-platform endpoint is not live yet (mirrors Gemini 3.5 Flash).
+    // EU multi-region availability was verified on 2026-09-04:
+    // https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations.
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };
 
@@ -400,10 +400,10 @@ export const GEMINI_3_7_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   supportsBatchProcessing: true,
   regionalAvailability: {
-    // Day-one Vertex AI availability in us-central1; the EU (europe-west1)
-    // agent-platform endpoint is not live yet (mirrors Gemini 3.6 Flash).
+    // EU multi-region availability was verified on 2026-09-04:
+    // https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations.
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };
 
@@ -440,10 +440,9 @@ export const GEMINI_3_8_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   supportsBatchProcessing: true,
   regionalAvailability: {
-    // The native Agent Platform API serves the model globally, but `eu` failed
-    // with "Invalid hostname: eu-aiplatform.googleapis.com" in a live test on
-    // 2026-09-04. Keep EU disabled until the native API supports it.
+    // EU multi-region availability was verified on 2026-09-04:
+    // https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations.
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,7 +312,7 @@
         "@emoji-mart/data": "^1.2.1",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
-        "@google/genai": "^1.42.0",
+        "@google/genai": "^1.50.0",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
         "@hubspot/api-client": "^12.0.1",
@@ -5960,9 +5960,10 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.43.0.tgz",
-      "integrity": "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",


### PR DESCRIPTION
## Description

- Upgrade @google/genai to a version that correctly routes the Vertex AI eu location through aiplatform.eu.rep.googleapis.com.
- Register the existing EU Agent Platform endpoints for Gemini 3.6 Flash, 3.7 Flash, and 3.8 Flash in both stream registries and the shared test setup registry.
- Mark europe-west1 availability as enabled for all three models and update the non-BYOK routing expectation.

This fixes the invalid eu-aiplatform.googleapis.com hostname generated by the older SDK. EU availability was also verified directly against Agent Platform.

## Tests

- 138/138 live Agent Platform EU endpoint cases passed across Gemini 3.6, 3.7, and 3.8.
- 26/26 focused routing and model configuration tests passed.
- Biome and git diff checks passed.
- Full TypeScript checking still reports unrelated pre-existing errors in Google Calendar, Metronome, Mistral, OpenAI, and Anthropic code.

## Risk

Low. The new endpoints use existing constructors and pricing configuration. The main risk is provider-side EU availability; this is mitigated by the complete live endpoint test suites for all three models.

## Deploy Plan

Deploy normally. The SDK upgrade and endpoint registration ship together, so EU routing cannot select these endpoints before the corrected hostname logic is available.