### PR TITLE
OAuth providers redirect to the app URL

### DIFF
--- a/front/lib/api/config.test.ts
+++ b/front/lib/api/config.test.ts
@@ -47,3 +47,27 @@ describe("getSandboxApiBaseUrl", () => {
     expect(config.getSandboxApiBaseUrl()).toBe(PUBLIC_URL);
   });
 });
+
+describe("getOAuthRedirectBaseUrl", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.env = { ...originalEnv };
+  });
+
+  it("points OAuth providers at the app, where the SPA serves the finalize page", () => {
+    process.env.NEXT_PUBLIC_DUST_APP_URL = "https://app.dust.tt";
+    process.env.NEXT_PUBLIC_DUST_API_URL = PUBLIC_URL;
+    delete process.env.DUST_OAUTH_REDIRECT_BASE_URL;
+
+    expect(config.getOAuthRedirectBaseUrl()).toBe("https://app.dust.tt");
+  });
+
+  it("honours an explicit override", () => {
+    process.env.NEXT_PUBLIC_DUST_APP_URL = "https://app.dust.tt";
+    process.env.DUST_OAUTH_REDIRECT_BASE_URL = "https://oauth.example.com";
+
+    expect(config.getOAuthRedirectBaseUrl()).toBe("https://oauth.example.com");
+  });
+});

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -125,12 +125,22 @@ const config = {
   getCloudflareAccessAud: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("CLOUDFLARE_ACCESS_AUD");
   },
-  // For OAuth/WorkOS redirects. Allows overriding the redirect base URL separately
-  // from NEXT_PUBLIC_DUST_API_URL. Falls back to getClientFacingUrl() when not set.
+  // For the WorkOS callback, which must reach the API. Allows overriding the
+  // redirect base URL separately from NEXT_PUBLIC_DUST_API_URL.
   getAuthRedirectBaseUrl: (): string => {
     return (
       EnvironmentConfig.getOptionalEnvVariable("DUST_AUTH_REDIRECT_BASE_URL") ??
       config.getApiBaseUrl()
+    );
+  },
+  // For OAuth provider redirects. The finalize page is served by the SPA on the
+  // app URL for every cell, so providers register one redirect URI per provider
+  // instead of one per cell.
+  getOAuthRedirectBaseUrl: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable(
+        "DUST_OAUTH_REDIRECT_BASE_URL"
+      ) ?? config.getAppUrl()
     );
   },
   getDustInviteTokenSecret: (): string => {

--- a/front/lib/api/oauth/providers/monday.test.ts
+++ b/front/lib/api/oauth/providers/monday.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
-    getAuthRedirectBaseUrl: () => "https://dust.tt",
+    getOAuthRedirectBaseUrl: () => "https://dust.tt",
     getOAuthMondayClientId: () => "client-id",
   },
 }));

--- a/front/lib/api/oauth/providers/shopify.test.ts
+++ b/front/lib/api/oauth/providers/shopify.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
-    getAuthRedirectBaseUrl: () => "https://dust.tt",
+    getOAuthRedirectBaseUrl: () => "https://dust.tt",
     getDevOAuthRedirectBaseUrl: () => undefined,
     getOAuthShopifyClientId: () => "shopify-client-id",
     getOAuthShopifyClientSecret: () => "shopify-client-secret",

--- a/front/lib/api/oauth/utils.test.ts
+++ b/front/lib/api/oauth/utils.test.ts
@@ -1,0 +1,43 @@
+import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const config = vi.hoisted(() => ({
+  getOAuthRedirectBaseUrl: vi.fn(),
+  getDevOAuthRedirectBaseUrl: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({ default: config }));
+
+describe("finalizeUriForProvider", () => {
+  beforeEach(() => {
+    config.getOAuthRedirectBaseUrl.mockReturnValue("https://app.dust.tt");
+    config.getDevOAuthRedirectBaseUrl.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("builds the finalize URI on the OAuth redirect base", () => {
+    expect(finalizeUriForProvider("google_drive")).toBe(
+      "https://app.dust.tt/oauth/google_drive/finalize"
+    );
+  });
+
+  it("prefers the development base URL in development", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    config.getDevOAuthRedirectBaseUrl.mockReturnValue("https://dev.example");
+    expect(finalizeUriForProvider("notion")).toBe(
+      "https://dev.example/oauth/notion/finalize"
+    );
+  });
+
+  it("does not use the development base URL outside development", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    config.getDevOAuthRedirectBaseUrl.mockReturnValue("https://dev.example");
+    expect(finalizeUriForProvider("notion")).toBe(
+      "https://app.dust.tt/oauth/notion/finalize"
+    );
+  });
+});

--- a/front/lib/api/oauth/utils.ts
+++ b/front/lib/api/oauth/utils.ts
@@ -10,7 +10,7 @@ export function finalizeUriForProvider(provider: OAuthProvider): string {
       return devBaseUrl + `/oauth/${provider}/finalize`;
     }
   }
-  return config.getAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
+  return config.getOAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
 }
 
 export function getStringFromQuery(


### PR DESCRIPTION
## Description

Yet another drama around callback URLs.

Today every OAuth flow, MCP servers included, sends the provider back to the API host: `https://eu.dust.tt/oauth/<provider>/finalize` or `https://dust.tt/oauth/<provider>/finalize`. The API has nothing to say there anymore. Front has no server page for that path, so front-api answers a 302 to the same path on `app.dust.tt`, and the SPA finalize page does the work against the region or cell the user is on. The API host is a hop we kept only because that is what providers have registered.

The hop breaks on cells. cell-00002 sends `https://eu2.dust.tt/oauth/google_drive/finalize`, Google has never heard of it, `redirect_uri_mismatch`. Registering every provider for every new cell is not a plan.

So the provider goes straight to the client side. The finalize URI is built on a new `DUST_OAUTH_REDIRECT_BASE_URL`, app URL by default, and the SPA takes it from there and picks the right region or cell as it already does. One redirect URI per provider, valid for every cell, present and future. The WorkOS callback is not touched, it is an API route and stays on the API host.

No flag day. Legacy sets the override to the hosts providers know today, `https://eu.dust.tt` and `https://dust.tt`, front-edge to its own hosts, so nothing changes there when this deploys. Cells run on the default and get `app.dust.tt`. Providers are switched one by one and the overrides go away at the end.

## Tests

Unit tests on the OAuth helpers and the config getters, all green. Added coverage for the new default, the override, and the development shortcut staying development-only. Typecheck clean.

## Risk

None on legacy once the four overrides are in place, the redirect URI it sends is byte for byte the one it sends today. Without them legacy would switch to `app.dust.tt` at deploy and any provider not yet listing it would reject the flow. On cells the finalize page selects the cell from the tab that opened the popup, same origin, same `localStorage`.

## Deploy Plan

1. Before the deploy, in dust-infra: `DUST_OAUTH_REDIRECT_BASE_URL` in the front bundles of both regions (`https://eu.dust.tt`, `https://dust.tt`) and the front-edge bundles (`https://eu.front-edge.dust.tt`, `https://front-edge.dust.tt`).
2. Add `https://app.dust.tt/oauth/google_drive/finalize` to the Google OAuth client, merge, deploy front everywhere. Legacy unchanged, cell-00002 connects Google Drive.
3. Provider by provider, add the app URI to its client. When every provider accepts it, delete the four overrides and the regional URIs.
