### PR TITLE
Poke: paginate the Frames v2 list server-side like the other tables

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/frames/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/index.test.ts
@@ -31,7 +31,7 @@ describe("GET /api/poke/workspaces/:wId/frames", () => {
       functionCount: 1,
       sandboxStatus: null,
     });
-    expect(data.hasMore).toBe(false);
+    expect(data.totalCount).toBe(1);
   });
 
   it("counts only the active publication's functions", async () => {
@@ -108,7 +108,7 @@ describe("GET /api/poke/workspaces/:wId/frames", () => {
     expect(data.items[0].fileName).toBe("manifest.json");
   });
 
-  it("orders by updatedAt desc and reports hasMore under a limit", async () => {
+  it("orders by updatedAt desc and pages with limit/offset over the total count", async () => {
     const { workspace, adminAuth } = await makeTestFrameFunction({
       isSuperUser: true,
     });
@@ -125,24 +125,38 @@ describe("GET /api/poke/workspaces/:wId/frames", () => {
     // Assert the ordering over the whole page rather than naming which row comes first: two rows
     // created in the same millisecond would make a positional assertion flaky.
     const ordered = await honoApp.request(
-      `${framesUrl(workspace.sId)}?limit=10&orderColumn=updatedAt&orderDirection=desc`
+      `${framesUrl(workspace.sId)}?limit=10&orderDirection=desc`
     );
     expect(ordered.status).toBe(200);
     const orderedData = await ordered.json();
     expect(orderedData.items).toHaveLength(2);
+    expect(orderedData.totalCount).toBe(2);
     const timestamps = orderedData.items.map((item: { updatedAt: string }) =>
       new Date(item.updatedAt).getTime()
     );
     expect(timestamps[0]).toBeGreaterThanOrEqual(timestamps[1]);
 
     const firstPage = await honoApp.request(
-      `${framesUrl(workspace.sId)}?limit=1&orderColumn=updatedAt&orderDirection=desc`
+      `${framesUrl(workspace.sId)}?limit=1&offset=0&orderDirection=desc`
     );
     expect(firstPage.status).toBe(200);
     const firstPageData = await firstPage.json();
     expect(firstPageData.items).toHaveLength(1);
-    expect(firstPageData.hasMore).toBe(true);
-    expect(firstPageData.lastValue).not.toBeNull();
+    expect(firstPageData.totalCount).toBe(2);
+
+    const secondPage = await honoApp.request(
+      `${framesUrl(workspace.sId)}?limit=1&offset=1&orderDirection=desc`
+    );
+    expect(secondPage.status).toBe(200);
+    const secondPageData = await secondPage.json();
+    expect(secondPageData.items).toHaveLength(1);
+    expect(secondPageData.totalCount).toBe(2);
+    expect(secondPageData.items[0].sId).not.toBe(firstPageData.items[0].sId);
+    expect(
+      new Set(orderedData.items.map((item: { sId: string }) => item.sId))
+    ).toEqual(
+      new Set([firstPageData.items[0].sId, secondPageData.items[0].sId])
+    );
   });
 
   it("does not leak frames from another workspace", async () => {

--- a/front-api/routes/poke/workspaces/[wId]/frames/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/index.ts
@@ -1,10 +1,18 @@
-import { getPaginationParams } from "@app/lib/api/pagination";
 import type { PokeListFrames } from "@app/lib/api/poke/frames";
 import { listWorkspaceFrames } from "@app/lib/api/poke/frames";
 import { pokeApp } from "@front-api/middlewares/ctx";
-import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import frameId from "./[frameId]";
+
+const ListFramesQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  offset: z.coerce.number().int().nonnegative().optional().default(0),
+  orderDirection: z.enum(["asc", "desc"]).optional().default("desc"),
+  hasSandbox: z.enum(["true", "false"]).optional().default("false"),
+});
 
 // Mounted at /api/poke/workspaces/:wId/frames.
 const app = pokeApp();
@@ -12,36 +20,23 @@ const app = pokeApp();
 app.route("/:frameId", frameId);
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<PokeListFrames> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("query", ListFramesQuerySchema),
+  async (ctx): HandlerResult<PokeListFrames> => {
+    const auth = ctx.get("auth");
+    const { limit, offset, orderDirection, hasSandbox } =
+      ctx.req.valid("query");
 
-  const paginationRes = getPaginationParams(ctx.req.query(), {
-    defaultLimit: 20,
-    defaultOrderColumn: "updatedAt",
-    defaultOrderDirection: "desc",
-    supportedOrderColumn: ["updatedAt"],
-  });
-  if (paginationRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: paginationRes.error.reason,
-      },
+    const frames = await listWorkspaceFrames(auth, {
+      limit,
+      offset,
+      orderDirection,
+      hasSandbox: hasSandbox === "true",
     });
+
+    return ctx.json(frames);
   }
-
-  const { limit, lastValue, orderDirection } = paginationRes.value;
-  const { hasSandbox } = ctx.req.query();
-
-  const frames = await listWorkspaceFrames(auth, {
-    limit,
-    lastValue,
-    orderDirection,
-    hasSandbox: hasSandbox === "true",
-  });
-
-  return ctx.json(frames);
-});
+);
 
 export default app;

--- a/front/components/poke/frames/table.tsx
+++ b/front/components/poke/frames/table.tsx
@@ -4,7 +4,8 @@ import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { usePokeFrames } from "@app/poke/swr/frames";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, CheckboxWithText } from "@dust-tt/sparkle";
+import { CheckboxWithText } from "@dust-tt/sparkle";
+import type { PaginationState } from "@tanstack/react-table";
 import { useState } from "react";
 
 const PAGE_SIZE = 20;
@@ -15,46 +16,46 @@ interface FramesDataTableProps {
 }
 
 export function FramesDataTable({ loadOnInit, owner }: FramesDataTableProps) {
-  const [limit, setLimit] = useState(PAGE_SIZE);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: PAGE_SIZE,
+  });
   const [hasSandbox, setHasSandbox] = useState(false);
-  const useFramesWithLimit = (props: PokeConditionalFetchProps) =>
-    usePokeFrames({ ...props, limit, hasSandbox });
+  const useFramesPage = (props: PokeConditionalFetchProps) =>
+    usePokeFrames({
+      ...props,
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      hasSandbox,
+    });
 
   return (
     <PokeDataTableConditionalFetch
       header="Frames"
       loadOnInit={loadOnInit}
       owner={owner}
-      useSWRHook={useFramesWithLimit}
+      useSWRHook={useFramesPage}
       globalActions={
         <CheckboxWithText
           text="Only with a sandbox"
           checked={hasSandbox}
           onCheckedChange={(checked) => {
             setHasSandbox(checked === true);
-            setLimit(PAGE_SIZE);
+            // A different filter makes the current page number meaningless.
+            setPagination((current) => ({ ...current, pageIndex: 0 }));
           }}
         />
       }
     >
-      {({ items, hasMore, isLoadingMore }) => (
-        <div className="flex flex-col gap-3">
-          <PokeDataTable
-            columns={makeColumnsForFrames({ owner })}
-            data={items}
-            pageSize={PAGE_SIZE}
-          />
-          {hasMore && (
-            <div className="flex justify-center">
-              <Button
-                variant="outline"
-                label="Load more"
-                isLoading={isLoadingMore}
-                onClick={() => setLimit((current) => current + PAGE_SIZE)}
-              />
-            </div>
-          )}
-        </div>
+      {({ items, totalCount, isValidating }) => (
+        <PokeDataTable
+          columns={makeColumnsForFrames({ owner })}
+          data={items}
+          isValidating={isValidating}
+          serverSideRowCount={totalCount}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+        />
       )}
     </PokeDataTableConditionalFetch>
   );

--- a/front/components/poke/frames/table.tsx
+++ b/front/components/poke/frames/table.tsx
@@ -20,7 +20,7 @@ export function FramesDataTable({ loadOnInit, owner }: FramesDataTableProps) {
     pageIndex: 0,
     pageSize: PAGE_SIZE,
   });
-  const [hasSandbox, setHasSandbox] = useState(false);
+  const [hasSandbox, setHasSandbox] = useState(true);
   const useFramesPage = (props: PokeConditionalFetchProps) =>
     usePokeFrames({
       ...props,

--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -54,8 +54,7 @@ export type PokeFrameListItem = {
 
 export type PokeListFrames = {
   items: PokeFrameListItem[];
-  hasMore: boolean;
-  lastValue: string | null;
+  totalCount: number;
 };
 
 // Shared by `listWorkspaceFrames` (batched across a page) and `getFrameDetails` (a single frame)
@@ -97,19 +96,19 @@ export async function listWorkspaceFrames(
     ...pagination
   }: {
     limit: number;
-    lastValue?: string;
+    offset: number;
     orderDirection: "asc" | "desc";
     hasSandbox: boolean;
   }
 ): Promise<PokeListFrames> {
-  const { frames, hasMore, lastValue } =
+  const { frames, totalCount } =
     await FileResource.listFrameV2ForWorkspacePaginated(auth, {
       ...pagination,
       hasSandbox,
     });
 
   if (frames.length === 0) {
-    return { items: [], hasMore, lastValue };
+    return { items: [], totalCount };
   }
 
   const frameModelIds = frames.map((frame) => frame.id);
@@ -141,8 +140,7 @@ export async function listWorkspaceFrames(
         author: frame.userId ? authorsByModelId.get(frame.userId) : undefined,
       })
     ),
-    hasMore,
-    lastValue,
+    totalCount,
   };
 }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -242,38 +242,22 @@ export class FileResource extends BaseResource<FileModel> {
     auth: Authenticator,
     {
       limit,
-      // Poke's own Frames table re-fetches from offset 0 with a growing `limit` instead (see
-      // `usePokeFrames`); `lastValue` stays wired for other API consumers that want true keyset
-      // pagination.
-      lastValue,
+      offset,
       orderDirection,
       hasSandbox = false,
     }: {
       limit: number;
-      lastValue?: string;
+      offset: number;
       orderDirection: "asc" | "desc";
       hasSandbox?: boolean;
     }
-  ): Promise<{
-    frames: FileResource[];
-    hasMore: boolean;
-    lastValue: string | null;
-  }> {
+  ): Promise<{ frames: FileResource[]; totalCount: number }> {
     const where: WhereOptions<InferAttributes<FileModel>> = {
       workspaceId: auth.getNonNullableWorkspace().id,
       contentType: frameV2ContentType,
     };
 
-    if (lastValue) {
-      const timestampMs = parseInt(lastValue, 10);
-      if (!Number.isNaN(timestampMs)) {
-        where.updatedAt = {
-          [orderDirection === "desc" ? Op.lt : Op.gt]: new Date(timestampMs),
-        };
-      }
-    }
-
-    const rows = await this.model.findAll({
+    const { rows, count } = await this.model.findAndCountAll({
       where,
       // A Frame has at most one sandbox owner link (unique index), so the inner join never
       // duplicates rows. `subQuery: false` keeps the join out of the LIMIT subquery.
@@ -288,18 +272,18 @@ export class FileResource extends BaseResource<FileModel> {
           ]
         : [],
       subQuery: false,
-      order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
-      limit: limit + 1,
+      // `id` breaks ties so a row cannot drift between pages as the offset moves.
+      order: [
+        ["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"],
+        ["id", "DESC"],
+      ],
+      limit,
+      offset,
     });
 
-    const hasMore = rows.length > limit;
-    const page = hasMore ? rows.slice(0, limit) : rows;
-    const last = page.at(-1);
-
     return {
-      frames: page.map((row) => new this(this.model, row.get())),
-      hasMore,
-      lastValue: last ? `${last.updatedAt.getTime()}` : null,
+      frames: rows.map((row) => new this(this.model, row.get())),
+      totalCount: count,
     };
   }
 

--- a/front/poke/swr/frames.ts
+++ b/front/poke/swr/frames.ts
@@ -15,25 +15,26 @@ interface UsePokeFramesProps {
   disabled?: boolean;
   hasSandbox: boolean;
   limit: number;
+  offset: number;
   owner: LightWorkspaceType;
-}
-
-export interface PokeFramesData {
-  items: PokeFrameListItem[];
-  hasMore: boolean;
-  isLoadingMore: boolean;
 }
 
 export function usePokeFrames({
   disabled,
   hasSandbox,
   limit,
+  offset,
   owner,
 }: UsePokeFramesProps) {
   const { fetcher } = useFetcher();
   const framesFetcher: Fetcher<PokeListFrames> = fetcher;
+  const params = new URLSearchParams({
+    limit: limit.toString(),
+    offset: offset.toString(),
+    hasSandbox: hasSandbox.toString(),
+  });
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/frames?limit=${limit}&hasSandbox=${hasSandbox}`,
+    `/api/poke/workspaces/${owner.sId}/frames?${params.toString()}`,
     framesFetcher,
     { disabled, keepPreviousData: true }
   );
@@ -41,8 +42,8 @@ export function usePokeFrames({
   return {
     data: {
       items: data?.items ?? emptyArray<PokeFrameListItem>(),
-      hasMore: data?.hasMore ?? false,
-      isLoadingMore: isValidating && !!data,
+      totalCount: data?.totalCount ?? 0,
+      isValidating,
     },
     isLoading: !error && !data && !disabled,
     isError: error,


### PR DESCRIPTION
## Description

The poke Frames v2 table showed two pagination systems at once: a "Load more" button that re-fetched with a growing `limit`, plus the shared data table's own client-side prev/next controls over the loaded rows.

This switches it to the pattern used by the agent conversations and triggers tables: server-side limit/offset pagination with a total count, driven through `serverSideRowCount` on `PokeDataTable`. The "Load more" button is gone.

- `FileResource.listFrameV2ForWorkspacePaginated` now takes `limit`/`offset` and returns `totalCount` (via `findAndCountAll`). The keyset `lastValue` path is removed since nothing used it; `id` breaks `updatedAt` ties so rows cannot drift between pages.
- `listWorkspaceFrames` returns `{ items, totalCount }` instead of `hasMore`/`lastValue`.
- The poke route validates `limit`, `offset`, `orderDirection` and `hasSandbox` with a zod query schema, like the conversations route.
- `usePokeFrames` takes `offset` and exposes `totalCount` and `isValidating`.
- The table holds a `PaginationState`; toggling the sandbox filter resets to the first page.

The endpoint is private and this table is its only consumer, so dropping `hasMore`/`lastValue` breaks no other client.

## Tests

- `front-api` poke frames route tests updated and passing, including a two-page limit/offset assertion.
- Type-checks for `front` and `front-api` pass.

## Risk

Low: poke-only UI.

## Deploy Plan

Deploy front-api and front-spa.