### PR TITLE
[Admin Governance] Shadow agent permissions and usage filters (11b)

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -1,3 +1,4 @@
+import { shadowCanAdminAgent } from "@app/lib/api/assistant/agent_permissions";
 import {
   getAgentConfiguration,
   updateAgentPermissions,
@@ -212,11 +213,14 @@ app.patch(
     }
 
     const editorGroup = editorGroupRes.value;
-    // TODO(governance) replace by permission check on agent resource
-    if (
-      !auth.isAdmin() &&
-      !(await editorGroup.isMember(auth.getNonNullableUser()))
-    ) {
+    // TODO(governance) serve the AgentResource permission after shadow verification.
+    const canAdministrate = await shadowCanAdminAgent(
+      auth,
+      agent,
+      auth.isAdmin() || (await editorGroup.isMember(auth.getNonNullableUser())),
+      "patchAgentEditorsRoute"
+    );
+    if (!canAdministrate) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -1,3 +1,4 @@
+import { shadowEditableAgents } from "@app/lib/api/assistant/agent_permissions";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -58,8 +59,11 @@ app.post(
       return apiError(ctx, ARCHIVED_AGENT_API_ERROR);
     }
 
-    const editableAgents = agents.filter(
-      (agent) => agent.canEdit || auth.isAdmin()
+    const editableAgents = await shadowEditableAgents(
+      auth,
+      agents,
+      agents.filter((agent) => agent.canEdit || auth.isAdmin()),
+      "batchUpdateAgentTags"
     );
 
     const addTagsResult = await TagResource.addToAgents(

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -1,4 +1,5 @@
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { shadowUsageConfigIds } from "@app/lib/api/assistant/agent_permissions";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -31,7 +32,11 @@ async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
     auth,
     auth.groupModelIds()
   );
-  return groups.map((g) => g.agentConfigurationId);
+  return shadowUsageConfigIds(
+    auth,
+    groups.map((group) => group.agentConfigurationId),
+    "getToolsUsage"
+  );
 }
 
 /**

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,3 +1,4 @@
+import { shadowUsageConfigIds } from "@app/lib/api/assistant/agent_permissions";
 import type { Authenticator } from "@app/lib/auth";
 import { isManagedConnectorProvider } from "@app/lib/data_sources";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
@@ -241,10 +242,12 @@ export async function getDataSourceViewsUsageByModelIds({
   );
 
   // Step 4: fetch the agent configurations
-  const getAgentsForUser = async () =>
-    (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
-      (g) => g.agentConfigurationId
-    );
+  const getAgentsForUser = async () => {
+    const legacy = (
+      await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())
+    ).map((group) => group.agentConfigurationId);
+    return shadowUsageConfigIds(auth, legacy, "getDataSourceViewsUsage");
+  };
 
   const getAgentWhereClauseAdmin = () => ({
     status: "active",

--- a/front/lib/api/agent_triggers.ts
+++ b/front/lib/api/agent_triggers.ts
@@ -1,3 +1,4 @@
+import { shadowUsageConfigIds } from "@app/lib/api/assistant/agent_permissions";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -26,10 +27,12 @@ async function getAccessibleAgentsInfoBySId({
     return new Map();
   }
 
-  const getAgentsForUser = async () =>
-    (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
-      (g) => g.agentConfigurationId
-    );
+  const getAgentsForUser = async () => {
+    const legacy = (
+      await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())
+    ).map((group) => group.agentConfigurationId);
+    return shadowUsageConfigIds(auth, legacy, "getWebhookSourcesUsage");
+  };
 
   const agentWhereClause = auth.isAdmin()
     ? {

--- a/front/lib/api/assistant/agent_permissions.ts
+++ b/front/lib/api/assistant/agent_permissions.ts
@@ -1,0 +1,92 @@
+import { shadowCompare } from "@app/lib/api/permissions/shadow";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentResource } from "@app/lib/resources/agent_resource";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ModelId } from "@app/types/shared/model_id";
+
+function sameIds<T extends ModelId | string>(left: T[], right: T[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((agentId, index) => agentId === right[index])
+  );
+}
+
+export async function shadowCanAdminAgent(
+  auth: Authenticator,
+  agent: LightAgentConfigurationType,
+  legacy: boolean,
+  callSite: string
+): Promise<boolean> {
+  return shadowCompare({
+    auth,
+    legacy,
+    candidate: async () => {
+      const resource = await AgentResource.fetchByAgentConfiguration(
+        auth,
+        agent
+      );
+      return auth.can("admin", resource);
+    },
+    context: {
+      check: "agent_permission",
+      callSite,
+      verb: "admin",
+      agentId: agent.sId,
+      agentConfigurationModelId: agent.id,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+  });
+}
+
+export async function shadowEditableAgents(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[],
+  legacy: LightAgentConfigurationType[],
+  callSite: string
+): Promise<LightAgentConfigurationType[]> {
+  await shadowCompare({
+    auth,
+    legacy: legacy.map((agent) => agent.sId).sort(),
+    candidate: async () => {
+      const customAgents = agents.filter((agent) => agent.scope !== "global");
+      const resources = await AgentResource.fetchByAgentConfigurations(
+        auth,
+        customAgents
+      );
+
+      return resources
+        .filter((resource) => auth.isAdmin() || auth.can("write", resource))
+        .map((resource) => resource.sId)
+        .sort();
+    },
+    context: {
+      check: "editable_agents",
+      callSite,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    equals: sameIds,
+  });
+
+  return legacy;
+}
+
+export async function shadowUsageConfigIds(
+  auth: Authenticator,
+  legacyModelIds: ModelId[],
+  callSite: string
+): Promise<ModelId[]> {
+  return shadowCompare({
+    auth,
+    legacy: [...legacyModelIds].sort((a, b) => a - b),
+    candidate: async () =>
+      (await AgentResource.listEditorConfigModelIds(auth)).sort(
+        (a, b) => a - b
+      ),
+    context: {
+      check: "agent_usage_filter",
+      callSite,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    equals: sameIds,
+  });
+}

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1,4 +1,8 @@
 import {
+  shadowCanAdminAgent,
+  shadowEditableAgents,
+} from "@app/lib/api/assistant/agent_permissions";
+import {
   enrichAgentConfigurations,
   getModelForAgentConfiguration,
   isSelfHostedImageWithValidContentType,
@@ -1646,6 +1650,14 @@ export async function updateAgentPermissions(
     return editorGroupRes;
   }
 
+  const canAdministrate = await shadowCanAdminAgent(
+    auth,
+    agent,
+    auth.isAdmin() ||
+      (await editorGroupRes.value.isMember(auth.getNonNullableUser())),
+    "updateAgentPermissions"
+  );
+
   try {
     const transactionResult = await withTransaction(async (t) => {
       const agentResource = await AgentResource.fetchByAgentConfiguration(
@@ -1655,11 +1667,8 @@ export async function updateAgentPermissions(
       );
 
       if (usersToAdd.length > 0) {
-        // TODO(governance) replace by permission check on agent resource
-        if (
-          !auth.isAdmin() &&
-          !(await editorGroupRes.value.isMember(auth.getNonNullableUser()))
-        ) {
+        // TODO(governance) serve the AgentResource permission after shadow verification.
+        if (!canAdministrate) {
           return new Err(
             new DustError(
               "unauthorized",
@@ -1682,11 +1691,8 @@ export async function updateAgentPermissions(
       }
 
       if (usersToRemove.length > 0) {
-        // TODO(governance) replace by permission check on agent resource
-        if (
-          !auth.isAdmin() &&
-          !(await editorGroupRes.value.isMember(auth.getNonNullableUser()))
-        ) {
+        // TODO(governance) serve the AgentResource permission after shadow verification.
+        if (!canAdministrate) {
           return new Err(
             new DustError(
               "unauthorized",
@@ -1840,8 +1846,11 @@ export async function updateAgentConfigurationsScope(
     );
   }
 
-  const editableAgents = agentConfigs.filter(
-    (a) => a.canEdit || auth.isAdmin()
+  const editableAgents = await shadowEditableAgents(
+    auth,
+    agentConfigs,
+    agentConfigs.filter((agent) => agent.canEdit || auth.isAdmin()),
+    "updateAgentConfigurationsScope"
   );
   if (editableAgents.length === 0) {
     return new Ok(undefined);

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -1,9 +1,11 @@
 import { fetchMCPServerActionConfigurations } from "@app/lib/actions/configuration/mcp";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
+import { shadowCompare } from "@app/lib/api/permissions/shadow";
 import type { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
@@ -93,6 +95,51 @@ export async function getAgentIdFromName(
   return agent.sId;
 }
 
+async function shadowAgentPermissions(
+  auth: Authenticator,
+  agentModels: AgentConfigurationModel[],
+  legacyAgents: AgentConfigurationType[]
+): Promise<void> {
+  await shadowCompare({
+    auth,
+    legacy: legacyAgents.map((agent) => ({
+      agentId: agent.sId,
+      agentConfigurationModelId: agent.id,
+      read: agent.canRead || auth.isAdmin(),
+      write: agent.canEdit,
+      admin: agent.canEdit || auth.isAdmin(),
+    })),
+    candidate: async () =>
+      agentModels.map((agent) => {
+        const resource = AgentResource.fromAgentConfigurationModel(agent);
+        return {
+          agentId: agent.sId,
+          agentConfigurationModelId: agent.id,
+          read: auth.can("read", resource),
+          write: auth.can("write", resource),
+          admin: auth.can("admin", resource),
+        };
+      }),
+    context: {
+      check: "agent_permissions",
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    equals: (legacy, candidate) =>
+      legacy.length === candidate.length &&
+      legacy.every((permissions, index) => {
+        const candidatePermissions = candidate[index];
+        return (
+          permissions.agentId === candidatePermissions.agentId &&
+          permissions.agentConfigurationModelId ===
+            candidatePermissions.agentConfigurationModelId &&
+          permissions.read === candidatePermissions.read &&
+          permissions.write === candidatePermissions.write &&
+          permissions.admin === candidatePermissions.admin
+        );
+      }),
+  });
+}
+
 /**
  * Enrich agent configurations with additional data (actions, tags, favorites).
  */
@@ -148,6 +195,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const isAuthor = agent.authorId === auth.user()?.id;
     const isMember = editorIds.includes(agent.id);
 
+    const canRead = isAuthor || isMember || agent.scope === "visible";
+    const canEdit = isAuthor || isMember;
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,
       sId: agent.sId,
@@ -181,12 +230,18 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       reinforcement: agent.reinforcement,
       lastReinforcementAnalysisAt:
         agent.lastReinforcementAnalysisAt?.toISOString() ?? null,
-      canRead: isAuthor || isMember || agent.scope === "visible",
-      canEdit: isAuthor || isMember,
+      canRead,
+      canEdit,
     };
 
     agentConfigurationTypes.push(agentConfigurationType);
   }
