### PR TITLE
[Dust Agent] Route issue creation to dust

### DIFF
--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -4,11 +4,13 @@ description: Call a Dust agent for Dust company context or to access tools, data
 ---
 
 Access Dust agents that have context on all the company, e.g. recent projects, engineering, sales, marketing, etc., via the Dust CLI non-interactively, e.g.:
-`$ dust chat -a issueBot -m "create an issue for this: ..."`
+`$ dust chat -a dust -m "create an issue for this: ..."`
 `$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks."`
 
+For GitHub issue creation, use the `dust` agent rather than `issueBot` or `gh`; `dust` has specific guidance for writing issues.
+
 A conversation with an agent can be continued after the first message using the argument `-c CONVERSATION_STRING_ID`. The conversation id will be returned in the JSON result from the initial call.
-`$ dust chat -a issueBot -c 'TdWyn4aDt1' -m "also add a subsequent issue about this: ..."`
+`$ dust chat -a dust -c 'TdWyn4aDt1' -m "also add a subsequent issue about this: ..."`
 
 Use `--projectName` or `--projectId` to create the conversation inside a specific project (space). These cannot be used with `-c` (only for new conversations):
 `$ dust chat -a prea --projectName "Engineering" -m "summarize recent incidents"`


### PR DESCRIPTION
## Description

The dust-call-agent skill still directed GitHub issue creation to issueBot. It now uses the dust agent, which has the task-specific issue-writing guidance, and makes this an explicit exception to using native gh.

## Risks

Blast radius: Guidance used by coding agents when creating GitHub issues.
Risk: low

## Deploy Plan

- No deployment required.

## Tests

- [x] Skill structure validation