### PR TITLE
[Admin Governance] Shadow agent editor lists (11a)

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -2,6 +2,7 @@ import {
   getAgentConfiguration,
   updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration/agent";
+import { shadowAgentEditors } from "@app/lib/api/assistant/editors";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
@@ -77,6 +78,7 @@ app.get(
       agent
     );
     if (editorGroupRes.isErr()) {
+      await shadowAgentEditors(auth, agent, [], "getAgentEditorsRoute");
       switch (editorGroupRes.error.code) {
         case "unauthorized":
           return apiError(ctx, {
@@ -117,7 +119,12 @@ app.get(
 
     const editorGroup = editorGroupRes.value;
     // Any workspace member can read the editors of an agent.
-    const members = await editorGroup.getActiveMembers(auth);
+    const members = await shadowAgentEditors(
+      auth,
+      agent,
+      await editorGroup.getActiveMembers(auth),
+      "getAgentEditorsRoute"
+    );
     const memberUsers = members.map((m) => m.toJSON());
 
     // biome-ignore lint/plugin/noDirectRoleCheck: non-admins receive only minimal essential user data (LightUserType)
@@ -165,6 +172,7 @@ app.patch(
       agent
     );
     if (editorGroupRes.isErr()) {
+      await shadowAgentEditors(auth, agent, [], "patchAgentEditorsRoute");
       switch (editorGroupRes.error.code) {
         case "unauthorized":
           return apiError(ctx, {
@@ -346,7 +354,12 @@ app.patch(
       }
     }
 
-    const updatedMembers = await editorGroup.getActiveMembers(auth);
+    const updatedMembers = await shadowAgentEditors(
+      auth,
+      agent,
+      await editorGroup.getActiveMembers(auth),
+      "patchAgentEditorsResponse"
+    );
     const updatedEditors = updatedMembers.map((m) => m.toJSON());
 
     // biome-ignore lint/plugin/noDirectRoleCheck: non-admins receive only minimal essential user data (LightUserType)

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -2,7 +2,7 @@ import {
   getAgentConfiguration,
   updateAgentPermissions,
 } from "@app/lib/api/assistant/configuration/agent";
-import { shadowAgentEditors } from "@app/lib/api/assistant/editors";
+import { getAgentEditorsShadowed } from "@app/lib/api/assistant/editors";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
@@ -78,7 +78,7 @@ app.get(
       agent
     );
     if (editorGroupRes.isErr()) {
-      await shadowAgentEditors(auth, agent, [], "getAgentEditorsRoute");
+      await getAgentEditorsShadowed(auth, agent, [], "getAgentEditorsRoute");
       switch (editorGroupRes.error.code) {
         case "unauthorized":
           return apiError(ctx, {
@@ -119,7 +119,7 @@ app.get(
 
     const editorGroup = editorGroupRes.value;
     // Any workspace member can read the editors of an agent.
-    const members = await shadowAgentEditors(
+    const members = await getAgentEditorsShadowed(
       auth,
       agent,
       await editorGroup.getActiveMembers(auth),
@@ -172,7 +172,7 @@ app.patch(
       agent
     );
     if (editorGroupRes.isErr()) {
-      await shadowAgentEditors(auth, agent, [], "patchAgentEditorsRoute");
+      await getAgentEditorsShadowed(auth, agent, [], "patchAgentEditorsRoute");
       switch (editorGroupRes.error.code) {
         case "unauthorized":
           return apiError(ctx, {
@@ -354,7 +354,7 @@ app.patch(
       }
     }
 
-    const updatedMembers = await shadowAgentEditors(
+    const updatedMembers = await getAgentEditorsShadowed(
       auth,
       agent,
       await editorGroup.getActiveMembers(auth),

--- a/front/lib/api/assistant/configuration/context.ts
+++ b/front/lib/api/assistant/configuration/context.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { shadowAgentEditors } from "@app/lib/api/assistant/editors";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -119,6 +120,12 @@ export async function getAgentConfigurationContext(
   );
 
   if (editorsResult.isErr()) {
+    await shadowAgentEditors(
+      auth,
+      agentConfiguration,
+      [],
+      "getAgentConfigurationContext"
+    );
     if (requireEditorGroup) {
       return new Err({
         status_code: 400,
@@ -136,9 +143,12 @@ export async function getAgentConfigurationContext(
     });
   }
 
-  return new Ok({
+  const editorUsers = await shadowAgentEditors(
+    auth,
     agentConfiguration,
-    editorUsers: await editorsResult.value.getActiveMembers(auth),
-    skills,
-  });
+    await editorsResult.value.getActiveMembers(auth),
+    "getAgentConfigurationContext"
+  );
+
+  return new Ok({ agentConfiguration, editorUsers, skills });
 }

--- a/front/lib/api/assistant/configuration/context.ts
+++ b/front/lib/api/assistant/configuration/context.ts
@@ -1,5 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { shadowAgentEditors } from "@app/lib/api/assistant/editors";
+import { getAgentEditorsShadowed } from "@app/lib/api/assistant/editors";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -120,7 +120,7 @@ export async function getAgentConfigurationContext(
   );
 
   if (editorsResult.isErr()) {
-    await shadowAgentEditors(
+    await getAgentEditorsShadowed(
       auth,
       agentConfiguration,
       [],
@@ -143,7 +143,7 @@ export async function getAgentConfigurationContext(
     });
   }
 
-  const editorUsers = await shadowAgentEditors(
+  const editorUsers = await getAgentEditorsShadowed(
     auth,
     agentConfiguration,
     await editorsResult.value.getActiveMembers(auth),

--- a/front/lib/api/assistant/editors.test.ts
+++ b/front/lib/api/assistant/editors.test.ts
@@ -1,0 +1,46 @@
+import { getEditors } from "@app/lib/api/assistant/editors";
+import { AgentResource } from "@app/lib/resources/agent_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import logger from "@app/logger/logger";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import assert from "assert";
+import { expect, it, vi } from "vitest";
+
+it("serves legacy agent editors and logs grant mismatches", async () => {
+  const { authenticator, user } = await createResourceTest({ role: "user" });
+  const agent = await AgentConfigurationFactory.createTestAgent(authenticator, {
+    scope: "hidden",
+  });
+  await FeatureFlagFactory.basic(authenticator, "group_permissions_shadow");
+
+  const resource = await AgentResource.fetchByAgentConfiguration(
+    authenticator,
+    agent
+  );
+  assert(resource.id !== null);
+  const revokeResult = await GroupPermissionResource.revokeFromUser(
+    authenticator,
+    {
+      user: user.toJSON(),
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: resource.id,
+    }
+  );
+  assert(revokeResult.isOk());
+
+  const warn = vi.spyOn(logger, "warn");
+  const editors = await getEditors(authenticator, agent);
+
+  expect(editors.map((editor) => editor.id)).toEqual([user.id]);
+  expect(warn).toHaveBeenCalledWith(
+    expect.objectContaining({
+      check: "agent_editors",
+      legacyResult: [user.id],
+      candidateResult: [],
+    }),
+    "group_permissions_shadow_mismatch"
+  );
+});

--- a/front/lib/api/assistant/editors.ts
+++ b/front/lib/api/assistant/editors.ts
@@ -1,9 +1,54 @@
+import { shadowCompare } from "@app/lib/api/permissions/shadow";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
+import assert from "assert";
+
+function sortedUserModelIds(users: { id: number }[]): number[] {
+  return [...new Set(users.map((user) => user.id))].sort((a, b) => a - b);
+}
+
+function sameModelIds(left: number[], right: number[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((modelId, index) => modelId === right[index])
+  );
+}
+
+export async function shadowAgentEditors(
+  auth: Authenticator,
+  agentConfiguration: LightAgentConfigurationType,
+  legacyEditors: UserResource[],
+  callSite: string
+): Promise<UserResource[]> {
+  await shadowCompare({
+    auth,
+    legacy: sortedUserModelIds(legacyEditors),
+    candidate: async () => {
+      const resource = await AgentResource.fetchByAgentConfiguration(
+        auth,
+        agentConfiguration
+      );
+      const editors = await resource.listEditors(auth);
+      assert(editors !== null);
+      return sortedUserModelIds(editors);
+    },
+    context: {
+      check: "agent_editors",
+      callSite,
+      agentId: agentConfiguration.sId,
+      agentConfigurationModelId: agentConfiguration.id,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    equals: sameModelIds,
+  });
+
+  return legacyEditors;
+}
 
 export const getAuthors = async (
   agentConfigurations: LightAgentConfigurationType[]
@@ -25,14 +70,70 @@ export const getEditors = async (
   );
   if (editorGroupRes.isErr()) {
     // We could do better here but this is not a critical path.
+    await shadowAgentEditors(auth, agentConfiguration, [], "getEditors");
     return [];
   }
 
   const editorGroup = editorGroupRes.value;
-  const members = await editorGroup.getActiveMembers(auth);
+  const members = await shadowAgentEditors(
+    auth,
+    agentConfiguration,
+    await editorGroup.getActiveMembers(auth),
+    "getEditors"
+  );
   const memberUsers = members.map((m) => m.toJSON());
   return memberUsers;
 };
+
+async function shadowAgentEditorsBatch(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[],
+  legacyEditors: Record<string, UserType[]>
+): Promise<void> {
+  const customAgents = agents.filter((agent) => agent.scope !== "global");
+  const canonicalLegacy = customAgents
+    .map(
+      (agent) =>
+        [agent.sId, sortedUserModelIds(legacyEditors[agent.sId] ?? [])] as const
+    )
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  await shadowCompare({
+    auth,
+    legacy: canonicalLegacy,
+    candidate: async () => {
+      const resources = await AgentResource.fetchByAgentConfigurations(
+        auth,
+        customAgents
+      );
+      const editorsByAgentId = await AgentResource.batchListEditors(
+        auth,
+        resources
+      );
+
+      return customAgents
+        .map(
+          (agent) =>
+            [
+              agent.sId,
+              sortedUserModelIds(editorsByAgentId.get(agent.sId) ?? []),
+            ] as const
+        )
+        .sort(([left], [right]) => left.localeCompare(right));
+    },
+    context: {
+      check: "agent_editors_batch",
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    equals: (legacy, candidate) =>
+      legacy.length === candidate.length &&
+      legacy.every(
+        ([agentId, editorModelIds], index) =>
+          agentId === candidate[index][0] &&
+          sameModelIds(editorModelIds, candidate[index][1])
+      ),
+  });
+}
 
 export const getAgentsEditors = async (
   auth: Authenticator,
@@ -42,28 +143,28 @@ export const getAgentsEditors = async (
     auth,
     agentConfigurations
   );
-  if (editorGroups.isErr()) {
-    return {};
-  }
-
-  const activeMemberships = await GroupResource.getActiveMembershipsForGroups(
-    auth,
-    Object.values(editorGroups.value)
-  );
-
-  const users = await UserResource.fetchByModelIds([
-    ...new Set(Object.values(activeMemberships).flat()),
-  ]);
-
-  // Create a map from userId to UserType for quick lookup
-  const userMap = new Map(users.map((u) => [u.id, u.toJSON()]));
-
-  // Build the result map: { agentId: [editors] }
   const result: Record<string, UserType[]> = {};
-  for (const [agentId, group] of Object.entries(editorGroups.value)) {
-    const userIds = activeMemberships[group.id] || [];
-    result[agentId] = removeNulls(userIds.map((userId) => userMap.get(userId)));
+  if (editorGroups.isOk()) {
+    const activeMemberships = await GroupResource.getActiveMembershipsForGroups(
+      auth,
+      Object.values(editorGroups.value)
+    );
+    const users = await UserResource.fetchByModelIds([
+      ...new Set(Object.values(activeMemberships).flat()),
+    ]);
+    // Create a map from userId to UserType for quick lookup
+    const userMap = new Map(users.map((user) => [user.id, user.toJSON()]));
+
+    // Build the result map: { agentId: [editors] }
+    for (const [agentId, group] of Object.entries(editorGroups.value)) {
+      const userModelIds = activeMemberships[group.id] ?? [];
+      result[agentId] = removeNulls(
+        userModelIds.map((userModelId) => userMap.get(userModelId))
+      );
+    }
   }
+
+  await shadowAgentEditorsBatch(auth, agentConfigurations, result);
 
   return result;
 };

--- a/front/lib/api/assistant/editors.ts
+++ b/front/lib/api/assistant/editors.ts
@@ -19,7 +19,7 @@ function sameModelIds(left: number[], right: number[]): boolean {
   );
 }
 
-export async function shadowAgentEditors(
+export async function getAgentEditorsShadowed(
   auth: Authenticator,
   agentConfiguration: LightAgentConfigurationType,
   legacyEditors: UserResource[],
@@ -70,12 +70,12 @@ export const getEditors = async (
   );
   if (editorGroupRes.isErr()) {
     // We could do better here but this is not a critical path.
-    await shadowAgentEditors(auth, agentConfiguration, [], "getEditors");
+    await getAgentEditorsShadowed(auth, agentConfiguration, [], "getEditors");
     return [];
   }
 
   const editorGroup = editorGroupRes.value;
-  const members = await shadowAgentEditors(
+  const members = await getAgentEditorsShadowed(
     auth,
     agentConfiguration,
     await editorGroup.getActiveMembers(auth),
@@ -91,7 +91,7 @@ async function shadowAgentEditorsBatch(
   legacyEditors: Record<string, UserType[]>
 ): Promise<void> {
   const customAgents = agents.filter((agent) => agent.scope !== "global");
-  const canonicalLegacy = customAgents
+  const normalizedLegacyEditors = customAgents
     .map(
       (agent) =>
         [agent.sId, sortedUserModelIds(legacyEditors[agent.sId] ?? [])] as const
@@ -100,7 +100,7 @@ async function shadowAgentEditorsBatch(
 
   await shadowCompare({
     auth,
-    legacy: canonicalLegacy,
+    legacy: normalizedLegacyEditors,
     candidate: async () => {
       const resources = await AgentResource.fetchByAgentConfigurations(
         auth,
@@ -111,7 +111,7 @@ async function shadowAgentEditorsBatch(
         resources
       );
 
-      return customAgents
+      const normalizedCandidateEditors = customAgents
         .map(
           (agent) =>
             [
@@ -120,6 +120,8 @@ async function shadowAgentEditorsBatch(
             ] as const
         )
         .sort(([left], [right]) => left.localeCompare(right));
+
+      return normalizedCandidateEditors;
     },
     context: {
       check: "agent_editors_batch",

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -32,6 +32,39 @@ describe("AgentResource", () => {
     expect(resource.workspaceId).toBe(testContext.workspace.id);
   });
 
+  it("lists agent editors from grants individually and in batches", async () => {
+    const firstAgent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator,
+      { name: "First agent" }
+    );
+    const secondAgent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator,
+      { name: "Second agent" }
+    );
+    const resources = await AgentResource.fetchByAgentConfigurations(
+      testContext.authenticator,
+      [firstAgent, secondAgent]
+    );
+
+    const firstEditors = await resources[0].listEditors(
+      testContext.authenticator
+    );
+    const editorsByAgentId = await AgentResource.batchListEditors(
+      testContext.authenticator,
+      resources
+    );
+
+    expect(firstEditors?.map((editor) => editor.id)).toEqual([
+      testContext.user.id,
+    ]);
+    expect(
+      editorsByAgentId.get(firstAgent.sId)?.map((editor) => editor.id)
+    ).toEqual([testContext.user.id]);
+    expect(
+      editorsByAgentId.get(secondAgent.sId)?.map((editor) => editor.id)
+    ).toEqual([testContext.user.id]);
+  });
+
   it("applies author, admin, and editor permissions to custom agents", async () => {
     const resource = AgentResource.fromAgentConfigurationModel({
       agentId: AGENT_MODEL_ID,

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -183,5 +183,6 @@ describe("AgentResource", () => {
     expect(managerAuth.hasPermission("read", analyst)).toBe(true);
     expect(managerAuth.hasPermission("write", analyst)).toBe(false);
     expect(managerAuth.hasPermission("admin", analyst)).toBe(false);
+    expect(await helper.listEditors(testContext.authenticator)).toBeNull();
   });
 });

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -3,6 +3,9 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentModel } from "@app/lib/models/agent/agent";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   AgentConfigurationScope,
   LightAgentConfigurationType,
@@ -10,6 +13,7 @@ import type {
 import type { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { GrantVerb } from "@app/types/group_permissions";
+import { grantKey } from "@app/types/group_permissions";
 import type {
   AccessControlList,
   RoleGrant,
@@ -17,6 +21,7 @@ import type {
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
@@ -113,6 +118,143 @@ export class AgentResource implements WithAccessControl {
       scope: configuration.scope,
       workspaceId: agent.workspaceId,
     });
+  }
+
+  static async fetchByAgentConfigurations(
+    auth: Authenticator,
+    configurations: Pick<
+      LightAgentConfigurationType,
+      "sId" | "scope" | "versionAuthorId"
+    >[]
+  ): Promise<AgentResource[]> {
+    if (configurations.length === 0) {
+      return [];
+    }
+
+    // agents.sId is unique, so the batch lookup stays indexed and workspace-scoped.
+    const agents = await AgentModel.findAll({
+      where: {
+        sId: configurations.map((configuration) => configuration.sId),
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      attributes: ["id", "sId", "workspaceId"],
+    });
+    const agentById = new Map(agents.map((agent) => [agent.sId, agent]));
+
+    return configurations.map((configuration) => {
+      assert(configuration.scope !== "global");
+      assert(
+        configuration.versionAuthorId !== null,
+        "Unexpected: custom agent author is missing"
+      );
+      const agent = agentById.get(configuration.sId);
+      assert(agent, "Unexpected: agent identity is missing");
+
+      return new AgentResource(
+        agent.id,
+        agent.sId,
+        agent.workspaceId,
+        "custom",
+        configuration.versionAuthorId,
+        configuration.scope
+      );
+    });
+  }
+
+  async listEditors(auth: Authenticator): Promise<UserResource[] | null> {
+    if (this.kind === "global") {
+      return null;
+    }
+    assert(this.id !== null);
+
+    const group = await GroupPermissionResource.findRegularAutoGroupForGrant(
+      auth,
+      {
+        grantType: "editor",
+        resourceType: "agent",
+        resourceId: this.id,
+      }
+    );
+
+    return group ? group.getActiveMembers(auth) : [];
+  }
+
+  static async batchListEditors(
+    auth: Authenticator,
+    agents: AgentResource[]
+  ): Promise<Map<string, UserResource[] | null>> {
+    const result = new Map<string, UserResource[] | null>(
+      agents.map((agent) => [agent.sId, null])
+    );
+    const customAgents = agents.filter((agent) => agent.id !== null);
+    if (customAgents.length === 0) {
+      return result;
+    }
+
+    const editorGrant = (agent: AgentResource) => {
+      assert(agent.id !== null);
+      return {
+        grantType: "editor" as const,
+        resourceType: "agent" as const,
+        resourceId: agent.id,
+      };
+    };
+    const groupByGrant =
+      await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+        grants: customAgents.map(editorGrant),
+      });
+    const groupByAgentModelId = new Map<ModelId, GroupResource>(
+      removeNulls(
+        customAgents.map((agent) => {
+          assert(agent.id !== null);
+          const group = groupByGrant.get(grantKey(editorGrant(agent)));
+          return group ? ([agent.id, group] as const) : null;
+        })
+      )
+    );
+    const membershipsByGroupId =
+      await GroupResource.getActiveMembershipsForGroups(auth, [
+        ...groupByAgentModelId.values(),
+      ]);
+    const userModelIds = [
+      ...new Set(Object.values(membershipsByGroupId).flat()),
+    ];
+    if (userModelIds.length === 0) {
+      for (const agent of customAgents) {
+        result.set(agent.sId, []);
+      }
+      return result;
+    }
+
+    const users = await UserResource.fetchByModelIds(userModelIds);
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      users,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    const activeUserModelIds = new Set(
+      memberships.map((membership) => membership.userId)
+    );
+    const userByModelId = new Map(
+      users
+        .filter((user) => activeUserModelIds.has(user.id))
+        .map((user) => [user.id, user])
+    );
+
+    for (const agent of customAgents) {
+      assert(agent.id !== null);
+      const group = groupByAgentModelId.get(agent.id);
+      const memberModelIds = group
+        ? (membershipsByGroupId[group.id] ?? [])
+        : [];
+      result.set(
+        agent.sId,
+        removeNulls(
+          memberModelIds.map((userModelId) => userByModelId.get(userModelId))
+        )
+      );
+    }
+
+    return result;
   }
 
   async grantEditors(

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -141,7 +141,7 @@ export class AgentResource implements WithAccessControl {
     });
     const agentById = new Map(agents.map((agent) => [agent.sId, agent]));
 
-    return configurations.map((configuration) => {
+    const resources = configurations.map((configuration) => {
       assert(configuration.scope !== "global");
       assert(
         configuration.versionAuthorId !== null,
@@ -150,33 +150,24 @@ export class AgentResource implements WithAccessControl {
       const agent = agentById.get(configuration.sId);
       assert(agent, "Unexpected: agent identity is missing");
 
-      return new AgentResource(
-        agent.id,
-        agent.sId,
-        agent.workspaceId,
-        "custom",
-        configuration.versionAuthorId,
-        configuration.scope
-      );
+      return this.fromAgentConfigurationModel({
+        agentId: agent.id,
+        authorId: configuration.versionAuthorId,
+        sId: agent.sId,
+        scope: configuration.scope,
+        workspaceId: agent.workspaceId,
+      });
     });
+
+    return resources;
   }
 
   async listEditors(auth: Authenticator): Promise<UserResource[] | null> {
-    if (this.kind === "global") {
-      return null;
-    }
-    assert(this.id !== null);
+    const editorsByAgentId = await AgentResource.batchListEditors(auth, [this]);
+    const editors = editorsByAgentId.get(this.sId);
+    assert(editors !== undefined);
 
-    const group = await GroupPermissionResource.findRegularAutoGroupForGrant(
-      auth,
-      {
-        grantType: "editor",
-        resourceType: "agent",
-        resourceId: this.id,
-      }
-    );
-
-    return group ? group.getActiveMembers(auth) : [];
+    return editors;
   }
 
   static async batchListEditors(
@@ -219,6 +210,7 @@ export class AgentResource implements WithAccessControl {
     const userModelIds = [
       ...new Set(Object.values(membershipsByGroupId).flat()),
     ];
+    // The user and workspace-membership lookups below still query the DB for empty inputs.
     if (userModelIds.length === 0) {
       for (const agent of customAgents) {
         result.set(agent.sId, []);

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -170,6 +170,11 @@ export class AgentResource implements WithAccessControl {
     return editors;
   }
 
+  /**
+   * @cc [owner:philipperolet,label:backend] editor-results-by-agent
+   * Each input agent has a map entry: `null` for globals and active workspace members
+   * of its editor grant for custom agents, or `[]` when there are none.
+   */
   static async batchListEditors(
     auth: Authenticator,
     agents: AgentResource[]
@@ -210,14 +215,6 @@ export class AgentResource implements WithAccessControl {
     const userModelIds = [
       ...new Set(Object.values(membershipsByGroupId).flat()),
     ];
-    // The user and workspace-membership lookups below still query the DB for empty inputs.
-    if (userModelIds.length === 0) {
-      for (const agent of customAgents) {
-        result.set(agent.sId, []);
-      }
-      return result;
-    }
-
     const users = await UserResource.fetchByModelIds(userModelIds);
     const { memberships } = await MembershipResource.getActiveMemberships({
       users,


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: [Admin Governance design doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)

Part 11a of the agent permission migration. When `group_permissions_shadow` is enabled, editor-list reads compare legacy group membership with editors found through grants and log differences. Responses continue to use the legacy editor lists.

Adds the single and batch resource lookups and covers editor endpoints and agent configuration context.

PR11 parts: **11a (this PR)** → [11b: permissions and usage](https://github.com/dust-tt/dust/pull/31919). [11c: agent views](https://github.com/dust-tt/dust/pull/31920) is independent and targets `main`.

## Risks

Blast radius: Agent editor lists and agent configuration context when shadowing is enabled.
Risk: standard

## Deploy Plan

- Deploy front.
- After PR9's dual writes and PR10's editor-grant backfill are complete, enable `group_permissions_shadow` progressively.
- Monitor editor mismatch/error logs; disable the flag if needed. Finish all PR11 parts and verify parity before PR12.

## Tests

- [x] Agent resource and editor shadow tests (6 tests).
- [x] Agent editor endpoint tests (20 tests).