+
+  await shadowAgentPermissions(
+    auth,
+    agentConfigurations,
+    agentConfigurationTypes
+  );
 
   return agentConfigurationTypes;
 }

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -1,7 +1,9 @@
 import { globalAgentReaderRoles } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { AgentModel } from "@app/lib/models/agent/agent";
+import {
+  AgentConfigurationModel,
+  AgentModel,
+} from "@app/lib/models/agent/agent";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -244,6 +246,24 @@ export class AgentResource implements WithAccessControl {
     }
 
     return result;
+  }
+
+  static async listEditorConfigModelIds(
+    auth: Authenticator
+  ): Promise<ModelId[]> {
+    const resources = auth.getResourceIdsWithVerb("agent", "write");
+    const where =
+      resources.kind === "all" ? {} : { agentId: resources.resourceIds };
+    // agentId is indexed for the normal per-user path; workspaceId indexes the rare type-wide path.
+    const configurations = await AgentConfigurationModel.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      attributes: ["id"],
+    });
+
+    return configurations.map((configuration) => configuration.id);
   }
 
   async grantEditors(


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: [Admin Governance design doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)

Part 11b of the agent permission migration, stacked on https://github.com/dust-tt/dust/pull/31889 for its batch resource lookup.

PR11 parts: [11a: editor lists](https://github.com/dust-tt/dust/pull/31889) → **11b (this PR)**. [11c: agent views](https://github.com/dust-tt/dust/pull/31920) is independent and targets `main`.

When `group_permissions_shadow` is enabled, compare legacy and grant-based read/write/admin decisions, the agents editable through scope and tag updates, and tool/data-source/webhook usage filters. Existing responses and authorization results continue to use the legacy checks; candidate errors and mismatches use the shared shadow logs.

## Risks

Blast radius: Agent permission checks, scope/tag updates, and agent usage filters when shadowing is enabled.
Risk: standard

## Deploy Plan

- Merge 11a, then deploy front with this PR.
- After PR9's dual writes and PR10's editor-grant backfill are complete, enable `group_permissions_shadow` progressively.
- Monitor permission and usage-filter mismatch/error logs; disable the flag if needed. Finish all PR11 parts and verify parity before PR12.

## Tests

- [x] Agent configuration tests (33 tests).
- [x] Agent editor, batch tag, and batch scope endpoint tests (28 tests).
