### PR TITLE
Show the published Frame name on the shared Frame v2 page

### DIFF
--- a/front-api/routes/share/frame/[token].test.ts
+++ b/front-api/routes/share/frame/[token].test.ts
@@ -3,7 +3,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { FileShareScope } from "@app/types/files";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -120,5 +120,49 @@ describe("GET /api/share/frame/:token - requiresEmailVerification", () => {
 
     expect(response.status).toBe(200);
     expect((await response.json()).requiresEmailVerification).toBe(false);
+  });
+});
+
+describe("GET /api/share/frame/:token - title", () => {
+  let auth: Authenticator;
+  let user: UserResource;
+
+  beforeEach(async () => {
+    const resources = await createResourceTest({ role: "admin" });
+    auth = resources.authenticator;
+    user = resources.user;
+  });
+
+  it("uses the formatted file name for a legacy Frame", async () => {
+    const { token } = await createFrameWithScope(auth, user, "public");
+
+    const response = await getShareFrame(token);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).title).toBe("Test");
+  });
+
+  it("uses the published Frame name for a Frame v2", async () => {
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: "manifest.json",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: {
+        activePublicationId: "publication-1",
+        frameName: "Task List",
+        frameDescription: "Track tasks.",
+      },
+    });
+    await file.setShareScope(auth, "public");
+    const shareInfo = await file.getShareInfo();
+    assert(shareInfo, "Share info should be available");
+    const token = shareInfo.shareUrl.split("/").at(-1)!;
+
+    const response = await getShareFrame(token);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).title).toBe("Task List");
   });
 });

--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -2,6 +2,7 @@ import config from "@app/lib/api/config";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { lookupShareToken } from "@app/lib/api/regions/lookup";
 import { getWorkspaceBrandingPublicUrls } from "@app/lib/api/workspace_branding";
