### PR TITLE
Gate Pod network settings, Computer admin scope and egress requests on frames_v2 instead of sandbox_functions

### DIFF
--- a/front-api/middlewares/with_sandbox_functions_feature.ts
+++ b/front-api/middlewares/with_sandbox_functions_feature.ts
@@ -6,35 +6,6 @@ import type {
 import { apiError } from "@front-api/middlewares/utils";
 import { createMiddleware } from "hono/factory";
 
-// Gates a route behind the `sandbox_functions` feature flag. This is the flag
-// for the newer Sandbox Functions surface (including the pod-level sandbox
-// admin), distinct from the workspace Computer admin gated by
-// `withComputerFeature`.
-export function withSandboxFunctionsFeature({
-  message = "Sandbox Functions are disabled for this workspace.",
-}: {
-  message?: string;
-} = {}) {
-  return createMiddleware<PublicApiCtx | WorkspaceAwareCtx>(
-    async (ctx, next) => {
-      const auth = ctx.get("auth");
-      const featureFlags = await getFeatureFlags(auth);
-
-      if (!featureFlags.includes("sandbox_functions")) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "feature_flag_not_found",
-            message,
-          },
-        });
-      }
-
-      await next();
-    }
-  );
-}
-
 /** Invocation routes are shared while Frames v2 progressively replaces Pod Functions. */
 export function withSandboxFunctionInvocationFeature() {
   return createMiddleware<PublicApiCtx | WorkspaceAwareCtx>(

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
@@ -59,7 +59,7 @@ async function setupTest({
   });
 
   if (enableSandboxFunctions) {
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
   }
 
   const podA = await SpaceFactory.project(workspace, user.id);
@@ -155,7 +155,7 @@ describe("GET /api/w/:wId/sandbox/egress-policy/bulk", () => {
     });
   });
 
-  it("returns 403 when sandbox_functions is disabled", async () => {
+  it("returns 403 when frames_v2 is disabled", async () => {
     const { workspace, podA } = await setupTest({
       enableSandboxFunctions: false,
     });
@@ -254,7 +254,7 @@ describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
     });
   });
 
