### PR TITLE
Poke: show tool function call name under each conversation step

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -378,15 +378,21 @@ function ToolActionContent({
         <span className="shrink-0 rounded-md border border-separator bg-background px-1.5 py-0.5 font-mono text-sm tabular-nums text-muted-foreground">
           Step {action.step}
         </span>
-        <span
-          className="min-w-0 truncate text-sm font-medium text-foreground"
-          title={
-            actionLabel === action.functionCallName
-              ? action.functionCallName
-              : `${actionLabel} (${action.functionCallName})`
-          }
-        >
-          {actionLabel}
+        <span className="flex min-w-0 flex-col">
+          <span
+            className="truncate text-sm font-medium text-foreground"
+            title={actionLabel}
+          >
+            {actionLabel}
+          </span>
+          {actionLabel !== action.functionCallName && (
+            <span
+              className="truncate font-mono text-xs text-muted-foreground"
+              title={action.functionCallName}
+            >
+              {action.functionCallName}
+            </span>
+          )}
         </span>
         {actionStatus && (
           <Chip


### PR DESCRIPTION
## Description

<img width="681" height="167" alt="Screenshot 2026-09-04 at 16 02 10" src="https://github.com/user-attachments/assets/995f5846-b07d-4c31-89c0-f0f4af8cbd5e" />

In the poke conversation view, each tool step showed only the tool's "done" display label (e.g. "Publish the persistent counter Frame"), with the actual function call name available only in a hover tooltip. This makes it hard to tell at a glance which tool an agent actually called.

This renders the function call name (e.g. `sandbox__bash`) on a second line under the label, in small muted monospace. It is omitted when the label already is the function call name, so rows without a display label stay single-line.

## Risk

Low, poke-only UI change.

## Deploy Plan

Deploy front-spa.