### PR TITLE
[front] enh: show active user percentage in consumption tooltip

### DIFF
--- a/front/components/poke/analytics/PokeConsumptionChart.tsx
+++ b/front/components/poke/analytics/PokeConsumptionChart.tsx
@@ -25,6 +25,7 @@ function PokeConsumptionDailyChart({
   filter,
   additionalControls,
 }: PokeConsumptionDailyChartProps) {
+  const showActiveUsers = filter?.users?.length !== 1;
   const { timeseries, isTimeseriesLoading, isTimeseriesError } =
     usePokeConsumptionTimeseries({
       workspaceId,
@@ -34,6 +35,12 @@ function PokeConsumptionDailyChart({
       breakdownCount: CONSUMPTION_CHART_BREAKDOWN_COUNT,
       filter,
     });
+  const { overview } = usePokeConsumptionOverview({
+    workspaceId,
+    period,
+    filter,
+    disabled: !showActiveUsers,
+  });
   const isFiltered = Object.values(filter ?? {}).some(
     (values) => values.length > 0
   );
@@ -49,7 +56,8 @@ function PokeConsumptionDailyChart({
           : "No consumption over this period."
       }
       additionalControls={additionalControls}
-      showActiveUsers={filter?.users?.length !== 1}
+      showActiveUsers={showActiveUsers}
+      totalUsers={overview?.members.total ?? null}
     />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.test.tsx
@@ -9,8 +9,15 @@ import { fireEvent, render } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseConsumptionTimeseries } = vi.hoisted(() => ({
-  mockUseConsumptionTimeseries: vi.fn(),
+const { mockUseConsumptionOverview, mockUseConsumptionTimeseries } = vi.hoisted(
+  () => ({
+    mockUseConsumptionOverview: vi.fn(),
+    mockUseConsumptionTimeseries: vi.fn(),
+  })
+);
+
+vi.mock("@app/hooks/useConsumptionOverview", () => ({
+  useConsumptionOverview: mockUseConsumptionOverview,
 }));
 
 vi.mock("@app/hooks/useConsumptionTimeseries", () => ({
@@ -145,6 +152,12 @@ function expectActiveUsersOverlay(container: HTMLElement) {
 
 describe("consumption active users overlay", () => {
   beforeEach(() => {
+    mockUseConsumptionOverview.mockReset().mockReturnValue({
+      overview: null,
+      isOverviewLoading: false,
+      isOverviewError: undefined,
+      isOverviewValidating: false,
+    });
     mockUseConsumptionTimeseries.mockReset().mockReturnValue({
       timeseries: null,
       isTimeseriesLoading: true,
@@ -184,15 +197,17 @@ describe("consumption active users overlay", () => {
         isTimeseriesError={false}
         emptyMessage="No consumption."
         showActiveUsers
+        totalUsers={20}
       />
     );
 
     expect(container.querySelector(".recharts-bar")).not.toBeNull();
     expectActiveUsersOverlay(container);
 
-    const activeUsersDot = container.querySelector(
+    const activeUsersDots = container.querySelectorAll(
       ".recharts-line.text-golden-500 circle"
     );
+    const activeUsersDot = activeUsersDots[1];
     const chart = container.querySelector<HTMLElement>(".recharts-wrapper");
     expect(chart).not.toBeNull();
     Object.defineProperties(chart!, {
@@ -218,7 +233,7 @@ describe("consumption active users overlay", () => {
     const activeUsersRow = Array.from(
       container.querySelectorAll('[role="tooltip"] li')
     ).find((row) => row.textContent?.includes("Active users"));
-    expect(activeUsersRow).toHaveTextContent("0");
+    expect(activeUsersRow).toHaveTextContent(/8\s*\(40%\)/);
 
     const activeDot = container.querySelector(".recharts-active-dot circle");
     expect(activeDot).toHaveClass("text-golden-500");

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -178,6 +178,7 @@ interface ConsumptionDailyTooltipProps
   partialTimestamp: number | undefined;
   currentBucketLabel: string;
   showActiveUsers: boolean;
+  totalUsers: number | null;
 }
 
 function ConsumptionDailyTooltip({
@@ -188,6 +189,7 @@ function ConsumptionDailyTooltip({
   partialTimestamp,
   currentBucketLabel,
   showActiveUsers,
+  totalUsers,
 }: ConsumptionDailyTooltipProps) {
   const datum = payload?.[0]?.payload;
   if (!active || !isConsumptionTimeseriesPoint(datum)) {
@@ -228,6 +230,10 @@ function ConsumptionDailyTooltip({
                 label: "Active users",
                 value: activeUsers,
                 colorClassName: ACTIVE_USERS_COLOR,
+                percent:
+                  totalUsers !== null && totalUsers > 0
+                    ? Math.round((activeUsers / totalUsers) * 100)
+                    : null,
               },
             ]
           : []),
@@ -254,6 +260,7 @@ interface ConsumptionDailyChartProps {
   isTimeseriesError: boolean;
   emptyMessage: string;
   showActiveUsers: boolean;
+  totalUsers: number | null;
   additionalControls?: ReactNode;
 }
 
@@ -263,6 +270,7 @@ export function ConsumptionDailyChart({
   isTimeseriesError,
   emptyMessage,
   showActiveUsers,
+  totalUsers,
   additionalControls,
 }: ConsumptionDailyChartProps) {
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);
@@ -315,6 +323,7 @@ export function ConsumptionDailyChart({
         partialTimestamp={partialTimestamp}
         currentBucketLabel={currentBucketLabel}
         showActiveUsers={showActiveUsers}
+        totalUsers={totalUsers}
       />
     ),
     [
@@ -323,6 +332,7 @@ export function ConsumptionDailyChart({
       partialTimestamp,
       currentBucketLabel,
       showActiveUsers,
+      totalUsers,
     ]
   );
 
@@ -514,6 +524,8 @@ function WorkspaceConsumptionDailyChart({
   analyticsScope,
   disabled,
 }: ConsumptionChartProps) {
+  const showActiveUsers =
+    analyticsScope?.kind !== "personal" && filter?.users?.length !== 1;
   const { timeseries, isTimeseriesLoading, isTimeseriesError } =
     useConsumptionTimeseries({
       workspaceId,
@@ -526,6 +538,13 @@ function WorkspaceConsumptionDailyChart({
       analyticsScope,
       disabled,
     });
+  const { overview } = useConsumptionOverview({
+    workspaceId,
+    period,
+    filter,
+    analyticsScope,
+    disabled: disabled || !showActiveUsers,
+  });
 
   return (
     <ConsumptionDailyChart
@@ -533,9 +552,8 @@ function WorkspaceConsumptionDailyChart({
       isTimeseriesLoading={isTimeseriesLoading}
       isTimeseriesError={Boolean(isTimeseriesError)}
       emptyMessage="No consumption over this period."
-      showActiveUsers={
-        analyticsScope?.kind !== "personal" && filter?.users?.length !== 1
-      }
+      showActiveUsers={showActiveUsers}
+      totalUsers={overview?.members.total ?? null}
     />
   );
 }


### PR DESCRIPTION
## Description

The consumption chart tooltip now shows each bucket’s active-user share next to the absolute count: DAU if the granularity is daily, WAU if weekly and MAU if monthly.

It reads the total user count from the existing consumption overview for the current analytics scope, which is most likely already in SWR cache. If the overview is unavailable, the absolute active-user count remains visible.

<img width="239" height="209" alt="Screenshot 2026-09-04 at 3 51 49 PM" src="https://github.com/user-attachments/assets/37171a25-66b8-40cd-85f5-a82dc35e5cda" />

## Tests

- Updated existing tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
