### PR TITLE
[front] fix: detach conversation scrolling during streaming

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -122,7 +122,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     workspaceId: context.owner.sId,
   });
   const methods = useVirtuosoMethods<VirtuosoMessage>();
-  const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
+  const { bottomOffset, listOffset } = useVirtuosoLocation();
   const {
     effectiveIsCompact,
     expandInputBar,
@@ -256,7 +256,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     canScrollUp,
     canScrollDown,
     scrollToPreviousUserMessage,
-    scrollToNextUserMessage,
+    scrollToBottom,
   } = useMemo(() => {
     const allMessages = methods.data.get();
 
@@ -284,22 +284,14 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     // Convert listOffset to positive scroll position.
     // listOffset is negative when scrolled down (distance from list top to viewport top).
     const viewportTop = -listOffset;
-    const viewportTopQuarter = viewportTop + visibleListHeight / 4;
 
     // Find user messages fully above viewport (for arrow up).
     const fullyAboveIndices = userMessageIndices.filter(
       (idx) => positions[idx] && positions[idx].bottom <= viewportTop
     );
 
-    // Find user messages whose top is below the top quarter of viewport (for arrow down).
-    const belowTopQuarterIndices = userMessageIndices.filter(
-      (idx) => positions[idx] && positions[idx].top >= viewportTopQuarter
-    );
-
     const canUp = fullyAboveIndices.length > 0;
-    const canDown =
-      (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
-      !methods.getScrollLocation().isAtBottom;
+    const canDown = bottomOffset > 0 && !methods.getScrollLocation().isAtBottom;
 
     return {
       canScrollUp: canUp,
@@ -315,29 +307,20 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           });
         }
       },
-      scrollToNextUserMessage: () => {
-        if (belowTopQuarterIndices.length > 0) {
-          // Scroll to the first user message below top quarter.
-          const targetIndex = belowTopQuarterIndices[0];
-          methods.scrollToItem({
-            index: targetIndex,
-            align: "start",
-            behavior: "smooth",
-          });
-        } else if (bottomOffset > 0) {
-          // No more user messages below, but there's content - scroll to bottom.
-          methods.scrollToItem({
-            index: "LAST",
-            align: "end",
-            behavior:
-              bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
-                ? "smooth"
-                : "instant",
-          });
-        }
+      scrollToBottom: () => {
+        // Reattach before scrolling so streaming keeps the bottom target active.
+        context.isAutoScrollEnabledRef.current = true;
+        methods.scrollToItem({
+          index: "LAST",
+          align: "end",
+          behavior:
+            bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
+              ? "smooth"
+              : "instant",
+        });
       },
     };
-  }, [methods, listOffset, visibleListHeight, bottomOffset]);
+  }, [methods, listOffset, bottomOffset, context.isAutoScrollEnabledRef]);
 
   const blockedActionItems = getBlockedActionItems(context.user.sId);
   const blockedActions = blockedActionItems.map((item) => item.blockedAction);
@@ -553,7 +536,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     canScrollUp,
     canScrollDown,
     onScrollUp: scrollToPreviousUserMessage,
-    onScrollDown: scrollToNextUserMessage,
+    onScrollDown: scrollToBottom,
   };
 
   if (context.projectId && context.isProjectArchived) {

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -122,7 +122,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     workspaceId: context.owner.sId,
   });
   const methods = useVirtuosoMethods<VirtuosoMessage>();
-  const { bottomOffset, listOffset } = useVirtuosoLocation();
+  const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
   const {
     effectiveIsCompact,
     expandInputBar,
@@ -256,7 +256,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     canScrollUp,
     canScrollDown,
     scrollToPreviousUserMessage,
-    scrollToBottom,
+    scrollToNextUserMessage,
   } = useMemo(() => {
     const allMessages = methods.data.get();
 
@@ -284,14 +284,22 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     // Convert listOffset to positive scroll position.
     // listOffset is negative when scrolled down (distance from list top to viewport top).
     const viewportTop = -listOffset;
+    const viewportTopQuarter = viewportTop + visibleListHeight / 4;
 
     // Find user messages fully above viewport (for arrow up).
     const fullyAboveIndices = userMessageIndices.filter(
       (idx) => positions[idx] && positions[idx].bottom <= viewportTop
     );
 
+    // Find user messages whose top is below the top quarter of viewport (for arrow down).
+    const belowTopQuarterIndices = userMessageIndices.filter(
+      (idx) => positions[idx] && positions[idx].top >= viewportTopQuarter
+    );
+
     const canUp = fullyAboveIndices.length > 0;
-    const canDown = bottomOffset > 0 && !methods.getScrollLocation().isAtBottom;
+    const canDown =
+      (belowTopQuarterIndices.length > 0 || bottomOffset > 0) &&
+      !methods.getScrollLocation().isAtBottom;
 
     return {
       canScrollUp: canUp,
@@ -307,20 +315,36 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           });
         }
       },
-      scrollToBottom: () => {
-        // Reattach before scrolling so streaming keeps the bottom target active.
-        context.isAutoScrollEnabledRef.current = true;
-        methods.scrollToItem({
-          index: "LAST",
-          align: "end",
-          behavior:
-            bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
-              ? "smooth"
-              : "instant",
-        });
+      scrollToNextUserMessage: () => {
+        if (belowTopQuarterIndices.length > 0) {
+          // Scroll to the first user message below top quarter.
+          const targetIndex = belowTopQuarterIndices[0];
+          methods.scrollToItem({
+            index: targetIndex,
+            align: "start",
+            behavior: "smooth",
+          });
+        } else if (bottomOffset > 0) {
+          // No more user messages below, but there's content - scroll to bottom.
+          context.isAutoScrollEnabledRef.current = true;
+          methods.scrollToItem({
+            index: "LAST",
+            align: "end",
+            behavior:
+              bottomOffset < MAX_DISTANCE_FOR_SMOOTH_SCROLL
+                ? "smooth"
+                : "instant",
+          });
+        }
       },
     };
-  }, [methods, listOffset, bottomOffset, context.isAutoScrollEnabledRef]);
+  }, [
+    methods,
+    listOffset,
+    visibleListHeight,
+    bottomOffset,
+    context.isAutoScrollEnabledRef,
+  ]);
 
   const blockedActionItems = getBlockedActionItems(context.user.sId);
   const blockedActions = blockedActionItems.map((item) => item.blockedAction);
@@ -536,7 +560,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     canScrollUp,
     canScrollDown,
     onScrollUp: scrollToPreviousUserMessage,
