### PR TITLE
Spend caps: remove the enforce_user_spend_limit_rate_cap flag (always rate-limiter)

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.test.ts
+++ b/front-api/routes/w/[wId]/usage-status.test.ts
@@ -1,10 +1,38 @@
+import * as userSpendLimit from "@app/lib/api/users/spend_limit";
 import { Authenticator } from "@app/lib/auth";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The per-user cap is enforced from the Redis rate-limiter counter (over the
+// contract billing cycle, which the test workspaces don't have). Mock that
+// single lever so "capped" scenarios don't need a seeded counter.
+vi.mock("@app/lib/api/users/spend_limit", async () => {
+  const actual = await vi.importActual<typeof userSpendLimit>(
+    "@app/lib/api/users/spend_limit"
+  );
+  return {
+    ...actual,
+    isUserSpendLimitRateCapReached: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(userSpendLimit.isUserSpendLimitRateCapReached).mockResolvedValue(
+    false
+  );
+});
+
+// Mark the current member as over their per-user spend cap (the rate limiter's
+// verdict), the way real enforcement blocks them.
+function mockUserRateCapReached() {
+  vi.mocked(userSpendLimit.isUserSpendLimitRateCapReached).mockResolvedValue(
+    true
+  );
+}
 
 function usageStatusUrl(wId: string) {
   return `/api/w/${wId}/usage-status`;
@@ -37,12 +65,12 @@ describe("/api/w/[wId]/usage-status", () => {
 
   it("lets a capped non-admin member request an upgrade", async () => {
     const workspace = await creditPricedWorkspace();
-    const { membership } = await createPrivateApiMockRequest({
+    await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
       workspace,
     });
-    await membership.updateCreditState("capped");
+    mockUserRateCapReached();
 
     const response = await honoApp.request(usageStatusUrl(workspace.sId));
 
@@ -55,12 +83,12 @@ describe("/api/w/[wId]/usage-status", () => {
 
   it("flips hasPendingUpgradeRequest once a request exists", async () => {
     const workspace = await creditPricedWorkspace();
-    const { membership } = await createPrivateApiMockRequest({
+    await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
       workspace,
     });
-    await membership.updateCreditState("capped");
+    mockUserRateCapReached();
 
     const postResponse = await honoApp.request(
       upgradeRequestsUrl(workspace.sId),
@@ -95,12 +123,12 @@ describe("/api/w/[wId]/usage-status", () => {
       autoSeatUpgradeEnabled: true,
     });
 
-    const { membership } = await createPrivateApiMockRequest({
+    await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
       workspace,
     });
-    await membership.updateCreditState("capped");
+    mockUserRateCapReached();
 
     const response = await honoApp.request(usageStatusUrl(workspace.sId));
 
@@ -111,12 +139,12 @@ describe("/api/w/[wId]/usage-status", () => {
 
   it("does not offer upgrade requests to admins", async () => {
     const workspace = await creditPricedWorkspace();
-    const { membership } = await createPrivateApiMockRequest({
+    await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
       workspace,
     });
-    await membership.updateCreditState("capped");
+    mockUserRateCapReached();
 
     const response = await honoApp.request(usageStatusUrl(workspace.sId));
 
@@ -140,12 +168,12 @@ describe("/api/w/[wId]/usage-status", () => {
     });
 
     // A capped member no longer sees the CTA.
-    const { membership } = await createPrivateApiMockRequest({
+    await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
       workspace,
     });
-    await membership.updateCreditState("capped");
+    mockUserRateCapReached();
 
     const statusResponse = await honoApp.request(usageStatusUrl(workspace.sId));
     expect(statusResponse.status).toBe(200);
@@ -175,12 +203,12 @@ describe("/api/w/[wId]/usage-status", () => {
       requireUpgradeRequestReason: true,
     });
 
-    const { membership } = await createPrivateApiMockRequest({
+    await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
       workspace,
     });
-    await membership.updateCreditState("capped");
+    mockUserRateCapReached();
 
     const response = await honoApp.request(usageStatusUrl(workspace.sId));
 

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -5,7 +5,6 @@ import {
 } from "@app/lib/api/credits/access_control";
 import { getUpgradeRequestAvailabilityForUser } from "@app/lib/api/credits/upgrade_requests";
 import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
-import { getFeatureFlags } from "@app/lib/auth";
 import type {
   GetWorkspaceUsageStatusResponseBody,
   ProgrammaticCreditStatus,
@@ -35,10 +34,10 @@ app.get(
     // Workspaces not on Metronome billing have no usage status to report,
     // unless we've overriden their default per-user credit limit.
     if (!workspace.metronomeCustomerId || !isCreditPriced) {
-      const featureFlags = await getFeatureFlags(auth);
-      const isLimitReached =
-        featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
-        (await isNonCreditPricedUserSpendLimitReached(auth, { user }));
+      const isLimitReached = await isNonCreditPricedUserSpendLimitReached(
+        auth,
+        { user }
+      );
 
       return ctx.json({
         userNearCreditLimit: false,
@@ -68,9 +67,8 @@ app.get(
       isWorkspaceBalanceThresholdReached(workspace.sId),
     ]);
 
-    // `isUserAwuWarned` is flag-aware: the Redis rate-limiter warning (80% of
-    // the effective cap) when the flag is on, the Metronome near-limit flag
-    // otherwise.
+    // `isUserAwuWarned`: the Redis rate-limiter warning (80% of the effective
+    // cap).
     const userNearCreditLimit =
       !userBlockedReason && (await isUserAwuWarned(auth, { user }));
 

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -38,9 +38,6 @@ interface PokeUsageTabProps {
   subscription: SubscriptionType;
   stripeSubscription: PokeStripeSubscriptionWire | null;
   poolCreditState: WorkspacePoolCreditState;
-  programmaticCreditState: WorkspaceProgrammaticCreditState;
-  programmaticWarningReached: boolean;
-  spendLimitRateCapEnabled: boolean;
   programmaticRateLimiterState: RateLimiterState | null;
   programmaticSpendLimitRateCapCount: number | null;
   programmaticEsConsumedAwuCredits: number | null;
@@ -108,9 +105,6 @@ interface PokeCreditStatesCardProps {
   owner: WorkspaceType;
   creditUsageConfig: PokeCreditUsageConfig | null;
   poolCreditState: WorkspacePoolCreditState;
-  programmaticCreditState: WorkspaceProgrammaticCreditState;
-  programmaticWarningReached: boolean;
-  spendLimitRateCapEnabled: boolean;
   programmaticRateLimiterState: RateLimiterState | null;
   programmaticSpendLimitRateCapCount: number | null;
   programmaticEsConsumedAwuCredits: number | null;
@@ -123,9 +117,6 @@ function PokeCreditStatesCard({
   owner,
   creditUsageConfig,
   poolCreditState,
-  programmaticCreditState,
-  programmaticWarningReached,
-  spendLimitRateCapEnabled,
   programmaticRateLimiterState,
   programmaticSpendLimitRateCapCount,
   programmaticEsConsumedAwuCredits,
@@ -152,25 +143,11 @@ function PokeCreditStatesCard({
         </div>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">Programmatic</span>
-          {spendLimitRateCapEnabled ? (
-            // Flag on: the rate-limiter is authoritative, so show its verdict
-            // and do not read the Metronome `programmaticCreditState`. The RL
-            // state already encodes near-limit, so no separate warning chip.
-            <RateLimiterStateChip
-              rateLimiterState={programmaticRateLimiterState}
-            />
-          ) : (
-            <>
-              <Chip
-                size="xs"
-                color={creditStateChipColor(programmaticCreditState)}
-                label={programmaticCreditState}
-              />
-              {programmaticWarningReached && (
-                <Chip size="xs" color="warning" label="near limit" />
-              )}
-            </>
-          )}
+          {/* The rate-limiter is authoritative; its verdict already encodes
+              near-limit, so there is no separate warning chip. */}
+          <RateLimiterStateChip
+            rateLimiterState={programmaticRateLimiterState}
+          />
           <span className="text-xs text-muted-foreground">
             cap:{" "}
             {creditUsageConfig
@@ -361,9 +338,6 @@ export function PokeUsageTab({
   subscription,
   stripeSubscription,
   poolCreditState,
-  programmaticCreditState,
-  programmaticWarningReached,
-  spendLimitRateCapEnabled,
   programmaticRateLimiterState,
   programmaticSpendLimitRateCapCount,
   programmaticEsConsumedAwuCredits,
@@ -403,9 +377,6 @@ export function PokeUsageTab({
         owner={owner}
         creditUsageConfig={creditUsageConfig}
         poolCreditState={poolCreditState}
-        programmaticCreditState={programmaticCreditState}
-        programmaticWarningReached={programmaticWarningReached}
-        spendLimitRateCapEnabled={spendLimitRateCapEnabled}
         programmaticRateLimiterState={programmaticRateLimiterState}
         programmaticSpendLimitRateCapCount={programmaticSpendLimitRateCapCount}
         programmaticEsConsumedAwuCredits={programmaticEsConsumedAwuCredits}

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -144,9 +144,6 @@ export function WorkspacePage() {
     programmaticAlerts,
     usageCapAlert,
     defaultAlerts,
-    programmaticCreditState,
-    programmaticWarningReached,
-    spendLimitRateCapEnabled,
     programmaticRateLimiterState,
     programmaticSpendLimitRateCapCount,
     programmaticEsConsumedAwuCredits,
@@ -389,9 +386,6 @@ export function WorkspacePage() {
                 subscription={activeSubscription}
                 stripeSubscription={stripeSubscription}
                 poolCreditState={poolCreditState}
-                programmaticCreditState={programmaticCreditState}
-                programmaticWarningReached={programmaticWarningReached}
-                spendLimitRateCapEnabled={spendLimitRateCapEnabled}
                 programmaticRateLimiterState={programmaticRateLimiterState}
                 programmaticSpendLimitRateCapCount={
                   programmaticSpendLimitRateCapCount

--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -16,7 +16,6 @@ import {
   DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
 } from "@app/temporal/activation_scheduler/config";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -217,18 +216,10 @@ describe("isEligibleForNudge", () => {
     const { authenticator, user, globalSpace } = await createResourceTest({
       role: "admin",
     });
-    await FeatureFlagFactory.basic(
-      authenticator,
-      "enforce_user_spend_limit_rate_cap"
-    );
-    const authWithFlag = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      authenticator.getNonNullableWorkspace().sId
-    );
-    const activationPod = await createActivationPod(authWithFlag, globalSpace);
+    const activationPod = await createActivationPod(authenticator, globalSpace);
 
     expect(
-      await isEligibleForNudge(authWithFlag, {
+      await isEligibleForNudge(authenticator, {
         pod: globalSpace,
         activationPod,
         user,

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import { isUserBlocked } from "@app/lib/api/credits/access_control";
 import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
@@ -156,12 +156,8 @@ export async function isEligibleForNudge(
     } else {
       // Legacy plans: `seatType === "none"` is the backfill/default, not a
       // block, so skip isUserBlocked. The matching conversation-posting gate
-      // is the non-CP spend cap when that flag is on.
-      const flags = await getFeatureFlags(auth);
-      if (
-        flags.includes("enforce_user_spend_limit_rate_cap") &&
-        (await isNonCreditPricedUserSpendLimitReached(auth, { user }))
-      ) {
+      // is the non-CP spend cap.
+      if (await isNonCreditPricedUserSpendLimitReached(auth, { user })) {
         return false;
       }
     }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -93,10 +93,7 @@ import {
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import { isFreeOrigin } from "@app/lib/metronome/events";
-import {
-  getWorkspaceCreditPoolStatus,
-  getWorkspaceProgrammaticCreditStatus,
-} from "@app/lib/metronome/user_block";
+import { getWorkspaceCreditPoolStatus } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
   AgentMCPActionModel,
@@ -2691,13 +2688,8 @@ export async function checkMessagesLimit(
     // counter, bucketed on the UTC calendar month. Admin-set (poke) workspace
     // default, overridable per member. Free origins produce no billable usage,
     // and API keys have no per-user limit (they are gated by the programmatic
-    // caps below). Flag-gated while we validate the counter; usage is recorded
-    // regardless (in credit_cost), so the flag only controls blocking.
-    const featureFlags = await getFeatureFlags(auth);
-    if (
-      featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
-      (await isNonCreditPricedUserSpendLimitReached(auth, { user }))
-    ) {
+    // caps below).
+    if (await isNonCreditPricedUserSpendLimitReached(auth, { user })) {
       return new Err({
         status_code: 403,
         api_error: {
@@ -2821,13 +2813,9 @@ async function checkProgrammaticCreditConcurrencyLimit(
   auth: Authenticator
 ): Promise<MessageLimit> {
   const owner = auth.getNonNullableWorkspace();
-  // With the rate-cap flag on, the concurrency band comes from the Redis
-  // rate-limiter counter; with it off, from the Metronome programmatic credit
-  // state. Matches the flag-aware enforcement in access_control.
-  const featureFlags = await getFeatureFlags(auth);
-  const status = featureFlags.includes("enforce_user_spend_limit_rate_cap")
-    ? await getProgrammaticRateLimiterCreditState(auth)
-    : await getWorkspaceProgrammaticCreditStatus(owner.sId);
+  // The concurrency band comes from the Redis rate-limiter counter (cycle-to-date
+  // programmatic spend vs the cap). Matches enforcement in access_control.
+  const status = await getProgrammaticRateLimiterCreditState(auth);
 
   const maxConcurrent = PROGRAMMATIC_CREDIT_CONCURRENCY_LIMITS[status];
   if (maxConcurrent === undefined) {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -188,7 +188,7 @@ export async function computeAndStoreAgentMessageCredits(
   const plan = auth.plan();
   const assistantLimits = plan?.limits.assistant;
 
-  // Feature flags gate the fair-use recording and the spend-cap backups below;
+  // The `disable_fair_use_awu_limit` flag gates the fair-use recording below;
   // fetch once when there is a delta to record.
   const featureFlags = recordedCostDelta > 0 ? await getFeatureFlags(auth) : [];
 
@@ -251,51 +251,49 @@ export async function computeAndStoreAgentMessageCredits(
     }
   }
 
-  // Record against the spend-cap backups (Redis fixed-window counters over the
-  // contract billing cycle).
+  // Record against the spend-cap counters (Redis fixed-window, over the contract
+  // billing cycle) that back enforcement in `lib/api/credits/access_control`.
   if (recordedCostDelta > 0) {
-    if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
-      // Per-user cap. Free and paid consumption are kept in separate counters:
-      // free seats accrue only against their lifetime counter, everyone else
-      // only against the per-cycle counter. Recording a free seat's usage into
-      // the per-cycle counter would leak it into their paid cap after a
-      // free→pro switch within the same cycle (mirrors the Metronome
-      // `free-<sId>` user-key split).
-      if (user) {
-        const membership =
-          await MembershipResource.getActiveMembershipOfUserInWorkspace({
-            user,
-            workspace: auth.getNonNullableWorkspace(),
-          });
-        if (membership?.seatType === "free") {
-          await recordFreeSeatLifetimeUsage(auth, {
-            user,
-            incrementBy: recordedCostDelta,
-          });
-        } else {
-          await recordUserSpendLimitUsage(auth, {
-            user,
-            incrementBy: recordedCostDelta,
-            cycle: spendLimitCycleOverrideForAuth(auth),
-          });
-        }
-      }
-
-      // Per-API-key cap, for calls authenticated with an API key.
-      const apiKey = auth.key();
-      if (apiKey) {
-        await recordApiKeySpendLimitUsage(auth, {
-          keyModelId: apiKey.id,
+    // Per-user cap. Free and paid consumption are kept in separate counters:
+    // free seats accrue only against their lifetime counter, everyone else only
+    // against the per-cycle counter. Recording a free seat's usage into the
+    // per-cycle counter would leak it into their paid cap after a free→pro
+    // switch within the same cycle (mirrors the Metronome `free-<sId>` user-key
+    // split).
+    if (user) {
+      const membership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user,
+          workspace: auth.getNonNullableWorkspace(),
+        });
+      if (membership?.seatType === "free") {
+        await recordFreeSeatLifetimeUsage(auth, {
+          user,
           incrementBy: recordedCostDelta,
         });
-      }
-
-      // Workspace programmatic cap, for programmatic calls.
-      if (isProgrammaticUsage(auth, { userMessageOrigin: messageOrigin })) {
-        await recordProgrammaticSpendLimitUsage(auth, {
+      } else {
+        await recordUserSpendLimitUsage(auth, {
+          user,
           incrementBy: recordedCostDelta,
+          cycle: spendLimitCycleOverrideForAuth(auth),
         });
       }
+    }
+
+    // Per-API-key cap, for calls authenticated with an API key.
+    const apiKey = auth.key();
+    if (apiKey) {
+      await recordApiKeySpendLimitUsage(auth, {
+        keyModelId: apiKey.id,
+        incrementBy: recordedCostDelta,
+      });
+    }
+
+    // Workspace programmatic cap, for programmatic calls.
+    if (isProgrammaticUsage(auth, { userMessageOrigin: messageOrigin })) {
+      await recordProgrammaticSpendLimitUsage(auth, {
+        incrementBy: recordedCostDelta,
+      });
     }
   }
 

--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -1,10 +1,10 @@
-// Flag-aware access-control readers.
+// Access-control readers for spend enforcement.
 //
-// Each reader switches on the `enforce_user_spend_limit_rate_cap` feature flag:
-// when enabled it enforces from the Redis fixed-window rate-limiter counters,
-// when disabled it falls back to the Metronome credit state in
-// `lib/metronome/user_block.ts`. Usage is recorded into the counters regardless
-// (in credit_cost), so the flag only controls which signal blocks.
+// Per-user, per-API-key and programmatic caps are enforced from the Redis
+// fixed-window rate-limiter counters (usage is recorded into them in
+// credit_cost). Pool depletion, no_seat and the personal-seat carve-out have no
+// rate-limiter dimension and always come from the Metronome pool state in
+// `lib/metronome/user_block.ts`.
 //
 // Callers doing access-control decisions should import from here. The low-level
 // Redis cache getters/setters and the fine-grained status reads still live in
@@ -19,23 +19,13 @@ import {
   isUserSpendLimitRateWarningReached,
 } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
-import { isApiKeyCappedByMetronome } from "@app/lib/metronome/api_key_block";
 import type { UserBlockedReason } from "@app/lib/metronome/user_block";
 import {
   isPoolDepletedByMetronome,
-  isProgrammaticApiBlockedByMetronome,
-  isUserAwuWarnedByMetronome,
   isUserBlockedByMetronome,
-  isWorkspaceProgrammaticWarningReachedByMetronome,
 } from "@app/lib/metronome/user_block";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { ModelId } from "@app/types/shared/model_id";
-
-async function spendLimitRateCapEnabled(auth: Authenticator): Promise<boolean> {
-  const featureFlags = await getFeatureFlags(auth);
-  return featureFlags.includes("enforce_user_spend_limit_rate_cap");
-}
 
 /**
  * Whether the workspace credit pool is depleted (API calls with no per-user
@@ -48,19 +38,16 @@ export async function isPoolDepleted(auth: Authenticator): Promise<boolean> {
 }
 
 /**
- * Whether the user is blocked from sending billable messages, and why. With the
- * rate-cap flag on, the per-user cap comes from the Redis fixed-window counter;
- * the pool part (no_seat, pool depletion, personal-seat carve-out) always comes
- * from the Metronome pool state. With the flag off, both come from Metronome.
+ * Whether the user is blocked from sending billable messages, and why. The
+ * per-user cap comes from the Redis fixed-window counter; the pool part
+ * (no_seat, pool depletion, personal-seat carve-out) comes from the Metronome
+ * pool state.
  */
 export async function isUserBlocked(
   auth: Authenticator,
   user: UserResource
 ): Promise<UserBlockedReason | null> {
   const workspace = auth.getNonNullableWorkspace();
-  if (!(await spendLimitRateCapEnabled(auth))) {
-    return isUserBlockedByMetronome(workspace, user);
-  }
   const userCapBlockedOverride = await isUserSpendLimitRateCapReached(auth, {
     user,
   });
@@ -68,64 +55,44 @@ export async function isUserBlocked(
 }
 
 /**
- * Whether the workspace programmatic monthly cap is reached. With the rate-cap
- * flag on, from the Redis fixed-window counter; with it off, from the
- * Metronome-driven programmatic credit state.
+ * Whether the workspace programmatic monthly cap is reached, from the Redis
+ * fixed-window counter.
  */
 export async function isProgrammaticApiBlocked(
   auth: Authenticator
 ): Promise<boolean> {
-  const workspace = auth.getNonNullableWorkspace();
-  if (!(await spendLimitRateCapEnabled(auth))) {
-    return isProgrammaticApiBlockedByMetronome(workspace.sId);
-  }
   return isProgrammaticSpendLimitRateCapReached(auth);
 }
 
 /**
- * Whether the API key has reached its per-key credit spend cap. With the
- * rate-cap flag on, from the Redis fixed-window counter; with it off, from the
- * Metronome-driven per-key credit state.
+ * Whether the API key has reached its per-key credit spend cap, from the Redis
+ * fixed-window counter.
  */
 export async function isApiKeyBlocked(
   auth: Authenticator,
   { keyModelId }: { keyModelId: ModelId }
 ): Promise<boolean> {
-  const workspace = auth.getNonNullableWorkspace();
-  if (!(await spendLimitRateCapEnabled(auth))) {
-    return isApiKeyCappedByMetronome(workspace.sId, keyModelId);
-  }
   return isApiKeySpendLimitRateCapReached(auth, { keyModelId });
 }
 
 /**
- * Whether the user has consumed ≥ 80% of their per-user cap (soft warning). With
- * the rate-cap flag on, entirely from the Redis fixed-window counters (per-cycle
- * cap for pool seats, lifetime allowance for free seats) — no Metronome
- * fallback. With the flag off, from the Metronome-driven near-limit flag.
+ * Whether the user has consumed ≥ 80% of their per-user cap (soft warning), from
+ * the Redis fixed-window counters (per-cycle cap for pool seats, lifetime
+ * allowance for free seats).
  */
 export async function isUserAwuWarned(
   auth: Authenticator,
   { user }: { user: UserResource }
 ): Promise<boolean> {
-  if (await spendLimitRateCapEnabled(auth)) {
-    return isUserSpendLimitRateWarningReached(auth, { user });
-  }
-  const workspace = auth.getNonNullableWorkspace();
-  return isUserAwuWarnedByMetronome(workspace.sId, user.sId);
+  return isUserSpendLimitRateWarningReached(auth, { user });
 }
 
 /**
  * Whether workspace programmatic usage has crossed 80% of the monthly cap (soft
- * warning). With the rate-cap flag on, from the Redis fixed-window counter; with
- * it off, from the Metronome-driven programmatic warning flag.
+ * warning), from the Redis fixed-window counter.
  */
 export async function isWorkspaceProgrammaticWarningReached(
   auth: Authenticator
 ): Promise<boolean> {
-  const workspace = auth.getNonNullableWorkspace();
-  if (!(await spendLimitRateCapEnabled(auth))) {
-    return isWorkspaceProgrammaticWarningReachedByMetronome(workspace.sId);
-  }
   return isProgrammaticSpendLimitRateWarningReached(auth);
 }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -16,7 +16,6 @@ import {
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
 import {
   microCreditsToCredits,
@@ -1660,25 +1659,18 @@ export async function getMemberUsage({
     defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
-  // Flag-aware per-user cap verdict, consistent with the members table and with
-  // enforcement in lib/api/credits/access_control.ts: under the flag, read the
-  // Redis rate-limiter counter (lifetime allowance for free seats, per-cycle cap
-  // otherwise) with no Metronome fallback; with it off, the persisted Metronome
-  // credit state.
-  const spendCapEnabled = (await getFeatureFlags(auth)).includes(
-    "enforce_user_spend_limit_rate_cap"
-  );
-  const isSpendCapped = spendCapEnabled
-    ? await isUserRateLimiterSpendCapped(auth, {
-        user: userResource,
-        isFreeSeat: membership.seatType === "free",
-        thresholdAwuCredits:
-          membership.seatType === "free"
-            ? freeSeatAllowanceAwu
-            : spendLimitAwuCredits,
-        billingCycle,
-      })
-    : membership.creditState === "capped";
+  // Per-user cap verdict, consistent with the members table and with enforcement
+  // in lib/api/credits/access_control.ts: the Redis rate-limiter counter
+  // (lifetime allowance for free seats, per-cycle cap otherwise).
+  const isSpendCapped = await isUserRateLimiterSpendCapped(auth, {
+    user: userResource,
+    isFreeSeat: membership.seatType === "free",
+    thresholdAwuCredits:
+      membership.seatType === "free"
+        ? freeSeatAllowanceAwu
+        : spendLimitAwuCredits,
+    billingCycle,
+  });
 
   const member: MemberUsageType = {
     sId: userId,
@@ -2345,15 +2337,6 @@ export async function getMembersUsage({
       userIds: memberships.map((m) => m.userId),
     });
 
-  // With the rate-cap flag on, the per-user "near limit" (≥ 80% of the effective
-  // cap) is derived from the Redis rate-limiter counter below; with it off, from
-  // the Metronome near-limit flag. Matches the flag-aware enforcement in
-  // `lib/api/credits/access_control.ts`.
-  const featureFlags = await getFeatureFlags(auth);
-  const spendCapEnabled = featureFlags.includes(
-    "enforce_user_spend_limit_rate_cap"
-  );
-
   // Bulk-fetch Metronome near-limit flags from Redis (poke-only). This backs the
   // "near limit" chip in the Metronome "Credit state" column; the rate-limiter's
   // own verdict is surfaced separately as `rateLimiterState`.
@@ -2378,48 +2361,46 @@ export async function getMembersUsage({
   // seat-usage pace below, so resolve it regardless.
   const rateLimiterSpendByUserId = new Map<string, number>();
   let billingCycle: BillingCycle | null = null;
-  if (includeAlertLinks || spendCapEnabled) {
-    const periodResult = await getCachedMetronomeCurrentBillingPeriod(
-      workspace.sId
-    );
-    if (periodResult.isOk() && periodResult.value) {
-      billingCycle = periodResult.value;
-    }
-    const cycleBounds = billingCycle
-      ? makeSpendLimitCycleWindowBounds(
-          billingCycle.cycleStart,
-          billingCycle.cycleEnd
-        )
-      : null;
-    const lifetimeBounds = makeSpendLimitLifetimeWindowBounds();
-    const entries = await concurrentExecutor(
-      users,
-      async (u) => {
-        const isFreeSeat = membershipByUserId.get(u.id)?.seatType === "free";
-        const key = isFreeSeat
-          ? makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
-              workspace,
-              u.toJSON()
-            )
-          : makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, u.toJSON());
-        const bounds = isFreeSeat ? lifetimeBounds : cycleBounds;
-        if (!bounds) {
-          // Non-free seat with no resolvable contract cycle: nothing to read.
-          return [u.sId, 0] as const;
-        }
-        const result = await getFixedWindowCount({ key, bounds });
-        // The counter stores microCredits; convert back to credits so it
-        // lines up with the ES/MT figures (all in credits).
-        return [
-          u.sId,
-          result.isOk() ? microCreditsToCredits(result.value) : 0,
-        ] as const;
-      },
-      { concurrency: 8 }
-    );
-    for (const [sId, value] of entries) {
-      rateLimiterSpendByUserId.set(sId, value);
-    }
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isOk() && periodResult.value) {
+    billingCycle = periodResult.value;
+  }
+  const cycleBounds = billingCycle
+    ? makeSpendLimitCycleWindowBounds(
+        billingCycle.cycleStart,
+        billingCycle.cycleEnd
+      )
+    : null;
+  const lifetimeBounds = makeSpendLimitLifetimeWindowBounds();
+  const entries = await concurrentExecutor(
+    users,
+    async (u) => {
+      const isFreeSeat = membershipByUserId.get(u.id)?.seatType === "free";
+      const key = isFreeSeat
+        ? makeFreeSeatLifetimeAwuCreditsRateLimitKeyForUser(
+            workspace,
+            u.toJSON()
+          )
+        : makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, u.toJSON());
+      const bounds = isFreeSeat ? lifetimeBounds : cycleBounds;
+      if (!bounds) {
+        // Non-free seat with no resolvable contract cycle: nothing to read.
+        return [u.sId, 0] as const;
+      }
+      const result = await getFixedWindowCount({ key, bounds });
+      // The counter stores microCredits; convert back to credits so it
+      // lines up with the ES/MT figures (all in credits).
+      return [
+        u.sId,
+        result.isOk() ? microCreditsToCredits(result.value) : 0,
+      ] as const;
+    },
+    { concurrency: 8 }
+  );
+  for (const [sId, value] of entries) {
+    rateLimiterSpendByUserId.set(sId, value);
   }
 
   // Bulk-fetch each user's Metronome-side per-user AWU consumption (poke-only),
@@ -2599,11 +2580,11 @@ export async function getMembersUsage({
         : spendLimitSource === "default" && normalizedSeatType
           ? (defaultCapAlertsBySeatType[normalizedSeatType] ?? null)
           : null;
-    // With the rate-cap flag on, the per-user cap / 80%-warning and free-seat
-    // balance Metronome alerts no longer drive enforcement (the Redis rate
-    // limiter does), so their poke badges/deep-links are dropped to avoid
-    // showing signals that are no longer authoritative.
-    const showMetronomeAlerts = includeAlertLinks && !spendCapEnabled;
+    // The per-user cap / 80%-warning and free-seat balance Metronome alerts no
+    // longer drive enforcement (the Redis rate limiter does); their poke
+    // badges/deep-links are kept for now and will be removed with the spend-alert
+    // cleanup. Poke-only.
+    const showMetronomeAlerts = includeAlertLinks;
     const spendLimitAlertId = showMetronomeAlerts
       ? (effectiveCapAlert?.alertId ?? null)
       : null;
@@ -2620,9 +2601,7 @@ export async function getMembersUsage({
         : null;
 
     const rateLimiterSpendAwuCredits =
-      includeAlertLinks || spendCapEnabled
-        ? (rateLimiterSpendByUserId.get(userId) ?? 0)
-        : null;
+      rateLimiterSpendByUserId.get(userId) ?? 0;
     // Poke-only near-limit for the Metronome "Credit state" column, from the
     // Metronome near-limit flag.
     const nearLimit =
@@ -2640,11 +2619,7 @@ export async function getMembersUsage({
         ? freeStartingBalanceAwu
         : effectiveSpendLimitAwuCredits;
     let rateLimiterState: RateLimiterState | null = null;
-    if (
-      (includeAlertLinks || spendCapEnabled) &&
-      rateCapThresholdAwuCredits !== null &&
-      rateCapThresholdAwuCredits > 0
-    ) {
+    if (rateCapThresholdAwuCredits !== null && rateCapThresholdAwuCredits > 0) {
       const spend = rateLimiterSpendAwuCredits ?? 0;
       rateLimiterState =
         spend >= rateCapThresholdAwuCredits
@@ -2654,12 +2629,9 @@ export async function getMembersUsage({
             : "ok";
     }
 
-    // Flag-aware per-user cap verdict for the poke Unblock action: the
-    // rate-limiter counter under the flag, the Metronome credit state otherwise
-    // (mirrors the enforcement switch in lib/api/credits/access_control.ts).
-    const isSpendCapped = spendCapEnabled
-      ? rateLimiterState === "capped"
-      : membership.creditState === "capped";
+    // Per-user cap verdict for the poke Unblock action: the rate-limiter counter
+    // (mirrors enforcement in lib/api/credits/access_control.ts).
+    const isSpendCapped = rateLimiterState === "capped";
 
     // Seat-allowance consumption used for pace classification below: free
     // seats track their live Metronome balance instead of the period spend

--- a/front/lib/api/poke/plugins/workspaces/set_default_user_credit_limit.ts
+++ b/front/lib/api/poke/plugins/workspaces/set_default_user_credit_limit.ts
@@ -3,7 +3,6 @@ import {
   getNonCreditPricedDefaultUserSpendLimit,
   setNonCreditPricedDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -38,8 +37,7 @@ export const setDefaultUserCreditLimitPlugin = createPlugin({
       "AWU credits any single member can spend per calendar month. Applies to " +
       "current and future members — it is a limit per member, not a shared " +
       "workspace pool. Once a member reaches it they cannot send messages until " +
-      "the next month. Enforcement requires the " +
-      "`enforce_user_spend_limit_rate_cap` feature flag.",
+      "the next month.",
     resourceTypes: ["workspaces"],
     args: {
       awuCredits: {
@@ -96,23 +94,11 @@ export const setDefaultUserCreditLimitPlugin = createPlugin({
       });
     }
 
-    // The limit is stored and read regardless, but only enforced where the flag
-    // is on — say so rather than letting an admin believe it is live.
-    const featureFlags = await getFeatureFlags(auth);
-    const enforcementNote = featureFlags.includes(
-      "enforce_user_spend_limit_rate_cap"
-    )
-      ? ""
-      : " Enforcement is OFF for this workspace: enable the " +
-        "`enforce_user_spend_limit_rate_cap` feature flag to block messages " +
-        "once a member reaches their limit.";
-
     return new Ok({
       display: "text",
       value:
         `Every member of ${workspace.name} can now spend up to ` +
-        `${awuCredits.toLocaleString()} AWU credits per calendar ` +
-        `month.${enforcementNote}`,
+        `${awuCredits.toLocaleString()} AWU credits per calendar month.`,
     });
   },
 });

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -96,14 +96,10 @@ export type PokeWorkspaceInfo = {
   defaultAlerts: DefaultMetronomeAlerts;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
-  // Whether the rate-cap enforcement flag is on for this workspace. When true,
-  // the poke programmatic badge must reflect the rate-limiter verdict
-  // (`programmaticRateLimiterState`), not the Metronome `programmaticCreditState`.
-  spendLimitRateCapEnabled: boolean;
-  // The rate-limiter's verdict for the programmatic monthly cap: "capped"
-  // (counter ≥ cap), "near_limit" (≥ 80%), or "ok", from the RL counter vs
-  // `creditUsageConfig.programmaticMonthlyCapAwuCredits`. Null when there's no
-  // cap or the counter couldn't be read. Mirrors the enforcement switch in
+  // The rate-limiter's verdict for the programmatic monthly cap (the poke badge):
+  // "capped" (counter ≥ cap), "near_limit" (≥ 80%), or "ok", from the RL counter
+  // vs `creditUsageConfig.programmaticMonthlyCapAwuCredits`. Null when there's no
+  // cap or the counter couldn't be read. Backs enforcement in
   // `isProgrammaticApiBlocked` (lib/api/credits/access_control.ts).
   programmaticRateLimiterState: RateLimiterState | null;
   // Programmatic spend for the current billing cycle across the three sources,
@@ -196,14 +192,9 @@ export async function getPokeWorkspaceInfo(
       : null;
   }
 
-  // Rate-limiter verdict for the programmatic monthly cap — the badge source
-  // under the flag (the Metronome `programmaticCreditState` must not be read
-  // then). Compare the RL counter to the configured cap; both are in credits
+  // Rate-limiter verdict for the programmatic monthly cap — the poke badge
+  // source. Compare the RL counter to the configured cap; both are in credits
   // here. Mirrors the api-key / member rate-limiter chips.
-  const spendLimitRateCapEnabled = await hasFeatureFlag(
-    auth,
-    "enforce_user_spend_limit_rate_cap"
-  );
   const programmaticCapAwuCredits =
     creditUsageConfig?.programmaticMonthlyCapAwuCredits ?? null;
   let programmaticRateLimiterState: RateLimiterState | null = null;
@@ -330,7 +321,6 @@ export async function getPokeWorkspaceInfo(
     programmaticCreditState: workspaceResource.programmaticCreditState,
     programmaticWarningReached:
       await isWorkspaceProgrammaticWarningReached(auth),
-    spendLimitRateCapEnabled,
     programmaticRateLimiterState,
     programmaticSpendLimitRateCapCount,
     programmaticEsConsumedAwuCredits,

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,10 +1,10 @@
 // Redis fast-path cache for credit-state-driven access control.
 //
-// This is the Metronome-credit-state layer. When the
-// `enforce_user_spend_limit_rate_cap` flag is on, callers should instead go
-// through the flag-aware readers in `lib/api/credits/access_control.ts`, which
-// enforce from the Redis rate-limiter counters and fall back to the functions
-// here when the flag is off.
+// This is the Metronome-credit-state layer. Access-control callers go through
+// `lib/api/credits/access_control.ts`, which enforces spend caps from the Redis
+// rate-limiter counters; the pool/no_seat/personal-seat logic here still backs
+// `isUserBlockedByMetronome` (via a `userCapBlockedOverride`) and
+// `isPoolDepletedByMetronome`.
 //
 // Four keys back the credit state machines:
 //   - `metronome:user_credit_state:<ws>:<user>`: fine-grained user credit state

--- a/front/lib/spend_limits/api_key_cap_status.ts
+++ b/front/lib/spend_limits/api_key_cap_status.ts
@@ -4,7 +4,6 @@ import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getFixedWindowCount } from "@app/lib/utils/rate_limiter";
-import type { ApiKeyCreditState } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 
 // The minimal key shape the verdict needs — kept structural (not `KeyResource`)
@@ -12,31 +11,19 @@ import type { ModelId } from "@app/types/shared/model_id";
 export type ApiKeySpendCapStatusInput = {
   id: ModelId;
   monthlyCapAwuCredits: number | null;
-  creditState: ApiKeyCreditState;
 };
 
 /**
- * The flag-aware per-key "capped" verdict for each of `keys`, keyed by key model
- * id — the signal the keys UI uses to show the "capped" status. Mirrors the
- * enforcement switch in `isApiKeyBlocked` (lib/api/credits/access_control.ts):
- * with the `enforce_user_spend_limit_rate_cap` flag on, the persisted Metronome
- * `creditState` must not be read — the per-key Redis fixed-window counter
- * (compared to the key's cap) is authoritative; with it off, from
- * `creditState === "capped"`. Fails open (not capped) when the flag is on but
+ * The per-key "capped" verdict for each of `keys`, keyed by key model id — the
+ * signal the keys UI uses to show the "capped" status. Mirrors enforcement in
+ * `isApiKeyBlocked` (lib/api/credits/access_control.ts): the per-key Redis
+ * fixed-window counter compared to the key's cap. Fails open (not capped) when
  * the billing cycle can't be resolved or a counter read errors.
  */
 export async function getApiKeysSpendCappedByModelId(
   auth: Authenticator,
   keys: ApiKeySpendCapStatusInput[]
 ): Promise<Map<ModelId, boolean>> {
-  const featureFlags = await auth.getFeatureFlags();
-  const spendCapEnabled = featureFlags.includes(
-    "enforce_user_spend_limit_rate_cap"
-  );
-  if (!spendCapEnabled) {
-    return new Map(keys.map((key) => [key.id, key.creditState === "capped"]));
-  }
-
   const workspace = auth.getNonNullableWorkspace();
   const bounds = await resolveSpendLimitCycleBounds(workspace);
   if (!bounds) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -405,12 +405,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "avervaet",
   },
-  enforce_user_spend_limit_rate_cap: {
-    description:
-      "Enable the Redis fixed-window spend-cap backups (per-user, per-API-key, programmatic, and workspace usage cap): record AWU usage into the counters and enforce them at message send. When off, usage is neither recorded nor enforced.",
-    stage: "ask_owner",
-    owner: "tdraier",
-  },
   enforce_premium_model_message_limit: {
     description:
       "Enforce the premium-model cap: once the user has spent 25 premium-tier messages in the rolling week, run the message on the Standard stream instead, on workspaces with a non-credit-priced (legacy) plan. Usage is counted regardless, so the flag only controls enforcement.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -825,7 +825,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "whitelabel_frames"
   | "user_memory"
   | "similar_agents_check"
-  | "enforce_user_spend_limit_rate_cap"
   | "enforce_premium_model_message_limit"
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"


### PR DESCRIPTION
## Description

Stacked on #31890. Removes the `enforce_user_spend_limit_rate_cap` feature flag entirely and makes the Redis fixed-window rate-limiter the only spend-cap enforcement path for every workspace.

- **`lib/api/credits/access_control.ts`** — every reader (`isUserBlocked`, `isProgrammaticApiBlocked`, `isApiKeyBlocked`, `isUserAwuWarned`, `isWorkspaceProgrammaticWarningReached`) now always uses the rate-limiter counters. Pool depletion / `no_seat` / personal-seat carve-out still come from the Metronome pool state (`isUserBlockedByMetronome` via `userCapBlockedOverride`, `isApiBlockedByMetronome`).
- **`credit_cost.ts`** — usage is always recorded into the counters (no longer flag-gated).
- **`conversation.ts` / `activation/nudge.ts` / `usage-status.ts`** — the non-credit-priced per-user cap always enforces.
- **Poke** — the programmatic badge always shows the rate-limiter verdict; the members / API-key capped verdicts (`members_usage.ts`, `keys/spend_limit.ts`) are always rate-limiter. Metronome alert deep-links in poke are kept for now (removed in the spend-alert cleanup follow-up).
- Flag definition removed from `front/types/shared/feature_flags.ts` **and** `sdks/js/src/types.ts`; the poke default-credit-limit plugin note is updated.

The now-dead Metronome-only cap readers (`isApiKeyCappedByMetronome`, `isProgrammaticApiBlockedByMetronome`, `isWorkspaceProgrammaticWarningReachedByMetronome`) and the `workspace.programmaticCreditState` / `apiKey.creditState` fields are left in place; their removal + spend-alert cleanup is a follow-up PR.

## Tests

- `tsgo --noEmit` clean in `front` and `front-api`; biome clean.
- No remaining references to the flag / `spendCapEnabled`.
- Green: nudge / user_block / spend_limit / key_resource (104), credit_check / credit_cost / programmatic_usage_limit (45), keys / usage-status / upgrade-requests.
- `usage-status.test.ts` migrated to cap members via the rate-limiter lever (`isUserSpendLimitRateCapReached`) instead of `creditState`; obsolete flag setup removed from `nudge.test.ts`.

## Risk

Medium. Changes which signal blocks spend for every workspace to the rate-limiter counters. These counters have been recorded and enforced for flagged workspaces already; this makes that the default. Pool/no_seat/personal-seat behavior is unchanged.

## Deploy Plan

Standard deploy. No migration. After deploy, all workspaces enforce spend caps from the rate-limiter. Follow-up PR removes the now-unused Metronome cap state + alerts.