### PR TITLE
[Admin Governance] Shadow agent list and archived views (11c)

### DIFF
--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -1,14 +1,17 @@
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 async function authenticatorForNewMember(
   workspace: LightWorkspaceType,
@@ -192,5 +195,79 @@ describe("getAgentConfigurationsForView, 'archived' view", () => {
     const memberAuth = await authenticatorForNewMember(workspace, "user");
 
     expect(await listAgentIdsForArchived(memberAuth)).not.toContain(agent.sId);
+  });
+
+  it("hides an archived agent from a non-editor with space access", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Private archived agent",
+      scope: "hidden",
+    });
+    const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId,
+      { dangerouslyRequestAllGroups: true }
+    );
+    await archiveAgentConfiguration(everySpaceAuth, agent.sId);
+
+    const memberAuth = await authenticatorForNewMember(workspace, "user");
+
+    expect(await listAgentIdsForArchived(memberAuth)).not.toContain(agent.sId);
+  });
+});
+
+describe("getAgentConfigurationsForView, grant shadow", () => {
+  it("serves the legacy archived view and logs stable-id mismatches", async () => {
+    const { workspace, authenticator: authorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(authorAuth, {
+      name: "Legacy-only agent",
+      scope: "hidden",
+    });
+    const member = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, member, { role: "user" });
+    const editorGroupResult = await GroupResource.findEditorGroupForAgent(
+      authorAuth,
+      agent
+    );
+    if (editorGroupResult.isErr()) {
+      throw editorGroupResult.error;
+    }
+    const addResult = await editorGroupResult.value.dangerouslyAddMembers(
+      authorAuth,
+      { users: [member.toJSON()] }
+    );
+    if (addResult.isErr()) {
+      throw addResult.error;
+    }
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId,
+      { dangerouslyRequestAllGroups: true }
+    );
+    await archiveAgentConfiguration(adminAuth, agent.sId);
+
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      member.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(memberAuth, "group_permissions_shadow");
+    const warn = vi.spyOn(logger, "warn");
+
+    const agents = await getAgentConfigurationsForView({
+      auth: memberAuth,
+      agentsGetView: "archived",
+      variant: "light",
+    });
+
+    expect(agents.map((listedAgent) => listedAgent.sId)).toContain(agent.sId);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        check: "agent_view",
+        view: "archived",
+      }),
+      "group_permissions_shadow_mismatch"
+    );
   });
 });

--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -262,12 +262,14 @@ describe("getAgentConfigurationsForView, grant shadow", () => {
     });
 
     expect(agents.map((listedAgent) => listedAgent.sId)).toContain(agent.sId);
-    expect(warn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        check: "agent_view",
-        view: "archived",
-      }),
-      "group_permissions_shadow_mismatch"
-    );
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check: "agent_view",
+          view: "archived",
+        }),
+        "group_permissions_shadow_mismatch"
+      );
+    });
   });
 });

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -6,6 +6,7 @@ import type {
 } from "@app/lib/api/assistant/configuration/types";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import { shadowCompare } from "@app/lib/api/permissions/shadow";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentConfigurationModel,
@@ -28,6 +29,24 @@ const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
   "instructions",
   "instructionsHtml",
 ] as const;
