### PR TITLE
Frames v2: declare egress domains in the manifest and file them as Pod or workspace requests on publish

### DIFF
--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -55,6 +55,9 @@ pub struct FramePublishResponse {
     pub publication_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<serde_json::Value>,
+    /// Egress requests filed for the manifest's declared domains (Frames v2 only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub egress_domains: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/front-api/middlewares/with_sandbox_functions_feature.ts
+++ b/front-api/middlewares/with_sandbox_functions_feature.ts
@@ -6,7 +6,9 @@ import type {
 import { apiError } from "@front-api/middlewares/utils";
 import { createMiddleware } from "hono/factory";
 
-/** Invocation routes are shared while Frames v2 progressively replaces Pod Functions. */
+// Function invocation routes serve both legacy Pod Functions and Frames v2
+// functions, so they accept either flag while Frames v2 replaces Pod
+// Functions. Settings routes are gated on `frames_v2` alone via withFeatureFlag.
 export function withSandboxFunctionInvocationFeature() {
   return createMiddleware<PublicApiCtx | WorkspaceAwareCtx>(
     async (ctx, next) => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -1,6 +1,7 @@
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { publishFrameFromSource } from "@app/lib/api/frames/publish_from_source";
 import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import type { EgressDomainRequestsSummary } from "@app/lib/api/sandbox/egress_domain_requests";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -27,6 +28,7 @@ type FramePublishResponse = {
   manifestPath: string;
   publicationId?: string;
   warnings?: ValidationWarning[];
+  egressDomains?: EgressDomainRequestsSummary;
 };
 
 // Mounted at /api/v1/w/:wId/sandbox/frames.
@@ -114,6 +116,9 @@ app.post(
             frameId: publication.value.frameId,
             manifestPath: publication.value.sourcePath,
             publicationId: publication.value.publicationId,
+            ...(publication.value.egressDomains
+              ? { egressDomains: publication.value.egressDomains }
+              : {}),
           },
           200
         );

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -4,12 +4,13 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getWritablePodContext } from "@app/lib/api/actions/servers/pod_manager/helpers";
-import { requestOwnerPolicyDomain } from "@app/lib/api/sandbox/egress_policy";
+import {
+  formatEgressDomainRequestsNote,
+  requestEgressDomainsForScope,
+} from "@app/lib/api/sandbox/egress_domain_requests";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
-import type { Authenticator } from "@app/lib/auth";
 import { shortSandboxFunctionBundleSha256 } from "@app/lib/resources/sandbox_function_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
   SandboxFunctionExecutionMode,
   SandboxFunctionStake,
@@ -65,10 +66,15 @@ export async function publishHandler(
 
   // Failures become a note, not a publish failure — the function is already
   // published and its domains can be retried.
-  const domainNote = await routePublishedFunctionDomains(auth, {
-    pod: podResult.value.pod,
-    domains: domains ?? [],
-  });
+  const domainNote =
+    domains && domains.length > 0
+      ? formatEgressDomainRequestsNote(
+          await requestEgressDomainsForScope(auth, {
+            scope: { kind: "pod", podId: podResult.value.pod.sId },
+            domains,
+          })
+        )
+      : null;
 
   const lines = [
     `Published pod function "${publishedSlug}" ` +
@@ -89,52 +95,6 @@ export async function publishHandler(
   }
 
   return new Ok([{ type: "text", text: lines.join("\n") }]);
-}
-
-// Files each declared domain as a Pod request. Bounded to one function's
-// domains, so the sequential per-domain writes are fine.
-async function routePublishedFunctionDomains(
-  auth: Authenticator,
-  { pod, domains }: { pod: SpaceResource; domains: string[] }
-): Promise<string | null> {
-  if (domains.length === 0) {
-    return null;
-  }
-
-  const requested: string[] = [];
-  const alreadyAllowed: string[] = [];
-  const failed: string[] = [];
-
-  for (const domain of domains) {
-    const result = await requestOwnerPolicyDomain(auth, {
-      ownerId: pod.sId,
-      domain,
-    });
-    if (result.isErr()) {
-      failed.push(domain);
-    } else if (result.value.outcome === "already_allowed") {
-      alreadyAllowed.push(domain);
-    } else {
-      // "requested" or "already_requested": pending an admin's review.
-      requested.push(domain);
-    }
-  }
-
-  const parts: string[] = [];
-  if (requested.length > 0) {
-    parts.push(
-      `Requested for the Pod (pending admin approval): ${requested.join(", ")}.`
-    );
-  }
-  if (alreadyAllowed.length > 0) {
-    parts.push(`Already allowed: ${alreadyAllowed.join(", ")}.`);
-  }
-  if (failed.length > 0) {
-    parts.push(
-      `Could not process (retry with request_egress_domain): ${failed.join(", ")}.`
-    );
-  }
-  return parts.join(" ");
 }
 
 function toMCPError(error: SandboxFunctionError): MCPError {

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -25,6 +25,7 @@ import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
 } from "@app/types/mount_path";
+import { SANDBOX_POLICY_MAX_REQUESTED_DOMAINS } from "@app/types/sandbox/egress_policy";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -148,10 +149,10 @@ describe("publishFrameFromSource", () => {
     assert(result.isOk());
     assert(result.value.kind === "v2");
     expect(result.value.egressDomains).toEqual({
+      kind: "filed",
       scope: "workspace",
       requested: ["api.stripe.com", "*.stripe.com"],
       alreadyAllowed: [],
-      failed: [],
     });
     expect(
       requestedDomainsAt(`w/${workspace.sId}/sandbox-egress-policy.json`)
@@ -189,13 +190,79 @@ describe("publishFrameFromSource", () => {
 
     assert(result.isOk());
     assert(result.value.kind === "v2");
-    expect(result.value.egressDomains?.scope).toBe("pod");
+    expect(result.value.egressDomains).toMatchObject({
+      kind: "filed",
+      scope: "pod",
+    });
     expect(
       requestedDomainsAt(`w/${workspace.sId}/sandboxes/${projectId}.json`)
     ).toEqual(["api.stripe.com", "*.stripe.com"]);
     expect(
       fileStorageMock.getObject(`w/${workspace.sId}/sandbox-egress-policy.json`)
     ).toBeUndefined();
+  });
+
+  it("reports domains the workspace already allows without re-requesting them", async () => {
+    const { auth, conversation, manifestPath, workspace } = await setup({
+      manifestContent: manifestWithDomains,
+    });
+    const policyPath = `w/${workspace.sId}/sandbox-egress-policy.json`;
+    fileStorageMock.setObject(
+      policyPath,
+      JSON.stringify({ allowedDomains: ["api.stripe.com"] })
+    );
+
+    const result = await publishFrameFromSource(auth, {
+      conversation,
+      publishedByAgentConfigurationId: "test-agent",
+      sourcePath: manifestPath,
+    });
+
+    assert(result.isOk());
+    assert(result.value.kind === "v2");
+    expect(result.value.egressDomains).toEqual({
+      kind: "filed",
+      scope: "workspace",
+      requested: ["*.stripe.com"],
+      alreadyAllowed: ["api.stripe.com"],
+    });
+    expect(requestedDomainsAt(policyPath)).toEqual(["*.stripe.com"]);
+  });
+
+  it("publishes but reports the domains as failed when the scope is at its pending cap", async () => {
+    const { auth, conversation, manifestPath, workspace } = await setup({
+      manifestContent: manifestWithDomains,
+    });
+    const policyPath = `w/${workspace.sId}/sandbox-egress-policy.json`;
+    fileStorageMock.setObject(
+      policyPath,
+      JSON.stringify({
+        allowedDomains: [],
+        requestedDomains: Array.from(
+          { length: SANDBOX_POLICY_MAX_REQUESTED_DOMAINS },
+          (_, index) => ({
+            domain: `service-${index}.example.com`,
+            requestedAtMs: 1,
+          })
+        ),
+      })
+    );
+
+    const result = await publishFrameFromSource(auth, {
+      conversation,
+      publishedByAgentConfigurationId: "test-agent",
+      sourcePath: manifestPath,
+    });
+
+    assert(result.isOk());
+    assert(result.value.kind === "v2");
+    expect(result.value.egressDomains).toMatchObject({
+      kind: "failed",
+      domains: ["api.stripe.com", "*.stripe.com"],
+    });
+    expect(requestedDomainsAt(policyPath)).toHaveLength(
+      SANDBOX_POLICY_MAX_REQUESTED_DOMAINS
+    );
   });
 
   it("reports no domain requests when the manifest declares none", async () => {

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -9,6 +9,7 @@ import { getRedisStreamClient } from "@app/lib/api/redis";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { setupProjectConversation } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -34,36 +35,18 @@ const manifest = JSON.stringify({
 });
 const uiSource = "export default function Status() { return <p>Ready</p>; }";
 
-async function setup({
+// Serves a Frame folder (manifest + index.tsx) from the mocked source bucket.
+function stageFrameSource({
+  gcsSourceDirectoryPath,
+  manifestContent,
   uiContentType = "text/typescript",
 }: {
+  gcsSourceDirectoryPath: string;
+  manifestContent: string;
   uiContentType?: string;
-} = {}) {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
-  const conversation = await ConversationFactory.create(auth, {
-    agentConfigurationId: "test-agent",
-    messagesCreatedAt: [],
-  });
-  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
-  const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
-  const gcsSourceDirectoryPath = `${getConversationFilesBasePath({
-    workspaceId: workspace.sId,
-    conversationId: conversation.sId,
-  })}Status`;
-  const frame = await FileFactory.create(auth, null, {
-    contentType: frameV2ContentType,
-    fileName: FRAME_MANIFEST_FILE,
-    fileSize: Buffer.byteLength(manifest),
-    status: "created",
-    useCase: "conversation",
-    useCaseMetadata: { conversationId: conversation.sId },
-    mountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
-  });
-
+}) {
   const sourceByPath = new Map([
-    [`${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifest],
+    [`${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`, manifestContent],
     [`${gcsSourceDirectoryPath}/index.tsx`, uiSource],
   ]);
   fileStorageMock.setFilesByPrefix((prefix) =>
@@ -82,6 +65,38 @@ async function setup({
   fileStorageMock.setFileContent(
     (filePath) => sourceByPath.get(filePath) ?? null
   );
+}
+
+async function setup({
+  manifestContent = manifest,
+  uiContentType = "text/typescript",
+}: {
+  manifestContent?: string;
+  uiContentType?: string;
+} = {}) {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: "test-agent",
+    messagesCreatedAt: [],
+  });
+  const sourceDirectoryPath = `conversation-${conversation.sId}/Status`;
+  const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+  const gcsSourceDirectoryPath = `${getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  })}Status`;
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: Buffer.byteLength(manifestContent),
+    status: "created",
+    useCase: "conversation",
+    useCaseMetadata: { conversationId: conversation.sId },
+    mountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+  });
+  stageFrameSource({ gcsSourceDirectoryPath, manifestContent, uiContentType });
 
   return {
     auth,
@@ -95,9 +110,108 @@ async function setup({
 
 beforeEach(() => {
   fileStorageMock.reset();
+  // Egress policy files are absent until written, so domain requests start
+  // from an empty policy instead of the mock's placeholder content.
+  fileStorageMock.setFetchFileContentNotFound(
+    (filePath) =>
+      filePath.endsWith("/sandbox-egress-policy.json") ||
+      /\/sandboxes\/[^/]+\.json$/.test(filePath)
+  );
 });
 
+const manifestWithDomains = JSON.stringify({
+  version: 1,
+  name: "Status",
+  description: "Show the current status.",
+  domains: ["API.Stripe.COM", "*.stripe.com"],
+});
+
+function requestedDomainsAt(policyPath: string): string[] {
+  const policy = JSON.parse(fileStorageMock.getObject(policyPath) ?? "{}");
+  return (policy.requestedDomains ?? []).map(
+    (request: { domain: string }) => request.domain
+  );
+}
+
 describe("publishFrameFromSource", () => {
+  it("files declared domains as workspace requests for a Frame outside a Pod", async () => {
+    const { auth, conversation, manifestPath, workspace } = await setup({
+      manifestContent: manifestWithDomains,
+    });
+
+    const result = await publishFrameFromSource(auth, {
+      conversation,
+      publishedByAgentConfigurationId: "test-agent",
+      sourcePath: manifestPath,
+    });
+
+    assert(result.isOk());
+    assert(result.value.kind === "v2");
+    expect(result.value.egressDomains).toEqual({
+      scope: "workspace",
+      requested: ["api.stripe.com", "*.stripe.com"],
+      alreadyAllowed: [],
+      failed: [],
+    });
+    expect(
+      requestedDomainsAt(`w/${workspace.sId}/sandbox-egress-policy.json`)
+    ).toEqual(["api.stripe.com", "*.stripe.com"]);
+  });
+
+  it("files declared domains as Pod requests for a Frame in a Pod", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const workspace = auth.getNonNullableWorkspace();
+    const sourceDirectoryPath = `pod-${projectId}/Status`;
+    const manifestPath = `${sourceDirectoryPath}/${FRAME_MANIFEST_FILE}`;
+    const gcsSourceDirectoryPath = `${getPodFilesBasePath({
+      workspaceId: workspace.sId,
+      podId: projectId,
+    })}Status`;
+    await FileFactory.create(auth, null, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: Buffer.byteLength(manifestWithDomains),
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: projectId },
+      mountFilePath: `${gcsSourceDirectoryPath}/${FRAME_MANIFEST_FILE}`,
+    });
+    stageFrameSource({
+      gcsSourceDirectoryPath,
+      manifestContent: manifestWithDomains,
+    });
+
+    const result = await publishFrameFromSource(auth, {
+      conversation: conversation.toJSON(),
+      publishedByAgentConfigurationId: "test-agent",
+      sourcePath: manifestPath,
+    });
+
+    assert(result.isOk());
+    assert(result.value.kind === "v2");
+    expect(result.value.egressDomains?.scope).toBe("pod");
+    expect(
+      requestedDomainsAt(`w/${workspace.sId}/sandboxes/${projectId}.json`)
+    ).toEqual(["api.stripe.com", "*.stripe.com"]);
+    expect(
+      fileStorageMock.getObject(`w/${workspace.sId}/sandbox-egress-policy.json`)
+    ).toBeUndefined();
+  });
+
+  it("reports no domain requests when the manifest declares none", async () => {
+    const { auth, conversation, manifestPath } = await setup();
+
+    const result = await publishFrameFromSource(auth, {
+      conversation,
+      publishedByAgentConfigurationId: "test-agent",
+      sourcePath: manifestPath,
+    });
+
+    assert(result.isOk());
+    assert(result.value.kind === "v2");
+    expect(result.value.egressDomains).toBeNull();
+  });
+
   it("rejects a Frame outside the signed conversation scope", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/frames/publish_from_source.test.ts
+++ b/front/lib/api/frames/publish_from_source.test.ts
@@ -181,6 +181,13 @@ describe("publishFrameFromSource", () => {
       gcsSourceDirectoryPath,
       manifestContent: manifestWithDomains,
     });
+    // The workspace layer applies to Pod sandboxes too, so a domain it
+    // already allows must not become a redundant Pod request.
+    const workspacePolicyPath = `w/${workspace.sId}/sandbox-egress-policy.json`;
+    fileStorageMock.setObject(
+      workspacePolicyPath,
+      JSON.stringify({ allowedDomains: ["api.stripe.com"] })
+    );
 
     const result = await publishFrameFromSource(auth, {
       conversation: conversation.toJSON(),
@@ -190,16 +197,16 @@ describe("publishFrameFromSource", () => {
 
     assert(result.isOk());
     assert(result.value.kind === "v2");
-    expect(result.value.egressDomains).toMatchObject({
+    expect(result.value.egressDomains).toEqual({
       kind: "filed",
       scope: "pod",
+      requested: ["*.stripe.com"],
+      alreadyAllowed: ["api.stripe.com"],
     });
     expect(
       requestedDomainsAt(`w/${workspace.sId}/sandboxes/${projectId}.json`)
-    ).toEqual(["api.stripe.com", "*.stripe.com"]);
-    expect(
-      fileStorageMock.getObject(`w/${workspace.sId}/sandbox-egress-policy.json`)
-    ).toBeUndefined();
+    ).toEqual(["*.stripe.com"]);
+    expect(requestedDomainsAt(workspacePolicyPath)).toEqual([]);
   });
 
   it("reports domains the workspace already allows without re-requesting them", async () => {
@@ -259,6 +266,7 @@ describe("publishFrameFromSource", () => {
     expect(result.value.egressDomains).toMatchObject({
       kind: "failed",
       domains: ["api.stripe.com", "*.stripe.com"],
+      message: expect.stringContaining("pending domain requests"),
     });
     expect(requestedDomainsAt(policyPath)).toHaveLength(
       SANDBOX_POLICY_MAX_REQUESTED_DOMAINS

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -9,6 +9,11 @@ import {
 import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
+import type {
+  EgressDomainRequestScope,
+  EgressDomainRequestsSummary,
+} from "@app/lib/api/sandbox/egress_domain_requests";
+import { requestEgressDomainsForScope } from "@app/lib/api/sandbox/egress_domain_requests";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import {
@@ -28,6 +33,7 @@ import {
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isPodConversation } from "@app/types/assistant/conversation";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
   contentTypeFromFileName,
@@ -71,6 +77,8 @@ export type PublishFrameFromSourceResult =
       frameId: string;
       sourcePath: string;
       publicationId: string;
+      // Null when the manifest declares no domains.
+      egressDomains: EgressDomainRequestsSummary | null;
     };
 
 export type ValidateFrameFromSourceResult = {
@@ -162,11 +170,23 @@ export async function publishFrameFromSource(
       return new Err(publication.error);
     }
 
+    // Never fails the publish: the publication is already active, and failed
+    // domains can be retried with request_egress_domain.
+    const { domains } = publication.value.manifest;
+    const egressDomains =
+      domains.length > 0
+        ? await requestEgressDomainsForScope(auth, {
+            scope: frameEgressRequestScope(frame, conversation),
+            domains,
+          })
+        : null;
+
     return new Ok({
       kind: "v2",
       frameId: frame.sId,
       sourcePath: normalizedPath,
       publicationId: publication.value.publicationId,
+      egressDomains,
     });
   }
 
@@ -193,6 +213,19 @@ export async function publishFrameFromSource(
     sourcePath: normalizedPath,
     warnings: publication.value.warnings,
   });
+}
+
+// Requests land where the Frame's functions run: the Pod whose policy the Frame
+// sandbox inherits (same rule as FrameSandboxAdapter.resolveScope), else the
+// workspace. Never the Frame's own owner file, which no admin surface lists.
+function frameEgressRequestScope(
+  frame: FileResource,
+  conversation: ConversationWithoutContentType
+): EgressDomainRequestScope {
+  const podId =
+    frame.useCaseMetadata?.spaceId ??
+    (isPodConversation(conversation) ? conversation.spaceId : null);
+  return podId ? { kind: "pod", podId } : { kind: "workspace" };
 }
 
 export async function validateFrameFromSource(
@@ -438,7 +471,7 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
   }
 ): Promise<
   Result<
-    { publicationId: string },
+    { publicationId: string; manifest: FrameManifest },
     FramePublicationError | SandboxFunctionError
   >
 > {
@@ -450,10 +483,18 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
     return source;
   }
 
-  return buildAndPublishFramePublication(auth, {
+  const publication = await buildAndPublishFramePublication(auth, {
     conversation,
     frame,
     ...source.value,
+  });
+  if (publication.isErr()) {
+    return publication;
+  }
+
+  return new Ok({
+    publicationId: publication.value.publicationId,
+    manifest: source.value.manifest,
   });
 }
 
@@ -470,7 +511,7 @@ export async function publishFrameV2FromSource(
   }
 ): Promise<
   Result<
-    { publicationId: string },
+    { publicationId: string; manifest: FrameManifest },
     FramePublicationError | SandboxFunctionError
   >
 > {

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -9,10 +9,7 @@ import {
 import { withFrameSourceLock } from "@app/lib/api/frames/operation_lock";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
-import type {
-  EgressDomainRequestScope,
-  EgressDomainRequestsSummary,
-} from "@app/lib/api/sandbox/egress_domain_requests";
+import type { EgressDomainRequestsSummary } from "@app/lib/api/sandbox/egress_domain_requests";
 import { requestEgressDomainsForScope } from "@app/lib/api/sandbox/egress_domain_requests";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
@@ -25,6 +22,7 @@ import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
 import { isLockAcquisitionTimeoutError } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FrameManifest } from "@app/types/api/frame_manifest";
 import {
@@ -33,7 +31,6 @@ import {
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isPodConversation } from "@app/types/assistant/conversation";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
   contentTypeFromFileName,
@@ -175,10 +172,7 @@ export async function publishFrameFromSource(
     const { domains } = publication.value.manifest;
     const egressDomains =
       domains.length > 0
-        ? await requestEgressDomainsForScope(auth, {
-            scope: frameEgressRequestScope(frame, conversation),
-            domains,
-          })
+        ? await requestFrameEgressDomains(auth, { frame, domains })
         : null;
 
     return new Ok({
@@ -216,16 +210,21 @@ export async function publishFrameFromSource(
 }
 
 // Requests land where the Frame's functions run: the Pod whose policy the Frame
-// sandbox inherits (same rule as FrameSandboxAdapter.resolveScope), else the
-// workspace. Never the Frame's own owner file, which no admin surface lists.
-function frameEgressRequestScope(
-  frame: FileResource,
-  conversation: ConversationWithoutContentType
-): EgressDomainRequestScope {
-  const podId =
-    frame.useCaseMetadata?.spaceId ??
-    (isPodConversation(conversation) ? conversation.spaceId : null);
-  return podId ? { kind: "pod", podId } : { kind: "workspace" };
+// sandbox inherits, else the workspace. Never the Frame's own owner file, which
+// no admin surface lists.
+async function requestFrameEgressDomains(
+  auth: Authenticator,
+  { frame, domains }: { frame: FileResource; domains: string[] }
+): Promise<EgressDomainRequestsSummary> {
+  const scope = await FrameSandboxAdapter.resolveScope(auth, frame);
+  if (scope.isErr()) {
+    return { kind: "failed", domains, message: scope.error.message };
+  }
+  const { spaceId } = scope.value;
+  return requestEgressDomainsForScope(auth, {
+    scope: spaceId ? { kind: "pod", podId: spaceId } : { kind: "workspace" },
+    domains,
+  });
 }
 
 export async function validateFrameFromSource(
@@ -642,6 +641,8 @@ export async function editFrameV2TextAtSource(
       dustFs.write(sourcePath, originalSource, contentType);
 
     try {
+      // A text edit republishes the same manifest: its domains were requested
+      // on the first publish, so none are filed here.
       const publishResult = await publishFrameV2FromSourceWithSourceLockHeld(
         auth,
         {

--- a/front/lib/api/sandbox/egress_domain_requests.test.ts
+++ b/front/lib/api/sandbox/egress_domain_requests.test.ts
@@ -1,0 +1,135 @@
+import type { Authenticator } from "@app/lib/auth";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequestOwnerPolicyDomains, mockRequestWorkspacePolicyDomains } =
+  vi.hoisted(() => ({
+    mockRequestOwnerPolicyDomains: vi.fn(),
+    mockRequestWorkspacePolicyDomains: vi.fn(),
+  }));
+
+vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
+  requestOwnerPolicyDomains: mockRequestOwnerPolicyDomains,
+  requestWorkspacePolicyDomains: mockRequestWorkspacePolicyDomains,
+}));
+
+import {
+  formatEgressDomainRequestsNote,
+  requestEgressDomainsForScope,
+} from "./egress_domain_requests";
+
+const mockAuth = {} as unknown as Authenticator;
+const EMPTY_POLICY = { allowedDomains: [] };
+
+describe("requestEgressDomainsForScope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("files on the Pod and splits outcomes into requested and already allowed", async () => {
+    mockRequestOwnerPolicyDomains.mockResolvedValue(
+      new Ok({
+        policy: EMPTY_POLICY,
+        outcomes: [
+          { domain: "api.stripe.com", outcome: "already_allowed" },
+          { domain: "*.stripe.com", outcome: "requested" },
+          { domain: "hooks.slack.com", outcome: "already_requested" },
+        ],
+      })
+    );
+
+    const summary = await requestEgressDomainsForScope(mockAuth, {
+      scope: { kind: "pod", podId: "vlt_pod" },
+      domains: ["api.stripe.com", "*.stripe.com", "hooks.slack.com"],
+    });
+
+    expect(mockRequestOwnerPolicyDomains).toHaveBeenCalledWith(mockAuth, {
+      ownerId: "vlt_pod",
+      domains: ["api.stripe.com", "*.stripe.com", "hooks.slack.com"],
+    });
+    expect(mockRequestWorkspacePolicyDomains).not.toHaveBeenCalled();
+    expect(summary).toEqual({
+      kind: "filed",
+      scope: "pod",
+      requested: ["*.stripe.com", "hooks.slack.com"],
+      alreadyAllowed: ["api.stripe.com"],
+    });
+  });
+
+  it("files on the workspace when there is no Pod", async () => {
+    mockRequestWorkspacePolicyDomains.mockResolvedValue(
+      new Ok({
+        policy: EMPTY_POLICY,
+        outcomes: [{ domain: "api.stripe.com", outcome: "requested" }],
+      })
+    );
+
+    const summary = await requestEgressDomainsForScope(mockAuth, {
+      scope: { kind: "workspace" },
+      domains: ["api.stripe.com"],
+    });
+
+    expect(mockRequestOwnerPolicyDomains).not.toHaveBeenCalled();
+    expect(summary).toEqual({
+      kind: "filed",
+      scope: "workspace",
+      requested: ["api.stripe.com"],
+      alreadyAllowed: [],
+    });
+  });
+
+  it("reports every domain as failed with the reason when the batch is rejected", async () => {
+    mockRequestWorkspacePolicyDomains.mockResolvedValue(
+      new Err(new Error("cap reached"))
+    );
+
+    const summary = await requestEgressDomainsForScope(mockAuth, {
+      scope: { kind: "workspace" },
+      domains: ["api.stripe.com", "*.stripe.com"],
+    });
+
+    expect(summary).toEqual({
+      kind: "failed",
+      domains: ["api.stripe.com", "*.stripe.com"],
+      message: "cap reached",
+    });
+  });
+});
+
+describe("formatEgressDomainRequestsNote", () => {
+  it("names the scope and lists pending and already allowed domains", () => {
+    expect(
+      formatEgressDomainRequestsNote({
+        kind: "filed",
+        scope: "pod",
+        requested: ["*.stripe.com"],
+        alreadyAllowed: ["api.stripe.com"],
+      })
+    ).toBe(
+      "Requested for the Pod (pending admin approval): *.stripe.com. Already allowed: api.stripe.com."
+    );
+  });
+
+  it("returns null when nothing was requested or already allowed", () => {
+    expect(
+      formatEgressDomainRequestsNote({
+        kind: "filed",
+        scope: "workspace",
+        requested: [],
+        alreadyAllowed: [],
+      })
+    ).toBeNull();
+  });
+
+  it("carries the failure reason and the retry hint", () => {
+    expect(
+      formatEgressDomainRequestsNote({
+        kind: "failed",
+        domains: ["api.stripe.com"],
+        message: "cap reached.",
+      })
+    ).toBe(
+      "Could not request api.stripe.com: cap reached. Retry with request_egress_domain once resolved."
+    );
+  });
+});

--- a/front/lib/api/sandbox/egress_domain_requests.ts
+++ b/front/lib/api/sandbox/egress_domain_requests.ts
@@ -1,6 +1,6 @@
 import {
-  requestOwnerPolicyDomain,
-  requestWorkspacePolicyDomain,
+  requestOwnerPolicyDomains,
+  requestWorkspacePolicyDomains,
 } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -10,67 +10,69 @@ export type EgressDomainRequestScope =
   | { kind: "pod"; podId: string }
   | { kind: "workspace" };
 
-export type EgressDomainRequestsSummary = {
-  scope: EgressDomainRequestScope["kind"];
-  requested: string[];
-  alreadyAllowed: string[];
-  failed: string[];
-};
+// The batch is filed whole or not at all, so a failure carries every domain.
+export type EgressDomainRequestsSummary =
+  | {
+      kind: "filed";
+      scope: EgressDomainRequestScope["kind"];
+      // "requested" or "already_requested": pending an admin's review.
+      requested: string[];
+      alreadyAllowed: string[];
+    }
+  | { kind: "failed"; domains: string[]; message: string };
 
-// Files each declared domain as a request on the scope for admin review —
-// never grants. Failures are collected, not returned: the publish that
-// declared the domains has already landed, and the caller reports them so the
-// domains can be retried with request_egress_domain. Sequential writes are
-// bounded by one publish's declared domains.
+// Files the declared domains as requests on the scope for admin review —
+// never grants. Failures are reported, not returned: the publish that
+// declared the domains has already landed.
 export async function requestEgressDomainsForScope(
   auth: Authenticator,
   { scope, domains }: { scope: EgressDomainRequestScope; domains: string[] }
 ): Promise<EgressDomainRequestsSummary> {
-  const summary: EgressDomainRequestsSummary = {
-    scope: scope.kind,
-    requested: [],
-    alreadyAllowed: [],
-    failed: [],
-  };
-
-  for (const domain of domains) {
-    const result =
-      scope.kind === "pod"
-        ? await requestOwnerPolicyDomain(auth, {
-            ownerId: scope.podId,
-            domain,
-          })
-        : await requestWorkspacePolicyDomain(auth, { domain });
-    if (result.isErr()) {
-      summary.failed.push(domain);
-    } else if (result.value.outcome === "already_allowed") {
-      summary.alreadyAllowed.push(domain);
-    } else {
-      // "requested" or "already_requested": pending an admin's review.
-      summary.requested.push(domain);
-    }
+  const result =
+    scope.kind === "pod"
+      ? await requestOwnerPolicyDomains(auth, {
+          ownerId: scope.podId,
+          domains,
+        })
+      : await requestWorkspacePolicyDomains(auth, { domains });
+  if (result.isErr()) {
+    return { kind: "failed", domains, message: result.error.message };
   }
 
-  return summary;
+  const { outcomes } = result.value;
+  return {
+    kind: "filed",
+    scope: scope.kind,
+    requested: outcomes
+      .filter(({ outcome }) => outcome !== "already_allowed")
+      .map(({ domain }) => domain),
+    alreadyAllowed: outcomes
+      .filter(({ outcome }) => outcome === "already_allowed")
+      .map(({ domain }) => domain),
+  };
 }
 
 export function formatEgressDomainRequestsNote(
   summary: EgressDomainRequestsSummary
 ): string | null {
-  const target = summary.scope === "pod" ? "Pod" : "workspace";
-  const parts: string[] = [];
-  if (summary.requested.length > 0) {
-    parts.push(
-      `Requested for the ${target} (pending admin approval): ${summary.requested.join(", ")}.`
-    );
+  switch (summary.kind) {
+    case "failed":
+      return (
+        `Could not request ${summary.domains.join(", ")}: ${summary.message} ` +
+        "Retry with request_egress_domain once resolved."
+      );
+    case "filed": {
+      const target = summary.scope === "pod" ? "Pod" : "workspace";
+      const parts: string[] = [];
+      if (summary.requested.length > 0) {
+        parts.push(
+          `Requested for the ${target} (pending admin approval): ${summary.requested.join(", ")}.`
+        );
+      }
+      if (summary.alreadyAllowed.length > 0) {
+        parts.push(`Already allowed: ${summary.alreadyAllowed.join(", ")}.`);
+      }
+      return parts.length > 0 ? parts.join(" ") : null;
+    }
   }
-  if (summary.alreadyAllowed.length > 0) {
-    parts.push(`Already allowed: ${summary.alreadyAllowed.join(", ")}.`);
-  }
-  if (summary.failed.length > 0) {
-    parts.push(
-      `Could not process (retry with request_egress_domain): ${summary.failed.join(", ")}.`
-    );
-  }
-  return parts.length > 0 ? parts.join(" ") : null;
 }

--- a/front/lib/api/sandbox/egress_domain_requests.ts
+++ b/front/lib/api/sandbox/egress_domain_requests.ts
@@ -1,0 +1,76 @@
+import {
+  requestOwnerPolicyDomain,
+  requestWorkspacePolicyDomain,
+} from "@app/lib/api/sandbox/egress_policy";
+import type { Authenticator } from "@app/lib/auth";
+
+// Where a publish files the domains it declares: the Pod whose policy the
+// published functions run under, or the workspace when there is no Pod.
+export type EgressDomainRequestScope =
+  | { kind: "pod"; podId: string }
+  | { kind: "workspace" };
+
+export type EgressDomainRequestsSummary = {
+  scope: EgressDomainRequestScope["kind"];
+  requested: string[];
+  alreadyAllowed: string[];
+  failed: string[];
+};
+
+// Files each declared domain as a request on the scope for admin review —
+// never grants. Failures are collected, not returned: the publish that
+// declared the domains has already landed, and the caller reports them so the
+// domains can be retried with request_egress_domain. Sequential writes are
+// bounded by one publish's declared domains.
+export async function requestEgressDomainsForScope(
+  auth: Authenticator,
+  { scope, domains }: { scope: EgressDomainRequestScope; domains: string[] }
+): Promise<EgressDomainRequestsSummary> {
+  const summary: EgressDomainRequestsSummary = {
+    scope: scope.kind,
+    requested: [],
+    alreadyAllowed: [],
+    failed: [],
+  };
+
+  for (const domain of domains) {
+    const result =
+      scope.kind === "pod"
+        ? await requestOwnerPolicyDomain(auth, {
+            ownerId: scope.podId,
+            domain,
+          })
+        : await requestWorkspacePolicyDomain(auth, { domain });
+    if (result.isErr()) {
+      summary.failed.push(domain);
+    } else if (result.value.outcome === "already_allowed") {
+      summary.alreadyAllowed.push(domain);
+    } else {
+      // "requested" or "already_requested": pending an admin's review.
+      summary.requested.push(domain);
+    }
+  }
+
+  return summary;
+}
+
+export function formatEgressDomainRequestsNote(
+  summary: EgressDomainRequestsSummary
+): string | null {
+  const target = summary.scope === "pod" ? "Pod" : "workspace";
+  const parts: string[] = [];
+  if (summary.requested.length > 0) {
+    parts.push(
+      `Requested for the ${target} (pending admin approval): ${summary.requested.join(", ")}.`
+    );
+  }
+  if (summary.alreadyAllowed.length > 0) {
+    parts.push(`Already allowed: ${summary.alreadyAllowed.join(", ")}.`);
+  }
+  if (summary.failed.length > 0) {
+    parts.push(
+      `Could not process (retry with request_egress_domain): ${summary.failed.join(", ")}.`
+    );
+  }
+  return parts.length > 0 ? parts.join(" ") : null;
+}

--- a/front/lib/api/sandbox/egress_domain_requests.ts
+++ b/front/lib/api/sandbox/egress_domain_requests.ts
@@ -1,8 +1,11 @@
+import type { PolicyDomainRequestOutcome } from "@app/lib/api/sandbox/egress_policy";
 import {
   requestOwnerPolicyDomains,
   requestWorkspacePolicyDomains,
 } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import type { Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Where a publish files the domains it declares: the Pod whose policy the
@@ -29,13 +32,7 @@ export async function requestEgressDomainsForScope(
   auth: Authenticator,
   { scope, domains }: { scope: EgressDomainRequestScope; domains: string[] }
 ): Promise<EgressDomainRequestsSummary> {
-  const result =
-    scope.kind === "pod"
-      ? await requestOwnerPolicyDomains(auth, {
-          ownerId: scope.podId,
-          domains,
-        })
-      : await requestWorkspacePolicyDomains(auth, { domains });
+  const result = await requestPolicyDomainsForScope(auth, { scope, domains });
   if (result.isErr()) {
     return { kind: "failed", domains, message: result.error.message };
   }
@@ -51,6 +48,28 @@ export async function requestEgressDomainsForScope(
       .filter(({ outcome }) => outcome === "already_allowed")
       .map(({ domain }) => domain),
   };
+}
+
+function requestPolicyDomainsForScope(
+  auth: Authenticator,
+  { scope, domains }: { scope: EgressDomainRequestScope; domains: string[] }
+): Promise<
+  Result<
+    { policy: EgressPolicy; outcomes: PolicyDomainRequestOutcome[] },
+    Error
+  >
+> {
+  switch (scope.kind) {
+    case "pod":
+      return requestOwnerPolicyDomains(auth, {
+        ownerId: scope.podId,
+        domains,
+      });
+    case "workspace":
+      return requestWorkspacePolicyDomains(auth, { domains });
+    default:
+      return assertNever(scope);
+  }
 }
 
 export function formatEgressDomainRequestsNote(

--- a/front/lib/api/sandbox/egress_domain_requests.ts
+++ b/front/lib/api/sandbox/egress_domain_requests.ts
@@ -3,6 +3,7 @@ import {
   requestWorkspacePolicyDomains,
 } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Where a publish files the domains it declares: the Pod whose policy the
 // published functions run under, or the workspace when there is no Pod.
@@ -74,5 +75,7 @@ export function formatEgressDomainRequestsNote(
       }
       return parts.length > 0 ? parts.join(" ") : null;
     }
+    default:
+      return assertNever(summary);
   }
 }

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -623,6 +623,33 @@ describe("pod egress domain batch requests", () => {
     expect(mockUploadRawContentToBucket).toHaveBeenCalledTimes(1);
   });
 
+  it("reports already_allowed for a domain the workspace allows when filing on a Pod", async () => {
+    setGcsObjects({
+      [WORKSPACE_PATH]: { allowedDomains: ["api.stripe.com"] },
+      [OWNER_PATH]: { allowedDomains: [] },
+    });
+
+    const result = await requestOwnerPolicyDomains(mockAuth, {
+      ownerId: "owner-sid",
+      domains: ["api.stripe.com", "hooks.slack.com"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.outcomes).toEqual([
+        { domain: "api.stripe.com", outcome: "already_allowed" },
+        { domain: "hooks.slack.com", outcome: "requested" },
+      ]);
+      expect(
+        result.value.policy.requestedDomains?.map((request) => request.domain)
+      ).toEqual(["hooks.slack.com"]);
+    }
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledTimes(1);
+    expect(mockUploadRawContentToBucket.mock.calls[0]?.[0]).toMatchObject({
+      filePath: OWNER_PATH,
+    });
+  });
+
   it("does not write when nothing new is requested", async () => {
     setGcsObjects({
       [OWNER_PATH]: {

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -54,6 +54,7 @@ import {
   readWorkspacePolicy,
   removeOwnerPolicyDomain,
   requestOwnerPolicyDomain,
+  requestOwnerPolicyDomains,
   writeOwnerPolicy,
   writeWorkspacePolicy,
 } from "./egress_policy";
@@ -579,6 +580,95 @@ describe("pod egress domain requests", () => {
     });
 
     expect(result).toEqual(new Ok({ allowedDomains: ["api.github.com"] }));
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+});
+
+describe("pod egress domain batch requests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupBucketMocks();
+  });
+
+  it("classifies every domain and files the new ones in a single write", async () => {
+    setGcsObjects({
+      [OWNER_PATH]: {
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+      },
+    });
+
+    const result = await requestOwnerPolicyDomains(mockAuth, {
+      ownerId: "owner-sid",
+      domains: [
+        "API.GitHub.COM",
+        "api.stripe.com",
+        "*.Stripe.COM",
+        "hooks.slack.com",
+      ],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.outcomes).toEqual([
+        { domain: "api.github.com", outcome: "already_allowed" },
+        { domain: "api.stripe.com", outcome: "already_requested" },
+        { domain: "*.stripe.com", outcome: "requested" },
+        { domain: "hooks.slack.com", outcome: "requested" },
+      ]);
+      expect(
+        result.value.policy.requestedDomains?.map((request) => request.domain)
+      ).toEqual(["api.stripe.com", "*.stripe.com", "hooks.slack.com"]);
+    }
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not write when nothing new is requested", async () => {
+    setGcsObjects({
+      [OWNER_PATH]: {
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+      },
+    });
+
+    const result = await requestOwnerPolicyDomains(mockAuth, {
+      ownerId: "owner-sid",
+      domains: ["api.github.com", "api.stripe.com"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("rejects the whole batch when it would exceed the pending cap", async () => {
+    setGcsObjects({
+      [OWNER_PATH]: {
+        allowedDomains: [],
+        requestedDomains: Array.from({ length: 49 }, (_, i) => ({
+          domain: `service-${i}.example.com`,
+          requestedAtMs: 1,
+        })),
+      },
+    });
+
+    const result = await requestOwnerPolicyDomains(mockAuth, {
+      ownerId: "owner-sid",
+      domains: ["one.example.com", "two.example.com"],
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("rejects the batch when any domain is malformed", async () => {
+    setGcsObjects({ [OWNER_PATH]: { allowedDomains: [] } });
+
+    const result = await requestOwnerPolicyDomains(mockAuth, {
+      ownerId: "owner-sid",
+      domains: ["api.stripe.com", "api.*.com"],
+    });
+
+    expect(result.isErr()).toBe(true);
     expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -419,13 +419,18 @@ export type PolicyDomainRequestOutcome = {
 // requests the workspace file — the logic is otherwise identical.
 type PolicyDomainScope = {
   read: () => Promise<Result<EgressPolicy, Error>>;
+  // A layer the sandbox also honors (the workspace file, for a Pod). Read
+  // only to skip redundant requests; requests always land on this scope.
+  readInherited: (() => Promise<Result<EgressPolicy, Error>>) | null;
   write: (policy: EgressPolicy) => Promise<Result<EgressPolicy, Error>>;
   label: string;
 };
 
 // Exact-string membership on the normalized pattern: a domain covered by an
 // existing wildcard still records a request and surfaces to the admin, who
-// resolves it by approving (redundant entry) or dismissing.
+// resolves it by approving (redundant entry) or dismissing. `allowed` spans
+// this scope and any inherited layer, so a Pod request for a domain the
+// workspace already allows reports already_allowed instead of duplicating it.
 function classifyDomainRequest(
   domain: string,
   { allowed, pending }: { allowed: Set<string>; pending: Set<string> }
@@ -459,14 +464,28 @@ async function requestPolicyDomains(
     return new Err(parsedDomains.error);
   }
 
-  const currentPolicy = await scope.read();
+  // Two reads at most: this scope's file and its inherited layer.
+  const [currentPolicy, inheritedPolicy] = await Promise.all([
+    scope.read(),
+    scope.readInherited ? scope.readInherited() : Promise.resolve(null),
+  ]);
   if (currentPolicy.isErr()) {
     return new Err(currentPolicy.error);
+  }
+  let inheritedAllowedDomains: string[] = [];
+  if (inheritedPolicy) {
+    if (inheritedPolicy.isErr()) {
+      return new Err(inheritedPolicy.error);
+    }
+    inheritedAllowedDomains = inheritedPolicy.value.allowedDomains;
   }
 
   const pending = currentPolicy.value.requestedDomains ?? [];
   const membership = {
-    allowed: new Set(currentPolicy.value.allowedDomains),
+    allowed: new Set([
+      ...currentPolicy.value.allowedDomains,
+      ...inheritedAllowedDomains,
+    ]),
     pending: new Set(pending.map((request) => request.domain)),
   };
   const outcomes = parsedDomains.value.map((domain) => ({
@@ -555,6 +574,7 @@ async function dismissRequestedPolicyDomain(
 function ownerScope(auth: Authenticator, ownerId: string): PolicyDomainScope {
   return {
     read: () => readOwnerPolicy(auth, ownerId),
+    readInherited: () => readWorkspacePolicy(auth),
     write: (policy) => writeOwnerPolicy(auth, { ownerId, policy }),
     label: "Pod",
   };
@@ -563,6 +583,7 @@ function ownerScope(auth: Authenticator, ownerId: string): PolicyDomainScope {
 function workspaceScope(auth: Authenticator): PolicyDomainScope {
   return {
     read: () => readWorkspacePolicy(auth),
+    readInherited: null,
     write: (policy) => writeWorkspacePolicy(auth, { policy }),
     label: "workspace",
   };

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -9,11 +9,14 @@ import {
   EMPTY_EGRESS_POLICY,
   normalizeEgressPolicy,
   normalizeEgressPolicyDomain,
+  normalizeEgressPolicyDomains,
   parseEgressPolicy,
+  SANDBOX_POLICY_MAX_REQUESTED_DOMAINS,
 } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
 
 const INVALIDATION_TIMEOUT_MS = 5_000;
 const SANDBOX_POLICY_MAX_DOMAINS = 100;
@@ -401,18 +404,16 @@ export async function removeWorkspacePolicyDomain(
   return new Ok({ policy: written.value, removedDomain: domain });
 }
 
-// Caps the pending-request section: the proxy re-reads this file on every
-// cache miss, so an agent must not be able to grow it unboundedly.
-const SANDBOX_POLICY_MAX_REQUESTED_DOMAINS = 50;
-
 export type RequestOwnerPolicyDomainOutcome =
   | "requested"
   | "already_allowed"
   | "already_requested";
 
-// Records an agent's pod-scoped domain request in the policy file's
-// requestedDomains section for admin review — never grants anything. Exact
-// domains only (same rule as tool approvals: no agent-supplied wildcards).
+export type PolicyDomainRequestOutcome = {
+  domain: string;
+  outcome: RequestOwnerPolicyDomainOutcome;
+};
+
 // The read/write pair a scope's request/dismiss helpers operate on, plus a
 // label for the cap error. Pod requests use the owner file, workspace
 // requests the workspace file — the logic is otherwise identical.
@@ -421,6 +422,89 @@ type PolicyDomainScope = {
   write: (policy: EgressPolicy) => Promise<Result<EgressPolicy, Error>>;
   label: string;
 };
+
+// Exact-string membership on the normalized pattern: a domain covered by an
+// existing wildcard still records a request and surfaces to the admin, who
+// resolves it by approving (redundant entry) or dismissing.
+function classifyDomainRequest(
+  domain: string,
+  { allowed, pending }: { allowed: Set<string>; pending: Set<string> }
+): RequestOwnerPolicyDomainOutcome {
+  if (allowed.has(domain)) {
+    return "already_allowed";
+  }
+  if (pending.has(domain)) {
+    return "already_requested";
+  }
+  return "requested";
+}
+
+// Records domain requests in the scope's requestedDomains section for admin
+// review — never grants anything. One read and at most one write for the
+// whole batch. Wildcards are accepted (unlike the conversation add): every
+// request is reviewed by an admin before it grants, the same trust boundary
+// as the admin settings PUT, which also allows them. The batch is rejected
+// whole when it would push the pending section past the cap.
+async function requestPolicyDomains(
+  scope: PolicyDomainScope,
+  { domains }: { domains: string[] }
+): Promise<
+  Result<
+    { policy: EgressPolicy; outcomes: PolicyDomainRequestOutcome[] },
+    Error
+  >
+> {
+  const parsedDomains = normalizeEgressPolicyDomains(domains);
+  if (parsedDomains.isErr()) {
+    return new Err(parsedDomains.error);
+  }
+
+  const currentPolicy = await scope.read();
+  if (currentPolicy.isErr()) {
+    return new Err(currentPolicy.error);
+  }
+
+  const pending = currentPolicy.value.requestedDomains ?? [];
+  const membership = {
+    allowed: new Set(currentPolicy.value.allowedDomains),
+    pending: new Set(pending.map((request) => request.domain)),
+  };
+  const outcomes = parsedDomains.value.map((domain) => ({
+    domain,
+    outcome: classifyDomainRequest(domain, membership),
+  }));
+
+  const newDomains = outcomes
+    .filter(({ outcome }) => outcome === "requested")
+    .map(({ domain }) => domain);
+  if (newDomains.length === 0) {
+    return new Ok({ policy: currentPolicy.value, outcomes });
+  }
+  if (
+    pending.length + newDomains.length >
+    SANDBOX_POLICY_MAX_REQUESTED_DOMAINS
+  ) {
+    return new Err(
+      new Error(
+        `This ${scope.label} has ${pending.length} pending domain requests and can hold at most ${SANDBOX_POLICY_MAX_REQUESTED_DOMAINS}. Ask an admin to review them before requesting more.`
+      )
+    );
+  }
+
+  const requestedAtMs = Date.now();
+  const written = await scope.write({
+    allowedDomains: currentPolicy.value.allowedDomains,
+    requestedDomains: [
+      ...pending,
+      ...newDomains.map((domain) => ({ domain, requestedAtMs })),
+    ],
+  });
+  if (written.isErr()) {
+    return written;
+  }
+
+  return new Ok({ policy: written.value, outcomes });
+}
 
 async function requestPolicyDomain(
   scope: PolicyDomainScope,
@@ -431,55 +515,13 @@ async function requestPolicyDomain(
     Error
   >
 > {
-  // Wildcards are accepted (unlike the conversation add): every request is
-  // reviewed by an admin before it grants, the same trust boundary as the
-  // admin settings PUT, which also allows them.
-  const parsedDomain = normalizeEgressPolicyDomain(domain);
-  if (parsedDomain.isErr()) {
-    return new Err(parsedDomain.error);
+  const result = await requestPolicyDomains(scope, { domains: [domain] });
+  if (result.isErr()) {
+    return result;
   }
-
-  const currentPolicy = await scope.read();
-  if (currentPolicy.isErr()) {
-    return new Err(currentPolicy.error);
-  }
-
-  // Exact-string membership on the normalized pattern: a domain covered by
-  // an existing wildcard still records a request and surfaces to the admin,
-  // who resolves it by approving (redundant entry) or dismissing.
-  if (currentPolicy.value.allowedDomains.includes(parsedDomain.value)) {
-    return new Ok({ policy: currentPolicy.value, outcome: "already_allowed" });
-  }
-  const pending = currentPolicy.value.requestedDomains ?? [];
-  if (pending.some((request) => request.domain === parsedDomain.value)) {
-    return new Ok({
-      policy: currentPolicy.value,
-      outcome: "already_requested",
-    });
-  }
-  if (pending.length >= SANDBOX_POLICY_MAX_REQUESTED_DOMAINS) {
-    return new Err(
-      new Error(
-        `This ${scope.label} already has ${SANDBOX_POLICY_MAX_REQUESTED_DOMAINS} pending domain requests. Ask an admin to review them before requesting more.`
-      )
-    );
-  }
-
-  const written = await scope.write({
-    allowedDomains: currentPolicy.value.allowedDomains,
-    requestedDomains: [
-      ...pending,
-      {
-        domain: parsedDomain.value,
-        requestedAtMs: Date.now(),
-      },
-    ],
-  });
-  if (written.isErr()) {
-    return written;
-  }
-
-  return new Ok({ policy: written.value, outcome: "requested" });
+  const [first] = result.value.outcomes;
+  assert(first, "One domain in, one outcome out.");
+  return new Ok({ policy: result.value.policy, outcome: first.outcome });
 }
 
 async function dismissRequestedPolicyDomain(
@@ -552,6 +594,33 @@ export async function requestWorkspacePolicyDomain(
   >
 > {
   return requestPolicyDomain(workspaceScope(auth), { domain });
+}
+
+// Batch form of requestOwnerPolicyDomain: one read and at most one write for
+// every domain a publish declares.
+export async function requestOwnerPolicyDomains(
+  auth: Authenticator,
+  { ownerId, domains }: { ownerId: string; domains: string[] }
+): Promise<
+  Result<
+    { policy: EgressPolicy; outcomes: PolicyDomainRequestOutcome[] },
+    Error
+  >
+> {
+  return requestPolicyDomains(ownerScope(auth, ownerId), { domains });
+}
+
+// Batch form of requestWorkspacePolicyDomain.
+export async function requestWorkspacePolicyDomains(
+  auth: Authenticator,
+  { domains }: { domains: string[] }
+): Promise<
+  Result<
+    { policy: EgressPolicy; outcomes: PolicyDomainRequestOutcome[] },
+    Error
+  >
+> {
+  return requestPolicyDomains(workspaceScope(auth), { domains });
 }
 
 // Removes a pending request without granting it. Approval needs no

--- a/front/lib/resources/frame_sandbox_adapter.ts
+++ b/front/lib/resources/frame_sandbox_adapter.ts
@@ -103,7 +103,10 @@ export class FrameSandboxAdapter {
     });
   }
 
-  private static async resolveScope(
+  // The Pod whose config and egress policy a Frame's sandbox inherits, or
+  // null outside a Pod. Publishing routes the manifest's egress domain
+  // requests with the same rule.
+  static async resolveScope(
     auth: Authenticator,
     frame: FrameSandboxScopeOwner
   ): Promise<Result<FrameSandboxScope, Error>> {

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -359,8 +359,9 @@ dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
 
 The publish output includes \`egressDomains\` when the manifest declares domains: which were
-requested (pending admin approval), already allowed, or failed. Tell the user about pending
-requests; the functions cannot reach those domains until an admin approves them.
+requested (pending admin approval) and which were already allowed, or why filing them failed.
+Tell the user about pending requests; the functions cannot reach those domains until an admin
+approves them.
 
 After a successful publish, call \`conversation_side_panel.open_frame\` exactly once with \`path\`
 set to the same canonical \`/files/...\` manifest path. This opens the Frame for the user and adds

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -131,8 +131,9 @@ The manifest declares the UI entry point, every server function, and every datab
 - \`domains\` lists every exact domain or \`*.example.com\` wildcard the functions make outbound
   HTTPS requests to. Publishing files each one as an egress request that a workspace admin reviews
   (for the Pod when the Frame lives in a Pod, otherwise for the workspace); it never grants access
-  on its own, and a domain already allowed is skipped. For a domain discovered after publishing,
-  use \`request_egress_domain\` instead of republishing.
+  on its own, and a domain already allowed for that scope (or the workspace) is skipped. For a
+  domain discovered after publishing, use \`request_egress_domain\` instead of republishing, and
+  add it to \`domains\` so the next publish stays accurate.
 - Input, output, and caller-identity schemas belong in the function's TypeScript \`schema\` export,
   not in \`manifest.json\`. The build extracts them from source.
 

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -91,6 +91,7 @@ The manifest declares the UI entry point, every server function, and every datab
   "name": "Comments",
   "description": "Read and add comments.",
   "uiEntryPoint": "index.tsx",
+  "domains": ["api.example.com"],
   "databases": [
     {
       "name": "comments",
@@ -127,6 +128,11 @@ The manifest declares the UI entry point, every server function, and every datab
   use \`durable\` when it calls \`dsbx tools\`.
 - \`defaultStake\` defaults to \`low\`. \`never_ask\` runs unattended, \`low\` asks once and can be
   always approved, and \`high\` asks on every call when the function is exposed as a tool.
+- \`domains\` lists every exact domain or \`*.example.com\` wildcard the functions make outbound
+  HTTPS requests to. Publishing files each one as an egress request that a workspace admin reviews
+  (for the Pod when the Frame lives in a Pod, otherwise for the workspace); it never grants access
+  on its own, and a domain already allowed is skipped. For a domain discovered after publishing,
+  use \`request_egress_domain\` instead of republishing.
 - Input, output, and caller-identity schemas belong in the function's TypeScript \`schema\` export,
   not in \`manifest.json\`. The build extracts them from source.
 
@@ -262,8 +268,9 @@ dsbx tools --json <server-name> <tool-name> <arguments...>
 
 Parse the JSON stdout envelope, including \`content\` and \`isError\`. Publishing a function that
 calls \`dsbx tools\` as \`fast\` is a bug: the runtime refuses the tool call. Function \`fetch()\`
-requests use the same workspace egress allowlist and \`DST_*\` / \`DSEC_*\` configuration rules as
-the Computer.
+requests only reach domains on the egress allowlist (workspace, plus the Pod's when the Frame lives
+in a Pod), so declare them in the manifest's \`domains\`; \`DST_*\` / \`DSEC_*\` configuration
+follows the same rules as the Computer.
 
 ### Knowing who called a function
 
@@ -350,6 +357,10 @@ stored, and activated atomically:
 \`\`\`bash
 dsbx frame publish /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
+
+The publish output includes \`egressDomains\` when the manifest declares domains: which were
+requested (pending admin approval), already allowed, or failed. Tell the user about pending
+requests; the functions cannot reach those domains until an admin approves them.
 
 After a successful publish, call \`conversation_side_panel.open_frame\` exactly once with \`path\`
 set to the same canonical \`/files/...\` manifest path. This opens the Frame for the user and adds

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -4,6 +4,7 @@ import {
   FrameManifestSchema,
   isSafeFrameRelativePath,
   MAX_FRAME_DATABASE_COUNT,
+  MAX_FRAME_DOMAIN_COUNT,
   MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
@@ -199,5 +200,48 @@ describe("isSafeFrameRelativePath", () => {
     ["src\\index.tsx", false],
   ])("validates %s", (relativePath, expected) => {
     expect(isSafeFrameRelativePath(relativePath)).toBe(expected);
+  });
+});
+
+describe("FrameManifestSchema domains", () => {
+  it("defaults to no domains", () => {
+    const parsed = FrameManifestSchema.safeParse(MANIFEST);
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.domains).toEqual([]);
+    }
+  });
+
+  it("normalizes and deduplicates declared domains", () => {
+    const parsed = FrameManifestSchema.safeParse({
+      ...MANIFEST,
+      domains: ["API.Stripe.COM", "api.stripe.com", "*.stripe.com"],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.domains).toEqual(["api.stripe.com", "*.stripe.com"]);
+    }
+  });
+
+  it("rejects malformed domains", () => {
+    expect(
+      FrameManifestSchema.safeParse({ ...MANIFEST, domains: ["api.*.com"] })
+        .success
+    ).toBe(false);
+    expect(
+      FrameManifestSchema.safeParse({ ...MANIFEST, domains: [""] }).success
+    ).toBe(false);
+  });
+
+  it("bounds the number of declared domains", () => {
+    const domains = Array.from(
+      { length: MAX_FRAME_DOMAIN_COUNT + 1 },
+      (_, index) => `host-${index}.example.com`
+    );
+    expect(
+      FrameManifestSchema.safeParse({ ...MANIFEST, domains }).success
+    ).toBe(false);
   });
 });

--- a/front/types/api/frame_manifest.test.ts
+++ b/front/types/api/frame_manifest.test.ts
@@ -4,7 +4,6 @@ import {
   FrameManifestSchema,
   isSafeFrameRelativePath,
   MAX_FRAME_DATABASE_COUNT,
-  MAX_FRAME_DOMAIN_COUNT,
   MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH,
   parseFrameManifest,
 } from "@app/types/api/frame_manifest";
@@ -12,6 +11,7 @@ import {
   DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
   DEFAULT_SANDBOX_FUNCTION_STAKE,
 } from "@app/types/api/sandbox_functions";
+import { SANDBOX_POLICY_MAX_REQUESTED_DOMAINS } from "@app/types/sandbox/egress_policy";
 import { describe, expect, it } from "vitest";
 
 const MANIFEST = {
@@ -237,7 +237,7 @@ describe("FrameManifestSchema domains", () => {
 
   it("bounds the number of declared domains", () => {
     const domains = Array.from(
-      { length: MAX_FRAME_DOMAIN_COUNT + 1 },
+      { length: SANDBOX_POLICY_MAX_REQUESTED_DOMAINS + 1 },
       (_, index) => `host-${index}.example.com`
     );
     expect(

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -78,6 +78,7 @@ const FrameDomainsSchema = z
   .array(z.string())
   .max(SANDBOX_POLICY_MAX_REQUESTED_DOMAINS)
   .default([])
+  // zod's documented abort-from-transform: addIssue, then return z.NEVER.
   .transform((domains, context) => {
     const normalized = normalizeEgressPolicyDomains(domains);
     if (normalized.isErr()) {

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -6,7 +6,10 @@ import {
   SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
   SANDBOX_FUNCTION_STAKES,
 } from "@app/types/api/sandbox_functions";
-import { normalizeEgressPolicyDomains } from "@app/types/sandbox/egress_policy";
+import {
+  normalizeEgressPolicyDomains,
+  SANDBOX_POLICY_MAX_REQUESTED_DOMAINS,
+} from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -21,8 +24,6 @@ export const MAX_FRAME_FUNCTION_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH = 255;
 // Each schema reconcile can take 60 seconds and runs under the 10-minute publication lease.
 export const MAX_FRAME_DATABASE_COUNT = 4;
-// Matches the pending-request cap of a single egress policy scope.
-export const MAX_FRAME_DOMAIN_COUNT = 50;
 export const FRAME_DATABASE_NAME_REGEX = SANDBOX_DATABASE_NAME_REGEX;
 
 /** Manifest paths are always relative to the Frame source folder. */
@@ -75,7 +76,7 @@ export const FrameDatabaseManifestSchema = z.object({
 // runtime. Publishing files each one as an egress request for admin review.
 const FrameDomainsSchema = z
   .array(z.string())
-  .max(MAX_FRAME_DOMAIN_COUNT)
+  .max(SANDBOX_POLICY_MAX_REQUESTED_DOMAINS)
   .default([])
   .transform((domains, context) => {
     const normalized = normalizeEgressPolicyDomains(domains);

--- a/front/types/api/frame_manifest.ts
+++ b/front/types/api/frame_manifest.ts
@@ -6,6 +6,7 @@ import {
   SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
   SANDBOX_FUNCTION_STAKES,
 } from "@app/types/api/sandbox_functions";
+import { normalizeEgressPolicyDomains } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -20,6 +21,8 @@ export const MAX_FRAME_FUNCTION_NAME_LENGTH = 128;
 export const MAX_FRAME_FUNCTION_DESCRIPTION_LENGTH = 255;
 // Each schema reconcile can take 60 seconds and runs under the 10-minute publication lease.
 export const MAX_FRAME_DATABASE_COUNT = 4;
+// Matches the pending-request cap of a single egress policy scope.
+export const MAX_FRAME_DOMAIN_COUNT = 50;
 export const FRAME_DATABASE_NAME_REGEX = SANDBOX_DATABASE_NAME_REGEX;
 
 /** Manifest paths are always relative to the Frame source folder. */
@@ -68,6 +71,21 @@ export const FrameDatabaseManifestSchema = z.object({
   schema: FrameRelativePathSchema,
 });
 
+// Exact domains or `*.example.com` wildcards the Frame's functions reach at
+// runtime. Publishing files each one as an egress request for admin review.
+const FrameDomainsSchema = z
+  .array(z.string())
+  .max(MAX_FRAME_DOMAIN_COUNT)
+  .default([])
+  .transform((domains, context) => {
+    const normalized = normalizeEgressPolicyDomains(domains);
+    if (normalized.isErr()) {
+      context.addIssue({ code: "custom", message: normalized.error.message });
+      return z.NEVER;
+    }
+    return normalized.value;
+  });
+
 export const FrameSourceManifestSchema = z
   .object({
     version: z.literal(FRAME_MANIFEST_VERSION),
@@ -79,6 +97,7 @@ export const FrameSourceManifestSchema = z
       .array(FrameDatabaseManifestSchema)
       .max(MAX_FRAME_DATABASE_COUNT)
       .default([]),
+    domains: FrameDomainsSchema,
   })
   .superRefine((manifest, context) => {
     const functionNames = new Set<string>();

--- a/front/types/api/frame_publication.test.ts
+++ b/front/types/api/frame_publication.test.ts
@@ -23,6 +23,7 @@ const publication = {
       },
     ],
     databases: [{ name: "tasks", schema: "databases/tasks.db.ts" }],
+    domains: ["api.example.com"],
   },
   publishedAt: "2026-08-28T12:00:00.000Z",
   publisherId: "usr_publisher",

--- a/front/types/sandbox/egress_policy.ts
+++ b/front/types/sandbox/egress_policy.ts
@@ -2,6 +2,11 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
+// Caps the pending-request section of one policy scope: the proxy re-reads
+// the file on every cache miss, so an agent must not be able to grow it
+// unboundedly. Also bounds the domains a Frame manifest may declare.
+export const SANDBOX_POLICY_MAX_REQUESTED_DOMAINS = 50;
+
 // A domain an agent asked to add to a Pod's allowlist, pending admin
 // approval. Lives as a section of the Pod's policy file: the proxy ignores
 // unknown fields, so only allowedDomains is authorization state — this


### PR DESCRIPTION
## Description

Frames v2 functions run in a Frame-owned sandbox whose egress is the workspace policy plus the Pod's when the Frame lives in a Pod. Nothing told an admin what a published function needs: the v2 publish is `dsbx frame publish <manifest>` with no other input, so unlike the legacy Pod Functions `publish` tool (which took a `domains` argument) there was no way to file egress requests. On-the-fly approvals don't help either: they write to the conversation's own policy, which function sandboxes never see.

Stacked on the `frames_v2` gate swap (`31909`).

**What this PR does:**

1. Adds a `domains` array to the Frames v2 manifest: exact domains or `*.example.com` wildcards, normalized and deduped, capped at the same 50 as a scope's pending-request section (constant now shared from `types/sandbox/egress_policy`). Persisted in the publication descriptor; old descriptors default to `[]`. `dsbx frame validate` surfaces malformed entries before publish.
2. After a successful v2 publish, files those domains as requests on the scope the Frame's sandbox inherits from (`FrameSandboxAdapter.resolveScope`, now public): the Pod, else the workspace. Never the Frame's own policy file, which no admin surface lists. A request failure never fails the publish.
3. Batches the policy writes: one read of the scope (plus the workspace layer when filing on a Pod, so workspace-allowed domains aren't re-requested), one write, one proxy invalidation per publish, via new `requestOwnerPolicyDomains` / `requestWorkspacePolicyDomains`. The single-domain helpers delegate to the batch. The batch is rejected whole if it would exceed the cap.
4. The legacy Pod Functions publish tool uses the same shared helper (`egress_domain_requests.ts`), behavior unchanged, about 60 lines shorter.
5. `egressDomains` on the publish response (`filed` with requested / already-allowed lists, or `failed` with the reason) and on the CLI response struct so the agent sees what is pending. Frames v2 skill text updated: declare domains in the manifest, relay pending approvals to the user, `request_egress_domain` for domains discovered after publish.

The edit-text republish path deliberately does not re-file: the manifest is unchanged, so its domains were already requested.

> [!NOTE]
> The CLI prints `egressDomains` only once the sandbox image carries the rebuilt `dsbx`. Requests are filed server-side regardless; until then the agent just doesn't see the summary.

## Tests

- Manifest parsing: defaults, normalization and dedup, malformed domains, cap.
- Policy batch: classification with a single write, workspace-layer skip when filing on a Pod, no-write when nothing is new, cap rejection, malformed batch.
- Shared helper: Pod and workspace filing, failed batch, formatter wording.
- Publish: workspace scope, Pod scope honoring the workspace allowlist, already-allowed, at-cap failure with message, no domains declared.
- Legacy publish tool tests pass unchanged. Biome and typecheck clean on `front` and `front-api`.

## Risk

Additive manifest field, additive response field, additive descriptor field with a default. Publish never fails on a domain request error. Worst case, a request lands on the wrong scope and an admin dismisses it, or the agent forgets to declare a domain and the function's fetch is denied at runtime as it is today. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front` and `front-api`
- [ ] Rebuild the sandbox image with the new `dsbx` (agents see `egressDomains` from then on)
