### PR TITLE
Spend caps DB migration: drop dead credit-state columns

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -105,7 +105,6 @@ export class KeyResource extends BaseResource<KeyModel> {
       role: key.role,
       monthlyCapMicroUsd: key.monthlyCapMicroUsd,
       monthlyCapAwuCredits: key.monthlyCapAwuCredits,
-      creditState: key.creditState,
       workspaceId: key.workspaceId,
       groupIds: key.groupIds,
       userId: key.userId,

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -2,7 +2,6 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { ApiKeyCreditState } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { RoleType } from "@app/types/user";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
@@ -25,12 +24,11 @@ export class KeyModel extends WorkspaceAwareModel<KeyModel> {
   declare monthlyCapMicroUsd: number | null;
   // Admin-set cap on workspace-pool AWU consumption, in AWU credits. NULL means
   // no cap (unlimited). On credit-priced plans this is the enforcement source:
-  // a Metronome `spend_threshold_reached` alert (group key `api_key_name`,
-  // threshold = this value) drives `creditState`. Key names are NOT unique, and
-  // Metronome aggregates spend by name — so the cap is effectively per-name:
-  // all active keys sharing a name share the limit and are blocked together.
+  // the Redis fixed-window rate-limiter counter is compared against this value
+  // at message-send time. Key names are NOT unique, and the counter aggregates
+  // spend by name — so the cap is effectively per-name: all active keys sharing
+  // a name share the limit and are blocked together.
   declare monthlyCapAwuCredits: number | null;
-  declare creditState: CreationOptional<ApiKeyCreditState>;
   declare user: NonAttribute<UserModel>;
 }
 KeyModel.init(
@@ -78,11 +76,6 @@ KeyModel.init(
     monthlyCapAwuCredits: {
       type: DataTypes.INTEGER,
       allowNull: true,
-    },
-    creditState: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "on_pool",
     },
     groupIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -4,10 +4,7 @@ import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
-import type {
-  WorkspacePoolCreditState,
-  WorkspaceProgrammaticCreditState,
-} from "@app/types/credits";
+import type { WorkspacePoolCreditState } from "@app/types/credits";
 import type {
   WorkspaceSegmentationType,
   WorkspaceSharingPolicy,
@@ -39,7 +36,6 @@ export class WorkspaceModel extends BaseModel<WorkspaceModel> {
   declare conversationsRetentionDays: number | null;
   declare metronomeCustomerId: string | null;
   declare poolCreditState: CreationOptional<WorkspacePoolCreditState>;
-  declare programmaticCreditState: CreationOptional<WorkspaceProgrammaticCreditState>;
 }
 WorkspaceModel.init(
   {
@@ -121,11 +117,6 @@ WorkspaceModel.init(
       defaultValue: DEFAULT_SHARING_POLICY,
     },
     poolCreditState: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "active",
-    },
-    programmaticCreditState: {
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "active",

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -301,7 +301,6 @@ describe("WorkspaceResource", () => {
           conversationsRetentionDays: null,
           metronomeCustomerId: null,
           poolCreditState: "active",
-          programmaticCreditState: "active",
           createdAt: 1755000000000,
           updatedAt: 1755000000000,
         };

--- a/front/migrations/post-deploy/20260905120001_drop_dead_spend_cap_credit_state_columns.sql
+++ b/front/migrations/post-deploy/20260905120001_drop_dead_spend_cap_credit_state_columns.sql
@@ -1,0 +1,28 @@
+/*
+Post-deploy: drop the dead spend-cap credit-state columns.
+
+Per-API-key and programmatic spend caps are enforced from the Redis rate limiter
+compared against DB-persisted cap values, so these columns are no longer read or
+written — the spend-cap cleanup PR removed the model fields and all readers.
+Safe once that code is fully deployed.
+
+  keys."creditState"                  (per-API-key credit state)
+  workspaces."programmaticCreditState"(workspace programmatic credit state)
+
+`memberships.creditState` is NOT dropped — it still carries the seat↔pool
+dimension (see the backfill migration).
+*/
+
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."keys" DROP COLUMN IF EXISTS "creditState";
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspaces" DROP COLUMN IF EXISTS "programmaticCreditState";

--- a/front/migrations/pre-deploy/20260905120000_backfill_membership_credit_state.sql
+++ b/front/migrations/pre-deploy/20260905120000_backfill_membership_credit_state.sql
@@ -1,0 +1,30 @@
+/*
+Pre-deploy: normalize legacy `memberships.creditState` values onto the narrowed
+`user_seat` / `on_pool` set.
+
+The per-user spend-cap credit-state machine was removed (spend caps are enforced
+from the Redis rate limiter); the column now only carries the seat↔pool
+dimension. Read paths already normalize legacy values via
+`normalizeUserCreditState`, so this backfill just cleans the stored rows.
+
+  user_seat_low_balance                     -> user_seat
+  normal / on_pool_low_balance / capped     -> on_pool
+*/
+
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 300000;
+SET SESSION lock_timeout = 3000;
+UPDATE "public"."memberships"
+    SET "creditState" = 'user_seat'
+    WHERE "creditState" = 'user_seat_low_balance';
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 300000;
+SET SESSION lock_timeout = 3000;
+UPDATE "public"."memberships"
+    SET "creditState" = 'on_pool'
+    WHERE "creditState" IN ('normal', 'on_pool_low_balance', 'capped');

--- a/front/types/key.ts
+++ b/front/types/key.ts
@@ -2,24 +2,6 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { SpaceType } from "@app/types/space";
 import type { RoleType } from "@app/types/user";
 
-// Per-API-key credit state, mirroring the per-user `memberships.creditState`
-// but with only two states for new-pricing (credit) plans:
-//   - "on_pool": the key can spend from the workspace pool.
-//   - "capped": the key hit its admin-configured per-key spend cap and is
-//     blocked until the cap resets (billing-period renewal) or is raised.
-export const API_KEY_CREDIT_STATES = ["on_pool", "capped"] as const;
-
-export type ApiKeyCreditState = (typeof API_KEY_CREDIT_STATES)[number];
-
-export function isApiKeyCreditState(
-  value: unknown
-): value is ApiKeyCreditState {
-  return (
-    typeof value === "string" &&
-    (API_KEY_CREDIT_STATES as readonly string[]).includes(value)
-  );
-}
-
 export type KeyType = {
   id: ModelId;
   createdAt: number;


### PR DESCRIPTION
## Description

Second PR of the spend-cap `creditState` cleanup (stacked on #31914). Now that
spend caps are enforced entirely from the Redis rate limiter against DB-persisted
cap values, two credit-state columns are dead. This drops them and normalizes the
one surviving column.

- Remove `keys.creditState` and `workspaces.programmaticCreditState` from the
  Sequelize models (`KeyModel` / `WorkspaceModel`) and the `KeyResource` cache
  mapping; delete the now-unused `ApiKeyCreditState` type. The
  `WorkspaceProgrammaticCreditState` type stays — the rate-limiter concurrency
  band still uses it.
- **post-deploy** migration: `DROP COLUMN keys."creditState"` +
  `workspaces."programmaticCreditState"` (safe once the model change above is
  deployed everywhere).
- **pre-deploy** migration: backfill legacy `memberships.creditState` values onto
  the narrowed `user_seat` / `on_pool` set. Read paths already normalize these via
  `normalizeUserCreditState`, so this is data hygiene, not a correctness gate.

`memberships.creditState` is kept (it carries the seat↔pool dimension).

## Tests

- `npx tsgo --noEmit`: 0 errors.
- `npm run test`: key_resource (25), workspace_resource (49), keys/spend_limit (2)
  all pass after dropping the columns.
- Migrations are hand-written (shadow-DB generator unavailable in this env),
  following the existing pre/post-deploy SQL conventions; `migration:check` runs
  in CI against the real shadow DB.

## Risk

Low. The columns are already unread/unwritten as of #31914. The post-deploy
timing ensures no deployed pod references the columns when they're dropped. The
membership backfill is idempotent and value-scoped.

## Deploy plan

Standard migration flow: 
pre-deploy runs the membership backfill;
deploy front + front-sse before running post-deploy scripts.
post-deploy drops the two columns once the code is live.