+import { formatFilenameForDisplay } from "@app/lib/files";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -129,7 +130,11 @@ app.get(
       requiresEmailVerification,
       shareUrl,
       showSignUpCta: !isBrandedWorkspace,
-      title: file.fileName,
+      // A Frame v2's file is its manifest, so its display name comes from the active
+      // publication rather than the file name.
+      title:
+        file.useCaseMetadata?.frameName ??
+        formatFilenameForDisplay(file.fileName),
       vizUrl: config.getVizPublicUrl(),
       workspaceId: workspace.sId,
       workspaceName: workspace.name,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -126,6 +126,7 @@ describe("PublicFrameRenderer", () => {
       fileId: "file_123",
       hideHeader: true,
       shareToken: "share-token",
+      title: "Frame",
       workspaceId: "w_current",
       vizUrl: "https://viz.dust.tt",
     };
@@ -150,6 +151,7 @@ describe("PublicFrameRenderer", () => {
         frameId: "fil_frame",
         hideHeader: true,
         shareToken: "share-token",
+        title: "Frame",
         workspaceId: "w_current",
         vizUrl: "https://viz.dust.tt",
       })
@@ -182,6 +184,7 @@ describe("PublicFrameRenderer", () => {
         fileId: "file_123",
         hideHeader: true,
         shareToken: "share-token",
+        title: "Frame",
         workspaceId: "w_current",
         vizUrl: "https://viz.dust.tt",
       })

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -2,7 +2,6 @@ import { VisualizationActionIframe } from "@app/components/assistant/conversatio
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { PublicInteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { formatFilenameForDisplay } from "@app/lib/files";
 import { usePublicFrame } from "@app/lib/swr/frames";
 import { useUser } from "@app/lib/swr/user";
 import type {
@@ -17,7 +16,7 @@ import { useCookies } from "react-cookie";
 interface PublicFrameRendererProps {
   fileId: string;
   frameId?: string;
-  fileName?: string;
+  title: string;
   hideHeader?: boolean;
   logoUrl?: string | null;
   showSignUpCta?: boolean;
@@ -64,7 +63,7 @@ export function getPublicFrameUserIdentity(
 export function PublicFrameRenderer({
   fileId,
   frameId,
-  fileName,
+  title,
   hideHeader = false,
   logoUrl,
   showSignUpCta = false,
@@ -136,7 +135,7 @@ export function PublicFrameRenderer({
     <div className="flex h-full flex-col">
       {!hideHeader && (
         <PublicInteractiveContentHeader
-          title={formatFilenameForDisplay(fileName ?? "Frame")}
+          title={title}
           user={user}
           conversationUrl={conversationUrl}
           projectUrl={projectUrl}

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.test.ts
@@ -54,6 +54,7 @@ describe("PublicInteractiveContentContainer", () => {
   it("passes the stable identity only for Frames v2", () => {
     const props = {
       shareToken: "share-token",
+      title: "App",
       workspaceId: "w_current",
       vizUrl: "https://viz.dust.tt",
     };

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -12,6 +12,8 @@ import { Spinner } from "@dust-tt/sparkle";
 
 interface PublicInteractiveContentContainerProps {
   shareToken: string;
+  // Display name of the Frame, resolved by the share metadata endpoint.
+  title: string;
   workspaceId: string;
   vizUrl: string;
   logoUrl?: string | null;
@@ -25,6 +27,7 @@ interface PublicInteractiveContentContainerProps {
  */
 export function PublicInteractiveContentContainer({
   shareToken,
+  title,
   workspaceId,
   vizUrl,
   logoUrl,
@@ -61,7 +64,7 @@ export function PublicInteractiveContentContainer({
                 ? frameMetadata.sId
                 : undefined
             }
-            fileName={frameMetadata.fileName}
+            title={title}
             shareToken={shareToken}
             workspaceId={workspaceId}
             vizUrl={vizUrl}

--- a/front/components/pages/share/SharedFramePage.test.tsx
+++ b/front/components/pages/share/SharedFramePage.test.tsx
@@ -61,10 +61,6 @@ vi.mock("@app/lib/cookies", () => ({
   hasSessionIndicator: () => mocks.hasSession,
 }));
 
-vi.mock("@app/lib/files", () => ({
-  formatFilenameForDisplay: (name: string) => name,
-}));
-
 vi.mock("@app/lib/platform", () => ({
   usePathParam: () => "share-token",
 }));

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -5,7 +5,6 @@ import { EmailVerificationFlow } from "@app/components/pages/share/EmailVerifica
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import config from "@app/lib/api/config";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { formatFilenameForDisplay } from "@app/lib/files";
 import { usePathParam } from "@app/lib/platform";
 import { usePublicFrame } from "@app/lib/swr/frames";
 import { useShareFrameMetadata } from "@app/lib/swr/share";
@@ -78,9 +77,7 @@ export function SharedFramePage() {
   const needsEmailVerification =
     !isVerified && !!shareMetadata?.requiresEmailVerification && !!frameError;
 
-  const humanFriendlyTitle = shareMetadata
-    ? formatFilenameForDisplay(shareMetadata.title)
-    : "";
+  const humanFriendlyTitle = shareMetadata?.title ?? "";
 
   useDocumentTitle(
     humanFriendlyTitle ? `${humanFriendlyTitle} - Powered by Dust` : "Dust"
@@ -210,6 +207,7 @@ export function SharedFramePage() {
     <div className="flex h-dvh w-full">
       <PublicInteractiveContentContainer
         shareToken={token}
+        title={shareMetadata.title}
         workspaceId={shareMetadata.workspaceId}
         vizUrl={shareMetadata.vizUrl}
         logoUrl={shareMetadata.logoUrl}


### PR DESCRIPTION
## Problem

Opening a shared Frame v2 showed "Manifest" as the page header and tab title. The share page derived the title from the file name, and a Frame v2's file is always `manifest.json`.

## Fix

- The share metadata endpoint (`front-api/routes/share/frame/[token].ts`) now returns a display-ready `title`: the published Frame name from `useCaseMetadata.frameName` for a Frame v2, and the formatted file name for legacy Frames (same output as the client-side formatting it replaces).
- `SharedFramePage` uses that title directly and passes it down through `PublicInteractiveContentContainer` to `PublicFrameRenderer`, which now takes a `title` prop instead of re-deriving one from `fileName`.

## Tests

- Added share route tests covering the legacy and Frame v2 titles.
- Updated the container and renderer tests for the new `title` prop.

## Risk

Low. Public share page only; legacy Frame titles render identically.