### PR TITLE
[sparkle] FilterChips: secondary selected variant and standalone FilterChip

### DIFF
--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -1,6 +1,58 @@
+import { cn } from "@sparkle/lib/utils";
 import React, { useCallback, useState } from "react";
-
 import { Button } from "./Button";
+
+export const FILTER_CHIP_VARIANTS = ["primary", "secondary"] as const;
+export type FilterChipVariant = (typeof FILTER_CHIP_VARIANTS)[number];
+
+interface FilterChipProps {
+  /** Chip text; omit it (with an `icon`) for an icon-only chip. */
+  label?: string;
+  /** Leading icon component. */
+  icon?: React.ComponentType<{ className?: string }>;
+  /** Whether this chip is the active one. */
+  isSelected?: boolean;
+  /** Selected look: `primary` fills the chip, `secondary` uses the lighter selected background. */
+  variant?: FilterChipVariant;
+  /** Tooltip label; required for icon-only chips. */
+  tooltip?: string;
+  onClick?: () => void;
+}
+
+/**
+ * A single filter chip whose selection is controlled by the caller, for
+ * toggles that filter a list or open a panel. Selected chips read as
+ * `primary` (filled) or `secondary` (lighter background); unselected chips
+ * are ghost buttons. Exposes `aria-pressed`.
+ * @summary Controlled single filter chip.
+ */
+export function FilterChip({
+  label,
+  icon,
+  isSelected = false,
+  variant = "primary",
+  tooltip,
+  onClick,
+}: FilterChipProps) {
+  const isFilled = isSelected && variant === "primary";
+  return (
+    <Button
+      size="xs"
+      label={label}
+      icon={icon}
+      tooltip={tooltip}
+      variant={isFilled ? "primary" : "ghost"}
+      aria-pressed={isSelected}
+      // Same token as NavTabPill's active pill, so the two selected states match.
+      className={cn(
+        isSelected &&
+          variant === "secondary" &&
+          "bg-selected hover:bg-selected dark:bg-selected dark:hover:bg-selected"
+      )}
+      onClick={onClick}
+    />
+  );
+}
 
 interface FilterChipsProps<T extends string> {
   /** Filter names, each rendered as a chip. */
@@ -9,6 +61,8 @@ interface FilterChipsProps<T extends string> {
   onFilterClick: (filterName: T) => void;
   /** Filter preselected on mount (must be one of filters). */
   defaultFilter?: T;
+  /** Selected look for every chip; see FilterChip. */
+  variant?: FilterChipVariant;
 }
 
 /**
@@ -22,6 +76,7 @@ export function FilterChips<T extends string>({
   filters,
   onFilterClick,
   defaultFilter,
+  variant = "primary",
 }: FilterChipsProps<T>) {
   const [selectedFilter, setSelectedFilter] = useState<T | null>(
     defaultFilter && filters.includes(defaultFilter) ? defaultFilter : null
@@ -41,11 +96,11 @@ export function FilterChips<T extends string>({
   return (
     <div className="flex flex-row flex-wrap gap-2">
       {filters.map((filterName) => (
-        <Button
-          label={filterName}
-          variant={selectedFilter === filterName ? "primary" : "ghost"}
+        <FilterChip
           key={filterName}
-          size="xs"
+          label={filterName}
+          isSelected={selectedFilter === filterName}
+          variant={variant}
           onClick={() => handleFilterClick(filterName)}
         />
       ))}

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -37,9 +37,9 @@ export interface FilterChipProps {
 }
 
 /**
- * A single filter chip whose selection is controlled by the caller, e.g. a
- * side panel toggle. Selected chips are `primary` (filled) or `secondary`
- * (lighter background); unselected chips are ghost. Sets `aria-pressed`.
+ * A single filter chip whose selection is controlled by the caller. Selected
+ * chips are `primary` (filled) or `secondary` (lighter background); unselected
+ * chips are ghost. Sets `aria-pressed`.
  * @summary Controlled single filter chip.
  */
 export function FilterChip({

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -25,14 +25,15 @@ function selectedButtonProps(
 export interface FilterChipProps {
   /** Chip text; omit it (with an `icon`) for an icon-only chip. */
   label?: string;
-  /** Leading icon component. */
-  icon?: React.ComponentType<{ className?: string }>;
+  /** Leading icon. */
+  icon?: ButtonProps["icon"];
   /** Whether this chip is selected. */
   isSelected?: boolean;
   /** Selected look: `primary` fills the chip, `secondary` uses the lighter selected background. */
   variant?: FilterChipVariant;
   /** Tooltip label; required for icon-only chips. */
   tooltip?: string;
+  /** Called on click; the caller owns the selection and toggles it. */
   onClick?: () => void;
 }
 

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -1,11 +1,30 @@
-import { cn } from "@sparkle/lib/utils";
+import { assertNever } from "@sparkle/lib/utils";
 import React, { useCallback, useState } from "react";
-import { Button } from "./Button";
+import { Button, type ButtonProps } from "./Button";
 
 export const FILTER_CHIP_VARIANTS = ["primary", "secondary"] as const;
 export type FilterChipVariant = (typeof FILTER_CHIP_VARIANTS)[number];
 
-interface FilterChipProps {
+// Selected look per variant. `bg-selected` is the token NavTabPill uses for its active pill and
+// flips with the theme on its own. Hover and active are pinned so a selected chip does not dip to
+// the ghost hover tint.
+function selectedButtonProps(
+  variant: FilterChipVariant
+): Pick<ButtonProps, "variant" | "className"> {
+  switch (variant) {
+    case "primary":
+      return { variant: "primary" };
+    case "secondary":
+      return {
+        variant: "ghost",
+        className: "bg-selected hover:bg-selected active:bg-selected",
+      };
+    default:
+      return assertNever(variant);
+  }
+}
+
+export interface FilterChipProps {
   /** Chip text; omit it (with an `icon`) for an icon-only chip. */
   label?: string;
   /** Leading icon component. */
@@ -34,22 +53,15 @@ export function FilterChip({
   tooltip,
   onClick,
 }: FilterChipProps) {
-  const isFilled = isSelected && variant === "primary";
   return (
     <Button
       size="xs"
       label={label}
       icon={icon}
       tooltip={tooltip}
-      variant={isFilled ? "primary" : "ghost"}
       aria-pressed={isSelected}
-      // Same token as NavTabPill's active pill, so the two selected states match.
-      className={cn(
-        isSelected &&
-          variant === "secondary" &&
-          "bg-selected hover:bg-selected dark:bg-selected dark:hover:bg-selected"
-      )}
       onClick={onClick}
+      {...(isSelected ? selectedButtonProps(variant) : { variant: "ghost" })}
     />
   );
 }

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -5,9 +5,7 @@ import { Button, type ButtonProps } from "./Button";
 export const FILTER_CHIP_VARIANTS = ["primary", "secondary"] as const;
 export type FilterChipVariant = (typeof FILTER_CHIP_VARIANTS)[number];
 
-// Selected look per variant. `bg-selected` is the token NavTabPill uses for its active pill and
-// flips with the theme on its own. Hover and active are pinned so a selected chip does not dip to
-// the ghost hover tint.
+// `bg-selected` is the NavTabPill active token; hover/active are pinned so the chip stays put.
 function selectedButtonProps(
   variant: FilterChipVariant
 ): Pick<ButtonProps, "variant" | "className"> {
@@ -29,7 +27,7 @@ export interface FilterChipProps {
   label?: string;
   /** Leading icon component. */
   icon?: React.ComponentType<{ className?: string }>;
-  /** Whether this chip is the active one. */
+  /** Whether this chip is selected. */
   isSelected?: boolean;
   /** Selected look: `primary` fills the chip, `secondary` uses the lighter selected background. */
   variant?: FilterChipVariant;
@@ -39,10 +37,9 @@ export interface FilterChipProps {
 }
 
 /**
- * A single filter chip whose selection is controlled by the caller, for
- * toggles that filter a list or open a panel. Selected chips read as
- * `primary` (filled) or `secondary` (lighter background); unselected chips
- * are ghost buttons. Exposes `aria-pressed`.
+ * A single filter chip whose selection is controlled by the caller, e.g. a
+ * side panel toggle. Selected chips are `primary` (filled) or `secondary`
+ * (lighter background); unselected chips are ghost. Sets `aria-pressed`.
  * @summary Controlled single filter chip.
  */
 export function FilterChip({

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -33,8 +33,8 @@ export interface FilterChipProps {
   variant?: FilterChipVariant;
   /** Tooltip label; required for icon-only chips. */
   tooltip?: string;
-  /** Called on click; the caller owns the selection and toggles it. */
-  onClick?: () => void;
+  /** Called on click; the caller owns the selection and toggles it. For a non-interactive badge use Chip. */
+  onClick: () => void;
 }
 
 /**

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -153,6 +153,7 @@ export { FaviconIcon } from "./FaviconIcon";
 export {
   FILTER_CHIP_VARIANTS,
   FilterChip,
+  type FilterChipProps,
   FilterChips,
   type FilterChipVariant,
 } from "./FilterChips";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -150,7 +150,12 @@ export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";
 export { FaviconIcon } from "./FaviconIcon";
-export { FilterChips } from "./FilterChips";
+export {
+  FILTER_CHIP_VARIANTS,
+  FilterChip,
+  FilterChips,
+  type FilterChipVariant,
+} from "./FilterChips";
 export { Div3D, Hover3D } from "./Hover3D";
 export { Hoverable } from "./Hoverable";
 export { HoveringBar } from "./HoveringBar";

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { expect, fn, waitFor } from "storybook/test";
 
 import {
+  FILTER_CHIP_VARIANTS,
   FilterChip,
   FilterChips,
   Folder,
@@ -34,7 +35,7 @@ const meta = {
   },
   argTypes: {
     variant: {
-      options: ["primary", "secondary"],
+      options: FILTER_CHIP_VARIANTS,
       control: { type: "radio" },
     },
   },
@@ -89,7 +90,9 @@ export const Secondary: Story = {
  * @summary Controlled single chips with icons.
  */
 export const SingleChips: Story = {
-  // Renders FilterChip directly; the row args are irrelevant here.
+  // Renders FilterChip directly: row args are irrelevant, and the manifest skips it so the story
+  // is not attributed to FilterChips.
+  tags: ["!manifest"],
   args: { filters: [] },
   render: () => (
     <div className="flex items-center gap-2">

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -83,9 +83,9 @@ export const Secondary: Story = {
 };
 
 /**
- * Standalone **FilterChip** with caller-controlled selection, as used for side
- * panel toggles: icon plus label, one selected in `secondary` style, and an
- * icon-only chip with its label as a tooltip.
+ * Standalone **FilterChip** with caller-controlled selection: icon plus label,
+ * one selected in `secondary` style, and an icon-only chip with its label as a
+ * tooltip.
  * @summary Controlled single chips with icons.
  */
 export const SingleChips: Story = {

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -84,14 +84,12 @@ export const Secondary: Story = {
 
 /**
  * Standalone **FilterChip** with caller-controlled selection, as used for side
- * panel toggles: icon plus label, the selected one in `secondary` style, and an
- * icon-only chip carrying its label as a tooltip. Every chip exposes
- * `aria-pressed`.
+ * panel toggles: icon plus label, one selected in `secondary` style, and an
+ * icon-only chip with its label as a tooltip.
  * @summary Controlled single chips with icons.
  */
 export const SingleChips: Story = {
-  // Renders FilterChip directly: row args are irrelevant, and the manifest skips it so the story
-  // is not attributed to FilterChips.
+  // Renders FilterChip on its own, so keep it out of the FilterChips manifest.
   tags: ["!manifest"],
   args: { filters: [] },
   render: () => (

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "storybook/test";
+import React from "react";
+import { expect, fn, waitFor } from "storybook/test";
 
-import { FilterChips } from "../index_with_tw_base";
+import {
+  FilterChip,
+  FilterChips,
+  Folder,
+  ListSelect,
+} from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/FilterChips",
@@ -17,12 +23,20 @@ const meta = {
 **Guidelines**
 - Selection is single-choice: only one chip is active at a time, so use it for filtering rather than multi-tagging.
 - Pass a **defaultFilter** that matches an entry in **filters** to highlight the initial category.
+- **variant** picks the selected look: \`primary\` fills the chip, \`secondary\` uses the lighter selected background for quieter surfaces such as a title bar.
+- For a single chip whose selection you control yourself (a panel toggle, an icon-only chip), use **FilterChip** directly.
 - For a standalone status or metadata label that is not interactive, use **Chip** instead.`,
       },
     },
   },
   args: {
     onFilterClick: fn(),
+  },
+  argTypes: {
+    variant: {
+      options: ["primary", "secondary"],
+      control: { type: "radio" },
+    },
   },
 } satisfies Meta<typeof FilterChips>;
 
@@ -51,5 +65,50 @@ export const Default: Story = {
 export const NoDefaultSelection: Story = {
   args: {
     filters: ["Featured", "Writing", "Productivity", "Research", "Knowledge"],
+  },
+};
+
+/**
+ * The lighter selected look: the active chip gets the `selected` background
+ * instead of a filled pill, for quieter surfaces such as a title bar.
+ * @summary Secondary selected style.
+ */
+export const Secondary: Story = {
+  args: {
+    filters: ["Featured", "Writing", "Productivity", "Research", "Knowledge"],
+    defaultFilter: "Featured",
+    variant: "secondary",
+  },
+};
+
+/**
+ * Standalone **FilterChip** with caller-controlled selection, as used for side
+ * panel toggles: icon plus label, the selected one in `secondary` style, and an
+ * icon-only chip carrying its label as a tooltip. Every chip exposes
+ * `aria-pressed`.
+ * @summary Controlled single chips with icons.
+ */
+export const SingleChips: Story = {
+  // Renders FilterChip directly; the row args are irrelevant here.
+  args: { filters: [] },
+  render: () => (
+    <div className="flex items-center gap-2">
+      <FilterChip label="Files" icon={Folder} variant="secondary" />
+      <FilterChip
+        label="Plan 2/7"
+        icon={ListSelect}
+        variant="secondary"
+        isSelected
+      />
+      <FilterChip icon={Folder} tooltip="Files" variant="secondary" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const pressed = Array.from(canvasElement.querySelectorAll("button")).map(
+        (chip) => chip.getAttribute("aria-pressed")
+      );
+      expect(pressed).toEqual(["false", "true", "false"]);
+    });
   },
 };

--- a/sparkle/src/stories/FilterChips.stories.tsx
+++ b/sparkle/src/stories/FilterChips.stories.tsx
@@ -94,14 +94,25 @@ export const SingleChips: Story = {
   args: { filters: [] },
   render: () => (
     <div className="flex items-center gap-2">
-      <FilterChip label="Files" icon={Folder} variant="secondary" />
+      <FilterChip
+        label="Files"
+        icon={Folder}
+        variant="secondary"
+        onClick={fn()}
+      />
       <FilterChip
         label="Plan 2/7"
         icon={ListSelect}
         variant="secondary"
         isSelected
+        onClick={fn()}
       />
-      <FilterChip icon={Folder} tooltip="Files" variant="secondary" />
+      <FilterChip
+        icon={Folder}
+        tooltip="Files"
+        variant="secondary"
+        onClick={fn()}
+      />
     </div>
   ),
   play: async ({ canvasElement }) => {


### PR DESCRIPTION
Design feedback on #31895: the filled primary chip is too heavy for the conversation title bar, so `FilterChips` gets a `variant` prop. `primary` is the current filled look and stays the default. `secondary` gives the selected chip the `bg-selected` token instead, the same one NavTabPill uses for its active pill.

The single chip is now exported as `FilterChip`, controlled by the caller (`isSelected`, `onClick`), with an optional `icon`, a `tooltip` for icon-only chips, and `aria-pressed`. `FilterChips` renders it internally, its API is unchanged apart from the new `variant`.

Two stories added: `Secondary` for the row, `SingleChips` for the standalone chip with icons.

Once merged, #31895 switches the Credits / Files / Plan toggles to `FilterChip variant="secondary"`.

<kbd>
<img width="1110" height="655" alt="Screenshot 2026-09-04 at 18 19 00" src="https://github.com/user-attachments/assets/50b39755-8352-4aea-9c52-65b3af85cf7e" />
</kbd>
