### PR TITLE
admin governance: end space memberships instead of suspending them

### DIFF
--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -90,7 +90,7 @@ export function CreateOrEditSpaceModal({
   const { spaceInfo, mutateSpaceInfo, isSpaceInfoLoading } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId: space?.sId ?? null,
-    includeAllMembers: true, // Always include all members so we can see suspended ones when switching modes
+    includeAllMembers: true, // Include members whose membership is not active yet.
   });
 
   const { groups } = useGroups({

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -78,7 +78,8 @@ export function RestrictedAccessBody({
         title: "Switch to groups",
         message:
           "This switches from manual member to group-based access. " +
-          "Your current member list will be saved but no longer active.",
+          "Your current member list will be removed; you'll need to re-add " +
+          "members to switch back.",
         validateLabel: "Confirm",
         validateVariant: "primary",
       });

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -476,10 +476,10 @@ describe("GroupResource", () => {
     });
   });
 
-  describe("suspendMembers", () => {
-    it("suspends active members and returns affected user IDs", async () => {
+  describe("endAllMemberships", () => {
+    it("ends active memberships and returns affected user IDs", async () => {
       const regularGroup = await GroupResource.makeNew({
-        name: "Suspend Test Group",
+        name: "End Memberships Test Group",
         workspaceId: workspace.id,
         kind: "regular_auto",
       });
@@ -494,10 +494,10 @@ describe("GroupResource", () => {
           workspaceId: workspace.id,
         },
       });
-      expect(membership?.status).toBe("active");
+      expect(membership?.endAt).toBeNull();
 
       const affectedUserIds =
-        await regularGroup.dangerouslySuspendMembers(authenticator);
+        await regularGroup.dangerouslyEndAllMemberships(authenticator);
 
       expect(affectedUserIds).toContain(user.id);
 
@@ -508,7 +508,26 @@ describe("GroupResource", () => {
           workspaceId: workspace.id,
         },
       });
-      expect(updatedMembership?.status).toBe("suspended");
+      // Ended, not suspended: the membership must not be restorable.
+      expect(updatedMembership?.endAt).not.toBeNull();
+      expect(updatedMembership?.status).toBe("active");
+      expect(await regularGroup.getActiveMembers(authenticator)).toEqual([]);
+    });
+
+    it("does not leave the user in the group after a restore", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "End Then Restore Test Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      await regularGroup.dangerouslyEndAllMemberships(authenticator);
+      await regularGroup.dangerouslyRestoreMembers(authenticator);
+
+      expect(await regularGroup.getActiveMembers(authenticator)).toEqual([]);
     });
 
     it("invalidates cache for all affected users", async () => {
@@ -525,11 +544,20 @@ describe("GroupResource", () => {
       const cacheKey = getCacheKeyForUser(user.id, workspace.id);
       expect(inMemoryCache.has(cacheKey)).toBe(true);
 
-      await regularGroup.dangerouslySuspendMembers(authenticator);
+      await regularGroup.dangerouslyEndAllMemberships(authenticator);
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
     });
   });
+
+  // Suspended memberships are only left over from the former management-mode switch; nothing
+  // creates them any more, so the tests below suspend the row by hand.
+  async function suspendMemberships(group: GroupResource) {
+    await GroupMembershipModel.update(
+      { status: "suspended" },
+      { where: { groupId: group.id, workspaceId: workspace.id } }
+    );
+  }
 
   describe("restoreMembers", () => {
     it("restores suspended members and returns affected user IDs", async () => {
@@ -542,7 +570,7 @@ describe("GroupResource", () => {
         users: [user.toJSON()],
       });
 
-      await regularGroup.dangerouslySuspendMembers(authenticator);
+      await suspendMemberships(regularGroup);
       const suspendedMembership = await GroupMembershipModel.findOne({
         where: {
           groupId: regularGroup.id,
@@ -577,7 +605,7 @@ describe("GroupResource", () => {
         users: [user.toJSON()],
       });
 
-      await regularGroup.dangerouslySuspendMembers(authenticator);
+      await suspendMemberships(regularGroup);
 
       await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
       const cacheKey = getCacheKeyForUser(user.id, workspace.id);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1984,22 +1984,24 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
-   * Suspends all active members of this group.
+   * Ends all active memberships of this group, exactly as removing every member would.
    * Returns array of affected user ModelIds.
    *
-   * Only regular_auto group members can be suspended: it is how a space keeps its
-   * manual members on record while it runs in group management mode.
+   * Only regular_auto groups: it is how a space clears its manual members when it switches to
+   * group management mode. Memberships used to be suspended (kept on record but inert) so that
+   * the switch could be undone; they are now ended, so the manual member list does not come back
+   * when the space switches back to manual mode.
    *
    * Dangerous: no permission check — the owning space authorizes the
    * management-mode switch.
    */
-  async dangerouslySuspendMembers(
+  async dangerouslyEndAllMemberships(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<ModelId[]> {
     assert(
       this.isRegularAuto(),
-      `You can't suspend members of ${this.kind} groups.`
+      `You can't end the memberships of ${this.kind} groups.`
     );
     const workspaceId = auth.getNonNullableWorkspace().id;
 
@@ -2018,8 +2020,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       ...new Set(affectedMemberships.map((m) => m.userId)),
     ];
 
+    // Same mutation as `dangerouslyRemoveMembers`: `endAt` set in the past, `status` untouched.
     await GroupMembershipModel.update(
-      { status: "suspended" },
+      { endAt: new Date() },
       {
         where: {
           groupId: this.id,
@@ -2164,9 +2167,14 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Restores all suspended members of this group.
    * Returns array of affected user ModelIds.
    *
-   * Counterpart of `dangerouslySuspendMembers`, so regular_auto only, and
-   * dangerous for the same reason: no permission check, the owning space
-   * authorizes the switch.
+   * Transitional: nothing suspends memberships any more (a space switching to group management
+   * mode ends them, see `dangerouslyEndAllMemberships`), so this only reactivates the rows left
+   * suspended by the previous behaviour. It becomes a no-op once the backfill
+   * (`20260904_end_suspended_group_memberships`) has run, and is removed with the `status`
+   * column.
+   *
+   * regular_auto only, and dangerous for the same reason as its former counterpart: no
+   * permission check, the owning space authorizes the switch.
    */
   async dangerouslyRestoreMembers(
     auth: Authenticator,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -447,13 +447,13 @@ describe("SpaceResource", () => {
         ).toEqual([{ groupId: regularGroup.id, grantType: "member" }]);
       });
 
-      it("should restore suspended members when switching from group to manual mode", async () => {
+      it("should not bring the former members back when switching from group to manual mode", async () => {
         // Add members first
         await regularGroup.dangerouslyAddMembers(adminAuth, {
           users: [user1.toJSON(), user2.toJSON()],
         });
 
-        // Switch to group mode (this should suspend members)
+        // Switch to group mode (this ends the manual memberships)
         const provisionedGroup = await GroupResource.makeNew({
           name: "Provisioned Group",
           workspaceId: workspace.id,
@@ -469,17 +469,7 @@ describe("SpaceResource", () => {
         });
         expect(groupResult.isOk()).toBe(true);
 
-        // Verify members are suspended
-        const membershipsAfterSuspend = await GroupMembershipModel.findAll({
-          where: {
-            groupId: regularGroup.id,
-            workspaceId: workspace.id,
-          },
-        });
-        const suspendedMemberships = membershipsAfterSuspend.filter(
-          (m) => m.status === "suspended"
-        );
-        expect(suspendedMemberships.length).toBe(2);
+        expect(await regularGroup.getActiveMembers(adminAuth)).toEqual([]);
 
         // Reload space to get updated state
         const spaceAfterGroup = await SpaceResource.fetchById(
@@ -487,28 +477,21 @@ describe("SpaceResource", () => {
           regularSpace.sId
         );
 
-        // Switch back to manual mode
+        // Switch back to manual mode with an empty member list: the memberships were ended, not
+        // suspended, so nobody regains access.
         const manualResult = await spaceAfterGroup!.updatePermissions(
           adminAuth,
           {
             name: "Test Space",
             isRestricted: true,
             managementMode: "manual",
-            memberIds: [user1.sId, user2.sId],
+            memberIds: [],
             editorIds: [],
           }
         );
         expect(manualResult.isOk()).toBe(true);
 
-        // Verify members are restored
-        const membershipsAfterRestore = await GroupMembershipModel.findAll({
-          where: {
-            groupId: regularGroup.id,
-            workspaceId: workspace.id,
-            status: "active",
-          },
-        });
-        expect(membershipsAfterRestore.length).toBe(2);
+        expect(await regularGroup.getActiveMembers(adminAuth)).toEqual([]);
       });
     });
 
@@ -696,7 +679,45 @@ describe("SpaceResource", () => {
         );
       });
 
-      it("should suspend active members when switching from manual to group mode", async () => {
+      it("should not end memberships when the switch to group mode is rejected", async () => {
+        await regularGroup.dangerouslyAddMembers(adminAuth, {
+          users: [user1.toJSON(), user2.toJSON()],
+        });
+
+        // The workspace global group is readable but cannot be selected as a member group (it
+        // would silently open the space): the request must be rejected before anything is mutated.
+        const globalGroupRes =
+          await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+        expect(globalGroupRes.isOk()).toBe(true);
+        if (globalGroupRes.isErr()) {
+          throw globalGroupRes.error;
+        }
+
+        const result = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          managementMode: "group",
+          groupIds: [globalGroupRes.value.sId],
+          editorGroupIds: [],
+        });
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+          expect(result.error.code).toBe("invalid_group_kind");
+        }
+
+        // The members are untouched and the space is still manually managed.
+        const members = await regularGroup.getActiveMembers(adminAuth);
+        expect(members.map((m) => m.sId).sort()).toEqual(
+          [user1.sId, user2.sId].sort()
+        );
+        const reloaded = await SpaceResource.fetchById(
+          adminAuth,
+          regularSpace.sId
+        );
+        expect(reloaded?.managementMode).toBe("manual");
+      });
+
+      it("should end active memberships when switching from manual to group mode", async () => {
         // Add members first
         await regularGroup.dangerouslyAddMembers(adminAuth, {
           users: [user1.toJSON(), user2.toJSON()],
@@ -743,15 +764,17 @@ describe("SpaceResource", () => {
         });
         expect(result.isOk()).toBe(true);
 
-        // Verify members are suspended
+        // Verify the memberships were ended rather than suspended.
         const membershipsAfter = await GroupMembershipModel.findAll({
           where: {
             groupId: regularGroup.id,
             workspaceId: workspace.id,
-            status: "suspended",
           },
         });
         expect(membershipsAfter.length).toBe(2);
+        expect(membershipsAfter.every((m) => m.endAt !== null)).toBe(true);
+        expect(membershipsAfter.every((m) => m.status === "active")).toBe(true);
+        expect(await regularGroup.getActiveMembers(adminAuth)).toEqual([]);
       });
     });
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -999,6 +999,91 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   // Permissions.
 
+  // Resolves and validates everything in an `updatePermissions` request that can reject it, before
+  // it mutates anything. `updatePermissions` runs in a transaction that only rolls back on a throw
+  // — an `Err` return commits — so a request that fails validation halfway through would leave the
+  // space's mode switched and its manual memberships ended.
+  //
+  // Returns the groups the request selected (empty in manual mode).
+  private async resolveAndValidatePermissionsUpdateGroups(
+    auth: Authenticator,
+    params:
+      | { memberIds: string[]; managementMode: "manual"; editorIds: string[] }
+      | {
+          groupIds: string[];
+          managementMode: "group";
+          editorGroupIds: string[];
+        }
+  ): Promise<
+    Result<
+      {
+        selectedGroups: GroupResource[];
+        selectedEditorGroups: GroupResource[];
+      },
+      DustError<
+        "unauthorized" | "group_not_found" | "invalid_group_kind" | "invalid_id"
+      >
+    >
+  > {
+    if (params.managementMode === "manual") {
+      // Admin-controlled Pods have an empty editor group; workspace admins administrate via role.
+      if (
+        this.isProject() &&
+        params.editorIds.length > 0 &&
+        (await this.fetchIsAdminControlled())
+      ) {
+        return new Err(
+          new DustError(
+            "unauthorized",
+            "Editors cannot be set while this Pod is admin-controlled."
+          )
+        );
+      }
+
+      return new Ok({ selectedGroups: [], selectedEditorGroups: [] });
+    }
+
+    const selectedGroupsRes = await GroupResource.fetchByIds(
+      auth,
+      params.groupIds
+    );
+    if (selectedGroupsRes.isErr()) {
+      return selectedGroupsRes;
+    }
+    const selectedGroups = selectedGroupsRes.value;
+
+    let selectedEditorGroups: GroupResource[] = [];
+    if (this.isProject()) {
+      const selectedEditorGroupsRes = await GroupResource.fetchByIds(
+        auth,
+        params.editorGroupIds
+      );
+      if (selectedEditorGroupsRes.isErr()) {
+        return selectedEditorGroupsRes;
+      }
+      selectedEditorGroups = selectedEditorGroupsRes.value;
+    }
+
+    // `fetchByIds` only checks that the caller can read the groups, not what they are. Without
+    // this, any readable group could be attached: the global group (which would silently make the
+    // space open), another space's regular_auto group (two of those on one space breaks
+    // `fetchManualMemberGroup`), or an agent/skill editors group.
+    const unsupportedGroups = [
+      ...selectedGroups,
+      ...selectedEditorGroups,
+    ].filter((group) => !isManageableGroupKind(group.kind));
+    if (unsupportedGroups.length > 0) {
+      return new Err(
+        new DustError(
+          "invalid_group_kind",
+          "Only provisioned and manual groups can be given access to a space."
+        )
+      );
+    }
+
+    return new Ok({ selectedGroups, selectedEditorGroups });
+  }
+
   async updatePermissions(
     auth: Authenticator,
     params: {
@@ -1059,6 +1144,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       // Update managementMode if provided
       const { managementMode } = params;
 
+      // Everything that can reject the request is resolved before anything is mutated: an `Err`
+      // returned from this callback does not roll back the transaction (`withTransaction` only
+      // rolls back on a throw), so validating later would leave a rejected request having already
+      // switched the mode and ended the space's manual memberships.
+      const requestedGroupsRes =
+        await this.resolveAndValidatePermissionsUpdateGroups(auth, params);
+      if (requestedGroupsRes.isErr()) {
+        return requestedGroupsRes;
+      }
+      const { selectedGroups, selectedEditorGroups } = requestedGroupsRes.value;
+
       // The space is open (unrestricted) exactly when the workspace global group is one of its
       // groups. There is no separate group_vaults add/remove: the global group is simply included in
       // `members` iff the space is (becoming) open.
@@ -1070,13 +1166,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       // Handle member status updates based on management mode changes
       if (previousManagementMode !== managementMode) {
         if (managementMode === "group") {
-          // When switching to group mode, suspend all active members of the default group
-          await this.suspendManualGroupMembers(auth, t);
+          // When switching to group mode, end the memberships of the space's own groups
+          await this.endManualGroupMembers(auth, t);
         } else if (
           managementMode === "manual" &&
           previousManagementMode === "group"
         ) {
-          // When switching from group to manual mode, restore suspended members
+          // When switching from group to manual mode, restore the memberships left suspended by
+          // the previous behaviour (a no-op once the backfill has run).
           await this.restoreManualGroupMembers(auth, t);
         }
       }
@@ -1098,20 +1195,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           "A user cannot be both a member and an editor of the same space."
         );
 
+        // Admin-controlled Pods have an empty editor group; workspace admins administrate via
+        // role. `resolveAndValidatePermissionsUpdate` already rejected any attempt to set editors.
         const isAdminControlled = await this.fetchIsAdminControlled();
-
-        // Admin-controlled Pods have an empty editor group; workspace admins
-        // administrate via role. Reject any attempt to set editors.
-        if (isAdminControlled && this.isProject()) {
-          if (editorIds.length > 0) {
-            return new Err(
-              new DustError(
-                "unauthorized",
-                "Editors cannot be set while this Pod is admin-controlled."
-              )
-            );
-          }
-        }
 
         // Handle member-based management
         const users = await UserResource.fetchByIds(memberIds);
@@ -1165,10 +1251,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           }
         }
       } else if (managementMode === "group") {
-        // Handle group-based management
-        const groupIds = params.groupIds;
-        const editorGroupIds = params.editorGroupIds;
-
         // The space's regular_auto member group (and, for projects, its regular_auto editor group)
         // are kept alongside the selected provisioned groups — group mode adds provisioned grants on
         // top of the manual groups rather than replacing them. Deselecting a group removes its
@@ -1180,32 +1262,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           members.push(globalGroup);
         }
 
-        // Add the new groups
-        const selectedGroupsResult = await GroupResource.fetchByIds(
-          auth,
-          groupIds
-        );
-        if (selectedGroupsResult.isErr()) {
-          await syncGroupPermissions();
-          return selectedGroupsResult;
-        }
-        const selectedGroups = selectedGroupsResult.value;
-        // `fetchByIds` only checks that the caller can read the groups, not what they are. Without
-        // this, any readable group could be attached: the global group (which would silently make
-        // the space open), another space's regular_auto group (two of those on one space breaks
-        // `fetchManualMemberGroup`), or an agent/skill editors group.
-        const unsupportedGroups = selectedGroups.filter(
-          (group) => !isManageableGroupKind(group.kind)
-        );
-        if (unsupportedGroups.length > 0) {
-          await syncGroupPermissions();
-          return new Err(
-            new DustError(
-              "invalid_group_kind",
-              "Only provisioned and manual groups can be given access to a space."
-            )
-          );
-        }
+        // Add the selected groups, resolved and kind-checked before any mutation.
         members.push(...selectedGroups);
 
         if (this.isProject()) {
@@ -1215,36 +1272,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           }
 
           assert(
-            editorGroupIds.length > 0,
-            "Pods must have at least one editor group."
-          );
-          // Add the new editor groups
-          const editorGroupsResult = await GroupResource.fetchByIds(
-            auth,
-            editorGroupIds
-          );
-          if (editorGroupsResult.isErr()) {
-            await syncGroupPermissions();
-            return editorGroupsResult;
-          }
-          const selectedEditorGroups = editorGroupsResult.value;
-          assert(
             selectedEditorGroups.length > 0,
             "Pods must have at least one editor group."
           );
-          // Same as above: an unsupported editor group kind must be a rejected request, not a 500.
-          const unsupportedEditorGroups = selectedEditorGroups.filter(
-            (group) => !isManageableGroupKind(group.kind)
-          );
-          if (unsupportedEditorGroups.length > 0) {
-            await syncGroupPermissions();
-            return new Err(
-              new DustError(
-                "invalid_group_kind",
-                "Only provisioned and manual groups can be given access to a space."
-              )
-            );
-          }
           editors.push(...selectedEditorGroups);
         }
       }
@@ -2394,21 +2424,26 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // Serialization.
 
   /**
-   * Suspends all active members of the default group when switching to group management mode
+   * Ends all active memberships of the space's own groups when switching to group management
+   * mode. The manual member list is dropped rather than kept suspended, so switching back to
+   * manual mode starts from an empty list instead of silently restoring access.
    */
-  private async suspendManualGroupMembers(
+  private async endManualGroupMembers(
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
     const groups = await this.fetchRegularAutoGroups(auth, transaction);
 
     for (const group of groups) {
-      await group.dangerouslySuspendMembers(auth, { transaction });
+      await group.dangerouslyEndAllMemberships(auth, { transaction });
     }
   }
 
   /**
-   * Restores all suspended members of the default group when switching to manual management mode
+   * Restores all suspended members of the default group when switching to manual management mode.
+   *
+   * Transitional: only memberships suspended by the previous behaviour are left to restore (see
+   * `GroupResource.dangerouslyRestoreMembers`); the switch to group mode now ends memberships.
    */
   private async restoreManualGroupMembers(
     auth: Authenticator,

--- a/front/migrations/20260904_end_suspended_group_memberships.ts
+++ b/front/migrations/20260904_end_suspended_group_memberships.ts
@@ -1,0 +1,124 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Op, QueryTypes } from "sequelize";
+
+// Ends every membership left `suspended` by the former space management-mode switch (see
+// `20251013_suspend_group_mode_members`): a space switching to group mode used to keep its manual
+// members on record but inert, so the switch back to manual mode could restore them.
+//
+// Suspended memberships are already excluded from every active-membership query, so this grants
+// and revokes nothing — no group-id cache invalidation is needed. What it does is move the
+// "inert" state from `status` onto `endAt`, so that merging the two membership modes cannot
+// resurrect a member list that an admin dropped by switching to group mode.
+//
+// Scoped to the space-owned groups only: the `regular_auto` groups holding a `space` grant, which
+// are exactly the groups a management-mode switch could suspend. Agent-editor and skill-editor
+// memberships were suspended by their own migrations and have their own restore backfills
+// (`20260828_restore_agent_editor_memberships`, `20260828_restore_skill_editor_memberships`);
+// ending them here would make them unrestorable.
+//
+// Run after deploying the change that ends (rather than suspends) memberships on a switch to
+// group mode, so no new suspended row can appear behind the script.
+//
+// Idempotent: it only touches suspended memberships that are still open.
+async function endSuspendedGroupMemberships(
+  logger: Logger,
+  { execute }: { execute: boolean }
+) {
+  const now = new Date();
+
+  // The space member/editor groups holding a still-open suspended membership. Raw query because
+  // it spans workspaces; bounded by the number of spaces that ever used group management mode.
+  const rows = await frontSequelize.query<{
+    workspaceId: ModelId;
+    groupId: ModelId;
+  }>(
+    `SELECT DISTINCT gm."workspaceId", gm."groupId"
+       FROM group_memberships gm
+       JOIN groups g
+         ON g.id = gm."groupId"
+        AND g."workspaceId" = gm."workspaceId"
+       JOIN group_permissions gp
+         ON gp."groupId" = gm."groupId"
+        AND gp."workspaceId" = gm."workspaceId"
+        AND gp."resourceType" = 'space'
+      WHERE gm.status = 'suspended'
+        AND (gm."endAt" IS NULL OR gm."endAt" > :now)
+        AND g.kind = 'regular_auto'`,
+    {
+      replacements: { now },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  // Grouped by workspace so every update below is workspace-scoped.
+  const groupModelIdsByWorkspaceModelId = new Map<ModelId, ModelId[]>();
+  for (const { workspaceId, groupId } of rows) {
+    const groupModelIds = groupModelIdsByWorkspaceModelId.get(workspaceId);
+    if (groupModelIds) {
+      groupModelIds.push(groupId);
+    } else {
+      groupModelIdsByWorkspaceModelId.set(workspaceId, [groupId]);
+    }
+  }
+
+  logger.info(
+    {
+      workspaces: groupModelIdsByWorkspaceModelId.size,
+      groups: rows.length,
+      execute,
+    },
+    "Ending suspended space memberships"
+  );
+
+  let totalEnded = 0;
+
+  for (const [
+    workspaceId,
+    groupModelIds,
+  ] of groupModelIdsByWorkspaceModelId.entries()) {
+    const where = {
+      workspaceId,
+      groupId: { [Op.in]: groupModelIds },
+      status: "suspended" as const,
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+    };
+
+    if (!execute) {
+      const count = await GroupMembershipModel.count({ where });
+      logger.info(
+        { workspaceId, groups: groupModelIds.length, memberships: count },
+        "Dry run: would end suspended memberships"
+      );
+      totalEnded += count;
+      continue;
+    }
+
+    const [ended] = await GroupMembershipModel.update(
+      { endAt: new Date() },
+      { where }
+    );
+
+    logger.info(
+      { workspaceId, groups: groupModelIds.length, memberships: ended },
+      "Ended memberships"
+    );
+    totalEnded += ended;
+  }
+
+  logger.info(
+    {
+      workspaces: groupModelIdsByWorkspaceModelId.size,
+      memberships: totalEnded,
+      execute,
+    },
+    "Suspended space memberships backfill done"
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  await endSuspendedGroupMemberships(logger, { execute });
+});


### PR DESCRIPTION
## Description

First of 4 PRs merging the two ways a space gets its members: the manual member list and the attached groups (provisioned or manual). Today `vaults.managementMode` makes them exclusive.

Switching a space to group mode suspends its manual memberships (`status = 'suspended'`, kept on record but inert) so switching back can restore them. The merged model has nowhere to hide an inert member list, and restoring one would silently re-grant access to people an admin dropped by switching to groups.

So: end those memberships instead of suspending them — the same mutation as removing every member (`endAt` in the past). Plus the backfill that ends the rows already suspended in prod, to run after this deploys. Once it has, no membership row is suspended-and-open any more, and nothing can create one, which is what lets the next PRs drop the mode without any chance of resurrecting access.

- `GroupResource.dangerouslySuspendMembers` → `dangerouslyEndAllMemberships`
- `SpaceResource.suspendManualGroupMembers` → `endManualGroupMembers`
- `dangerouslyRestoreMembers` / `restoreManualGroupMembers` are kept on purpose: until the backfill runs, a group → manual switch must still restore what the old behaviour suspended. They go away with the `status` column.

The backfill is scoped to the `regular_auto` groups holding a `space` grant, i.e. exactly the groups a mode switch could suspend. Agent-editor and skill-editor memberships were suspended by their own migrations and have their own restore backfills; ending them here would make them unrestorable.

User-visible: switching a space from manual to group access now drops its member list for good. The confirm dialog says so.

## Tests

 - updated unit tests

## Risk

Medium. Permission-adjacent, but it only makes access strictly narrower, never wider, and the backfill grants nothing: suspended memberships are already excluded from every active-membership query, so ending them changes no one's access — it moves the "inert" state from `status` onto `endAt`.

Not reversible for the spaces it touches: a space switching to group mode loses its manual member list, where before it could be restored. That is the intended product change.

## Deploy Plan

- Deploy front
- Run the backfill: `front/migrations/20260904_end_suspended_group_memberships.ts` (dry run
  first, then `--execute`)


Check afterwards, expected to stay at 0:

```sql
SELECT count(*) FROM group_memberships WHERE status = 'suspended' AND "endAt" IS NULL;
```
