### PR TITLE
[skills] take out reference from the input

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -222,10 +222,6 @@ function sanitizeSkillInstructionsHtml(html: string): string {
 }
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[50vh]";
-const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_CONTAINER_SIZE =
-  "h-80 min-h-80 max-h-[50vh]";
-const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE =
-  "h-full min-h-0 max-h-none resize-none rounded-b-none border-b-0 pb-44";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -736,8 +732,6 @@ export function SkillBuilderInstructionsEditor({
               readOnly: isInstructionsReadOnly,
             }),
             INSTRUCTIONS_EDITOR_SIZE,
-            hasInstructionReferenceSummary &&
-              INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE
           ),
         },
       },
@@ -840,8 +834,6 @@ export function SkillBuilderInstructionsEditor({
         <div
           className={cn(
             "group relative overflow-hidden rounded-xl",
-            hasInstructionReferenceSummary &&
-              INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_CONTAINER_SIZE,
             hasInstructionReferenceSummary && !isDiffMode && "resize-y"
           )}
         >
@@ -849,14 +841,6 @@ export function SkillBuilderInstructionsEditor({
             className={hasInstructionReferenceSummary ? "h-full" : undefined}
             editor={editor}
             isReadOnly={isInstructionsReadOnly}
-          />
-          <SkillBuilderInstructionsReferenceSummary
-            attachedKnowledge={attachedKnowledgeField.value}
-            containerRef={instructionReferenceSummaryRef}
-            hasError={displayError}
-            instructions={instructionsField.value ?? ""}
-            onReferenceClick={handleReferenceClick}
-            tools={tools}
           />
         </div>
 
@@ -866,6 +850,15 @@ export function SkillBuilderInstructionsEditor({
           </div>
         )}
       </div>
+
+      <SkillBuilderInstructionsReferenceSummary
+            attachedKnowledge={attachedKnowledgeField.value}
+            containerRef={instructionReferenceSummaryRef}
+            hasError={displayError}
+            instructions={instructionsField.value ?? ""}
+            onReferenceClick={handleReferenceClick}
+            tools={tools}
+        />
 
       <CapabilityDetailsSheets
         owner={owner}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -303,13 +303,6 @@ export function SkillBuilderInstructionsEditor({
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
-  const hasInstructionReferenceSummary =
-    (attachedKnowledgeField.value?.length ?? 0) > 0 ||
-    tools.length > 0 ||
-    (instructionsField.value?.includes("<knowledge ") ?? false) ||
-    (instructionsField.value?.includes("<tool ") ?? false) ||
-    (instructionsField.value?.includes("<skill ") ?? false) ||
-    (instructionsField.value?.includes("<unavailable_skill ") ?? false);
 
   const syncAttachedKnowledgeFromEditor = useCallback(
     (editor: Editor) => {
@@ -731,7 +724,7 @@ export function SkillBuilderInstructionsEditor({
               disabled: isDiffMode || isReadOnly,
               readOnly: isInstructionsReadOnly,
             }),
-            INSTRUCTIONS_EDITOR_SIZE,
+            INSTRUCTIONS_EDITOR_SIZE
           ),
         },
       },
@@ -742,7 +735,6 @@ export function SkillBuilderInstructionsEditor({
     isDiffMode,
     isInstructionsReadOnly,
     isReadOnly,
-    hasInstructionReferenceSummary,
   ]);
 
   // Sync external changes to the editor content
@@ -834,11 +826,9 @@ export function SkillBuilderInstructionsEditor({
         <div
           className={cn(
             "group relative overflow-hidden rounded-xl",
-            hasInstructionReferenceSummary && !isDiffMode && "resize-y"
           )}
         >
           <SkillInstructionsEditorContent
-            className={hasInstructionReferenceSummary ? "h-full" : undefined}
             editor={editor}
             isReadOnly={isInstructionsReadOnly}
           />
@@ -852,13 +842,13 @@ export function SkillBuilderInstructionsEditor({
       </div>
 
       <SkillBuilderInstructionsReferenceSummary
-            attachedKnowledge={attachedKnowledgeField.value}
-            containerRef={instructionReferenceSummaryRef}
-            hasError={displayError}
-            instructions={instructionsField.value ?? ""}
-            onReferenceClick={handleReferenceClick}
-            tools={tools}
-        />
+        attachedKnowledge={attachedKnowledgeField.value}
+        containerRef={instructionReferenceSummaryRef}
+        hasError={displayError}
+        instructions={instructionsField.value ?? ""}
+        onReferenceClick={handleReferenceClick}
+        tools={tools}
+      />
 
       <CapabilityDetailsSheets
         owner={owner}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -834,7 +834,6 @@ export function SkillBuilderInstructionsEditor({
       <SkillBuilderInstructionsReferenceSummary
         attachedKnowledge={attachedKnowledgeField.value}
         containerRef={instructionReferenceSummaryRef}
-        hasError={displayError}
         instructions={instructionsField.value ?? ""}
         onReferenceClick={handleReferenceClick}
         tools={tools}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -729,13 +729,7 @@ export function SkillBuilderInstructionsEditor({
         },
       },
     });
-  }, [
-    editor,
-    displayError,
-    isDiffMode,
-    isInstructionsReadOnly,
-    isReadOnly,
-  ]);
+  }, [editor, displayError, isDiffMode, isInstructionsReadOnly, isReadOnly]);
 
   // Sync external changes to the editor content
   useEffect(() => {
@@ -823,11 +817,7 @@ export function SkillBuilderInstructionsEditor({
   return (
     <>
       <div className="space-y-1 p-px">
-        <div
-          className={cn(
-            "group relative overflow-hidden rounded-xl",
-          )}
-        >
+        <div className={cn("group relative overflow-hidden rounded-xl")}>
           <SkillInstructionsEditorContent
             editor={editor}
             isReadOnly={isInstructionsReadOnly}

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -7,13 +7,13 @@ import { getSkillIcon } from "@app/lib/skill";
 import { extractSkillReferenceTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { AttachmentChip, Chip, cn, File02 } from "@dust-tt/sparkle";
-import type { Ref } from "react";
-import { useMemo } from "react";
+import { AttachmentChip, Button, ChevronDown, ChevronUp, Chip, cn, File02 } from "@dust-tt/sparkle";
+import type { Ref, RefObject } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
-  containerRef?: Ref<HTMLDivElement>;
+  containerRef?: RefObject<HTMLDivElement>;
   hasError: boolean;
   instructions: string;
   onReferenceClick: (target: ReferenceSummaryItem) => void;
@@ -117,8 +117,12 @@ export function SkillBuilderInstructionsReferenceSummary({
   onReferenceClick,
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
+  const [isOverflow, setIsOverflow] = useState(false);
+  const [isExpand, setIsExpand] = useState(false);
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
+
+  
 
   const knowledgeReferences = useMemo(
     () =>
@@ -202,16 +206,23 @@ export function SkillBuilderInstructionsReferenceSummary({
     [knowledgeReferences, skillReferences, toolReferences]
   );
 
-  if (referenceItems.length === 0) {
-    return null;
-  }
 
+  useEffect(() => {
+    // check everytime reference items number changes if the content is overflowing or not
+    if (containerRef?.current) {
+      console.log("overflow", containerRef.current.scrollHeight, containerRef.current.offsetHeight);
+      setIsOverflow(containerRef.current.scrollHeight > containerRef.current.offsetHeight);
+    }
+  }, [referenceItems.length]);
+
+ // have min height to always keep space to show references so there is less content shift.
   return (
-    <div
+    <div className="min-h-6"> 
+    {
+      referenceItems.length > 0 &&  <div
       ref={containerRef}
-      className={cn(
-        "absolute inset-x-0 bottom-0 z-10 max-h-40 overflow-y-auto rounded-b-xl border-x border-b bg-background px-3 pb-3 pt-3",
-        "",
+      className={cn(!isExpand &&
+        "overflow-y-hidden max-h-15",
         hasError
           ? [
               "border-border-warning/30 group-focus-within:border-border-warning",
@@ -220,14 +231,19 @@ export function SkillBuilderInstructionsReferenceSummary({
           : ["border-border group-focus-within:border-highlight-300", ""]
       )}
     >
-      <div className="mb-2 text-sm font-medium text-foreground">
-        Capabilities and knowledge
-      </div>
       <div className="flex flex-wrap gap-2">
         {referenceItems.map((item) =>
           renderReferenceSummaryItem({ item, onReferenceClick })
-        )}
+        )} 
+      </div> 
+      </div> 
+      }
+            {
+        isOverflow && 
+         <div className="flex justify-end">
+      <Button label={`See ${isExpand ? "less" : "more"}`} onClick={() => setIsExpand((prev) => !prev)} icon={isExpand ? ChevronUp : ChevronDown} variant="ghost-secondary" size="xs" />
       </div>
+      }
     </div>
-  );
+  )
 }

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -17,7 +17,7 @@ import {
   File02,
 } from "@dust-tt/sparkle";
 import type { RefObject } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
@@ -117,6 +117,10 @@ function renderReferenceSummaryItem({
   }
 }
 
+const BROWSER_DEFAULT_FONT_SIZE = 16;
+const THRESHOLD_HEIGHT_REM = 3.75; // max-h-15 => 3.75 rem 
+const DEFAULT_OVERFLOW_THRESHOLD_HEIGHT = BROWSER_DEFAULT_FONT_SIZE * THRESHOLD_HEIGHT_REM; // 60px
+
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
   containerRef,
@@ -125,8 +129,9 @@ export function SkillBuilderInstructionsReferenceSummary({
   onReferenceClick,
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
-  const [isOverflow, setIsOverflow] = useState(false);
   const [isExpand, setIsExpand] = useState(false);
+  const [overflowThresholdHeight, setOverflowThresholdHeight] = useState(DEFAULT_OVERFLOW_THRESHOLD_HEIGHT);
+  const contentRef = useRef<HTMLDivElement>(null);
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
 
@@ -212,24 +217,27 @@ export function SkillBuilderInstructionsReferenceSummary({
     [knowledgeReferences, skillReferences, toolReferences]
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ref is a stable reference
+  // compute root font size only once
   useEffect(() => {
-    // check everytime reference items number changes if the content is overflowing or not
-    if (containerRef?.current) {
-      setIsOverflow(
-        containerRef.current.scrollHeight > containerRef.current.offsetHeight
-      );
+    const rootFontSize = parseFloat(
+      getComputedStyle(document.documentElement).fontSize
+    );
+
+    if (rootFontSize !== BROWSER_DEFAULT_FONT_SIZE) {
+      setOverflowThresholdHeight(rootFontSize * THRESHOLD_HEIGHT_REM)
     }
-  }, [referenceItems.length]);
+  }, []);
+
+  const isOverflow = contentRef.current && contentRef.current.scrollHeight > overflowThresholdHeight
 
   // have min height to always keep space to show references so there is less content shift.
   return (
-    <div className="min-h-6">
+    <div>
       {referenceItems.length > 0 && (
         <div
           ref={containerRef}
           className={cn(
-            !isExpand && "overflow-y-hidden max-h-15",
+            !isExpand && "overflow-y-hidden max-h-14",
             hasError
               ? [
                   "border-border-warning/30 group-focus-within:border-border-warning",
@@ -238,7 +246,7 @@ export function SkillBuilderInstructionsReferenceSummary({
               : ["border-border group-focus-within:border-highlight-300", ""]
           )}
         >
-          <div className="flex flex-wrap gap-2">
+          <div ref={contentRef} className="flex flex-wrap gap-2">
             {referenceItems.map((item) =>
               renderReferenceSummaryItem({ item, onReferenceClick })
             )}

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -7,8 +7,16 @@ import { getSkillIcon } from "@app/lib/skill";
 import { extractSkillReferenceTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { AttachmentChip, Button, ChevronDown, ChevronUp, Chip, cn, File02 } from "@dust-tt/sparkle";
-import type { Ref, RefObject } from "react";
+import {
+  AttachmentChip,
+  Button,
+  ChevronDown,
+  ChevronUp,
+  Chip,
+  cn,
+  File02,
+} from "@dust-tt/sparkle";
+import type { RefObject } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 interface SkillBuilderInstructionsReferenceSummaryProps {
@@ -122,8 +130,6 @@ export function SkillBuilderInstructionsReferenceSummary({
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
 
-  
-
   const knowledgeReferences = useMemo(
     () =>
       dedupeById(
@@ -206,44 +212,50 @@ export function SkillBuilderInstructionsReferenceSummary({
     [knowledgeReferences, skillReferences, toolReferences]
   );
 
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ref is a stable reference
   useEffect(() => {
     // check everytime reference items number changes if the content is overflowing or not
     if (containerRef?.current) {
-      console.log("overflow", containerRef.current.scrollHeight, containerRef.current.offsetHeight);
-      setIsOverflow(containerRef.current.scrollHeight > containerRef.current.offsetHeight);
+      setIsOverflow(
+        containerRef.current.scrollHeight > containerRef.current.offsetHeight
+      );
     }
   }, [referenceItems.length]);
 
- // have min height to always keep space to show references so there is less content shift.
+  // have min height to always keep space to show references so there is less content shift.
   return (
-    <div className="min-h-6"> 
-    {
-      referenceItems.length > 0 &&  <div
-      ref={containerRef}
-      className={cn(!isExpand &&
-        "overflow-y-hidden max-h-15",
-        hasError
-          ? [
-              "border-border-warning/30 group-focus-within:border-border-warning",
-              "",
-            ]
-          : ["border-border group-focus-within:border-highlight-300", ""]
+    <div className="min-h-6">
+      {referenceItems.length > 0 && (
+        <div
+          ref={containerRef}
+          className={cn(
+            !isExpand && "overflow-y-hidden max-h-15",
+            hasError
+              ? [
+                  "border-border-warning/30 group-focus-within:border-border-warning",
+                  "",
+                ]
+              : ["border-border group-focus-within:border-highlight-300", ""]
+          )}
+        >
+          <div className="flex flex-wrap gap-2">
+            {referenceItems.map((item) =>
+              renderReferenceSummaryItem({ item, onReferenceClick })
+            )}
+          </div>
+        </div>
       )}
-    >
-      <div className="flex flex-wrap gap-2">
-        {referenceItems.map((item) =>
-          renderReferenceSummaryItem({ item, onReferenceClick })
-        )} 
-      </div> 
-      </div> 
-      }
-            {
-        isOverflow && 
-         <div className="flex justify-end">
-      <Button label={`See ${isExpand ? "less" : "more"}`} onClick={() => setIsExpand((prev) => !prev)} icon={isExpand ? ChevronUp : ChevronDown} variant="ghost-secondary" size="xs" />
-      </div>
-      }
+      {isOverflow && (
+        <div className="flex justify-end">
+          <Button
+            label={`See ${isExpand ? "less" : "more"}`}
+            onClick={() => setIsExpand((prev) => !prev)}
+            icon={isExpand ? ChevronUp : ChevronDown}
+            variant="ghost-secondary"
+            size="xs"
+          />
+        </div>
+      )}
     </div>
-  )
+  );
 }

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -244,7 +244,6 @@ export function SkillBuilderInstructionsReferenceSummary({
   // have min height to always keep space to show references so there is less content shift.
   return (
     <>
-      {referenceItems.length > 0 && (
         <div
           ref={containerRef}
           className={cn(!isExpand && "overflow-y-hidden max-h-14")}
@@ -255,7 +254,6 @@ export function SkillBuilderInstructionsReferenceSummary({
             )}
           </div>
         </div>
-      )}
       {isOverflow && (
         <div className="flex justify-end">
           <Button

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -118,8 +118,9 @@ function renderReferenceSummaryItem({
 }
 
 const BROWSER_DEFAULT_FONT_SIZE = 16;
-const THRESHOLD_HEIGHT_REM = 3.75; // max-h-15 => 3.75 rem 
-const DEFAULT_OVERFLOW_THRESHOLD_HEIGHT = BROWSER_DEFAULT_FONT_SIZE * THRESHOLD_HEIGHT_REM; // 60px
+const THRESHOLD_HEIGHT_REM = 3.5; // max-h-14 => 3.5 rem
+const DEFAULT_OVERFLOW_THRESHOLD_HEIGHT =
+  BROWSER_DEFAULT_FONT_SIZE * THRESHOLD_HEIGHT_REM;
 
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
@@ -130,7 +131,10 @@ export function SkillBuilderInstructionsReferenceSummary({
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
   const [isExpand, setIsExpand] = useState(false);
-  const [overflowThresholdHeight, setOverflowThresholdHeight] = useState(DEFAULT_OVERFLOW_THRESHOLD_HEIGHT);
+  const [overflowThresholdHeight, setOverflowThresholdHeight] = useState(
+    DEFAULT_OVERFLOW_THRESHOLD_HEIGHT
+  );
+  const [isOverflow, setIsOverflow] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
@@ -224,11 +228,16 @@ export function SkillBuilderInstructionsReferenceSummary({
     );
 
     if (rootFontSize !== BROWSER_DEFAULT_FONT_SIZE) {
-      setOverflowThresholdHeight(rootFontSize * THRESHOLD_HEIGHT_REM)
+      setOverflowThresholdHeight(rootFontSize * THRESHOLD_HEIGHT_REM);
     }
   }, []);
 
-  const isOverflow = contentRef.current && contentRef.current.scrollHeight > overflowThresholdHeight
+  // biome-ignore lint/correctness/useExhaustiveDependencies: referenceItems.length triggers re-measurement
+  useEffect(() => {
+    if (contentRef.current) {
+      setIsOverflow(contentRef.current.scrollHeight > overflowThresholdHeight);
+    }
+  }, [referenceItems.length, overflowThresholdHeight]);
 
   // have min height to always keep space to show references so there is less content shift.
   return (

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -241,7 +241,6 @@ export function SkillBuilderInstructionsReferenceSummary({
     return null;
   }
 
-  // have min height to always keep space to show references so there is less content shift.
   return (
     <>
       <div

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -244,16 +244,16 @@ export function SkillBuilderInstructionsReferenceSummary({
   // have min height to always keep space to show references so there is less content shift.
   return (
     <>
-        <div
-          ref={containerRef}
-          className={cn(!isExpand && "overflow-y-hidden max-h-14")}
-        >
-          <div ref={contentRef} className="flex flex-wrap gap-2">
-            {referenceItems.map((item) =>
-              renderReferenceSummaryItem({ item, onReferenceClick })
-            )}
-          </div>
+      <div
+        ref={containerRef}
+        className={cn(!isExpand && "overflow-y-hidden max-h-14")}
+      >
+        <div ref={contentRef} className="flex flex-wrap gap-2">
+          {referenceItems.map((item) =>
+            renderReferenceSummaryItem({ item, onReferenceClick })
+          )}
         </div>
+      </div>
       {isOverflow && (
         <div className="flex justify-end">
           <Button

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -237,9 +237,13 @@ export function SkillBuilderInstructionsReferenceSummary({
     }
   }, [referenceItems.length, overflowThresholdHeight]);
 
+  if (referenceItems.length === 0) {
+    return null;
+  }
+
   // have min height to always keep space to show references so there is less content shift.
   return (
-    <div>
+    <>
       {referenceItems.length > 0 && (
         <div
           ref={containerRef}
@@ -263,6 +267,6 @@ export function SkillBuilderInstructionsReferenceSummary({
           />
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -243,9 +243,7 @@ export function SkillBuilderInstructionsReferenceSummary({
       {referenceItems.length > 0 && (
         <div
           ref={containerRef}
-          className={cn(
-            !isExpand && "overflow-y-hidden max-h-14",
-          )}
+          className={cn(!isExpand && "overflow-y-hidden max-h-14")}
         >
           <div ref={contentRef} className="flex flex-wrap gap-2">
             {referenceItems.map((item) =>

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -22,7 +22,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
   containerRef?: RefObject<HTMLDivElement>;
-  hasError: boolean;
   instructions: string;
   onReferenceClick: (target: ReferenceSummaryItem) => void;
   tools: BuilderAction[];
@@ -125,7 +124,6 @@ const DEFAULT_OVERFLOW_THRESHOLD_HEIGHT =
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
   containerRef,
-  hasError,
   instructions,
   onReferenceClick,
   tools,
@@ -247,12 +245,6 @@ export function SkillBuilderInstructionsReferenceSummary({
           ref={containerRef}
           className={cn(
             !isExpand && "overflow-y-hidden max-h-14",
-            hasError
-              ? [
-                  "border-border-warning/30 group-focus-within:border-border-warning",
-                  "",
-                ]
-              : ["border-border group-focus-within:border-highlight-300", ""]
           )}
         >
           <div ref={contentRef} className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Description
This PR is to take out skill's references from the input, and add an option to show more/less. Show more/less button only appears when the content height when we show three lines of chips.

<img width="2002" height="880" alt="CleanShot 2026-09-07 at 12 35 20@2x" src="https://github.com/user-attachments/assets/5584ab47-97b6-4b30-9fd7-d47cd60490ef" />




<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