-  it("returns 403 when sandbox_functions is disabled", async () => {
+  it("returns 403 when frames_v2 is disabled", async () => {
     const { workspace, podA } = await setupTest({
       enableSandboxFunctions: false,
     });

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.ts
@@ -20,11 +20,11 @@ import { z } from "zod";
 // Mounted at /api/w/:wId/sandbox/egress-policy/bulk. Multi-pod read (GET) and
 // add/remove write (POST) for the central Computer admin page. The parent
 // sub-app applies the workspace-admin + Computer gates; the multi-Pod feature
-// is gated on the sandbox_functions flag. Only Pods with their own policy are
+// is gated on the frames_v2 flag. Only Pods with their own policy are
 // surfaced.
 const app = workspaceApp();
 
-app.use("*", withFeatureFlag("sandbox_functions"));
+app.use("*", withFeatureFlag("frames_v2"));
 
 const PostBulkEgressPolicyBodySchema = z
   .object({

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.test.ts
@@ -20,7 +20,7 @@ async function setupTest({
   });
 
   if (enableSandboxFunctions) {
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
   }
 
   const podA = await SpaceFactory.project(workspace, user.id);
@@ -92,7 +92,7 @@ describe("GET /api/w/:wId/sandbox/egress-policy/pods", () => {
     expect(await response.json()).toEqual({ pods: [] });
   });
 
-  it("returns 403 when sandbox_functions is disabled", async () => {
+  it("returns 403 when frames_v2 is disabled", async () => {
     const { workspace } = await setupTest({ enableSandboxFunctions: false });
 
     const response = await getPods(workspace.sId);

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
@@ -11,7 +11,7 @@ import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 // baseline. Same gates as the bulk read.
 const app = workspaceApp();
 
-app.use("*", withFeatureFlag("sandbox_functions"));
+app.use("*", withFeatureFlag("frames_v2"));
 
 /** @ignoreswagger */
 app.get("/", async (ctx): HandlerResult<GetEgressPolicyPodsResponseBody> => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
@@ -32,7 +32,7 @@ async function setupTest({
   });
 
   if (enableSandboxFunctions) {
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
   }
 
   return { workspace, auth, ...rest };
@@ -268,7 +268,7 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     ).toBeUndefined();
   });
 
-  it("rejects workspaces without the sandbox_functions flag with a 403", async () => {
+  it("rejects workspaces without the frames_v2 flag with a 403", async () => {
     const { workspace } = await setupTest({ enableSandboxFunctions: false });
     const pod = await SpaceFactory.project(workspace);
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
@@ -31,7 +31,7 @@ async function setupTest({
     role,
   });
 
-  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  await FeatureFlagFactory.basic(auth, "frames_v2");
 
   const pod = await SpaceFactory.project(workspace, user.id);
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.test.ts
@@ -32,7 +32,7 @@ async function setupTest({
   });
 
   if (!withoutSandboxFunctionsFeature) {
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
   }
 
   const pod = await SpaceFactory.project(workspace, user.id);
@@ -68,7 +68,7 @@ describe("GET/POST /api/w/:wId/spaces/:spaceId/sandbox/env-vars", () => {
     });
   });
 
-  it("returns 403 without the sandbox_functions feature", async () => {
+  it("returns 403 without the frames_v2 feature", async () => {
     const { workspace, pod } = await setupTest({
       withoutSandboxFunctionsFeature: true,
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
@@ -1,16 +1,16 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { withSandboxFunctionsFeature } from "@front-api/middlewares/with_sandbox_functions_feature";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 
 import egressPolicy from "./egress-policy";
 import envVars from "./env-vars";
 
-// Mounted at /api/w/:wId/spaces/:spaceId/sandbox. Only the `sandbox_functions`
+// Mounted at /api/w/:wId/spaces/:spaceId/sandbox. Only the `frames_v2`
 // gate is applied here; access control is per leaf — egress-policy opens GET to
 // Pod readers (writes admin-only), env-vars stays admin-only. Keep in sync with
 // the UI gate in PodSettingsTab.
 const app = workspaceApp();
 
-app.use("*", withSandboxFunctionsFeature());
+app.use("*", withFeatureFlag("frames_v2"));
 
 app.route("/egress-policy", egressPolicy);
 app.route("/env-vars", envVars);

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -102,12 +102,12 @@ export function PodSettingsTab({
   const hasAdminControlledPodsFeature = hasFeature("admin_controlled_pods");
   // The pod env vars section stays workspace-admin only (matching the API,
   // which keeps env-vars admin-only). Mirrors that gate — change both together.
-  const isPodSandboxAdminEnabled = isAdmin && hasFeature("sandbox_functions");
+  const isPodSandboxAdminEnabled = isAdmin && hasFeature("frames_v2");
   // The pod network section is visible to anyone who can open this page once
   // the feature is on (the API opens the egress GET to Pod readers); editing
   // stays workspace-admin only. Mirrors the egress-policy route gates — change
   // both together.
-  const canViewPodNetwork = hasFeature("sandbox_functions");
+  const canViewPodNetwork = hasFeature("frames_v2");
   const canEditPodNetwork = isPodSandboxAdminEnabled;
 
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({

--- a/front/hooks/useComputerAdminAccess.ts
+++ b/front/hooks/useComputerAdminAccess.ts
@@ -10,11 +10,10 @@ export function useComputerAdminAccess() {
   const { featureFlags } = useFeatureFlags();
   const isComputerEnabled = isComputerFeatureEnabled(featureFlags);
   const canAdministrateComputer = isAdmin && isComputerEnabled;
-  const hasSandboxFunctions = featureFlags.includes("sandbox_functions");
-  // The multi-Pod scope selector and Pod network editing ride the Pod Functions
-  // flag (sandbox_functions), on top of Computer admin access.
-  const canAdministratePodNetwork =
-    canAdministrateComputer && hasSandboxFunctions;
+  const hasFramesV2 = featureFlags.includes("frames_v2");
+  // The multi-Pod scope selector and Pod network editing ride the Frames v2
+  // flag (frames_v2), on top of Computer admin access.
+  const canAdministratePodNetwork = canAdministrateComputer && hasFramesV2;
 
   return {
     isAdmin,

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -138,7 +138,7 @@ import {
 describe("createSandboxTools", () => {
   it("keeps request_egress_domain but omits self-serve add_egress_domain by default", async () => {
     const { authenticator: auth } = await createResourceTest({});
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
 
     const tools = await createSandboxTools(auth);
     const names = tools.map((tool) => tool.name);
@@ -156,7 +156,7 @@ describe("createSandboxTools", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
 
     const tools = await createSandboxTools(auth);
     const names = tools.map((tool) => tool.name);
@@ -174,7 +174,7 @@ describe("createSandboxTools", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
     await FeatureFlagFactory.basic(auth, "disable_computer_feature");
 
     const tools = await createSandboxTools(auth);
@@ -184,7 +184,7 @@ describe("createSandboxTools", () => {
     expect(names).not.toContain("request_egress_domain");
   });
 
-  it("omits request_egress_domain when sandbox_functions is off", async () => {
+  it("omits request_egress_domain when frames_v2 is off", async () => {
     const { workspace, user } = await createResourceTest({});
     await WorkspaceResource.updateMetadata(workspace.id, {
       sandboxAllowAgentEgressRequests: true,
@@ -207,7 +207,7 @@ describe("createSandboxTools", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+    await FeatureFlagFactory.basic(auth, "frames_v2");
 
     const tools = await createSandboxTools(auth);
     const names = tools.map((tool) => tool.name);

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -304,7 +304,7 @@ export async function createSandboxTools(
   const tools = buildTools(SANDBOX_TOOLS_METADATA, handlers);
 
   // Both require Computer. add_egress_domain is also gated on the self-serve
-  // toggle; request_egress_domain on sandbox_functions instead — so it only
+  // toggle; request_egress_domain on frames_v2 instead — so it only
   // appears where its Pod/workspace review settings exist, never the toggle.
   const flags = await getFeatureFlags(auth);
   const computerEnabled = isComputerFeatureEnabled(flags);
@@ -312,7 +312,7 @@ export async function createSandboxTools(
   if (!computerEnabled || !isSandboxAgentEgressRequestsAllowed(auth)) {
     excluded.add(ADD_EGRESS_DOMAIN_TOOL_NAME);
   }
-  if (!computerEnabled || !flags.includes("sandbox_functions")) {
+  if (!computerEnabled || !flags.includes("frames_v2")) {
     excluded.add(REQUEST_EGRESS_DOMAIN_TOOL_NAME);
   }
 


### PR DESCRIPTION
## Description

The Pod network / env vars settings and the multi-Pod Computer admin scope were gated on `sandbox_functions`, the Pod Functions flag. Egress review is now a Frames v2 concern (Frames v2 functions run under the same Pod / workspace egress policies), so this moves those gates to `frames_v2`.

Swapped to `frames_v2`:

- Computer admin page: multi-Pod scope selector and Pod network editing (`useComputerAdminAccess`).
- Pod settings tab: network section (view) and env vars section (admin edit).
- `front-api`: `/spaces/:spaceId/sandbox/*` (Pod egress-policy + env-vars), `/sandbox/egress-policy/pods`, `/sandbox/egress-policy/bulk`.
- `request_egress_domain` agent tool availability.

Left on `sandbox_functions` on purpose, because they are only reached by Pod Functions code: the `sandbox_functions` MCP server and its publish tool, the Pod Functions skill, the legacy Frames skill's `hasPodFunctions` hint, and the Pod Function branch of share-capability resolution. The invocation middleware keeps accepting either flag.

`withSandboxFunctionsFeature` had no remaining consumer and is removed; the Pod sandbox routes use the generic `withFeatureFlag("frames_v2")` like their siblings.

A follow-up PR stacked on this one adds `domains` to the Frames v2 manifest and files them as Pod / workspace egress requests on publish.

## Tests

- Updated the route tests for the three `front-api` sub-apps and the `request_egress_domain` tool tests to seed `frames_v2` instead; 69 + 35 tests pass locally.
- Biome and typecheck clean on `front` and `front-api`.

## Risk

A workspace that has `sandbox_functions` but not `frames_v2` loses the Pod network / env vars sections and the multi-Pod admin view (UI hidden, API 403) until `frames_v2` is enabled. `frames_v2` is self-serve while `sandbox_functions` is dust-only, so this should only affect internal workspaces. Worst case, flip `frames_v2` on for the affected workspace or revert; no data changes. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front` and `front-api` (UI and API gates flip together; no ordering constraint).
