### PR TITLE
[sparkle] Storybook: paint the canvas with the background token

### DIFF
--- a/sparkle/.storybook/preview.ts
+++ b/sparkle/.storybook/preview.ts
@@ -61,29 +61,9 @@ const preview: Preview = {
     themes: {
       default: "light",
       list: [
+        // Swatches mirror --color-background in each theme (see the canvas decorator below).
         { name: "light", class: "", color: "#ffffff" },
-        { name: "dark", class: "dark", color: "#000000" },
-      ],
-    },
-    backgrounds: {
-      default: "white",
-      values: [
-        {
-          name: "white",
-          value: "#ffffff",
-        },
-        {
-          name: "light",
-          value: "#F7F7F7",
-        },
-        {
-          name: "dark",
-          value: "#090F18",
-        },
-        {
-          name: "black",
-          value: "#000000",
-        },
+        { name: "dark", class: "dark", color: "#141211" },
       ],
     },
   },

--- a/sparkle/.storybook/preview.ts
+++ b/sparkle/.storybook/preview.ts
@@ -89,9 +89,10 @@ const preview: Preview = {
   },
 
   decorators: [
-    (Story, context) => {
-      const isDark = context.globals.theme === "dark";
-      const background = isDark ? "#000000" : "#ffffff";
+    (Story) => {
+      // Paint the canvas with the product's background token so components sit on the surface
+      // they ship on. The variable follows the theme class set by withThemeByClassName below.
+      const background = "var(--color-background)";
 
       // Update the document and every story canvas on a docs page (one per story).
       document.documentElement.style.backgroundColor = background;


### PR DESCRIPTION
Follow-up to #31905. Storybook painted the canvas pure black in dark mode, but nothing in the product is black: dark surfaces are stone. Subtle things like a `bg-selected` chip looked much fainter in Storybook than in the app.

The canvas now uses `var(--color-background)` in both themes, so components sit on the surface they ship on. The dark swatch in the toolbar matches, and I removed the `backgrounds` config since that addon isn't loaded.
