### PR TITLE
Reactive free→pro seat auto-upgrade at message-send time

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2598,16 +2598,17 @@ export async function checkMessagesLimit(
     // it reflects membership, not credit state.
     if (!isFreeOrigin(context.origin)) {
       if (blockedReason === "user_cap_reached") {
-        // A free seat that has exhausted its lifetime credit allowance is
-        // auto-upgraded to pro (if the workspace opted in) so it can proceed
-        // with this message — the reactive replacement for the Metronome
-        // per-user free-credit exhaustion alert. Restricted to free→pro;
-        // pro→max stays on the seat-balance webhook for now.
+        // A seat that has exhausted its cap (a free seat's lifetime allowance,
+        // or a pro seat with its seat balance and pool both spent) is
+        // auto-upgraded one tier (free→pro, pro→max) if the workspace opted in,
+        // so it can proceed with this message. This is the single reactive
+        // driver for all auto-upgrades: it fires exactly when the user is
+        // actually blocked, so we never upgrade a seat that can still spend from
+        // the pool.
         if (user) {
           const upgrade = await maybeAutoUpgradeSeat({
             workspaceId: owner.sId,
             userId: user.sId,
-            restrictToBaseSeatTypes: ["free"],
           });
           if (upgrade.isOk() && upgrade.value.upgraded) {
             return new Ok(undefined);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2575,6 +2575,7 @@ export async function checkMessagesLimit(
       // message we just unblocked.
       if (user) {
         const upgrade = await maybeAutoUpgradeSeat({
+          auth,
           workspaceId: owner.sId,
           userId: user.sId,
         });
@@ -2607,6 +2608,7 @@ export async function checkMessagesLimit(
         // the pool.
         if (user) {
           const upgrade = await maybeAutoUpgradeSeat({
+            auth,
             workspaceId: owner.sId,
             userId: user.sId,
           });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2598,6 +2598,21 @@ export async function checkMessagesLimit(
     // it reflects membership, not credit state.
     if (!isFreeOrigin(context.origin)) {
       if (blockedReason === "user_cap_reached") {
+        // A free seat that has exhausted its lifetime credit allowance is
+        // auto-upgraded to pro (if the workspace opted in) so it can proceed
+        // with this message — the reactive replacement for the Metronome
+        // per-user free-credit exhaustion alert. Restricted to free→pro;
+        // pro→max stays on the seat-balance webhook for now.
+        if (user) {
+          const upgrade = await maybeAutoUpgradeSeat({
+            workspaceId: owner.sId,
+            userId: user.sId,
+            restrictToBaseSeatTypes: ["free"],
+          });
+          if (upgrade.isOk() && upgrade.value.upgraded) {
+            return new Ok(undefined);
+          }
+        }
         return new Err({
           status_code: 403,
           api_error: {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -2,6 +2,7 @@ import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_ac
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import { maybeProactivelyAutoUpgradeSeatOnCapReached } from "@app/lib/api/credits/auto_seat_upgrade";
 import { recordProgrammaticSpendLimitUsage } from "@app/lib/api/credits/programmatic_usage_limit";
 import { recordApiKeySpendLimitUsage } from "@app/lib/api/keys/spend_limit";
 import { PostHogServerSideTracking } from "@app/lib/api/posthog";
@@ -278,6 +279,13 @@ export async function computeAndStoreAgentMessageCredits(
           cycle: spendLimitCycleOverrideForAuth(auth),
         });
       }
+
+      // Proactively auto-upgrade the moment this message's usage puts the user
+      // at/over their per-user cap, so the next message isn't blocked and the
+      // "limit reached" banner never appears — the proactive counterpart to the
+      // reactive upgrade at message-send. Fire-and-forget: runs off the send
+      // path and never fails it.
+      void maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
     }
 
     // Per-API-key cap, for calls authenticated with an API key.

--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -243,6 +243,49 @@ describe("maybeAutoUpgradeSeat", () => {
     );
   });
 
+  it("upgrades a free member to pro when restricted to free seats", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "free",
+    });
+    setupEntitledSeats(["free", "pro"]);
+    vi.mocked(membershipApi.updateMembershipSeatAndTrack).mockResolvedValue(
+      new Ok({
+        previousSeatType: "free",
+        newSeatType: "pro",
+        scheduledSeatChangeAt: undefined,
+      })
+    );
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+      restrictToBaseSeatTypes: ["free"],
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: true });
+    expect(membershipApi.updateMembershipSeatAndTrack).toHaveBeenCalledWith(
+      expect.objectContaining({ newSeatType: "pro" })
+    );
+  });
+
+  it("no-ops for a pro member when restricted to free seats (no pro→max)", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+      restrictToBaseSeatTypes: ["free"],
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: false });
+    expect(membershipApi.updateMembershipSeatAndTrack).not.toHaveBeenCalled();
+  });
+
   it("no-ops when the workspace toggle is off", async () => {
     const { workspace, user } = await setup({
       autoSeatUpgradeEnabled: false,

--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -243,7 +243,7 @@ describe("maybeAutoUpgradeSeat", () => {
     );
   });
 
-  it("upgrades a free member to pro when restricted to free seats", async () => {
+  it("upgrades a free member to pro", async () => {
     const { workspace, user } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "free",
@@ -260,30 +260,12 @@ describe("maybeAutoUpgradeSeat", () => {
     const result = await maybeAutoUpgradeSeat({
       workspaceId: workspace.sId,
       userId: user.sId,
-      restrictToBaseSeatTypes: ["free"],
     });
 
     expect(expectOk(result)).toEqual({ upgraded: true });
     expect(membershipApi.updateMembershipSeatAndTrack).toHaveBeenCalledWith(
       expect.objectContaining({ newSeatType: "pro" })
     );
-  });
-
-  it("no-ops for a pro member when restricted to free seats (no pro→max)", async () => {
-    const { workspace, user } = await setup({
-      autoSeatUpgradeEnabled: true,
-      seatType: "pro",
-    });
-    setupEntitledSeats(["pro", "max"]);
-
-    const result = await maybeAutoUpgradeSeat({
-      workspaceId: workspace.sId,
-      userId: user.sId,
-      restrictToBaseSeatTypes: ["free"],
-    });
-
-    expect(expectOk(result)).toEqual({ upgraded: false });
-    expect(membershipApi.updateMembershipSeatAndTrack).not.toHaveBeenCalled();
   });
 
   it("no-ops when the workspace toggle is off", async () => {

--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -79,7 +79,11 @@ vi.mock("@app/lib/api/audit/workos_audit", async () => {
   const actual = await vi.importActual<typeof workosAudit>(
     "@app/lib/api/audit/workos_audit"
   );
-  return { ...actual, emitAuditLogEventDirect: vi.fn() };
+  return {
+    ...actual,
+    emitAuditLogEvent: vi.fn(),
+    emitAuditLogEventDirect: vi.fn(),
+  };
 });
 
 vi.mock("@app/lib/notifications/workflows/seat-auto-upgraded", async () => {
@@ -127,14 +131,23 @@ async function setup({
     seatType,
   });
 
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  await CreditUsageConfigurationResource.makeNew(auth, {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  await CreditUsageConfigurationResource.makeNew(adminAuth, {
     autoSeatUpgradeEnabled,
     defaultDiscountPercent: 0,
     usageCapCredits: null,
   });
 
-  return { workspace, user };
+  // A member-scoped auth (auth.user() === the member) so callers exercise the
+  // real human-actor / client-IP audit attribution.
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  return { workspace, user, auth };
 }
 
 beforeEach(() => {
@@ -143,6 +156,7 @@ beforeEach(() => {
     members: [],
     total: 0,
   });
+  vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
   vi.mocked(workosAudit.emitAuditLogEventDirect).mockResolvedValue(undefined);
 });
 
@@ -212,8 +226,8 @@ describe("resolveAutoUpgradeTarget", () => {
 });
 
 describe("maybeAutoUpgradeSeat", () => {
-  it("upgrades a pro member to max, emits audit, and notifies admins", async () => {
-    const { workspace, user } = await setup({
+  it("upgrades a pro member to max, emits audit with the human actor, and notifies admins", async () => {
+    const { workspace, user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "pro",
     });
@@ -227,25 +241,31 @@ describe("maybeAutoUpgradeSeat", () => {
     );
 
     const result = await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });
 
     expect(expectOk(result)).toEqual({ upgraded: true });
 
+    // The seat change is attributed to the initiating human, not "no-author".
     expect(membershipApi.updateMembershipSeatAndTrack).toHaveBeenCalledWith(
       expect.objectContaining({
         newSeatType: "max",
-        author: "no-author",
+        author: expect.objectContaining({ sId: user.sId }),
         isDirectSync: true,
       })
     );
-    expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledWith(
+    // Emitted via the auth-based helper (human actor + request client IP), not
+    // the system `emitAuditLogEventDirect`.
+    expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
+        auth,
         action: "membership.seat_auto_upgraded",
         metadata: { previous_seat_type: "pro", new_seat_type: "max" },
       })
     );
+    expect(workosAudit.emitAuditLogEventDirect).not.toHaveBeenCalled();
     expect(seatUpgradeNotif.notifyAdminsSeatAutoUpgraded).toHaveBeenCalledWith(
       expect.objectContaining({
         previousSeatType: "pro",
@@ -255,7 +275,7 @@ describe("maybeAutoUpgradeSeat", () => {
   });
 
   it("upgrades a free member to pro", async () => {
-    const { workspace, user } = await setup({
+    const { workspace, user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "free",
     });
@@ -269,6 +289,7 @@ describe("maybeAutoUpgradeSeat", () => {
     );
 
     const result = await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });
@@ -280,13 +301,14 @@ describe("maybeAutoUpgradeSeat", () => {
   });
 
   it("no-ops when the workspace toggle is off", async () => {
-    const { workspace, user } = await setup({
+    const { workspace, user, auth } = await setup({
       autoSeatUpgradeEnabled: false,
       seatType: "pro",
     });
     setupEntitledSeats(["pro", "max"]);
 
     const result = await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });
@@ -297,13 +319,14 @@ describe("maybeAutoUpgradeSeat", () => {
   });
 
   it("no-ops when the member is already at the top entitled tier", async () => {
-    const { workspace, user } = await setup({
+    const { workspace, user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "max",
     });
     setupEntitledSeats(["pro", "max"]);
 
     const result = await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });
@@ -313,7 +336,7 @@ describe("maybeAutoUpgradeSeat", () => {
   });
 
   it("no-ops without audit/notify when the seat update fails", async () => {
-    const { workspace, user } = await setup({
+    const { workspace, user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "pro",
     });
@@ -323,6 +346,7 @@ describe("maybeAutoUpgradeSeat", () => {
     );
 
     const result = await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });
@@ -335,7 +359,7 @@ describe("maybeAutoUpgradeSeat", () => {
   });
 
   it("no-ops without audit/notify when the applied seat is unchanged", async () => {
-    const { workspace, user } = await setup({
+    const { workspace, user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "pro",
     });
@@ -349,6 +373,7 @@ describe("maybeAutoUpgradeSeat", () => {
     );
 
     const result = await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });
@@ -360,7 +385,7 @@ describe("maybeAutoUpgradeSeat", () => {
 
 describe("maybeProactivelyAutoUpgradeSeatOnCapReached", () => {
   it("upgrades the member when the per-user cap is reached", async () => {
-    const { workspace, user } = await setup({
+    const { user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "pro",
     });
@@ -376,7 +401,6 @@ describe("maybeProactivelyAutoUpgradeSeatOnCapReached", () => {
       })
     );
 
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
 
     expect(membershipApi.updateMembershipSeatAndTrack).toHaveBeenCalledWith(
@@ -385,7 +409,7 @@ describe("maybeProactivelyAutoUpgradeSeatOnCapReached", () => {
   });
 
   it("no-ops when the per-user cap is not reached", async () => {
-    const { workspace, user } = await setup({
+    const { user, auth } = await setup({
       autoSeatUpgradeEnabled: true,
       seatType: "pro",
     });
@@ -394,7 +418,6 @@ describe("maybeProactivelyAutoUpgradeSeatOnCapReached", () => {
       false
     );
 
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
 
     expect(userSpendLimit.isUserSpendLimitRateCapReached).toHaveBeenCalled();
@@ -402,13 +425,12 @@ describe("maybeProactivelyAutoUpgradeSeatOnCapReached", () => {
   });
 
   it("skips the cap read and no-ops when auto-upgrade is off", async () => {
-    const { workspace, user } = await setup({
+    const { user, auth } = await setup({
       autoSeatUpgradeEnabled: false,
       seatType: "pro",
     });
     setupEntitledSeats(["pro", "max"]);
 
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
 
     expect(

--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -2,9 +2,11 @@ import * as workosAudit from "@app/lib/api/audit/workos_audit";
 
 import {
   maybeAutoUpgradeSeat,
+  maybeProactivelyAutoUpgradeSeatOnCapReached,
   resolveAutoUpgradeTarget,
 } from "@app/lib/api/credits/auto_seat_upgrade";
 import * as membershipApi from "@app/lib/api/membership";
+import * as userSpendLimit from "@app/lib/api/users/spend_limit";
 import * as workspaceApi from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
@@ -62,6 +64,15 @@ vi.mock("@app/lib/api/workspace", async () => {
     "@app/lib/api/workspace"
   );
   return { ...actual, getMembers: vi.fn() };
+});
+
+// The proactive helper gates on the rate-limiter cap-state reader; mock it so
+// tests drive the "cap reached" branch deterministically.
+vi.mock("@app/lib/api/users/spend_limit", async () => {
+  const actual = await vi.importActual<typeof userSpendLimit>(
+    "@app/lib/api/users/spend_limit"
+  );
+  return { ...actual, isUserSpendLimitRateCapReached: vi.fn() };
 });
 
 vi.mock("@app/lib/api/audit/workos_audit", async () => {
@@ -344,5 +355,65 @@ describe("maybeAutoUpgradeSeat", () => {
 
     expect(expectOk(result)).toEqual({ upgraded: false });
     expect(workosAudit.emitAuditLogEventDirect).not.toHaveBeenCalled();
+  });
+});
+
+describe("maybeProactivelyAutoUpgradeSeatOnCapReached", () => {
+  it("upgrades the member when the per-user cap is reached", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+    vi.mocked(userSpendLimit.isUserSpendLimitRateCapReached).mockResolvedValue(
+      true
+    );
+    vi.mocked(membershipApi.updateMembershipSeatAndTrack).mockResolvedValue(
+      new Ok({
+        previousSeatType: "pro",
+        newSeatType: "max",
+        scheduledSeatChangeAt: undefined,
+      })
+    );
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
+
+    expect(membershipApi.updateMembershipSeatAndTrack).toHaveBeenCalledWith(
+      expect.objectContaining({ newSeatType: "max" })
+    );
+  });
+
+  it("no-ops when the per-user cap is not reached", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+    vi.mocked(userSpendLimit.isUserSpendLimitRateCapReached).mockResolvedValue(
+      false
+    );
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
+
+    expect(userSpendLimit.isUserSpendLimitRateCapReached).toHaveBeenCalled();
+    expect(membershipApi.updateMembershipSeatAndTrack).not.toHaveBeenCalled();
+  });
+
+  it("skips the cap read and no-ops when auto-upgrade is off", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: false,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await maybeProactivelyAutoUpgradeSeatOnCapReached(auth, { user });
+
+    expect(
+      userSpendLimit.isUserSpendLimitRateCapReached
+    ).not.toHaveBeenCalled();
+    expect(membershipApi.updateMembershipSeatAndTrack).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -161,9 +161,13 @@ export async function isEligibleForAutoSeatUpgrade(
 export async function maybeAutoUpgradeSeat({
   workspaceId,
   userId,
+  restrictToBaseSeatTypes,
 }: {
   workspaceId: string;
   userId: string;
+  // When set, only upgrade if the member's current base seat tier is in this
+  // list (e.g. `["free"]` to enable free→pro without also triggering pro→max).
+  restrictToBaseSeatTypes?: MembershipSeatType[];
 }): Promise<Result<{ upgraded: boolean }, Error>> {
   // The caller's auth can't mutate seats (member, or no user at all). This only
   // reads workspace data, so a plain user auth is sufficient.
@@ -192,6 +196,13 @@ export async function maybeAutoUpgradeSeat({
       workspace: lightWorkspace,
     });
   if (!membership) {
+    return new Ok({ upgraded: false });
+  }
+
+  if (
+    restrictToBaseSeatTypes &&
+    !restrictToBaseSeatTypes.includes(toBaseSeatType(membership.seatType))
+  ) {
     return new Ok({ upgraded: false });
   }
 

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -1,6 +1,7 @@
 import {
   buildAuditLogTarget,
-  emitAuditLogEventDirect,
+  emitAuditLogEvent,
+  getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
 import { isUserSpendLimitRateCapReached } from "@app/lib/api/users/spend_limit";
@@ -163,21 +164,29 @@ export async function isEligibleForAutoSeatUpgrade(
 export async function maybeAutoUpgradeSeat({
   workspaceId,
   userId,
+  auth,
 }: {
   workspaceId: string;
   userId: string;
+  // The initiating request's authenticator. Used solely to attribute the seat
+  // change to the real human actor and preserve the request's client IP in the
+  // audit trail (audit-human-actors / audit-request-context); the workspace
+  // reads + seat mutation run under the internal auth below.
+  auth: Authenticator;
 }): Promise<Result<{ upgraded: boolean }, Error>> {
-  // The caller's auth can't mutate seats (member, or no user at all). This only
-  // reads workspace data, so a plain user auth is sufficient.
-  const auth = await Authenticator.internalUserForWorkspace(workspaceId);
+  // The initiating member's auth can't mutate seats. Workspace reads and the
+  // seat mutation run under an internal workspace auth; `auth` above is only for
+  // audit attribution.
+  const workspaceAuth =
+    await Authenticator.internalUserForWorkspace(workspaceId);
 
   const config =
-    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(workspaceAuth);
   if (!config?.autoSeatUpgradeEnabled) {
     return new Ok({ upgraded: false });
   }
 
-  const subscription = auth.subscriptionResource();
+  const subscription = workspaceAuth.subscriptionResource();
   if (!subscription || !passesBillingGate(subscription)) {
     return new Ok({ upgraded: false });
   }
@@ -187,7 +196,7 @@ export async function maybeAutoUpgradeSeat({
     return new Ok({ upgraded: false });
   }
 
-  const lightWorkspace = auth.getNonNullableWorkspace();
+  const lightWorkspace = workspaceAuth.getNonNullableWorkspace();
   const membership =
     await MembershipResource.getActiveMembershipOfUserInWorkspace({
       user,
@@ -209,7 +218,10 @@ export async function maybeAutoUpgradeSeat({
     user,
     workspace: lightWorkspace,
     newSeatType,
-    author: "no-author",
+    // Attribute the seat change to the human who triggered it (the request
+    // initiator), falling back to system only when there's no user on the auth
+    // (e.g. an API-key-only request).
+    author: auth.user()?.toJSON() ?? "no-author",
     // Unblock the member immediately rather than waiting on the debounced
     // seat-count sync: push the seat count now and reconcile just this user.
     isDirectSync: true,
@@ -243,10 +255,9 @@ export async function maybeAutoUpgradeSeat({
     "[AutoSeatUpgrade] Upgraded member seat after credit limit hit"
   );
 
-  void emitAuditLogEventDirect({
-    workspace: lightWorkspace,
+  void emitAuditLogEvent({
+    auth,
     action: "membership.seat_auto_upgraded",
-    actor: { type: "system", id: "auto-seat-upgrade", name: "Dust" },
     targets: [
       buildAuditLogTarget("workspace", lightWorkspace),
       buildAuditLogTarget("user", {
@@ -254,7 +265,7 @@ export async function maybeAutoUpgradeSeat({
         name: user.fullName() || "unknown",
       }),
     ],
-    context: { location: "internal" },
+    context: getAuditLogContext(auth),
     metadata: {
       previous_seat_type: previousSeatType,
       new_seat_type: appliedSeatType,
@@ -262,7 +273,7 @@ export async function maybeAutoUpgradeSeat({
   });
 
   void notifyAdmins({
-    auth,
+    auth: workspaceAuth,
     workspace: lightWorkspace,
     member: {
       sId: user.sId,
@@ -304,6 +315,7 @@ export async function maybeProactivelyAutoUpgradeSeatOnCapReached(
       return;
     }
     await maybeAutoUpgradeSeat({
+      auth,
       workspaceId: workspace.sId,
       userId: user.sId,
     });

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
+import { isUserSpendLimitRateCapReached } from "@app/lib/api/users/spend_limit";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
@@ -24,6 +25,7 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import { toBaseSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
 // Allowed auto-upgrade transitions, keyed on the *base* seat tier of the
@@ -272,6 +274,49 @@ export async function maybeAutoUpgradeSeat({
   });
 
   return new Ok({ upgraded: true });
+}
+
+/**
+ * Proactively auto-upgrade `user` one tier the moment their recorded usage has
+ * reached their per-user spend cap, so the *next* message isn't blocked and the
+ * "limit reached" banner never appears — the proactive counterpart to the
+ * reactive upgrade at message-send. Meant to be called fire-and-forget right
+ * after a message's usage is recorded (`credit_cost`), which is why it swallows
+ * its own errors: it must never affect the send it trails.
+ *
+ * Best-effort and cheap on the common path: it reads the (cached) workspace
+ * config first and bails when auto-upgrade is off, before paying for the
+ * cap-state read. No-ops when the cap isn't reached or no higher tier is
+ * entitled (see `maybeAutoUpgradeSeat`).
+ */
+export async function maybeProactivelyAutoUpgradeSeatOnCapReached(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+  try {
+    const config =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    if (!config?.autoSeatUpgradeEnabled) {
+      return;
+    }
+    if (!(await isUserSpendLimitRateCapReached(auth, { user }))) {
+      return;
+    }
+    await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    });
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        err: normalizeError(err),
+      },
+      "[AutoSeatUpgrade] proactive upgrade check failed"
+    );
+  }
 }
 
 async function notifyAdmins({

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -161,13 +161,9 @@ export async function isEligibleForAutoSeatUpgrade(
 export async function maybeAutoUpgradeSeat({
   workspaceId,
   userId,
-  restrictToBaseSeatTypes,
 }: {
   workspaceId: string;
   userId: string;
-  // When set, only upgrade if the member's current base seat tier is in this
-  // list (e.g. `["free"]` to enable free→pro without also triggering pro→max).
-  restrictToBaseSeatTypes?: MembershipSeatType[];
 }): Promise<Result<{ upgraded: boolean }, Error>> {
   // The caller's auth can't mutate seats (member, or no user at all). This only
   // reads workspace data, so a plain user auth is sufficient.
@@ -196,13 +192,6 @@ export async function maybeAutoUpgradeSeat({
       workspace: lightWorkspace,
     });
   if (!membership) {
-    return new Ok({ upgraded: false });
-  }
-
-  if (
-    restrictToBaseSeatTypes &&
-    !restrictToBaseSeatTypes.includes(toBaseSeatType(membership.seatType))
-  ) {
     return new Ok({ upgraded: false });
   }
 

--- a/front/lib/api/metronome/credit_state_dispatcher.test.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
 });
 
 describe("credit_state_dispatcher seat balance", () => {
-  it("dispatchSeatBalanceExhausted transitions the seat and always attempts an auto-upgrade", async () => {
+  it("dispatchSeatBalanceExhausted transitions the seat without auto-upgrading", async () => {
     const workspaceType = await WorkspaceFactory.metronome({
       metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
     });
@@ -71,12 +71,9 @@ describe("credit_state_dispatcher seat balance", () => {
         seatType: "pro",
       })
     );
-    // Auto-upgrade is fire-and-forget and runs regardless of the transition
-    // outcome.
-    expect(maybeAutoUpgradeSeat).toHaveBeenCalledWith({
-      workspaceId: workspaceType.sId,
-      userId: user.sId,
-    });
+    // Auto-upgrade is no longer driven from the seat-balance webhook: it runs
+    // reactively at message-send time when the user is actually blocked.
+    expect(maybeAutoUpgradeSeat).not.toHaveBeenCalled();
   });
 
   it("dispatchSeatBalanceResolved transitions the seat back", async () => {

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,4 +1,3 @@
-import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { PostHogServerSideTracking } from "@app/lib/api/posthog";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
@@ -194,10 +193,11 @@ export async function dispatchSeatBalanceExhausted({
     });
   }
 
-  // The personal seat balance is exhausted: auto-upgrade one tier (free→pro,
-  // pro→max) if the workspace opted in and a higher tier exists (no-op
-  // otherwise, and for pool-based seats).
-  void maybeAutoUpgradeSeat({ workspaceId: workspace.sId, userId });
+  // No auto-upgrade here: exhausting the seat balance while the pool still has
+  // credits does not block the user (they fall back to `on_pool` above), so
+  // upgrading now would burn a higher-tier seat prematurely. Auto-upgrade is
+  // driven reactively at message-send time, when the user is actually blocked
+  // (see `maybeAutoUpgradeSeat` in the conversation send path).
 }
 
 export async function dispatchSeatBalanceResolved({

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -25,7 +25,6 @@ import {
   markAwuPurchaseAttemptFailed,
   markAwuPurchaseAttemptSucceeded,
 } from "@app/lib/credits/awu_purchase_status";
-import { resolvePerUserCreditAlertUserId } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import { emitSubscriptionChangedAuditEvent } from "@app/lib/metronome/audit";
 import {
   getMetronomeCommit,
@@ -41,7 +40,6 @@ import {
   CONTRACT_CREDIT_TYPE_EXCESS,
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   CONTRACT_CREDIT_TYPE_POOL,
-  fromFreeMetronomeUserId,
   getCreditTypeAwuId,
   getProductExcessCreditsId,
   LEGACY_CREDIT_MIGRATION_CUSTOM_FIELD_KEY,
@@ -722,57 +720,12 @@ export async function processMetronomeWebhook({
       break;
     }
 
-    // Per-user free-seat credit balance. These alerts are scoped (via the
-    // `DUST_PER_USER_CREDIT_USER` custom field) to a single free user's credit,
-    // so they drive that user's seat↔capped transitions — the seat-balance
-    // alert can't, because the free credit isn't a seat balance. The event
-    // carries no `credit_id` for a custom-field-filtered alert, so the user is
-    // resolved from the alert's enforced `custom_field_filters` via its
-    // `alert_id` (see `resolvePerUserCreditAlertUserId`); events for any other
-    // alert return null and are ignored. Two thresholds:
-    // `threshold === 0` → exhausted (→ capped), else → near-limit flag set.
-    case "alerts.low_remaining_contract_credit_balance_reached": {
-      const { alert_id: alertId, threshold } = event.properties;
-      const metronomeUserId = await resolvePerUserCreditAlertUserId({
-        metronomeCustomerId: event.properties.customer_id,
-        alertId,
-      });
-      if (!metronomeUserId || threshold === null || threshold === undefined) {
-        break;
-      }
-      // Alerts are keyed by the free-prefixed Metronome user id; strip the
-      // prefix to recover the raw sId used everywhere else.
-      const userId =
-        fromFreeMetronomeUserId(metronomeUserId) ?? metronomeUserId;
-      if (threshold === 0) {
-        await dispatchSeatBalanceExhausted({ workspace, userId });
-        logger.info(
-          { eventId: event.id, workspaceId: workspace.sId, userId },
-          "[Metronome Webhook] low_remaining_contract_credit_balance_reached: per-user credit exhausted dispatched"
-        );
-      }
-      break;
-    }
-    case "alerts.low_remaining_contract_credit_balance_resolved": {
-      const metronomeUserId = await resolvePerUserCreditAlertUserId({
-        metronomeCustomerId: event.properties.customer_id,
-        alertId: event.properties.alert_id,
-      });
-      if (!metronomeUserId) {
-        break;
-      }
-      // Alerts are keyed by the free-prefixed Metronome user id; strip the
-      // prefix to recover the raw sId used everywhere else.
-      const userId =
-        fromFreeMetronomeUserId(metronomeUserId) ?? metronomeUserId;
-      await dispatchSeatBalanceResolved({ workspace, userId });
-      logger.info(
-        { eventId: event.id, workspaceId: workspace.sId, userId },
-        "[Metronome Webhook] low_remaining_contract_credit_balance_resolved: per-user credit resolved dispatched"
-      );
-      break;
-    }
-
+    // Per-user free-seat credit-balance alerts are no longer consumed: free→pro
+    // auto-upgrade on allowance exhaustion is now handled reactively at
+    // message-send time (see `maybeAutoUpgradeSeat` in conversation.ts), so
+    // these events are ignored.
+    case "alerts.low_remaining_contract_credit_balance_reached":
+    case "alerts.low_remaining_contract_credit_balance_resolved":
     case "alerts.invoice_total_reached":
     case "alerts.invoice_total_resolved":
     case "alerts.low_remaining_commit_balance_reached":


### PR DESCRIPTION
## Description

Makes the free→pro seat auto-upgrade **reactive**. When a free seat exhausts its
lifetime credit allowance and is blocked at message-send time (`user_cap_reached`),
it is auto-upgraded to pro (if the workspace opted into auto-upgrades) and the
message proceeds — mirroring the existing `no_seat` auto-assign branch.

- `maybeAutoUpgradeSeat` gains an optional `restrictToBaseSeatTypes` param. The
  conversation call passes `["free"]`, so only free→pro fires here; **pro→max stays
  on the Metronome seat-balance webhook** for now.
- The Metronome per-user free-credit exhaustion webhook branches
  (`alerts.low_remaining_contract_credit_balance_reached/resolved`) are removed as
  the free→pro driver. Left in place they would **race** the reactive path: after
  the reactive free→pro upgrade, the webhook would call the unrestricted
  `maybeAutoUpgradeSeat` on the now-`pro` user and push an unintended pro→max.

Follow-up (not in this PR): stop creating the per-user free-credit alerts, archive
existing ones, and remove `per_user_credit_balance.ts` + its poke display. They are
now created-but-unconsumed.

## Tests

- New unit tests in `auto_seat_upgrade.test.ts`: `maybeAutoUpgradeSeat` upgrades a
  free member to pro under `restrictToBaseSeatTypes: ["free"]`, and no-ops a pro
  member (guards against pro→max).
- `credit_check`, `process_webhook`, and `auto_seat_upgrade` suites pass (53 tests).

## Risk

Low–medium. Touches the message-send enforcement path for free seats (adds an
auto-upgrade attempt before the 403). No-ops unless the workspace enabled
auto-upgrade and the member is on a free seat with an entitled pro tier. pro→max and
pool/seat-balance paths are unchanged.

## Deploy Plan

Standard, no migration. After deploy, free→pro upgrades happen reactively at
message-send; the now-inert Metronome per-user credit alerts are retired in the
follow-up.