### PR TITLE
Sandbox functions: name the egress-blocked domains on a failed invocation

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -27,7 +27,7 @@ import {
   generateSandboxExecToken,
   revokeExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
-import { readNewDenyLogEntries } from "@app/lib/api/sandbox/egress";
+import { collectEgressDenials } from "@app/lib/api/sandbox/egress_deny_log";
 import type { RequestOwnerPolicyDomainOutcome } from "@app/lib/api/sandbox/egress_policy";
 import {
   addOwnerPolicyDomain,
@@ -66,7 +66,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
-import { z } from "zod";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
@@ -106,70 +105,6 @@ function formatExecOutput(
   }
 
   return sections.join("\n") || "(no output)";
-}
-
-// The egress proxy's domain-allowlist gate writes this reason. It is the only
-// deny reason that means "this domain was blocked" and is actionable by the
-// agent (ask an admin / add_egress_domain).
-const PROXY_ALLOWLIST_DENY_REASON = "proxy_denied";
-
-const DenyLogLineSchema = z.object({
-  reason: z.string(),
-  domain: z.string().nullish(),
-  port: z.number().nullish(),
-});
-
-function safeJsonParse(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return undefined;
-  }
-}
-
-// The sandbox deny log is written by two distinct layers into one file: the
-// egress proxy's domain-allowlist gate (`proxy_denied`) and the in-sandbox
-// request-rewrite harness (malformed headers, secret-to-host scoping, SNI
-// checks, ...). Only the allowlist denials mean "this domain was blocked".
-// Surfacing the harness reasons under the same `<network_proxy_logs>` block
-// makes agents misread auth/4xx failures on *allowed* domains as proxy blocks,
-// so we keep only allowlist denials for the agent and present them as a clean,
-// unambiguous line. Unrecognized lines are kept verbatim (fail open) so we
-// never silently swallow a real denial we don't understand.
-//
-// Harness denials are hidden from the agent but still returned here so the
-// caller can log them: they are how we notice a request-policy check firing in
-// production, whether that is a real attack or legitimate traffic we broke.
-function partitionDenyLogEntries(rawLines: string[]): {
-  agentFacing: string[];
-  harnessDenials: { reason: string; domain: string | null }[];
-} {
-  const agentFacing: string[] = [];
-  const harnessDenials: { reason: string; domain: string | null }[] = [];
-
-  for (const line of rawLines) {
-    const parsed = DenyLogLineSchema.safeParse(safeJsonParse(line));
-    if (!parsed.success) {
-      agentFacing.push(line);
-      continue;
-    }
-
-    const { reason, domain, port } = parsed.data;
-    if (reason !== PROXY_ALLOWLIST_DENY_REASON) {
-      harnessDenials.push({ reason, domain: domain ?? null });
-      continue;
-    }
-    if (!domain) {
-      agentFacing.push(line);
-      continue;
-    }
-
-    agentFacing.push(
-      `denied ${domain}${port ? `:${port}` : ""} (blocked by egress allowlist)`
-    );
-  }
-
-  return { agentFacing, harnessDenials };
 }
 
 // Shannon entropy in bits/char. Uniform random characters approach
@@ -516,31 +451,11 @@ export async function runSandboxBashTool(
     return new Err(new MCPError(execResult.error.message));
   }
 
