### PR TITLE
[front] plan mode: move the plan card into the title bar

### DIFF
--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -61,6 +61,7 @@ vi.mock(
     ...(await importOriginal()),
     useConversationSidePanelContext: () => ({
       currentPanel: undefined,
+      isPanelClosing: false,
       openPanel: vi.fn(),
       togglePanel: togglePanelMock,
       closePanel: vi.fn(),

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -155,9 +155,11 @@ export function ConversationSidePanelProvider({
     }
   }, [panelRef, onPanelClosed]);
 
-  // Shared selection; `toggle` decides whether re-selecting the shown panel closes it.
+  // Shared selection; `toggle` decides whether re-selecting the shown panel closes it. A panel
+  // that is already closing reads as unselected, so re-selecting it reopens instead.
   const applyPanel = useCallback(
     (params: OpenPanelParams, { toggle }: { toggle: boolean }) => {
+      const closeOnReselect = toggle && !isPanelClosing;
       setIsPanelClosing(false);
       setCurrentPanel(params.type);
 
@@ -168,7 +170,7 @@ export function ConversationSidePanelProvider({
             : params.messageId;
 
           // A different message/action switches content; only the same data toggles closed.
-          if (toggle && newData === data) {
+          if (closeOnReselect && newData === data) {
             closePanel();
             return;
           }
@@ -189,7 +191,7 @@ export function ConversationSidePanelProvider({
           break;
 
         case FILES_SIDE_PANEL_TYPE:
-          if (toggle && currentPanel === FILES_SIDE_PANEL_TYPE) {
+          if (closeOnReselect && currentPanel === FILES_SIDE_PANEL_TYPE) {
             closePanel();
             return;
           }
@@ -197,7 +199,7 @@ export function ConversationSidePanelProvider({
           break;
 
         case CREDITS_SIDE_PANEL_TYPE:
-          if (toggle && currentPanel === CREDITS_SIDE_PANEL_TYPE) {
+          if (closeOnReselect && currentPanel === CREDITS_SIDE_PANEL_TYPE) {
             closePanel();
             return;
           }
@@ -205,7 +207,7 @@ export function ConversationSidePanelProvider({
           break;
 
         case PLAN_SIDE_PANEL_TYPE:
-          if (toggle && currentPanel === PLAN_SIDE_PANEL_TYPE) {
+          if (closeOnReselect && currentPanel === PLAN_SIDE_PANEL_TYPE) {
             closePanel();
             return;
           }
@@ -214,7 +216,7 @@ export function ConversationSidePanelProvider({
 
         case SKILL_SIDE_PANEL_TYPE:
           // A different skill switches content; only the same skill toggles closed.
-          if (toggle && params.skillId === data) {
+          if (closeOnReselect && params.skillId === data) {
             closePanel();
             return;
           }
@@ -229,7 +231,7 @@ export function ConversationSidePanelProvider({
       // changes, so a close→reopen race (same value) wouldn't re-run it. No-op on mobile.
       panelRef.current?.expand(getDefaultRightPanelSize(params.type));
     },
-    [setCurrentPanel, setData, data, closePanel, currentPanel]
+    [setCurrentPanel, setData, data, closePanel, currentPanel, isPanelClosing]
   );
 
   // Idempotent open for programmatic callers: a toggle could mis-close during a close→reopen

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -61,6 +61,10 @@ const isSupportedPanelType = (
 
 interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
+  // True between closePanel() and the end of the collapse transition. `currentPanel` keeps the
+  // old value meanwhile so the panel content does not flicker; toggles read this to unselect
+  // right away.
+  isPanelClosing: boolean;
   openPanel: (params: OpenPanelParams) => void;
   togglePanel: (params: OpenPanelParams) => void;
   closePanel: () => void;
@@ -117,6 +121,7 @@ export function ConversationSidePanelProvider({
   const previousConversationIdRef = React.useRef(activeConversationId);
 
   const panelRef = React.useRef<ImperativePanelHandle | null>(null);
+  const [isPanelClosing, setIsPanelClosing] = React.useState(false);
   const [virtuosoMsg, setVirtuosoMsg] =
     React.useState<AgentMessageWithStreaming | null>(null);
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -130,6 +135,7 @@ export function ConversationSidePanelProvider({
   // This should be called once the closing animation is done (onTransitionEnd)
   // so you won't have content flickering
   const onPanelClosed = useCallback(() => {
+    setIsPanelClosing(false);
     setData(undefined);
     setCurrentPanel(undefined);
   }, [setData, setCurrentPanel]);
@@ -137,6 +143,11 @@ export function ConversationSidePanelProvider({
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const closePanel = useCallback(() => {
     if (panelRef && panelRef.current) {
+      // Only flag a real collapse: on an already collapsed panel no transition runs, so
+      // onPanelClosed would never clear the flag.
+      if (!panelRef.current.isCollapsed()) {
+        setIsPanelClosing(true);
+      }
       panelRef.current.collapse();
     } else {
       // in case there is no ref found (agent builder preview), close the panel directly
@@ -147,6 +158,7 @@ export function ConversationSidePanelProvider({
   // Shared selection; `toggle` decides whether re-selecting the shown panel closes it.
   const applyPanel = useCallback(
     (params: OpenPanelParams, { toggle }: { toggle: boolean }) => {
+      setIsPanelClosing(false);
       setCurrentPanel(params.type);
 
       switch (params.type) {
@@ -265,6 +277,7 @@ export function ConversationSidePanelProvider({
       currentPanel: isSupportedPanelType(currentPanel)
         ? currentPanel
         : undefined,
+      isPanelClosing,
       openPanel,
       togglePanel,
       closePanel,
@@ -277,6 +290,7 @@ export function ConversationSidePanelProvider({
     }),
     [
       currentPanel,
+      isPanelClosing,
       openPanel,
       togglePanel,
       closePanel,

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -76,8 +76,8 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     ? getConversationDisplayTitle(conversation)
     : "";
   // Side panel toggles read as filter chips: primary while their panel is open.
-  const panelChipVariant = (type: ConversationSidePanelType) =>
-    currentPanel === type && !isPanelClosing ? "primary" : "ghost";
+  const isPanelSelected = (type: ConversationSidePanelType) =>
+    currentPanel === type && !isPanelClosing;
 
   if (!activeConversationId) {
     return null;
@@ -192,14 +192,20 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             size="xs"
             label={isMobile ? undefined : "Credit usage"}
             icon={CoinsStacked01}
-            variant={panelChipVariant(CREDITS_SIDE_PANEL_TYPE)}
+            variant={
+              isPanelSelected(CREDITS_SIDE_PANEL_TYPE) ? "primary" : "ghost"
+            }
+            aria-pressed={isPanelSelected(CREDITS_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: CREDITS_SIDE_PANEL_TYPE })}
           />
           <Button
             size="xs"
             label={isMobile ? undefined : "Files"}
             icon={Folder}
-            variant={panelChipVariant(FILES_SIDE_PANEL_TYPE)}
+            variant={
+              isPanelSelected(FILES_SIDE_PANEL_TYPE) ? "primary" : "ghost"
+            }
+            aria-pressed={isPanelSelected(FILES_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: FILES_SIDE_PANEL_TYPE })}
           />
           <PlanPanelButton

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -4,6 +4,7 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { EditConversationTitleDialog } from "@app/components/assistant/conversation/EditConversationTitleDialog";
+import { PlanPanelButton } from "@app/components/assistant/conversation/plan_mode/PlanPanelButton";
 import { getParentConversationTitleLabel } from "@app/components/assistant/conversation/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversation } from "@app/hooks/conversations";
@@ -191,6 +192,11 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             icon={Folder}
             variant="ghost"
             onClick={() => togglePanel({ type: "files" })}
+          />
+          <PlanPanelButton
+            key={activeConversationId}
+            conversationId={activeConversationId}
+            workspaceId={owner.sId}
           />
           <ConversationMenu
             activeConversationId={activeConversationId}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -4,7 +4,7 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { EditConversationTitleDialog } from "@app/components/assistant/conversation/EditConversationTitleDialog";
-import { PlanPanelButton } from "@app/components/assistant/conversation/plan_mode/PlanPanelButton";
+import { PlanPanelChip } from "@app/components/assistant/conversation/plan_mode/PlanPanelChip";
 import { getParentConversationTitleLabel } from "@app/components/assistant/conversation/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversation } from "@app/hooks/conversations";
@@ -205,7 +205,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             isSelected={isPanelSelected(FILES_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: FILES_SIDE_PANEL_TYPE })}
           />
-          <PlanPanelButton
+          <PlanPanelChip
             key={activeConversationId}
             conversationId={activeConversationId}
             workspaceId={owner.sId}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -33,6 +33,7 @@ import {
   Chip,
   CoinsStacked01,
   DotsHorizontal,
+  FilterChip,
   Folder,
   GitBranch01,
   Tooltip,
@@ -75,7 +76,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const currentTitle = conversation
     ? getConversationDisplayTitle(conversation)
     : "";
-  // Side panel toggles read as filter chips: primary while their panel is open.
+  // Side panel toggles are filter chips, selected while their panel is open.
   const isPanelSelected = (type: ConversationSidePanelType) =>
     currentPanel === type && !isPanelClosing;
 
@@ -188,24 +189,20 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           currentTitle={currentTitle}
         />
         <div className="flex items-center gap-2">
-          <Button
-            size="xs"
+          <FilterChip
             label={isMobile ? undefined : "Credit usage"}
+            tooltip={isMobile ? "Credit usage" : undefined}
             icon={CoinsStacked01}
-            variant={
-              isPanelSelected(CREDITS_SIDE_PANEL_TYPE) ? "primary" : "ghost"
-            }
-            aria-pressed={isPanelSelected(CREDITS_SIDE_PANEL_TYPE)}
+            variant="secondary"
+            isSelected={isPanelSelected(CREDITS_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: CREDITS_SIDE_PANEL_TYPE })}
           />
-          <Button
-            size="xs"
+          <FilterChip
             label={isMobile ? undefined : "Files"}
+            tooltip={isMobile ? "Files" : undefined}
             icon={Folder}
-            variant={
-              isPanelSelected(FILES_SIDE_PANEL_TYPE) ? "primary" : "ghost"
-            }
-            aria-pressed={isPanelSelected(FILES_SIDE_PANEL_TYPE)}
+            variant="secondary"
+            isSelected={isPanelSelected(FILES_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: FILES_SIDE_PANEL_TYPE })}
           />
           <PlanPanelButton

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -19,6 +19,10 @@ import {
   getPodRoute,
 } from "@app/lib/utils/router";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
+import {
+  CREDITS_SIDE_PANEL_TYPE,
+  FILES_SIDE_PANEL_TYPE,
+} from "@app/types/conversation_side_panel";
 import type { WorkspaceType } from "@app/types/user";
 import type { BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
@@ -41,7 +45,7 @@ const MOBILE_FORKED_TITLE_TRUNCATE_LENGTH = 35;
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
   const { user } = useAuth();
-  const { togglePanel } = useConversationSidePanelContext();
+  const { currentPanel, togglePanel } = useConversationSidePanelContext();
   const { conversation } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
@@ -179,19 +183,24 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           currentTitle={currentTitle}
         />
         <div className="flex items-center gap-2">
+          {/* Side panel toggles read as filter chips: primary while their panel is open. */}
           <Button
-            size="sm"
+            size="xs"
             label={isMobile ? undefined : "Credit usage"}
             icon={CoinsStacked01}
-            variant="ghost"
-            onClick={() => togglePanel({ type: "credits" })}
+            variant={
+              currentPanel === CREDITS_SIDE_PANEL_TYPE ? "primary" : "ghost"
+            }
+            onClick={() => togglePanel({ type: CREDITS_SIDE_PANEL_TYPE })}
           />
           <Button
-            size="sm"
+            size="xs"
             label={isMobile ? undefined : "Files"}
             icon={Folder}
-            variant="ghost"
-            onClick={() => togglePanel({ type: "files" })}
+            variant={
+              currentPanel === FILES_SIDE_PANEL_TYPE ? "primary" : "ghost"
+            }
+            onClick={() => togglePanel({ type: FILES_SIDE_PANEL_TYPE })}
           />
           <PlanPanelButton
             key={activeConversationId}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -19,6 +19,7 @@ import {
   getPodRoute,
 } from "@app/lib/utils/router";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
+import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   CREDITS_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
@@ -45,7 +46,8 @@ const MOBILE_FORKED_TITLE_TRUNCATE_LENGTH = 35;
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
   const { user } = useAuth();
-  const { currentPanel, togglePanel } = useConversationSidePanelContext();
+  const { currentPanel, isPanelClosing, togglePanel } =
+    useConversationSidePanelContext();
   const { conversation } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
@@ -73,6 +75,9 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const currentTitle = conversation
     ? getConversationDisplayTitle(conversation)
     : "";
+  // Side panel toggles read as filter chips: primary while their panel is open.
+  const panelChipVariant = (type: ConversationSidePanelType) =>
+    currentPanel === type && !isPanelClosing ? "primary" : "ghost";
 
   if (!activeConversationId) {
     return null;
@@ -183,23 +188,18 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           currentTitle={currentTitle}
         />
         <div className="flex items-center gap-2">
-          {/* Side panel toggles read as filter chips: primary while their panel is open. */}
           <Button
             size="xs"
             label={isMobile ? undefined : "Credit usage"}
             icon={CoinsStacked01}
-            variant={
-              currentPanel === CREDITS_SIDE_PANEL_TYPE ? "primary" : "ghost"
-            }
+            variant={panelChipVariant(CREDITS_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: CREDITS_SIDE_PANEL_TYPE })}
           />
           <Button
             size="xs"
             label={isMobile ? undefined : "Files"}
             icon={Folder}
-            variant={
-              currentPanel === FILES_SIDE_PANEL_TYPE ? "primary" : "ghost"
-            }
+            variant={panelChipVariant(FILES_SIDE_PANEL_TYPE)}
             onClick={() => togglePanel({ type: FILES_SIDE_PANEL_TYPE })}
           />
           <PlanPanelButton

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1056,7 +1056,7 @@ export const ConversationViewer = ({
             break;
           case "plan_updated": {
             // The acting client already updates via the per-message plan tool action; this handles
-            // cross-client propagation (e.g. another viewer) and is a backstop. PlanCard opens/closes
+            // cross-client propagation (e.g. another viewer) and is a backstop. PlanPanelButton opens/closes
             // the panel in reaction to the content change.
             const planKey = planFileKey({
               workspaceId: owner.sId,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1056,7 +1056,7 @@ export const ConversationViewer = ({
             break;
           case "plan_updated": {
             // The acting client already updates via the per-message plan tool action; this handles
-            // cross-client propagation (e.g. another viewer) and is a backstop. PlanPanelButton opens/closes
+            // cross-client propagation (e.g. another viewer) and is a backstop. PlanPanelChip opens/closes
             // the panel in reaction to the content change.
             const planKey = planFileKey({
               workspaceId: owner.sId,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -14,7 +14,6 @@ import {
   INPUT_BAR_COMPACT_PILL_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
-import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
   useAddDeleteConversationTool,
   useConversationTools,
@@ -686,10 +685,6 @@ export const InputBar = React.memo(function InputBar({
       )}
     >
       <InputBarUsageBanner owner={owner} />
-      <PlanCard
-        conversationId={conversation?.sId ?? null}
-        workspaceId={owner.sId}
-      />
       <div
         onAnimationEnd={() => setIsShaking(false)}
         onClick={(e) => {

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -1,10 +1,13 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { extractPlanTitle } from "@app/components/assistant/conversation/plan_mode/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
+import {
+  useClosePlan,
+  usePlanFile,
+} from "@app/hooks/conversations/usePlanFile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Markdown, Spinner, XClose } from "@dust-tt/sparkle";
+import { Button, Markdown, Spinner, Trash04, XClose } from "@dust-tt/sparkle";
 
 interface ConversationPlanModePanelProps {
   conversation: ConversationWithoutContentType;
@@ -20,6 +23,10 @@ export function ConversationPlanModePanel({
     conversationId: conversation.sId,
     workspaceId: owner.sId,
   });
+  const { closePlan, isClosing } = useClosePlan({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+  });
 
   const title = extractPlanTitle(content);
 
@@ -32,12 +39,24 @@ export function ConversationPlanModePanel({
               Plan: {title}
             </span>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={closePanel}
-            icon={XClose}
-          />
+          <div className="flex items-center gap-1">
+            {content && (
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={Trash04}
+                tooltip="Close plan"
+                isLoading={isClosing}
+                onClick={() => void closePlan()}
+              />
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={closePanel}
+              icon={XClose}
+            />
+          </div>
         </div>
       </AppLayoutTitle>
       <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">

--- a/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
@@ -32,8 +32,10 @@ export function PlanPanelButton({
   const { currentPanel, isPanelClosing, openPanel, togglePanel, closePanel } =
     useConversationSidePanelContext();
   const isMobile = useIsMobile();
-  const isPlanPanelOpen =
-    currentPanel === PLAN_SIDE_PANEL_TYPE && !isPanelClosing;
+  const isPlanPanelOpen = currentPanel === PLAN_SIDE_PANEL_TYPE;
+  // The chip unselects as soon as the panel starts closing; the decision below keeps seeing the
+  // panel as open until it is gone.
+  const isChipSelected = isPlanPanelOpen && !isPanelClosing;
 
   // Single owner of the plan panel: open when the plan appears, close when it goes away. Driving
   // this off `content` (not a specific event) keeps it correct however the change arrived (live
@@ -77,11 +79,11 @@ export function PlanPanelButton({
   return (
     <Button
       size="xs"
-      variant={isPlanPanelOpen ? "primary" : "ghost"}
+      variant={isChipSelected ? "primary" : "ghost"}
       icon={ListSelect}
       label={isMobile ? undefined : label}
       tooltip={isMobile ? label : undefined}
-      aria-pressed={isPlanPanelOpen}
+      aria-pressed={isChipSelected}
       onClick={() => togglePanel({ type: PLAN_SIDE_PANEL_TYPE })}
     />
   );

--- a/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
@@ -29,10 +29,11 @@ export function PlanPanelButton({
     conversationId: isPlanModeEnabled ? conversationId : null,
     workspaceId,
   });
-  const { currentPanel, openPanel, togglePanel, closePanel } =
+  const { currentPanel, isPanelClosing, openPanel, togglePanel, closePanel } =
     useConversationSidePanelContext();
   const isMobile = useIsMobile();
-  const isPlanPanelOpen = currentPanel === PLAN_SIDE_PANEL_TYPE;
+  const isPlanPanelOpen =
+    currentPanel === PLAN_SIDE_PANEL_TYPE && !isPanelClosing;
 
   // Single owner of the plan panel: open when the plan appears, close when it goes away. Driving
   // this off `content` (not a specific event) keeps it correct however the change arrived (live

--- a/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
@@ -8,7 +8,7 @@ import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { PLAN_SIDE_PANEL_TYPE } from "@app/types/conversation_side_panel";
-import { Button, ListSelect } from "@dust-tt/sparkle";
+import { FilterChip, ListSelect } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 interface PlanPanelButtonProps {
@@ -75,15 +75,13 @@ export function PlanPanelButton({
   const label =
     progress.total > 0 ? `Plan ${progress.done}/${progress.total}` : "Plan";
 
-  // Filter chip look, like the other side panel toggles in the title bar.
   return (
-    <Button
-      size="xs"
-      variant={isChipSelected ? "primary" : "ghost"}
-      icon={ListSelect}
+    <FilterChip
       label={isMobile ? undefined : label}
       tooltip={isMobile ? label : undefined}
-      aria-pressed={isChipSelected}
+      icon={ListSelect}
+      variant="secondary"
+      isSelected={isChipSelected}
       onClick={() => togglePanel({ type: PLAN_SIDE_PANEL_TYPE })}
     />
   );

--- a/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
@@ -2,32 +2,25 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import type { PlanPresence } from "@app/components/assistant/conversation/plan_mode/utils";
 import {
   countProgress,
-  extractPlanTitle,
   planPanelDecision,
 } from "@app/components/assistant/conversation/plan_mode/utils";
-import {
-  useClosePlan,
-  usePlanFile,
-} from "@app/hooks/conversations/usePlanFile";
+import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
-import {
-  ContentMessageAction,
-  ContentMessageInline,
-  ListSelect,
-  Trash04,
-} from "@dust-tt/sparkle";
-import React, { useEffect, useMemo, useRef } from "react";
+import { Button, ListSelect } from "@dust-tt/sparkle";
+import { useEffect, useMemo, useRef } from "react";
 
-interface PlanCardProps {
-  conversationId: string | null;
+interface PlanPanelButtonProps {
+  conversationId: string;
   workspaceId: string;
 }
 
-export const PlanCard = React.memo(function PlanCard({
+// Title bar entry point for the plan panel: shows progress and toggles the panel. Mount it keyed
+// by conversation so the presence tracking below restarts on navigation.
+export function PlanPanelButton({
   conversationId,
   workspaceId,
-}: PlanCardProps) {
+}: PlanPanelButtonProps) {
   const { hasFeature } = useFeatureFlags();
   const isPlanModeEnabled = hasFeature("plan_mode");
   const { content, isPlanLoading } = usePlanFile({
@@ -38,22 +31,19 @@ export const PlanCard = React.memo(function PlanCard({
   const { currentPanel, openPanel, togglePanel, closePanel } =
     useConversationSidePanelContext();
   const isMobile = useIsMobile();
-  const { closePlan, isClosing } = useClosePlan({
-    workspaceId,
-    conversationId,
-  });
+  const isPlanPanelOpen = currentPanel === "plan";
 
   // Single owner of the plan panel: open when the plan appears, close when it goes away. Driving
   // this off `content` (not a specific event) keeps it correct however the change arrived (live
   // action event, cross-client `plan_updated`, reconnect refetch). Must stay above the early return
-  // so the close transition is observed when the card unmounts its content.
+  // so the close transition is observed when the button unmounts its content.
   const planPresenceRef = useRef<PlanPresence>("unknown");
   useEffect(() => {
     const { next, action } = planPanelDecision({
       isLoading: isPlanLoading,
       hasContent: !!content,
       isMobile,
-      isPanelOpen: currentPanel === "plan",
+      isPanelOpen: isPlanPanelOpen,
       prev: planPresenceRef.current,
     });
     planPresenceRef.current = next;
@@ -62,9 +52,8 @@ export const PlanCard = React.memo(function PlanCard({
     } else if (action === "close") {
       closePanel();
     }
-  }, [content, isMobile, isPlanLoading, currentPanel, openPanel, closePanel]);
+  }, [content, isMobile, isPlanLoading, isPlanPanelOpen, openPanel, closePanel]);
 
-  const title = useMemo(() => extractPlanTitle(content), [content]);
   const progress = useMemo(() => countProgress(content), [content]);
 
   // No active plan (including post-close): `getActivePlanContent` returns null.
@@ -72,33 +61,19 @@ export const PlanCard = React.memo(function PlanCard({
     return null;
   }
 
+  const label =
+    progress.total > 0 ? `Plan ${progress.done}/${progress.total}` : "Plan";
+
   return (
-    <ContentMessageInline
+    <Button
+      size="sm"
+      variant="ghost"
       icon={ListSelect}
-      variant="outline"
-      className="mb-3 flex w-full bg-background"
-    >
-      <button
-        type="button"
-        onClick={() => togglePanel({ type: "plan" })}
-        className="flex w-full min-w-0 items-center gap-2 text-left"
-      >
-        <span className="min-w-0 truncate text-foreground">{title}</span>
-        {progress.total > 0 && (
-          <span className="shrink-0">
-            {progress.done}/{progress.total} done
-          </span>
-        )}
-      </button>
-      <ContentMessageAction
-        icon={Trash04}
-        variant="ghost"
-        size="xs"
-        tooltip="Close plan"
-        isLoading={isClosing}
-        className="text-muted-foreground"
-        onClick={() => void closePlan()}
-      />
-    </ContentMessageInline>
+      label={isMobile ? undefined : label}
+      tooltip={isMobile ? label : undefined}
+      aria-pressed={isPlanPanelOpen}
+      className={isPlanPanelOpen ? "bg-foreground/[0.06]" : undefined}
+      onClick={() => togglePanel({ type: "plan" })}
+    />
   );
-});
+}

--- a/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanPanelButton.tsx
@@ -7,6 +7,7 @@ import {
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { PLAN_SIDE_PANEL_TYPE } from "@app/types/conversation_side_panel";
 import { Button, ListSelect } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
@@ -31,7 +32,7 @@ export function PlanPanelButton({
   const { currentPanel, openPanel, togglePanel, closePanel } =
     useConversationSidePanelContext();
   const isMobile = useIsMobile();
-  const isPlanPanelOpen = currentPanel === "plan";
+  const isPlanPanelOpen = currentPanel === PLAN_SIDE_PANEL_TYPE;
 
   // Single owner of the plan panel: open when the plan appears, close when it goes away. Driving
   // this off `content` (not a specific event) keeps it correct however the change arrived (live
@@ -48,11 +49,18 @@ export function PlanPanelButton({
     });
     planPresenceRef.current = next;
     if (action === "open") {
-      openPanel({ type: "plan" });
+      openPanel({ type: PLAN_SIDE_PANEL_TYPE });
     } else if (action === "close") {
       closePanel();
     }
-  }, [content, isMobile, isPlanLoading, isPlanPanelOpen, openPanel, closePanel]);
+  }, [
+    content,
+    isMobile,
+    isPlanLoading,
+    isPlanPanelOpen,
+    openPanel,
+    closePanel,
+  ]);
 
   const progress = useMemo(() => countProgress(content), [content]);
 
@@ -64,16 +72,16 @@ export function PlanPanelButton({
   const label =
     progress.total > 0 ? `Plan ${progress.done}/${progress.total}` : "Plan";
 
+  // Filter chip look, like the other side panel toggles in the title bar.
   return (
     <Button
-      size="sm"
-      variant="ghost"
+      size="xs"
+      variant={isPlanPanelOpen ? "primary" : "ghost"}
       icon={ListSelect}
       label={isMobile ? undefined : label}
       tooltip={isMobile ? label : undefined}
       aria-pressed={isPlanPanelOpen}
-      className={isPlanPanelOpen ? "bg-foreground/[0.06]" : undefined}
-      onClick={() => togglePanel({ type: "plan" })}
+      onClick={() => togglePanel({ type: PLAN_SIDE_PANEL_TYPE })}
     />
   );
 }

--- a/front/components/assistant/conversation/plan_mode/PlanPanelChip.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanPanelChip.tsx
@@ -11,17 +11,17 @@ import { PLAN_SIDE_PANEL_TYPE } from "@app/types/conversation_side_panel";
 import { FilterChip, ListSelect } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
-interface PlanPanelButtonProps {
+interface PlanPanelChipProps {
   conversationId: string;
   workspaceId: string;
 }
 
 // Title bar entry point for the plan panel: shows progress and toggles the panel. Mount it keyed
 // by conversation so the presence tracking below restarts on navigation.
-export function PlanPanelButton({
+export function PlanPanelChip({
   conversationId,
   workspaceId,
-}: PlanPanelButtonProps) {
+}: PlanPanelChipProps) {
   const { hasFeature } = useFeatureFlags();
   const isPlanModeEnabled = hasFeature("plan_mode");
   const { content, isPlanLoading } = usePlanFile({

--- a/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
+++ b/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
@@ -10,7 +10,8 @@ export interface PlanUpdatedDeps {
 }
 
 // Reacts to a `plan_updated` event: on close, drop the cache to null; on create/edit, revalidate.
-// Opening and closing the panel is owned by PlanCard, which reacts to the resulting content change.
+// Opening and closing the panel is owned by PlanPanelButton, which reacts to the resulting content
+// change.
 // Pulled out of ConversationViewer to be unit-testable.
 export function handlePlanUpdatedEvent(
   event: PlanUpdatedEvent,

--- a/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
+++ b/front/components/assistant/conversation/plan_mode/handle_plan_updated.ts
@@ -10,7 +10,7 @@ export interface PlanUpdatedDeps {
 }
 
 // Reacts to a `plan_updated` event: on close, drop the cache to null; on create/edit, revalidate.
-// Opening and closing the panel is owned by PlanPanelButton, which reacts to the resulting content
+// Opening and closing the panel is owned by PlanPanelChip, which reacts to the resulting content
 // change.
 // Pulled out of ConversationViewer to be unit-testable.
 export function handlePlanUpdatedEvent(

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -191,6 +191,7 @@ describe("getFilePreviewPlugin", () => {
       <ConversationSidePanelContext.Provider
         value={{
           currentPanel: undefined,
+          isPanelClosing: false,
           openPanel,
           togglePanel: vi.fn(),
           closePanel: vi.fn(),


### PR DESCRIPTION
## Description

Goal: make the plan mode pretty so we can ship 💅🏻 
Follow-up to #31873 and #31874.

The plan card above the composer is gone. The title bar gets a `Plan 4/5` chip next to Credits and Files that toggles the plan panel, like in the design prototype. The three of them are `FilterChip variant="secondary"` (#31903), selected while their panel is open.

The chip stayed selected during the whole closing animation because `currentPanel` only clears once the panel has collapsed. The side panel context now exposes `isPanelClosing` and the chips use it to unselect right away.

The card was the only way to close a plan, so the trash moved to the plan panel header. The auto open/close logic moved to the chip as is, keyed by conversation so opening a conversation that already has a plan no longer pops the panel.


## Tests

Locally, and on a review app https://pr-31895-merge--app.preview.dust.tt/w/0ec9852c2f/conversation/HE3JRv9LzO#?spid=plan&spt=plan

## Deployments

Deploy front. 
