### PR TITLE
Preserve canonical folder paths in file explorers

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -5,6 +5,7 @@ import type {
   FileEntry,
   FileExplorerEntry,
   FileExplorerPathEntry,
+  FileExplorerVirtualScopeRoot,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
@@ -25,8 +26,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { Button, XClose } from "@dust-tt/sparkle";
 import { useCallback, useContext, useMemo } from "react";
 
-const POD_CONVERSATION_SCOPE_ROOTS = ["conversation", "pod"] as const;
-
 function isFramePackageEntry(entry: FileExplorerEntry): boolean {
   return entry.kind === "frame_package";
 }
@@ -44,6 +43,22 @@ export function ConversationFileExplorer({
   const { hasFeature } = useFeatureFlags();
   const confirm = useContext(ConfirmContext);
   const isPod = isPodConversation(conversation);
+
+  const virtualScopeRoots = useMemo<
+    readonly FileExplorerVirtualScopeRoot[] | undefined
+  >(() => {
+    if (!isPod) {
+      return undefined;
+    }
+
+    return [
+      {
+        path: "conversation",
+        canonicalPath: `conversation-${conversation.sId}`,
+      },
+      { path: "pod", canonicalPath: `pod-${conversation.spaceId}` },
+    ];
+  }, [conversation, isPod]);
 
   const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
 
@@ -169,7 +184,7 @@ export function ConversationFileExplorer({
           onOpenInteractive={onOpenInteractive}
           onOpenInPanel={onOpenInPanel}
           owner={owner}
-          virtualScopeRoots={isPod ? POD_CONVERSATION_SCOPE_ROOTS : undefined}
+          virtualScopeRoots={virtualScopeRoots}
         />
       </div>
     </div>

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -202,6 +202,44 @@ describe("FileExplorer navigation", () => {
 
     expect(screen.getByText("nested.txt")).toBeInTheDocument();
   });
+
+  it("passes a folder's canonical path to folder actions", async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    const nestedFile = makeFile({
+      contentType: "text/plain",
+      fileName: "nested.txt",
+      lastModifiedMs: 1,
+      path: "folder/nested.txt",
+    });
+
+    render(
+      <ControlledFileExplorer
+        defaultViewMode="list"
+        files={[nestedFile]}
+        getFileUrl={(path) => `/files/${path}`}
+        isLoading={false}
+        onFileDownload={vi.fn().mockResolvedValue(undefined)}
+        onRename={onRename}
+      />
+    );
+
+    const folderTitle = screen.getByText("folder");
+    const folderRow = folderTitle.closest("div.cursor-pointer");
+    expect(folderRow).toBeInstanceOf(HTMLElement);
+    if (!(folderRow instanceof HTMLElement)) {
+      throw new Error("Folder row not found.");
+    }
+
+    await user.click(within(folderRow).getByRole("button"));
+    await user.click(screen.getByText("Rename"));
+
+    expect(onRename).toHaveBeenCalledWith({
+      kind: "folder",
+      name: "folder",
+      path: "conversation-c1/folder",
+    });
+  });
 });
 
 describe("FileExplorer Frame packages", () => {

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -16,6 +16,7 @@ import type {
   FileExplorerMenuAction,
   FileExplorerPathEntry,
   FileExplorerSortMode,
+  FileExplorerVirtualScopeRoot,
   FileSystemTreeNode,
   FolderEntry,
   FramePackageEntry,
@@ -65,7 +66,7 @@ interface FileExplorerProps {
     entry: FileExplorerEntry
   ) => FileExplorerMenuAction[];
   /** Top-level scope folders at the virtual root (e.g. `conversation`, `pod`). */
-  virtualScopeRoots?: readonly string[];
+  virtualScopeRoots?: readonly FileExplorerVirtualScopeRoot[];
 }
 
 export function FileExplorer({

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -61,13 +61,9 @@ export function FileExplorerContent({
 }: FileExplorerContentProps) {
   const items = sortedNodes.map((node) => {
     if (node.isDirectory) {
-      // TODO: FolderEntry.path is currently the relative path (scope prefix stripped).
-      // Refactor FileSystemTreeNode to carry the canonical scoped path so that callers
-      // (e.g. PodFileExplorer) can use entry.path directly for API calls without having
-      // to re-prepend the scope prefix.
       const folderEntry: FolderEntry = {
         kind: "folder",
-        path: node.path,
+        path: node.canonicalPath,
         name: node.name,
       };
       return (
@@ -126,7 +122,6 @@ export function FileExplorerContent({
         );
 
       case "folder":
-      case "frame_package":
         return null;
 
       default:

--- a/front/components/file_explorer/fileExplorerPipeline.test.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.test.ts
@@ -5,6 +5,11 @@ import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { frameV2ContentType } from "@app/types/files";
 import { describe, expect, it } from "vitest";
 
+const virtualScopeRoots = [
+  { path: "conversation", canonicalPath: "conversation-c1" },
+  { path: "pod", canonicalPath: "pod-p1" },
+] as const;
+
 function mountFile(
   scopedPath: string,
   fileName = scopedPath.split("/").pop() ?? scopedPath,
@@ -67,6 +72,7 @@ describe("getFileExplorerPipeline Frame packages", () => {
     expect(pipeline.entryByRelativePath.get("apps/status")).toMatchObject({
       kind: "frame_package",
       fileId: "frame-1",
+      sourceFolderCanonicalPath: "conversation-c1/apps/status",
       sourceFolderPath: "apps/status",
     });
     expect(pipeline.filterCounts.frames).toBe(1);
@@ -165,7 +171,7 @@ describe("getFileExplorerPipeline Frame packages", () => {
       files,
       searchQuery: "",
       sortMode: "last-modified",
-      virtualScopeRoots: ["conversation", "pod"],
+      virtualScopeRoots,
     });
 
     expect(pipeline.sortedNodes).toMatchObject([
@@ -175,6 +181,12 @@ describe("getFileExplorerPipeline Frame packages", () => {
         path: "conversation/status",
       },
     ]);
+    expect(
+      pipeline.entryByRelativePath.get("conversation/status")
+    ).toMatchObject({
+      sourceFolderCanonicalPath: "conversation-c1/status",
+      sourceFolderPath: "conversation/status",
+    });
   });
 });
 
@@ -194,10 +206,14 @@ describe("getFileExplorerPipeline virtualScopeRoots", () => {
       files,
       searchQuery: "",
       sortMode: "last-modified",
-      virtualScopeRoots: ["conversation", "pod"],
+      virtualScopeRoots,
     });
 
     expect(sortedNodes.map((n) => n.path)).toEqual(["conversation", "pod"]);
+    expect(sortedNodes.map((n) => n.canonicalPath)).toEqual([
+      "conversation-c1",
+      "pod-p1",
+    ]);
   });
 
   it("lists files inside a scope folder", () => {
@@ -216,7 +232,7 @@ describe("getFileExplorerPipeline virtualScopeRoots", () => {
       files,
       searchQuery: "",
       sortMode: "last-modified",
-      virtualScopeRoots: ["conversation", "pod"],
+      virtualScopeRoots,
     });
 
     expect(sortedNodes.map((n) => n.path)).toEqual(["conversation/notes.txt"]);
@@ -247,7 +263,7 @@ describe("getFileExplorerPipeline search", () => {
       files,
       searchQuery: "readme",
       sortMode: "last-modified",
-      virtualScopeRoots: ["conversation", "pod"],
+      virtualScopeRoots,
     });
 
     expect(sortedNodes).toEqual([]);
@@ -272,7 +288,7 @@ describe("getFileExplorerPipeline search", () => {
       files,
       searchQuery: "summary",
       sortMode: "last-modified",
-      virtualScopeRoots: ["conversation", "pod"],
+      virtualScopeRoots,
     });
 
     expect(sortedNodes.map((n) => n.path)).toEqual([
@@ -295,7 +311,7 @@ describe("getFileExplorerPipeline search", () => {
       files,
       searchQuery: "reports",
       sortMode: "last-modified",
-      virtualScopeRoots: ["conversation", "pod"],
+      virtualScopeRoots,
     });
 
     expect(sortedNodes.map((n) => n.path)).toEqual([

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -4,6 +4,7 @@ import type {
   FileExplorerFilter,
   FileExplorerPathEntry,
   FileExplorerSortMode,
+  FileExplorerVirtualScopeRoot,
   FileSystemTreeNode,
   FramePackageEntry,
 } from "@app/components/file_explorer/types";
@@ -45,7 +46,7 @@ interface GetFileExplorerPipelineParams {
   /** Collapse registered Frames v2 source folders into package entries. */
   displayFramePackages?: boolean;
   /** Top-level scope folders at the virtual root (e.g. `conversation`, `pod`). */
-  virtualScopeRoots?: readonly string[];
+  virtualScopeRoots?: readonly FileExplorerVirtualScopeRoot[];
 }
 
 function isPathAtOrBelow(path: string, parentPath: string): boolean {
@@ -73,6 +74,7 @@ function getCollapsedFramePackages({
 
     const manifestExplorerPath = getExplorerRelativePath(file);
     const sourceFolderPath = getParentFolderRelativePath(manifestExplorerPath);
+    const sourceFolderCanonicalPath = getParentFolderRelativePath(file.path);
     if (
       !sourceFolderPath ||
       isPathAtOrBelow(currentFolderPath, sourceFolderPath)
@@ -87,6 +89,7 @@ function getCollapsedFramePackages({
       fileId: file.fileId,
       fileName: sourceFolderPath.slice(sourceFolderPath.lastIndexOf("/") + 1),
       sourceFolderPath,
+      sourceFolderCanonicalPath,
       virtualPath: sourceFolderPath,
     });
   }
@@ -219,6 +222,7 @@ export function getFileExplorerPipeline({
     name: cn.fileName,
     path: cn.path,
     isDirectory: false,
+    canonicalPath: null,
     contentType: null,
     fileId: null,
     children: [],

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -28,6 +28,8 @@ export type FramePackageEntry = Omit<
   fileName: string;
   /** Explorer navigation path of the package's source folder. */
   sourceFolderPath: string;
+  /** Canonical filesystem path of the package's source folder. */
+  sourceFolderCanonicalPath: string;
 };
 
 export type ContentNodeEntry = {
@@ -71,14 +73,38 @@ export type FilePanelCategory =
   | "knowledge"
   | "other";
 
-export type FileSystemTreeNode = {
+type FileSystemTreeNodeBase = {
   name: string;
   /** Explorer-relative path (mount-relative, or virtual when `virtualPath` is used). */
   path: string;
-  isDirectory: boolean;
+  children: FileSystemTreeNode[];
+};
+
+export type FileSystemDirectoryTreeNode = FileSystemTreeNodeBase & {
+  isDirectory: true;
+  /** Canonical filesystem path, including the scope prefix. */
+  canonicalPath: string;
+  contentType: null;
+  fileId: null;
+};
+
+export type FileSystemFileTreeNode = FileSystemTreeNodeBase & {
+  isDirectory: false;
+  /** Null only for synthetic content nodes that are not filesystem entries. */
+  canonicalPath: string | null;
   contentType: string | null;
   fileId: string | null;
-  children: FileSystemTreeNode[];
+};
+
+export type FileSystemTreeNode =
+  | FileSystemDirectoryTreeNode
+  | FileSystemFileTreeNode;
+
+export type FileExplorerVirtualScopeRoot = {
+  /** Explorer path shown at the merged root. */
+  path: string;
+  /** Canonical filesystem mount path represented by this root. */
+  canonicalPath: string;
 };
 
 export type FileExplorerBucket =

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -1,5 +1,6 @@
 import type {
   FileEntry,
+  FileSystemFileTreeNode,
   FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
 import {
@@ -120,10 +121,11 @@ describe("file preview configuration", () => {
   });
 
   it("keeps code and text in separate explorer filters", () => {
-    const node: FileSystemTreeNode = {
+    const node: FileSystemFileTreeNode = {
       name: "file",
       path: "file",
       isDirectory: false,
+      canonicalPath: "project/file",
       contentType: "text/javascript",
       fileId: "file-1",
       children: [],
@@ -186,8 +188,14 @@ describe("buildFileSystemTree", () => {
     const q1 = findTreeNodeByPath(tree, "reports/q1");
     const summary = findTreeNodeByPath(tree, "reports/q1/summary.pdf");
 
-    expect(reports?.isDirectory).toBe(true);
-    expect(q1?.isDirectory).toBe(true);
+    expect(reports).toMatchObject({
+      isDirectory: true,
+      canonicalPath: "project/reports",
+    });
+    expect(q1).toMatchObject({
+      isDirectory: true,
+      canonicalPath: "project/reports/q1",
+    });
     expect(summary?.isDirectory).toBe(false);
     expect(q1?.children.map((n) => n.path)).toEqual(["reports/q1/summary.pdf"]);
   });
@@ -196,7 +204,10 @@ describe("buildFileSystemTree", () => {
     const tree = buildFileSystemTree([mountDir("archive")]);
 
     const archive = findTreeNodeByPath(tree, "archive");
-    expect(archive?.isDirectory).toBe(true);
+    expect(archive).toMatchObject({
+      isDirectory: true,
+      canonicalPath: "project/archive",
+    });
     expect(archive?.children).toEqual([]);
   });
 
@@ -403,6 +414,14 @@ describe("buildFileSystemTree with virtualPath", () => {
     expect(
       getChildrenAtFolderPath(tree, "pod/shared").map((n) => n.path)
     ).toEqual(["pod/shared/readme.md"]);
+    expect(findTreeNodeByPath(tree, "conversation")).toMatchObject({
+      canonicalPath: "conversation",
+      path: "conversation",
+    });
+    expect(findTreeNodeByPath(tree, "pod/shared")).toMatchObject({
+      canonicalPath: "project/shared",
+      path: "pod/shared",
+    });
   });
 });
 
@@ -412,8 +431,15 @@ describe("getVirtualScopeRootNodes", () => {
       withVirtualExplorerPath(mountFile("a.txt"), "pod"),
     ]);
 
-    const roots = getVirtualScopeRootNodes(tree, ["conversation", "pod"]);
+    const roots = getVirtualScopeRootNodes(tree, [
+      { path: "conversation", canonicalPath: "conversation-c1" },
+      { path: "pod", canonicalPath: "pod-p1" },
+    ]);
     expect(roots.map((n) => n.path)).toEqual(["conversation", "pod"]);
+    expect(roots.map((n) => n.canonicalPath)).toEqual([
+      "conversation-c1",
+      "pod-p1",
+    ]);
     expect(roots[0]?.children).toEqual([]);
     expect(roots[1]?.children).toHaveLength(1);
   });

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -175,8 +175,11 @@ import type {
   FileExplorerEntry,
   FileExplorerPathEntry,
   FileExplorerSortMode,
+  FileExplorerVirtualScopeRoot,
   FilePanelCategory,
+  FileSystemDirectoryTreeNode,
   FileSystemTreeNode,
+  FramePackageEntry,
 } from "./types";
 
 export const MIN_FILES_FOR_SEARCH = 10;
@@ -382,7 +385,8 @@ function ensureDirectoryNode(
   nodeMap: Map<string, FileSystemTreeNode>,
   root: FileSystemTreeNode[],
   path: string,
-  name: string
+  name: string,
+  canonicalPath: string
 ): void {
   if (nodeMap.has(path)) {
     return;
@@ -392,6 +396,7 @@ function ensureDirectoryNode(
     name,
     path,
     isDirectory: true,
+    canonicalPath,
     contentType: null,
     fileId: null,
     children: [],
@@ -431,26 +436,29 @@ export function withVirtualExplorerPath(
 /** Top-level scope folders shown at the virtual root (includes empty scopes). */
 export function getVirtualScopeRootNodes(
   tree: FileSystemTreeNode[],
-  scopeRoots: readonly string[]
-): FileSystemTreeNode[] {
-  const topLevelDirs = new Map<string, FileSystemTreeNode>();
+  scopeRoots: readonly FileExplorerVirtualScopeRoot[]
+): FileSystemDirectoryTreeNode[] {
+  const topLevelDirs = new Map<string, FileSystemDirectoryTreeNode>();
   for (const node of tree) {
     if (node.isDirectory && !node.path.includes("/")) {
       topLevelDirs.set(node.path, node);
     }
   }
 
-  return scopeRoots.map(
-    (label) =>
-      topLevelDirs.get(label) ?? {
-        name: label,
-        path: label,
-        isDirectory: true,
-        contentType: null,
-        fileId: null,
-        children: [],
-      }
-  );
+  return scopeRoots.map((scopeRoot) => {
+    const existingNode = topLevelDirs.get(scopeRoot.path);
+    return existingNode
+      ? { ...existingNode, canonicalPath: scopeRoot.canonicalPath }
+      : {
+          name: scopeRoot.path,
+          path: scopeRoot.path,
+          canonicalPath: scopeRoot.canonicalPath,
+          isDirectory: true,
+          contentType: null,
+          fileId: null,
+          children: [],
+        };
+  });
 }
 
 /** Search result card title: explorer path with the current folder prefix stripped. */
@@ -513,7 +521,7 @@ export function fileExplorerNodeMatchesSearch(
  * Uses `virtualPath` when set; otherwise strips the scoped prefix from `path`.
  */
 export function buildFileSystemTree(
-  entries: FileExplorerPathEntry[]
+  entries: (FileExplorerPathEntry | FramePackageEntry)[]
 ): FileSystemTreeNode[] {
   const root: FileSystemTreeNode[] = [];
   const nodeMap = new Map<string, FileSystemTreeNode>();
@@ -526,6 +534,15 @@ export function buildFileSystemTree(
     }
 
     const parts = relativePath.split("/");
+    const canonicalPath =
+      "sourceFolderCanonicalPath" in entry
+        ? entry.sourceFolderCanonicalPath
+        : entry.path;
+    const canonicalParts = canonicalPath.split("/");
+    const canonicalPartOffset = canonicalParts.length - parts.length;
+
+    const getCanonicalPathAtDepth = (depth: number): string =>
+      canonicalParts.slice(0, canonicalPartOffset + depth).join("/");
 
     if (entry.isDirectory) {
       if (nodeMap.has(relativePath)) {
@@ -535,7 +552,13 @@ export function buildFileSystemTree(
       let currentPath = "";
       for (let i = 0; i < parts.length; i++) {
         currentPath = currentPath ? `${currentPath}/${parts[i]!}` : parts[i]!;
-        ensureDirectoryNode(nodeMap, root, currentPath, parts[i]!);
+        ensureDirectoryNode(
+          nodeMap,
+          root,
+          currentPath,
+          parts[i]!,
+          getCanonicalPathAtDepth(i + 1)
+        );
       }
       continue;
     }
@@ -543,13 +566,20 @@ export function buildFileSystemTree(
     let currentPath = "";
     for (let i = 0; i < parts.length - 1; i++) {
       currentPath = currentPath ? `${currentPath}/${parts[i]!}` : parts[i]!;
-      ensureDirectoryNode(nodeMap, root, currentPath, parts[i]!);
+      ensureDirectoryNode(
+        nodeMap,
+        root,
+        currentPath,
+        parts[i]!,
+        getCanonicalPathAtDepth(i + 1)
+      );
     }
 
     const fileNode: FileSystemTreeNode = {
       name: parts[parts.length - 1]!,
       path: relativePath,
       isDirectory: false,
+      canonicalPath,
       contentType: entry.contentType,
       fileId: entry.fileId,
       children: [],

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -544,8 +544,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
           validateVariant: "warning",
         });
         if (confirmed) {
-          // TODO: once FileSystemTreeNode carries the canonical scoped path, use entry.path directly.
-          const result = await deletePodFile(`pod-${pod.sId}/${entry.path}`);
+          const result = await deletePodFile(entry.path);
           if (result.isOk()) {
             await refreshPodFiles();
           }
@@ -586,33 +585,28 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     [
       confirm,
       deletePodFile,
-      pod.sId,
       refreshPodContextAttachments,
       refreshPodFiles,
       removePodContextContentNodes,
     ]
   );
 
-  const onRename = useCallback(
-    (entry: FileEntry | FolderEntry) => {
-      if (entry.kind === "file") {
-        setItemToRename({
-          kind: "file",
-          path: entry.path,
-          name: entry.fileName,
-        });
-      } else {
-        // TODO: once FileSystemTreeNode carries the canonical scoped path, use entry.path directly.
-        setItemToRename({
-          kind: "folder",
-          path: `pod-${pod.sId}/${entry.path}`,
-          name: entry.name,
-        });
-      }
-      setShowRenameDialog(true);
-    },
-    [pod.sId]
-  );
+  const onRename = useCallback((entry: FileEntry | FolderEntry) => {
+    if (entry.kind === "file") {
+      setItemToRename({
+        kind: "file",
+        path: entry.path,
+        name: entry.fileName,
+      });
+    } else {
+      setItemToRename({
+        kind: "folder",
+        path: entry.path,
+        name: entry.name,
+      });
+    }
+    setShowRenameDialog(true);
+  }, []);
 
   const onMoveFile = useCallback(
     async (entry: FileEntry, parentRelativePath: string) => {


### PR DESCRIPTION
## Description

- Carry canonical scoped paths on explorer directory nodes and virtual scope roots.
- Preserve the canonical source-folder path when Frame V2 files collapse into a package card.
- Use canonical folder paths for pod rename and delete actions.

This is PR 1 of 3. PR 2 adds the ZIP endpoint and is based on this branch.

## Tests

- npm run test -- components/file_explorer/utils.test.ts components/file_explorer/fileExplorerPipeline.test.ts components/file_explorer/FileExplorer.test.tsx
- npx tsgo --noEmit in front

## Risk

Low. This extends internal explorer types and switches existing folder actions to the canonical path already returned by the filesystem. The focused explorer tests cover ordinary, virtual-root, and Frame V2 paths.

## Deploy Plan

Deploy normally. Merge before the ZIP API and explorer UI PRs above it in the stack.