### PR TITLE
[sparkle] Storybook: paint every docs canvas in dark mode

### DIFF
--- a/sparkle/.storybook/preview.ts
+++ b/sparkle/.storybook/preview.ts
@@ -93,11 +93,13 @@ const preview: Preview = {
       const isDark = context.globals.theme === "dark";
       const background = isDark ? "#000000" : "#ffffff";
 
-      // Update both document and storybook-docs background
+      // Update the document and every story canvas on a docs page (one per story).
       document.documentElement.style.backgroundColor = background;
       document
-        .querySelector(".docs-story")
-        ?.setAttribute("style", `background-color: ${background}`);
+        .querySelectorAll<HTMLElement>(".docs-story")
+        .forEach((canvas) => {
+          canvas.style.backgroundColor = background;
+        });
 
       return Story();
     },


### PR DESCRIPTION
In dark mode, docs pages only painted the first story canvas black: the theme decorator used `querySelector(".docs-story")`. Every other story on the page kept a white canvas while its content switched to dark colors, so ghost text became invisible (see FilterChips docs, "No Default Selection" and below).

The decorator now paints every `.docs-story` on the page.

Ex here: https://sparkle.dust.tt/?path=/docs/forms-inputs-filterchips--docs&globals=theme:dark