+
+type EditorFilter =
+  | { kind: "all" }
+  | { kind: "agent" | "configuration"; modelIds: ModelId[] };
+
+function editorWhere(filter: EditorFilter) {
+  // Configuration ids use the primary key; stable agent ids use the agentId index.
+  switch (filter.kind) {
+    case "all":
+      return {};
+    case "agent":
+      return { agentId: { [Op.in]: filter.modelIds } };
+    case "configuration":
+      return { id: { [Op.in]: filter.modelIds } };
+    default:
+      return assertNever(filter);
+  }
+}
 
 const sortStrategies: Record<SortStrategyType, SortStrategy> = {
   alphabetical: {
@@ -135,7 +154,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
   {
     agentPrefix,
     agentsGetView,
-    agentIdsForUserAsEditor,
+    editorFilter,
     limit,
     owner,
     sort,
@@ -143,7 +162,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
   }: {
     agentPrefix?: string;
     agentsGetView: Exclude<AgentsGetViewType, "global">;
-    agentIdsForUserAsEditor: ModelId[];
+    editorFilter: EditorFilter;
     limit?: number;
     owner: WorkspaceType;
     sort?: SortStrategyType;
@@ -229,17 +248,11 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         const maxIds = result.map(
           (entry) => (entry as unknown as { maxId: number }).maxId
         );
-        const filteredIds = maxIds.filter(
-          (id) => agentIdsForUserAsEditor.includes(id) || auth.isAdmin()
-        );
-
         return AgentConfigurationModel.findAll({
           ...excludeAttributesFromSelect,
           where: {
             workspaceId: owner.id,
-            id: {
-              [Op.in]: filteredIds,
-            },
+            [Op.and]: [editorWhere(editorFilter), { id: { [Op.in]: maxIds } }],
             status: "archived",
             ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
           },
@@ -270,7 +283,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
             ...(user
               ? [
                   { authorId: user.id, scope: "private" },
-                  { id: { [Op.in]: agentIdsForUserAsEditor }, scope: "hidden" },
+                  { ...editorWhere(editorFilter), scope: "hidden" },
                 ]
               : []),
           ],
@@ -306,6 +319,70 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
   }
 }
 
+type ShadowAgentViewArgs = {
+  auth: Authenticator;
+  owner: WorkspaceType;
+  view: "list" | "manage" | "archived";
+  legacyModels: AgentConfigurationModel[];
+  skipPermissionFiltering: boolean;
+  agentPrefix?: string;
+  limit?: number;
+  sort?: SortStrategyType;
+  omitHeavyAttributes?: boolean;
+};
+
+async function shadowAgentView({
+  auth,
+  owner,
+  view,
+  legacyModels,
+  skipPermissionFiltering,
+  agentPrefix,
+  limit,
+  sort,
+  omitHeavyAttributes,
+}: ShadowAgentViewArgs): Promise<void> {
+  const stableAgentModelIds = (models: AgentConfigurationModel[]) =>
+    [...new Set(models.map((model) => model.agentId))].sort((a, b) => a - b);
+
+  await shadowCompare({
+    auth,
+    legacy: stableAgentModelIds(legacyModels),
+    candidate: async () => {
+      const grantResources = auth.getResourceIdsWithVerb("agent", "write");
+      const editorFilter: EditorFilter =
+        auth.isAdmin() && view === "archived"
+          ? { kind: "all" }
+          : grantResources.kind === "all"
+            ? { kind: "all" }
+            : { kind: "agent", modelIds: grantResources.resourceIds };
+      const candidateModels =
+        await fetchWorkspaceAgentConfigurationsWithoutActions(auth, {
+          agentPrefix,
+          agentsGetView: view,
+          editorFilter,
+          limit,
+          owner,
+          sort,
+          omitHeavyAttributes,
+        });
+      const allowedCandidateModels = skipPermissionFiltering
+        ? candidateModels
+        : await filterAgentsByRequestedSpaces(auth, candidateModels);
+
+      return stableAgentModelIds(allowedCandidateModels);
+    },
+    context: {
+      check: "agent_view",
+      view,
+      workspaceId: owner.sId,
+    },
+    equals: (legacy, candidate) =>
+      legacy.length === candidate.length &&
+      legacy.every((agentModelId, index) => agentModelId === candidate[index]),
+  });
+}
+
 async function fetchWorkspaceAgentConfigurationsForView(
   auth: Authenticator,
   owner: WorkspaceType,
@@ -336,13 +413,19 @@ async function fetchWorkspaceAgentConfigurationsForView(
   const agentIdsForUserAsEditor = agentIdsForGroups.map(
     (g) => g.agentConfigurationId
   );
+  const legacyEditorFilter: EditorFilter = auth.isAdmin()
+    ? { kind: "all" }
+    : { kind: "configuration", modelIds: agentIdsForUserAsEditor };
 
   const agentModels = await fetchWorkspaceAgentConfigurationsWithoutActions(
     auth,
     {
       agentPrefix,
       agentsGetView,
-      agentIdsForUserAsEditor,
+      editorFilter:
+        agentsGetView === "archived"
+          ? legacyEditorFilter
+          : { kind: "configuration", modelIds: agentIdsForUserAsEditor },
       limit,
       owner,
       sort,
@@ -363,6 +446,24 @@ async function fetchWorkspaceAgentConfigurationsForView(
   const allowedAgentModels = skipPermissionFiltering
     ? agentModels
     : await filterAgentsByRequestedSpaces(auth, agentModels);
+
+  if (
+    agentsGetView === "list" ||
+    agentsGetView === "manage" ||
+    agentsGetView === "archived"
+  ) {
+    await shadowAgentView({
+      auth,
+      owner,
+      view: agentsGetView,
+      legacyModels: allowedAgentModels,
+      skipPermissionFiltering,
+      agentPrefix,
+      limit,
+      sort,
+      omitHeavyAttributes,
+    });
+  }
 
   return enrichAgentConfigurations(auth, allowedAgentModels, {
     variant,

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -13,6 +13,7 @@ import {
   AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
   AgentFetchVariant,
@@ -22,6 +23,7 @@ import type {
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { Op, Sequelize } from "sequelize";
 
@@ -383,6 +385,10 @@ async function shadowCompareAgentView({
   });
 }
 
+/**
+ * @cc [owner:philipperolet,label:performance;error-handling] view-shadow-is-best-effort
+ * View shadow comparisons are not awaited; their failures are logged without rejecting legacy reads.
+ */
 async function fetchWorkspaceAgentConfigurationsForView(
   auth: Authenticator,
   owner: WorkspaceType,
@@ -452,7 +458,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     agentsGetView === "manage" ||
     agentsGetView === "archived"
   ) {
-    await shadowCompareAgentView({
+    void shadowCompareAgentView({
       auth,
       owner,
       view: agentsGetView,
@@ -462,6 +468,16 @@ async function fetchWorkspaceAgentConfigurationsForView(
       limit,
       sort,
       omitHeavyAttributes,
+    }).catch((err) => {
+      logger.error(
+        {
+          err: normalizeError(err),
+          check: "agent_view",
+          view: agentsGetView,
+          workspaceId: owner.sId,
+        },
+        "group_permissions_shadow_candidate_error"
+      );
     });
   }
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -319,7 +319,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
   }
 }
 
-type ShadowAgentViewArgs = {
+type ShadowCompareAgentViewArgs = {
   auth: Authenticator;
   owner: WorkspaceType;
   view: "list" | "manage" | "archived";
@@ -331,7 +331,7 @@ type ShadowAgentViewArgs = {
   omitHeavyAttributes?: boolean;
 };
 
-async function shadowAgentView({
+async function shadowCompareAgentView({
   auth,
   owner,
   view,
@@ -341,7 +341,7 @@ async function shadowAgentView({
   limit,
   sort,
   omitHeavyAttributes,
-}: ShadowAgentViewArgs): Promise<void> {
+}: ShadowCompareAgentViewArgs): Promise<void> {
   const stableAgentModelIds = (models: AgentConfigurationModel[]) =>
     [...new Set(models.map((model) => model.agentId))].sort((a, b) => a - b);
 
@@ -452,7 +452,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     agentsGetView === "manage" ||
     agentsGetView === "archived"
   ) {
-    await shadowAgentView({
+    await shadowCompareAgentView({
       auth,
       owner,
       view: agentsGetView,

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -3,9 +3,9 @@
 This plan migrates workspace-agent editor permissions from the `agent_editors` group kind and
 `group_agents` join table to the `regular_auto` group kind and `group_permissions` table.
 
-Each numbered item is one PR. The 300-line target is a soft bound: combine related changes when an
-intermediate state has no review or operational value. Split at real deploy, backfill, observation,
-or rollback boundaries.
+Each numbered item is one PR, except PR 11's three parts. The 300-line target is a soft bound: combine
+related changes when an intermediate state has no review or operational value. Split at real deploy,
+backfill, observation, or rollback boundaries.
 
 ## Decisions
 
@@ -86,12 +86,26 @@ idempotent and report editor-set differences.
 
 ### PR 11: Shadow all grant-backed reads
 
-Add grant-backed editor-list and batch-list helpers, permission checks, and editable-agent filters.
-Continue serving legacy results while comparing editor sets, effective `read`/`write`/`admin`
-decisions, and list/manage/archive stable-id results under one shadow switch.
+All three parts continue serving legacy results and use the same `group_permissions_shadow` switch.
 
-**Operational gate:** enable shadowing progressively and wait for editor-list, permission, listing,
-backfill, and cache-related mismatches to reach zero.
+#### PR 11a: Shadow editor lists
+
+Add grant-backed single and batch editor-list helpers and the batch resource lookup. Compare editor
+sets in editor endpoints and agent configuration context, with resource and shadow regression tests.
+Base this PR on `main`.
+
+#### PR 11b: Shadow permissions and usage filters
+
+Compare effective `read`/`write`/`admin` decisions, editable-agent filters for scope and tag updates,
+and tool/data-source/webhook usage filters. Stack on PR 11a to reuse its batch resource lookup.
+
+#### PR 11c: Shadow agent views
+
+Compare list/manage/archive results using stable agent identities, preserving archived-editor
+filtering and covering it with regression tests. Base this PR independently on `main`.
+
+**Operational gate:** after all three parts merge, enable shadowing progressively and wait for
+editor-list, permission, listing, backfill, and cache-related mismatches to reach zero before PR 12.
 
 ## 3. Flip and remove the legacy model
 

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -118,8 +118,19 @@ time, behind one operational switch with a single kill-switch fallback to legacy
 
 ### PR 13: Remove legacy reads and rollout infrastructure
 
-Remove all legacy read fallbacks and shadow comparisons. Remove `group_permissions_shadow`,
-`use_legacy_acls`, and shared migration helpers once no other resource migration uses them.
+After PR 12's observation gate, remove all legacy read fallbacks and agent shadowing introduced by
+PRs 11a–11c: editor-list, permission, editable-agent, usage-filter, and list/manage/archive comparisons.
+Remove shadow wrappers and update every direct and indirect caller to use the permanent grant-backed
+path. Delete comparison-only normalization helpers, types, logging, tests, and migration TODOs; retain
+resource methods and regression tests needed by the final behavior.
+
+Remove `shadowCompare` and its module/tests, `group_permissions_shadow`, `use_legacy_acls`, and shared
+migration helpers once no other resource migration uses them. If shared cleanup must wait, track it
+explicitly in the last dependent migration; disabling a flag is not a substitute for deleting code.
+
+**Completion check:** search definitions, imports, and call sites across `front`, `front-api`, and the
+SDK to verify that no agent shadow path remains, including through wrappers. Verify that no callers
+remain before deleting shared utilities and flag/kill-switch declarations.
 
 ### PR 14: Stop all legacy agent-editor writes
 

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -102,7 +102,9 @@ and tool/data-source/webhook usage filters. Stack on PR 11a to reuse its batch r
 #### PR 11c: Shadow agent views
 
 Compare list/manage/archive results using stable agent identities, preserving archived-editor
-filtering and covering it with regression tests. Base this PR independently on `main`.
+filtering and covering it with regression tests. Run these comparisons in the background without
+awaiting them; diagnostics are best-effort and can be lost on shutdown. Base this PR independently on
+`main`.
 
 **Operational gate:** after all three parts merge, enable shadowing progressively and wait for
 editor-list, permission, listing, backfill, and cache-related mismatches to reach zero before PR 12.


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9481

Context: [Admin Governance design doc](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)

Part 11c of the agent permission migration, independently based on `main`.

Companion stack: [11a: editor lists](https://github.com/dust-tt/dust/pull/31889) → [11b: permissions and usage](https://github.com/dust-tt/dust/pull/31919). This PR can merge before or after either one.

When `group_permissions_shadow` is enabled, compare list/manage/archived results using stable agent identities while continuing to serve the legacy results. Keep the existing archived-editor restriction in the database query and cover it with regression tests.

Updates the migration plan to describe the three PR11 parts and the shared gate before PR12.

## Risks

Blast radius: Agent list, manage, and archived views.
Risk: standard

## Deploy Plan

- Deploy front; this PR can merge independently of 11a and 11b.
- After PR9's dual writes and PR10's editor-grant backfill are complete, enable `group_permissions_shadow` progressively.
- Monitor agent-view mismatch/error logs; disable the flag if needed. Finish all PR11 parts and verify parity before PR12.

## Tests

- [x] Archived-view permission and shadow regression tests (4 tests).
