### PR TITLE
[front] enh: sort group attribution by workspace average

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top.ts
@@ -1,11 +1,12 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopBodySchema,
+  ConsumptionTopGroupsBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopGroupSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
@@ -43,6 +44,7 @@ type ConsumptionTopFetcher = (
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopGroupSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ) => Promise<Result<ConsumptionTopResponse, ElasticsearchError>>;
@@ -59,11 +61,18 @@ export function createConsumptionTopRoute({
   /** @ignoreswagger */
   app.post(
     "/",
-    validate("json", ConsumptionTopBodySchema),
+    validate("json", ConsumptionTopGroupsBodySchema),
     async (ctx): HandlerResult<ConsumptionTopResponse> => {
       const auth = ctx.get("auth");
-      const { limit, offset, search, filter, sortOrder, ...periodQuery } =
-        ctx.req.valid("json");
+      const {
+        limit,
+        offset,
+        search,
+        filter,
+        sortBy,
+        sortOrder,
+        ...periodQuery
+      } = ctx.req.valid("json");
 
       const period = await resolveConsumptionPeriod(
         auth,
@@ -76,6 +85,7 @@ export function createConsumptionTopRoute({
         offset,
         search,
         filter,
+        ...(sortBy ? { sortBy } : {}),
         sortOrder,
       });
       if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopBodySchema,
+  ConsumptionTopGroupsBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
@@ -19,12 +19,12 @@ const app = consumptionAnalyticsApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  validate("json", ConsumptionTopBodySchema),
+  validate("json", ConsumptionTopGroupsBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
     const userId = ctx.get("consumptionUserId");
     const agentId = ctx.get("consumptionAgentId");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -42,6 +42,7 @@ app.post(
         ...(userId ? { users: [userId] } : {}),
         ...(agentId ? { agents: [agentId] } : {}),
       },
+      ...(sortBy ? { sortBy } : {}),
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -568,6 +568,25 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
     );
   });
 
+  it("forwards workspace-average sorting to the group ranking", async () => {
+    vi.mocked(fetchConsumptionTopGroups).mockResolvedValue(new Ok(TOP_GROUPS));
+    const { workspace } = await setupTest();
+
+    const response = await postRankingRequest(workspace.sId, "top-groups", {
+      sortBy: "workspace_average",
+      sortOrder: "asc",
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchConsumptionTopGroups)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sortBy: "workspace_average",
+        sortOrder: "asc",
+      })
+    );
+  });
+
   it("normalizes a null limit to the default", async () => {
     vi.mocked(fetchConsumptionTopAgents).mockResolvedValue(new Ok(TOP_AGENTS));
     const { workspace } = await setupTest();

--- a/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
+++ b/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
@@ -95,6 +95,7 @@ function PokeConsumptionAttributionRows(
     offset: queryState.pagination.pageIndex * queryState.pagination.pageSize,
     search: props.search,
     filter: props.filter,
+    sortBy: queryState.sortBy,
     sortOrder: queryState.sortOrder,
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -283,7 +283,7 @@ describe("ConsumptionAttributionTable", () => {
     expect(screen.getByRole("tab", { name: "Groups" })).toBeInTheDocument();
   });
 
-  it("shows active members and per-member usage for groups", async () => {
+  it("shows active members and sorts groups by per-member usage", async () => {
     mockUseConsumptionTop.mockReturnValue({
       rows: [
         {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -283,7 +283,7 @@ describe("ConsumptionAttributionTable", () => {
     expect(screen.getByRole("tab", { name: "Groups" })).toBeInTheDocument();
   });
 
-  it("shows active members and per-member usage for groups", () => {
+  it("shows active members and per-member usage for groups", async () => {
     mockUseConsumptionTop.mockReturnValue({
       rows: [
         {
@@ -325,9 +325,10 @@ describe("ConsumptionAttributionTable", () => {
     expect(
       screen.getByRole("columnheader", { name: "Active / total members" })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("columnheader", { name: "Vs workspace avg" })
-    ).toBeInTheDocument();
+    const workspaceAverageHeader = screen.getByRole("columnheader", {
+      name: "Vs workspace avg",
+    });
+    expect(workspaceAverageHeader).toBeInTheDocument();
     expect(
       screen.queryByRole("columnheader", { name: "Consumption share" })
     ).not.toBeInTheDocument();
@@ -335,6 +336,28 @@ describe("ConsumptionAttributionTable", () => {
     const usagePercentage = screen.getByText("+150%");
     expect(usagePercentage.parentElement).toHaveClass("text-highlight-600");
     expect(usagePercentage.parentElement?.querySelector("svg")).toBeNull();
+
+    fireEvent.click(workspaceAverageHeader);
+    await waitFor(() => {
+      expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          offset: 0,
+          sortBy: "workspace_average",
+          sortOrder: "desc",
+        })
+      );
+    });
+
+    fireEvent.click(workspaceAverageHeader);
+    await waitFor(() => {
+      expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          offset: 0,
+          sortBy: "workspace_average",
+          sortOrder: "asc",
+        })
+      );
+    });
   });
 
   it("caps the available pages and fetches the selected fixed-size page", async () => {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -444,16 +444,11 @@ function buildColumns({
             sortDescFirst: true,
             sortUndefined: "last",
             meta: { sizeRatio: 22, headerAlign: "right" },
-            cell: (info) => {
-              const usagePercent = usageDifferenceFromAveragePercent({
-                credits: info.row.original.credits,
-                activeMembers: info.row.original.activeMembers,
-                totalCredits,
-                totalActiveMembers,
-              });
-
-              return <UsageVsAverageCell percentage={usagePercent} />;
-            },
+            cell: (info) => (
+              <UsageVsAverageCell
+                percentage={info.getValue<number | undefined>() ?? null}
+              />
+            ),
           },
         ] satisfies ColumnDef<AttributionRowData>[])
       : ([

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -29,6 +29,7 @@ import { LinkWrapper } from "@app/lib/platform";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopGroupSortBy,
   ConsumptionTopSortOrder,
 } from "@app/types/api/analytics/consumption";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/types/api/analytics/consumption";
@@ -98,6 +99,7 @@ const DEFAULT_ATTRIBUTION_SORTING: SortingState = [
 const ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS = new Set([
   "credits",
   "costShare",
+  "usageVsAverage",
 ]);
 
 type AttributionTransitionDirection = -1 | 0 | 1;
@@ -430,8 +432,17 @@ function buildColumns({
           },
           {
             id: "usageVsAverage",
+            accessorFn: (row) =>
+              usageDifferenceFromAveragePercent({
+                credits: row.credits,
+                activeMembers: row.activeMembers,
+                totalCredits,
+                totalActiveMembers,
+              }) ?? undefined,
             header: "Vs workspace avg",
-            enableSorting: false,
+            enableSorting: true,
+            sortDescFirst: true,
+            sortUndefined: "last",
             meta: { sizeRatio: 22, headerAlign: "right" },
             cell: (info) => {
               const usagePercent = usageDifferenceFromAveragePercent({
@@ -604,6 +615,7 @@ export interface ConsumptionAttributionRowsQueryState {
   setPagination: Dispatch<SetStateAction<PaginationState>>;
   sorting: SortingState;
   onSortingChange: OnChangeFn<SortingState>;
+  sortBy: ConsumptionTopGroupSortBy;
   sortOrder: ConsumptionTopSortOrder;
 }
 
@@ -624,22 +636,23 @@ export function useConsumptionAttributionRowsQueryState(): ConsumptionAttributio
   };
 
   const activeSort = sorting[0];
-  // Ranking is always by credits: only forward asc/desc when the sorted
-  // column actually rides that ranking, so sorting by anything else keeps
-  // fetching pages in the default credits-desc order and reorders them
-  // locally instead.
+  // Only forward asc/desc for columns backed by a server ranking. Other
+  // columns keep fetching pages in the default credits-desc order.
   const sortOrder =
     activeSort?.id &&
     ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS.has(activeSort.id) &&
     !activeSort.desc
       ? "asc"
       : "desc";
+  const sortBy =
+    activeSort?.id === "usageVsAverage" ? "workspace_average" : "credits";
 
   return {
     pagination,
     setPagination,
     sorting,
     onSortingChange,
+    sortBy,
     sortOrder,
   };
 }
@@ -867,6 +880,7 @@ function WorkspaceConsumptionAttributionRows(
     search: props.search,
     filter: props.filter,
     analyticsScope: props.analyticsScope,
+    sortBy: queryState.sortBy,
     sortOrder: queryState.sortOrder,
     disabled: props.disabled,
   });

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -9,7 +9,7 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
-import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
+import type { ConsumptionTopGroupsBody } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopApiKeysResponse } from "@app/lib/api/analytics/consumption/top_api_keys";
 import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
@@ -22,6 +22,7 @@ import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/cons
 import { emptyArray } from "@app/lib/swr/swr";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopGroupSortBy,
   ConsumptionTopSortOrder,
 } from "@app/types/api/analytics/consumption";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -77,6 +78,7 @@ export interface UseConsumptionTopParams {
   search?: string;
   filter?: ConsumptionScopeFilter;
   analyticsScope?: ConsumptionAnalyticsScope;
+  sortBy?: ConsumptionTopGroupSortBy;
   sortOrder?: ConsumptionTopSortOrder;
   disabled?: boolean;
 }
@@ -228,6 +230,7 @@ export function useConsumptionTop({
   search,
   filter,
   analyticsScope,
+  sortBy,
   sortOrder = "desc",
   disabled,
 }: UseConsumptionTopParams) {
@@ -236,7 +239,7 @@ export function useConsumptionTop({
     analyticsScope,
     endpoint: CONSUMPTION_TOP_ENDPOINTS[dimension],
   });
-  const body: ConsumptionTopBody = {
+  const body: ConsumptionTopGroupsBody = {
     period: period.kind,
     days:
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
@@ -244,11 +247,12 @@ export function useConsumptionTop({
     limit,
     offset,
     search: search?.trim(),
+    ...(dimension === "group" && sortBy ? { sortBy } : {}),
     sortOrder,
   };
 
   const { data, error, isLoading, isValidating } = useConsumptionQuery<
-    ConsumptionTopBody,
+    ConsumptionTopGroupsBody,
     ConsumptionTopResponse
   >({ url, body, disabled });
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -5,6 +5,7 @@ import {
   CONSUMPTION_METRICS,
   CONSUMPTION_SCOPE_DIMENSIONS,
   CONSUMPTION_SCOPE_FILTER_KEYS,
+  CONSUMPTION_TOP_GROUP_SORT_BY,
   CONSUMPTION_TOP_SORT_ORDER,
   DEFAULT_CONSUMPTION_METRIC,
 } from "@app/lib/api/analytics/consumption/scope";
@@ -89,6 +90,14 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
 });
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;
+
+export const ConsumptionTopGroupsBodySchema = ConsumptionTopBodySchema.extend({
+  sortBy: z.enum(CONSUMPTION_TOP_GROUP_SORT_BY).optional(),
+});
+
+export type ConsumptionTopGroupsBody = z.infer<
+  typeof ConsumptionTopGroupsBodySchema
+>;
 
 // The attribution table's CSV export: same period/filter as the `top-*`
 // endpoints, but always returns the breakdown for every dimension.

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -84,8 +84,8 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
-  // Always ranks by gross credits; see the comment on
-  // CONSUMPTION_TOP_SORT_ORDER for why other metrics aren't supported yet.
+  // Defaults to gross credit ranking; the group schema also supports
+  // ranking by credits per active member.
   sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
 });
 

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -15,6 +15,7 @@ export type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
   ConsumptionScopeFilterKey,
+  ConsumptionTopGroupSortBy,
   ConsumptionTopSortOrder,
 } from "@app/types/api/analytics/consumption";
 export {
@@ -23,6 +24,7 @@ export {
   CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION,
   CONSUMPTION_SCOPE_DIMENSIONS,
   CONSUMPTION_SCOPE_FILTER_KEYS,
+  CONSUMPTION_TOP_GROUP_SORT_BY,
   CONSUMPTION_TOP_SORT_ORDER,
 } from "@app/types/api/analytics/consumption";
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -642,6 +642,119 @@ describe("consumption top rankings", () => {
     });
   });
 
+  it.each([
+    { sortOrder: "desc" as const, expectedGroupIds: ["group-b", "group-a"] },
+    { sortOrder: "asc" as const, expectedGroupIds: ["group-b", "group-c"] },
+  ])("sorts and paginates groups by workspace-average usage $sortOrder on the server", async ({
+    sortOrder,
+    expectedGroupIds,
+  }) => {
+    const { auth } = await setup();
+    mockLabels({
+      "group-a": "Group A",
+      "group-b": "Group B",
+      "group-c": "Group C",
+    });
+    vi.mocked(searchConsumptionAnalytics).mockImplementation(
+      async (_query, options) => {
+        const composite = options?.aggregations?.by_group?.composite;
+        if (composite) {
+          const isSecondPage = composite.after !== undefined;
+          return esResponse({
+            by_group: {
+              buckets: isSecondPage
+                ? [
+                    {
+                      key: { group: "group-c" },
+                      doc_count: 1,
+                      credit_micro: { value: 40_000_000 },
+                      messages: { value: 1 },
+                      active_members: { value: 1 },
+                    },
+                    {
+                      key: { group: "group-d" },
+                      doc_count: 1,
+                      credit_micro: { value: 20_000_000 },
+                      messages: { value: 1 },
+                      active_members: { value: 0 },
+                    },
+                  ]
+                : [
+                    {
+                      key: { group: "group-a" },
+                      doc_count: 10,
+                      credit_micro: { value: 100_000_000 },
+                      messages: { value: 10 },
+                      active_members: { value: 10 },
+                    },
+                    {
+                      key: { group: "group-b" },
+                      doc_count: 2,
+                      credit_micro: { value: 60_000_000 },
+                      messages: { value: 2 },
+                      active_members: { value: 2 },
+                    },
+                  ],
+              ...(isSecondPage ? {} : { after_key: { group: "group-b" } }),
+            },
+            total_credit_micro: { value: 200_000_000 },
+            active_members: { value: 12 },
+          });
+        }
+
+        const terms = options?.aggregations?.by_group?.terms;
+        const includedKeys = Array.isArray(terms?.include)
+          ? terms.include.map(String)
+          : [];
+        return esResponse({
+          by_group: {
+            buckets: includedKeys.map((key) => ({
+              key,
+              doc_count: 1,
+              credit_micro: { value: 1_000_000 },
+            })),
+          },
+        });
+      }
+    );
+
+    const result = await fetchConsumptionTopGroups(auth, {
+      period: PERIOD,
+      limit: 2,
+      offset: 1,
+      sortBy: "workspace_average",
+      sortOrder,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.groups.map((group) => group.groupId)).toEqual(
+      expectedGroupIds
+    );
+    expect(result.value.totalCredits).toBe(200);
+    expect(result.value.totalActiveMembers).toBe(12);
+    expect(result.value.totalCount).toBe(4);
+    expect(result.value.hasMore).toBe(true);
+
+    const compositeCalls = vi
+      .mocked(searchConsumptionAnalytics)
+      .mock.calls.filter(
+        ([, options]) => options?.aggregations?.by_group?.composite
+      );
+    expect(compositeCalls).toHaveLength(2);
+    expect(
+      compositeCalls[0]?.[1]?.aggregations?.by_group?.composite
+    ).toMatchObject({
+      size: 1_000,
+      sources: [{ group: { terms: { field: "user.group_ids" } } }],
+    });
+    expect(
+      compositeCalls[1]?.[1]?.aggregations?.by_group?.composite?.after
+    ).toEqual({ group: "group-b" });
+  });
+
   it("ranks reasoning efforts per message for the selected model", async () => {
     const { auth } = await setup();
     mockAggs({

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -643,10 +643,34 @@ describe("consumption top rankings", () => {
   });
 
   it.each([
-    { sortOrder: "desc" as const, expectedGroupIds: ["group-b", "group-a"] },
-    { sortOrder: "asc" as const, expectedGroupIds: ["group-b", "group-c"] },
-  ])("sorts and paginates groups by workspace-average usage $sortOrder on the server", async ({
+    {
+      sortOrder: "desc" as const,
+      offset: 1,
+      limit: 3,
+      expectedGroupIds: ["group-b", "group-e", "group-a"],
+    },
+    {
+      sortOrder: "asc" as const,
+      offset: 1,
+      limit: 3,
+      expectedGroupIds: ["group-b", "group-e", "group-c"],
+    },
+    {
+      sortOrder: "desc" as const,
+      offset: 0,
+      limit: 5,
+      expectedGroupIds: ["group-c", "group-b", "group-e", "group-a", "group-d"],
+    },
+    {
+      sortOrder: "asc" as const,
+      offset: 0,
+      limit: 5,
+      expectedGroupIds: ["group-a", "group-b", "group-e", "group-c", "group-d"],
+    },
+  ])("sorts groups by workspace-average usage $sortOrder with offset $offset", async ({
     sortOrder,
+    offset,
+    limit,
     expectedGroupIds,
   }) => {
     const { auth } = await setup();
@@ -678,6 +702,13 @@ describe("consumption top rankings", () => {
                       messages: { value: 1 },
                       active_members: { value: 0 },
                     },
+                    {
+                      key: { group: "group-e" },
+                      doc_count: 3,
+                      credit_micro: { value: 90_000_000 },
+                      messages: { value: 3 },
+                      active_members: { value: 3 },
+                    },
                   ]
                 : [
                     {
@@ -697,8 +728,12 @@ describe("consumption top rankings", () => {
                   ],
               ...(isSecondPage ? {} : { after_key: { group: "group-b" } }),
             },
-            total_credit_micro: { value: 200_000_000 },
-            active_members: { value: 12 },
+            ...(!isSecondPage
+              ? {
+                  total_credit_micro: { value: 200_000_000 },
+                  active_members: { value: 12 },
+                }
+              : {}),
           });
         }
 
@@ -720,8 +755,8 @@ describe("consumption top rankings", () => {
 
     const result = await fetchConsumptionTopGroups(auth, {
       period: PERIOD,
-      limit: 2,
-      offset: 1,
+      limit,
+      offset,
       sortBy: "workspace_average",
       sortOrder,
     });
@@ -735,8 +770,11 @@ describe("consumption top rankings", () => {
     );
     expect(result.value.totalCredits).toBe(200);
     expect(result.value.totalActiveMembers).toBe(12);
-    expect(result.value.totalCount).toBe(4);
-    expect(result.value.hasMore).toBe(true);
+    expect(result.value.totalCount).toBe(5);
+    expect(result.value.hasMore).toBe(offset + limit < 5);
+    expect(result.value.groups.map((group) => group.previousCredits)).toEqual(
+      expectedGroupIds.map(() => 1)
+    );
 
     const compositeCalls = vi
       .mocked(searchConsumptionAnalytics)
@@ -753,6 +791,12 @@ describe("consumption top rankings", () => {
     expect(
       compositeCalls[1]?.[1]?.aggregations?.by_group?.composite?.after
     ).toEqual({ group: "group-b" });
+    expect(
+      compositeCalls[1]?.[1]?.aggregations?.total_credit_micro
+    ).toBeUndefined();
+    expect(
+      compositeCalls[1]?.[1]?.aggregations?.active_members
+    ).toBeUndefined();
   });
 
   it("ranks reasoning efforts per message for the selected model", async () => {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -353,13 +353,18 @@ function buildConsumptionTopWorkspaceAverageAggregations({
 
   return {
     ...rankingRootAggregations,
-    total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
-    [ACTIVE_MEMBERS_AGG]: {
-      cardinality: {
-        field: CONSUMPTION_DIMENSION_FIELDS.user,
-        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-      },
-    },
+    // Workspace totals are independent of the composite cursor.
+    ...(!afterKey
+      ? {
+          total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+          [ACTIVE_MEMBERS_AGG]: {
+            cardinality: {
+              field: CONSUMPTION_DIMENSION_FIELDS.user,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        }
+      : {}),
   };
 }
 
@@ -389,18 +394,15 @@ function compareGroupsByWorkspaceAverage(
   return sortOrder === "asc" ? comparison : -comparison;
 }
 
-async function fetchConsumptionGroupsRankedByWorkspaceAverage(
-  auth: Authenticator,
-  {
-    query,
-    searchFilter,
-    sortOrder,
-  }: {
-    query: estypes.QueryDslQueryContainer;
-    searchFilter: estypes.QueryDslQueryContainer | null;
-    sortOrder: ConsumptionTopSortOrder;
-  }
-): Promise<Result<CurrentConsumptionTopRanking, ElasticsearchError>> {
+async function fetchConsumptionGroupsRankedByWorkspaceAverage({
+  query,
+  searchFilter,
+  sortOrder,
+}: {
+  query: estypes.QueryDslQueryContainer;
+  searchFilter: estypes.QueryDslQueryContainer | null;
+  sortOrder: ConsumptionTopSortOrder;
+}): Promise<Result<CurrentConsumptionTopRanking, ElasticsearchError>> {
   const groups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
   let afterKey: CompositeGroupKey | undefined;
   let buckets: CompositeGroupBucket[];
@@ -435,12 +437,14 @@ async function fetchConsumptionGroupsRankedByWorkspaceAverage(
         activeMembers: Math.round(bucket[ACTIVE_MEMBERS_AGG]?.value ?? 0),
       }))
     );
-    totalCredits = microCreditsToCredits(
-      result.value.aggregations?.total_credit_micro?.value ?? 0
-    );
-    totalActiveMembers = Math.round(
-      result.value.aggregations?.[ACTIVE_MEMBERS_AGG]?.value ?? 0
-    );
+    if (!afterKey) {
+      totalCredits = microCreditsToCredits(
+        result.value.aggregations?.total_credit_micro?.value ?? 0
+      );
+      totalActiveMembers = Math.round(
+        result.value.aggregations?.[ACTIVE_MEMBERS_AGG]?.value ?? 0
+      );
+    }
     afterKey = ranking?.by_group?.after_key;
   } while (afterKey !== undefined && buckets.length > 0);
 
@@ -593,7 +597,6 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
-    sortBy = "credits",
     sortOrder = "desc",
     rankBy = "credits",
     includePreviousCredits = true,
@@ -605,9 +608,8 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopGroupSortBy;
     sortOrder?: ConsumptionTopSortOrder;
-    rankBy?: ConsumptionTopRankBy;
+    rankBy?: ConsumptionTopRankBy | ConsumptionTopGroupSortBy;
     includePreviousCredits?: boolean;
     includeTotalCount?: boolean;
   }
@@ -624,17 +626,18 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
 
-  if (sortBy === "workspace_average") {
-    if (dimension !== "group" || rankBy !== "credits") {
+  if (rankBy === "workspace_average") {
+    if (dimension !== "group") {
       throw new Error(
         "Workspace-average consumption sorting is only supported for " +
           "group credit rankings."
       );
     }
-    const rankingResult = await fetchConsumptionGroupsRankedByWorkspaceAverage(
-      auth,
-      { query, searchFilter, sortOrder }
-    );
+    const rankingResult = await fetchConsumptionGroupsRankedByWorkspaceAverage({
+      query,
+      searchFilter,
+      sortOrder,
+    });
     if (rankingResult.isErr()) {
       return rankingResult;
     }

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,6 +5,7 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeFilter,
   ConsumptionTopDimension,
+  ConsumptionTopGroupSortBy,
   ConsumptionTopRankBy,
   ConsumptionTopSortOrder,
   ConsumptionTopUnit,
@@ -66,6 +67,7 @@ const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const ACTIVE_MEMBERS_AGG = "active_members";
 const TOTAL_COUNT_AGG = "total_count";
+const RANKING_COMPOSITE_PAGE_SIZE = 1_000;
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
@@ -76,6 +78,12 @@ type GroupBucket = {
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
   [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
+};
+
+type CompositeGroupKey = { group: string };
+
+type CompositeGroupBucket = Omit<GroupBucket, "key"> & {
+  key: CompositeGroupKey;
 };
 
 function subAggs(unit: ConsumptionTopUnit, dimension: ConsumptionTopDimension) {
@@ -108,8 +116,29 @@ type TopAggs = RankingAggs & {
   [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
+type CompositeRankingAggs = {
+  by_group?: estypes.AggregationsCompositeAggregate & {
+    buckets: CompositeGroupBucket[];
+    after_key?: CompositeGroupKey;
+  };
+};
+
+type CompositeTopAggs = CompositeRankingAggs & {
+  ranking?: estypes.AggregationsSingleBucketAggregateBase &
+    CompositeRankingAggs;
+  total_credit_micro?: estypes.AggregationsSumAggregate;
+  [ACTIVE_MEMBERS_AGG]?: estypes.AggregationsCardinalityAggregate;
+};
+
+type CurrentConsumptionTopRanking = {
+  groups: Omit<ConsumptionTopGroup, "previousCredits">[];
+  totalCount: number;
+  totalCredits: number;
+  totalActiveMembers: number;
+};
+
 function countFromBucket(
-  bucket: GroupBucket,
+  bucket: Omit<GroupBucket, "key">,
   unit: ConsumptionTopUnit
 ): number {
   switch (unit) {
@@ -289,6 +318,142 @@ function buildConsumptionTopAggregations({
   };
 }
 
+function buildConsumptionTopWorkspaceAverageAggregations({
+  afterKey,
+  searchFilter,
+}: {
+  afterKey?: CompositeGroupKey;
+  searchFilter: estypes.QueryDslQueryContainer | null;
+}): Record<string, estypes.AggregationsAggregationContainer> {
+  const rankingAggregations = {
+    by_group: {
+      composite: {
+        size: RANKING_COMPOSITE_PAGE_SIZE,
+        sources: [
+          {
+            group: {
+              terms: { field: CONSUMPTION_TOP_DIMENSION_FIELDS.group },
+            },
+          },
+        ],
+        ...(afterKey ? { after: afterKey } : {}),
+      },
+      aggs: subAggs("message", "group"),
+    },
+  } satisfies Record<string, estypes.AggregationsAggregationContainer>;
+
+  const rankingRootAggregations = searchFilter
+    ? {
+        ranking: {
+          filter: searchFilter,
+          aggs: rankingAggregations,
+        },
+      }
+    : rankingAggregations;
+
+  return {
+    ...rankingRootAggregations,
+    total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+    [ACTIVE_MEMBERS_AGG]: {
+      cardinality: {
+        field: CONSUMPTION_DIMENSION_FIELDS.user,
+        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+      },
+    },
+  };
+}
+
+function compareGroupsByWorkspaceAverage(
+  left: Omit<ConsumptionTopGroup, "previousCredits">,
+  right: Omit<ConsumptionTopGroup, "previousCredits">,
+  sortOrder: ConsumptionTopSortOrder
+): number {
+  const leftAverage = left.activeMembers
+    ? left.credits / left.activeMembers
+    : null;
+  const rightAverage = right.activeMembers
+    ? right.credits / right.activeMembers
+    : null;
+
+  if (leftAverage === null || rightAverage === null) {
+    if (leftAverage === rightAverage) {
+      return left.key.localeCompare(right.key);
+    }
+    return leftAverage === null ? 1 : -1;
+  }
+
+  const comparison = leftAverage - rightAverage;
+  if (comparison === 0) {
+    return left.key.localeCompare(right.key);
+  }
+  return sortOrder === "asc" ? comparison : -comparison;
+}
+
+async function fetchConsumptionGroupsRankedByWorkspaceAverage(
+  auth: Authenticator,
+  {
+    query,
+    searchFilter,
+    sortOrder,
+  }: {
+    query: estypes.QueryDslQueryContainer;
+    searchFilter: estypes.QueryDslQueryContainer | null;
+    sortOrder: ConsumptionTopSortOrder;
+  }
+): Promise<Result<CurrentConsumptionTopRanking, ElasticsearchError>> {
+  const groups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
+  let afterKey: CompositeGroupKey | undefined;
+  let buckets: CompositeGroupBucket[];
+  let totalCredits = 0;
+  let totalActiveMembers = 0;
+
+  // The workspace-average comparison is credits per active member relative to
+  // a workspace-wide constant. Composite pagination retrieves every group
+  // safely, then the server sorts the derived per-member value before paging.
+  do {
+    const aggregations = buildConsumptionTopWorkspaceAverageAggregations({
+      afterKey,
+      searchFilter,
+    });
+    const result = await searchConsumptionAnalytics<never, CompositeTopAggs>(
+      query,
+      { aggregations, size: 0 }
+    );
+    if (result.isErr()) {
+      return result;
+    }
+
+    const ranking = searchFilter
+      ? result.value.aggregations?.ranking
+      : result.value.aggregations;
+    buckets = bucketsToArray<CompositeGroupBucket>(ranking?.by_group?.buckets);
+    groups.push(
+      ...buckets.map((bucket) => ({
+        key: String(bucket.key.group),
+        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+        count: countFromBucket(bucket, "message"),
+        activeMembers: Math.round(bucket[ACTIVE_MEMBERS_AGG]?.value ?? 0),
+      }))
+    );
+    totalCredits = microCreditsToCredits(
+      result.value.aggregations?.total_credit_micro?.value ?? 0
+    );
+    totalActiveMembers = Math.round(
+      result.value.aggregations?.[ACTIVE_MEMBERS_AGG]?.value ?? 0
+    );
+    afterKey = ranking?.by_group?.after_key;
+  } while (afterKey !== undefined && buckets.length > 0);
+
+  return new Ok({
+    groups: groups.toSorted((left, right) =>
+      compareGroupsByWorkspaceAverage(left, right, sortOrder)
+    ),
+    totalCount: groups.length,
+    totalCredits,
+    totalActiveMembers,
+  });
+}
+
 type PreviousCreditsAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
 };
@@ -356,9 +521,68 @@ async function fetchConsumptionPreviousCredits(
   );
 }
 
+async function completeConsumptionTopRanking(
+  auth: Authenticator,
+  {
+    dimension,
+    period,
+    filter,
+    limit,
+    offset,
+    includePreviousCredits,
+    ranking,
+  }: {
+    dimension: ConsumptionTopDimension;
+    period: ConsumptionPeriod;
+    filter?: ConsumptionScopeFilter;
+    limit: number;
+    offset: number;
+    includePreviousCredits: boolean;
+    ranking: CurrentConsumptionTopRanking;
+  }
+): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
+  const pagedGroups = ranking.groups.slice(offset, offset + limit);
+  const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
+    dimension,
+    previousPeriod: previousConsumptionPeriod(period),
+    filter,
+    keys: includePreviousCredits ? pagedGroups.map((group) => group.key) : [],
+  });
+  // The prior-period lookup only feeds the vs-prev display column: a failure
+  // there should not take down the current-period ranking, which already
+  // succeeded. Fall back to unknown growth for every group instead.
+  if (previousCreditsResult.isErr()) {
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        dimension,
+        err: previousCreditsResult.error,
+      },
+      "[ConsumptionAnalytics] Failed to fetch previous-period credits, " +
+        "falling back to null vs-prev values."
+    );
+  }
+  const previousCreditsByKey = previousCreditsResult.isOk()
+    ? previousCreditsResult.value
+    : new Map<string, number>();
+
+  return new Ok({
+    groups: pagedGroups.map((group) => ({
+      ...group,
+      previousCredits: previousCreditsByKey.get(group.key) ?? null,
+    })),
+    hasMore: ranking.totalCount > offset + limit,
+    totalCount: ranking.totalCount,
+    totalCredits: ranking.totalCredits,
+    ...(dimension === "group"
+      ? { totalActiveMembers: ranking.totalActiveMembers }
+      : {}),
+  });
+}
+
 /**
- * Top `limit` keys of `dimension` by gross credits over the period, with the
- * count each one's average is denominated in.
+ * Top `limit` keys of `dimension` over the period, with the count each one's
+ * average is denominated in.
  */
 export async function fetchConsumptionTopGroups(
   auth: Authenticator,
@@ -369,6 +593,7 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    sortBy = "credits",
     sortOrder = "desc",
     rankBy = "credits",
     includePreviousCredits = true,
@@ -380,6 +605,7 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopGroupSortBy;
     sortOrder?: ConsumptionTopSortOrder;
     rankBy?: ConsumptionTopRankBy;
     includePreviousCredits?: boolean;
@@ -397,6 +623,32 @@ export async function fetchConsumptionTopGroups(
     endDate: period.endDate,
     filter,
   });
+
+  if (sortBy === "workspace_average") {
+    if (dimension !== "group" || rankBy !== "credits") {
+      throw new Error(
+        "Workspace-average consumption sorting is only supported for " +
+          "group credit rankings."
+      );
+    }
+    const rankingResult = await fetchConsumptionGroupsRankedByWorkspaceAverage(
+      auth,
+      { query, searchFilter, sortOrder }
+    );
+    if (rankingResult.isErr()) {
+      return rankingResult;
+    }
+
+    return completeConsumptionTopRanking(auth, {
+      dimension,
+      period,
+      filter,
+      limit,
+      offset,
+      includePreviousCredits,
+      ranking: rankingResult.value,
+    });
+  }
 
   const requestedBucketCount = offset + limit;
   const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
@@ -467,41 +719,19 @@ export async function fetchConsumptionTopGroups(
     buckets.length === batchSize
   );
 
-  const pagedGroups = rankedGroups.slice(offset, offset + limit);
-
-  const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
+  return completeConsumptionTopRanking(auth, {
     dimension,
-    previousPeriod: previousConsumptionPeriod(period),
+    period,
     filter,
-    keys: includePreviousCredits ? pagedGroups.map((group) => group.key) : [],
-  });
-  // The prior-period lookup only feeds the vs-prev display column: a failure
-  // there should not take down the current-period ranking, which already
-  // succeeded. Fall back to unknown growth for every group instead.
-  if (previousCreditsResult.isErr()) {
-    logger.warn(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        dimension,
-        err: previousCreditsResult.error,
-      },
-      "[ConsumptionAnalytics] Failed to fetch previous-period credits, " +
-        "falling back to null vs-prev values."
-    );
-  }
-  const previousCreditsByKey = previousCreditsResult.isOk()
-    ? previousCreditsResult.value
-    : new Map<string, number>();
-
-  return new Ok({
-    groups: pagedGroups.map((group) => ({
-      ...group,
-      previousCredits: previousCreditsByKey.get(group.key) ?? null,
-    })),
-    hasMore: totalCount > offset + limit,
-    totalCount,
-    totalCredits,
-    ...(dimension === "group" ? { totalActiveMembers } : {}),
+    limit,
+    offset,
+    includePreviousCredits,
+    ranking: {
+      groups: rankedGroups,
+      totalCount,
+      totalCredits,
+      totalActiveMembers,
+    },
   });
 }
 

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopGroupSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -37,7 +38,7 @@ export type ConsumptionTopGroups = {
   totalActiveMembers: number;
   hasMore: boolean;
   totalCount: number;
-  // Highest credits first.
+  // Ordered by the requested group ranking.
   groups: ConsumptionTopGroupRow[];
 };
 
@@ -51,6 +52,7 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    sortBy = "credits",
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -58,6 +60,7 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopGroupSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
@@ -68,6 +71,7 @@ export async function fetchConsumptionTopGroups(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -71,7 +71,7 @@ export async function fetchConsumptionTopGroups(
     offset,
     search,
     filter,
-    sortBy,
+    rankBy: sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/poke/swr/consumption.ts
+++ b/front/poke/swr/consumption.ts
@@ -19,7 +19,7 @@ import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consum
 import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
 import type {
   ConsumptionBody,
-  ConsumptionTopBody,
+  ConsumptionTopGroupsBody,
 } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionBreakdownDimension,
@@ -182,11 +182,12 @@ export function usePokeConsumptionTop({
   offset = 0,
   search,
   filter,
+  sortBy,
   sortOrder = "desc",
   disabled,
 }: UseConsumptionTopParams) {
   const url = `/api/poke/workspaces/${workspaceId}/analytics/consumption/${CONSUMPTION_TOP_ENDPOINTS[dimension]}`;
-  const body: ConsumptionTopBody = {
+  const body: ConsumptionTopGroupsBody = {
     period: period.kind,
     days:
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
@@ -194,11 +195,12 @@ export function usePokeConsumptionTop({
     limit,
     offset,
     search: search?.trim(),
+    ...(dimension === "group" && sortBy ? { sortBy } : {}),
     sortOrder,
   };
 
   const { data, error, isLoading, isValidating } = useConsumptionQuery<
-    ConsumptionTopBody,
+    ConsumptionTopGroupsBody,
     ConsumptionTopResponse
   >({ url, body, disabled });
 

--- a/front/types/api/analytics/consumption.ts
+++ b/front/types/api/analytics/consumption.ts
@@ -59,3 +59,11 @@ export const CONSUMPTION_TOP_SORT_ORDER = ["asc", "desc"] as const;
 
 export type ConsumptionTopSortOrder =
   (typeof CONSUMPTION_TOP_SORT_ORDER)[number];
+
+export const CONSUMPTION_TOP_GROUP_SORT_BY = [
+  "credits",
+  "workspace_average",
+] as const;
+
+export type ConsumptionTopGroupSortBy =
+  (typeof CONSUMPTION_TOP_GROUP_SORT_BY)[number];


### PR DESCRIPTION
## Description

The Groups attribution tab can now sort the `Vs workspace avg` column in either direction.

The group endpoint ranks this derived per-active-member value server-side before applying pagination. Normal credit sorting keeps the existing bounded metric query; only the explicit workspace-average sort enumerates group buckets so the derived order stays correct across pages.

## Tests

- Added focused coverage for UI sort wiring, API forwarding, and server-side ordering across composite pages.

## Risk

- Low, limited to group attribution sorting.

## Deploy Plan

- Deploy front.