-  let denyLogEntries: string[] | undefined;
-  const denyResult = await readNewDenyLogEntries(auth, sandbox);
-  if (denyResult.isErr()) {
-    logger.warn(
-      { err: denyResult.error, providerId: sandbox.providerId },
-      "Failed to read egress deny log"
-    );
-  } else if (denyResult.value.length > 0) {
-    const { agentFacing, harnessDenials } = partitionDenyLogEntries(
-      denyResult.value
-    );
-    if (harnessDenials.length > 0) {
-      logger.info(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          sandboxId: sandbox.sId,
-          harnessDenials,
-        },
-        "Sandbox egress request policy denied requests"
-      );
-    }
-    if (agentFacing.length > 0) {
-      denyLogEntries = agentFacing;
-    }
-  }
+  const denials = await collectEgressDenials(auth, sandbox, {
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+  const denyLogEntries =
+    denials && denials.agentFacing.length > 0 ? denials.agentFacing : undefined;
 
   const output = formatExecOutput(execResult.value, { denyLogEntries });
   const redactedOutputResult = await redactSandboxEnvVarsFromOutput(

--- a/front/lib/api/sandbox/egress_deny_log.test.ts
+++ b/front/lib/api/sandbox/egress_deny_log.test.ts
@@ -1,0 +1,100 @@
+import {
+  partitionDenyLogEntries,
+  withBlockedEgressHint,
+} from "@app/lib/api/sandbox/egress_deny_log";
+import { describe, expect, it } from "vitest";
+
+const denyLine = (fields: Record<string, unknown>) =>
+  JSON.stringify({
+    ts: "t",
+    secret_name: "unknown",
+    sni: null,
+    host: null,
+    ...fields,
+  });
+
+describe("partitionDenyLogEntries", () => {
+  it("renders allowlist denials for the agent and collects their domains once", () => {
+    const summary = partitionDenyLogEntries([
+      denyLine({ reason: "proxy_denied", domain: "api.stripe.com", port: 443 }),
+      denyLine({ reason: "proxy_denied", domain: "api.stripe.com", port: 443 }),
+      denyLine({ reason: "proxy_denied", domain: "hooks.slack.com" }),
+    ]);
+
+    expect(summary.agentFacing).toEqual([
+      "denied api.stripe.com:443 (blocked by egress allowlist)",
+      "denied api.stripe.com:443 (blocked by egress allowlist)",
+      "denied hooks.slack.com (blocked by egress allowlist)",
+    ]);
+    expect(summary.blockedDomains).toEqual([
+      "api.stripe.com",
+      "hooks.slack.com",
+    ]);
+    expect(summary.harnessDenials).toEqual([]);
+  });
+
+  it("hides harness denials from the agent but keeps them for logging", () => {
+    const summary = partitionDenyLogEntries([
+      denyLine({
+        reason: "placeholder_on_non_allowed",
+        domain: "api.openai.com",
+        port: 443,
+      }),
+    ]);
+
+    expect(summary.agentFacing).toEqual([]);
+    expect(summary.blockedDomains).toEqual([]);
+    expect(summary.harnessDenials).toEqual([
+      { reason: "placeholder_on_non_allowed", domain: "api.openai.com" },
+    ]);
+  });
+
+  it("keeps unrecognized lines verbatim and does not treat them as blocked domains", () => {
+    const summary = partitionDenyLogEntries([
+      "not json at all",
+      denyLine({ reason: "proxy_denied", domain: null }),
+    ]);
+
+    expect(summary.agentFacing).toEqual([
+      "not json at all",
+      denyLine({ reason: "proxy_denied", domain: null }),
+    ]);
+    expect(summary.blockedDomains).toEqual([]);
+  });
+});
+
+describe("withBlockedEgressHint", () => {
+  const error = { code: "threw" as const, message: "fetch failed." };
+
+  it("points a Frame function at the manifest", () => {
+    expect(
+      withBlockedEgressHint(error, {
+        blockedDomains: ["api.stripe.com"],
+        ownerKind: "frame",
+      })
+    ).toEqual({
+      code: "threw",
+      message:
+        "fetch failed. Egress blocked for: api.stripe.com. To allow them, add them to the " +
+        'manifest\'s "domains" and republish, or call request_egress_domain.',
+    });
+  });
+
+  it("points a Pod Function at the publish tool", () => {
+    expect(
+      withBlockedEgressHint(error, {
+        blockedDomains: ["api.stripe.com", "hooks.slack.com"],
+        ownerKind: "pod",
+      }).message
+    ).toContain(
+      "Egress blocked for: api.stripe.com, hooks.slack.com. To allow them, declare them in the " +
+        'publish tool\'s "domains", or call request_egress_domain.'
+    );
+  });
+
+  it("returns the error unchanged when nothing was blocked", () => {
+    expect(
+      withBlockedEgressHint(error, { blockedDomains: [], ownerKind: "frame" })
+    ).toBe(error);
+  });
+});

--- a/front/lib/api/sandbox/egress_deny_log.ts
+++ b/front/lib/api/sandbox/egress_deny_log.ts
@@ -1,0 +1,139 @@
+import { readNewDenyLogEntries } from "@app/lib/api/sandbox/egress";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import { z } from "zod";
+
+// The egress proxy's domain-allowlist gate writes this reason. It is the only
+// deny reason that means "this domain was blocked" and is actionable by the
+// agent (ask an admin / add_egress_domain / declare it at publish).
+const PROXY_ALLOWLIST_DENY_REASON = "proxy_denied";
+
+const DenyLogLineSchema = z.object({
+  reason: z.string(),
+  domain: z.string().nullish(),
+  port: z.number().nullish(),
+});
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export type EgressDenyLogSummary = {
+  // Allowlist denials rendered for the agent, plus unrecognized lines verbatim,
+  // in log order.
+  agentFacing: string[];
+  // Domains the allowlist blocked, deduped, in first-seen order.
+  blockedDomains: string[];
+  // Request-rewrite harness denials: hidden from the agent, kept for logging.
+  harnessDenials: { reason: string; domain: string | null }[];
+};
+
+// The sandbox deny log is written by two distinct layers into one file: the
+// egress proxy's domain-allowlist gate (`proxy_denied`) and the in-sandbox
+// request-rewrite harness (malformed headers, secret-to-host scoping, SNI
+// checks, ...). Only the allowlist denials mean "this domain was blocked".
+// Surfacing the harness reasons to the agent makes it misread auth/4xx
+// failures on *allowed* domains as proxy blocks, so those are kept for the
+// caller to log. Unrecognized lines are kept verbatim (fail open) so a real
+// denial we don't understand is never silently swallowed.
+export function partitionDenyLogEntries(
+  rawLines: string[]
+): EgressDenyLogSummary {
+  const agentFacing: string[] = [];
+  const blockedDomains = new Set<string>();
+  const harnessDenials: { reason: string; domain: string | null }[] = [];
+
+  for (const line of rawLines) {
+    const parsed = DenyLogLineSchema.safeParse(safeJsonParse(line));
+    if (!parsed.success) {
+      agentFacing.push(line);
+      continue;
+    }
+
+    const { reason, domain, port } = parsed.data;
+    if (reason !== PROXY_ALLOWLIST_DENY_REASON) {
+      harnessDenials.push({ reason, domain: domain ?? null });
+      continue;
+    }
+    if (!domain) {
+      agentFacing.push(line);
+      continue;
+    }
+
+    blockedDomains.add(domain);
+    agentFacing.push(
+      `denied ${domain}${port ? `:${port}` : ""} (blocked by egress allowlist)`
+    );
+  }
+
+  return {
+    agentFacing,
+    blockedDomains: [...blockedDomains],
+    harnessDenials,
+  };
+}
+
+// Best-effort: reads the sandbox's new deny-log lines and partitions them.
+// Harness denials are logged here so every caller reports them the same way.
+// Returns null when the log cannot be read; that is never worth failing the
+// caller's own outcome over.
+export async function collectEgressDenials(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  logContext: Record<string, unknown>
+): Promise<EgressDenyLogSummary | null> {
+  const denyResult = await readNewDenyLogEntries(auth, sandbox);
+  if (denyResult.isErr()) {
+    logger.warn(
+      { ...logContext, err: denyResult.error, providerId: sandbox.providerId },
+      "Failed to read egress deny log"
+    );
+    return null;
+  }
+
+  const summary = partitionDenyLogEntries(denyResult.value);
+  if (summary.harnessDenials.length > 0) {
+    logger.info(
+      {
+        ...logContext,
+        sandboxId: sandbox.sId,
+        harnessDenials: summary.harnessDenials,
+      },
+      "Sandbox egress request policy denied requests"
+    );
+  }
+
+  return summary;
+}
+
+// Appends the blocked domains and the way to get them allowed to a function's
+// error, so the agent learns which domain to declare instead of seeing a bare
+// network failure. Frames declare domains in the manifest; Pod Functions at
+// publish.
+export function withBlockedEgressHint(
+  error: SandboxFunctionCallError,
+  {
+    blockedDomains,
+    ownerKind,
+  }: { blockedDomains: string[]; ownerKind: "frame" | "pod" }
+): SandboxFunctionCallError {
+  if (blockedDomains.length === 0) {
+    return error;
+  }
+  const declareHint =
+    ownerKind === "frame"
+      ? 'add them to the manifest\'s "domains" and republish'
+      : 'declare them in the publish tool\'s "domains"';
+  return {
+    ...error,
+    message:
+      `${error.message} Egress blocked for: ${blockedDomains.join(", ")}. ` +
+      `To allow them, ${declareHint}, or call request_egress_domain.`,
+  };
+}

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1110,6 +1110,93 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(ensureFrameSandboxReady).not.toHaveBeenCalled();
   });
 
+  it("names the blocked egress domains on a failed Frame invocation", async () => {
+    const { authenticator, invocation, sandbox } =
+      await setupFrameExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: stdoutEnvelope({
+          ok: false,
+          error: { code: "threw", message: "fetch failed." },
+        }),
+        stderr: "",
+      })
+    );
+    const execRootSpy = vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout:
+          JSON.stringify({
+            reason: "proxy_denied",
+            domain: "api.stripe.com",
+            port: 443,
+          }) + "\n",
+        stderr: "",
+      })
+    );
+
+    const result = await invocation.execute(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    expect(execRootSpy).toHaveBeenCalledTimes(1);
+    const outcome = invocation.settledOutcome();
+    expect(outcome?.status).toBe("errored");
+    if (outcome?.status === "errored") {
+      expect(outcome.error.code).toBe("threw");
+      expect(outcome.error.message).toBe(
+        "fetch failed. Egress blocked for: api.stripe.com. To allow them, add them to the " +
+          'manifest\'s "domains" and republish, or call request_egress_domain.'
+      );
+    }
+  });
+
+  it("does not read the deny log when the invocation succeeds", async () => {
+    const { authenticator, invocation, sandbox } =
+      await setupFrameExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: SUCCEEDED_STDOUT, stderr: "" })
+    );
+    const execRootSpy = vi.spyOn(sandbox, "execRoot");
+
+    const result = await invocation.execute(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    expect(execRootSpy).not.toHaveBeenCalled();
+    expect(invocation.settledOutcome()?.status).toBe("succeeded");
+  });
+
+  it("keeps the runner error as-is when the deny log cannot be read", async () => {
+    const { authenticator, invocation, sandbox } =
+      await setupFrameExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: stdoutEnvelope({
+          ok: false,
+          error: { code: "threw", message: "fetch failed." },
+        }),
+        stderr: "",
+      })
+    );
+    vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Err(new Error("sandbox gone"))
+    );
+
+    const result = await invocation.execute(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    const outcome = invocation.settledOutcome();
+    if (outcome?.status === "errored") {
+      expect(outcome.error).toEqual({
+        code: "threw",
+        message: "fetch failed.",
+      });
+    } else {
+      throw new Error("expected an errored outcome");
+    }
+  });
+
   it("reads back a spilled result and delivers the full output", async () => {
     const { authenticator, sandboxFunction, sandbox, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -8,6 +8,10 @@ import {
   generateExecId,
   generateSandboxFunctionInvocationToken,
 } from "@app/lib/api/sandbox/access_tokens";
+import {
+  collectEgressDenials,
+  withBlockedEgressHint,
+} from "@app/lib/api/sandbox/egress_deny_log";
 import { isSandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { recordSandboxFunctionRun } from "@app/lib/api/sandbox/instrumentation";
 import type { EnsureSandboxReadyResult } from "@app/lib/api/sandbox/lifecycle";
@@ -35,6 +39,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { FrameSandboxScope } from "@app/lib/resources/frame_sandbox_adapter";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   SandboxFunctionInvocationModel,
@@ -996,13 +1001,40 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       if (normalized.ok) {
         await this.succeed(normalized.output);
       } else {
-        await this.fail(normalized.error);
+        await this.fail(
+          await this.withBlockedEgressDomains(auth, sandbox, normalized.error)
+        );
       }
 
       return new Ok(undefined);
     } catch (error) {
       return new Err(normalizeError(error));
     }
+  }
+
+  // Names the domains the egress allowlist blocked during a failed run, so a
+  // bare "fetch failed" tells the agent what to declare. Failures only: the
+  // read is a root exec round-trip kept off the fast-function happy path, and
+  // a function that swallowed a blocked fetch already chose what its caller
+  // sees. The deny log is sandbox-global, so under concurrent invocations the
+  // domains are "blocked since the last read", not strictly this run's.
+  private async withBlockedEgressDomains(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    error: SandboxFunctionCallError
+  ): Promise<SandboxFunctionCallError> {
+    const denials = await collectEgressDenials(
+      auth,
+      sandbox,
+      this.observabilityContext(auth)
+    );
+    if (!denials || denials.blockedDomains.length === 0) {
+      return error;
+    }
+    return withBlockedEgressHint(error, {
+      blockedDomains: denials.blockedDomains,
+      ownerKind: this.sandboxFunction.frame ? "frame" : "pod",
+    });
   }
 
   static modelIdToSId({

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -270,8 +270,9 @@ dsbx tools --json <server-name> <tool-name> <arguments...>
 Parse the JSON stdout envelope, including \`content\` and \`isError\`. Publishing a function that
 calls \`dsbx tools\` as \`fast\` is a bug: the runtime refuses the tool call. Function \`fetch()\`
 requests only reach domains on the egress allowlist (workspace, plus the Pod's when the Frame lives
-in a Pod), so declare them in the manifest's \`domains\`; \`DST_*\` / \`DSEC_*\` configuration
-follows the same rules as the Computer.
+in a Pod), so declare them in the manifest's \`domains\`. A function that fails because a fetch
+was blocked reports the blocked domains in its error; add them to \`domains\` and republish.
+\`DST_*\` / \`DSEC_*\` configuration follows the same rules as the Computer.
 
 ### Knowing who called a function
 


### PR DESCRIPTION
## Description

A Frame or Pod function whose `fetch()` hits a domain the egress allowlist blocks fails with a bare network error. The proxy writes the denial to the sandbox's deny log, but nothing reads that log for function sandboxes, so the agent has no way to learn which domain to declare. The Computer's bash tool already does this for the conversation sandbox: it reads the deny log after each command and appends the blocked domains to the tool output.

Stacked on the Frames v2 manifest `domains` PR (`31910`), which is stacked on the gate swap (`31909`).

**What this PR does:**

1. Moves the deny-log parsing out of the Computer tool into `lib/api/sandbox/egress_deny_log.ts`: `partitionDenyLogEntries` (allowlist denials for the agent, harness denials for logging, unrecognized lines verbatim) now also returns the deduped blocked domains, and `collectEgressDenials` wraps the read plus the harness-denial logging so both callers report them the same way. The Computer tool's `<network_proxy_logs>` output is unchanged.
2. When a function invocation fails, the invocation resource reads its sandbox's deny log and appends the blocked domains to the runner error: `Egress blocked for: api.stripe.com. To allow them, add them to the manifest's "domains" and republish, or call request_egress_domain.` Pod Functions get the equivalent hint pointing at the publish tool's `domains`. The error `code` is untouched, so callers keep classifying it the same way.
3. The Frames v2 skill tells the agent that a blocked fetch reports the blocked domains in the function error.

The read happens only on the failure path: it is a root exec round-trip kept off the fast-function happy path, and a function that swallowed a blocked fetch has already decided what its caller sees. The deny log is sandbox-global with a consumed offset, so under concurrent invocations in one Frame sandbox the domains are "blocked since the last read" rather than strictly this run's; the existing Computer tool has the same property.

## Tests

- `egress_deny_log.test.ts`: partitioning (allowlist rendering plus deduped domains, harness denials hidden but kept, unrecognized lines verbatim) and the hint wording for Frame and Pod owners.
- Invocation resource: a failed Frame invocation carries the blocked domain in its error; a successful one never reads the deny log; a deny-log read failure leaves the runner error untouched.
- Computer tool suite passes unchanged (its deny-log tests exercise the moved code through the bash tool).
- Biome and typecheck clean.

## Risk

Adds one root exec to the failure path of function invocations, bounded by the existing 2 s deny-log timeout and never fatal. Error messages get longer when domains were blocked; codes are unchanged. Worst case, a hint names a domain blocked by a concurrent invocation in the same sandbox. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front`