-    onScrollDown: scrollToBottom,
+    onScrollDown: scrollToNextUserMessage,
   };
 
   if (context.projectId && context.isProjectArchived) {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -33,6 +33,7 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
+import { useConversationAutoScroll } from "@app/components/assistant/conversation/useConversationAutoScroll";
 import {
   requestConversationMarkAsRead,
   useConversation,
@@ -94,7 +95,6 @@ import {
   VirtuosoMessageList,
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
-import type { MutableRefObject } from "react";
 import {
   useCallback,
   useContext,
@@ -137,35 +137,6 @@ function customSmoothScroll() {
     animationFrameCount: 30,
     easing: easeOutQuint,
   };
-}
-
-// This function is used to update the auto scroll enabled state based on the scroll location.
-// Goal is to detect when the user is scrolling manually to pause the auto scroll.
-function updateAutoScrollEnabledFromLocation({
-  isAutoScrollEnabledRef,
-  location,
-  prevLocationRef,
-}: {
-  isAutoScrollEnabledRef: MutableRefObject<boolean>;
-  location: Pick<ListScrollLocation, "scrollHeight" | "bottomOffset">;
-  prevLocationRef: MutableRefObject<
-    Pick<ListScrollLocation, "scrollHeight" | "bottomOffset">
-  >;
-}) {
-  const { scrollHeight, bottomOffset } = location;
-  const prev = prevLocationRef.current;
-
-  // Scroll up with out change in content.
-  if (scrollHeight === prev.scrollHeight && bottomOffset > prev.bottomOffset) {
-    isAutoScrollEnabledRef.current = false;
-  }
-
-  // Scroll to bottom with no change in content.
-  if (scrollHeight === prev.scrollHeight && bottomOffset == 0) {
-    isAutoScrollEnabledRef.current = true;
-  }
-
-  prevLocationRef.current = { scrollHeight, bottomOffset };
 }
 
 function makeConversationForkNoticeMessage(
@@ -293,10 +264,9 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const isMobile = useIsMobile();
-  const isAutoScrollEnabledRef = useRef(true);
-  const prevScrollLocationRef = useRef({
-    scrollHeight: 0,
-    bottomOffset: 0,
+  const isAutoScrollEnabledRef = useConversationAutoScroll({
+    isMobile,
+    messageListRef: virtuosoMessageListRef,
   });
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
@@ -1264,6 +1234,7 @@ export const ConversationViewer = ({
         // the bottom padding needed for align:"start" near the end of the
         // list, causing the scroll to undershoot.
         if (shouldScrollToUserMessage && virtuosoMessageListRef.current) {
+          isAutoScrollEnabledRef.current = true;
           virtuosoMessageListRef.current.scrollToItem({
             index: nbMessages,
             align: "start",
@@ -1375,17 +1346,12 @@ export const ConversationViewer = ({
       submitMessage,
       user,
       incrementPendingSteeringCount,
+      isAutoScrollEnabledRef,
     ]
   );
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
-      updateAutoScrollEnabledFromLocation({
-        isAutoScrollEnabledRef,
-        location,
-        prevLocationRef: prevScrollLocationRef,
-      });
-
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
 
@@ -1497,6 +1463,7 @@ export const ConversationViewer = ({
     spaceInfo?.name,
     limitReachedCode,
     setLimitReachedCode,
+    isAutoScrollEnabledRef,
   ]);
 
   return (

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -766,6 +766,14 @@ export const ConversationViewer = ({
               const exists =
                 virtuosoMessageListRef.current.data.find(predicate);
 
+              // Reattach for a new response, but not when the stream replays it.
+              if (
+                agentMessage.status === "created" &&
+                exists?.sId !== agentMessage.sId
+              ) {
+                isAutoScrollEnabledRef.current = true;
+              }
+
               if (exists) {
                 // Guard against conversation SSE replays overwriting a message
                 // that the message-level SSE has already partially or fully
@@ -1074,6 +1082,7 @@ export const ConversationViewer = ({
     [
       conversation?.forkingData?.forkedFrom?.fileCopyStatus,
       conversationId,
+      isAutoScrollEnabledRef,
       mutateContextUsage,
       mutateConversation,
       mutateConversationAttachments,

--- a/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
@@ -120,7 +120,7 @@ export function InputBarMessageNavigation({
             ArrowDown,
             onScrollDown,
             !canScrollDown,
-            "Scroll to bottom"
+            "Next user message"
           )}
         </>
       )}

--- a/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
@@ -120,7 +120,7 @@ export function InputBarMessageNavigation({
             ArrowDown,
             onScrollDown,
             !canScrollDown,
-            "Next user message"
+            "Scroll to bottom"
           )}
         </>
       )}

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -134,6 +134,32 @@ describe.each([
   false,
   true,
 ])("conversation auto-scroll (mobile: %s)", (isMobile) => {
+  it("detaches on upward scrolling even while content grows", () => {
+    const { result, methods, scroll } = setup(isMobile);
+    scroll(1110, 2072);
+    expect(result.current.current).toBe(false);
+    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+  });
+
+  it("clears a retained bottom target after the native scroll moves", () => {
+    const { methods, wheel, scroll } = setup(isMobile);
+    vi.spyOn(methods, "getScrollLocation").mockReturnValue({
+      ...methods.getScrollLocation(),
+      isAtBottom: true,
+      bottomOffset: 90,
+    });
+    wheel(-90);
+    expect(methods.scrollToItem).not.toHaveBeenCalled();
+
+    scroll(1110);
+    expect(methods.scrollToItem).toHaveBeenCalledWith({
+      index: 0,
+      align: "start-no-overflow",
+      offset: 1110,
+      behavior: "instant",
+    });
+  });
+
   it("detaches on upward intent and reattaches only at the bottom above the input", () => {
     const { result, methods, wheel, scroll } = setup(isMobile);
     expect(result.current.current).toBe(true);

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -1,0 +1,224 @@
+import { useConversationAutoScroll } from "@app/components/assistant/conversation/useConversationAutoScroll";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = [];
+
+beforeEach(() => {
+  resizeCallbacks.length = 0;
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push((entries) => callback(entries, this));
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  vi.stubGlobal(
+    "DOMMatrixReadOnly",
+    class {
+      m42: number;
+      constructor(transform: string) {
+        this.m42 = Number(
+          transform.match(/translateY\(([-\d.]+)px\)/)?.[1] ?? 0
+        );
+      }
+    }
+  );
+});
+
+afterEach(() => {
+  for (const element of document.querySelectorAll("[data-scroll-test-root]")) {
+    element.remove();
+  }
+  Reflect.deleteProperty(document, "scrollingElement");
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function setup(isMobile = false) {
+  const list = document.createElement("div");
+  list.dataset.scrollTestRoot = "true";
+  const content = document.createElement("div");
+  const row = document.createElement("div");
+  content.appendChild(row);
+  content.dataset.testid = "virtuoso-list";
+  list.appendChild(content);
+  document.body.appendChild(list);
+  const scroller = isMobile ? document.documentElement : list;
+  let height = 2000;
+  let itemCount = 10;
+  scroller.scrollTop = 1200;
+  vi.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => height);
+  vi.spyOn(scroller, "clientHeight", "get").mockReturnValue(800);
+  vi.spyOn(list, "getBoundingClientRect").mockImplementation(
+    () => new DOMRect(0, -scroller.scrollTop, 400, height)
+  );
+  vi.spyOn(row, "getBoundingClientRect").mockImplementation(
+    () => new DOMRect(0, 0, 400, height - 180)
+  );
+  if (isMobile) {
+    Object.defineProperty(document, "scrollingElement", {
+      configurable: true,
+      value: scroller,
+    });
+    vi.stubGlobal("innerHeight", 800);
+  }
+  const methods = {
+    cancelSmoothScroll: vi.fn(),
+    scrollToItem: vi.fn(),
+    getScrollLocation: () => ({
+      isAtBottom: false,
+      bottomOffset: height - scroller.scrollTop - 800,
+      listOffset: -scroller.scrollTop,
+      scrollHeight: height - 180,
+      visibleListHeight: 620,
+      lastVisibleItemIndex: itemCount - 1,
+      lastItemBottomOffset: 0,
+    }),
+    scrollerElement: () => list,
+    data: { get: () => Array.from({ length: itemCount }) },
+  };
+  const messageListRef = { current: methods };
+  const hook = renderHook(() =>
+    useConversationAutoScroll({ isMobile, messageListRef })
+  );
+  const measureRow = (compensatedTop: number) => {
+    const entry: ResizeObserverEntry = {
+      target: row,
+      contentRect: new DOMRect(0, 0, 400, height - 180),
+      borderBoxSize: [],
+      contentBoxSize: [],
+      devicePixelContentBoxSize: [],
+    };
+    resizeCallbacks[0]([entry]);
+    // Virtuoso's observer runs between the two conversation observers.
+    scroller.scrollTop = compensatedTop;
+    resizeCallbacks[1]([entry]);
+  };
+  measureRow(scroller.scrollTop);
+  return {
+    ...hook,
+    content,
+    methods,
+    scroller,
+    wheel: (deltaY: number) => {
+      list.dispatchEvent(new WheelEvent("wheel", { deltaY }));
+    },
+    touch: (type: "touchstart" | "touchmove", clientY: number) => {
+      const event = new Event(type);
+      Object.defineProperty(event, "touches", { value: [{ clientY }] });
+      list.dispatchEvent(event);
+    },
+    scroll: (top: number, newHeight = height) => {
+      height = newHeight;
+      scroller.scrollTop = top;
+      (isMobile ? window : scroller).dispatchEvent(new Event("scroll"));
+    },
+    resize: (
+      newHeight: number,
+      top = scroller.scrollTop,
+      count = itemCount
+    ) => {
+      height = newHeight;
+      itemCount = count;
+      measureRow(top);
+    },
+  };
+}
+
+describe.each([
+  false,
+  true,
+])("conversation auto-scroll (mobile: %s)", (isMobile) => {
+  it("detaches on upward intent and reattaches only at the bottom above the input", () => {
+    const { result, methods, wheel, scroll } = setup(isMobile);
+    expect(result.current.current).toBe(true);
+    wheel(-90);
+    expect(result.current.current).toBe(false);
+    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+
+    scroll(1110);
+    wheel(10);
+    scroll(1120);
+    // With a 180px sticky input bar, 80px from the scroll bottom still hides text.
+    expect(result.current.current).toBe(false);
+    scroll(1198);
+    expect(result.current.current).toBe(true);
+    expect(methods.scrollToItem).toHaveBeenCalledWith({
+      index: "LAST",
+      align: "end",
+      behavior: "instant",
+    });
+  });
+
+  it("preserves upward movement coalesced with streamed row growth", () => {
+    const { result, scroller, wheel, scroll, resize } = setup(isMobile);
+    wheel(-90);
+    scroll(1110);
+    wheel(-90);
+    // The browser delivers user scrolling before ResizeObserver measures growth.
+    scroll(1020);
+    resize(2072, 1092);
+    expect(scroller.scrollTop).toBe(1020);
+    expect(result.current.current).toBe(false);
+  });
+
+  it("preserves idle reading and subsequent movement in either direction", () => {
+    const { scroller, wheel, scroll, resize } = setup(isMobile);
+    wheel(-90);
+    scroll(1110);
+    resize(2072, 1182);
+    expect(scroller.scrollTop).toBe(1110);
+
+    // Once Virtuoso stops compensating, new content does not move the viewport.
+    resize(2144);
+    wheel(-90);
+    scroll(1020);
+    expect(scroller.scrollTop).toBe(1020);
+    wheel(90);
+    scroll(1110);
+    resize(2216);
+    expect(scroller.scrollTop).toBe(1110);
+  });
+
+  it("keeps Virtuoso's anchoring when older messages are prepended", () => {
+    const { scroller, wheel, scroll, resize } = setup(isMobile);
+    wheel(-90);
+    scroll(1110);
+    resize(2240, 1350, 12);
+    expect(scroller.scrollTop).toBe(1350);
+  });
+
+  it("detaches before an upward touch moves the viewport", () => {
+    const { result, touch, methods } = setup(isMobile);
+    touch("touchstart", 300);
+    touch("touchmove", 340);
+    expect(result.current.current).toBe(false);
+    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+  });
+});
+
+it("cancels iOS transforms and the delayed scroll adjustment without moving a touch gesture", async () => {
+  const { content, scroller, touch, scroll, resize } = setup(true);
+  touch("touchstart", 300);
+  touch("touchmove", 390);
+  scroll(1110);
+
+  await act(async () => {
+    content.style.transform = "translateY(-72px)";
+    resize(2072);
+  });
+  expect(scroller.scrollTop).toBe(1110);
+  expect(content.style.translate).toBe("0px 72px");
+
+  await act(async () => {
+    scroller.scrollTop += 72;
+    content.style.transform = "translateY(0px)";
+  });
+  expect(scroller.scrollTop).toBe(1110);
+  expect(content.style.translate).toBe("0px 0px");
+});

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -134,39 +134,6 @@ describe.each([
   false,
   true,
 ])("conversation auto-scroll (mobile: %s)", (isMobile) => {
-  it.each([
-    0, 200,
-  ])("stays attached when the viewport grows with %ipx of new padding", (padding) => {
-    const { result, methods, scroller, scroll } = setup(isMobile);
-    vi.spyOn(scroller, "clientHeight", "get").mockReturnValue(1000);
-    if (isMobile) {
-      vi.stubGlobal("innerHeight", 1000);
-    }
-
-    scroll(1000, 2000 + padding);
-
-    expect(result.current.current).toBe(true);
-    expect(methods.cancelSmoothScroll).not.toHaveBeenCalled();
-
-    scroll(990, 2000 + padding);
-    expect(result.current.current).toBe(false);
-    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
-  });
-
-  it("detaches on native upward scrolling despite a retained bottom target", () => {
-    const { result, methods, scroll } = setup(isMobile);
-    vi.spyOn(methods, "getScrollLocation").mockReturnValue({
-      ...methods.getScrollLocation(),
-      isAtBottom: true,
-      bottomOffset: 90,
-    });
-
-    scroll(1110);
-
-    expect(result.current.current).toBe(false);
-    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
-  });
-
   it("detaches on upward scrolling even while content grows", () => {
     const { result, methods, scroll } = setup(isMobile);
     scroll(1110, 2072);

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -1,5 +1,5 @@
 import { useConversationAutoScroll } from "@app/components/assistant/conversation/useConversationAutoScroll";
-import { act, renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = [];
@@ -15,17 +15,6 @@ beforeEach(() => {
       observe() {}
       unobserve() {}
       disconnect() {}
-    }
-  );
-  vi.stubGlobal(
-    "DOMMatrixReadOnly",
-    class {
-      m42: number;
-      constructor(transform: string) {
-        this.m42 = Number(
-          transform.match(/translateY\(([-\d.]+)px\)/)?.[1] ?? 0
-        );
-      }
     }
   );
 });
@@ -102,7 +91,6 @@ function setup(isMobile = false) {
   measureRow(scroller.scrollTop);
   return {
     ...hook,
-    content,
     methods,
     scroller,
     wheel: (deltaY: number) => {
@@ -226,25 +214,4 @@ describe.each([
     expect(result.current.current).toBe(false);
     expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
   });
-});
-
-it("cancels iOS transforms and the delayed scroll adjustment without moving a touch gesture", async () => {
-  const { content, scroller, touch, scroll, resize } = setup(true);
-  touch("touchstart", 300);
-  touch("touchmove", 390);
-  scroll(1110);
-
-  await act(async () => {
-    content.style.transform = "translateY(-72px)";
-    resize(2072);
-  });
-  expect(scroller.scrollTop).toBe(1110);
-  expect(content.style.translate).toBe("0px 72px");
-
-  await act(async () => {
-    scroller.scrollTop += 72;
-    content.style.transform = "translateY(0px)";
-  });
-  expect(scroller.scrollTop).toBe(1110);
-  expect(content.style.translate).toBe("0px 0px");
 });

--- a/front/components/assistant/conversation/useConversationAutoScroll.test.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.test.ts
@@ -134,6 +134,39 @@ describe.each([
   false,
   true,
 ])("conversation auto-scroll (mobile: %s)", (isMobile) => {
+  it.each([
+    0, 200,
+  ])("stays attached when the viewport grows with %ipx of new padding", (padding) => {
+    const { result, methods, scroller, scroll } = setup(isMobile);
+    vi.spyOn(scroller, "clientHeight", "get").mockReturnValue(1000);
+    if (isMobile) {
+      vi.stubGlobal("innerHeight", 1000);
+    }
+
+    scroll(1000, 2000 + padding);
+
+    expect(result.current.current).toBe(true);
+    expect(methods.cancelSmoothScroll).not.toHaveBeenCalled();
+
+    scroll(990, 2000 + padding);
+    expect(result.current.current).toBe(false);
+    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+  });
+
+  it("detaches on native upward scrolling despite a retained bottom target", () => {
+    const { result, methods, scroll } = setup(isMobile);
+    vi.spyOn(methods, "getScrollLocation").mockReturnValue({
+      ...methods.getScrollLocation(),
+      isAtBottom: true,
+      bottomOffset: 90,
+    });
+
+    scroll(1110);
+
+    expect(result.current.current).toBe(false);
+    expect(methods.cancelSmoothScroll).toHaveBeenCalledOnce();
+  });
+
   it("detaches on upward scrolling even while content grows", () => {
     const { result, methods, scroll } = setup(isMobile);
     scroll(1110, 2072);

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -105,10 +105,7 @@ export function useConversationAutoScroll({
       }
       if (!isAutoScrollEnabledRef.current) {
         if (translation === 0 && previousTranslation !== 0) {
-          const viewportHeight = isMobile
-            ? window.innerHeight
-            : scrollElement.clientHeight;
-          const maxScrollTop = scrollElement.scrollHeight - viewportHeight;
+          const maxScrollTop = scrollElement.scrollHeight - window.innerHeight;
           const compensation = Math.max(
             -previousScrollTop,
             Math.min(-previousTranslation, maxScrollTop - previousScrollTop)
@@ -146,12 +143,22 @@ export function useConversationAutoScroll({
         direction = scrollTopDelta < 0 ? "up" : "down";
       }
 
-      if (
-        scrollTopDelta < 0 &&
-        scrollHeightDelta >= 0 &&
-        !methods.getScrollLocation().isAtBottom
-      ) {
+      if (scrollTopDelta < 0 && scrollHeightDelta >= 0) {
         detach();
+      }
+
+      const { isAtBottom, bottomOffset } = methods.getScrollLocation();
+      if (!isAutoScrollEnabledRef.current && isAtBottom && bottomOffset > 0) {
+        // isAtBottom also includes an active bottom target after cancellation.
+        // Clear it after the native scroll moves, so growth cannot pull us back.
+        methods.scrollToItem({
+          index: 0,
+          align: "start-no-overflow",
+          offset: isMobile
+            ? -listElement.getBoundingClientRect().top
+            : scrollElement.scrollTop,
+          behavior: "instant",
+        });
       }
 
       if (scrollTopDelta > 0) {
@@ -172,26 +179,6 @@ export function useConversationAutoScroll({
       }
     };
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (
-        !(event.target instanceof HTMLElement) ||
-        (!listElement.contains(event.target) &&
-          event.target !== document.body) ||
-        event.target.closest("input, textarea, [contenteditable=true]")
-      ) {
-        return;
-      }
-      if (
-        event.key === "ArrowUp" ||
-        event.key === "PageUp" ||
-        event.key === "Home" ||
-        (event.key === " " && event.shiftKey)
-      ) {
-        direction = "up";
-        detach();
-      }
-    };
-
     const onTouchStart = (event: TouchEvent) => {
       lastTouchY = event.touches.length === 1 ? event.touches[0].clientY : null;
     };
@@ -201,10 +188,7 @@ export function useConversationAutoScroll({
         lastTouchY = null;
         return;
       }
-      const touchY = event.touches[0]?.clientY;
-      if (touchY === undefined) {
-        return;
-      }
+      const touchY = event.touches[0].clientY;
       if (lastTouchY !== null && touchY !== lastTouchY) {
         direction = touchY > lastTouchY ? "up" : "down";
         if (direction === "up") {
@@ -279,7 +263,6 @@ export function useConversationAutoScroll({
     observeContent();
 
     scrollTarget.addEventListener("scroll", onScroll, { passive: true });
-    document.addEventListener("keydown", onKeyDown);
     listElement.addEventListener("wheel", onWheel, { passive: true });
     listElement.addEventListener("touchstart", onTouchStart, { passive: true });
     listElement.addEventListener("touchmove", onTouchMove, { passive: true });
@@ -293,7 +276,6 @@ export function useConversationAutoScroll({
         contentElement.style.translate = "";
       }
       scrollTarget.removeEventListener("scroll", onScroll);
-      document.removeEventListener("keydown", onKeyDown);
       listElement.removeEventListener("wheel", onWheel);
       listElement.removeEventListener("touchstart", onTouchStart);
       listElement.removeEventListener("touchmove", onTouchMove);

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -1,0 +1,304 @@
+import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+
+type ConversationScrollMethods = Pick<
+  VirtuosoMessageListMethods,
+  | "cancelSmoothScroll"
+  | "getScrollLocation"
+  | "scrollerElement"
+  | "scrollToItem"
+> & {
+  data: Pick<VirtuosoMessageListMethods["data"], "get">;
+};
+
+const BOTTOM_THRESHOLD_PX = 4;
+
+interface UseConversationAutoScrollProps {
+  isMobile: boolean;
+  messageListRef: RefObject<ConversationScrollMethods | null>;
+}
+
+export function useConversationAutoScroll({
+  isMobile,
+  messageListRef,
+}: UseConversationAutoScrollProps) {
+  const isAutoScrollEnabledRef = useRef(true);
+  const beforeResizeRef = useRef<ResizeObserverCallback | null>(null);
+  // Observer callbacks run in creation order. This one must be created before
+  // the child Virtuoso list creates its own observer.
+  const [beforeResizeObserver] = useState(() =>
+    typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver((entries, observer) => {
+          beforeResizeRef.current?.(entries, observer);
+        })
+  );
+
+  useEffect(() => {
+    const methods = messageListRef.current;
+    const listElement = methods?.scrollerElement();
+    const scrollElement = isMobile ? document.scrollingElement : listElement;
+    if (!methods || !listElement || !(scrollElement instanceof HTMLElement)) {
+      return;
+    }
+
+    const scrollTarget = isMobile ? window : scrollElement;
+    let previousScrollTop = scrollElement.scrollTop;
+    let previousScrollHeight = scrollElement.scrollHeight;
+    let previousItemCount = methods.data.get().length;
+    let direction: "up" | "down" | null = null;
+    let lastTouchY: number | null = null;
+    let contentElement: HTMLElement | null = null;
+    let previousTranslation = 0;
+    let translationItemCount = previousItemCount;
+    let isChangingItemCount = false;
+
+    const reattachAtBottom = () => {
+      const viewportHeight = isMobile
+        ? window.innerHeight
+        : scrollElement.clientHeight;
+      // The scrollable height includes the sticky input bar. At this boundary,
+      // the last message is visible above it, rather than hidden behind it.
+      const bottomOffset = isMobile
+        ? listElement.getBoundingClientRect().bottom - viewportHeight
+        : scrollElement.scrollHeight - scrollElement.scrollTop - viewportHeight;
+      if (
+        !isAutoScrollEnabledRef.current &&
+        direction === "down" &&
+        previousTranslation === 0 &&
+        bottomOffset <= BOTTOM_THRESHOLD_PX
+      ) {
+        isAutoScrollEnabledRef.current = true;
+        // Make the last few pixels visible above the floating input bar.
+        methods.scrollToItem({
+          index: "LAST",
+          align: "end",
+          behavior: "instant",
+        });
+      }
+    };
+
+    // On iOS, Virtuoso defers its scrollTop compensation with a transform
+    // until scrolling stops. Cancel that visual displacement without writing
+    // scrollTop during the touch gesture, which would interrupt momentum.
+    const syncTranslation = () => {
+      if (!isMobile || !contentElement) {
+        return;
+      }
+      const translation = new DOMMatrixReadOnly(contentElement.style.transform)
+        .m42;
+      const itemCount = methods.data.get().length;
+      if (itemCount !== translationItemCount) {
+        isChangingItemCount = true;
+        translationItemCount = itemCount;
+      }
+      // Prepending history also uses a transform, but that movement anchors
+      // the existing messages and must be kept.
+      if (isChangingItemCount) {
+        previousTranslation = 0;
+        isChangingItemCount = translation !== 0;
+        if (contentElement.style.translate) {
+          contentElement.style.translate = "";
+        }
+        return;
+      }
+      if (!isAutoScrollEnabledRef.current) {
+        if (translation === 0 && previousTranslation !== 0) {
+          const viewportHeight = isMobile
+            ? window.innerHeight
+            : scrollElement.clientHeight;
+          const maxScrollTop = scrollElement.scrollHeight - viewportHeight;
+          const compensation = Math.max(
+            -previousScrollTop,
+            Math.min(-previousTranslation, maxScrollTop - previousScrollTop)
+          );
+          scrollElement.scrollTop -= compensation;
+          previousScrollTop = scrollElement.scrollTop;
+        }
+        const translate = `0px ${-translation}px`;
+        if (contentElement.style.translate !== translate) {
+          contentElement.style.translate = translate;
+        }
+      } else if (contentElement.style.translate) {
+        contentElement.style.translate = "";
+      }
+      previousTranslation = translation;
+      reattachAtBottom();
+    };
+
+    const detach = () => {
+      if (isAutoScrollEnabledRef.current) {
+        isAutoScrollEnabledRef.current = false;
+        methods.cancelSmoothScroll();
+        previousScrollTop = scrollElement.scrollTop;
+        previousScrollHeight = scrollElement.scrollHeight;
+      }
+    };
+
+    const onScroll = () => {
+      syncTranslation();
+      const scrollTopDelta = scrollElement.scrollTop - previousScrollTop;
+      const scrollHeightDelta =
+        scrollElement.scrollHeight - previousScrollHeight;
+
+      if (scrollHeightDelta === 0 && scrollTopDelta !== 0) {
+        direction = scrollTopDelta < 0 ? "up" : "down";
+      }
+
+      if (
+        scrollTopDelta < 0 &&
+        scrollHeightDelta >= 0 &&
+        !methods.getScrollLocation().isAtBottom
+      ) {
+        detach();
+      }
+
+      if (scrollTopDelta > 0) {
+        reattachAtBottom();
+      }
+
+      previousScrollTop = scrollElement.scrollTop;
+      previousScrollHeight = scrollElement.scrollHeight;
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey || event.deltaY === 0) {
+        return;
+      }
+      direction = event.deltaY < 0 ? "up" : "down";
+      if (direction === "up") {
+        detach();
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        !(event.target instanceof HTMLElement) ||
+        (!listElement.contains(event.target) &&
+          event.target !== document.body) ||
+        event.target.closest("input, textarea, [contenteditable=true]")
+      ) {
+        return;
+      }
+      if (
+        event.key === "ArrowUp" ||
+        event.key === "PageUp" ||
+        event.key === "Home" ||
+        (event.key === " " && event.shiftKey)
+      ) {
+        direction = "up";
+        detach();
+      }
+    };
+
+    const onTouchStart = (event: TouchEvent) => {
+      lastTouchY = event.touches.length === 1 ? event.touches[0].clientY : null;
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (event.touches.length !== 1) {
+        lastTouchY = null;
+        return;
+      }
+      const touchY = event.touches[0]?.clientY;
+      if (touchY === undefined) {
+        return;
+      }
+      if (lastTouchY !== null && touchY !== lastTouchY) {
+        direction = touchY > lastTouchY ? "up" : "down";
+        if (direction === "up") {
+          detach();
+        }
+      }
+      lastTouchY = touchY;
+    };
+
+    const rowHeights = new WeakMap<Element, number>();
+    let scrollTopBeforeResize = scrollElement.scrollTop;
+    let preserveScrollPosition = false;
+    beforeResizeRef.current = (entries) => {
+      scrollTopBeforeResize = scrollElement.scrollTop;
+      preserveScrollPosition = false;
+      const viewportTop = isMobile
+        ? 0
+        : listElement.getBoundingClientRect().top;
+      for (const entry of entries) {
+        const previousHeight = rowHeights.get(entry.target);
+        const height = entry.contentRect.height;
+        rowHeights.set(entry.target, height);
+        if (
+          previousHeight !== undefined &&
+          height !== previousHeight &&
+          entry.target.getBoundingClientRect().top + previousHeight >
+            viewportTop
+        ) {
+          preserveScrollPosition = true;
+        }
+      }
+      preserveScrollPosition &&=
+        !isAutoScrollEnabledRef.current &&
+        methods.data.get().length === previousItemCount;
+    };
+    // This observer is created after Virtuoso's. Restore only movement caused
+    // by measuring existing rows, preserving the native scroll before that
+    // measurement and Virtuoso's anchoring when history is prepended.
+    const resizeObserver = new ResizeObserver(() => {
+      if (
+        preserveScrollPosition &&
+        scrollElement.scrollTop !== scrollTopBeforeResize
+      ) {
+        scrollElement.scrollTop = scrollTopBeforeResize;
+      }
+      previousScrollHeight = scrollElement.scrollHeight;
+      previousScrollTop = scrollElement.scrollTop;
+      previousItemCount = methods.data.get().length;
+    });
+    const translationObserver = new MutationObserver(syncTranslation);
+    const observeContent = () => {
+      resizeObserver.disconnect();
+      beforeResizeObserver?.disconnect();
+      translationObserver.disconnect();
+      contentElement = listElement.querySelector(
+        '[data-testid="virtuoso-list"]'
+      );
+      if (contentElement) {
+        translationObserver.observe(contentElement, {
+          attributes: true,
+          attributeFilter: ["style"],
+        });
+        mutationObserver.observe(contentElement, { childList: true });
+        for (const row of contentElement.children) {
+          beforeResizeObserver?.observe(row);
+          resizeObserver.observe(row);
+        }
+      }
+    };
+    const mutationObserver = new MutationObserver(observeContent);
+    mutationObserver.observe(listElement, { childList: true });
+    observeContent();
+
+    scrollTarget.addEventListener("scroll", onScroll, { passive: true });
+    document.addEventListener("keydown", onKeyDown);
+    listElement.addEventListener("wheel", onWheel, { passive: true });
+    listElement.addEventListener("touchstart", onTouchStart, { passive: true });
+    listElement.addEventListener("touchmove", onTouchMove, { passive: true });
+    return () => {
+      resizeObserver.disconnect();
+      beforeResizeObserver?.disconnect();
+      beforeResizeRef.current = null;
+      mutationObserver.disconnect();
+      translationObserver.disconnect();
+      if (contentElement) {
+        contentElement.style.translate = "";
+      }
+      scrollTarget.removeEventListener("scroll", onScroll);
+      document.removeEventListener("keydown", onKeyDown);
+      listElement.removeEventListener("wheel", onWheel);
+      listElement.removeEventListener("touchstart", onTouchStart);
+      listElement.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [beforeResizeObserver, isMobile, messageListRef]);
+
+  return isAutoScrollEnabledRef;
+}

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -12,6 +12,8 @@ type ConversationScrollMethods = Pick<
   data: Pick<VirtuosoMessageListMethods["data"], "get">;
 };
 
+// Downward scrolling reattaches within this many pixels of the bottom.
+// Increase to reattach sooner; decrease to require scrolling closer to the bottom.
 const BOTTOM_THRESHOLD_PX = 4;
 
 interface UseConversationAutoScrollProps {

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -44,8 +44,11 @@ export function useConversationAutoScroll({
     }
 
     const scrollTarget = isMobile ? window : scrollElement;
+    const getViewportHeight = () =>
+      isMobile ? window.innerHeight : scrollElement.clientHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let previousScrollHeight = scrollElement.scrollHeight;
+    let previousViewportHeight = getViewportHeight();
     let previousItemCount = methods.data.get().length;
     let direction: "up" | "down" | null = null;
     let lastTouchY: number | null = null;
@@ -55,9 +58,7 @@ export function useConversationAutoScroll({
     let isChangingItemCount = false;
 
     const reattachAtBottom = () => {
-      const viewportHeight = isMobile
-        ? window.innerHeight
-        : scrollElement.clientHeight;
+      const viewportHeight = getViewportHeight();
       // The scrollable height includes the sticky input bar. At this boundary,
       // the last message is visible above it, rather than hidden behind it.
       const bottomOffset = isMobile
@@ -135,6 +136,7 @@ export function useConversationAutoScroll({
 
     const onScroll = () => {
       syncTranslation();
+      const viewportHeight = getViewportHeight();
       const scrollTopDelta = scrollElement.scrollTop - previousScrollTop;
       const scrollHeightDelta =
         scrollElement.scrollHeight - previousScrollHeight;
@@ -143,7 +145,12 @@ export function useConversationAutoScroll({
         direction = scrollTopDelta < 0 ? "up" : "down";
       }
 
-      if (scrollTopDelta < 0 && scrollHeightDelta >= 0) {
+      // A growing viewport can reduce scrollTop without an upward gesture.
+      if (
+        scrollTopDelta <
+          -Math.max(0, viewportHeight - previousViewportHeight) &&
+        scrollHeightDelta >= 0
+      ) {
         detach();
       }
 
@@ -167,6 +174,7 @@ export function useConversationAutoScroll({
 
       previousScrollTop = scrollElement.scrollTop;
       previousScrollHeight = scrollElement.scrollHeight;
+      previousViewportHeight = viewportHeight;
     };
 
     const onWheel = (event: WheelEvent) => {

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -51,10 +51,6 @@ export function useConversationAutoScroll({
     let previousItemCount = methods.data.get().length;
     let direction: "up" | "down" | null = null;
     let lastTouchY: number | null = null;
-    let contentElement: HTMLElement | null = null;
-    let previousTranslation = 0;
-    let translationItemCount = previousItemCount;
-    let isChangingItemCount = false;
 
     const reattachAtBottom = () => {
       const viewportHeight = isMobile
@@ -68,7 +64,6 @@ export function useConversationAutoScroll({
       if (
         !isAutoScrollEnabledRef.current &&
         direction === "down" &&
-        previousTranslation === 0 &&
         bottomOffset <= BOTTOM_THRESHOLD_PX
       ) {
         isAutoScrollEnabledRef.current = true;
@@ -81,52 +76,6 @@ export function useConversationAutoScroll({
       }
     };
 
-    // On iOS, Virtuoso defers its scrollTop compensation with a transform
-    // until scrolling stops. Cancel that visual displacement without writing
-    // scrollTop during the touch gesture, which would interrupt momentum.
-    const syncTranslation = () => {
-      if (!isMobile || !contentElement) {
-        return;
-      }
-      const translation = new DOMMatrixReadOnly(contentElement.style.transform)
-        .m42;
-      const itemCount = methods.data.get().length;
-      if (itemCount !== translationItemCount) {
-        isChangingItemCount = true;
-        translationItemCount = itemCount;
-      }
-      // Prepending history also uses a transform, but that movement anchors
-      // the existing messages and must be kept.
-      if (isChangingItemCount) {
-        previousTranslation = 0;
-        isChangingItemCount = translation !== 0;
-        if (contentElement.style.translate) {
-          contentElement.style.translate = "";
-        }
-        return;
-      }
-      // While detached, undo Virtuoso's shifts to keep the text in place.
-      if (!isAutoScrollEnabledRef.current) {
-        if (translation === 0 && previousTranslation !== 0) {
-          const maxScrollTop = scrollElement.scrollHeight - window.innerHeight;
-          const compensation = Math.max(
-            -previousScrollTop,
-            Math.min(-previousTranslation, maxScrollTop - previousScrollTop)
-          );
-          scrollElement.scrollTop -= compensation;
-          previousScrollTop = scrollElement.scrollTop;
-        }
-        const translate = `0px ${-translation}px`;
-        if (contentElement.style.translate !== translate) {
-          contentElement.style.translate = translate;
-        }
-      } else if (contentElement.style.translate) {
-        contentElement.style.translate = "";
-      }
-      previousTranslation = translation;
-      reattachAtBottom();
-    };
-
     const detach = () => {
       if (isAutoScrollEnabledRef.current) {
         isAutoScrollEnabledRef.current = false;
@@ -137,7 +86,6 @@ export function useConversationAutoScroll({
     };
 
     const onScroll = () => {
-      syncTranslation();
       const scrollTopDelta = scrollElement.scrollTop - previousScrollTop;
       const scrollHeightDelta =
         scrollElement.scrollHeight - previousScrollHeight;
@@ -241,19 +189,13 @@ export function useConversationAutoScroll({
       previousScrollTop = scrollElement.scrollTop;
       previousItemCount = methods.data.get().length;
     });
-    const translationObserver = new MutationObserver(syncTranslation);
     const observeContent = () => {
       resizeObserver.disconnect();
       beforeResizeObserver?.disconnect();
-      translationObserver.disconnect();
-      contentElement = listElement.querySelector(
+      const contentElement = listElement.querySelector(
         '[data-testid="virtuoso-list"]'
       );
       if (contentElement) {
-        translationObserver.observe(contentElement, {
-          attributes: true,
-          attributeFilter: ["style"],
-        });
         mutationObserver.observe(contentElement, { childList: true });
         for (const row of contentElement.children) {
           beforeResizeObserver?.observe(row);
@@ -274,10 +216,6 @@ export function useConversationAutoScroll({
       beforeResizeObserver?.disconnect();
       beforeResizeRef.current = null;
       mutationObserver.disconnect();
-      translationObserver.disconnect();
-      if (contentElement) {
-        contentElement.style.translate = "";
-      }
       scrollTarget.removeEventListener("scroll", onScroll);
       listElement.removeEventListener("wheel", onWheel);
       listElement.removeEventListener("touchstart", onTouchStart);

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -44,11 +44,8 @@ export function useConversationAutoScroll({
     }
 
     const scrollTarget = isMobile ? window : scrollElement;
-    const getViewportHeight = () =>
-      isMobile ? window.innerHeight : scrollElement.clientHeight;
     let previousScrollTop = scrollElement.scrollTop;
     let previousScrollHeight = scrollElement.scrollHeight;
-    let previousViewportHeight = getViewportHeight();
     let previousItemCount = methods.data.get().length;
     let direction: "up" | "down" | null = null;
     let lastTouchY: number | null = null;
@@ -58,7 +55,9 @@ export function useConversationAutoScroll({
     let isChangingItemCount = false;
 
     const reattachAtBottom = () => {
-      const viewportHeight = getViewportHeight();
+      const viewportHeight = isMobile
+        ? window.innerHeight
+        : scrollElement.clientHeight;
       // The scrollable height includes the sticky input bar. At this boundary,
       // the last message is visible above it, rather than hidden behind it.
       const bottomOffset = isMobile
@@ -136,7 +135,6 @@ export function useConversationAutoScroll({
 
     const onScroll = () => {
       syncTranslation();
-      const viewportHeight = getViewportHeight();
       const scrollTopDelta = scrollElement.scrollTop - previousScrollTop;
       const scrollHeightDelta =
         scrollElement.scrollHeight - previousScrollHeight;
@@ -145,12 +143,7 @@ export function useConversationAutoScroll({
         direction = scrollTopDelta < 0 ? "up" : "down";
       }
 
-      // A growing viewport can reduce scrollTop without an upward gesture.
-      if (
-        scrollTopDelta <
-          -Math.max(0, viewportHeight - previousViewportHeight) &&
-        scrollHeightDelta >= 0
-      ) {
+      if (scrollTopDelta < 0 && scrollHeightDelta >= 0) {
         detach();
       }
 
@@ -174,7 +167,6 @@ export function useConversationAutoScroll({
 
       previousScrollTop = scrollElement.scrollTop;
       previousScrollHeight = scrollElement.scrollHeight;
-      previousViewportHeight = viewportHeight;
     };
 
     const onWheel = (event: WheelEvent) => {

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -105,6 +105,8 @@ export function useConversationAutoScroll({
         }
         return;
       }
+      // Keep the reader in place while detached by cancelling Virtuoso's temporary
+      // visual shift and the scrollTop adjustment that replaces it.
       if (!isAutoScrollEnabledRef.current) {
         if (translation === 0 && previousTranslation !== 0) {
           const maxScrollTop = scrollElement.scrollHeight - window.innerHeight;

--- a/front/components/assistant/conversation/useConversationAutoScroll.ts
+++ b/front/components/assistant/conversation/useConversationAutoScroll.ts
@@ -105,8 +105,7 @@ export function useConversationAutoScroll({
         }
         return;
       }
-      // Keep the reader in place while detached by cancelling Virtuoso's temporary
-      // visual shift and the scrollTop adjustment that replaces it.
+      // While detached, undo Virtuoso's shifts to keep the text in place.
       if (!isAutoScrollEnabledRef.current) {
         if (translation === 0 && previousTranslation !== 0) {
           const maxScrollTop = scrollElement.scrollHeight - window.innerHeight;

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -21,12 +21,13 @@ const mockUseVirtuosoMethods = vi.fn();
 const mockIsAutoScrollEnabledRef = { current: true };
 
 function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
+  const scroller = document.createElement("div");
   return {
+    scrollerElement: () => scroller,
+    getScrollLocation: () => ({ bottomOffset: 0 }),
+    scrollToItem: vi.fn(),
     data: {
       map,
-      batch: (callback: () => void) => {
-        callback();
-      },
     },
   };
 }
@@ -139,6 +140,7 @@ const mockOwner: LightWorkspaceType = {
 };
 
 beforeEach(() => {
+  mockIsAutoScrollEnabledRef.current = true;
   mockUseEventSource.mockReset();
   mockMutateContextUsage.mockReset();
   mockUseVirtuosoMethods.mockReset();
@@ -290,6 +292,121 @@ describe("appendThinkingStep", () => {
 });
 
 describe("useAgentMessageStream", () => {
+  it.each([
+    {
+      scenario: "first answer tokens while detached",
+      isInitiallyAttached: false,
+      shouldScroll: false,
+    },
+    {
+      scenario: "first reasoning tokens while detached",
+      classification: "chain_of_thought",
+      isInitiallyAttached: false,
+      shouldScroll: false,
+    },
+    {
+      scenario: "detachment after scheduling a scroll",
+      isInitiallyAttached: true,
+      detachBeforeFrame: true,
+      shouldScroll: false,
+    },
+    {
+      scenario: "following while window measurements catch up",
+      isInitiallyAttached: true,
+      afterBottomOffset: -1,
+      shouldScroll: true,
+    },
+    {
+      scenario: "preserving space below a short new turn",
+      isInitiallyAttached: true,
+      beforeBottomOffset: -100,
+      afterBottomOffset: -50,
+      shouldScroll: false,
+    },
+    {
+      scenario: "following once a new turn fills the viewport",
+      isInitiallyAttached: true,
+      beforeBottomOffset: -100,
+      afterBottomOffset: 20,
+      shouldScroll: true,
+    },
+  ])("respects scroll intent: $scenario", ({
+    classification = "tokens",
+    isInitiallyAttached,
+    detachBeforeFrame = false,
+    beforeBottomOffset = 0,
+    afterBottomOffset = 0,
+    shouldScroll,
+  }) => {
+    vi.useFakeTimers();
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: "", chainOfThought: "" })
+    );
+    let onEvent = (_event: string) => {};
+    mockIsAutoScrollEnabledRef.current = isInitiallyAttached;
+    let bottomOffset = beforeBottomOffset;
+    const methods = makeVirtuosoMethodsMock(
+      (updater: (message: typeof currentMessage) => typeof currentMessage) => {
+        currentMessage = updater(currentMessage);
+        return [currentMessage];
+      }
+    );
+    methods.getScrollLocation = () => ({ bottomOffset });
+    mockUseVirtuosoMethods.mockReturnValue(methods);
+    mockUseEventSource.mockImplementation(
+      (_buildURL: unknown, callback: (event: string) => void) => {
+        onEvent = callback;
+        return { isError: null };
+      }
+    );
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+    act(() => {
+      onEvent(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "New text",
+            classification,
+          },
+        })
+      );
+    });
+    if (detachBeforeFrame) {
+      mockIsAutoScrollEnabledRef.current = false;
+    }
+    bottomOffset = afterBottomOffset;
+    expect(mockIsAutoScrollEnabledRef.current).toBe(
+      isInitiallyAttached && !detachBeforeFrame
+    );
+    vi.advanceTimersByTime(48);
+    if (shouldScroll) {
+      expect(methods.scrollToItem).toHaveBeenCalledWith({
+        index: "LAST",
+        align: "end",
+        behavior: "smooth",
+      });
+    } else {
+      expect(methods.scrollToItem).not.toHaveBeenCalled();
+    }
+    expect(
+      classification === "tokens"
+        ? currentMessage.content
+        : currentMessage.chainOfThought
+    ).toBe("New text");
+  });
+
   it("clears stale database content before replaying fresh-mount tokens", () => {
     let currentMessage = makeInitialMessageStreamState(makeLightAgentMessage());
     const snapshots: Array<{

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -13,6 +13,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { act, renderHook } from "@testing-library/react";
+import type { ItemLocation } from "@virtuoso.dev/message-list";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockUseEventSource = vi.fn();
@@ -21,13 +22,15 @@ const mockUseVirtuosoMethods = vi.fn();
 const mockIsAutoScrollEnabledRef = { current: true };
 
 function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
-  const scroller = document.createElement("div");
   return {
-    scrollerElement: () => scroller,
     getScrollLocation: () => ({ bottomOffset: 0 }),
-    scrollToItem: vi.fn(),
     data: {
-      map,
+      map: vi.fn(
+        (
+          updater: (message: T) => T,
+          _scroll?: { location: () => ItemLocation | null | undefined }
+        ) => map(updater)
+      ),
     },
   };
 }
@@ -307,44 +310,33 @@ describe("useAgentMessageStream", () => {
     {
       scenario: "detachment after scheduling a scroll",
       isInitiallyAttached: true,
-      detachBeforeFrame: true,
+      detachBeforeScroll: true,
       shouldScroll: false,
-    },
-    {
-      scenario: "following while window measurements catch up",
-      isInitiallyAttached: true,
-      afterBottomOffset: -1,
-      shouldScroll: true,
     },
     {
       scenario: "preserving space below a short new turn",
       isInitiallyAttached: true,
-      beforeBottomOffset: -100,
-      afterBottomOffset: -50,
+      bottomOffset: -50,
       shouldScroll: false,
     },
     {
       scenario: "following once a new turn fills the viewport",
       isInitiallyAttached: true,
-      beforeBottomOffset: -100,
-      afterBottomOffset: 20,
+      bottomOffset: 20,
       shouldScroll: true,
     },
   ])("respects scroll intent: $scenario", ({
     classification = "tokens",
     isInitiallyAttached,
-    detachBeforeFrame = false,
-    beforeBottomOffset = 0,
-    afterBottomOffset = 0,
+    detachBeforeScroll = false,
+    bottomOffset = 0,
     shouldScroll,
   }) => {
-    vi.useFakeTimers();
     let currentMessage = makeInitialMessageStreamState(
       makeLightAgentMessage({ content: "", chainOfThought: "" })
     );
     let onEvent = (_event: string) => {};
     mockIsAutoScrollEnabledRef.current = isInitiallyAttached;
-    let bottomOffset = beforeBottomOffset;
     const methods = makeVirtuosoMethodsMock(
       (updater: (message: typeof currentMessage) => typeof currentMessage) => {
         currentMessage = updater(currentMessage);
@@ -383,23 +375,17 @@ describe("useAgentMessageStream", () => {
         })
       );
     });
-    if (detachBeforeFrame) {
+    if (detachBeforeScroll) {
       mockIsAutoScrollEnabledRef.current = false;
     }
-    bottomOffset = afterBottomOffset;
     expect(mockIsAutoScrollEnabledRef.current).toBe(
-      isInitiallyAttached && !detachBeforeFrame
+      isInitiallyAttached && !detachBeforeScroll
     );
-    vi.advanceTimersByTime(48);
-    if (shouldScroll) {
-      expect(methods.scrollToItem).toHaveBeenCalledWith({
-        index: "LAST",
-        align: "end",
-        behavior: "smooth",
-      });
-    } else {
-      expect(methods.scrollToItem).not.toHaveBeenCalled();
-    }
+    const scrollLocation = methods.data.map.mock.calls.at(-1)?.[1]?.location;
+    expect(scrollLocation).toBeDefined();
+    expect(scrollLocation?.()).toEqual(
+      shouldScroll ? { index: "LAST", align: "end", behavior: "smooth" } : null
+    );
     expect(
       classification === "tokens"
         ? currentMessage.content

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -31,41 +31,30 @@ type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessageListContext
 >;
 
-function createAutoScrollToBottomBehavior(
-  isAutoScrollEnabledRef: MutableRefObject<boolean>
-) {
-  return ({
-    scrollLocation,
-    scrollInProgress,
-  }: {
-    scrollLocation: { bottomOffset: number };
-    scrollInProgress: boolean;
-  }) => {
-    if (!isAutoScrollEnabledRef.current || scrollInProgress) {
-      return false;
-    }
-
-    if (scrollLocation.bottomOffset < 0) {
-      return false;
-    }
-
-    return {
-      index: "LAST" as const,
-      align: "end" as const,
-      behavior: "smooth" as const,
-    };
-  };
-}
-
-function batchMapMessagesWithAutoScroll(
+function mapMessagesAndScroll(
   methods: VirtuosoMethods,
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
   mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
 ) {
-  methods.data.batch(
-    () => methods.data.map(mapFn),
-    createAutoScrollToBottomBehavior(isAutoScrollEnabledRef)
-  );
+  const wasUsingBottomPadding = methods.getScrollLocation().bottomOffset < 0;
+  methods.data.map(mapFn);
+  // Let the updated rows render and Virtuoso measure them before choosing the
+  // target. Check attachment when the scroll actually starts: Virtuoso's batch
+  // callback can queue a scroll that outlives an upward gesture cancelling it.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      if (!isAutoScrollEnabledRef.current || !methods.scrollerElement()) {
+        return;
+      }
+      const { bottomOffset } = methods.getScrollLocation();
+      // Keep a new turn aligned at the top until it fills the viewport. When
+      // already following, window-scroll measurements can briefly lag growth.
+      if (wasUsingBottomPadding && bottomOffset < 0) {
+        return;
+      }
+      methods.scrollToItem({ index: "LAST", align: "end", behavior: "smooth" });
+    });
+  });
 }
 
 function createUpdateMessageThrottled(
@@ -82,15 +71,8 @@ function createUpdateMessageThrottled(
       content: string;
       sId: string;
     }) => {
-      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
+      mapMessagesAndScroll(methods, isAutoScrollEnabledRef, (m) => {
         if (isAgentMessageWithStreaming(m) && m.sId === sId) {
-          // Enable auto scroll if we are starting to receive content or chain of thought.
-          if (
-            (!m.content && content) ||
-            (!m.chainOfThought && chainOfThought)
-          ) {
-            isAutoScrollEnabledRef.current = true;
-          }
           return {
             ...m,
             content,
@@ -341,7 +323,7 @@ export function useAgentMessageStream({
 
   const mapMessagesWithAutoScroll = useCallback(
     (mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage) => {
-      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, mapFn);
+      mapMessagesAndScroll(methods, isAutoScrollEnabledRef, mapFn);
     },
     [methods, isAutoScrollEnabledRef]
   );

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -36,24 +36,19 @@ function mapMessagesAndScroll(
   isAutoScrollEnabledRef: MutableRefObject<boolean>,
   mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
 ) {
-  const wasUsingBottomPadding = methods.getScrollLocation().bottomOffset < 0;
-  methods.data.map(mapFn);
-  // Let the updated rows render and Virtuoso measure them before choosing the
-  // target. Check attachment when the scroll actually starts: Virtuoso's batch
-  // callback can queue a scroll that outlives an upward gesture cancelling it.
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      if (!isAutoScrollEnabledRef.current || !methods.scrollerElement()) {
-        return;
+  methods.data.map(mapFn, {
+    // Virtuoso calls this after measuring growth. Read the current attachment
+    // so an upward gesture can cancel following even after the update is queued.
+    location: () => {
+      // A negative offset keeps a new turn aligned at the top of the viewport.
+      if (
+        !isAutoScrollEnabledRef.current ||
+        methods.getScrollLocation().bottomOffset < 0
+      ) {
+        return null;
       }
-      const { bottomOffset } = methods.getScrollLocation();
-      // Keep a new turn aligned at the top until it fills the viewport. When
-      // already following, window-scroll measurements can briefly lag growth.
-      if (wasUsingBottomPadding && bottomOffset < 0) {
-        return;
-      }
-      methods.scrollToItem({ index: "LAST", align: "end", behavior: "smooth" });
-    });
+      return { index: "LAST", align: "end", behavior: "smooth" };
+    },
   });
 }
 


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10209.

Long agent responses currently keep pulling the conversation to the bottom when someone scrolls up to read, which is especially disruptive on mobile because the screen is usually quite narrow, and when you try reading the message you are fighting against the scroll.

This PR makes auto-scroll distinguish streamed content growth from the user's upward viewport movement. If you don't do anything, content keeps following, but scrolling up "detaches" auto-scroll. Reaching the bottom re-attaches.

The main catch here is that Virtuoso resizes the message rows during the streaming: updates the CSS first, then scrolls into it. We unfortunately can't reliably opt-out from this entirely, so what we're doing here is compensating for this resize when detached.

## Tests

- Added tests extensively (checks the detach, the re-attach, the normal scroll, etc..).
- Tested using preview on desktop + mobile.

## Risk

- Low.

## Deploy Plan

- Deploy front.
